### PR TITLE
Change to unrolling options

### DIFF
--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -270,7 +270,6 @@ void Patch::AddOptimizationPasses(
         passMgr.add(createInstructionCombiningPass(expensiveCombines));
         passMgr.add(createIndVarSimplifyPass());
         passMgr.add(createLoopIdiomPass());
-        passMgr.add(CreatePatchLoopUnrollInfoRectify());
         passMgr.add(createLoopDeletionPass());
         passMgr.add(createSimpleLoopUnrollPass(optLevel));
         passMgr.add(CreatePatchPeepholeOpt());
@@ -333,11 +332,6 @@ void Patch::AddOptimizationPasses(
                 // running the scalarizer can be folded away before instruction combining tries to re-create them.
                 passMgr.add(createInstSimplifyLegacyPass());
             });
-        passBuilder.addExtension(PassManagerBuilder::EP_LateLoopOptimizations,
-                                 [](const PassManagerBuilder&, legacy::PassManagerBase& passMgr)
-                                 {
-                                     passMgr.add(CreatePatchLoopUnrollInfoRectify());
-                                 });
 
         passBuilder.populateModulePassManager(passMgr);
     }

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -245,13 +245,16 @@ static Result Init(
         // which arguments are not option names.
         static const char* defaultOptions[] =
         {
-            // Name                     Option
-            "-gfxip",                   "-gfxip=8.0.0",
-            "-pragma-unroll-threshold", "-pragma-unroll-threshold=4096",
-            "-unroll-allow-partial",    "-unroll-allow-partial",
-            "-simplifycfg-sink-common", "-simplifycfg-sink-common=false",
-            "-amdgpu-vgpr-index-mode",  "-amdgpu-vgpr-index-mode",         // force VGPR indexing on GFX8
-            "-filetype",                "-filetype=obj",   // target = obj, ELF binary; target = asm, ISA assembly text
+            // Name                                Option
+            "-gfxip",                              "-gfxip=8.0.0",
+            "-unroll-max-percent-threshold-boost", "-unroll-max-percent-threshold-boost=1000",
+            "-unroll-threshold",                   "-unroll-threshold=700",
+            "-unroll-partial-threshold",           "-unroll-partial-threshold=700",
+            "-pragma-unroll-threshold",            "-pragma-unroll-threshold=1000",
+            "-unroll-allow-partial",               "-unroll-allow-partial",
+            "-simplifycfg-sink-common",            "-simplifycfg-sink-common=false",
+            "-amdgpu-vgpr-index-mode",             "-amdgpu-vgpr-index-mode",         // force VGPR indexing on GFX8
+            "-filetype",                           "-filetype=obj",   // target = obj, ELF binary; target = asm, ISA assembly text
         };
 
         // Build new arguments, starting with those supplied in command line


### PR DESCRIPTION
Disabled the loop unrolling guidance pass in LLPC, and modified the
default unrolling options that are passed to LLVM.

The overall impact is expected to be fairly neutral, with performance
improving in some cases and degrading in others. However, this will
provide a better baseline for further unrolling changes.