### PR TITLE
Support dynamic index in interpolate functions

### DIFF
--- a/lower/llpcSpirvLowerGlobal.h
+++ b/lower/llpcSpirvLowerGlobal.h
@@ -121,6 +121,10 @@ private:
 
     void ReplaceConstWithInsts(Constant* const pConst);
 
+    void InterpolateInputElement(uint32_t           interpLoc,
+                                 llvm::Value*       pInterpInfo,
+                                 llvm::CallInst&    callInst);
+
     // -----------------------------------------------------------------------------------------------------------------
 
     std::unordered_map<llvm::Value*, llvm::Value*>  m_globalVarProxyMap;    // Proxy map for lowering global variables

--- a/test/shaderdb/OpExtInst_TestInterpolateDynIdx1DArray.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateDynIdx1DArray.frag
@@ -1,0 +1,30 @@
+#version 450 core
+
+#define ITER 4
+
+layout(location = 0) out vec4 frag_color;
+layout(location = 0) in flat int index;
+layout(location = 17) in vec4 interp[ITER];
+
+void main()
+{
+   frag_color = interpolateAtOffset(interp[index], vec2(0));
+}
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @_Z19interpolateAtOffsetPDv4_fDv2_f(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 17, i32 0, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 17, i32 1, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 17, i32 2, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 17, i32 3, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateDynIdx1DArrayInStruct.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateDynIdx1DArrayInStruct.frag
@@ -1,0 +1,44 @@
+#version 450 core
+
+#define ITER 5
+
+struct Struct_2
+{
+   float f1;
+   vec4 array[ITER];
+};
+struct Struct_1
+{
+   float f1;
+   Struct_2 s2;
+};
+
+layout(location = 0) out vec4 frag_color;
+layout(location = 0) in flat int index;
+layout(location = 1) in Struct_1 interp;
+
+void main()
+{
+    frag_color = interpolateAtOffset(interp.s2.array[index], vec2(0));
+}
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @_Z19interpolateAtOffsetPDv4_fDv2_f(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 3, i32 0, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 3, i32 1, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 3, i32 2, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 3, i32 3, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.interpolate.evalij.offset.v2f32(<2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 3, i32 4, i32 0, i32 0, <2 x float> %{{.*}})
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+


### PR DESCRIPTION
- InterpolateInputElement() is used to interpolate each element in the array to avoid relative addressing not working for interoplate functions.
- Covers all kinds of array cases: 1D  and multi-dimension array; The input can ba a vector/float array, a struct array and a struct with an array member.
- Shader tests are not supported by amdspv which are not added in this submission.