### PR TITLE
Added PipelineState and used it for user data nodes

### DIFF
--- a/builder/llpcPipelineState.cpp
+++ b/builder/llpcPipelineState.cpp
@@ -28,3 +28,408 @@
  * @brief LLPC source file: contains implementation of class Llpc::PipelineState.
  ***********************************************************************************************************************
  */
+#define DEBUG_TYPE "llpc-pipeline-state"
+
+#include "llpc.h"
+#include "llpcInternal.h"
+#include "llpcPipelineState.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Debug.h"
+
+using namespace Llpc;
+using namespace llvm;
+
+// User data nodes metadata name prefix
+static const char* const BuilderUserDataMetadataName = "llpc.user.data.nodes";
+
+// =====================================================================================================================
+// Set the resource mapping nodes for the pipeline.
+// The table entries are flattened and stored in IR metadata.
+void PipelineState::SetUserDataNodes(
+    ArrayRef<ResourceMappingNode>   nodes,            // The resource mapping nodes
+    ArrayRef<DescriptorRangeValue>  rangeValues)      // The descriptor range values
+{
+    // Create a map of immutable nodes.
+    ImmutableNodesMap immutableNodesMap;
+    for (auto& rangeValue : rangeValues)
+    {
+        immutableNodesMap[{ rangeValue.set, rangeValue.binding }] = &rangeValue;
+    }
+
+    // Count how many user data nodes we have, and allocate the buffer.
+    uint32_t nodeCount = nodes.size();
+    for (auto& node : nodes)
+    {
+        if (node.type == ResourceMappingNodeType::DescriptorTableVaPtr)
+        {
+            nodeCount += node.tablePtr.nodeCount;
+        }
+    }
+    LLPC_ASSERT(m_allocUserDataNodes == nullptr);
+    m_allocUserDataNodes = make_unique<ResourceNode[]>(nodeCount);
+
+    // Copy nodes in.
+    ResourceNode* pDestTable = m_allocUserDataNodes.get();
+    ResourceNode* pDestInnerTable = pDestTable + nodeCount;
+    m_userDataNodes = ArrayRef<ResourceNode>(pDestTable, nodes.size());
+    SetUserDataNodesTable(nodes, immutableNodesMap, pDestTable, pDestInnerTable);
+    LLPC_ASSERT(pDestInnerTable == pDestTable + nodes.size());
+}
+
+// =====================================================================================================================
+// Set one user data table, and its inner tables.
+void PipelineState::SetUserDataNodesTable(
+    ArrayRef<ResourceMappingNode> nodes,              // The resource mapping nodes
+    const ImmutableNodesMap&      immutableNodesMap,  // [in] Map of immutable nodes
+    ResourceNode*                 pDestTable,         // [out] Where to write nodes
+    ResourceNode*&                pDestInnerTable)    // [in/out] End of space available for inner tables
+{
+    for (uint32_t idx = 0; idx != nodes.size(); ++idx)
+    {
+        auto& node = nodes[idx];
+        auto& destNode = pDestTable[idx];
+
+        destNode.type = node.type;
+        destNode.sizeInDwords = node.sizeInDwords;
+        destNode.offsetInDwords = node.offsetInDwords;
+
+        switch (node.type)
+        {
+        case ResourceMappingNodeType::DescriptorTableVaPtr:
+            {
+                // Process an inner table.
+                pDestInnerTable -= node.tablePtr.nodeCount;
+                destNode.innerTable = ArrayRef<ResourceNode>(pDestInnerTable, node.tablePtr.nodeCount);
+                SetUserDataNodesTable(ArrayRef<ResourceMappingNode>(node.tablePtr.pNext, node.tablePtr.nodeCount),
+                                      immutableNodesMap,
+                                      pDestInnerTable,
+                                      pDestInnerTable);
+                break;
+            }
+        case ResourceMappingNodeType::IndirectUserDataVaPtr:
+        case ResourceMappingNodeType::StreamOutTableVaPtr:
+            {
+                // Process an indirect pointer.
+                destNode.indirectSizeInDwords = node.userDataPtr.sizeInDwords;
+                break;
+            }
+        default:
+            {
+                // Process an SRD.
+                destNode.set = node.srdRange.set;
+                destNode.binding = node.srdRange.binding;
+                destNode.pImmutableValue = nullptr;
+
+                auto it = immutableNodesMap.find(std::pair<uint32_t, uint32_t>(destNode.set, destNode.binding));
+                if (it != immutableNodesMap.end())
+                {
+                    // This set/binding is (or contains) an immutable value. The value can only be a sampler, so we
+                    // can assume it is four dwords.
+                    auto& immutableNode = *it->second;
+
+                    IRBuilder<> builder(*m_pContext);
+                    SmallVector<Constant*, 4> values;
+
+                    if (immutableNode.arraySize != 0)
+                    {
+                        for (uint32_t compIdx = 0; compIdx < immutableNode.arraySize; ++compIdx)
+                        {
+                            Constant* compValues[4] =
+                            {
+                                builder.getInt32(immutableNode.pValue[compIdx * 4]),
+                                builder.getInt32(immutableNode.pValue[compIdx * 4 + 1]),
+                                builder.getInt32(immutableNode.pValue[compIdx * 4 + 2]),
+                                builder.getInt32(immutableNode.pValue[compIdx * 4 + 3])
+                            };
+                            values.push_back(ConstantVector::get(compValues));
+                        }
+                        destNode.pImmutableValue = ConstantArray::get(ArrayType::get(values[0]->getType(), values.size()),
+                                                                      values);
+                    }
+                }
+                break;
+            }
+        }
+    }
+}
+
+// =====================================================================================================================
+// Record the pipeline state to IR metadata
+void PipelineState::RecordState(
+    Module* pModule)    // [in/out] Module to record the IR metadata in
+{
+    RecordUserDataNodes(pModule);
+}
+
+// =====================================================================================================================
+// Record user data nodes into IR metadata.
+void PipelineState::RecordUserDataNodes(
+    Module*   pModule)    // [in/out] Module to write IR metadata to
+{
+    auto pUserDataMetaNode = pModule->getOrInsertNamedMetadata(BuilderUserDataMetadataName);
+    RecordUserDataTable(m_userDataNodes, pUserDataMetaNode);
+}
+
+// =====================================================================================================================
+// Record one table of user data nodes into IR metadata, calling itself recursively for inner tables.
+void PipelineState::RecordUserDataTable(
+    ArrayRef<ResourceNode>  nodes,              // Table of user data nodes
+    NamedMDNode*            pUserDataMetaNode)  // IR metadata node to record them into
+{
+    IRBuilder<> builder(*m_pContext);
+
+    for (const ResourceNode& node : nodes)
+    {
+        SmallVector<Metadata*, 5> operands;
+        LLPC_ASSERT(node.type < ResourceMappingNodeType::Count);
+        // Operand 0: type
+        operands.push_back(GetResourceTypeName(node.type));
+        // Operand 1: offsetInDwords
+        operands.push_back(ConstantAsMetadata::get(builder.getInt32(node.offsetInDwords)));
+        // Operand 2: sizeInDwords
+        operands.push_back(ConstantAsMetadata::get(builder.getInt32(node.sizeInDwords)));
+
+        switch (node.type)
+        {
+        case ResourceMappingNodeType::DescriptorTableVaPtr:
+            {
+                // Operand 3: Node count in sub-table.
+                operands.push_back(ConstantAsMetadata::get(builder.getInt32(node.innerTable.size())));
+                // Create the metadata node here.
+                pUserDataMetaNode->addOperand(MDNode::get(*m_pContext, operands));
+                // Create nodes for the sub-table.
+                RecordUserDataTable(node.innerTable, pUserDataMetaNode);
+                continue;
+            }
+        case ResourceMappingNodeType::IndirectUserDataVaPtr:
+        case ResourceMappingNodeType::StreamOutTableVaPtr:
+            {
+                // Operand 3: Size of the indirect data in dwords.
+                operands.push_back(ConstantAsMetadata::get(builder.getInt32(node.indirectSizeInDwords)));
+                break;
+            }
+        default:
+            {
+                // Operand 3: set
+                operands.push_back(ConstantAsMetadata::get(builder.getInt32(node.set)));
+                // Operand 4: binding
+                operands.push_back(ConstantAsMetadata::get(builder.getInt32(node.binding)));
+                if (node.pImmutableValue != nullptr)
+                {
+                    // Operand 5 onwards: immutable descriptor constant.
+                    // Writing the constant array directly does not seem to work, as it does not survive IR linking.
+                    // Maybe it is a problem with the IR linker when metadata contains a non-ConstantData constant.
+                    // So we write the individual ConstantInts instead.
+                    // We can assume that the descriptor is <4 x i32> as an immutable descriptor is always a sampler.
+                    static const uint32_t SamplerDescriptorSize = 4;
+                    uint32_t elemCount = node.pImmutableValue->getType()->getArrayNumElements();
+                    for (uint32_t elemIdx = 0; elemIdx != elemCount; ++elemIdx)
+                    {
+                        Constant* pVectorValue = ConstantExpr::getExtractValue(node.pImmutableValue, elemIdx);
+                        for (uint32_t compIdx = 0; compIdx != SamplerDescriptorSize; ++compIdx)
+                        {
+                            operands.push_back(ConstantAsMetadata::get(
+                                                      ConstantExpr::getExtractElement(pVectorValue,
+                                                                                      builder.getInt32(compIdx))));
+                        }
+                    }
+                }
+                break;
+            }
+        }
+
+        // Create the metadata node.
+        pUserDataMetaNode->addOperand(MDNode::get(*m_pContext, operands));
+    }
+}
+
+// =====================================================================================================================
+// Set up the pipeline state from the specified linked IR module.
+void PipelineState::ReadStateFromModule(
+    Module* pModule)  // [in] Module
+{
+    ReadUserDataNodes(pModule);
+}
+
+// =====================================================================================================================
+// Read user data nodes for the pipeline from IR metadata
+void PipelineState::ReadUserDataNodes(
+    Module* pModule)  // [in] Module
+{
+    LLPC_ASSERT(m_allocUserDataNodes.get() == nullptr);
+
+    // Find the named metadata node.
+    auto pUserDataMetaNode = pModule->getNamedMetadata(BuilderUserDataMetadataName);
+
+    // Prepare to read the resource nodes from the named MD node. We allocate a single buffer, with the
+    // outer table at the start, and inner tables allocated from the end backwards.
+    uint32_t totalNodeCount = pUserDataMetaNode->getNumOperands();
+    m_allocUserDataNodes = make_unique<ResourceNode[]>(totalNodeCount);
+
+    ResourceNode* pNextOuterNode = m_allocUserDataNodes.get();
+    ResourceNode* pNextNode = pNextOuterNode;
+    ResourceNode* pEndNextInnerTable = pNextOuterNode + totalNodeCount;
+    ResourceNode* pEndThisInnerTable = nullptr;
+
+    // Read the nodes.
+    for (uint32_t nodeIndex = 0; nodeIndex < totalNodeCount; ++nodeIndex)
+    {
+        MDNode* pMetadataNode = pUserDataMetaNode->getOperand(nodeIndex);
+        // Operand 0: node type
+        pNextNode->type = GetResourceTypeFromName(cast<MDString>(pMetadataNode->getOperand(0)));
+        // Operand 1: offsetInDwords
+        pNextNode->offsetInDwords =
+              mdconst::dyn_extract<ConstantInt>(pMetadataNode->getOperand(1))->getZExtValue();
+        // Operand 2: sizeInDwords
+        pNextNode->sizeInDwords =
+              mdconst::dyn_extract<ConstantInt>(pMetadataNode->getOperand(2))->getZExtValue();
+
+        if (pNextNode->type == ResourceMappingNodeType::DescriptorTableVaPtr)
+        {
+            // Operand 3: number of nodes in inner table
+            uint32_t innerNodeCount =
+                  mdconst::dyn_extract<ConstantInt>(pMetadataNode->getOperand(3))->getZExtValue();
+            // Go into inner table.
+            LLPC_ASSERT(pEndThisInnerTable == nullptr);
+            pEndThisInnerTable = pEndNextInnerTable;
+            pEndNextInnerTable -= innerNodeCount;
+            pNextNode = pEndNextInnerTable;
+            pNextOuterNode->innerTable = ArrayRef<ResourceNode>(pNextNode, innerNodeCount);
+            ++pNextOuterNode;
+        }
+        else
+        {
+            if ((pNextNode->type == ResourceMappingNodeType::IndirectUserDataVaPtr) ||
+                (pNextNode->type == ResourceMappingNodeType::StreamOutTableVaPtr))
+            {
+                // Operand 3: Size of the indirect data in dwords
+                pNextNode->indirectSizeInDwords =
+                    mdconst::dyn_extract<ConstantInt>(pMetadataNode->getOperand(3))->getZExtValue();
+            }
+            else
+            {
+                // Operand 3: set
+                pNextNode->set =
+                    mdconst::dyn_extract<ConstantInt>(pMetadataNode->getOperand(3))->getZExtValue();
+                // Operand 4: binding
+                pNextNode->binding =
+                    mdconst::dyn_extract<ConstantInt>(pMetadataNode->getOperand(4))->getZExtValue();
+                pNextNode->pImmutableValue = nullptr;
+                if (pMetadataNode->getNumOperands() >= 6)
+                {
+                    // Operand 5 onward: immutable descriptor constant
+                    static const uint32_t SamplerDescriptorSize = 4;
+                    static const uint32_t OperandStartIdx = 5;
+
+                    uint32_t elemCount = (pMetadataNode->getNumOperands() - OperandStartIdx) / SamplerDescriptorSize;
+                    SmallVector<Constant*, 4> descriptors;
+                    for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
+                    {
+                        Constant* compValues[SamplerDescriptorSize];
+                        for (uint32_t compIdx = 0; compIdx < SamplerDescriptorSize; ++compIdx)
+                        {
+                            compValues[compIdx] = mdconst::dyn_extract<ConstantInt>(
+                                  pMetadataNode->getOperand(OperandStartIdx + SamplerDescriptorSize * elemIdx + compIdx));
+                        }
+                        descriptors.push_back(ConstantVector::get(compValues));
+                    }
+                    pNextNode->pImmutableValue = ConstantArray::get(ArrayType::get(descriptors[0]->getType(),
+                                                                                   elemCount),
+                                                                    descriptors);
+                }
+            }
+            // Move on to next node to write in table.
+            ++pNextNode;
+            if (pEndThisInnerTable == nullptr)
+            {
+                pNextOuterNode = pNextNode;
+            }
+        }
+        // See if we have reached the end of the inner table.
+        if (pNextNode == pEndThisInnerTable)
+        {
+            pEndThisInnerTable = nullptr;
+            pNextNode = pNextOuterNode;
+        }
+    }
+    m_userDataNodes = ArrayRef<ResourceNode>(m_allocUserDataNodes.get(), pNextOuterNode);
+}
+
+// =====================================================================================================================
+// Get the cached MDString for the name of a resource mapping node type, as used in IR metadata for user data nodes.
+MDString* PipelineState::GetResourceTypeName(
+    ResourceMappingNodeType type)   // Resource mapping node type
+{
+    return GetResourceTypeNames()[static_cast<uint32_t>(type)];
+}
+
+// =====================================================================================================================
+// Get the resource mapping node type given its MDString name.
+ResourceMappingNodeType PipelineState::GetResourceTypeFromName(
+    MDString* pTypeName)  // [in] Name of resource type as MDString
+{
+    auto typeNames = GetResourceTypeNames();
+    for (uint32_t type = 0; ; ++type)
+    {
+        if (typeNames[type] == pTypeName)
+        {
+            return static_cast<ResourceMappingNodeType>(type);
+        }
+    }
+}
+
+// =====================================================================================================================
+// Get the array of cached MDStrings for names of resource mapping node type, as used in IR metadata for user
+// data nodes.
+ArrayRef<MDString*> PipelineState::GetResourceTypeNames()
+{
+    if (m_resourceNodeTypeNames[0] == nullptr)
+    {
+        for (uint32_t type = 0; type < static_cast<uint32_t>(ResourceMappingNodeType::Count); ++type)
+        {
+            m_resourceNodeTypeNames[type] =
+                MDString::get(*m_pContext, GetResourceMappingNodeTypeName(static_cast<ResourceMappingNodeType>(type)));
+        }
+    }
+    return ArrayRef<MDString*>(m_resourceNodeTypeNames);
+}
+
+// =====================================================================================================================
+char PipelineStateWrapper::ID = 0;
+
+// =====================================================================================================================
+PipelineStateWrapper::PipelineStateWrapper()
+    :
+    ImmutablePass(ID)
+{
+    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
+}
+
+// =====================================================================================================================
+// Clean-up of PipelineStateWrapper at end of pass manager run
+bool PipelineStateWrapper::doFinalization(
+    Module& module)     // [in] Module
+{
+    delete m_pPipelineState;
+    m_pPipelineState = nullptr;
+    return false;
+}
+
+// =====================================================================================================================
+// Get the PipelineState from the wrapper pass.
+PipelineState* PipelineStateWrapper::GetPipelineState(
+    Module* pModule)   // [in] Module
+{
+    if (m_pPipelineState == nullptr)
+    {
+        m_pPipelineState = new PipelineState(&pModule->getContext());
+        m_pPipelineState->ReadStateFromModule(pModule);
+    }
+    return m_pPipelineState;
+}
+
+// =====================================================================================================================
+// Initialize the pipeline state wrapper pass
+INITIALIZE_PASS(PipelineStateWrapper, DEBUG_TYPE, "LLPC pipeline state wrapper", false, true)
+

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -28,3 +28,135 @@
  * @brief LLPC header file: contains declaration of class Llpc::PipelineState
  ***********************************************************************************************************************
  */
+#pragma once
+
+#include "llpc.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include <map>
+
+namespace llvm
+{
+
+class LLVMContext;
+class Module;
+class MDString;
+class NamedMDNode;
+class PassRegistry;
+
+void initializePipelineStateWrapperPass(PassRegistry&);
+
+} // llvm
+
+namespace Llpc
+{
+
+class PipelineState;
+
+// =====================================================================================================================
+// The representation of a user data resource node in builder and patching
+struct ResourceNode
+{
+    ResourceNode() {}
+
+    ResourceMappingNodeType                 type;
+    uint32_t                                sizeInDwords;
+    uint32_t                                offsetInDwords;
+
+    union
+    {
+        // Info for generic descriptor nodes.
+        struct
+        {
+            uint32_t                        set;
+            uint32_t                        binding;
+            llvm::Constant*                 pImmutableValue;
+        };
+
+        // Info for DescriptorTableVaPtr
+        llvm::ArrayRef<ResourceNode>        innerTable;
+
+        // Info for indirect data nodes (IndirectUserDataVaPtr, StreamOutVaTablePtr)
+        uint32_t                            indirectSizeInDwords;
+    };
+};
+
+// =====================================================================================================================
+// The pipeline state in the middle-end (Builder and Patch)
+class PipelineState
+{
+public:
+    PipelineState()
+        : m_pContext(nullptr)
+    {}
+
+    PipelineState(llvm::LLVMContext* pContext)
+        : m_pContext(pContext)
+    {}
+
+    // Set the resource mapping nodes for the pipeline.
+    void SetUserDataNodes(llvm::ArrayRef<ResourceMappingNode>   nodes,
+                          llvm::ArrayRef<DescriptorRangeValue>  rangeValues);
+
+    // Record pipeline state into IR metadata.
+    void RecordState(llvm::Module* pModule);
+
+    // Set up the pipeline state from the specified linked IR module.
+    void ReadStateFromModule(llvm::Module* pModule);
+
+    // Get user data nodes
+    llvm::ArrayRef<ResourceNode> GetUserDataNodes() const { return m_userDataNodes; }
+
+private:
+    // Type of immutable nodes map used in SetUserDataNodes
+    typedef std::map<std::pair<uint32_t, uint32_t>, const DescriptorRangeValue*> ImmutableNodesMap;
+
+    void SetUserDataNodesTable(llvm::ArrayRef<ResourceMappingNode>  nodes,
+                               const ImmutableNodesMap&             immutableNodesMap,
+                               ResourceNode*                        pDestTable,
+                               ResourceNode*&                       pDestInnerTable);
+    void RecordUserDataNodes(llvm::Module* pModule);
+    void RecordUserDataTable(llvm::ArrayRef<ResourceNode> nodes, llvm::NamedMDNode* pUserDataMetaNode);
+
+    // Read user data nodes for each shader stage from IR metadata
+    void ReadUserDataNodes(llvm::Module* pModule);
+
+    // Get the array of cached MDStrings for names of resource mapping node type, as used in IR metadata for user
+    // data nodes.
+    llvm::ArrayRef<llvm::MDString*> GetResourceTypeNames();
+
+    // Get the cached MDString for the name of a resource mapping node type, as used in IR metadata for user data nodes.
+    llvm::MDString* GetResourceTypeName(ResourceMappingNodeType type);
+
+    // Get the resource mapping node type given its MDString name.
+    ResourceMappingNodeType GetResourceTypeFromName(llvm::MDString* pTypeName);
+
+    // -----------------------------------------------------------------------------------------------------------------
+    llvm::LLVMContext*              m_pContext;                         // LLVM context
+    std::unique_ptr<ResourceNode[]> m_allocUserDataNodes;               // Allocated buffer for user data
+    llvm::ArrayRef<ResourceNode>    m_userDataNodes;                    // Top-level user data node table
+    llvm::MDString*                 m_resourceNodeTypeNames[uint32_t(ResourceMappingNodeType::Count)] = {};
+                                                                        // Cached MDString for each resource node type
+};
+
+// =====================================================================================================================
+// Wrapper pass for the pipeline state in the middle-end
+class PipelineStateWrapper : public llvm::ImmutablePass
+{
+public:
+    PipelineStateWrapper();
+
+    bool doFinalization(llvm::Module& module) override;
+
+    // Get the PipelineState from this wrapper pass.
+    PipelineState* GetPipelineState(llvm::Module* pModule);
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    static char ID;   // ID of this pass
+
+private:
+    PipelineState* m_pPipelineState = nullptr;  // Cached pipeline state
+};
+
+} // Llpc

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -653,6 +653,19 @@ Result Compiler::BuildPipelineInternal(
                                          *pContext);
             modules[stage] = pModule;
             pContext->SetModuleTargetMachine(pModule);
+        }
+
+        // Give the pipeline state to the Builder. (If we know we are using BuilderRecorder, in a future change
+        // we could choose to delay this until after linking into a pipeline module.)
+        pContext->GetPipelineContext()->SetBuilderPipelineState(pContext->GetBuilder());
+
+        for (uint32_t stage = 0; (stage < shaderInfo.size()) && (result == Result::Success); ++stage)
+        {
+            const PipelineShaderInfo* pShaderInfo = shaderInfo[stage];
+            if ((pShaderInfo == nullptr) || (pShaderInfo->pModuleData == nullptr))
+            {
+                continue;
+            }
 
             PassManager lowerPassMgr(&passIndex);
 

--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -735,26 +735,26 @@ void GraphicsContext::DoUserDataNodeMerge()
         while (rangeValues.empty() == false)
         {
             // Find the next block of duplicate rangeValues.
-            uint32_t duplicatesCount = 1;
-            for (; duplicatesCount != rangeValues.size(); ++duplicatesCount)
+            uint32_t duplicateCount = 1;
+            for (; duplicateCount != rangeValues.size(); ++duplicateCount)
             {
-                if ((rangeValues[0].set != rangeValues[duplicatesCount].set) || (rangeValues[0].binding != rangeValues[duplicatesCount].binding))
+                if ((rangeValues[0].set != rangeValues[duplicateCount].set) || (rangeValues[0].binding != rangeValues[duplicateCount].binding))
                 {
                     break;
                 }
-                LLPC_ASSERT((rangeValues[0].type == rangeValues[duplicatesCount].type) &&
+                LLPC_ASSERT((rangeValues[0].type == rangeValues[duplicateCount].type) &&
                             "Descriptor range value merge conflict: type");
-                LLPC_ASSERT((rangeValues[0].arraySize == rangeValues[duplicatesCount].arraySize) &&
+                LLPC_ASSERT((rangeValues[0].arraySize == rangeValues[duplicateCount].arraySize) &&
                             "Descriptor range value merge conflict: arraySize");
                 LLPC_ASSERT((memcmp(rangeValues[0].pValue,
-                                    rangeValues[duplicatesCount].pValue,
+                                    rangeValues[duplicateCount].pValue,
                                     rangeValues[0].arraySize * sizeof(uint32_t)) == 0) &&
                             "Descriptor range value merge conflict: value");
             }
 
             // Keep the merged range.
             mergedRangeValues.push_back(rangeValues[0]);
-            rangeValues = rangeValues.slice(duplicatesCount);
+            rangeValues = rangeValues.slice(duplicateCount);
         }
     }
 

--- a/context/llpcPipelineContext.cpp
+++ b/context/llpcPipelineContext.cpp
@@ -35,6 +35,7 @@
 #include "llvm/Support/CommandLine.h"
 
 #include "SPIRVInternal.h"
+#include "llpcBuilder.h"
 #include "llpcCompiler.h"
 #include "llpcPipelineContext.h"
 
@@ -257,6 +258,23 @@ uint64_t PipelineContext::GetShaderHashCode(
 
     return (pModuleData == nullptr) ? 0 :
         MetroHash::Compact64(reinterpret_cast<const MetroHash::Hash*>(&pModuleData->hash));
+}
+
+// =====================================================================================================================
+// Set pipeline state in Builder
+void PipelineContext::SetBuilderPipelineState(
+    Builder*          pBuilder) const   // [in] The builder
+{
+    // Give the user data nodes and descriptor range values to the Builder.
+    // The user data nodes have been merged so they are the same in each shader stage. Get them from
+    // the first active stage.
+    uint32_t stageMask = GetShaderStageMask();
+    auto pShaderInfo = GetPipelineShaderInfo(ShaderStage(countTrailingZeros(stageMask)));
+    ArrayRef<ResourceMappingNode> userDataNodes(pShaderInfo->pUserDataNodes,
+                                                pShaderInfo->userDataNodeCount);
+    ArrayRef<DescriptorRangeValue> descriptorRangeValues(pShaderInfo->pDescriptorRangeValues,
+                                                         pShaderInfo->descriptorRangeValueCount);
+    pBuilder->SetUserDataNodes(userDataNodes, descriptorRangeValues);
 }
 
 } // Llpc

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -789,6 +789,9 @@ public:
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const = 0;
 
+    // Set pipeline state in Builder
+    void SetBuilderPipelineState(Builder* pBuilder) const;
+
 protected:
     // Gets dummy vertex input create info
     virtual VkPipelineVertexInputStateCreateInfo* GetDummyVertexInputInfo() { return nullptr; }

--- a/patch/llpcPatch.h
+++ b/patch/llpcPatch.h
@@ -107,6 +107,7 @@ llvm::ModulePass* CreatePatchResourceCollect();
 llvm::ModulePass* CreatePatchSetupTargetFeatures();
 
 class Context;
+class PipelineState;
 
 // =====================================================================================================================
 // Represents the pass of LLVM patching operations, as the base class.

--- a/patch/llpcPatchDescriptorLoad.h
+++ b/patch/llpcPatchDescriptorLoad.h
@@ -35,6 +35,7 @@
 #include <unordered_set>
 #include "llpcPatch.h"
 #include "llpcPipelineShaders.h"
+#include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 
 namespace Llpc
@@ -51,6 +52,7 @@ public:
 
     void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
     {
+        analysisUsage.addRequired<PipelineStateWrapper>();
         analysisUsage.addRequired<PipelineShaders>();
         analysisUsage.addPreserved<PipelineShaders>();
     }
@@ -73,9 +75,9 @@ private:
                                                         uint32_t*                 pStride,
                                                         uint32_t*                 pDynDescIdx) const;
 
-    const DescriptorRangeValue* GetDescriptorRangeValue(ResourceMappingNodeType   nodeType,
-                                                        uint32_t                  descSet,
-                                                        uint32_t                  binding) const;
+    llvm::Constant* GetDescriptorRangeValue(ResourceMappingNodeType   nodeType,
+                                            uint32_t                  descSet,
+                                            uint32_t                  binding) const;
 
     void PatchWaterfallLastUseCalls();
 
@@ -94,6 +96,9 @@ private:
 
     // Map from descriptor range value to global variables modeling related descriptors (act as immediate constants)
     std::unordered_map<const DescriptorRangeValue*, llvm::GlobalVariable*> m_descs;
+
+    PipelineState*                      m_pPipelineState = nullptr;
+                                                              // PipelineState from PipelineStateWrapper pass
 };
 
 } // Llpc

--- a/patch/llpcPatchEntryPointMutate.h
+++ b/patch/llpcPatchEntryPointMutate.h
@@ -33,6 +33,7 @@
 #include "llvm/IR/InstVisitor.h"
 
 #include "llpcPatch.h"
+#include "llpcPipelineState.h"
 
 namespace Llpc
 {
@@ -50,6 +51,7 @@ public:
 
     void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
     {
+        analysisUsage.addRequired<PipelineStateWrapper>();
         analysisUsage.addRequired<PipelineShaders>();
         // Does not preserve PipelineShaders because it replaces the entrypoints.
     }
@@ -67,7 +69,7 @@ private:
 
     llvm::FunctionType* GenerateEntryPointType(uint64_t* pInRegMask) const;
 
-    bool IsResourceMappingNodeActive(const ResourceMappingNode* pNode, bool isRootNode) const;
+    bool IsResourceNodeActive(const ResourceNode* pNode, bool isRootNode) const;
 
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -76,6 +78,8 @@ private:
 
     bool    m_hasTs;    // Whether the pipeline has tessllation shader
     bool    m_hasGs;    // Whether the pipeline has geometry shader
+    PipelineState*  m_pPipelineState = nullptr;
+                        // PipelineState from PipelineStateWrapper pass
 };
 
 } // Llpc

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -68,6 +68,7 @@ PatchInOutImportExport::PatchInOutImportExport()
     memset(&m_gfxIp, 0, sizeof(m_gfxIp));
     InitPerShader();
 
+    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
     initializePipelineShadersPass(*PassRegistry::getPassRegistry());
     initializePatchInOutImportExportPass(*PassRegistry::getPassRegistry());
 }
@@ -107,6 +108,7 @@ bool PatchInOutImportExport::runOnModule(
     Patch::Init(&module);
 
     m_gfxIp = m_pContext->GetGfxIpVersion();
+    m_pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
 
     const uint32_t stageMask = m_pContext->GetShaderStageMask();
     m_hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
@@ -174,7 +176,7 @@ void PatchInOutImportExport::ProcessShader()
     if (m_shaderStage == ShaderStageVertex)
     {
         // Create vertex fetch manager
-        m_pVertexFetch = new VertexFetch(m_pEntryPoint, m_pipelineSysValues.Get(m_pEntryPoint));
+        m_pVertexFetch = new VertexFetch(m_pEntryPoint, m_pipelineSysValues.Get(m_pEntryPoint), m_pPipelineState);
     }
     else if (m_shaderStage == ShaderStageFragment)
     {
@@ -4323,7 +4325,7 @@ void PatchInOutImportExport::PatchXfbOutputExport(
                 (m_shaderStage == ShaderStageTessEval) ||
                 (m_shaderStage == ShaderStageCopyShader));
 
-    Value* pStreamOutBufDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetStreamOutBufDesc(xfbBuffer);
+    Value* pStreamOutBufDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetStreamOutBufDesc(m_pPipelineState, xfbBuffer);
 
     const auto& xfbStrides = m_pContext->GetShaderResourceUsage(m_shaderStage)->inOutUsage.xfbStrides;
     uint32_t xfbStride = xfbStrides[xfbBuffer];

--- a/patch/llpcPatchInOutImportExport.h
+++ b/patch/llpcPatchInOutImportExport.h
@@ -36,6 +36,7 @@
 #include "llpcIntrinsDefs.h"
 #include "llpcPatch.h"
 #include "llpcPipelineShaders.h"
+#include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 
 namespace Llpc
@@ -56,6 +57,7 @@ public:
 
     void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
     {
+        analysisUsage.addRequired<PipelineStateWrapper>();
         analysisUsage.addRequired<PipelineShaders>();
         analysisUsage.addPreserved<PipelineShaders>();
     }
@@ -328,6 +330,7 @@ private:
 
     std::vector<llvm::CallInst*> m_importCalls; // List of "call" instructions to import inputs
     std::vector<llvm::CallInst*> m_exportCalls; // List of "call" instructions to export outputs
+    PipelineState*          m_pPipelineState = nullptr; // PipelineState from PipelineStateWrapper pass
 };
 
 } // Llpc

--- a/patch/llpcPatchPushConstOp.h
+++ b/patch/llpcPatchPushConstOp.h
@@ -64,7 +64,8 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    llvm::SmallVector<llvm::Instruction*, 8> m_instsToRemove; // List of instructions to remove.
+    llvm::SmallVector<llvm::Instruction*, 8> m_instsToRemove;   // List of instructions to remove.
+    PipelineState*  m_pPipelineState = nullptr;                 // PipelineState from PipelineStateWrapper pass
 };
 
 } // Llpc

--- a/patch/llpcSystemValues.h
+++ b/patch/llpcSystemValues.h
@@ -40,6 +40,9 @@
 namespace Llpc
 {
 
+class PipelineState;
+struct ResourceNode;
+
 // =====================================================================================================================
 // "Shader system values" are values set up in a shader entrypoint, such as the ES->GS ring buffer descriptor, or the
 // user descriptor table pointer, that some passes need access to. The ShaderSystemValues class has an instance for each
@@ -83,13 +86,13 @@ public:
     llvm::ArrayRef<llvm::Value*> GetEmitCounterPtr();
 
     // Get descriptor table pointer
-    llvm::Value* GetDescTablePtr(uint32_t descSet);
+    llvm::Value* GetDescTablePtr(PipelineState* pPipelineState, uint32_t descSet);
 
     // Get shadow descriptor table pointer
-    llvm::Value* GetShadowDescTablePtr(uint32_t descSet);
+    llvm::Value* GetShadowDescTablePtr(PipelineState* pPipelineState, uint32_t descSet);
 
     // Get dynamic descriptor
-    llvm::Value* GetDynamicDesc(uint32_t dynDescIdx);
+    llvm::Value* GetDynamicDesc(PipelineState* pPipelineState, uint32_t dynDescIdx);
 
     // Get global internal table pointer
     llvm::Value* GetInternalGlobalTablePtr();
@@ -101,26 +104,29 @@ public:
     llvm::Value* GetNumWorkgroups();
 
     // Get spilled push constant pointer
-    llvm::Value* GetSpilledPushConstTablePtr();
+    llvm::Value* GetSpilledPushConstTablePtr(PipelineState* pPipelineState);
 
     // Get vertex buffer table pointer
-    llvm::Value* GetVertexBufTablePtr();
+    llvm::Value* GetVertexBufTablePtr(PipelineState* pPipelineState);
 
     // Get stream-out buffer descriptor
-    llvm::Value* GetStreamOutBufDesc(uint32_t xfbBuffer);
+    llvm::Value* GetStreamOutBufDesc(PipelineState* pPipelineState, uint32_t xfbBuffer);
 
 private:
     // Get stream-out buffer table pointer
-    llvm::Instruction* GetStreamOutTablePtr();
+    llvm::Instruction* GetStreamOutTablePtr(PipelineState* pPipelineState);
 
     // Make 64-bit pointer of specified type from 32-bit int, extending with the specified value, or PC if InvalidValue
     llvm::Instruction* MakePointer(llvm::Value* pLowValue, llvm::Type* pPtrTy, uint32_t highValue);
 
     // Get 64-bit extended resource node value
-    llvm::Value* GetExtendedResourceNodeValue(uint32_t resNodeIdx, llvm::Type* pResNodeTy, uint32_t highValue);
+    llvm::Value* GetExtendedResourceNodeValue(PipelineState* pPipelineState,
+                                              uint32_t resNodeIdx,
+                                              llvm::Type* pResNodeTy,
+                                              uint32_t highValue);
 
     // Get 32 bit resource node value
-    llvm::Value* GetResourceNodeValue(uint32_t resNodeIdx);
+    llvm::Value* GetResourceNodeValue(PipelineState* pPipelineState, uint32_t resNodeIdx);
 
     // Get spill table pointer
     llvm::Instruction* GetSpillTablePtr();
@@ -134,10 +140,10 @@ private:
                                          llvm::Instruction* pInsertPos) const;
 
     // Find resource node by type
-    const ResourceMappingNode* FindResourceNodeByType(ResourceMappingNodeType type);
+    const ResourceNode* FindResourceNodeByType(PipelineState* pPipelineState, ResourceMappingNodeType type);
 
     // Find resource node by descriptor set ID
-    uint32_t FindResourceNodeByDescSet(uint32_t descSet);
+    uint32_t FindResourceNodeByDescSet(PipelineState* pPipelineState, uint32_t descSet);
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -890,11 +890,13 @@ const VertexCompFormatInfo VertexFetch::m_vertexCompFormatInfo[] =
 // =====================================================================================================================
 VertexFetch::VertexFetch(
     Function*           pEntryPoint,      // [in] Entry-point of API vertex shader
-    ShaderSystemValues* pShaderSysValues) // [in] ShaderSystemValues object for getting vertex buffer pointer from
+    ShaderSystemValues* pShaderSysValues, // [in] ShaderSystemValues object for getting vertex buffer pointer from
+    PipelineState*      pPipelineState)   // [in] Pipeline state
     :
     m_pModule(pEntryPoint->getParent()),
     m_pContext(static_cast<Context*>(&m_pModule->getContext())),
     m_pShaderSysValues(pShaderSysValues),
+    m_pPipelineState(pPipelineState),
     m_pVertexInput(static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo())->pVertexInput)
 {
     LLPC_ASSERT(GetShaderStageFromFunction(pEntryPoint) == ShaderStageVertex); // Must be vertex shader
@@ -1476,7 +1478,7 @@ Value* VertexFetch::LoadVertexBufferDescriptor(
     idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), 0, false));
     idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), binding, false));
 
-    auto pVbTablePtr = m_pShaderSysValues->GetVertexBufTablePtr();
+    auto pVbTablePtr = m_pShaderSysValues->GetVertexBufTablePtr(m_pPipelineState);
     auto pVbDescPtr = GetElementPtrInst::Create(nullptr, pVbTablePtr, idxs, "", pInsertPos);
     pVbDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
 

--- a/patch/llpcVertexFetch.h
+++ b/patch/llpcVertexFetch.h
@@ -37,6 +37,7 @@ namespace Llpc
 {
 
 class Context;
+class PipelineState;
 class ShaderSystemValues;
 
 // Represents vertex format info corresponding to vertex attribute format (VkFormat).
@@ -66,7 +67,7 @@ struct VertexCompFormatInfo
 class VertexFetch
 {
 public:
-    VertexFetch(llvm::Function* pEntrypoint, ShaderSystemValues* pShaderSysValues);
+    VertexFetch(llvm::Function* pEntrypoint, ShaderSystemValues* pShaderSysValues, PipelineState* pPipelineState);
 
     static const VertexFormatInfo* GetVertexFormatInfo(VkFormat format);
 
@@ -115,6 +116,7 @@ private:
     llvm::Module*       m_pModule;          // LLVM module
     Context*            m_pContext;         // LLPC context
     ShaderSystemValues* m_pShaderSysValues; // ShaderSystemValues object for getting vertex buffer pointer from
+    PipelineState*      m_pPipelineState;   // Pipeline state
 
     const VkPipelineVertexInputStateCreateInfo*   m_pVertexInput; // Vertex input info
     const VkPipelineVertexInputDivisorStateCreateInfoEXT* m_pVertexDivisor; // Vertex input divisor info

--- a/util/llpcPipelineDumper.cpp
+++ b/util/llpcPipelineDumper.cpp
@@ -1681,26 +1681,7 @@ std::ostream& operator<<(
     std::ostream&           out,   // [out] Output stream
     ResourceMappingNodeType type)  // Resource map node type
 {
-    const char* pString = nullptr;
-    switch (type)
-    {
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorResource)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorSampler)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorCombinedTexture)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorTexelBuffer)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorFmask)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorBuffer)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorTableVaPtr)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, IndirectUserDataVaPtr)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, PushConst)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorBufferCompact)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, StreamOutTableVaPtr)
-        break;
-    default:
-        LLPC_NEVER_CALLED();
-        break;
-    }
-    return out << pString;
+    return out << GetResourceMappingNodeTypeName(type);
 }
 
 // =====================================================================================================================

--- a/util/llpcUtil.cpp
+++ b/util/llpcUtil.cpp
@@ -154,4 +154,37 @@ bool CreateDirectory(
 #endif
 }
 
+// =====================================================================================================================
+// Helper macro
+#define CASE_CLASSENUM_TO_STRING(TYPE, ENUM) \
+    case TYPE::ENUM: pString = #ENUM; break;
+
+// =====================================================================================================================
+// Translate enum "ResourceMappingNodeType" to string
+const char* GetResourceMappingNodeTypeName(
+    ResourceMappingNodeType type)  // Resource map node type
+{
+    const char* pString = nullptr;
+    switch (type)
+    {
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, Unknown)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorResource)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorSampler)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorCombinedTexture)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorTexelBuffer)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorFmask)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorBuffer)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorTableVaPtr)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, IndirectUserDataVaPtr)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, PushConst)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorBufferCompact)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, StreamOutTableVaPtr)
+        break;
+    default:
+        LLPC_NEVER_CALLED();
+        break;
+    }
+    return pString;
+}
+
 } // Llpc

--- a/util/llpcUtil.h
+++ b/util/llpcUtil.h
@@ -55,6 +55,9 @@ uint32_t ShaderStageToMask(ShaderStage stage);
 // Create directory.
 bool CreateDirectory(const char* pDir);
 
+// Translate enum "ResourceMappingNodeType" to string
+const char* GetResourceMappingNodeTypeName(ResourceMappingNodeType type);
+
 // =====================================================================================================================
 // Increments a pointer by nBytes by first casting it to a uint8_t*.
 //


### PR DESCRIPTION
    This commit is one step towards two goals of the Builder interface:
    a. Make Builder the interface between the frontend and the middle-end of
       LLPC, without any on-the-side context data structures.
    b. Allow the middle-end (Builder and Patch) to work without needing any
       outside-IR persistent state, so we can add and use proposed
       -stop-before, -start-before and -run-pass options to amdllpc and test
       individual passes.
    
    The changes in this commit are:
    
    1. There is a new PipelineState object, designed to hold pipeline state
       (i.e. things that are supplied from the frontend and do not change
       through the middle-end). In this commit, it only contains the user
       data nodes.
    
    2. State from PipelineState is written into IR as metadata. (Again,
       currently only the user data nodes.)
    
    3. There is a new PipelineStateWrapper immutable pass used to query the
       pipeline state. The first time you use it, it reads the state out of
       the IR and caches it for the rest of the compile. Because it is an
       immutable pass, it is always considered preserved by other passes.
    
    4. Patch passes that access the user data nodes now use
       PipelineStateWrapper.
    
    5. There is a new Builder method to set user data nodes from the
       frontend.
    
    Change-Id: Ia7264874e4f0a9dce1927a54bb2a11df644a0ac3
