### PR TITLE
Use more unordered maps in EmuLib.

### DIFF
--- a/util/llpcEmuLib.cpp
+++ b/util/llpcEmuLib.cpp
@@ -49,18 +49,14 @@ using namespace object;
 void EmuLib::AddArchive(
     MemoryBufferRef buffer) // Buffer required to create the archive
 {
-    m_archives.push_back(EmuLibArchive(cantFail(Archive::create(buffer), "Failed to parse archive")));
+    m_archives.emplace_back(cantFail(Archive::create(buffer), "Failed to parse archive"));
 
     // Update symbol index in the symbol index map
     auto& archive = m_archives.back();
     auto index = m_archives.size() - 1;
     for (auto& symbol : archive.archive->symbols())
     {
-        auto symbolIndexIt = m_symbolIndices.find(symbol.getName());
-        if (symbolIndexIt == m_symbolIndices.end())
-        {
-            m_symbolIndices[symbol.getName()] = index;
-        }
+        m_symbolIndices.insert(std::make_pair(symbol.getName(), index));
     }
 }
 
@@ -154,12 +150,12 @@ Function* EmuLib::GetFunction(
                     auto funcIt = unknownKindFuncs.find(&libFunc);
                     if (funcIt == unknownKindFuncs.end())
                     {
-                        // Native if isn't in non-native list and unknonw list
+                        // Native if isn't in non-native list and unknown list
                         archive.functions[libFunc.getName()] = EmuLibFunction(&libFunc, true);
                     }
                     else
                     {
-                        // Non-native if any referenced unknown kind function is non-natigve.
+                        // Non-native if any referenced unknown kind function is non-native.
                         for (auto pFunc : funcIt->second)
                         {
                             if (GetFunction(pFunc->getName(), true) == nullptr)

--- a/util/llpcEmuLib.h
+++ b/util/llpcEmuLib.h
@@ -42,6 +42,22 @@ class Function;
 class Module;
 } // llvm
 
+namespace std
+{
+
+template<>
+struct hash<llvm::StringRef>
+{
+    typedef llvm::StringRef argument_type;
+    typedef std::size_t result_type;
+    result_type operator()(argument_type const& str) const noexcept
+    {
+        return llvm::hash_value(str);
+    }
+};
+
+} // std
+
 namespace Llpc
 {
 class Context;
@@ -67,7 +83,7 @@ class EmuLib
     struct EmuLibArchive
     {
         std::unique_ptr<llvm::object::Archive> archive;       // The bitcode archive
-        std::map<llvm::StringRef, EmuLibFunction> functions;  // Store of already-parsed functions from this archive
+        std::unordered_map<llvm::StringRef, EmuLibFunction> functions;  // Store of already-parsed functions from this archive
 
         EmuLibArchive(std::unique_ptr<llvm::object::Archive> archive) : archive(std::move(archive)) {}
     };
@@ -75,7 +91,7 @@ class EmuLib
     Context* pContext;                                    // The LLPC context
     std::vector<EmuLibArchive> m_archives;                // Bitcode archives that make up this EmuLib
     std::vector<std::unique_ptr<llvm::Module>> m_modules; // Modules that have been parsed out of archives
-    std::map<llvm::StringRef, size_t> m_symbolIndices;    // All available symbols in this EmuLib and the indices
+    std::unordered_map<llvm::StringRef, size_t> m_symbolIndices;    // All available symbols in this EmuLib and the indices
                                                           // in m_archives
 public:
     EmuLib(Context* pContext) : pContext(pContext) {}


### PR DESCRIPTION
When I was doing some compile time investigation, I noticed that we
spend around 15% of the time searching the symbol table of the archive
for a specific symbol name.  The reason it takes so long is that it is
doing a linear search, and the string comparisons are slow.  I noticed
that this was fix with the latest source.  However, while looking at the
latest code, I found a couple things that could be improved.

Doing searches in std::map data structures where a string is the key can
still take a while.  It is a log n search and the key comparision is not
very fast.  I would suggest changing those to std::unordered_map.  LLVM
already provides a decent hash function for strings.

The other is to avoid duplicating work.  For sets and maps, insert will
search for the element.  If it is not already in the set or map, it will
insert it.  If it is already in, it will not do change the container.
You do not need to check if it is already in the container and then
insert.  That duplicates the search.

These changes do not make a huge difference, but they seem to improve
compile time by about 2% in the pipelines I am looking at.