### PR TITLE
Deprecate includeIrBinary flag and add support for dumping AMDIL text via .pipe file

### DIFF
--- a/include/llpc.h
+++ b/include/llpc.h
@@ -39,7 +39,7 @@
 #undef Status
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 26
+#define LLPC_INTERFACE_MAJOR_VERSION 27
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -50,6 +50,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     27.0 | Remove the includeIrBinary option from PipelineOptions as only IR disassembly is now dumped           |
 //* |     25.0 | Add includeIrBinary option into PipelineOptions for including IR binaries into ELF files.             |
 //* |     24.0 | Add forceLoopUnrollCount option into PipelineShaderOptions.                                           |
 //* |     23.0 | Add flag robustBufferAccess in PipelineOptions to check out of bounds of private array.               |
@@ -228,7 +229,7 @@ struct PipelineOptions
                               ///  for now this option is used by LLPC shader and affects only the private array,
                               ///  the out of bounds accesses will be skipped with this setting.
 #endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25
+#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
     bool includeIrBinary;     ///< If set, the IR binary for all compiled shaders will be included in the pipeline ELF.
 #endif
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1122,7 +1122,7 @@ public:
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
 #endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25
+#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIrBinary, MemberTypeBool, false);
 #endif
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);


### PR DESCRIPTION
via .pipe files