### PR TITLE
Fixed illegal IR for load of spilled fmask descriptor

### DIFF
--- a/patch/llpcSystemValues.cpp
+++ b/patch/llpcSystemValues.cpp
@@ -710,11 +710,6 @@ Instruction* ShaderSystemValues::MakePointer(
             ConstantInt::get(pLowValue->getType(), highValue)
         };
         pExtendedPtrValue = ConstantVector::get(elements);
-        pInsertPos = dyn_cast<Instruction>(pLowValue);
-        if (pInsertPos == nullptr)
-        {
-            pInsertPos = &*m_pEntryPoint->front().getFirstInsertionPt();
-        }
     }
     pExtendedPtrValue = InsertElementInst::Create(pExtendedPtrValue,
                                           pLowValue,


### PR DESCRIPTION
The code to extend to 64 bit with the shadow descriptor high value
(default 2) was accidentally being inserted before the code that loaded
the 32 bit value to extend.

Change-Id: Ifdd851e0c26842def6e2f91464e9574e0cb9be3f