### PR TITLE
Added Builder::SetShaderStage

### DIFF
--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -81,7 +81,6 @@ Builder::~Builder()
 
 // =====================================================================================================================
 // Base implementation of linking shader modules into a pipeline module.
-// Shader modules were supplied by SetShaderModules.
 Module* Builder::Link(
     ArrayRef<Module*> modules)     // Array of modules indexed by shader stage, with nullptr entry
                                    //  for any stage not present in the pipeline

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -147,6 +147,9 @@ public:
     // If this is a BuilderRecorder, create the BuilderReplayer pass, otherwise return nullptr.
     virtual llvm::ModulePass* CreateBuilderReplayer() { return nullptr; }
 
+    // Set the current shader stage.
+    void SetShaderStage(ShaderStage stage) { m_shaderStage = stage; }
+
     // Link the individual shader modules into a single pipeline module. The frontend must have
     // finished calling Builder::Create* methods and finished building the IR. In the case that
     // there are multiple shader modules, they are all freed by this call, and the linked pipeline
@@ -238,6 +241,10 @@ public:
 
 protected:
     Builder(llvm::LLVMContext& context) : llvm::IRBuilder<>(context) {}
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    ShaderStage m_shaderStage = ShaderStageInvalid;   // Current shader stage being built.
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(Builder)

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -552,6 +552,9 @@ Result Compiler::BuildPipelineInternal(
 
             PassManager passMgr;
 
+            // Set the shader stage in the Builder.
+            pContext->GetBuilder()->SetShaderStage(static_cast<ShaderStage>(stage));
+
             // Start timer for translate.
             if (TimePassesIsEnabled)
             {


### PR DESCRIPTION
The frontend (and BuilderReplayer) calls this to tell Builder what
shader stage we are in. It will be needed by subsequent Builder changes.

(Until "Put pipeline linking into Builder" has been merged and I rebase on top of it, this PR also contains that change. Please view just the topmost commit in this PR for "Added Builder::SetShaderStage".)