### PR TITLE
Refine LLPC

### DIFF
--- a/context/llpcComputeContext.cpp
+++ b/context/llpcComputeContext.cpp
@@ -91,24 +91,6 @@ const PipelineShaderInfo* ComputeContext::GetPipelineShaderInfo(
     return &m_pPipelineInfo->cs;
 }
 
-// =====================================================================================================================
-// Gets the hash code of input shader with specified shader stage.
-uint64_t ComputeContext::GetShaderHashCode(
-    ShaderStage stage       // Shader stage
-    ) const
-{
-    auto pShaderInfo = GetPipelineShaderInfo(stage);
-    LLPC_ASSERT(pShaderInfo != nullptr);
-
-    MetroHash::MetroHash64 hasher;
-
-    UpdateShaderHashForPipelineShaderInfo(ShaderStageCompute, pShaderInfo, &hasher);
-    hasher.Update(m_pPipelineInfo->deviceIndex);
-
-    uint64_t hash;
-    hasher.Finalize(reinterpret_cast<uint8_t* const>(&hash));
-    return hash;
-}
 
 // =====================================================================================================================
 // Gets wave size for the specified shader stage

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -50,7 +50,6 @@ public:
     virtual ResourceUsage* GetShaderResourceUsage(ShaderStage shaderStage);
     virtual InterfaceData* GetShaderInterfaceData(ShaderStage shaderStage);
     virtual const PipelineShaderInfo* GetPipelineShaderInfo(ShaderStage shaderStage) const;
-    virtual uint64_t GetShaderHashCode(ShaderStage stage) const;
 
     // Checks whether the pipeline is graphics or compute
     virtual bool IsGraphics() const { return false; }

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -50,7 +50,6 @@ public:
     virtual ResourceUsage* GetShaderResourceUsage(ShaderStage shaderStage);
     virtual InterfaceData* GetShaderInterfaceData(ShaderStage shaderStage);
     virtual const PipelineShaderInfo* GetPipelineShaderInfo(ShaderStage shaderStage) const;
-    virtual uint64_t GetShaderHashCode(ShaderStage stage) const;
 
     // Checks whether the pipeline is graphics or compute
     virtual bool IsGraphics() const { return true; }
@@ -98,17 +97,6 @@ public:
 
     void InitShaderInfoForNullFs();
 
-protected:
-    // Gets dummy vertex input create info
-    virtual VkPipelineVertexInputStateCreateInfo* GetDummyVertexInputInfo() { return &m_dummyVertexInput; }
-
-    // Gets dummy vertex binding info
-    virtual std::vector<VkVertexInputBindingDescription>* GetDummyVertexBindings() { return &m_dummyVertexBindings; }
-
-    // Gets dummy vertex attribute info
-    virtual std::vector<VkVertexInputAttributeDescription>* GetDummyVertexAttributes()
-        { return &m_dummyVertexAttribs; }
-
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(GraphicsContext);
     LLPC_DISALLOW_COPY_AND_ASSIGN(GraphicsContext);
@@ -127,11 +115,6 @@ private:
 
     ResourceUsage   m_resUsages[ShaderStageGfxCount];   // Resource usages of all graphics shader stages
     InterfaceData   m_intfData[ShaderStageGfxCount];    // Interface data of all graphics shader stages
-
-    // Dummy vertex-specific info (for vertex shader only)
-    VkPipelineVertexInputStateCreateInfo           m_dummyVertexInput;    // Dummy vertex input create info
-    std::vector<VkVertexInputBindingDescription>   m_dummyVertexBindings; // Dummy vertex binding info
-    std::vector<VkVertexInputAttributeDescription> m_dummyVertexAttribs;  // Dummy vertex attribute info
 
     bool            m_tessOffchip; // Whether to enable tessellation off-chip mode
     bool            m_gsOnChip;    // Whether to enable GS on-chip mode

--- a/context/llpcPipelineContext.cpp
+++ b/context/llpcPipelineContext.cpp
@@ -142,35 +142,6 @@ const char* PipelineContext::GetGpuNameAbbreviation() const
 }
 
 // =====================================================================================================================
-// Updates hash code context from pipeline shader info for shader hash code.
-void PipelineContext::UpdateShaderHashForPipelineShaderInfo(
-    ShaderStage               stage,           // Shader stage
-    const PipelineShaderInfo* pShaderInfo,     // [in] Shader info in specified shader stage
-    MetroHash::MetroHash64*   pHasher          // [in,out] Haher to generate hash code
-    ) const
-{
-    const ShaderModuleData* pModuleData = reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
-    pHasher->Update(stage);
-    pHasher->Update(pModuleData->hash);
-
-    if (pShaderInfo->pEntryTarget)
-    {
-        size_t entryNameLen = strlen(pShaderInfo->pEntryTarget);
-        pHasher->Update(reinterpret_cast<const uint8_t*>(pShaderInfo->pEntryTarget), entryNameLen);
-    }
-
-    if ((pShaderInfo->pSpecializationInfo) && (pShaderInfo->pSpecializationInfo->mapEntryCount > 0))
-    {
-        auto pSpecializationInfo = pShaderInfo->pSpecializationInfo;
-        pHasher->Update(pSpecializationInfo->mapEntryCount);
-        pHasher->Update(reinterpret_cast<const uint8_t*>(pSpecializationInfo->pMapEntries),
-                        sizeof(VkSpecializationMapEntry) * pSpecializationInfo->mapEntryCount);
-        pHasher->Update(pSpecializationInfo->dataSize);
-        pHasher->Update(reinterpret_cast<const uint8_t*>(pSpecializationInfo->pData), pSpecializationInfo->dataSize);
-    }
-}
-
-// =====================================================================================================================
 // Initializes resource usage of the specified shader stage.
 void PipelineContext::InitShaderResourceUsage(
     ShaderStage shaderStage)    // Shader stage
@@ -268,6 +239,21 @@ void PipelineContext::InitShaderInterfaceData(
 
     memset(&pIntfData->entryArgIdxs, 0, sizeof(pIntfData->entryArgIdxs));
     pIntfData->entryArgIdxs.spillTable = InvalidValue;
+}
+
+// =====================================================================================================================
+// Gets the hash code of input shader with specified shader stage.
+uint64_t PipelineContext::GetShaderHashCode(
+    ShaderStage stage       // Shader stage
+) const
+{
+    auto pShaderInfo = GetPipelineShaderInfo(stage);
+    LLPC_ASSERT(pShaderInfo != nullptr);
+
+    const ShaderModuleData* pModuleData = reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
+
+    return (pModuleData == nullptr) ? 0 :
+        MetroHash::Compact64(reinterpret_cast<const MetroHash::Hash*>(&pModuleData->hash));
 }
 
 } // Llpc

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -421,12 +421,6 @@ struct ResourceUsage
 
         struct
         {
-            std::vector<BasicType>    inputTypes;       // Array of basic types of vertex inputs (vertex input location
-                                                        // -> vertex input type, used by "auto-layout-desc" option)
-        } vs;
-
-        struct
-        {
             struct
             {
                 uint32_t inVertexStride;                // Stride of vertices of input patch (in DWORD, correspond to
@@ -786,7 +780,8 @@ public:
 
     // Gets pipeline hash code
     uint64_t GetPiplineHashCode() const { return MetroHash::Compact64(&m_hash); }
-    virtual uint64_t GetShaderHashCode(ShaderStage stage) const = 0;
+
+    virtual uint64_t GetShaderHashCode(ShaderStage stage) const;
 
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const = 0;
@@ -804,10 +799,6 @@ protected:
     void InitShaderResourceUsage(ShaderStage shaderStage);
 
     void InitShaderInterfaceData(ShaderStage shaderStage);
-
-    void UpdateShaderHashForPipelineShaderInfo(ShaderStage               stage,
-                                               const PipelineShaderInfo* pShaderInfo,
-                                               MetroHash::MetroHash64*   pHasher) const;
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/lower/llpcSpirvLowerResourceCollect.cpp
@@ -964,14 +964,7 @@ void SpirvLowerResourceCollect::CollectInOutUsage(
             }
 
             // Special stage-specific processing
-            if (m_shaderStage == ShaderStageVertex)
-            {
-                if (addrSpace == SPIRAS_Input)
-                {
-                    CollectVertexInputUsage(pBaseTy, (inOutMeta.Signedness != 0), startLoc, locCount);
-                }
-            }
-            else if (m_shaderStage == ShaderStageFragment)
+            if (m_shaderStage == ShaderStageFragment)
             {
                 if (addrSpace == SPIRAS_Input)
                 {
@@ -1546,14 +1539,7 @@ void SpirvLowerResourceCollect::CollectInOutUsage(
             }
 
             // Special stage-specific processing
-            if (m_shaderStage == ShaderStageVertex)
-            {
-                if (addrSpace == SPIRAS_Input)
-                {
-                    CollectVertexInputUsage(pBaseTy, (inOutMeta.Signedness != 0), startLoc, locCount);
-                }
-            }
-            else if (m_shaderStage == ShaderStageFragment)
+            if (m_shaderStage == ShaderStageFragment)
             {
                 if (addrSpace == SPIRAS_Input)
                 {
@@ -1647,74 +1633,6 @@ void SpirvLowerResourceCollect::CollectInOutUsage(
                 }
             }
         }
-    }
-}
-
-// =====================================================================================================================
-// Collects the usage info of vertex inputs (particularly for the map from vertex input location to vertex basic type).
-void SpirvLowerResourceCollect::CollectVertexInputUsage(
-    const Type* pVertexTy,  // [in] Vertex input type
-    bool        signedness, // Whether the type is signed (valid for integer type)
-    uint32_t    startLoc,   // Start location
-    uint32_t    locCount)   // Count of locations
-{
-    auto bitWidth = pVertexTy->getScalarSizeInBits();
-    auto pCompTy  = pVertexTy->isVectorTy() ? pVertexTy->getVectorElementType() : pVertexTy;
-
-    // Get basic type of vertex input
-    BasicType basicTy = BasicType::Unknown;
-    if (pCompTy->isIntegerTy())
-    {
-        // Integer type
-        if (bitWidth == 8)
-        {
-            basicTy = signedness ? BasicType::Int8 : BasicType::Uint8;
-        }
-        else if (bitWidth == 16)
-        {
-            basicTy = signedness ? BasicType::Int16 : BasicType::Uint16;
-        }
-        else if (bitWidth == 32)
-        {
-            basicTy = signedness ? BasicType::Int : BasicType::Uint;
-        }
-        else
-        {
-            LLPC_ASSERT(bitWidth == 64);
-            basicTy = signedness ? BasicType::Int64 : BasicType::Uint64;
-        }
-    }
-    else if (pCompTy->isFloatingPointTy())
-    {
-        // Floating-point type
-        if (bitWidth == 16)
-        {
-            basicTy = BasicType::Float16;
-        }
-        else if (bitWidth == 32)
-        {
-            basicTy = BasicType::Float;
-        }
-        else
-        {
-            LLPC_ASSERT(bitWidth == 64);
-            basicTy = BasicType::Double;
-        }
-    }
-    else
-    {
-        LLPC_NEVER_CALLED();
-    }
-
-    auto& vsInputTypes = m_pResUsage->inOutUsage.vs.inputTypes;
-    while ((startLoc + locCount) > vsInputTypes.size())
-    {
-        vsInputTypes.push_back(BasicType::Unknown);
-    }
-
-    for (uint32_t i = 0; i < locCount; ++i)
-    {
-        vsInputTypes[startLoc + i] = basicTy;
     }
 }
 

--- a/lower/llpcSpirvLowerResourceCollect.h
+++ b/lower/llpcSpirvLowerResourceCollect.h
@@ -66,7 +66,6 @@ private:
     void CollectExecutionModeUsage();
     void CollectDescriptorUsage(uint32_t descSet, uint32_t binding, const DescriptorBinding* pBinding);
     void CollectInOutUsage(const llvm::Type* pInOutTy, llvm::Constant* pInOutMeta, SPIRAddressSpace addrSpace);
-    void CollectVertexInputUsage(const llvm::Type* pVertexTy, bool signedness, uint32_t startLoc, uint32_t locCount);
     void CollectGsOutputInfo(const Type* pOutputTy, uint32_t location, const ShaderInOutMetadata& outputMeta);
     void CollectXfbOutputInfo(const llvm::Type* pOutputTy, const ShaderInOutMetadata& inOutMeta);
 

--- a/util/llpcPassManager.cpp
+++ b/util/llpcPassManager.cpp
@@ -61,8 +61,8 @@ static cl::list<uint32_t> DisablePassIndices("disable-pass-indices", cl::ZeroOrM
 } // llvm
 
 using namespace llvm;
-using namespace Llpc;
-
+namespace Llpc
+{
 // =====================================================================================================================
 // Get the PassInfo for a registered pass given short name
 static const PassInfo* GetPassInfo(
@@ -94,7 +94,7 @@ static AnalysisID GetPassIdFromName(
 
 // =====================================================================================================================
 // Constructor
-Llpc::PassManager::PassManager(
+PassManager::PassManager(
     uint32_t* pPassIndex)   // [in,out] Pointer of PassIndex
     :
     m_pPassIndex(pPassIndex)
@@ -110,7 +110,7 @@ Llpc::PassManager::PassManager(
 
 // =====================================================================================================================
 // Add a pass to the pass manager.
-void Llpc::PassManager::add(
+void PassManager::add(
     Pass* pPass)    // [in] Pass to add to the pass manager
 {
     // Do not add any passes after calling stop(), except immutable passes.
@@ -164,8 +164,30 @@ void Llpc::PassManager::add(
 
 // =====================================================================================================================
 // Stop adding passes to the pass manager, except immutable ones.
-void Llpc::PassManager::stop()
+void PassManager::stop()
 {
     m_stopped = true;
 }
 
+// =====================================================================================================================
+// Runs passes on the module
+bool PassManager::run(
+    Module* pModule)  // [in] LLVM module
+{
+    bool success = false;
+#if LLPC_ENABLE_EXCEPTION
+    try
+#endif
+    {
+        success = legacy::PassManager::run(*pModule);
+    }
+#if LLPC_ENABLE_EXCEPTION
+    catch (const char*)
+    {
+        success = false;
+    }
+#endif
+    return success;
+}
+
+} // Llpc

--- a/util/llpcPassManager.h
+++ b/util/llpcPassManager.h
@@ -45,6 +45,7 @@ public:
 
     void add(llvm::Pass* pPass) override;
     void stop();
+    bool run(llvm::Module* pModule);
 
 private:
     bool              m_stopped = false;         // Whether we have already stopped adding new passes.


### PR DESCRIPTION
1. Simplify API shader hash code, API shader hash code isn't used as a shader cache key, we needn't make it unique, this change use SPIRV hash code as API shader code in BIL.
2. Move CodeGenManager::Run to Llpc::PassManager and set LlpcDiagnosticHandler in llpcCompiler
3. Remove unused code