### PR TITLE
Fix sizeInDwords in spillTable in  PatchEntryPointMutate::GenerateEntryPointType

### DIFF
--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -867,7 +867,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
         pIntfData->userDataUsage.spillTable = userDataIdx++;
         pIntfData->entryArgIdxs.spillTable = argIdx++;
 
-        pIntfData->spillTable.sizeInDwords = requiredUserDataCount - pIntfData->spillTable.offsetInDwords;
+        pIntfData->spillTable.sizeInDwords = requiredUserDataCount;
     }
     pIntfData->userDataCount = userDataIdx;
 


### PR DESCRIPTION
root cause: If useFixedLayout is false, requiredUserDataCount is the sum of sizeInDword of all input node. it doesn't include offsets. so we should not minus offsetInDwords when calculate spillTable.sizeInDwords.

This issue affects the userDataLimits in ELF metadata, but it is hidden by indirect table ptr. In new PAL change, we removed indirect table ptr and exposed this issue.