### PR TITLE
Fixed llpc -emit-llvm

### DIFF
--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -46,6 +46,7 @@ class Builder;
 class ComputeContext;
 class Context;
 class GraphicsContext;
+class PassManager;
 
 // Enumerates types of shader binary.
 enum class BinaryType : uint32_t
@@ -228,6 +229,8 @@ private:
                                             uint32_t            candidateCount) const;
 
     static llvm::Module* LinkShaderModules(Context* pContext, llvm::ArrayRef<llvm::Module*> modules);
+
+    bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule);
 
     ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
                                         MetroHash::Hash*    pCacheHash,

--- a/util/llpcPassManager.cpp
+++ b/util/llpcPassManager.cpp
@@ -169,25 +169,4 @@ void PassManager::stop()
     m_stopped = true;
 }
 
-// =====================================================================================================================
-// Runs passes on the module
-bool PassManager::run(
-    Module* pModule)  // [in] LLVM module
-{
-    bool success = false;
-#if LLPC_ENABLE_EXCEPTION
-    try
-#endif
-    {
-        success = legacy::PassManager::run(*pModule);
-    }
-#if LLPC_ENABLE_EXCEPTION
-    catch (const char*)
-    {
-        success = false;
-    }
-#endif
-    return success;
-}
-
 } // Llpc

--- a/util/llpcPassManager.h
+++ b/util/llpcPassManager.h
@@ -45,7 +45,6 @@ public:
 
     void add(llvm::Pass* pPass) override;
     void stop();
-    bool run(llvm::Module* pModule);
 
 private:
     bool              m_stopped = false;         // Whether we have already stopped adding new passes.


### PR DESCRIPTION
The earlier change "Refine LLPC" broke llpc -emit-llvm. This commit
fixes it. Note that llvm::legacy::PassManager::run() returns false to
mean that no changes were made to the module, not that there is an
error.

Change-Id: I201570d4afbef60ba3a8a0225f042c0ba3d41f42