### PR TITLE
Support LLPC_PATH in amdllpc

### DIFF
--- a/tool/Makefile.apillpctool
+++ b/tool/Makefile.apillpctool
@@ -40,19 +40,19 @@ LCXXINCS += -I$(LLVM_DEPTH)/include
 LCXXINCS += -I$(ICD_DEPTH)/build/$(ICD_OS_BUILD)/imported/llvm/B_$(BUILD_TYPE)/include
 
 LCXXINCS += -I$(ICD_DEPTH)/api/include/khronos
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/imported/chip/gfx6
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/imported/chip/gfx9
+LCXXINCS += -I$(LLPC_DEPTH)/imported/chip/gfx6
+LCXXINCS += -I$(LLPC_DEPTH)/imported/chip/gfx9
 ifeq ($(ICD_BUILD_LLPCONLY),1)
-    LCXXINCS += -I$(ICD_DEPTH)/api/llpc/imported/cwpack/src/util
+    LCXXINCS += -I$(LLPC_DEPTH)/imported/cwpack/src/util
 endif
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/imported/cwpath/inc
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/imported/spirv
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/include
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/translator/lib/SPIRV/libSPIRV
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/util
-LCXXINCS += -I$(ICD_DEPTH)/api/llpc/tool/vfx
+LCXXINCS += -I$(LLPC_DEPTH)/imported/cwpath/inc
+LCXXINCS += -I$(LLPC_DEPTH)/imported/spirv
+LCXXINCS += -I$(LLPC_DEPTH)/include
+LCXXINCS += -I$(LLPC_DEPTH)/translator/lib/SPIRV/libSPIRV
+LCXXINCS += -I$(LLPC_DEPTH)/util
+LCXXINCS += -I$(LLPC_DEPTH)/tool/vfx
 
-vpath %.cpp $(ICD_DEPTH)/api/llpc/tool
+vpath %.cpp $(LLPC_DEPTH)/tool
 
 CPPFILES +=             \
     amdllpc.cpp         \


### PR DESCRIPTION
Replace $(ICD_DEPTH)/api/llpc with $(LLPC_DEPTH) in Makefile.apillpctool. It is missed in original change.