### PR TITLE
Add option lower-dyn-index back to fix build error.

### DIFF
--- a/lower/llpcSpirvLower.cpp
+++ b/lower/llpcSpirvLower.cpp
@@ -58,6 +58,21 @@
 
 using namespace llvm;
 
+namespace llvm
+{
+
+namespace cl
+{
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27
+// -lower-dyn-index: lower SPIR-V dynamic (non-constant) index in access chain
+static opt<bool> LowerDynIndex("lower-dyn-index", desc("Lower SPIR-V dynamic (non-constant) index in access chain"));
+#endif
+
+} // cl
+
+} // llvm
+
 namespace Llpc
 {
 


### PR DESCRIPTION
1. This issue only happen when we use old xgl + new llpc
2. This option is protected with LLPC_INTERFACE_MAJOR_VERSION < 27, and it is a dummy option now.