### PR TITLE
Builder tidy-up

### DIFF
--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -347,3 +347,33 @@ Context& Builder::getContext() const
 {
     return *static_cast<Llpc::Context*>(&IRBuilder<>::getContext());
 }
+
+// =====================================================================================================================
+// Get the type of pointer returned by CreateLoadBufferDesc.
+PointerType* Builder::GetBufferDescTy(
+    Type*         pPointeeTy)         // [in] Type that the returned pointer should point to.
+{
+    return PointerType::get(pPointeeTy, ADDR_SPACE_BUFFER_FAT_POINTER);
+}
+
+// =====================================================================================================================
+// Get the type returned by CreateLoadResourceDesc.
+VectorType* Builder::GetResourceDescTy()
+{
+    return VectorType::get(getInt32Ty(), 8);
+}
+
+// =====================================================================================================================
+// Get the type returned by CreateLoadTexelBufferDesc.
+VectorType* Builder::GetTexelBufferDescTy()
+{
+    return VectorType::get(getInt32Ty(), 4);
+}
+
+// =====================================================================================================================
+// Get the type returned by CreateLoadSamplerDesc.
+VectorType* Builder::GetSamplerDescTy()
+{
+    return VectorType::get(getInt32Ty(), 4);
+}
+

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -198,9 +198,8 @@ public:
         llvm::ArrayRef<llvm::Module*> modules);     // Array of modules indexed by shader stage, with nullptr entry
                                                     //  for any stage not present in the pipeline
 
-    //
-    // Methods implemented in BuilderImplDesc:
-    //
+    // -----------------------------------------------------------------------------------------------------------------
+    // Descriptor operations
 
     // Create a waterfall loop containing the specified instruction.
     // This does not use the current insert point; new code is inserted before and after pNonUniformInst.
@@ -209,6 +208,9 @@ public:
         llvm::ArrayRef<uint32_t>  operandIdxs,        // The operand index/indices for non-uniform inputs that need to
                                                       //  be uniform
         const llvm::Twine&        instName = "") = 0; // [in] Name to give instruction(s)
+
+    // Get the type of pointer returned by CreateLoadBufferDesc.
+    llvm::PointerType* GetBufferDescTy(llvm::Type* pPointeeTy);
 
     // Create a load of a buffer descriptor.
     virtual llvm::Value* CreateLoadBufferDesc(
@@ -219,6 +221,9 @@ public:
         llvm::Type*         pPointeeTy,         // [in] Type that the returned pointer should point to.
         const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
+    // Get the type of pointer returned by CreateLoadSamplerDesc.
+    llvm::VectorType* GetSamplerDescTy();
+
     // Create a load of a sampler descriptor. Returns a <4 x i32> descriptor.
     virtual llvm::Value* CreateLoadSamplerDesc(
         uint32_t            descSet,          // Descriptor set
@@ -228,6 +233,9 @@ public:
         const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 
+    // Get the type of pointer returned by CreateLoadResourceDesc and CreateLoadFmaskDesc.
+    llvm::VectorType* GetResourceDescTy();
+
     // Create a load of a resource descriptor. Returns a <8 x i32> descriptor.
     virtual llvm::Value* CreateLoadResourceDesc(
         uint32_t            descSet,          // Descriptor set
@@ -236,6 +244,9 @@ public:
         bool                isNonUniform,     // Whether the descriptor index is non-uniform
         const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
+
+    // Get the type of pointer returned by CreateLoadTexelBufferDesc.
+    llvm::VectorType* GetTexelBufferDescTy();
 
     // Create a load of a texel buffer descriptor. Returns a <4 x i32> descriptor.
     virtual llvm::Value* CreateLoadTexelBufferDesc(
@@ -266,18 +277,16 @@ public:
         llvm::Value* const  pBufferDesc,        // [in] The buffer descriptor to query.
         const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
-    //
-    // Methods implemented in BuilderImplMatrix:
-    //
+    // -----------------------------------------------------------------------------------------------------------------
+    // Matrix operations
 
     // Create a matrix transpose.
     virtual llvm::Value* CreateTransposeMatrix(
         llvm::Value* const pMatrix,            // [in] The matrix to transpose
         const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
-    //
-    // Methods implemented in BuilderImplMisc:
-    //
+    // -----------------------------------------------------------------------------------------------------------------
+    // Miscellaneous operations
 
     // Create a "kill". Only allowed in a fragment shader.
     virtual llvm::Instruction* CreateKill(
@@ -291,9 +300,8 @@ public:
     // Get the LLPC context. This overrides the IRBuilder method that gets the LLVM context.
     Llpc::Context& getContext() const;
 
-    //
-    // Methods implemented in BuilderImplSubgroup:
-    //
+    // -----------------------------------------------------------------------------------------------------------------
+    // Subgroup operations
 
     // Create a get subgroup size query.
     virtual llvm::Value* CreateGetSubgroupSize(
@@ -459,6 +467,8 @@ public:
     virtual llvm::Value* CreateSubgroupMbcnt(
         llvm::Value* const pMask,              // [in] The mask to mbcnt with.
         const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
+
+    // -----------------------------------------------------------------------------------------------------------------
 
 protected:
     Builder(llvm::LLVMContext& context);

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -67,7 +67,7 @@ public:
     // Create a waterfall loop containing the specified instruction.
     llvm::Instruction* CreateWaterfallLoop(llvm::Instruction*       pNonUniformInst,
                                            llvm::ArrayRef<uint32_t> operandIdxs,
-                                           const llvm::Twine&       instName) override final;
+                                           const llvm::Twine&       instName = "") override final;
 
     // Create a load of a buffer descriptor.
     llvm::Value* CreateLoadBufferDesc(uint32_t            descSet,
@@ -365,7 +365,10 @@ private:
 
 // =====================================================================================================================
 // The Builder implementation, encompassing all the individual builder implementation subclasses
-class BuilderImpl final : public BuilderImplDesc, public BuilderImplMatrix, public BuilderImplMisc, BuilderImplSubgroup
+class BuilderImpl final : public BuilderImplDesc,
+                                 BuilderImplMatrix,
+                                 BuilderImplMisc,
+                                 BuilderImplSubgroup
 {
 public:
     BuilderImpl(llvm::LLVMContext& context) : BuilderImplBase(context),

--- a/builder/llpcBuilderImplDesc.cpp
+++ b/builder/llpcBuilderImplDesc.cpp
@@ -223,7 +223,7 @@ Value* BuilderImplDesc::CreateLoadBufferDesc(
                                 Attribute::ReadNone,
                                 pInsertPos);
 
-    return CreateBitCast(pBufDescLoadCall, PointerType::get(pPointeeTy, ADDR_SPACE_BUFFER_FAT_POINTER));
+    return CreateBitCast(pBufDescLoadCall, GetBufferDescTy(pPointeeTy));
 }
 
 // =====================================================================================================================
@@ -242,7 +242,7 @@ Value* BuilderImplDesc::CreateLoadSamplerDesc(
     // look up the descSet/binding and generate the code directly.
     auto pSamplerDescLoadCall = EmitCall(pInsertPos->getModule(),
                                          LlpcName::DescriptorLoadSampler,
-                                         VectorType::get(getInt32Ty(), 4),
+                                         GetSamplerDescTy(),
                                          {
                                              getInt32(descSet),
                                              getInt32(binding),
@@ -271,7 +271,7 @@ Value* BuilderImplDesc::CreateLoadResourceDesc(
     // look up the descSet/binding and generate the code directly.
     auto pResDescLoadCall = EmitCall(pInsertPos->getModule(),
                                      LlpcName::DescriptorLoadResource,
-                                     VectorType::get(getInt32Ty(), 8),
+                                     GetResourceDescTy(),
                                      {
                                          getInt32(descSet),
                                          getInt32(binding),

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -179,6 +179,18 @@ Module* BuilderRecorder::Link(
 #endif
 
 // =====================================================================================================================
+// This is a BuilderRecorder. If it was created with wantReplay=true, create the BuilderReplayer pass.
+ModulePass* BuilderRecorder::CreateBuilderReplayer()
+{
+    if (m_wantReplay)
+    {
+        // Create a new BuilderImpl to replay the recorded Builder calls in.
+        return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(getContext()));
+    }
+    return nullptr;
+}
+
+// =====================================================================================================================
 // Create a "kill". Only allowed in a fragment shader.
 Instruction* BuilderRecorder::CreateKill(
     const Twine& instName)  // [in] Name to give final instruction
@@ -263,7 +275,7 @@ Value* BuilderRecorder::CreateLoadBufferDesc(
     const Twine&  instName)         // [in] Name to give instruction(s)
 {
     return Record(Opcode::LoadBufferDesc,
-                  PointerType::get(pPointeeTy, ADDR_SPACE_BUFFER_FAT_POINTER),
+                  GetBufferDescTy(pPointeeTy),
                   {
                       getInt32(descSet),
                       getInt32(binding),
@@ -283,7 +295,7 @@ Value* BuilderRecorder::CreateLoadSamplerDesc(
     const Twine&  instName)         // [in] Name to give instruction(s)
 {
     return Record(Opcode::LoadSamplerDesc,
-                  VectorType::get(getInt32Ty(), 4),
+                  GetSamplerDescTy(),
                   {
                       getInt32(descSet),
                       getInt32(binding),
@@ -303,7 +315,7 @@ Value* BuilderRecorder::CreateLoadResourceDesc(
     const Twine&  instName)         // [in] Name to give instruction(s)
 {
     return Record(Opcode::LoadResourceDesc,
-                  VectorType::get(getInt32Ty(), 8),
+                  GetResourceDescTy(),
                   {
                       getInt32(descSet),
                       getInt32(binding),
@@ -323,7 +335,7 @@ Value* BuilderRecorder::CreateLoadTexelBufferDesc(
     const Twine&  instName)         // [in] Name to give instruction(s)
 {
     return Record(Opcode::LoadTexelBufferDesc,
-                  VectorType::get(getInt32Ty(), 4),
+                  GetTexelBufferDescTy(),
                   {
                       getInt32(descSet),
                       getInt32(binding),
@@ -343,7 +355,7 @@ Value* BuilderRecorder::CreateLoadFmaskDesc(
     const Twine&  instName)         // [in] Name to give instruction(s)
 {
     return Record(Opcode::LoadFmaskDesc,
-                  VectorType::get(getInt32Ty(), 8),
+                  GetResourceDescTy(),
                   {
                       getInt32(descSet),
                       getInt32(binding),
@@ -682,18 +694,6 @@ Value* BuilderRecorder::CreateSubgroupMbcnt(
         const Twine& instName) // [in] Name to give instruction(s)
 {
     return Record(Opcode::SubgroupMbcnt, getInt32Ty(), pMask, instName);
-}
-
-// =====================================================================================================================
-// This is a BuilderRecorder. If it was created with wantReplay=true, create the BuilderReplayer pass.
-ModulePass* BuilderRecorder::CreateBuilderReplayer()
-{
-    if (m_wantReplay)
-    {
-        // Create a new BuilderImpl to replay the recorded Builder calls in.
-        return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(getContext()));
-    }
-    return nullptr;
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -132,9 +132,11 @@ public:
     llvm::Module* Link(llvm::ArrayRef<llvm::Module*> modules) override final;
 #endif
 
-    //
-    // Builder methods implemented in BuilderImplDesc
-    //
+    // If this is a BuilderRecorder created with wantReplay=true, create the BuilderReplayer pass.
+    llvm::ModulePass* CreateBuilderReplayer() override;
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Descriptor operations
 
     llvm::Instruction* CreateWaterfallLoop(llvm::Instruction*       pNonUniformInst,
                                            llvm::ArrayRef<uint32_t> operandIdxs,
@@ -176,9 +178,8 @@ public:
     llvm::Value* CreateGetBufferDescLength(llvm::Value* const pBufferDesc,
                                            const llvm::Twine& instName = "") override final;
 
-    //
-    // Builder methods implemented in BuilderImplMisc
-    //
+    // -----------------------------------------------------------------------------------------------------------------
+    // Miscellaneous operations
 
     llvm::Instruction* CreateKill(const llvm::Twine& instName = "") override final;
     llvm::Instruction* CreateReadClock(bool realtime, const llvm::Twine& instName = "") override final;
@@ -186,9 +187,8 @@ public:
     // Builder methods implemented in BuilderImplMatrix
     llvm::Value* CreateTransposeMatrix(llvm::Value* const pMatrix, const llvm::Twine& instName = "") override final;
 
-    //
-    // Builder methods implemented in BuilderImplSubgroup
-    //
+    // -----------------------------------------------------------------------------------------------------------------
+    // Subgroup operations
 
     llvm::Value* CreateGetSubgroupSize(const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupElect(const llvm::Twine& instName) override final;
@@ -265,9 +265,6 @@ public:
                                                const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupMbcnt(llvm::Value* const pMask,
                                      const llvm::Twine& instName ) override final;
-
-    // If this is a BuilderRecorder created with wantReplay=true, create the BuilderReplayer pass.
-    llvm::ModulePass* CreateBuilderReplayer() override;
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(BuilderRecorder)


### PR DESCRIPTION
1. Better formatting for comments in header files.
    
2. Introduced builder methods to return IR type of each descriptor type,
   for use both by client code and internally in BuilderRecorder.
    
Change-Id: I2826bf1efbbcce11ce90efcc73580d7e3ed634b8
