### PR TITLE
[Vulkan CTS] dEQP-VK.memory_model.* fail

### DIFF
--- a/lower/llpcSpirvLowerGlobal.cpp
+++ b/lower/llpcSpirvLowerGlobal.cpp
@@ -342,7 +342,7 @@ void SpirvLowerGlobal::visitLoadInst(
             pInOut = dyn_cast<GlobalVariable>(pCurrGetElemPtr->getPointerOperand());
         }
 
-        // The root of the gep should always be the global variable.
+        // The root of the GEP should always be the global variable.
         LLPC_ASSERT(pInOut != nullptr);
 
         uint32_t operandIdx = 0;
@@ -2414,7 +2414,7 @@ void SpirvLowerGlobal::LowerBufferBlock()
                             pGetElemPtr = dyn_cast<GetElementPtrInst>(pBitCast);
                         }
 
-                        // If even after we've stripped away all the bitcasts we did not find a gep, we need to modify
+                        // If even after we've stripped away all the bitcasts we did not find a GEP, we need to modify
                         // the bitcast instead.
                         if (pGetElemPtr == nullptr)
                         {
@@ -2514,7 +2514,7 @@ void SpirvLowerGlobal::LowerBufferBlock()
 
                     Value* const pBitCast = m_pBuilder->CreateBitCast(pBufferDesc, pBlockType);
 
-                    // We need to remove the block index from the original gep indices so that we can use them.
+                    // We need to remove the block index from the original GEP indices so that we can use them.
                     indices[1] = indices[0];
 
                     ArrayRef<Value*> newIndices(indices);

--- a/test/shaderdb/OpMemoryBarrier_TestGroupMemoryBarrier_lit.comp
+++ b/test/shaderdb/OpMemoryBarrier_TestGroupMemoryBarrier_lit.comp
@@ -19,7 +19,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: fence syncscope("singlethread") acq_rel
+; SHADERTEST: fence syncscope("workgroup") acq_rel
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3424,7 +3424,6 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpAccessChain>(
     SPIRVValue* const pSpvValue) // [in] A SPIR-V value.
 {
     SPIRVAccessChainBase* const pSpvAccessChain = static_cast<SPIRVAccessChainBase*>(pSpvValue);
-    pSpvAccessChain->propagateMemoryDecorates();
 
     Value* const pBase = transValue(pSpvAccessChain->getBase(),
                                     m_pBuilder->GetInsertBlock()->getParent(),
@@ -4901,7 +4900,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpPhi: {
     auto Phi = static_cast<SPIRVPhi *>(BV);
-    Phi->propagateMemoryDecorates();
     PHINode* PhiNode = nullptr;
     if (BB->getFirstInsertionPt() != BB->end())
       PhiNode = PHINode::Create(transType(Phi->getType()),
@@ -4962,7 +4960,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpSelect: {
     SPIRVSelect *BS = static_cast<SPIRVSelect *>(BV);
-    BS->propagateMemoryDecorates();
     return mapValue(BV,
                     SelectInst::Create(transValue(BS->getCondition(), F, BB),
                                        transValue(BS->getTrueValue(), F, BB),
@@ -5016,7 +5013,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpCopyObject: {
     SPIRVCopyObject *CO = static_cast<SPIRVCopyObject *>(BV);
-    CO->propagateMemoryDecorates();
     AllocaInst* AI = nullptr;
     // NOTE: Alloc instructions not in the entry block will prevent LLVM from doing function
     // inlining. Try to move those alloc instructions to the entry block.

--- a/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -56,7 +56,7 @@ bool SPIRVValue::hasAlignment(SPIRVWord *Result) const {
   return hasDecorate(DecorationAlignment, 0, Result);
 }
 
-bool SPIRVValue::isVolatile() const { return hasDecorate(DecorationVolatile); }
+bool SPIRVValue::isVolatile() { return hasDecorate(DecorationVolatile); }
 
 void SPIRVValue::setVolatile(bool IsVolatile) {
   if (!IsVolatile) {
@@ -68,7 +68,7 @@ void SPIRVValue::setVolatile(bool IsVolatile) {
                      << " for obj " << Id << "\n")
 }
 
-bool SPIRVValue::isCoherent() const { return hasDecorate(DecorationCoherent); }
+bool SPIRVValue::isCoherent() { return hasDecorate(DecorationCoherent); }
 
 void SPIRVValue::setCoherent(bool IsCoherent) {
   if (!IsCoherent) {

--- a/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -68,4 +68,16 @@ void SPIRVValue::setVolatile(bool IsVolatile) {
                      << " for obj " << Id << "\n")
 }
 
+bool SPIRVValue::isCoherent() const { return hasDecorate(DecorationCoherent); }
+
+void SPIRVValue::setCoherent(bool IsCoherent) {
+  if (!IsCoherent) {
+    eraseDecorate(DecorationCoherent);
+    return;
+  }
+  addDecorate(new SPIRVDecorate(DecorationCoherent, this));
+  SPIRVDBG(spvdbgs() << "Set coherent "
+                     << " for obj " << Id << "\n")
+}
+
 } // namespace SPIRV

--- a/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -90,10 +90,10 @@ public:
     return Type;
   }
 
-  bool isVolatile() const;
+  virtual bool isVolatile();
   void setVolatile(bool IsVolatile = true);
 
-  bool isCoherent() const;
+  virtual bool isCoherent();
   void setCoherent(bool IsCoherent = true);
 
   bool hasAlignment(SPIRVWord *Result = 0) const;

--- a/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -89,11 +89,15 @@ public:
     assert(hasType() && "value has no type");
     return Type;
   }
-  bool isVolatile() const;
-  bool hasAlignment(SPIRVWord *Result = 0) const;
 
+  bool isVolatile() const;
+  void setVolatile(bool IsVolatile = true);
+
+  bool isCoherent() const;
+  void setCoherent(bool IsCoherent = true);
+
+  bool hasAlignment(SPIRVWord *Result = 0) const;
   void setAlignment(SPIRVWord);
-  void setVolatile(bool IsVolatile);
 
   void validate() const override {
     SPIRVEntry::validate();


### PR DESCRIPTION
- Propagate memory decorations for OpAccessChain, OpSelect, OpPhi,
  OpCopyObject.
- The fence sync scope is set incorrectly leading to missing s_barrier.