### PR TITLE
Fix use-after-free in image lowering

### DIFF
--- a/lower/llpcSpirvLowerImageOp.cpp
+++ b/lower/llpcSpirvLowerImageOp.cpp
@@ -97,6 +97,7 @@ bool SpirvLowerImageOp::runOnModule(
         {
             pInst->dropAllReferences();
             pInst->eraseFromParent();
+            m_imageLoadOperands.erase(pInst);
         }
     }
 


### PR DESCRIPTION
Fixes #1

If an image was used in both a fetch operation and sampling operation
the image load would end up in both the image load set and image load
operands set. This change prevents accessing free'd memory when dealing
with image load operands.