### PR TITLE
Fix CTS failures: dEQP-VK.clipping.user_defined.*fragmentshader_read

### DIFF
--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -2936,7 +2936,7 @@ Value* PatchInOutImportExport::PatchFsBuiltInInputImport(
                             inOutUsage.builtInInputLocMap.end());
                 loc = inOutUsage.builtInInputLocMap[BuiltInCullDistance];
                 locCount = (builtInUsage.clipDistance + builtInUsage.cullDistance > 4) ? 2 : 1;
-                startChannel = builtInUsage.clipDistance;
+                startChannel = builtInUsage.clipDistance % 4;
             }
 
             auto& interpInfo = inOutUsage.fs.interpInfo;


### PR DESCRIPTION
The startChannel should be within the range [0, 3].