### PR TITLE
Wrong compile in ObjOutput_TestVsMatrix*.

### DIFF
--- a/patch/llpcPatchNullFragShader.cpp
+++ b/patch/llpcPatchNullFragShader.cpp
@@ -45,6 +45,20 @@
 using namespace Llpc;
 using namespace llvm;
 
+namespace llvm
+{
+
+namespace cl
+{
+
+// -disable-null-frag-shader: disable to generate null fragment shader
+opt<bool> DisableNullFragShader("disable-null-frag-shader",
+                                cl::desc("Disable to add a null fragment shader"), cl::init(false));
+
+} // cl
+
+} // llvm
+
 namespace Llpc
 {
 
@@ -84,6 +98,13 @@ bool PatchNullFragShader::runOnModule(
     LLVM_DEBUG(dbgs() << "Run the pass Patch-Null-Frag-Shader\n");
 
     Patch::Init(&module);
+
+    if (cl::DisableNullFragShader)
+    {
+        // NOTE: If the option -disable-null-frag-shader is set to TRUE, we skip this pass. This is done by
+        // standalone compiler.
+        return false;
+    }
 
     const bool hasCs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageCompute)) != 0);
     const bool hasVs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)) != 0);

--- a/test/shaderdb/ObjOutput_TestVsMatrix.vert
+++ b/test/shaderdb/ObjOutput_TestVsMatrix.vert
@@ -15,6 +15,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-COUNT-5: call void @llvm.amdgcn.exp.f32
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ObjOutput_TestVsMatrixArray.vert
+++ b/test/shaderdb/ObjOutput_TestVsMatrixArray.vert
@@ -17,6 +17,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-COUNT-9: call void @llvm.amdgcn.exp.f32
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -148,6 +148,7 @@ namespace cl
 
 extern opt<bool> EnablePipelineDump;
 extern opt<std::string> PipelineDumpDir;
+extern opt<bool> DisableNullFragShader;
 
 // -filter-pipeline-dump-by-type: filter which kinds of pipeline should be disabled.
 static opt<uint32_t> FilterPipelineDumpByType("filter-pipeline-dump-by-type",
@@ -363,6 +364,10 @@ static Result Init(
             strncpy(shaderCacheFileDirOption, "-shader-cache-file-dir=.", sizeof(shaderCacheFileDirOption));
         }
         newArgs.push_back(shaderCacheFileDirOption);
+
+        // NOTE: We set the option -disable-null-frag-shader to TRUE for standalone compiler as the default.
+        // Subsequent command option parse will correct its value if this option is specified externally.
+        cl::DisableNullFragShader.setValue(true);
 
         result = ICompiler::Create(ParsedGfxIp, newArgs.size(), &newArgs[0], ppCompiler);
     }
@@ -1200,6 +1205,10 @@ static Result ProcessPipeline(
         }
         else if (IsPipelineInfoFile(inFile))
         {
+            // NOTE: If the input file is pipeline file, we set the option -disable-null-frag-shader to FALSE
+            // unconditionally.
+            cl::DisableNullFragShader.setValue(false);
+
             const char* pLog = nullptr;
             bool vfxResult = Vfx::vfxParseFile(inFile.c_str(),
                                                0,


### PR DESCRIPTION
- Add a global llvm option llvm::cl::DisableNullFragShader to control whether we need to add a null fragment shader for standalone compiler.For .pipe file, this option is always set to FALSE, otherwise its value can be set by user or be TRUE by default.
- Add testing pattern in ObjOutput_TextVsMatrix*.vert