### PR TITLE
Force the alignment of LDS variable to 16bytes

### DIFF
--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1697,6 +1697,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                           Ty->getArrayElementType()->isIntegerTy(8))
                              ? GlobalValue::UnnamedAddr::Global
                              : GlobalValue::UnnamedAddr::None);
+    if (AddrSpace == SPIRAS_Local)
+        LVar->setAlignment(16);
 
     SPIRVBuiltinVariableKind BVKind;
     if (BVar->isBuiltin(&BVKind))


### PR DESCRIPTION
It seems LLVM back-end can't set alignment correctly for ds_read/write_b64 instructions.
we should force the alignment to 16 bytes.