### PR TITLE
Mark PatchLoopUnrollInfoRectify as preserving the dominator tree

### DIFF
--- a/patch/llpcPatchLoopUnrollInfoRectify.cpp
+++ b/patch/llpcPatchLoopUnrollInfoRectify.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/Support/Debug.h"
@@ -171,6 +172,7 @@ void PatchLoopUnrollInfoRectify::getAnalysisUsage(
     analysisUsage.addPreserved<LoopInfoWrapperPass>();
     analysisUsage.addRequired<ScalarEvolutionWrapperPass>();
     analysisUsage.addPreserved<ScalarEvolutionWrapperPass>();
+    analysisUsage.addPreserved<DominatorTreeWrapperPass>();
 }
 
 } // Llpc


### PR DESCRIPTION
With a newer LLVM and without this fix, LLVM's loop unrolling gets
confused and uses two different versions of the dominator tree at the
same time, resulting in incorrect code.

Change-Id: I88d5fd7430ec5e2df4ce2d8c49e872b561889787