### PR TITLE
Set calling conversion explicitly for vfx and spvgen interface

### DIFF
--- a/imported/spirv/spvgen.h
+++ b/imported/spirv/spvgen.h
@@ -36,9 +36,14 @@
 #define SPVGEN_MAJOR_VERSION(version)  (version >> 16)
 #define SPVGEN_MINOR_VERSION(version)  (version & 0xFFFF)
 
+#ifdef _WIN32
+    #define SPVAPI __cdecl
+#else
+    #define SPVAPI
+#endif
+
 #ifndef SH_IMPORT_EXPORT
     #ifdef _WIN32
-        #define SPVAPI __cdecl
         #ifdef SH_EXPORTING
             #define SH_IMPORT_EXPORT __declspec(dllexport)
         #else
@@ -46,7 +51,6 @@
         #endif
     #else
         #define SH_IMPORT_EXPORT
-        #define SPVAPI
     #endif
 #endif
 
@@ -337,7 +341,7 @@ DECL_EXPORT_FUNC(vfxGetRenderDoc);
 DECL_EXPORT_FUNC(vfxGetPipelineDoc);
 DECL_EXPORT_FUNC(vfxPrintDoc);
 
-bool InitSpvGen(const char* pSpvGenDir = nullptr);
+bool SPVAPI InitSpvGen(const char* pSpvGenDir = nullptr);
 
 #endif
 
@@ -409,7 +413,7 @@ static const char* SpvGeneratorName = "spvgen.so";
 // =====================================================================================================================
 // Initialize SPIR-V generator entry-points
 // This can be called multiple times in the same application.
-bool InitSpvGen(
+bool SPVAPI InitSpvGen(
     const char* pSpvGenDir)   // [in] Directory to load SPVGEN library from, or null to use OS's default search path
 {
     if (g_pfnspvGetVersion != nullptr)

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -41,6 +41,13 @@
 #define VFX_REVISION 1
 
 #include "llpc.h"
+
+#ifdef _WIN32
+#define VFXAPI __cdecl
+#else
+#define VFXAPI
+#endif
+
 using namespace Llpc;
 
 extern int Snprintf(char* pOutput, size_t bufSize, const char* pFormat, ...);
@@ -642,7 +649,7 @@ typedef struct VfxPipelineState* VfxPipelineStatePtr;
 namespace Vfx
 {
 
-bool vfxParseFile(
+bool VFXAPI vfxParseFile(
     const char*  pFilename,
     unsigned int numMacro,
     const char*  pMacros[],
@@ -650,18 +657,18 @@ bool vfxParseFile(
     void**       ppDoc,
     const char** ppErrorMsg);
 
-void vfxCloseDoc(
+void VFXAPI vfxCloseDoc(
     void* pDoc);
 
-void vfxGetRenderDoc(
+void VFXAPI vfxGetRenderDoc(
     void*              pDoc,
     VfxRenderStatePtr* pRenderState);
 
-void vfxGetPipelineDoc(
+void VFXAPI vfxGetPipelineDoc(
     void*                pDoc,
     VfxPipelineStatePtr* pPipelineState);
 
-void vfxPrintDoc(
+void VFXAPI vfxPrintDoc(
     void*                pDoc);
 
 } // Vfx

--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -1546,7 +1546,7 @@ namespace Vfx
 {
 // =====================================================================================================================
 // Parses input file
-bool vfxParseFile(
+bool VFXAPI vfxParseFile(
     const char*     pFilename,      // [in] Input file name
     unsigned int    numMacro,       // Number of marcos
     const char*     pMacros[],      // [in] Marco list, Two strings are a macro, and macro will be extract before parse
@@ -1574,7 +1574,7 @@ bool vfxParseFile(
 
 // =====================================================================================================================
 // Closes document handle
-void vfxCloseDoc(
+void VFXAPI vfxCloseDoc(
     void* pDoc)    // [in] Document handle
 {
     delete reinterpret_cast<Document*>(pDoc);
@@ -1584,7 +1584,7 @@ void vfxCloseDoc(
 // Gets render document from document handle
 //
 // NOTE: The document contents are not accessable after call vfxCloseDoc
-void vfxGetRenderDoc(
+void VFXAPI vfxGetRenderDoc(
     void*              pDoc,         // [in] Document handle
     VfxRenderStatePtr* pRenderState) // [out] Pointer of struct VfxRenderState
 {
@@ -1595,7 +1595,7 @@ void vfxGetRenderDoc(
 // Gets pipeline document from document handle
 //
 // NOTE: The document contents are not accessable after call vfxCloseDoc
-void vfxGetPipelineDoc(
+void VFXAPI vfxGetPipelineDoc(
     void*                pDoc,            // [in] Document handle
     VfxPipelineStatePtr* pPipelineState)  // [out] Pointer of struct VfxPipelineState
 {
@@ -1604,7 +1604,7 @@ void vfxGetPipelineDoc(
 
 // =====================================================================================================================
 // Print Document to STDOUT
-void vfxPrintDoc(
+void VFXAPI vfxPrintDoc(
     void*                pDoc)            // [in] Document handle
 {
    reinterpret_cast<Document*>(pDoc)->PrintSelf();


### PR DESCRIPTION
If we don't set calling conversion explicitly and vfx client uses different call conversion with vfx library, link may fail with unresolved symbols.
We have hit this issue in 32bit build