### PR TITLE
Set PAL_CLIENT_INTERFACE_MAJOR_VERSION for amdllpc building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,7 @@ target_compile_definitions(amdllpc PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIA
 target_compile_definitions(amdllpc PRIVATE _SPIRV_LLVM_API)
 if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
     target_compile_definitions(amdllpc PRIVATE LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION})
+    target_compile_definitions(amdllpc PRIVATE PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION})
 endif()
 
 target_include_directories(amdllpc


### PR DESCRIPTION
Without this, amdllpc and llpcElf disagree on the size and layout of
ElfReader, and I get a trap when using amdllpc -v with my forthcoming
MsgPack PAL metadata changes.

Change-Id: Ia7dc68c8a9c672b178d2ddf4e2d0ce5854c5d823