### PR TITLE
Merge user data nodes

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -630,6 +630,9 @@ Result Compiler::BuildPipelineInternal(
         }
     }
 
+    // Merge user data for shader stages into one.
+    pContext->GetPipelineContext()->DoUserDataNodeMerge();
+
     // If not IR input, run the per-shader passes, including SPIR-V translation, and then link the modules
     // into a single pipeline module.
     if (pPipelineModule == nullptr)

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -75,8 +75,8 @@ public:
     // Enables GS on-chip mode
     virtual void SetGsOnChip(bool gsOnChip) { LLPC_NEVER_CALLED(); }
 
-    // Does user data node merge for merged shader
-    virtual void DoUserDataNodeMerge() { LLPC_NEVER_CALLED(); }
+    // Does user data node merging for all shader stages
+    virtual void DoUserDataNodeMerge() { }
 
     // Gets float control settings of the specified shader stage for the provide floating-point type.
     virtual FloatControl GetShaderFloatControl(ShaderStage shaderStage, uint32_t bitWidth) const;

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "llpcPipelineContext.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace Llpc
 {
@@ -101,12 +103,7 @@ private:
     LLPC_DISALLOW_DEFAULT_CTOR(GraphicsContext);
     LLPC_DISALLOW_COPY_AND_ASSIGN(GraphicsContext);
 
-    void MergeUserDataNode(uint32_t                    nodeCount1,
-                           const ResourceMappingNode*  pNodes1,
-                           uint32_t                    nodeCount2,
-                           const ResourceMappingNode*  pNodes2,
-                           uint32_t*                   pMergedNodeCount,
-                           const ResourceMappingNode** ppMergedNodes);
+    llvm::ArrayRef<ResourceMappingNode> MergeUserDataNodeTable(llvm::SmallVectorImpl<ResourceMappingNode>& allNodes);
 
     const GraphicsPipelineBuildInfo*    m_pPipelineInfo; // Info to build a graphics pipeline
 
@@ -119,7 +116,10 @@ private:
     bool            m_tessOffchip; // Whether to enable tessellation off-chip mode
     bool            m_gsOnChip;    // Whether to enable GS on-chip mode
 
-    std::vector<ResourceMappingNode*>  m_allocUserDataNodes;    // Allocated user data nodes for merged shader
+    llvm::SmallVector<std::unique_ptr<llvm::SmallVectorImpl<ResourceMappingNode>>, 4>
+                    m_allocUserDataNodes;               // Allocated merged user data nodes
+    std::unique_ptr<llvm::SmallVectorImpl<DescriptorRangeValue>>
+                    m_allocDescriptorRangeValues;       // Allocated merged descriptor range values
 };
 
 } // Llpc

--- a/patch/llpcPatchResourceCollect.cpp
+++ b/patch/llpcPatchResourceCollect.cpp
@@ -102,12 +102,6 @@ bool PatchResourceCollect::runOnModule(
             bool gsOnChip = m_pContext->CheckGsOnChipValidity();
             m_pContext->SetGsOnChip(gsOnChip);
         }
-
-        // Do user data node merge for merged shader
-        if (m_pContext->GetGfxIpVersion().major >= 9)
-        {
-            m_pContext->DoUserDataNodeMerge();
-        }
     }
 
     return true;

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -208,6 +208,7 @@ struct CompileInfo
     void*                       pPipelineBuf;                   // Alllocation buffer of building pipeline
     void*                       pPipelineInfoFile;              // VFX-style file containing pipeline info
     const char*                 pFileNames;                     // Names of input shader source files
+    bool                        doAutoLayout;                   // Whether to auto layout descriptors
 };
 
 // =====================================================================================================================
@@ -799,8 +800,8 @@ static Result BuildShaderModules(
 // =====================================================================================================================
 // Builds pipeline and do linking.
 static Result BuildPipeline(
-    ICompiler*    pCompiler,     // [in] LLPC compiler object
-    CompileInfo*  pCompileInfo)  // [in,out] Compilation info of LLPC standalone tool
+    ICompiler*    pCompiler,        // [in] LLPC compiler object
+    CompileInfo*  pCompileInfo)     // [in,out] Compilation info of LLPC standalone tool
 {
     Result result = Result::Success;
 
@@ -821,6 +822,7 @@ static Result BuildPipeline(
             &pGraphicsPipelineInfo->fs,
         };
 
+        uint32_t userDataOffset = 0;
         for (uint32_t stage = 0; stage < ShaderStageGfxCount; ++stage)
         {
             if (pCompileInfo->stageMask & ShaderStageToMask(static_cast<ShaderStage>(stage)))
@@ -837,13 +839,14 @@ static Result BuildPipeline(
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 21
                 pShaderInfo->entryStage = static_cast<ShaderStage>(stage);
 #endif
-                // If no user data nodes (not compiling from pipeline), lay them out now.
-                if (pShaderInfo->pUserDataNodes == nullptr)
+                // If not compiling from pipeline, lay out user data now.
+                if (pCompileInfo->doAutoLayout)
                 {
                     DoAutoLayoutDesc(static_cast<ShaderStage>(stage),
                                      pCompileInfo->spirvBin[stage],
                                      pGraphicsPipelineInfo,
-                                     pShaderInfo);
+                                     pShaderInfo,
+                                     userDataOffset);
                 }
             }
         }
@@ -923,10 +926,15 @@ static Result BuildPipeline(
 #endif
         pShaderInfo->pModuleData  = pShaderOut->pModuleData;
 
-        // If no user data nodes (not compiling from pipeline), lay them out now.
-        if (pShaderInfo->pUserDataNodes == nullptr)
+        // If not compiling from pipeline, lay out user data now.
+        if (pCompileInfo->doAutoLayout)
         {
-            DoAutoLayoutDesc(ShaderStageCompute, pCompileInfo->spirvBin[ShaderStageCompute], nullptr, pShaderInfo);
+            uint32_t userDataOffset = 0;
+            DoAutoLayoutDesc(ShaderStageCompute,
+                             pCompileInfo->spirvBin[ShaderStageCompute],
+                             nullptr,
+                             pShaderInfo,
+                             userDataOffset);
         }
 
         pComputePipelineInfo->pInstance      = nullptr; // Dummy, unused
@@ -1091,6 +1099,7 @@ static Result ProcessPipeline(
     Result result = Result::Success;
     CompileInfo compileInfo = {};
     std::string fileNames;
+    compileInfo.doAutoLayout = true;
 
     result = InitCompileInfo(&compileInfo);
 
@@ -1265,6 +1274,7 @@ static Result ProcessPipeline(
                     fileNames += inFile;
                     fileNames += " ";
                     *pNextFile = i + 1;
+                    compileInfo.doAutoLayout = false;
                     break;
                 }
             }

--- a/tool/amdllpc.h
+++ b/tool/amdllpc.h
@@ -38,5 +38,6 @@
 void DoAutoLayoutDesc(Llpc::ShaderStage                 shaderStage,
                       Llpc::BinaryData                  spirvBin,
                       Llpc::GraphicsPipelineBuildInfo*  pPipelineInfo,
-                      Llpc::PipelineShaderInfo*         pShaderInfo);
+                      Llpc::PipelineShaderInfo*         pShaderInfo,
+                      uint32_t&                         topLevelOffset);
 

--- a/tool/llpcAutoLayout.cpp
+++ b/tool/llpcAutoLayout.cpp
@@ -102,7 +102,9 @@ void DoAutoLayoutDesc(
     BinaryData                  spirvBin,       // SPIR-V binary
     GraphicsPipelineBuildInfo*  pPipelineInfo,  // [in/out] Graphics pipeline info, will have dummy information filled
                                                 //   in. nullptr if not a graphics pipeline.
-    PipelineShaderInfo*         pShaderInfo)    // [in/out] Shader info, will have user data nodes added to it
+    PipelineShaderInfo*         pShaderInfo,    // [in/out] Shader info, will have user data nodes added to it
+    uint32_t&                   topLevelOffset) // [in/out] User data offset; ensures that multiple shader stages use
+                                                //    disjoint offsets
 {
     // Read the SPIR-V.
     std::string spirvCode(static_cast<const char*>(spirvBin.pCode), spirvBin.codeSize);
@@ -589,7 +591,6 @@ void DoAutoLayoutDesc(
     auto pResNode = pResNodes;
 
     // Add a node for each set.
-    uint32_t topLevelOffset = 0;
     for (const auto& resNodeSet : resNodeSets)
     {
         pResNode->type = ResourceMappingNodeType::DescriptorTableVaPtr;


### PR DESCRIPTION
The Vulkan driver ensures that the user data nodes for different shader
stages are always compatible. This LLPC commit merges them (including
the descriptor range values) into a single set of user data nodes for
the whole pipeline, in preparation for a subsequent commit where the
whole pipeline user data nodes will be passed through the Builder
interface.

Change-Id: I2b49a7ba315890a89e381ce5aa5ec55cc8e6129a