### PR TITLE
Added names to some IR function args

### DIFF
--- a/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
@@ -7,9 +7,9 @@
 ; SHADERTEST: %{{.*}} = call <16 x i8> @llpc.buffer.load.v16i8(<4 x i32> %{{.*}}, i32 0, i1 false, i32 0, i1 false)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{.*}} = getelementptr inbounds [512 x i8], [512 x i8] {{.*}} %{{.*}}, i64 0, i64 16
-; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %23 to <16 x i32> {{.*}}
+; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %{{.*}} to <16 x i32> {{.*}}
 ; SHADERTEST: %{{.*}} = load <16 x i32>, <16 x i32> {{.*}} %{{.*}}, align 64
-; SHADERTEST: %{{.*}} = shufflevector <16 x i32> %25, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; SHADERTEST: %{{.*}} = shufflevector <16 x i32> %{{.*}}, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; SHADERTEST: %{{.*}} = call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; END_SHADERTEST
 

--- a/test/shaderdb/PipelineCs_TestMultiEntryPoint_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestMultiEntryPoint_lit.pipe
@@ -6,7 +6,7 @@
 ; SHADERTEST: !{{.*}} = !{void ()* @entrypoint1, !{{.*}}}
 ; SHADERTEST: !{{.*}} = !{!"spirv.ExecutionMode.GLCompute", i32 0, i32 1, i32 1, i32 1}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg, i32 inreg, i32 inreg, <3 x i32> inreg, i32 inreg, <3 x i32>)
+; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg, i32 inreg, i32 inreg{{[^,]*}}, <3 x i32> inreg, i32 inreg, <3 x i32>)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -346,15 +346,16 @@ ShaderStage GetShaderStageFromCallingConv(
 // =====================================================================================================================
 // Gets the argument from the specified function according to the argument index.
 Value* GetFunctionArgument(
-    Function* pFunc,    // [in] LLVM function
-    uint32_t  idx)      // Index of the query argument
+    Function*     pFunc,    // [in] LLVM function
+    uint32_t      idx,      // Index of the query argument
+    const Twine&  name)     // Name to give the argument if currently empty
 {
-    auto pArg = pFunc->arg_begin();
-    while (idx-- > 0)
+    Argument* pArg = &pFunc->arg_begin()[idx];
+    if ((name.isTriviallyEmpty() == false) && (pArg->getName() == ""))
     {
-        ++pArg;
+        pArg->setName(name);
     }
-    return &*pArg;
+    return pArg;
 }
 
 // =====================================================================================================================

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -226,7 +226,7 @@ ShaderStage GetShaderStageFromFunction(llvm::Function* pFunc);
 ShaderStage GetShaderStageFromCallingConv(uint32_t stageMask, llvm::CallingConv::ID callConv);
 
 // Gets the argument from the specified function according to the argument index.
-llvm::Value* GetFunctionArgument(llvm::Function* pFunc, uint32_t idx);
+llvm::Value* GetFunctionArgument(llvm::Function* pFunc, uint32_t idx, const llvm::Twine& name = "");
 
 // Checks if one type can be bitcasted to the other (type1 -> type2).
 bool CanBitCast(const llvm::Type* pTy1, const llvm::Type* pTy2);


### PR DESCRIPTION
This adds a mechanism, and starts to use it, to add a name to an IR
function arg, based on how it is used. It makes the IR a bit more
readable.

Change-Id: I34690e8093c1a786b86d97e4ea5e604052066987