### PR TITLE
Put pipeline linking into Builder

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpc.h"
 #include "llpcDebug.h"
 
 #include "llvm/IR/IRBuilder.h"
@@ -57,6 +58,76 @@ inline static void InitializeBuilderPasses(
 
 // =====================================================================================================================
 // The LLPC Builder interface
+//
+// The Builder interface is used by the frontend to generate IR for LLPC-specific operations. It is
+// a subclass of llvm::IRBuilder, so it uses its concept of an insertion point with debug location,
+// and it exposes all the IRBuilder methods for building IR. However, unlike IRBuilder, LLPC's
+// Builder is designed to have a single instance that contains some other state used during the IR
+// building process.
+//
+// The frontend can use Builder in one of three ways:
+// 1. BuilderImpl-only with full pipeline state
+// 2. BuilderRecorder with full pipeline state
+// 3. Per-shader frontend compilation (This is proposed but currently unsupported and untested.)
+//
+// 1. BuilderImpl-only with full pipeline state
+//
+//    This is used where the frontend has full pipeline state, and it wants to generate IR for LLPC
+//    operations directly, instead of recording it in the frontend and then replaying the recorded
+//    calls at the start of the middle-end.
+//
+//    The frontend does this:
+//
+//    * Create an instance of BuilderImpl.
+//    * Create an IR module per shader stage.
+//    * Populate the per-shader-stage IR modules, using Builder::Create* calls to generate the IR
+//      for LLPC operations.
+//    * After finishing, call Builder::Link() to link the per-stage IR modules into a single
+//      pipeline module.
+//    * Run middle-end passes on it.
+//
+// 2. BuilderRecorder with full pipeline state
+//
+//    This is also used where the frontend has full pipeline state, but it wants to record its
+//    Builder::Create* calls such that they get replayed (and generated into normal IR) as the first
+//    middle-end pass.
+//
+//    The frontend's actions are pretty much the same as in (1):
+//
+//    * Create an instance of BuilderRecorder.
+//    * Create an IR module per shader stage.
+//    * Populate the per-shader-stage IR modules, using Builder::Create* calls to generate the IR
+//      for LLPC operations.
+//    * After finishing, call Builder::Link() to link the per-stage IR modules into a single
+//      pipeline module.
+//    * Run middle-end passes on it, starting with BuilderReplayer to replay all the recorded
+//      Builder::Create* calls into its own instance of BuilderImpl (but with a single pipeline IR
+//      module).
+//
+//    With this scheme, the intention is that the whole-pipeline IR module after linking is a
+//    representation of the pipeline. For testing purposes, the IR module could be output to a .ll
+//    file, and later read in and compiled through the middle-end passes and backend to ISA.
+//    However, that is not supported yet, as there is still some outside-IR state at that point.
+//
+// 3. Per-shader frontend compilation (This is proposed but currently unsupported and untested.)
+//
+//    The frontend can compile a single shader with no pipeline state available using
+//    BuilderRecorder, without linking at the end, giving a shader IR module containing recorded
+//    llpc.call.* calls but no pipeline state.
+//
+//    The frontend does this:
+//
+//    * Per shader:
+//      - Create an instance of BuilderRecorder.
+//      - Create an IR module per shader stage.
+//      - Populate the per-shader-stage IR modules, using Builder::Create* calls to generate the IR
+//        for LLPC operations.
+//    * Then, later on, bring the shader IR modules together, and link them with Builder::Link()
+//      into a single pipeline IR module.
+//    * Run middle-end passes on it, starting with BuilderReplayer to replay all the recorded
+//      Builder::Create* calls into its own instance of BuilderImpl (but with a single pipeline IR
+//      module).
+//
 class Builder : public llvm::IRBuilder<>
 {
 public:
@@ -75,6 +146,17 @@ public:
 
     // If this is a BuilderRecorder, create the BuilderReplayer pass, otherwise return nullptr.
     virtual llvm::ModulePass* CreateBuilderReplayer() { return nullptr; }
+
+    // Link the individual shader modules into a single pipeline module. The frontend must have
+    // finished calling Builder::Create* methods and finished building the IR. In the case that
+    // there are multiple shader modules, they are all freed by this call, and the linked pipeline
+    // module is returned. If there is a single shader module, this might instead just return that.
+    // Before calling this, each shader module needs to have one global function for the shader
+    // entrypoint, then all other functions with internal linkage.
+    // Returns the pipeline module, or nullptr on link failure.
+    virtual llvm::Module* Link(
+        llvm::ArrayRef<llvm::Module*> modules);     // Array of modules indexed by shader stage, with nullptr entry
+                                                    //  for any stage not present in the pipeline
 
     //
     // Methods implemented in BuilderImplDesc:

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -72,6 +72,14 @@ StringRef BuilderRecorder::GetCallName(
 }
 
 // =====================================================================================================================
+// BuilderRecordedMetadataKinds constructor : get the metadata kind IDs
+BuilderRecorderMetadataKinds::BuilderRecorderMetadataKinds(
+    llvm::LLVMContext& context)   // [in] LLVM context
+{
+    m_opcodeMetaKindId = context.getMDKindID(BuilderCallOpcodeMetadataName);
+}
+
+// =====================================================================================================================
 // Create a BuilderRecorder
 Builder* Builder::CreateBuilderRecorder(
     LLVMContext&  context,    // [in] LLVM context
@@ -307,7 +315,7 @@ Instruction* BuilderRecorder::Record(
 
         MDNode* const pFuncMeta = MDNode::get(getContext(), ConstantAsMetadata::get(getInt32(opcode)));
 
-        pFunc->setMetadata(BuilderCallMetadataName, pFuncMeta);
+        pFunc->setMetadata(m_opcodeMetaKindId, pFuncMeta);
     }
 
     // Create the call.
@@ -315,3 +323,4 @@ Instruction* BuilderRecorder::Record(
 
     return pCall;
 }
+

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -38,14 +38,25 @@ namespace Llpc
 // Prefix of all recorded calls.
 static const char* const BuilderCallPrefix = "llpc.call.";
 
-// LLPC call metadata name.
-static const char* const BuilderCallMetadataName = "llpc_call_metadata";
+// LLPC call opcode metadata name.
+static const char* const BuilderCallOpcodeMetadataName = "llpc.call.opcode";
+
+// =====================================================================================================================
+// A class that caches the metadata kind IDs used by BuilderRecorder and BuilderReplayer.
+class BuilderRecorderMetadataKinds
+{
+public:
+    BuilderRecorderMetadataKinds() {}
+    BuilderRecorderMetadataKinds(llvm::LLVMContext& context);
+
+    uint32_t        m_opcodeMetaKindId;                         // Cached metadata kinds for opcode
+};
 
 // =====================================================================================================================
 // Builder recorder, to record all Builder calls as intrinsics
 // Each call to a Builder method causes the insertion of a call to llpc.call.*, so the Builder calls can be replayed
 // later on.
-class BuilderRecorder final : public Builder
+class BuilderRecorder final : public Builder, BuilderRecorderMetadataKinds
 {
 public:
     // llpc.call.* opcodes
@@ -72,7 +83,10 @@ public:
     // Given an opcode, get the call name (without the "llpc.call." prefix)
     static llvm::StringRef GetCallName(Opcode opcode);
 
-    BuilderRecorder(llvm::LLVMContext& context, bool wantReplay) : Builder(context), m_wantReplay(wantReplay) {}
+    BuilderRecorder(llvm::LLVMContext& context, bool wantReplay)
+        : Builder(context), BuilderRecorderMetadataKinds(context), m_wantReplay(wantReplay)
+    {}
+
     ~BuilderRecorder() {}
 
     //
@@ -139,7 +153,8 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    bool      m_wantReplay;     // true to make CreateBuilderReplayer return a replayer  pass
+    bool            m_wantReplay;                             // true to make CreateBuilderReplayer return a replayer
+                                                              //   pass
 };
 
 } // Llpc

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -255,6 +255,14 @@ ShaderStage GetShaderStageFromFunction(
 {
     ShaderStage stage = ShaderStageInvalid;
 
+    // First check for the metadata that is added by the builder. This works in the patch phase.
+    MDNode* pStageMetaNode = pFunc->getMetadata(LlpcName::ShaderStageMetadata);
+    if (pStageMetaNode != nullptr)
+    {
+        return ShaderStage(mdconst::dyn_extract<ConstantInt>(pStageMetaNode->getOperand(0))->getZExtValue());
+    }
+
+    // Then check for the execution model metadata that is added by the SPIR-V reader.
     MDNode* pExecModelNode = pFunc->getMetadata(gSPIRVMD::ExecutionModel);
     if (pExecModelNode == nullptr)
     {

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -147,6 +147,8 @@ namespace LlpcName
     const static char EntryPointPrefix[]              = "llpc.shader.";
     const static char CopyShaderEntryPoint[]          = "llpc.shader.COPY.main";
     const static char NullFsEntryPoint[]              = "llpc.shader.FS.null.main";
+
+    const static char ShaderStageMetadata[]           = "llpc.shaderstage";
 } // LlpcName
 
 // Maximum count of input/output locations that a shader stage (except fragment shader outputs) is allowed to specify


### PR DESCRIPTION
This is a step towards Builder being the interface between the frontend
and the middle-end.

Also sorted out and documented how Builder is used with individual
shader modules and with a pipeline module.

Includes adding a new class inherited by both BuilderRecorder and
BuilderReplayer that caches the LLVM metadata kind ids used by both.

Change-Id: I4b476cc789970cbb2ed2569a9140d7831d66f68d