### PR TITLE
AMDVLK issue#39 - dxvk: F.E.A.R. 3 black screen in menu

### DIFF
--- a/translator/SPIRVReader.cpp
+++ b/translator/SPIRVReader.cpp
@@ -1642,8 +1642,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     llvm::GlobalValue::LinkageTypes LinkageTy = transLinkageType(BVar);
     Constant *Initializer = nullptr;
     SPIRVValue *Init = BVar->getInitializer();
-    if (Init)
+    if (Init) {
       Initializer = dyn_cast<Constant>(transValue(Init, F, BB, false));
+      Initializer = widenBoolConstant(Initializer);
+    }
     else if (LinkageTy == GlobalValue::CommonLinkage)
       // In LLVM variables with common linkage type must be initilized by 0
       Initializer = Constant::getNullValue(Ty);


### PR DESCRIPTION
root cause: we widen the bool type for all global variables, but we didn't widen the bool value in the initializer.