### PR TITLE
Skip the store instruction when the index is out-of-bound if feature …

### DIFF
--- a/include/llpc.h
+++ b/include/llpc.h
@@ -39,7 +39,7 @@
 #undef Status
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 21
+#define LLPC_INTERFACE_MAJOR_VERSION 23
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -50,6 +50,8 @@
  * %Version History
  * | %Version | Change Description                                                                                     |
  * | -------- | ------------------------------------------------------------------------------------------------------ |
+ * |     23.0 | Add flag robustBufferAccess in PipelineOptions to check out of bounds of private array.                |
+ * |     22.0 | Internal revision.                                                                                     |
  * |     21.0 | Add stage in Pipeline shader info and struct PipelineBuildInfo to simplify pipeline dump interface.    |
  **/
 namespace Llpc

--- a/lower/llpcSpirvLowerDynIndex.h
+++ b/lower/llpcSpirvLowerDynIndex.h
@@ -39,6 +39,15 @@ namespace Llpc
 {
 
 // =====================================================================================================================
+// The structure for store instruction which needs to be expanded.
+struct StoreExpandInfo
+{
+    StoreInst*                          pStoreInst;  ///< "Store" instruction
+    SmallVector<GetElementPtrInst*, 1>  getElemPtrs; ///< A group of "getelementptr" with constant indices
+    Value*                              pDynIndex;   ///< Dynamic index of destination.
+};
+
+// =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for dynamic index in access chain.
 class SpirvLowerDynIndex:
     public SpirvLower,
@@ -63,12 +72,16 @@ private:
     void ExpandLoadInst(llvm::LoadInst*                          pLoadInst,
                         llvm::ArrayRef<llvm::GetElementPtrInst*> getElemPtrs,
                         llvm::Value*                             pDynIndex);
+    void RecordStoreExpandInfo(llvm::StoreInst*                         pStoreInst,
+                               llvm::ArrayRef<llvm::GetElementPtrInst*> getElemPtrs,
+                               llvm::Value*                             pDynIndex);
     void ExpandStoreInst(llvm::StoreInst*                         pStoreInst,
                          llvm::ArrayRef<llvm::GetElementPtrInst*> getElemPtrs,
                          llvm::Value*                             pDynIndex);
 
     std::unordered_set<llvm::Instruction*> m_getElemPtrInsts;
     std::unordered_set<llvm::Instruction*> m_loadInsts;
+    SmallVector<StoreExpandInfo, 1>        m_storeExpandInfo;
 };
 
 } // Llpc

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -125,7 +125,11 @@ Result CodeGenManager::CreateTargetMachine(
         (pPipelineOptions->includeDisassembly == pContext->GetTargetMachinePipelineOptions()->includeDisassembly) &&
         (pPipelineOptions->autoLayoutDesc == pContext->GetTargetMachinePipelineOptions()->autoLayoutDesc) &&
         (pPipelineOptions->scalarBlockLayout == pContext->GetTargetMachinePipelineOptions()->scalarBlockLayout) &&
-        (pPipelineOptions->includeIr == pContext->GetTargetMachinePipelineOptions()->includeIr))
+        (pPipelineOptions->includeIr == pContext->GetTargetMachinePipelineOptions()->includeIr)
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+        && (pPipelineOptions->robustBufferAccess == pContext->GetTargetMachinePipelineOptions()->robustBufferAccess)
+#endif
+        )
     {
         return Result::Success;
     }

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -837,6 +837,9 @@ static Result BuildPipeline(
         {
             pGraphicsPipelineInfo->iaState.patchControlPoints = 3;
         }
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+        pPipelineInfo->options.robustBufferAccess = RobustBufferAccess;
+#endif
 
         void* pPipelineDumpHandle = nullptr;
         if (llvm::cl::EnablePipelineDump)
@@ -901,6 +904,9 @@ static Result BuildPipeline(
         pComputePipelineInfo->pInstance      = nullptr; // Dummy, unused
         pComputePipelineInfo->pUserData      = &pCompileInfo->pPipelineBuf;
         pComputePipelineInfo->pfnOutputAlloc = AllocateBuffer;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+        pPipelineInfo->options.robustBufferAccess = RobustBufferAccess;
+#endif
 
         void* pPipelineDumpHandle = nullptr;
         if (llvm::cl::EnablePipelineDump)

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1119,13 +1119,16 @@ public:
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, autoLayoutDesc, MemberTypeBool, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
+#endif
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);
     }
 
     void GetSubState(SubState& state) { state = m_state; };
 
 private:
-    static const uint32_t  MemberCount = 4;
+    static const uint32_t  MemberCount = 5;
     static StrToMemberAddr m_addrTable[MemberCount];
 
     SubState               m_state;

--- a/util/llpcPipelineDumper.cpp
+++ b/util/llpcPipelineDumper.cpp
@@ -673,6 +673,9 @@ void PipelineDumper::DumpPipelineOptions(
     dumpFile << "options.autoLayoutDesc = " << pOptions->autoLayoutDesc << "\n";
     dumpFile << "options.scalarBlockLayout = " << pOptions->scalarBlockLayout << "\n";
     dumpFile << "options.includeIr = " << pOptions->includeIr << "\n";
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+    dumpFile << "options.robustBufferAccess = " << pOptions->robustBufferAccess << "\n";
+#endif
 }
 
 // =====================================================================================================================
@@ -882,6 +885,9 @@ MetroHash::Hash PipelineDumper::GenerateHashForGraphicsPipeline(
     hasher.Update(pPipeline->options.autoLayoutDesc);
     hasher.Update(pPipeline->options.scalarBlockLayout);
     hasher.Update(pPipeline->options.includeIr);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+    hasher.Update(pPipeline->options.robustBufferAccess);
+#endif
 
     MetroHash::Hash hash = {};
     hasher.Finalize(hash.bytes);
@@ -904,6 +910,9 @@ MetroHash::Hash PipelineDumper::GenerateHashForComputePipeline(
     hasher.Update(pPipeline->options.autoLayoutDesc);
     hasher.Update(pPipeline->options.scalarBlockLayout);
     hasher.Update(pPipeline->options.includeIr);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+    hasher.Update(pPipeline->options.robustBufferAccess);
+#endif
 
     MetroHash::Hash hash = {};
     hasher.Finalize(hash.bytes);


### PR DESCRIPTION
…robustBufferAccess is used. In Vulkan sepc the robustBufferAccess is only for buffer, but in this change it's also applied to private array.