### PR TITLE
Factored out new base class ConfigBuilderBase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ target_sources(llpc PRIVATE
     patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
     patch/gfx9/llpcShaderMerger.cpp
     patch/llpcCodeGenManager.cpp
+    patch/llpcConfigBuilderBase.cpp
     patch/llpcFragColorExport.cpp
     patch/llpcPatch.cpp
     patch/llpcPatchBufferOp.cpp

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -131,6 +131,7 @@ ifeq ($(ICD_BUILD_LLPC), 1)
         llpcShaderMerger.cpp                \
         \
         llpcCodeGenManager.cpp              \
+        llpcConfigBuilderBase.cpp           \
         llpcFragColorExport.cpp             \
         llpcPatch.cpp                       \
         llpcPatchBufferOp.cpp               \

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -57,6 +57,48 @@ namespace Gfx6
 #include "si_ci_vi_merged_offset.h"
 
 // =====================================================================================================================
+// Builds PAL metadata for pipeline.
+void ConfigBuilder::BuildPalMetadata()
+{
+    Result result = Result::Success;
+
+    if (m_pContext->IsGraphics() == false)
+    {
+        result = BuildPipelineCsRegConfig(m_pContext, &m_pConfig, &m_configSize);
+    }
+    else
+    {
+        const bool hasTs = (m_hasTcs || m_hasTes);
+
+        if ((hasTs == false) && (m_hasGs == false))
+        {
+            // VS-FS pipeline
+            result = BuildPipelineVsFsRegConfig(m_pContext, &m_pConfig, &m_configSize);
+        }
+        else if (hasTs && (m_hasGs == false))
+        {
+            // VS-TS-FS pipeline
+            result = BuildPipelineVsTsFsRegConfig(m_pContext, &m_pConfig, &m_configSize);
+        }
+        else if ((hasTs == false) && m_hasGs)
+        {
+            // VS-GS-FS pipeline
+            result = BuildPipelineVsGsFsRegConfig(m_pContext, &m_pConfig, &m_configSize);
+        }
+        else
+        {
+            // VS-TS-GS-FS pipeline
+            result = BuildPipelineVsTsGsFsRegConfig(m_pContext, &m_pConfig, &m_configSize);
+        }
+    }
+
+    LLPC_ASSERT(result == Result::Success);
+    LLPC_UNUSED(result);
+
+    WritePalMetadata();
+}
+
+// =====================================================================================================================
 // Builds register configuration for graphics pipeline (VS-FS).
 Result ConfigBuilder::BuildPipelineVsFsRegConfig(
     Context*            pContext,         // [in] LLPC context

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.h
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpcConfigBuilderBase.h"
 #include "llpcGfx6Chip.h"
 
 namespace Llpc
@@ -44,83 +45,87 @@ namespace Gfx6
 
 // =====================================================================================================================
 // Represents the builder to generate register configurations for GFX6-generation chips.
-class ConfigBuilder
+class ConfigBuilder : public ConfigBuilderBase
 {
 public:
-    static Result BuildPipelineVsFsRegConfig(Context*            pContext,
-                                             uint8_t**           ppConfig,
-                                             size_t*             pConfigSize);
+    ConfigBuilder(llvm::Module* pModule) : ConfigBuilderBase(pModule) {}
 
-    static Result BuildPipelineVsTsFsRegConfig(Context*            pContext,
-                                               uint8_t**           ppConfig,
-                                               size_t*             pConfigSize);
+    void BuildPalMetadata();
 
-    static Result BuildPipelineVsGsFsRegConfig(Context*            pContext,
-                                               uint8_t**           ppConfig,
-                                               size_t*             pConfigSize);
+    Result BuildPipelineVsFsRegConfig(Context*            pContext,
+                                      uint8_t**           ppConfig,
+                                      size_t*             pConfigSize);
 
-    static Result BuildPipelineVsTsGsFsRegConfig(Context*            pContext,
-                                                 uint8_t**           ppConfig,
-                                                 size_t*             pConfigSize);
+    Result BuildPipelineVsTsFsRegConfig(Context*            pContext,
+                                        uint8_t**           ppConfig,
+                                        size_t*             pConfigSize);
 
-    static Result BuildPipelineCsRegConfig(Context*            pContext,
-                                           uint8_t**              ppConfig,
-                                           size_t*             pConfigSize);
+    Result BuildPipelineVsGsFsRegConfig(Context*            pContext,
+                                        uint8_t**           ppConfig,
+                                        size_t*             pConfigSize);
+
+    Result BuildPipelineVsTsGsFsRegConfig(Context*            pContext,
+                                          uint8_t**           ppConfig,
+                                          size_t*             pConfigSize);
+
+    Result BuildPipelineCsRegConfig(Context*            pContext,
+                                    uint8_t**              ppConfig,
+                                    size_t*             pConfigSize);
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(ConfigBuilder);
     LLPC_DISALLOW_COPY_AND_ASSIGN(ConfigBuilder);
 
     template <typename T>
-    static Result BuildVsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildVsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
     template <typename T>
-    static Result BuildHsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildHsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
     template <typename T>
-    static Result BuildEsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildEsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
     template <typename T>
-    static Result BuildLsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildLsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
     template <typename T>
-    static Result BuildGsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildGsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
     template <typename T>
-    static Result BuildPsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildPsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
-    static Result BuildCsRegConfig(Context*             pContext,
-                                   ShaderStage          shaderStage,
-                                   PipelineCsRegConfig* pConfig);
-
-    template <typename T>
-    static Result BuildUserDataConfig(Context*    pContext,
-                                      ShaderStage shaderStage,
-                                      uint32_t    startUserData,
-                                      T*          pConfig);
+    Result BuildCsRegConfig(Context*             pContext,
+                            ShaderStage          shaderStage,
+                            PipelineCsRegConfig* pConfig);
 
     template <typename T>
-    static void SetupVgtTfParam(Context* pContext, T* pConfig);
+    Result BuildUserDataConfig(Context*    pContext,
+                               ShaderStage shaderStage,
+                               uint32_t    startUserData,
+                               T*          pConfig);
 
-    static void BuildApiHwShaderMapping(uint32_t           vsHwShader,
-                                        uint32_t           tcsHwShader,
-                                        uint32_t           tesHwShader,
-                                        uint32_t           gsHwShader,
-                                        uint32_t           fsHwShader,
-                                        uint32_t           csHwShader,
-                                        PipelineRegConfig* pConfig);
+    template <typename T>
+    void SetupVgtTfParam(Context* pContext, T* pConfig);
+
+    void BuildApiHwShaderMapping(uint32_t           vsHwShader,
+                                 uint32_t           tcsHwShader,
+                                 uint32_t           tesHwShader,
+                                 uint32_t           gsHwShader,
+                                 uint32_t           fsHwShader,
+                                 uint32_t           csHwShader,
+                                 PipelineRegConfig* pConfig);
 
     static uint32_t SetupFloatingPointMode(Context* pContext, ShaderStage shaderStage);
 

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.h
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpcConfigBuilderBase.h"
 #include "llpcGfx9Chip.h"
 
 namespace Llpc
@@ -44,75 +45,79 @@ namespace Gfx9
 
 // =====================================================================================================================
 // Represents the builder to generate register configurations for GFX6-generation chips.
-class ConfigBuilder
+class ConfigBuilder : public ConfigBuilderBase
 {
 public:
-    static Result BuildPipelineVsFsRegConfig(Context*            pContext,
-                                             uint8_t**           ppConfig,
-                                             size_t*             pConfigSize);
+    ConfigBuilder(llvm::Module* pModule) : ConfigBuilderBase(pModule) {}
 
-    static Result BuildPipelineVsTsFsRegConfig(Context*            pContext,
-                                               uint8_t**           ppConfig,
-                                               size_t*             pConfigSize);
+    void BuildPalMetadata();
 
-    static Result BuildPipelineVsGsFsRegConfig(Context*            pContext,
-                                               uint8_t**           ppConfig,
-                                               size_t*             pConfigSize);
+    Result BuildPipelineVsFsRegConfig(Context*            pContext,
+                                      uint8_t**           ppConfig,
+                                      size_t*             pConfigSize);
 
-    static Result BuildPipelineVsTsGsFsRegConfig(Context*            pContext,
-                                                 uint8_t**           ppConfig,
-                                                 size_t*             pConfigSize);
+    Result BuildPipelineVsTsFsRegConfig(Context*            pContext,
+                                        uint8_t**           ppConfig,
+                                        size_t*             pConfigSize);
 
-    static Result BuildPipelineCsRegConfig(Context*            pContext,
-                                           uint8_t**           ppConfig,
-                                           size_t*             pConfigSize);
+    Result BuildPipelineVsGsFsRegConfig(Context*            pContext,
+                                        uint8_t**           ppConfig,
+                                        size_t*             pConfigSize);
+
+    Result BuildPipelineVsTsGsFsRegConfig(Context*            pContext,
+                                          uint8_t**           ppConfig,
+                                          size_t*             pConfigSize);
+
+    Result BuildPipelineCsRegConfig(Context*            pContext,
+                                    uint8_t**           ppConfig,
+                                    size_t*             pConfigSize);
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(ConfigBuilder);
     LLPC_DISALLOW_COPY_AND_ASSIGN(ConfigBuilder);
 
     template <typename T>
-    static Result BuildVsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildVsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
     template <typename T>
-    static Result BuildLsHsRegConfig(Context*            pContext,
-                                     ShaderStage         shaderStage1,
-                                     ShaderStage         shaderStage2,
-                                     T*                  pConfig);
+    Result BuildLsHsRegConfig(Context*            pContext,
+                              ShaderStage         shaderStage1,
+                              ShaderStage         shaderStage2,
+                              T*                  pConfig);
 
     template <typename T>
-    static Result BuildEsGsRegConfig(Context*            pContext,
-                                     ShaderStage         shaderStage1,
-                                     ShaderStage         shaderStage2,
-                                     T*                  pConfig);
+    Result BuildEsGsRegConfig(Context*            pContext,
+                              ShaderStage         shaderStage1,
+                              ShaderStage         shaderStage2,
+                              T*                  pConfig);
 
     template <typename T>
-    static Result BuildPsRegConfig(Context*            pContext,
-                                   ShaderStage         shaderStage,
-                                   T*                  pConfig);
+    Result BuildPsRegConfig(Context*            pContext,
+                            ShaderStage         shaderStage,
+                            T*                  pConfig);
 
-    static Result BuildCsRegConfig(Context*             pContext,
-                                   ShaderStage          shaderStage,
-                                   PipelineCsRegConfig* pConfig);
+    Result BuildCsRegConfig(Context*             pContext,
+                            ShaderStage          shaderStage,
+                            PipelineCsRegConfig* pConfig);
 
     template <typename T>
-    static Result BuildUserDataConfig(Context*    pContext,
-                                      ShaderStage shaderStage1,
-                                      ShaderStage shaderStage2,
-                                      uint32_t    startUserData,
-                                      T*          pConfig);
+    Result BuildUserDataConfig(Context*    pContext,
+                               ShaderStage shaderStage1,
+                               ShaderStage shaderStage2,
+                               uint32_t    startUserData,
+                               T*          pConfig);
 
-    static void SetupVgtTfParam(Context* pContext, LsHsRegConfig* pConfig);
+    void SetupVgtTfParam(Context* pContext, LsHsRegConfig* pConfig);
 
-    static void BuildApiHwShaderMapping(uint32_t           vsHwShader,
-                                        uint32_t           tcsHwShader,
-                                        uint32_t           tesHwShader,
-                                        uint32_t           gsHwShader,
-                                        uint32_t           fsHwShader,
-                                        uint32_t           csHwShader,
-                                        PipelineRegConfig* pConfig);
+    void BuildApiHwShaderMapping(uint32_t           vsHwShader,
+                                 uint32_t           tcsHwShader,
+                                 uint32_t           tesHwShader,
+                                 uint32_t           gsHwShader,
+                                 uint32_t           fsHwShader,
+                                 uint32_t           csHwShader,
+                                 PipelineRegConfig* pConfig);
 
     static uint32_t SetupFloatingPointMode(Context* pContext, ShaderStage shaderStage);
 };

--- a/patch/llpcConfigBuilderBase.cpp
+++ b/patch/llpcConfigBuilderBase.cpp
@@ -1,0 +1,93 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2017-2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcConfigBuilderBase.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::ConfigBuilderBase.
+ ***********************************************************************************************************************
+ */
+#define DEBUG_TYPE "llpc-config-builder-base"
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+#include "llpcConfigBuilderBase.h"
+#include "llpcAbiMetadata.h"
+
+using namespace Llpc;
+using namespace llvm;
+
+// =====================================================================================================================
+ConfigBuilderBase::ConfigBuilderBase(
+    llvm::Module* pModule)  // [in/out] LLVM module
+    :
+    m_pModule(pModule)
+{
+    m_pContext = static_cast<Context*>(&pModule->getContext());
+
+    m_hasVs  = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)) != 0);
+    m_hasTcs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessControl)) != 0);
+    m_hasTes = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessEval)) != 0);
+    m_hasGs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
+
+    m_gfxIp = m_pContext->GetGfxIpVersion();
+}
+
+// =====================================================================================================================
+ConfigBuilderBase::~ConfigBuilderBase()
+{
+    delete[] m_pConfig;
+}
+
+// =====================================================================================================================
+// Write the config into PAL metadata in the LLVM IR module
+void ConfigBuilderBase::WritePalMetadata()
+{
+    std::vector<Metadata*> abiMeta;
+    size_t sizeInDword = m_configSize / sizeof(uint32_t);
+    // Configs are composed of DWORD key/value pair, the size should be even
+    LLPC_ASSERT((sizeInDword % 2) == 0);
+    for (size_t i = 0; i < sizeInDword; i += 2)
+    {
+        uint32_t key   = (reinterpret_cast<uint32_t*>(m_pConfig))[i];
+        uint32_t value = (reinterpret_cast<uint32_t*>(m_pConfig))[i + 1];
+        // Don't export invalid metadata key and value
+        if (key == InvalidMetadataKey)
+        {
+            LLPC_ASSERT(value == InvalidMetadataValue);
+        }
+        else
+        {
+            abiMeta.push_back(ConstantAsMetadata::get(ConstantInt::get(m_pContext->Int32Ty(), key, false)));
+            abiMeta.push_back(ConstantAsMetadata::get(ConstantInt::get(m_pContext->Int32Ty(), value, false)));
+        }
+    }
+
+    auto pAbiMetaTuple = MDTuple::get(*m_pContext, abiMeta);
+    auto pAbiMetaNode = m_pModule->getOrInsertNamedMetadata("amdgpu.pal.metadata");
+    pAbiMetaNode->addOperand(pAbiMetaTuple);
+}
+

--- a/patch/llpcConfigBuilderBase.h
+++ b/patch/llpcConfigBuilderBase.h
@@ -1,0 +1,62 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2017-2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcConfigBuilderBase.h
+ * @brief LLPC header file: contains declaration of class Llpc::ConfigBuilderBase.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcContext.h"
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Register configuration builder base class.
+class ConfigBuilderBase
+{
+public:
+    ConfigBuilderBase(llvm::Module* pModule);
+    ~ConfigBuilderBase();
+
+    void WritePalMetadata();
+
+    // -----------------------------------------------------------------------------------------------------------------
+protected:
+    llvm::Module*                   m_pModule;            // LLVM module being processed
+    Context*                        m_pContext;           // LLPC context
+    uint8_t*                        m_pConfig = nullptr;  // Register/metadata configuration
+    size_t                          m_configSize = 0;     // Size of register/metadata configuration
+    GfxIpVersion                    m_gfxIp;              // Graphics IP version info
+
+    bool                            m_hasVs;              // Whether the pipeline has vertex shader
+    bool                            m_hasTcs;             // Whether the pipeline has tessellation control shader
+    bool                            m_hasTes;             // Whether the pipeline has tessellation evaluation shader
+    bool                            m_hasGs;              // Whether the pipeline has geometry shader
+};
+
+} // Llpc


### PR DESCRIPTION
This is the first of three changes to support MsgPack format PAL
metadata.

This commit creates a new class ConfigBuilderBase that both
gfx6::ConfigBuilder and gfx9::ConfigBuilder inherit from. It also makes
the ConfigBuilder methods non-static, in preparation for them being able
to access state.

Change-Id: Iac101f144af4e913b78eb69d3cdaced2f1e0c003