### PR TITLE
World War Z - black patches Corruption in game

### DIFF
--- a/lower/llpcSpirvLowerAlgebraTransform.h
+++ b/lower/llpcSpirvLowerAlgebraTransform.h
@@ -65,6 +65,7 @@ private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(SpirvLowerAlgebraTransform);
 
     bool IsOperandNoContract(llvm::Value* pOperand);
+    void DisableFastMath(Value* pValue);
 
     bool m_enableConstFolding; // Whether enable constant folding in this pass
     bool m_enableFloatOpt;     // Whether enable floating point optimization in this pass


### PR DESCRIPTION
Root cause: Position is different  in two pipeline with same input value, and it causes depth test (EQUAL) can't pass.
In detail, this issue related with the code in Shader_0x503BE09E44C0B0DD and Shader_0x5190B83BD5F97819
float _1577 = (_836._m8[0].x * _676._m12[3].z) + (4.0 * _1573) + _1626;
float _1577 is calculated with different order in two shaders.
It is due to we set all fast math flags for all fp instructions in default.

Solution: remove all fast math flags for all instructions affect Position