### PR TITLE
Reduce optimizations run by llpc

### DIFF
--- a/test/shaderdb/ExtFragMask_TestFragFetch_lit.frag
+++ b/test/shaderdb/ExtFragMask_TestFragFetch_lit.frag
@@ -40,12 +40,12 @@ void main()
 ; SHADERTEST: call i32 @llpc.image.fetch.u32.SubpassData.fmaskvalue
 ; SHADERTEST: call <4 x i32> @llpc.image.fetch.u32.SubpassData.sample
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: tail call float @llvm.amdgcn.image.load.2d.f32.i32
-; SHADERTEST: tail call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32
-; SHADERTEST: tail call float @llvm.amdgcn.image.load.3d.f32.i32
-; SHADERTEST: tail call <4 x float> @llvm.amdgcn.image.load.2darraymsaa.v4f32.i32
-; SHADERTEST: tail call float @llvm.amdgcn.image.load.2d.f32.i32
-; SHADERTEST: tail call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32
+; SHADERTEST: call float @llvm.amdgcn.image.load.2d.f32.i32
+; SHADERTEST: call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32
+; SHADERTEST: call float @llvm.amdgcn.image.load.3d.f32.i32
+; SHADERTEST: call <4 x float> @llvm.amdgcn.image.load.2darraymsaa.v4f32.i32
+; SHADERTEST: call float @llvm.amdgcn.image.load.2d.f32.i32
+; SHADERTEST: call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ExtGcnShader_TestBuiltInFunc_lit.frag
+++ b/test/shaderdb/ExtGcnShader_TestBuiltInFunc_lit.frag
@@ -27,11 +27,11 @@ void main()
 ; SHADERTEST: call {{.*}} <2 x float> @_Z16CubeFaceCoordAMDDv3_f
 ; SHADERTEST: call {{.*}} i64 @_Z7TimeAMDv
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: tail call float @llvm.amdgcn.cubeid
-; SHADERTEST: tail call float @llvm.amdgcn.cubema
-; SHADERTEST: tail call float @llvm.amdgcn.cubesc
-; SHADERTEST: tail call float @llvm.amdgcn.cubetc
-; SHADERTEST: tail call i64 @llvm.amdgcn.s.memtime
+; SHADERTEST: call float @llvm.amdgcn.cubeid
+; SHADERTEST: call float @llvm.amdgcn.cubema
+; SHADERTEST: call float @llvm.amdgcn.cubesc
+; SHADERTEST: call float @llvm.amdgcn.cubetc
+; SHADERTEST: call i64 @llvm.amdgcn.s.memtime
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ExtShaderBallot_TestGeneral_lit.frag
+++ b/test/shaderdb/ExtShaderBallot_TestGeneral_lit.frag
@@ -47,10 +47,10 @@ void main(void)
 ; SHADERTEST: call i32 @_Z26SubgroupFirstInvocationKHRi
 ; SHADERTEST: call void @llpc.output.export.generic{{.*}}f32
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: tail call i32 asm sideeffect "; %{{[0-9]*}}", "=v,0"(i32 1)
-; SHADERTEST: tail call i64 @llvm.amdgcn.icmp.i32
-; SHADERTEST: tail call i32 @llvm.amdgcn.readlane
-; SHADERTEST: tail call i32 @llvm.amdgcn.readfirstlane
+; SHADERTEST: call i32 asm sideeffect "; %{{[0-9]*}}", "=v,0"(i32 1)
+; SHADERTEST: call i64 @llvm.amdgcn.icmp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.readlane
+; SHADERTEST: call i32 @llvm.amdgcn.readfirstlane
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ExtShaderBallot_TestMiscAMD_lit.frag
+++ b/test/shaderdb/ExtShaderBallot_TestMiscAMD_lit.frag
@@ -33,11 +33,11 @@ void main()
 ; SHADERTEST: call {{.*}} i32 @_Z8MbcntAMDl
 ; SHADERTEST: call i32 @_Z18WriteInvocationAMDiii
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: tail call i32 asm sideeffect "; %{{[0-9]*}}", "=v,0"(i32 1)
-; SHADERTEST: tail call i64 @llvm.amdgcn.icmp.i32
-; SHADERTEST: tail call i32 @llvm.amdgcn.mbcnt.lo
-; SHADERTEST: tail call i32 @llvm.amdgcn.mbcnt.hi
-; SHADERTEST: tail call i32 @llvm.amdgcn.writelane
+; SHADERTEST: call i32 asm sideeffect "; %{{[0-9]*}}", "=v,0"(i32 1)
+; SHADERTEST: call i64 @llvm.amdgcn.icmp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mbcnt.lo
+; SHADERTEST: call i32 @llvm.amdgcn.mbcnt.hi
+; SHADERTEST: call i32 @llvm.amdgcn.writelane
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ExtShaderBallot_TestSwizzleAMD_lit.frag
+++ b/test/shaderdb/ExtShaderBallot_TestSwizzleAMD_lit.frag
@@ -30,9 +30,9 @@ void main()
 ; SHADERTEST: call i32 @_Z21SwizzleInvocationsAMDiDv4_i
 ; SHADERTEST: call i32 @_Z27SwizzleInvocationsMaskedAMDiDv3_i
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: tail call i32 @llvm.amdgcn.ds.swizzle(i32 %{{[0-9]*}}, i32 8272)
-; SHADERTEST: tail call i32 @llvm.amdgcn.ds.swizzle(i32 %{{[0-9]*}}, i32 8078)
-; SHADERTEST: tail call i32 @llvm.amdgcn.ds.swizzle(i32 %{{[0-9]*}}, i32 6627)
+; SHADERTEST: call i32 @llvm.amdgcn.ds.swizzle(i32 %{{[0-9]*}}, i32 8272)
+; SHADERTEST: call i32 @llvm.amdgcn.ds.swizzle(i32 %{{[0-9]*}}, i32 8078)
+; SHADERTEST: call i32 @llvm.amdgcn.ds.swizzle(i32 %{{[0-9]*}}, i32 6627)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ObjFragMask_TestFragFetch_lit.frag
+++ b/test/shaderdb/ObjFragMask_TestFragFetch_lit.frag
@@ -39,10 +39,10 @@ void main()
 ; SHADERTEST: call i32 @llpc.image.fetch.u32.SubpassData.fmaskvalue
 ; SHADERTEST: call <4 x i32> @llpc.image.fetch.u32.SubpassData.sample
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: tail call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32
-; SHADERTEST: tail call float @llvm.amdgcn.image.load.3d.f32.i32
-; SHADERTEST: tail call <4 x float> @llvm.amdgcn.image.load.2darraymsaa.v4f32.i32
-; SHADERTEST: tail call float @llvm.amdgcn.image.load.2d.f32.i32
+; SHADERTEST: call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32
+; SHADERTEST: call float @llvm.amdgcn.image.load.3d.f32.i32
+; SHADERTEST: call <4 x float> @llvm.amdgcn.image.load.2darraymsaa.v4f32.i32
+; SHADERTEST: call float @llvm.amdgcn.image.load.2d.f32.i32
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFloorDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFloorDouble_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call double @llvm.floor.f64(double %{{[0-9]*}})
 ; SHADERTEST: %{{[0-9]*}} = call double @llvm.floor.f64(double %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = tail call double @llvm.floor.f64(double %{{[0-9]*}})
-; SHADERTEST: %{{[0-9]*}} = tail call double @llvm.floor.f64(double %.i{{[0-9]*}}.upto1.extract)
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.floor.f64(double %{{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.floor.f64(double %.i{{[0-9]*}}.upto1.extract)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFloorFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFloorFloat_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = tail call float @llvm.floor.f32(float %{{[0-9]*}})
-; SHADERTEST: %{{[0-9]*}} = tail call float @llvm.floor.f32(float %.bitcast.i{{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %.bitcast.i{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFloorVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFloorVec4Const_lit.frag
@@ -19,9 +19,9 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = tail call float @llvm.floor.f32(float %{{[0-9]*}})
-; SHADERTEST: %{{[0-9]*}} = tail call float @llvm.floor.f32(float %{{[0-9]*}})
-; SHADERTEST: %{{[0-9]*}} = tail call float @llvm.floor.f32(float %{{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.floor.f32(float %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFractDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFractDouble_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} double @_Z5fractd(double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x double> @_Z5fractDv3_d(<3 x double> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.fract.f64(double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.fract.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.fract.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.fract.f64(double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFractFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFractFloat_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @_Z5fractf(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x float> @_Z5fractDv3_f(<3 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fract.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fract.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fract.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fract.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFractVec4Const-lit.frag
+++ b/test/shaderdb/OpExtInst_TestFractVec4Const-lit.frag
@@ -15,9 +15,9 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @_Z5fractDv4_f(<4 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fract.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fract.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fract.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fract.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fract.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fract.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFrexpDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFrexpDouble_lit.frag
@@ -25,10 +25,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { double, i32 } @_Z11frexpStructd(double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { <3 x double>, <3 x i32> } @_Z11frexpStructDv3_d(<3 x double> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFrexpFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFrexpFloat_lit.frag
@@ -25,10 +25,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { float, i32 } @_Z11frexpStructf(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { <3 x float>, <3 x i32> } @_Z11frexpStructDv3_f(<3 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFrexpStructDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFrexpStructDouble_lit.frag
@@ -19,8 +19,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { double, i32 } @_Z11frexpStructd(double %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFrexpStructFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFrexpStructFloat_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { float, i32 } @_Z11frexpStructf(float %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestFrexpStructVec4_lit.frag
+++ b/test/shaderdb/OpExtInst_TestFrexpStructVec4_lit.frag
@@ -17,14 +17,14 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} { <4 x float>, <4 x i32> } @_Z11frexpStructDv4_f(<4 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateAtCentroid_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateAtCentroid_lit.frag
@@ -23,10 +23,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.import.builtin.InterpPerspCentroid(i32 268435458)
 ; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.import.builtin.InterpPerspCentroid(i32 268435458)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 1, i32 1, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 1, i32 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 1, i32 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 1, i32 1, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateAtOffset_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateAtOffset_lit.frag
@@ -30,9 +30,9 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32{{.*}}v2f32({{.*}}<2 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.mov(i32 2, i32 1, i32 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.mov(i32 2, i32 1, i32 1, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateAtSample_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateAtSample_lit.frag
@@ -30,9 +30,9 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.sample(i32 %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 1, i32 0, i32 0, i32 1, <2 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.interp.mov(i32 2, i32 1, i32 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.mov(i32 2, i32 1, i32 1, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLdexpDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLdexpDouble_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} double @_Z5ldexpdi(double %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x double> @_Z5ldexpDv3_dDv3_i(<3 x double> %{{.*}}, <3 x i32> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.ldexp.f64(double %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call double @llvm.amdgcn.ldexp.f64(double %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.ldexp.f64(double %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.ldexp.f64(double %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLdexpFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLdexpFloat_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @_Z5ldexpfi(float %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x float> @_Z5ldexpDv3_fDv3_i(<3 x float> %{{.*}}, <3 x i32> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLdexpVec4_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLdexpVec4_lit.frag
@@ -16,10 +16,10 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @_Z5ldexpDv4_fDv4_i(<4 x float> %{{.*}}, <4 x i32> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLog2Vec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLog2Vec4Const_lit.frag
@@ -20,9 +20,9 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLog2_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLog2_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLogVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLogVec4Const_lit.frag
@@ -20,9 +20,9 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLog_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLog_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.log2.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestPow2_lit.frag
+++ b/test/shaderdb/OpExtInst_TestPow2_lit.frag
@@ -16,9 +16,9 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @_Z3powff(float 2.000000e+00, float %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.ldexp.f32(float 1.000000e+00, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.ldexp.f32(float 1.000000e+00, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
@@ -22,10 +22,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = insertelement <4 x float> <float 1.200000e+01, float undef, float undef, float undef>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: {{.*}} call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.200000e+01, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 immarg true, i1 immarg true)
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.200000e+01, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 immarg true, i1 immarg true)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST: %{{.*}} = fmul float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: %{{.*}} = fmul float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: %{{.*}} = fmul float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: {{.*}} call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 0x3F9ACEEA00000000, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 immarg true, i1 immarg true)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 0x3F9ACEEA00000000, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 immarg true, i1 immarg true)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestTanVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTanVec4Const_lit.frag
@@ -28,16 +28,16 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @_Z4fdivff(float 1.000000e+00, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.cos.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.cos.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fdiv float 1.000000e+00, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.cos.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.cos.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fdiv float 1.000000e+00, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.cos.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.cos.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fdiv float 1.000000e+00, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/OpExtInst_TestTan_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTan_lit.frag
@@ -32,12 +32,12 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call float @_Z4fdivff(float 1.000000e+00, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.cos.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.cos.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fdiv float 1.000000e+00, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.cos.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.cos.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fdiv float 1.000000e+00, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fcmp one float %{{.*}}, %{{.*}}

--- a/test/shaderdb/OpExtInst_TestTanhFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTanhFloat_lit.frag
@@ -16,11 +16,11 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, 0x3FF7154760000000
 ; SHADERTEST: %{{[0-9]*}} = fsub float 0.000000e+00, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.exp2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fsub float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fadd float %{{.*}}, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestTanh_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTanh_lit.frag
@@ -25,18 +25,18 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, 0x3FF7154760000000
 ; SHADERTEST: %{{[0-9]*}} = fsub float 0.000000e+00, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.exp2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fsub float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fadd float %{{.*}}, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fmul float %{{.*}}, 0x3FF7154760000000
 ; SHADERTEST: %{{[0-9]*}} = fsub float 0.000000e+00, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.exp2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fsub float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fadd float %{{.*}}, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = {{.*}} call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/PipelineCs_TestDynDescNoSpill_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestDynDescNoSpill_lit.pipe
@@ -5,7 +5,7 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{.*}} = call <4 x i32> {{.*}}@llpc.call.desc.load.buffer.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0, i1 false)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = tail call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
+; SHADERTEST: %{{.*}} = call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
@@ -10,7 +10,7 @@
 ; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %23 to <16 x i32> {{.*}}
 ; SHADERTEST: %{{.*}} = load <16 x i32>, <16 x i32> {{.*}} %{{.*}}, align 64
 ; SHADERTEST: %{{.*}} = shufflevector <16 x i32> %25, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; SHADERTEST: %{{.*}} = tail call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
+; SHADERTEST: %{{.*}} = call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; END_SHADERTEST
 
 [CsGlsl]

--- a/test/shaderdb/PipelineCs_TestFetch2DMSFmaskBased_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestFetch2DMSFmaskBased_lit.pipe
@@ -6,8 +6,8 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{.*}} = call <4 x float> @llpc.image.fetch.f32.2D.sample.fmaskbased.dimaware
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = tail call float @llvm.amdgcn.image.load.2d.f32.i32(i32 1, i32 0, i32 1, <8 x i32> %{{.*}}, i32 0, i32 0)
-; SHADERTEST: %{{.*}} = tail call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32(i32 15, i32 0, i32 1, i32 %{{.*}}, <8 x i32> %{{.*}}, i32 0, i32 0)
+; SHADERTEST: %{{.*}} = call float @llvm.amdgcn.image.load.2d.f32.i32(i32 1, i32 0, i32 1, <8 x i32> %{{.*}}, i32 0, i32 0)
+; SHADERTEST: %{{.*}} = call <4 x float> @llvm.amdgcn.image.load.2dmsaa.v4f32.i32(i32 15, i32 0, i32 1, i32 %{{.*}}, <8 x i32> %{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -10,7 +10,7 @@
 ; SHADERTEST: %{{.*}} = add i32 %{{.*}}, 16
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i32 0
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST: %{{.*}} = tail call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{.*}}, i32 0, i32 0)
+; SHADERTEST: %{{.*}} = call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{.*}}, i32 0, i32 0)
 ; SHADERTEST : AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
Llpc runs the O3 optimization from llvm-opt.  Many of these
optimizations are focused on optimizing C/C++ code, but are not useful
for code that comes from Vulkan spir-v.

To fix this, I have changed Patch::AddOptimizationPasses to explicityly
list the optimizations it wants to add.  I added the optimizations that
llvm would have added, removing those that would not do anything or seem
redundant.

My analysis of which optimizations are useful was determined by look at
a shaders from games where the shaders where compiled with DXC.  This
could bias the results.

In my tests, the GCN that is output is the exact same, while reducing
the compile time around 7%.