### PR TITLE
Fix crash in CTS dEQP-VK.spirv_assembly.instruction.graphics.indexing.input.struct.opaccesschain_u64_vert

### DIFF
--- a/lower/llpcSpirvLowerAccessChain.cpp
+++ b/lower/llpcSpirvLowerAccessChain.cpp
@@ -119,7 +119,15 @@ llvm::GetElementPtrInst* SpirvLowerAccessChain::TryToCoalesceChain(
     do
     {
         chainedInsts.push(pPtrVal);
-        pPtrVal = dyn_cast<GetElementPtrInst>(pPtrVal->getPointerOperand());
+        auto pPointer = pPtrVal->getPointerOperand();
+        if (isa<ConstantExpr>(pPointer))
+        {
+            pPtrVal = dyn_cast<GetElementPtrInst>(cast<ConstantExpr>(pPointer)->getAsInstruction());
+        }
+        else
+        {
+            pPtrVal = dyn_cast<GetElementPtrInst>(pPointer);
+        }
     } while ((pPtrVal != nullptr) && (pPtrVal->getType()->getPointerAddressSpace() == addrSpace));
 
     // If there are more than one "getelementptr" instructions, do coalescing
@@ -156,7 +164,14 @@ llvm::GetElementPtrInst* SpirvLowerAccessChain::TryToCoalesceChain(
             if (pInst->user_empty())
             {
                 pInst->dropAllReferences();
-                pInst->eraseFromParent();
+                if (pInst->getParent() != nullptr)
+                {
+                    pInst->eraseFromParent();
+                }
+                else
+                {
+                    pInst->deleteValue();
+                }
             }
             removedInsts.pop();
         }


### PR DESCRIPTION
root cause: Constantexpr isn't handled in pass SpirvLowerAccessChain, and it causes some chained getelementptr isn't lowered
solution: Check constantexpr in SpirvLowerAccessChain::TryToCoalesceChain, and translate constantexpr to normal instruction if found.