### PR TITLE
Move readlane's into WWM section to ensure correct reductions.

### DIFF
--- a/patch/generate/gfx8/glslGroupOpEmu.ll
+++ b/patch/generate/gfx8/glslGroupOpEmu.ll
@@ -101,11 +101,10 @@ define spir_func i32 @llpc.subgroup.reduce.i32(i32 %binaryOp, i32 %value)
     %i6.1 = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %i5.3, i32 323, i32 12, i32 15, i1 false)
     %i6.2 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.1)
     %i6.3 = call i32 @llpc.subgroup.arithmetic.i32(i32 %binaryOp, i32 %i5.3, i32 %i6.2)
-    %i6.4 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.3)
+    %i6.4 = call i32 @llvm.amdgcn.readlane(i32 %i6.3, i32 63)
+    %i6.5 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.4)
 
-    %i7 = call i32 @llvm.amdgcn.readlane(i32 %i6.4, i32 63)
-
-    ret i32 %i7
+    ret i32 %i6.5
 }
 
 ; GLSL: int/uint/float subgroupExclusiveXXX(int/uint/float)

--- a/patch/generate/gfx8/glslGroupOpEmuD16.ll
+++ b/patch/generate/gfx8/glslGroupOpEmuD16.ll
@@ -109,11 +109,10 @@ define spir_func i32 @llpc.subgroup.reduce.i16(i32 %binaryOp, i32 %value)
     %i6.1 = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %i5.3, i32 323, i32 12, i32 15, i1 false)
     %i6.2 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.1)
     %i6.3 = call i32 @llpc.subgroup.arithmetic.i16(i32 %binaryOp, i32 %i5.3, i32 %i6.2)
-    %i6.4 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.3)
+    %i6.4 = call i32 @llvm.amdgcn.readlane(i32 %i6.3, i32 63)
+    %i6.5 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.4)
 
-    %i7 = call i32 @llvm.amdgcn.readlane(i32 %i6.4, i32 63)
-
-    ret i32 %i7
+    ret i32 %i6.5
 }
 
 ; GLSL: int16_t/uint16_t/float16_t subgroupExclusiveXXX(int16_t/uint16_t/float16_t)

--- a/patch/generate/gfx8/glslGroupOpEmuD64.ll
+++ b/patch/generate/gfx8/glslGroupOpEmuD64.ll
@@ -146,11 +146,10 @@ define spir_func i64 @llpc.subgroup.reduce.i64(i32 %binaryOp, i64 %value)
     %i6.1 = call i64 @llpc.mov.dpp.i64(i64 %i5.3, i32 323, i32 12, i32 15, i1 false)
     %i6.2 = call i64 @llvm.amdgcn.wwm.i64(i64 %i6.1)
     %i6.3 = call i64 @llpc.subgroup.arithmetic.i64(i32 %binaryOp, i64 %i5.3, i64 %i6.2)
-    %i6.4 = call i64 @llvm.amdgcn.wwm.i64(i64 %i6.3)
+    %i6.4 = call i64 @llpc.readlane.i64(i64 %i6.3, i32 63)
+    %i6.5 = call i64 @llvm.amdgcn.wwm.i64(i64 %i6.4)
 
-    %i7 = call i64 @llpc.readlane.i64(i64 %i6.4, i32 63)
-
-    ret i64 %i7
+    ret i64 %i6.5
 }
 
 ; GLSL: int64_t/uint64_t subgroupExclusiveXXX(int64_t/uint64_t)

--- a/patch/generate/glslGroupOpEmu.ll
+++ b/patch/generate/glslGroupOpEmu.ll
@@ -1893,7 +1893,9 @@ define spir_func i32 @llpc.subgroup.reduce.i32(i32 %binaryOp, i32 %value)
     %i6.1 = call i32 @llvm.amdgcn.readlane(i32 %i5.4, i32 31)
     %i6.2 = call i32 @llvm.amdgcn.readlane(i32 %i5.4, i32 63)
     %i6.3 = call i32 @llpc.subgroup.arithmetic.i32(i32 %binaryOp, i32 %i6.1, i32 %i6.2)
-    ret i32 %i6.3
+    %i6.4 = call i32 @llvm.amdgcn.wwm.i32(i32 %i6.3)
+
+    ret i32 %i6.4
 }
 
 ; GLSL: int/uint/float subgroupExclusiveXXX(int/uint/float)

--- a/patch/generate/glslGroupOpEmuD64.ll
+++ b/patch/generate/glslGroupOpEmuD64.ll
@@ -233,8 +233,8 @@ define spir_func i64 @llpc.subgroup.reduce.i64(i32 %binaryOp, i64 %value)
 
     %i6.1 = call i64 @llpc.readlane.i64(i64 %i5.4, i32 31)
     %i6.2 = call i64 @llpc.subgroup.arithmetic.i64(i32 %binaryOp, i64 %i6.1, i64 %i5.4)
-    %i6.3 = call i64 @llvm.amdgcn.wwm.i64(i64 %i6.2)
-    %i6.4 = call i64 @llpc.readlane.i64(i64 %i6.3, i32 63)
+    %i6.3 = call i64 @llpc.readlane.i64(i64 %i6.2, i32 63)
+    %i6.4 = call i64 @llvm.amdgcn.wwm.i64(i64 %i6.3)
 
     ret i64 %i6.4
 }


### PR DESCRIPTION
This change moves the readlanes for subgroup reductions into the WWM sections. There is a really subtle issue that is super unlikely but still possible whereby the readlane could be sourced from a register copy, where the copy happens outwith the WWM section. This would mean that if it just so happened that the invocation with a `gl_SubgroupInvocationID == 63` was inactive, an undef value could be read into all lanes.