### PR TITLE
Fix MGPU regression with scratch bounds enabled

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -1489,6 +1489,7 @@ MetroHash::Hash Compiler::GenerateHashForCompileOptions(
         cl::LogFileOuts.ArgStr,
         cl::EnableShadowDescriptorTable.ArgStr,
         cl::ShadowDescTablePtrHigh.ArgStr,
+        "amdgpu-scratch-bounds-checking",
     };
 
     std::set<StringRef> effectingOptions;


### PR DESCRIPTION
In a system with a mixture of GFX9/8/7 parts the scratch bounds
option is only enabled for GFX9 parts.  This causes an error
initialising the compiler as the options are inconsistent.
Fix this by ignoring the scratch bounds options when generating
the options hash.