### PR TITLE
Ensure that late generated funcs get inlined

### DIFF
--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -4526,6 +4526,7 @@ void PatchInOutImportExport::CreateStreamOutBufferStoreFunction(
 
     pFunc->setCallingConv(CallingConv::C);
     pFunc->addFnAttr(Attribute::NoUnwind);
+    pFunc->addFnAttr(Attribute::AlwaysInline);
 
     auto argIt = pFunc->arg_begin();
     Value* pStoredValue = argIt++;
@@ -5786,6 +5787,7 @@ void PatchInOutImportExport::CreateTessBufferStoreFunction()
 
     pFunc->setCallingConv(CallingConv::C);
     pFunc->addFnAttr(Attribute::NoUnwind);
+    pFunc->addFnAttr(Attribute::AlwaysInline);
 
     auto argIt = pFunc->arg_begin();
 


### PR DESCRIPTION
Functions llpc.streamoutbuffer.store and llpc.tfbuffer.store get
generated in PatchInOutImportExport.

Not inlining either was causing an assert with a newer LLVM because they
were not being inlined. It looks like an older LLVM would inline them in
the AMDGPU backend, but that is no longer the case in a newer backend.

Fixed by marking them "always inline".

Change-Id: If56f80fca7232c5599efc8e63541ff9cba1cd215