### PR TITLE
Separated descriptor load into three parts

### DIFF
--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -357,23 +357,62 @@ PointerType* Builder::GetBufferDescTy(
 }
 
 // =====================================================================================================================
-// Get the type returned by CreateLoadResourceDesc.
-VectorType* Builder::GetResourceDescTy()
+// Get the type of an image descriptor
+VectorType* Builder::GetImageDescTy()
 {
     return VectorType::get(getInt32Ty(), 8);
 }
 
 // =====================================================================================================================
-// Get the type returned by CreateLoadTexelBufferDesc.
+// Get the type of an fmask descriptor
+VectorType* Builder::GetFmaskDescTy()
+{
+    return VectorType::get(getInt32Ty(), 8);
+}
+
+// =====================================================================================================================
+// Get the type of a texel buffer descriptor
 VectorType* Builder::GetTexelBufferDescTy()
 {
     return VectorType::get(getInt32Ty(), 4);
 }
 
 // =====================================================================================================================
-// Get the type returned by CreateLoadSamplerDesc.
+// Get the type of a sampler descriptor
 VectorType* Builder::GetSamplerDescTy()
 {
     return VectorType::get(getInt32Ty(), 4);
+}
+
+// =====================================================================================================================
+// Get the type of pointer to image descriptor.
+// This is in fact a struct containing the pointer itself plus the stride in dwords.
+Type* Builder::GetImageDescPtrTy()
+{
+    return StructType::get(getContext(), { PointerType::get(GetImageDescTy(), ADDR_SPACE_CONST), getInt32Ty() });
+}
+
+// =====================================================================================================================
+// Get the type of pointer to fmask descriptor.
+// This is in fact a struct containing the pointer itself plus the stride in dwords.
+Type* Builder::GetFmaskDescPtrTy()
+{
+    return StructType::get(getContext(), { PointerType::get(GetFmaskDescTy(), ADDR_SPACE_CONST), getInt32Ty() });
+}
+
+// =====================================================================================================================
+// Get the type of pointer to texel buffer descriptor.
+// This is in fact a struct containing the pointer itself plus the stride in dwords.
+Type* Builder::GetTexelBufferDescPtrTy()
+{
+    return StructType::get(getContext(), { PointerType::get(GetTexelBufferDescTy(), ADDR_SPACE_CONST), getInt32Ty() });
+}
+
+// =====================================================================================================================
+// Get the type of pointer to sampler descriptor.
+// This is in fact a struct containing the pointer itself plus the stride in dwords.
+Type* Builder::GetSamplerDescPtrTy()
+{
+    return StructType::get(getContext(), { PointerType::get(GetSamplerDescTy(), ADDR_SPACE_CONST), getInt32Ty() });
 }
 

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -221,48 +221,82 @@ public:
         llvm::Type*         pPointeeTy,         // [in] Type that the returned pointer should point to.
         const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
-    // Get the type of pointer returned by CreateLoadSamplerDesc.
+    // Add index onto pointer to image/sampler/texelbuffer/fmask array of descriptors.
+    virtual llvm::Value* CreateIndexDescPtr(
+        llvm::Value*        pDescPtr,           // [in] Descriptor pointer, as returned by this function or one of
+                                                //    the CreateGet*DescPtr methods
+        llvm::Value*        pIndex,             // [in] Index value
+        bool                isNonUniform,       // Whether the descriptor index is non-uniform
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+
+    // Load image/sampler/texelbuffer/fmask descriptor from pointer.
+    // Returns <8 x i32> descriptor for image or fmask, or <4 x i32> descriptor for sampler or texel buffer.
+    virtual llvm::Value* CreateLoadDescFromPtr(
+        llvm::Value*        pDescPtr,           // [in] Descriptor pointer, as returned by CreateIndexDesc or one of
+                                                //    the CreateGet*DescPtr methods
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+
+    // Get the type of an image descriptor.
+    llvm::VectorType* GetImageDescTy();
+
+    // Get the type of an fmask descriptor.
+    llvm::VectorType* GetFmaskDescTy();
+
+    // Get the type of a sampler descriptor.
     llvm::VectorType* GetSamplerDescTy();
 
-    // Create a load of a sampler descriptor. Returns a <4 x i32> descriptor.
-    virtual llvm::Value* CreateLoadSamplerDesc(
-        uint32_t            descSet,          // Descriptor set
-        uint32_t            binding,          // Descriptor binding
-        llvm::Value*        pDescIndex,       // [in] Descriptor index
-        bool                isNonUniform,     // Whether the descriptor index is non-uniform
-        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
-    ) = 0;
-
-    // Get the type of pointer returned by CreateLoadResourceDesc and CreateLoadFmaskDesc.
-    llvm::VectorType* GetResourceDescTy();
-
-    // Create a load of a resource descriptor. Returns a <8 x i32> descriptor.
-    virtual llvm::Value* CreateLoadResourceDesc(
-        uint32_t            descSet,          // Descriptor set
-        uint32_t            binding,          // Descriptor binding
-        llvm::Value*        pDescIndex,       // [in] Descriptor index
-        bool                isNonUniform,     // Whether the descriptor index is non-uniform
-        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
-    ) = 0;
-
-    // Get the type of pointer returned by CreateLoadTexelBufferDesc.
+    // Get the type of a texel buffer descriptor.
     llvm::VectorType* GetTexelBufferDescTy();
 
-    // Create a load of a texel buffer descriptor. Returns a <4 x i32> descriptor.
-    virtual llvm::Value* CreateLoadTexelBufferDesc(
+    // Get the type of pointer to image or fmask descriptor, as returned by CreateGetImageDescPtr.
+    // The type is in fact a struct containing the actual pointer plus a stride in dwords.
+    // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
+    // set up the stride, and CreateIndexDescPtr will use it.
+    llvm::Type* GetImageDescPtrTy();
+
+    // Get the type of pointer to fmask descriptor, as returned by CreateGetFmaskDescPtr.
+    // The type is in fact a struct containing the actual pointer plus a stride in dwords.
+    // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
+    // set up the stride, and CreateIndexDescPtr will use it.
+    llvm::Type* GetFmaskDescPtrTy();
+
+    // Get the type of pointer to texel buffer descriptor, as returned by CreateGetTexelBufferDescPtr.
+    // The type is in fact a struct containing the actual pointer plus a stride in dwords.
+    // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
+    // set up the stride, and CreateIndexDescPtr will use it.
+    llvm::Type* GetTexelBufferDescPtrTy();
+
+    // Get the type of pointer to sampler descriptor, as returned by CreateGetSamplerDescPtr.
+    // The type is in fact a struct containing the actual pointer plus a stride in dwords.
+    // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
+    // set up the stride, and CreateIndexDescPtr will use it.
+    llvm::Type* GetSamplerDescPtrTy();
+
+    // Create a pointer to sampler descriptor. Returns a value of the type returned by GetSamplerDescPtrTy.
+    virtual llvm::Value* CreateGetSamplerDescPtr(
         uint32_t            descSet,          // Descriptor set
         uint32_t            binding,          // Descriptor binding
-        llvm::Value*        pDescIndex,       // [in] Descriptor index
-        bool                isNonUniform,     // Whether the descriptor index is non-uniform
         const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 
-    // Create a load of a F-mask descriptor. Returns a <8 x i32> descriptor.
-    virtual llvm::Value* CreateLoadFmaskDesc(
+    // Create a pointer to image descriptor. Returns a value of the type returned by GetImageDescPtrTy.
+    virtual llvm::Value* CreateGetImageDescPtr(
         uint32_t            descSet,          // Descriptor set
         uint32_t            binding,          // Descriptor binding
-        llvm::Value*        pDescIndex,       // [in] Descriptor index
-        bool                isNonUniform,     // Whether the descriptor index is non-uniform
+        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
+    ) = 0;
+
+    // Create a pointer to texel buffer descriptor. Returns a value of the type returned by GetTexelBufferDescPtrTy.
+    virtual llvm::Value* CreateGetTexelBufferDescPtr(
+        uint32_t            descSet,          // Descriptor set
+        uint32_t            binding,          // Descriptor binding
+        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
+    ) = 0;
+
+    // Create a load of a F-mask descriptor. Returns a value of the type returned by GetFmaskDescPtrTy.
+    virtual llvm::Value* CreateGetFmaskDescPtr(
+        uint32_t            descSet,          // Descriptor set
+        uint32_t            binding,          // Descriptor binding
         const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -82,33 +82,36 @@ public:
                                       llvm::Type*         pPointeeTy,
                                       const llvm::Twine&  instName) override final;
 
-    // Create a load of a sampler descriptor. Returns a <4 x i32> descriptor.
-    llvm::Value* CreateLoadSamplerDesc(uint32_t            descSet,
-                                       uint32_t            binding,
-                                       llvm::Value*        pDescIndex,
-                                       bool                isNonUniform,
+    // Add index onto pointer to image/sampler/texelbuffer/fmask array of descriptors.
+    llvm::Value* CreateIndexDescPtr(llvm::Value*        pDescPtr,
+                                    llvm::Value*        pIndex,
+                                    bool                isNonUniform,
+                                    const llvm::Twine&  instName) override final;
+
+    // Load image/sampler/texelbuffer/fmask descriptor from pointer.
+    llvm::Value* CreateLoadDescFromPtr(llvm::Value*        pDescPtr,
                                        const llvm::Twine&  instName) override final;
 
-    // Create a load of a resource descriptor. Returns a <8 x i32> descriptor.
-    llvm::Value* CreateLoadResourceDesc(uint32_t            descSet,
-                                        uint32_t            binding,
-                                        llvm::Value*        pDescIndex,
-                                        bool                isNonUniform,
-                                        const llvm::Twine&  instName) override final;
 
-    // Create a load of a texel buffer descriptor. Returns a <4 x i32> descriptor.
-    llvm::Value* CreateLoadTexelBufferDesc(uint32_t            descSet,
-                                           uint32_t            binding,
-                                           llvm::Value*        pDescIndex,
-                                           bool                isNonUniform,
-                                           const llvm::Twine&  instName) override final;
+    // Create a pointer to sampler descriptor. Returns a value of the type returned by GetSamplerDescPtrTy.
+    llvm::Value* CreateGetSamplerDescPtr(uint32_t            descSet,
+                                         uint32_t            binding,
+                                         const llvm::Twine&  instName) override final;
 
-    // Create a load of a F-mask descriptor. Returns a <8 x i32> descriptor.
-    llvm::Value* CreateLoadFmaskDesc(uint32_t            descSet,
-                                     uint32_t            binding,
-                                     llvm::Value*        pDescIndex,
-                                     bool                isNonUniform,
-                                     const llvm::Twine&  instName) override final;
+    // Create a pointer to image descriptor. Returns a value of the type returned by GetImageDescPtrTy.
+    llvm::Value* CreateGetImageDescPtr(uint32_t            descSet,
+                                       uint32_t            binding,
+                                       const llvm::Twine&  instName) override final;
+
+    // Create a pointer to texel buffer descriptor. Returns a value of the type returned by GetTexelBufferDescPtrTy.
+    llvm::Value* CreateGetTexelBufferDescPtr(uint32_t            descSet,
+                                             uint32_t            binding,
+                                             const llvm::Twine&  instName) override final;
+
+    // Create a pointer to fmask descriptor. Returns a value of the type returned by GetFmaskDescPtrTy.
+    llvm::Value* CreateGetFmaskDescPtr(uint32_t            descSet,
+                                       uint32_t            binding,
+                                       const llvm::Twine&  instName) override final;
 
     // Create a load of the push constants pointer.
     llvm::Value* CreateLoadPushConstantsPtr(llvm::Type*         pPushConstantsTy,

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -69,10 +69,12 @@ public:
         WaterfallLoop,
         WaterfallStoreLoop,
         LoadBufferDesc,
-        LoadSamplerDesc,
-        LoadResourceDesc,
-        LoadTexelBufferDesc,
-        LoadFmaskDesc,
+        IndexDescPtr,
+        LoadDescFromPtr,
+        GetSamplerDescPtr,
+        GetImageDescPtr,
+        GetTexelBufferDescPtr,
+        GetFmaskDescPtr,
         LoadPushConstantsPtr,
         GetBufferDescLength,
 
@@ -148,29 +150,29 @@ public:
                                       llvm::Type*         pPointeeTy,
                                       const llvm::Twine&  instName) override final;
 
-    llvm::Value* CreateLoadSamplerDesc(uint32_t            descSet,
-                                       uint32_t            binding,
-                                       llvm::Value*        pDescIndex,
-                                       bool                isNonUniform,
+    llvm::Value* CreateIndexDescPtr(llvm::Value*        pDescPtr,
+                                    llvm::Value*        pIndex,
+                                    bool                isNonUniform,
+                                    const llvm::Twine&  instName) override final;
+
+    llvm::Value* CreateLoadDescFromPtr(llvm::Value*        pDescPtr,
                                        const llvm::Twine&  instName) override final;
 
-    llvm::Value* CreateLoadResourceDesc(uint32_t            descSet,
-                                        uint32_t            binding,
-                                        llvm::Value*        pDescIndex,
-                                        bool                isNonUniform,
-                                        const llvm::Twine&  instName) override final;
+    llvm::Value* CreateGetSamplerDescPtr(uint32_t            descSet,
+                                         uint32_t            binding,
+                                         const llvm::Twine&  instName) override final;
 
-    llvm::Value* CreateLoadTexelBufferDesc(uint32_t            descSet,
-                                           uint32_t            binding,
-                                           llvm::Value*        pDescIndex,
-                                           bool                isNonUniform,
-                                           const llvm::Twine&  instName) override final;
+    llvm::Value* CreateGetImageDescPtr(uint32_t            descSet,
+                                       uint32_t            binding,
+                                       const llvm::Twine&  instName) override final;
 
-    llvm::Value* CreateLoadFmaskDesc(uint32_t            descSet,
-                                     uint32_t            binding,
-                                     llvm::Value*        pDescIndex,
-                                     bool                isNonUniform,
-                                     const llvm::Twine&  instName) override final;
+    llvm::Value* CreateGetTexelBufferDescPtr(uint32_t            descSet,
+                                             uint32_t            binding,
+                                             const llvm::Twine&  instName) override final;
+
+    llvm::Value* CreateGetFmaskDescPtr(uint32_t            descSet,
+                                       uint32_t            binding,
+                                       const llvm::Twine&  instName) override final;
 
     llvm::Value* CreateLoadPushConstantsPtr(llvm::Type*         pPushConstantsTy,
                                             const llvm::Twine&  instName) override final;

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -318,40 +318,40 @@ Value* BuilderReplayer::ProcessCall(
                       nullptr);                                // pPointeeTy
         }
 
-    case BuilderRecorder::Opcode::LoadSamplerDesc:
+    case BuilderRecorder::Opcode::IndexDescPtr:
         {
-            return m_pBuilder->CreateLoadSamplerDesc(
-                  cast<ConstantInt>(args[0])->getZExtValue(),  // descSet
-                  cast<ConstantInt>(args[1])->getZExtValue(),  // binding
-                  args[2],                                     // pDescIndex
-                  cast<ConstantInt>(args[3])->getZExtValue()); // isNonUniform
+            return m_pBuilder->CreateIndexDescPtr(args[0],                                      // pDescPtr
+                                                  args[1],                                      // pIndex
+                                                  cast<ConstantInt>(args[2])->getZExtValue());  // isNonUniform
         }
 
-    case BuilderRecorder::Opcode::LoadResourceDesc:
+    case BuilderRecorder::Opcode::LoadDescFromPtr:
         {
-            return m_pBuilder->CreateLoadResourceDesc(
-                  cast<ConstantInt>(args[0])->getZExtValue(),  // descSet
-                  cast<ConstantInt>(args[1])->getZExtValue(),  // binding
-                  args[2],                                     // pDescIndex
-                  cast<ConstantInt>(args[3])->getZExtValue()); // isNonUniform
+            return m_pBuilder->CreateLoadDescFromPtr(args[0]);
         }
 
-    case BuilderRecorder::Opcode::LoadTexelBufferDesc:
+    case BuilderRecorder::Opcode::GetSamplerDescPtr:
         {
-            return m_pBuilder->CreateLoadTexelBufferDesc(
-                  cast<ConstantInt>(args[0])->getZExtValue(),  // descSet
-                  cast<ConstantInt>(args[1])->getZExtValue(),  // binding
-                  args[2],                                     // pDescIndex
-                  cast<ConstantInt>(args[3])->getZExtValue()); // isNonUniform
+            return m_pBuilder->CreateGetSamplerDescPtr(cast<ConstantInt>(args[0])->getZExtValue(),   // descSet
+                                                       cast<ConstantInt>(args[1])->getZExtValue());  // binding
         }
 
-    case BuilderRecorder::Opcode::LoadFmaskDesc:
+    case BuilderRecorder::Opcode::GetImageDescPtr:
         {
-            return m_pBuilder->CreateLoadFmaskDesc(
-                  cast<ConstantInt>(args[0])->getZExtValue(),  // descSet
-                  cast<ConstantInt>(args[1])->getZExtValue(),  // binding
-                  args[2],                                     // pDescIndex
-                  cast<ConstantInt>(args[3])->getZExtValue()); // isNonUniform
+            return m_pBuilder->CreateGetImageDescPtr(cast<ConstantInt>(args[0])->getZExtValue(),   // descSet
+                                                     cast<ConstantInt>(args[1])->getZExtValue());  // binding
+        }
+
+    case BuilderRecorder::Opcode::GetFmaskDescPtr:
+        {
+            return m_pBuilder->CreateGetFmaskDescPtr(cast<ConstantInt>(args[0])->getZExtValue(),   // descSet
+                                                     cast<ConstantInt>(args[1])->getZExtValue());  // binding
+        }
+
+    case BuilderRecorder::Opcode::GetTexelBufferDescPtr:
+        {
+            return m_pBuilder->CreateGetTexelBufferDescPtr(cast<ConstantInt>(args[0])->getZExtValue(),   // descSet
+                                                           cast<ConstantInt>(args[1])->getZExtValue());  // binding
         }
 
     case BuilderRecorder::Opcode::LoadPushConstantsPtr:

--- a/lower/llpcSpirvLowerImageOp.cpp
+++ b/lower/llpcSpirvLowerImageOp.cpp
@@ -793,47 +793,33 @@ llvm::Value* SpirvLowerImageOp::LoadImageDescriptor(
         bool isNonUniform = IsNonUniformValue(pArrayIndex, checkedValues);
 
         m_pBuilder->SetInsertPoint(cast<Instruction>(pLoadInst));
+        uint32_t descSet = pDescSet->getZExtValue();
+        uint32_t binding = pBinding->getZExtValue();
 
         switch (descType)
         {
         case ResourceMappingNodeType::DescriptorSampler:
             {
                 pImageCallMeta->NonUniformSampler = isNonUniform ? 1 : 0;
-                pDesc = m_pBuilder->CreateLoadSamplerDesc(
-                    pDescSet->getZExtValue(),
-                    pBinding->getZExtValue(),
-                    pArrayIndex,
-                    isNonUniform);
+                pDesc = m_pBuilder->CreateGetSamplerDescPtr(descSet, binding);
                 break;
             }
         case ResourceMappingNodeType::DescriptorResource:
             {
                 pImageCallMeta->NonUniformResource = isNonUniform ? 1 : 0;
-                pDesc = m_pBuilder->CreateLoadResourceDesc(
-                    pDescSet->getZExtValue(),
-                    pBinding->getZExtValue(),
-                    pArrayIndex,
-                    isNonUniform);
+                pDesc = m_pBuilder->CreateGetImageDescPtr(descSet, binding);
                 break;
             }
         case ResourceMappingNodeType::DescriptorTexelBuffer:
             {
                 pImageCallMeta->NonUniformResource = isNonUniform ? 1 : 0;
-                pDesc = m_pBuilder->CreateLoadTexelBufferDesc(
-                    pDescSet->getZExtValue(),
-                    pBinding->getZExtValue(),
-                    pArrayIndex,
-                    isNonUniform);
+                pDesc = m_pBuilder->CreateGetTexelBufferDescPtr(descSet, binding);
                 break;
             }
         case ResourceMappingNodeType::DescriptorFmask:
             {
                 pImageCallMeta->NonUniformResource = isNonUniform ? 1 : 0;
-                pDesc = m_pBuilder->CreateLoadFmaskDesc(
-                    pDescSet->getZExtValue(),
-                    pBinding->getZExtValue(),
-                    pArrayIndex,
-                    isNonUniform);
+                pDesc = m_pBuilder->CreateGetFmaskDescPtr(descSet, binding);
                 break;
             }
         default:
@@ -841,6 +827,9 @@ llvm::Value* SpirvLowerImageOp::LoadImageDescriptor(
                 break;
             }
         }
+
+        pDesc = m_pBuilder->CreateIndexDescPtr(pDesc, pArrayIndex, isNonUniform);
+        pDesc = m_pBuilder->CreateLoadDescFromPtr(pDesc);
     }
     else
     {

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -121,8 +121,71 @@ bool PatchDescriptorLoad::runOnModule(
     }
     m_descLoadFuncs.clear();
 
+    // Remove dead llpc.descriptor.point* and llpc.descriptor.index calls that were not
+    // processed by the code above. That happens if they were never used in llpc.descriptor.load.from.ptr.
+    SmallVector<Function*, 4> deadDescFuncs;
+    for (Function& func : *m_pModule)
+    {
+        if (func.isDeclaration() && (func.getName().startswith(LlpcName::DescriptorGetPtrPrefix) ||
+                                     func.getName().startswith(LlpcName::DescriptorIndex)))
+        {
+            deadDescFuncs.push_back(&func);
+        }
+    }
+    for (Function* pFunc : deadDescFuncs)
+    {
+        while (pFunc->use_empty() == false)
+        {
+            pFunc->use_begin()->set(UndefValue::get(pFunc->getType()));
+        }
+        pFunc->eraseFromParent();
+    }
+
     m_pipelineSysValues.Clear();
     return m_changed;
+}
+
+// =====================================================================================================================
+// Process "llpc.descriptor.load.from.ptr" call.
+// Currently we assume that everything is inlined, so here we can trace the pointer back through any
+// "llpc.descriptor.index" calls back to an "llpc.descriptor.point.*" call.
+// In the future, we want to remove the assumption that everything is inlined. To do that, we will need to
+// do some internal rearrangement to the descriptor load code. That will probably happen at the same time
+// as moving descriptor load code up into the builder.
+void PatchDescriptorLoad::ProcessLoadDescFromPtr(
+    CallInst* pLoadFromPtr)   // [in] Call to llpc.descriptor.load.from.ptr
+{
+    m_pEntryPoint = pLoadFromPtr->getFunction();
+    IRBuilder<> builder(*m_pContext);
+    builder.SetInsertPoint(pLoadFromPtr);
+    Value* pIndex = builder.getInt32(0);
+
+    auto pLoadPtr = cast<CallInst>(pLoadFromPtr->getOperand(0));
+    while (pLoadPtr->getCalledFunction()->getName().startswith(LlpcName::DescriptorIndex))
+    {
+        pIndex = builder.CreateAdd(pIndex, pLoadPtr->getOperand(1));
+        pLoadPtr = cast<CallInst>(pLoadPtr->getOperand(0));
+    }
+
+    LLPC_ASSERT(pLoadPtr->getCalledFunction()->getName().startswith(LlpcName::DescriptorGetPtrPrefix));
+
+    uint32_t descSet = cast<ConstantInt>(pLoadPtr->getOperand(0))->getZExtValue();
+    uint32_t binding = cast<ConstantInt>(pLoadPtr->getOperand(1))->getZExtValue();
+    Value* pDesc = LoadDescriptor(*pLoadPtr, descSet, binding, pIndex, pLoadFromPtr);
+
+    pLoadFromPtr->replaceAllUsesWith(pDesc);
+
+    Instruction* pDeadInst = pLoadFromPtr;
+    while ((pDeadInst != nullptr) && pDeadInst->use_empty())
+    {
+        Instruction* pNextDeadInst = nullptr;
+        if ((isa<PHINode>(pDeadInst) == false) && (pDeadInst->getNumOperands() >= 1))
+        {
+            pNextDeadInst = dyn_cast<Instruction>(pDeadInst->getOperand(0));
+        }
+        pDeadInst->eraseFromParent();
+        pDeadInst = pNextDeadInst;
+    }
 }
 
 // =====================================================================================================================
@@ -136,40 +199,86 @@ void PatchDescriptorLoad::visitCallInst(
         return;
     }
 
-    auto mangledName = pCallee->getName();
+    StringRef mangledName = pCallee->getName();
 
     std::string descLoadPrefix = LlpcName::DescriptorLoadPrefix;
-    bool isDescLoad = (strncmp(mangledName.data(),descLoadPrefix.c_str(), descLoadPrefix.size()) == 0);
-
+    bool isDescLoad = mangledName.startswith(LlpcName::DescriptorLoadPrefix);
     if (isDescLoad == false)
     {
-        return; // Not descriptor load call
+        return; // Not descriptor load
+    }
+
+    if (mangledName.startswith(LlpcName::DescriptorGetPtrPrefix) ||
+        mangledName.startswith(LlpcName::DescriptorIndex))
+    {
+        // Ignore llpc.descriptor.point.* calls and llpc.descriptor.index calls, as they
+        // get processed at llpc.descriptor.load.from.ptr.
+        return;
+    }
+
+    if (mangledName.startswith(LlpcName::DescriptorLoadFromPtr))
+    {
+        ProcessLoadDescFromPtr(&callInst);
+        return;
     }
 
     // Descriptor loading should be inlined and stay in shader entry-point
     LLPC_ASSERT(callInst.getParent()->getParent() == m_pEntryPoint);
 
     m_changed = true;
+
+    // Create the descriptor load (unless the call has no uses).
+    if (callInst.use_empty() == false)
+    {
+        Value* pDesc = nullptr;
+        if (mangledName == LlpcName::DescriptorLoadSpillTable)
+        {
+            pDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetSpilledPushConstTablePtr(m_pPipelineState);
+        }
+        else
+        {
+            uint32_t descSet = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
+            uint32_t binding = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
+            Value* pArrayOffset = callInst.getOperand(2); // Offset for arrayed resource (index)
+            pDesc = LoadDescriptor(callInst, descSet, binding, pArrayOffset, &callInst);
+        }
+
+        // Replace the call with the loaded descriptor.
+        callInst.replaceAllUsesWith(pDesc);
+    }
+
+    m_descLoadCalls.push_back(&callInst);
+    m_descLoadFuncs.insert(pCallee);
+}
+
+// =====================================================================================================================
+// Generate the code for the descriptor load
+Value* PatchDescriptorLoad::LoadDescriptor(
+    CallInst&     callInst,       // [in] The llpc.descriptor.load.* or llpc.descriptor.point.* call being replaced
+    uint32_t      descSet,        // Descriptor set
+    uint32_t      binding,        // Binding
+    Value*        pArrayOffset,   // [in] Index in descriptor array
+    Instruction*  pInsertPoint)   // [in] Insert point
+{
+    StringRef mangledName = callInst.getCalledFunction()->getName();
     Type* pDescPtrTy = nullptr;
     ResourceMappingNodeType nodeType1 = ResourceMappingNodeType::Unknown;
     ResourceMappingNodeType nodeType2 = ResourceMappingNodeType::Unknown;
 
-    bool loadSpillTable = false;
-
     // TODO: The address space ID 2 is a magic number. We have to replace it with defined LLPC address space ID.
-    if (mangledName == LlpcName::DescriptorLoadResource)
+    if (mangledName == LlpcName::DescriptorGetResourcePtr)
     {
         pDescPtrTy = m_pContext->Int32x8Ty()->getPointerTo(ADDR_SPACE_CONST);
         nodeType1 = ResourceMappingNodeType::DescriptorResource;
         nodeType2 = nodeType1;
     }
-    else if (mangledName == LlpcName::DescriptorLoadSampler)
+    else if (mangledName == LlpcName::DescriptorGetSamplerPtr)
     {
         pDescPtrTy = m_pContext->Int32x4Ty()->getPointerTo(ADDR_SPACE_CONST);
         nodeType1 = ResourceMappingNodeType::DescriptorSampler;
         nodeType2 = nodeType1;
     }
-    else if (mangledName == LlpcName::DescriptorLoadFmask)
+    else if (mangledName == LlpcName::DescriptorGetFmaskPtr)
     {
         pDescPtrTy = m_pContext->Int32x8Ty()->getPointerTo(ADDR_SPACE_CONST);
         nodeType1 = ResourceMappingNodeType::DescriptorFmask;
@@ -186,380 +295,351 @@ void PatchDescriptorLoad::visitCallInst(
         nodeType1 = ResourceMappingNodeType::PushConst;
         nodeType2 = nodeType1;
     }
-    else if (mangledName == LlpcName::DescriptorLoadTexelBuffer)
+    else if (mangledName == LlpcName::DescriptorGetTexelBufferPtr)
     {
         pDescPtrTy = m_pContext->Int32x4Ty()->getPointerTo(ADDR_SPACE_CONST);
         nodeType1 = ResourceMappingNodeType::DescriptorTexelBuffer;
         nodeType2 = nodeType1;
-    }
-    else if (mangledName == LlpcName::DescriptorLoadSpillTable)
-    {
-        loadSpillTable = true;
     }
     else
     {
         LLPC_NEVER_CALLED();
     }
 
-    if (loadSpillTable)
+    LLPC_ASSERT(nodeType1 != ResourceMappingNodeType::Unknown);
+
+    // Calculate descriptor offset (in bytes)
+    uint32_t descOffset = 0;
+    uint32_t descSize   = 0;
+    uint32_t dynDescIdx = InvalidValue;
+    Value*   pDesc = nullptr;
+    Constant* pDescRangeValue = nullptr;
+
+    if (nodeType1 == ResourceMappingNodeType::DescriptorSampler)
     {
-        // Do not do this if the llpc.descriptor.load.spilltable is unused, as no spill table pointer has
-        // been set up in PatchEntryPointMutate. That happens if PatchPushConst has unspilled all push constants.
-        if (callInst.use_empty() == false)
-        {
-            auto pSpilledPushConstTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->
-                                                GetSpilledPushConstTablePtr(m_pPipelineState);
-            callInst.replaceAllUsesWith(pSpilledPushConstTablePtr);
-        }
-        m_descLoadCalls.push_back(&callInst);
-        m_descLoadFuncs.insert(pCallee);
+        pDescRangeValue = GetDescriptorRangeValue(nodeType1, descSet, binding);
     }
-    else
+
+    if (pDescRangeValue != nullptr)
     {
-        LLPC_ASSERT(nodeType1 != ResourceMappingNodeType::Unknown);
+        // Descriptor range value (immutable sampler in Vulkan). pDescRangeValue is a constant array of
+        // <4 x i32> descriptors.
+        IRBuilder<> builder(*m_pContext);
+        builder.SetInsertPoint(pInsertPoint);
 
-        // Calculate descriptor offset (in bytes)
-        auto pDescSet = cast<ConstantInt>(callInst.getOperand(0));
-        auto pBinding = cast<ConstantInt>(callInst.getOperand(1));
-        auto pArrayOffset = callInst.getOperand(2); // Offset for arrayed resource (index)
-
-        uint32_t descOffset = 0;
-        uint32_t descSize   = 0;
-        uint32_t dynDescIdx = InvalidValue;
-        Value*   pDesc = nullptr;
-        Constant* pDescRangeValue = nullptr;
-        if (nodeType1 == ResourceMappingNodeType::DescriptorSampler)
+        if (pDescRangeValue->getType()->getArrayNumElements() == 1)
         {
-            pDescRangeValue = GetDescriptorRangeValue(nodeType1, pDescSet->getZExtValue(), pBinding->getZExtValue());
+            // Immutable descriptor array is size 1, so we can assume index 0.
+            pDesc = builder.CreateExtractValue(pDescRangeValue, 0);
+        }
+        else if (auto pConstArrayOffset = dyn_cast<ConstantInt>(pArrayOffset))
+        {
+            // Array index is constant.
+            uint32_t index = pConstArrayOffset->getZExtValue();
+            pDesc = builder.CreateExtractValue(pDescRangeValue, {index});
+        }
+        else
+        {
+            // Array index is variable.
+            GlobalVariable* pDescs = new GlobalVariable(*m_pModule,
+                                                        pDescRangeValue->getType(),
+                                                        true, // isConstant
+                                                        GlobalValue::InternalLinkage,
+                                                        pDescRangeValue,
+                                                        "",
+                                                        nullptr,
+                                                        GlobalValue::NotThreadLocal,
+                                                        ADDR_SPACE_CONST);
+
+            auto pDescPtr = builder.CreateGEP(pDescs, {builder.getInt32(0), pArrayOffset});
+            pDesc = builder.CreateLoad(pDescPtr);
+        }
+    }
+
+    if (pDesc == nullptr)
+    {
+        auto foundNodeType = CalcDescriptorOffsetAndSize(nodeType1,
+                                                         nodeType2,
+                                                         descSet,
+                                                         binding,
+                                                         &descOffset,
+                                                         &descSize,
+                                                         &dynDescIdx);
+        if (foundNodeType == ResourceMappingNodeType::PushConst)
+        {
+            // Handle the case of an inline const node when we were expecting a buffer descriptor.
+            nodeType1 = foundNodeType;
         }
 
-        if (pDescRangeValue != nullptr)
+        uint32_t descSizeInDword = descSize / sizeof(uint32_t);
+        if (dynDescIdx != InvalidValue)
         {
-            // Descriptor range value (immutable sampler in Vulkan). pDescRangeValue is a constant array of
-            // <4 x i32> descriptors.
-            IRBuilder<> builder(*m_pContext);
-            builder.SetInsertPoint(&callInst);
-
-            if (pDescRangeValue->getType()->getArrayNumElements() == 1)
+            // Dynamic descriptors
+            pDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetDynamicDesc(m_pPipelineState, dynDescIdx);
+            if (pDesc != nullptr)
             {
-                // Immutable descriptor array is size 1, so we can assume index 0.
-                pDesc = builder.CreateExtractValue(pDescRangeValue, 0);
-            }
-            else if (auto pConstArrayOffset = dyn_cast<ConstantInt>(pArrayOffset))
-            {
-                // Array index is constant.
-                uint32_t index = pConstArrayOffset->getZExtValue();
-                pDesc = builder.CreateExtractValue(pDescRangeValue, {index});
-            }
-            else
-            {
-                // Array index is variable.
-                GlobalVariable* pDescs = new GlobalVariable(*m_pModule,
-                                                            pDescRangeValue->getType(),
-                                                            true, // isConstant
-                                                            GlobalValue::InternalLinkage,
-                                                            pDescRangeValue,
-                                                            "",
-                                                            nullptr,
-                                                            GlobalValue::NotThreadLocal,
-                                                            ADDR_SPACE_CONST);
-
-                auto pDescPtr = builder.CreateGEP(pDescs, {builder.getInt32(0), pArrayOffset});
-                pDesc = builder.CreateLoad(pDescPtr);
-            }
-        }
-
-        if (pDesc == nullptr)
-        {
-            auto foundNodeType = CalcDescriptorOffsetAndSize(nodeType1,
-                                                             nodeType2,
-                                                             pDescSet->getZExtValue(),
-                                                             pBinding->getZExtValue(),
-                                                             &descOffset,
-                                                             &descSize,
-                                                             &dynDescIdx);
-            if (foundNodeType == ResourceMappingNodeType::PushConst)
-            {
-                // Handle the case of an inline const node when we were expecting a buffer descriptor.
-                nodeType1 = foundNodeType;
-            }
-
-            uint32_t descSizeInDword = descSize / sizeof(uint32_t);
-            if (dynDescIdx != InvalidValue)
-            {
-                // Dynamic descriptors
-                pDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetDynamicDesc(m_pPipelineState, dynDescIdx);
-                if (pDesc != nullptr)
+                auto pDescTy = VectorType::get(m_pContext->Int32Ty(), descSizeInDword);
+                if (pDesc->getType() != pDescTy)
                 {
-                    auto pDescTy = VectorType::get(m_pContext->Int32Ty(), descSizeInDword);
-                    if (pDesc->getType() != pDescTy)
+                    // Array dynamic descriptor
+                    Value* pDynDesc = UndefValue::get(pDescTy);
+                    auto pDescStride = ConstantInt::get(m_pContext->Int32Ty(), descSizeInDword);
+                    auto pIndex = BinaryOperator::CreateMul(pArrayOffset, pDescStride, "", pInsertPoint);
+                    for (uint32_t i = 0; i < descSizeInDword; ++i)
                     {
-                        // Array dynamic descriptor
-                        Value* pDynDesc = UndefValue::get(pDescTy);
-                        auto pDescStride = ConstantInt::get(m_pContext->Int32Ty(), descSizeInDword);
-                        auto pIndex = BinaryOperator::CreateMul(pArrayOffset, pDescStride, "", &callInst);
-                        for (uint32_t i = 0; i < descSizeInDword; ++i)
-                        {
-                            auto pDescElem = ExtractElementInst::Create(pDesc, pIndex, "", &callInst);
-                            pDynDesc = InsertElementInst::Create(pDynDesc,
-                                                                 pDescElem,
-                                                                 ConstantInt::get(m_pContext->Int32Ty(), i),
-                                                                 "",
-                                                                 &callInst);
-                            pIndex = BinaryOperator::CreateAdd(pIndex,
-                                                               ConstantInt::get(m_pContext->Int32Ty(), 1),
-                                                               "",
-                                                               &callInst);
-                        }
-                        pDesc = pDynDesc;
+                        auto pDescElem = ExtractElementInst::Create(pDesc, pIndex, "", pInsertPoint);
+                        pDynDesc = InsertElementInst::Create(pDynDesc,
+                                                             pDescElem,
+                                                             ConstantInt::get(m_pContext->Int32Ty(), i),
+                                                             "",
+                                                             pInsertPoint);
+                        pIndex = BinaryOperator::CreateAdd(pIndex,
+                                                           ConstantInt::get(m_pContext->Int32Ty(), 1),
+                                                           "",
+                                                           pInsertPoint);
                     }
+                    pDesc = pDynDesc;
+                }
 
+                // Extract compact buffer descriptor
+                if (descSizeInDword == DescriptorSizeBufferCompact / sizeof(uint32_t))
+                {
                     // Extract compact buffer descriptor
-                    if (descSizeInDword == DescriptorSizeBufferCompact / sizeof(uint32_t))
-                    {
-                        // Extract compact buffer descriptor
-                        Value* pDescElem0 = ExtractElementInst::Create(pDesc,
-                            ConstantInt::get(m_pContext->Int32Ty(), 0),
-                            "",
-                            &callInst);
-
-                        Value* pDescElem1 = ExtractElementInst::Create(pDesc,
-                            ConstantInt::get(m_pContext->Int32Ty(), 1),
-                            "",
-                            &callInst);
-
-                        // Build normal buffer descriptor
-                        auto pBufDescTy = m_pContext->Int32x4Ty();
-                        Value* pBufDesc = UndefValue::get(pBufDescTy);
-
-                        // DWORD0
-                        pBufDesc = InsertElementInst::Create(pBufDesc,
-                            pDescElem0,
-                            ConstantInt::get(m_pContext->Int32Ty(), 0),
-                            "",
-                            &callInst);
-
-                        // DWORD1
-                        SqBufRsrcWord1 sqBufRsrcWord1 = {};
-                        sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
-
-                        pDescElem1 = BinaryOperator::CreateAnd(pDescElem1,
-                            ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord1.u32All),
-                            "",
-                            &callInst);
-                        pBufDesc = InsertElementInst::Create(pBufDesc,
-                            pDescElem1,
-                            ConstantInt::get(m_pContext->Int32Ty(), 1),
-                            "",
-                            &callInst);
-
-                        // DWORD2
-                        SqBufRsrcWord2 sqBufRsrcWord2 = {};
-                        sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
-
-                        pBufDesc = InsertElementInst::Create(pBufDesc,
-                            ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord2.u32All),
-                            ConstantInt::get(m_pContext->Int32Ty(), 2),
-                            "",
-                            &callInst);
-
-                        // DWORD3
-#if LLPC_BUILD_GFX10
-                        const GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
-                        if (gfxIp.major < 10)
-#endif
-                        {
-                            SqBufRsrcWord3 sqBufRsrcWord3 = {};
-                            sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
-                            sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
-                            sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
-                            sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
-                            sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
-                            sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
-                            LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
-
-                            pBufDesc = InsertElementInst::Create(pBufDesc,
-                                ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
-                                ConstantInt::get(m_pContext->Int32Ty(), 3),
-                                "",
-                                &callInst);
-                        }
-#if LLPC_BUILD_GFX10
-                        else if (gfxIp.major == 10)
-                        {
-                            SqBufRsrcWord3 sqBufRsrcWord3 = {};
-                            sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
-                            sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
-                            sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
-                            sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
-                            sqBufRsrcWord3.gfx10.FORMAT = BUF_FORMAT_32_UINT;
-                            sqBufRsrcWord3.gfx10.RESOURCE_LEVEL = 1;
-                            sqBufRsrcWord3.gfx10.OOB_SELECT = 2;
-                            LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x21014FAC);
-
-                            pBufDesc = InsertElementInst::Create(pBufDesc,
-                                ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
-                                ConstantInt::get(m_pContext->Int32Ty(), 3),
-                                "",
-                                &callInst);
-                        }
-                        else
-                        {
-                            LLPC_NOT_IMPLEMENTED();
-                        }
-#endif
-
-                        pDesc = pBufDesc;
-                    }
-
-                }
-                else
-                {
-                    LLPC_NEVER_CALLED();
-                }
-            }
-            else if (nodeType1 == ResourceMappingNodeType::PushConst)
-            {
-                auto pDescTablePtr =
-                    m_pipelineSysValues.Get(m_pEntryPoint)->GetDescTablePtr(m_pPipelineState, pDescSet->getZExtValue());
-
-                Value* pDescTableAddr = new PtrToIntInst(pDescTablePtr,
-                                                         m_pContext->Int64Ty(),
-                                                         "",
-                                                         &callInst);
-
-                pDescTableAddr = new BitCastInst(pDescTableAddr, m_pContext->Int32x2Ty(), "", &callInst);
-
-                // Extract descriptor table address
-                Value* pDescElem0 = ExtractElementInst::Create(pDescTableAddr,
-                    ConstantInt::get(m_pContext->Int32Ty(), 0),
-                    "",
-                    &callInst);
-
-                auto pDescOffset = ConstantInt::get(m_pContext->Int32Ty(), descOffset);
-
-                pDescElem0 = BinaryOperator::CreateAdd(pDescElem0, pDescOffset, "", &callInst);
-
-                if (pDescPtrTy == nullptr)
-                {
-                    // Load the address of inline constant buffer
-                    pDesc = InsertElementInst::Create(pDescTableAddr,
-                        pDescElem0,
+                    Value* pDescElem0 = ExtractElementInst::Create(pDesc,
                         ConstantInt::get(m_pContext->Int32Ty(), 0),
                         "",
-                        &callInst);
-                }
-                else
-                {
-                    // Build buffer descriptor from inline constant buffer address
-                    SqBufRsrcWord1 sqBufRsrcWord1 = {};
-                    SqBufRsrcWord2 sqBufRsrcWord2 = {};
-                    SqBufRsrcWord3 sqBufRsrcWord3 = {};
+                        pInsertPoint);
 
-                    sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
-                    sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
-
-                    sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
-                    sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
-                    sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
-                    sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
-                    sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
-                    sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
-                    LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
-
-                    Value* pDescElem1 = ExtractElementInst::Create(pDescTableAddr,
+                    Value* pDescElem1 = ExtractElementInst::Create(pDesc,
                         ConstantInt::get(m_pContext->Int32Ty(), 1),
                         "",
-                        &callInst);
+                        pInsertPoint);
 
+                    // Build normal buffer descriptor
                     auto pBufDescTy = m_pContext->Int32x4Ty();
-                    pDesc = UndefValue::get(pBufDescTy);
+                    Value* pBufDesc = UndefValue::get(pBufDescTy);
 
                     // DWORD0
-                    pDesc = InsertElementInst::Create(pDesc,
+                    pBufDesc = InsertElementInst::Create(pBufDesc,
                         pDescElem0,
                         ConstantInt::get(m_pContext->Int32Ty(), 0),
                         "",
-                        &callInst);
+                        pInsertPoint);
 
                     // DWORD1
+                    SqBufRsrcWord1 sqBufRsrcWord1 = {};
+                    sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
+
                     pDescElem1 = BinaryOperator::CreateAnd(pDescElem1,
                         ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord1.u32All),
                         "",
-                        &callInst);
-                    pDesc = InsertElementInst::Create(pDesc,
+                        pInsertPoint);
+                    pBufDesc = InsertElementInst::Create(pBufDesc,
                         pDescElem1,
                         ConstantInt::get(m_pContext->Int32Ty(), 1),
                         "",
-                        &callInst);
+                        pInsertPoint);
 
                     // DWORD2
-                    pDesc = InsertElementInst::Create(pDesc,
+                    SqBufRsrcWord2 sqBufRsrcWord2 = {};
+                    sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
+
+                    pBufDesc = InsertElementInst::Create(pBufDesc,
                         ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord2.u32All),
                         ConstantInt::get(m_pContext->Int32Ty(), 2),
                         "",
-                        &callInst);
+                        pInsertPoint);
 
                     // DWORD3
-                    pDesc = InsertElementInst::Create(pDesc,
-                        ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
-                        ConstantInt::get(m_pContext->Int32Ty(), 3),
-                        "",
-                        &callInst);
+#if LLPC_BUILD_GFX10
+                    const GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
+                    if (gfxIp.major < 10)
+#endif
+                    {
+                        SqBufRsrcWord3 sqBufRsrcWord3 = {};
+                        sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+                        sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+                        sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+                        sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+                        sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
+                        sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
+                        LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
+
+                        pBufDesc = InsertElementInst::Create(pBufDesc,
+                            ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
+                            ConstantInt::get(m_pContext->Int32Ty(), 3),
+                            "",
+                            &callInst);
+                    }
+#if LLPC_BUILD_GFX10
+                    else if (gfxIp.major == 10)
+                    {
+                        SqBufRsrcWord3 sqBufRsrcWord3 = {};
+                        sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+                        sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+                        sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+                        sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+                        sqBufRsrcWord3.gfx10.FORMAT = BUF_FORMAT_32_UINT;
+                        sqBufRsrcWord3.gfx10.RESOURCE_LEVEL = 1;
+                        sqBufRsrcWord3.gfx10.OOB_SELECT = 2;
+                        LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x21014FAC);
+
+                        pBufDesc = InsertElementInst::Create(pBufDesc,
+                            ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
+                            ConstantInt::get(m_pContext->Int32Ty(), 3),
+                            "",
+                            &callInst);
+                    }
+                    else
+                    {
+                        LLPC_NOT_IMPLEMENTED();
+                    }
+#endif
+
+                    pDesc = pBufDesc;
                 }
+
             }
             else
             {
-                auto pDescOffset = ConstantInt::get(m_pContext->Int32Ty(), descOffset);
-                auto pDescSize   = ConstantInt::get(m_pContext->Int32Ty(), descSize, 0);
-
-                Value* pOffset = BinaryOperator::CreateMul(pArrayOffset, pDescSize, "", &callInst);
-                pOffset = BinaryOperator::CreateAdd(pOffset, pDescOffset, "", &callInst);
-
-                pOffset = CastInst::CreateZExtOrBitCast(pOffset, m_pContext->Int64Ty(), "", &callInst);
-
-                // Get descriptor address
-                std::vector<Value*> idxs;
-                idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), 0, false));
-                idxs.push_back(pOffset);
-
-                Value* pDescTablePtr = nullptr;
-                uint32_t descSet = pDescSet->getZExtValue();
-
-                if (descSet == InternalResourceTable)
-                {
-                    pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalGlobalTablePtr();
-                }
-                else if (descSet == InternalPerShaderTable)
-                {
-                    pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalPerShaderTablePtr();
-                }
-                else if ((cl::EnableShadowDescriptorTable) && (nodeType1 == ResourceMappingNodeType::DescriptorFmask))
-                {
-                    pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->
-                                      GetShadowDescTablePtr(m_pPipelineState, descSet);
-                }
-                else
-                {
-                    pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetDescTablePtr(m_pPipelineState, descSet);
-                }
-                auto pDescPtr = GetElementPtrInst::Create(nullptr, pDescTablePtr, idxs, "", &callInst);
-                auto pCastedDescPtr = CastInst::Create(Instruction::BitCast, pDescPtr, pDescPtrTy, "", &callInst);
-
-                // Load descriptor
-                pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
-                pDesc = new LoadInst(pCastedDescPtr, "", &callInst);
-                cast<LoadInst>(pDesc)->setAlignment(16);
+                LLPC_NEVER_CALLED();
             }
         }
-
-        if (pDesc != nullptr)
+        else if (nodeType1 == ResourceMappingNodeType::PushConst)
         {
-            callInst.replaceAllUsesWith(pDesc);
-            m_descLoadCalls.push_back(&callInst);
-            m_descLoadFuncs.insert(pCallee);
+            auto pDescTablePtr =
+                m_pipelineSysValues.Get(m_pEntryPoint)->GetDescTablePtr(m_pPipelineState, descSet);
+
+            Value* pDescTableAddr = new PtrToIntInst(pDescTablePtr,
+                                                     m_pContext->Int64Ty(),
+                                                     "",
+                                                     pInsertPoint);
+
+            pDescTableAddr = new BitCastInst(pDescTableAddr, m_pContext->Int32x2Ty(), "", pInsertPoint);
+
+            // Extract descriptor table address
+            Value* pDescElem0 = ExtractElementInst::Create(pDescTableAddr,
+                ConstantInt::get(m_pContext->Int32Ty(), 0),
+                "",
+                pInsertPoint);
+
+            auto pDescOffset = ConstantInt::get(m_pContext->Int32Ty(), descOffset);
+
+            pDescElem0 = BinaryOperator::CreateAdd(pDescElem0, pDescOffset, "", pInsertPoint);
+
+            if (pDescPtrTy == nullptr)
+            {
+                // Load the address of inline constant buffer
+                pDesc = InsertElementInst::Create(pDescTableAddr,
+                    pDescElem0,
+                    ConstantInt::get(m_pContext->Int32Ty(), 0),
+                    "",
+                    pInsertPoint);
+            }
+            else
+            {
+                // Build buffer descriptor from inline constant buffer address
+                SqBufRsrcWord1 sqBufRsrcWord1 = {};
+                SqBufRsrcWord2 sqBufRsrcWord2 = {};
+                SqBufRsrcWord3 sqBufRsrcWord3 = {};
+
+                sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
+                sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
+
+                sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+                sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+                sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+                sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+                sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
+                sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
+                LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
+
+                Value* pDescElem1 = ExtractElementInst::Create(pDescTableAddr,
+                    ConstantInt::get(m_pContext->Int32Ty(), 1),
+                    "",
+                    pInsertPoint);
+
+                auto pBufDescTy = m_pContext->Int32x4Ty();
+                pDesc = UndefValue::get(pBufDescTy);
+
+                // DWORD0
+                pDesc = InsertElementInst::Create(pDesc,
+                    pDescElem0,
+                    ConstantInt::get(m_pContext->Int32Ty(), 0),
+                    "",
+                    pInsertPoint);
+
+                // DWORD1
+                pDescElem1 = BinaryOperator::CreateAnd(pDescElem1,
+                    ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord1.u32All),
+                    "",
+                    pInsertPoint);
+                pDesc = InsertElementInst::Create(pDesc,
+                    pDescElem1,
+                    ConstantInt::get(m_pContext->Int32Ty(), 1),
+                    "",
+                    pInsertPoint);
+
+                // DWORD2
+                pDesc = InsertElementInst::Create(pDesc,
+                    ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord2.u32All),
+                    ConstantInt::get(m_pContext->Int32Ty(), 2),
+                    "",
+                    pInsertPoint);
+
+                // DWORD3
+                pDesc = InsertElementInst::Create(pDesc,
+                    ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
+                    ConstantInt::get(m_pContext->Int32Ty(), 3),
+                    "",
+                    pInsertPoint);
+            }
+        }
+        else
+        {
+            auto pDescOffset = ConstantInt::get(m_pContext->Int32Ty(), descOffset);
+            auto pDescSize   = ConstantInt::get(m_pContext->Int32Ty(), descSize, 0);
+
+            Value* pOffset = BinaryOperator::CreateMul(pArrayOffset, pDescSize, "", pInsertPoint);
+            pOffset = BinaryOperator::CreateAdd(pOffset, pDescOffset, "", pInsertPoint);
+
+            pOffset = CastInst::CreateZExtOrBitCast(pOffset, m_pContext->Int64Ty(), "", pInsertPoint);
+
+            // Get descriptor address
+            std::vector<Value*> idxs;
+            idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), 0, false));
+            idxs.push_back(pOffset);
+
+            Value* pDescTablePtr = nullptr;
+
+            if (descSet == InternalResourceTable)
+            {
+                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalGlobalTablePtr();
+            }
+            else if (descSet == InternalPerShaderTable)
+            {
+                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalPerShaderTablePtr();
+            }
+            else if ((cl::EnableShadowDescriptorTable) && (nodeType1 == ResourceMappingNodeType::DescriptorFmask))
+            {
+                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->
+                                  GetShadowDescTablePtr(m_pPipelineState, descSet);
+            }
+            else
+            {
+                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetDescTablePtr(m_pPipelineState, descSet);
+            }
+            auto pDescPtr = GetElementPtrInst::Create(nullptr, pDescTablePtr, idxs, "", pInsertPoint);
+            auto pCastedDescPtr = CastInst::Create(Instruction::BitCast, pDescPtr, pDescPtrTy, "", pInsertPoint);
+
+            // Load descriptor
+            pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
+            pDesc = new LoadInst(pCastedDescPtr, "", pInsertPoint);
+            cast<LoadInst>(pDesc)->setAlignment(16);
         }
     }
+
+    return pDesc;
 }
 
 // =====================================================================================================================

--- a/patch/llpcPatchDescriptorLoad.h
+++ b/patch/llpcPatchDescriptorLoad.h
@@ -67,6 +67,14 @@ public:
 private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(PatchDescriptorLoad);
 
+    void ProcessLoadDescFromPtr(llvm::CallInst* pLoadFromPtr);
+
+    llvm::Value* LoadDescriptor(llvm::CallInst&     callInst,
+                                uint32_t            descSet,
+                                uint32_t            binding,
+                                llvm::Value*        pArrayOffset,
+                                llvm::Instruction*  pInsertPoint);
+
     ResourceMappingNodeType CalcDescriptorOffsetAndSize(ResourceMappingNodeType   nodeType1,
                                                         ResourceMappingNodeType   nodeType2,
                                                         uint32_t                  descSet,
@@ -91,7 +99,7 @@ private:
 
     bool                                m_changed;            // Whether the pass has modified the code
     PipelineSystemValues                m_pipelineSysValues;  // Cache of ShaderValues object per shader
-    std::vector<llvm::CallInst*>        m_descLoadCalls;      // List of "call" instructions to load descriptors
+    std::vector<llvm::CallInst*>        m_descLoadCalls;      // List of instructions to load descriptors
     std::unordered_set<llvm::Function*> m_descLoadFuncs;      // Set of descriptor load functions
 
     // Map from descriptor range value to global variables modeling related descriptors (act as immediate constants)

--- a/patch/llpcPatchResourceCollect.cpp
+++ b/patch/llpcPatchResourceCollect.cpp
@@ -201,10 +201,10 @@ void PatchResourceCollect::visitCallInst(
         }
     }
     else if (mangledName.startswith(LlpcName::DescriptorLoadBuffer) ||
-             mangledName.startswith(LlpcName::DescriptorLoadTexelBuffer) ||
-             mangledName.startswith(LlpcName::DescriptorLoadResource) ||
-             mangledName.startswith(LlpcName::DescriptorLoadFmask) ||
-             mangledName.startswith(LlpcName::DescriptorLoadSampler))
+             mangledName.startswith(LlpcName::DescriptorGetTexelBufferPtr) ||
+             mangledName.startswith(LlpcName::DescriptorGetResourcePtr) ||
+             mangledName.startswith(LlpcName::DescriptorGetFmaskPtr) ||
+             mangledName.startswith(LlpcName::DescriptorGetSamplerPtr))
     {
         uint32_t descSet = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
         uint32_t binding = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();

--- a/patch/llpcSystemValues.cpp
+++ b/patch/llpcSystemValues.cpp
@@ -841,7 +841,6 @@ Instruction* ShaderSystemValues::LoadDescFromDriverTable(
         ConstantInt::get(m_pContext->Int32Ty(), InternalResourceTable),
         ConstantInt::get(m_pContext->Int32Ty(), tableOffset),
         ConstantInt::get(m_pContext->Int32Ty(), 0),
-        ConstantInt::get(m_pContext->BoolTy(), false)
     };
     return EmitCall(pModule,
                     LlpcName::DescriptorLoadBuffer,

--- a/test/shaderdb/OpImageDrefGather_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageDrefGather_TestBasic_lit.frag
@@ -15,9 +15,13 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref{{.*}}({{.*}},{{.*}},{{.*}}, float 2.000000e+00,{{.*}})
+; SHADERTEST: [[SAMPLERPTR:%[0-9A-Za-z_.-]+]] = call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: [[SAMPLERPTR2:%[0-9A-Za-z_.-]+]] = call {{.*}} @"llpc.call.index.desc.ptr.s[p4v4i32,i32]"({ <4 x i32> addrspace(4)*, i32 } [[SAMPLERPTR]],
+; SHADERTEST: [[SAMPLER:%[0-9A-Za-z_.-]+]] = call <4 x i32> (...) @llpc.call.load.desc.from.ptr.v4i32({ <4 x i32> addrspace(4)*, i32 } [[SAMPLERPTR2]])
+; SHADERTEST: [[IMAGEPTR:%[0-9A-Za-z_.-]+]] = call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: [[IMAGEPTR2:%[0-9A-Za-z_.-]+]] = call {{.*}} @"llpc.call.index.desc.ptr.s[p4v8i32,i32]"({ <8 x i32> addrspace(4)*, i32 } [[IMAGEPTR]],
+; SHADERTEST: [[IMAGE:%[0-9A-Za-z_.-]+]] = call <8 x i32> (...) @llpc.call.load.desc.from.ptr.v8i32({ <8 x i32> addrspace(4)*, i32 } [[IMAGEPTR2]])
+; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref{{.*}}(<4 x i32> [[SAMPLER]], <8 x i32> [[IMAGE]],{{.*}}, float 2.000000e+00,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
 ; SHADERTEST: call <4 x float> @llvm.amdgcn.image.gather4.c.lz.2d.v4f32.f32(i32 1, float 2.000000e+00,{{.*}},{{.*}},{{.*}},{{.*}}, i1 false, i32 0, i32 0)

--- a/test/shaderdb/OpImageDrefGather_TestOffset_lit.frag
+++ b/test/shaderdb/OpImageDrefGather_TestOffset_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref.offset{{.*}}({{.*}},{{.*}},{{.*}}, float 2.000000e+00,{{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageDrefGather_TestTextureGatherOffset_lit.frag
+++ b/test/shaderdb/OpImageDrefGather_TestTextureGatherOffset_lit.frag
@@ -25,14 +25,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref.constoffset{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 0x3FECCCCCC0000000, <2 x i32> <i32 1, i32 1>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.dref.offset{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, float 0x3FE99999A0000000,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Rect.dref.offset{{.*}}({{.*}},{{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, float 0x3FE6666660000000,{{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageDrefGather_TestTextureGatherOffsets_lit.frag
+++ b/test/shaderdb/OpImageDrefGather_TestTextureGatherOffsets_lit.frag
@@ -26,14 +26,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref.constoffsets{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 0x3FECCCCCC0000000, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.dref.constoffsets{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, float 0x3FE99999A0000000, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Rect.dref.constoffsets{{.*}}({{.*}},{{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, float 0x3FE6666660000000, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageDrefGather_TestTextureGather_lit.frag
+++ b/test/shaderdb/OpImageDrefGather_TestTextureGather_lit.frag
@@ -24,14 +24,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 0x3FECCCCCC0000000,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.dref{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, float 0x3FE99999A0000000,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Rect.dref{{.*}}({{.*}},{{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, float 0x3FE6666660000000,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageExplicitLod_TestDrefLodOffset_lit.frag
+++ b/test/shaderdb/OpImageExplicitLod_TestDrefLodOffset_lit.frag
@@ -15,8 +15,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call float @llpc.image.sample.f32.2D.dref.lod.constoffset{{.*}}({{.*}},{{.*}},{{.*}},{{.*}}, float 1.000000e+00, <2 x i32> <i32 2, i32 3>,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_Test2DMSArray_lit.frag
+++ b/test/shaderdb/OpImageFetch_Test2DMSArray_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.fmask.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.fmask.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2DArray.sample.fmaskbased{{.*}}({{.*}},{{.*}},{{.*}}, i32 2,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_Test2DMS_lit.frag
+++ b/test/shaderdb/OpImageFetch_Test2DMS_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.fmask.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.fmask.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2D.sample.fmaskbased{{.*}}({{.*}},{{.*}},{{.*}}, i32 2,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageFetch_TestBasic_lit.frag
@@ -16,7 +16,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2D.lod{{.*}}({{.*}},{{.*}}, i32 2,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_TestBuffer_lit.comp
+++ b/test/shaderdb/OpImageFetch_TestBuffer_lit.comp
@@ -18,7 +18,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.Buffer({{.*}}, i32 3,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_TestIntegerSampler_lit.frag
+++ b/test/shaderdb/OpImageFetch_TestIntegerSampler_lit.frag
@@ -16,9 +16,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.fetch.i32.2D.lod{{.*}}({{.*}}, <2 x i32> <i32 0, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.fetch.u32.2D.lod{{.*}}({{.*}}, <2 x i32> <i32 0, i32 1>, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_TestOffset_lit.frag
+++ b/test/shaderdb/OpImageFetch_TestOffset_lit.frag
@@ -16,7 +16,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2D.lod.constoffset{{.*}}({{.*}},{{.*}}, i32 2, <2 x i32> <i32 3, i32 4>,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_TestTexelFetchOffset_lit.frag
+++ b/test/shaderdb/OpImageFetch_TestTexelFetchOffset_lit.frag
@@ -30,17 +30,17 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.1D.lod.constoffset{{.*}}({{.*}}, i32 2, i32 3, i32 4,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2D.lod.constoffset{{.*}}({{.*}}, <2 x i32> <i32 5, i32 5>, i32 6, <2 x i32> <i32 7, i32 7>,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.3D.lod.constoffset{{.*}}({{.*}}, <3 x i32> <i32 1, i32 1, i32 1>, i32 2, <3 x i32> <i32 3, i32 3, i32 3>,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.Rect.constoffset{{.*}}({{.*}}, <2 x i32> <i32 4, i32 4>, <2 x i32> <i32 5, i32 5>,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.1DArray.lod.constoffset{{.*}}({{.*}}, <2 x i32> <i32 5, i32 5>, i32 6, i32 7,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 2, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 2, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2DArray.lod.constoffset{{.*}}({{.*}}, <3 x i32> <i32 1, i32 1, i32 1>, i32 2, <2 x i32> <i32 3, i32 3>,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageFetch_TestTexelFetch_lit.frag
+++ b/test/shaderdb/OpImageFetch_TestTexelFetch_lit.frag
@@ -28,15 +28,15 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.1D.lod{{.*}}({{.*}}, i32 2, i32 2,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2D.lod{{.*}}({{.*}}, <2 x i32> <i32 7, i32 7>, i32 8,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.Rect{{.*}}({{.*}}, <2 x i32> <i32 3, i32 3>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.Buffer({{.*}}, i32 5,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x float> @llpc.image.fetch.f32.2D.sample.fmaskbased{{.*}}({{.*}},{{.*}}, <2 x i32> <i32 6, i32 6>, i32 4,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageGather_TestBasic_lit.frag
@@ -15,8 +15,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestConstOffsets_lit.frag
+++ b/test/shaderdb/OpImageGather_TestConstOffsets_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.constoffsets{{.*}}({{.*}},{{.*}},{{.*}}, i32 2, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 2>, <2 x i32> <i32 3, i32 4>, <2 x i32> <i32 5, i32 6>, <2 x i32> <i32 7, i32 8>],{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestDrefConstOffsets_lit.frag
+++ b/test/shaderdb/OpImageGather_TestDrefConstOffsets_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.dref.constoffsets{{.*}}({{.*}},{{.*}},{{.*}}, float 1.000000e+00, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 2>, <2 x i32> <i32 3, i32 4>, <2 x i32> <i32 5, i32 6>, <2 x i32> <i32 7, i32 8>],{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestIntegerSampler.fragOpImageGather_TestIntegerSampler_lit.frag
+++ b/test/shaderdb/OpImageGather_TestIntegerSampler.fragOpImageGather_TestIntegerSampler_lit.frag
@@ -21,23 +21,23 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.gather.i32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.gather.i32.2D.constoffset{{.*}}({{.*}},{{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, i32 0, <2 x i32> <i32 1, i32 2>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.gather.i32.2D.constoffsets{{.*}}({{.*}},{{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, i32 0, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.gather.u32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.gather.u32.2D.constoffset{{.*}}({{.*}},{{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, i32 0, <2 x i32> <i32 1, i32 2>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.gather.u32.2D.constoffsets{{.*}}({{.*}},{{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, i32 0, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestOffset_lit.frag
+++ b/test/shaderdb/OpImageGather_TestOffset_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.offset{{.*}}({{.*}},{{.*}},{{.*}}, i32 2,{{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestTextureGatherBiasLod_lit.frag
+++ b/test/shaderdb/OpImageGather_TestTextureGatherBiasLod_lit.frag
@@ -53,53 +53,53 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.bias{{.*}}({{.*}},{{.*}},{{.*}}, i32 0,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.bias{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 2, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 2
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Cube.bias{{.*}}({{.*}},{{.*}},{{.*}}, i32 2,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 3, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 3
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.CubeArray.bias{{.*}}({{.*}},{{.*}},{{.*}}, i32 3,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.bias.constoffset{{.*}}({{.*}},{{.*}},{{.*}}, i32 0,{{.*}}, <2 x i32> zeroinitializer,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.bias.constoffset{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}}, <2 x i32> <i32 0, i32 1>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.bias.constoffsets{{.*}}({{.*}},{{.*}},{{.*}}, i32 0,{{.*}}, [4 x <2 x i32>] [<2 x i32> zeroinitializer, <2 x i32> <i32 0, i32 1>, <2 x i32> <i32 1, i32 0>, <2 x i32> <i32 1, i32 1>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.bias.constoffsets{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}}, [4 x <2 x i32>] [<2 x i32> zeroinitializer, <2 x i32> <i32 0, i32 1>, <2 x i32> <i32 1, i32 0>, <2 x i32> <i32 1, i32 1>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.lod{{.*}}({{.*}},{{.*}},{{.*}}, i32 0,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.lod{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 2, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 2
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Cube.lod{{.*}}({{.*}},{{.*}},{{.*}}, i32 2,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 3, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 3
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.CubeArray.lod{{.*}}({{.*}},{{.*}},{{.*}}, i32 3,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.lod.constoffset{{.*}}({{.*}},{{.*}},{{.*}}, i32 0,{{.*}}, <2 x i32> zeroinitializer,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.lod.constoffset{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}}, <2 x i32> <i32 0, i32 1>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.lod.constoffsets{{.*}}({{.*}},{{.*}},{{.*}}, i32 0,{{.*}}, [4 x <2 x i32>] [<2 x i32> zeroinitializer, <2 x i32> <i32 0, i32 1>, <2 x i32> <i32 1, i32 0>, <2 x i32> <i32 1, i32 1>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.lod.constoffsets{{.*}}({{.*}},{{.*}},{{.*}}, i32 1,{{.*}}, [4 x <2 x i32>] [<2 x i32> zeroinitializer, <2 x i32> <i32 0, i32 1>, <2 x i32> <i32 1, i32 0>, <2 x i32> <i32 1, i32 1>],{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestTextureGatherOffset_lit.frag
+++ b/test/shaderdb/OpImageGather_TestTextureGatherOffset_lit.frag
@@ -25,14 +25,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.offset{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 2,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.offset{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, i32 3,{{.*}},{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Rect.constoffset{{.*}}({{.*}},{{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, i32 0, <2 x i32> <i32 1, i32 1>,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestTextureGatherOffsets_lit.frag
+++ b/test/shaderdb/OpImageGather_TestTextureGatherOffsets_lit.frag
@@ -26,14 +26,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D.constoffsets{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 2, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray.constoffsets{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, i32 3, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Rect.constoffsets{{.*}}({{.*}},{{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, i32 0, [4 x <2 x i32>] [<2 x i32> <i32 1, i32 1>, <2 x i32> <i32 2, i32 2>, <2 x i32> <i32 3, i32 3>, <2 x i32> <i32 4, i32 4>],{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageGather_TestTextureGather_lit.frag
+++ b/test/shaderdb/OpImageGather_TestTextureGather_lit.frag
@@ -24,14 +24,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 2,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.2DArray{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, i32 3,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.gather.f32.Rect{{.*}}({{.*}},{{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQueryLevels_TestBasic_lit.comp
+++ b/test/shaderdb/OpImageQueryLevels_TestBasic_lit.comp
@@ -47,33 +47,33 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.1D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.1D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.2D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.3D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.Cube{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.1DArray{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.2DArray{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 6, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 6
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.CubeArray{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 7, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 7
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.1D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 8, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 8
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.2D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 9, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 9
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.Cube{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 10, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 10
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.1DArray{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 11, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 11
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.2DArray{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 12, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 12
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.CubeArray{{.*}}({{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQueryLevels_TestTextureQueryLevels_lit.frag
+++ b/test/shaderdb/OpImageQueryLevels_TestTextureQueryLevels_lit.frag
@@ -26,13 +26,13 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.1D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.2D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.2D{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 2, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 2, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.levels.CubeArray{{.*}}({{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQueryLod_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageQueryLod_TestBasic_lit.frag
@@ -46,44 +46,44 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.1D{{.*}}({{.*}},{{.*}}, float 7.000000e+00,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 7.000000e+00, float 8.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 2, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 2
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.3D{{.*}}({{.*}},{{.*}}, <3 x float> <float 7.000000e+00, float 8.000000e+00, float 9.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 3, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 3
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.Cube{{.*}}({{.*}},{{.*}}, <3 x float> <float 7.000000e+00, float 8.000000e+00, float 9.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 4, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 4
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.1D{{.*}}({{.*}},{{.*}}, float 7.000000e+00,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 5, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 5
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 7.000000e+00, float 8.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 6, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 6, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 6
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 6
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.Cube{{.*}}({{.*}},{{.*}}, <3 x float> <float 7.000000e+00, float 8.000000e+00, float 9.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 7, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 7, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 7
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 7
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.1D{{.*}}({{.*}},{{.*}}, float 7.000000e+00,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 8, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 8, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 8
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 8
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 7.000000e+00, float 8.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 9, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 9, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 9
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 9
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.Cube{{.*}}({{.*}},{{.*}}, <3 x float> <float 7.000000e+00, float 8.000000e+00, float 9.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 10, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 10, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 10
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 10
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.1D{{.*}}({{.*}},{{.*}}, float 7.000000e+00,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 11, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 11, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 11
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 11
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 7.000000e+00, float 8.000000e+00>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 12, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 12, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 12
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 12
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.Cube{{.*}}({{.*}},{{.*}}, <3 x float> <float 7.000000e+00, float 8.000000e+00, float 9.000000e+00>,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQueryLod_TestTextureQueryLod_lit.frag
+++ b/test/shaderdb/OpImageQueryLod_TestTextureQueryLod_lit.frag
@@ -29,20 +29,20 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.1D{{.*}}({{.*}},{{.*}}, float 1.000000e+00,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 1, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 1, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 1, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.2D{{.*}}({{.*}},{{.*}}, <2 x float> <float 0x3FD99999A0000000, float 0x3FD99999A0000000>,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 2, i32 0,{{.*}}, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 2, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 2, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 2, i32 0
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.Cube{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FE3333340000000, float 0x3FE3333340000000, float 0x3FE3333340000000>,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 3, i32 0, i32 0, i1 false)
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.sampler.desc.v4i32(i32 3, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 3, i32 0
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr{{.*}}(i32 3, i32 1
 ; SHADERTEST: call <2 x float> @llpc.image.querylod.f32.3D{{.*}}({{.*}},{{.*}}, <3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySamples_TestBasic_lit.comp
+++ b/test/shaderdb/OpImageQuerySamples_TestBasic_lit.comp
@@ -23,9 +23,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.samples{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call i32 @llpc.image.querynonlod.samples{{.*}}({{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySamples_TestImageSamples_lit.frag
+++ b/test/shaderdb/OpImageQuerySamples_TestImageSamples_lit.frag
@@ -22,9 +22,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.samples{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call i32 @llpc.image.querynonlod.samples{{.*}}({{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySamples_TestTextureSamples_lit.frag
+++ b/test/shaderdb/OpImageQuerySamples_TestTextureSamples_lit.frag
@@ -22,9 +22,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.samples{{.*}}({{.*}},{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call i32 @llpc.image.querynonlod.samples{{.*}}({{.*}},{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySizeLod_TestTextureSize_lit.frag
+++ b/test/shaderdb/OpImageQuerySizeLod_TestTextureSize_lit.frag
@@ -22,11 +22,11 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 3,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 4,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.3D.v3i32{{.*}}({{.*}}, i32 5,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySize_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageQuerySize_TestBasic_lit.frag
@@ -78,37 +78,37 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.1D.i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.3D.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.Cube.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.1D.i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 6, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 6
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.Cube.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 7, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 7
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.CubeArray.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 8, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 8
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.CubeArray.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 9, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 9
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 10, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 10
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 11, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 11
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.1DArray.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 12, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 12
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.2DArray.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 0, i32 15, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 0, i32 15
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.Buffer.i32({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 16, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 16
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.sample.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 17, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 17
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.2DArray.sample.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySize_TestImageSize_lit.frag
+++ b/test/shaderdb/OpImageQuerySize_TestImageSize_lit.frag
@@ -29,15 +29,15 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.1D.i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.sample.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 1, i32 0, i32 %{{[0-9]+}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.Buffer.i32({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 2, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 2, i32 0
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.CubeArray.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySize_TestImage_lit.comp
+++ b/test/shaderdb/OpImageQuerySize_TestImage_lit.comp
@@ -40,27 +40,27 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.1D.i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.3D.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.Cube.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.1DArray.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 6, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 6
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.2DArray.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 7, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 7
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.CubeArray.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 8, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 8
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.sample.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 9, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 9
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.2DArray.sample.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 0, i32 10, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 0, i32 10
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.Buffer.i32({{.*}}, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySize_TestSeparated_lit.frag
+++ b/test/shaderdb/OpImageQuerySize_TestSeparated_lit.frag
@@ -15,7 +15,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageQuerySize_TestTextureSize_lit.frag
+++ b/test/shaderdb/OpImageQuerySize_TestTextureSize_lit.frag
@@ -24,13 +24,13 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 1, i32 0, i32 %{{[0-9]+}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call i32 @llpc.image.querynonlod.sizelod.Buffer.i32({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <2 x i32> @llpc.image.querynonlod.sizelod.2D.sample.v2i32{{.*}}({{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 2, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 2, i32 0
 ; SHADERTEST: call <3 x i32> @llpc.image.querynonlod.sizelod.2DArray.sample.v3i32{{.*}}({{.*}}, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageReadWrite_TestImageLoadStoreLod_lit.comp
+++ b/test/shaderdb/OpImageReadWrite_TestImageLoadStoreLod_lit.comp
@@ -34,33 +34,33 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.1D.lod{{.*}}({{.*}}, i32 9, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.2D.lod{{.*}}({{.*}}, <2 x i32> <i32 9, i32 9>, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.3D.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.Cube.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.1DArray.lod{{.*}}({{.*}}, <2 x i32> <i32 9, i32 9>, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.2DArray.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 6, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 6
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.CubeArray.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call void @llpc.image.write.i32.1D.lod{{.*}}({{.*}}, i32 9,{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call void @llpc.image.write.i32.2D.lod{{.*}}({{.*}}, <2 x i32> <i32 9, i32 9>,{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call void @llpc.image.write.i32.3D.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>,{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call void @llpc.image.write.i32.Cube.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>,{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call void @llpc.image.write.i32.1DArray.lod{{.*}}({{.*}}, <2 x i32> <i32 9, i32 9>,{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call void @llpc.image.write.i32.2DArray.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>,{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 6, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 6
 ; SHADERTEST: call void @llpc.image.write.i32.CubeArray.lod{{.*}}({{.*}}, <3 x i32> <i32 9, i32 9, i32 9>,{{.*}}, i32 7, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_Test2DMS_lit.comp
+++ b/test/shaderdb/OpImageRead_Test2DMS_lit.comp
@@ -20,9 +20,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D.sample{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 1, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2DArray.sample{{.*}}({{.*}}, <3 x i32> zeroinitializer, i32 1, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestBasic_lit.comp
+++ b/test/shaderdb/OpImageRead_TestBasic_lit.comp
@@ -27,17 +27,17 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.1D{{.*}}({{.*}}, i32 0, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.3D{{.*}}({{.*}}, <3 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.1DArray{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2DArray{{.*}}({{.*}}, <3 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.Rect{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestBuffer_lit.comp
+++ b/test/shaderdb/OpImageRead_TestBuffer_lit.comp
@@ -18,7 +18,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.Buffer({{.*}}, i32 3, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestCube_lit.comp
+++ b/test/shaderdb/OpImageRead_TestCube_lit.comp
@@ -20,9 +20,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.Cube{{.*}}({{.*}}, <3 x i32> <i32 0, i32 0, i32 6>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.CubeArray{{.*}}({{.*}}, <3 x i32> <i32 0, i32 0, i32 6>, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestImageLoad_lit.frag
+++ b/test/shaderdb/OpImageRead_TestImageLoad_lit.frag
@@ -29,15 +29,15 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.1D{{.*}}({{.*}}, i32 1, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.Rect{{.*}}({{.*}}, <2 x i32> <i32 2, i32 3>, i32 0,{{.*}})
-; SHADERTEST: call <4 x i32> {{.*}} @llpc.call.load.texel.buffer.desc.v4i32(i32 1, i32 0, i32 %{{[0-9]+}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.texel.buffer.desc.ptr{{.*}}(i32 1, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.Buffer({{.*}}, i32 4, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 2, i32 0,{{.*}}, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 2, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.CubeArray{{.*}}({{.*}}, <3 x i32> <i32 5, i32 6, i32 7>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D.sample{{.*}}({{.*}}, <2 x i32> <i32 8, i32 9>, i32 2, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestIntImage_lit.comp
+++ b/test/shaderdb/OpImageRead_TestIntImage_lit.comp
@@ -20,9 +20,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.2D{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.read.u32.2D{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestMemoryQualifier_lit.comp
+++ b/test/shaderdb/OpImageRead_TestMemoryQualifier_lit.comp
@@ -23,13 +23,13 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> <i32 1, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> <i32 2, i32 2>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> <i32 3, i32 3>, i32 1,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> <i32 4, i32 4>, i32 3,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestNonVec4Data_lit.spvas
+++ b/test/shaderdb/OpImageRead_TestNonVec4Data_lit.spvas
@@ -3,23 +3,23 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.read.u32.2D{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.read.u32.2D{{.*}}({{.*}}, <2 x i32> <i32 0, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x i32> @llpc.image.read.u32.2D{{.*}}({{.*}}, <2 x i32> <i32 1, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.2D{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.2D{{.*}}({{.*}}, <2 x i32> <i32 0, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.2D{{.*}}({{.*}}, <2 x i32> <i32 1, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> zeroinitializer, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> <i32 0, i32 1>, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.2D{{.*}}({{.*}}, <2 x i32> <i32 1, i32 1>, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageRead_TestSubpassInput_lit.frag
+++ b/test/shaderdb/OpImageRead_TestSubpassInput_lit.frag
@@ -26,20 +26,20 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 0, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 0
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.SubpassData{{.*}}({{.*}},{{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.fmask.desc.v8i32(i32 0, i32 1, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 1
+; SHADERTEST: call {{.*}} @"llpc.call.get.fmask.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call <4 x float> @llpc.image.read.f32.SubpassData.sample.fmaskbased{{.*}}({{.*}},{{.*}},{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 2, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 2
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.SubpassData{{.*}}({{.*}},{{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.fmask.desc.v8i32(i32 0, i32 3, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 3
+; SHADERTEST: call {{.*}} @"llpc.call.get.fmask.desc.ptr{{.*}}(i32 0, i32 3
 ; SHADERTEST: call <4 x i32> @llpc.image.read.i32.SubpassData.sample.fmaskbased{{.*}}({{.*}},{{.*}},{{.*}}, i32 7, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 4, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 4
 ; SHADERTEST: call <4 x i32> @llpc.image.read.u32.SubpassData{{.*}}({{.*}},{{.*}}, i32 0,{{.*}})
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.resource.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
-; SHADERTEST: call <8 x i32> {{.*}} @llpc.call.load.fmask.desc.v8i32(i32 0, i32 5, i32 0, i1 false)
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr{{.*}}(i32 0, i32 5
+; SHADERTEST: call {{.*}} @"llpc.call.get.fmask.desc.ptr{{.*}}(i32 0, i32 5
 ; SHADERTEST: call <4 x i32> @llpc.image.read.u32.SubpassData.sample.fmaskbased{{.*}}({{.*}},{{.*}},{{.*}}, i32 7, i32 0,{{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_Test1DArray_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_Test1DArray_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.1DArray({{.*}}, <2 x float> <float 1.000000e+00, float 2.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1DArray{{.*}}({{.*}}, <2 x float> <float 1.000000e+00, float 2.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_Test1D_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_Test1D_lit.frag
@@ -18,8 +18,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.1D
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_Test2DArray_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_Test2DArray_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2DArray({{.*}}, <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2DArray{{.*}}({{.*}}, <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_Test2DRect_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_Test2DRect_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.Rect({{.*}}, <2 x float> <float 1.000000e+00, float 2.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.Rect{{.*}}({{.*}}, <2 x float> <float 1.000000e+00, float 2.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_Test3D_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_Test3D_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.3D({{.*}}, <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.3D{{.*}}({{.*}}, <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestArrayDirectAccess_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestArrayDirectAccess_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D({{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D{{.*}}({{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestBasic_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D({{.*}}, <2 x float> zeroinitializer, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D{{.*}}({{.*}}, <2 x float> zeroinitializer, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestBias_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestBias_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D.bias({{.*}}, <2 x float> zeroinitializer, float 1.000000e+00, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.bias{{.*}}({{.*}}, <2 x float> zeroinitializer, float 1.000000e+00, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestCubeArray_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestCubeArray_lit.frag
@@ -18,8 +18,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.CubeArray
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.CubeArray
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestCubeShadow_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestCubeShadow_lit.frag
@@ -18,8 +18,8 @@ void main()
 ; SHADERTEST: float @spirv.image.sample.f32.Cube.dref
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call float @llpc.image.sample.f32.Cube.dref
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestCube_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestCube_lit.frag
@@ -18,8 +18,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.Cube
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.Cube
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestDrefGrad_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestDrefGrad_lit.frag
@@ -18,8 +18,8 @@ void main()
 ; SHADERTEST: float @spirv.image.sample.f32.2D.dref.grad({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD99999A0000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call float @llpc.image.sample.f32.2D.dref.grad{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD99999A0000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestGrad_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestGrad_lit.frag
@@ -18,8 +18,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D.grad({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD99999A0000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.grad{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD99999A0000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestIntegerSampler_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestIntegerSampler_lit.frag
@@ -20,11 +20,11 @@ void main()
 ; SHADERTEST: <4 x i32> @spirv.image.sample.u32.2D({{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x i32> @llpc.image.sample.i32.2D{{.*}}({{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x i32> @llpc.image.sample.u32.2D{{.*}}({{.*}}, <2 x float> <float 0.000000e+00, float 1.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestMultiDimArrayDirectAccess_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestMultiDimArrayDirectAccess_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D({{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D{{.*}}({{.*}}, <2 x float> <float 1.000000e+00, float 1.000000e+00>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestOffset_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestOffset_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D.constoffset({{.*}}, <2 x i32> <i32 2, i32 3>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.constoffset{{.*}}({{.*}}, <2 x i32> <i32 2, i32 3>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestProjDrefGradOffset_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestProjDrefGradOffset_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: float @spirv.image.sample.f32.2D.dref.grad.constoffset({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD99999A0000000>, <2 x i32> <i32 2, i32 3>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call float @llpc.image.sample.f32.2D.dref.grad.constoffset{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD99999A0000000>, <2 x i32> <i32 2, i32 3>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestSeparate_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestSeparate_lit.frag
@@ -17,8 +17,8 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D({{.*}}, <2 x float> zeroinitializer, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D{{.*}}({{.*}}, <2 x float> zeroinitializer, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTextureBiasClamp_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTextureBiasClamp_lit.frag
@@ -50,26 +50,26 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.CubeArray.bias.minlod({{.*}}, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.bias.minlod{{.*}}({{.*}}, float 0x3FB99999A0000000, float 2.000000e+00, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.bias.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.3D.bias.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.Cube.bias.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1DArray.bias.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2DArray.bias.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.CubeArray.bias.minlod{{.*}}({{.*}}, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 2.000000e+00, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTextureClamp_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTextureClamp_lit.frag
@@ -50,26 +50,26 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.CubeArray.minlod({{.*}}, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.minlod{{.*}}({{.*}}, float 0x3FB99999A0000000, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.3D.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.Cube.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1DArray.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2DArray.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.CubeArray.minlod{{.*}}({{.*}}, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTextureGradClamp_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTextureGradClamp_lit.frag
@@ -50,26 +50,26 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.CubeArray.grad.minlod({{.*}}, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <3 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000, float 0x3FD3333340000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.grad.minlod{{.*}}({{.*}}, float 0x3FB99999A0000000, float 0x3FC99999A0000000, float 0x3FD3333340000000, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.grad.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.3D.grad.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <3 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000, float 0x3FD3333340000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.Cube.grad.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <3 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000, float 0x3FD3333340000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1DArray.grad.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 0x3FC99999A0000000, float 0x3FD3333340000000, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2DArray.grad.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.CubeArray.grad.minlod{{.*}}({{.*}}, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <3 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000, float 0x3FD3333340000000>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTextureGradOffsetClamp_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTextureGradOffsetClamp_lit.frag
@@ -44,20 +44,20 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2DArray.grad.constoffset.minlod({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000>, <2 x i32> <i32 2, i32 2>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.grad.constoffset.minlod{{.*}}({{.*}}, float 0x3FB99999A0000000, float 0x3FC99999A0000000, float 0x3FD3333340000000, i32 2, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.grad.constoffset.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000>, <2 x i32> <i32 2, i32 2>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.3D.grad.constoffset.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <3 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000, float 0x3FD3333340000000>, <3 x i32> <i32 2, i32 2, i32 2>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1DArray.grad.constoffset.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, float 0x3FC99999A0000000, float 0x3FD3333340000000, i32 2, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2DArray.grad.constoffset.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <2 x float> <float 0x3FD3333340000000, float 0x3FD3333340000000>, <2 x i32> <i32 2, i32 2>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTextureOffsetClamp_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTextureOffsetClamp_lit.frag
@@ -44,20 +44,20 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2DArray.constoffset.minlod({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x i32> <i32 2, i32 2>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.constoffset.minlod{{.*}}({{.*}}, float 0x3FB99999A0000000, i32 2, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.constoffset.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x i32> <i32 2, i32 2>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.3D.constoffset.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x i32> <i32 2, i32 2, i32 2>, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1DArray.constoffset.minlod{{.*}}({{.*}}, <2 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000>, i32 2, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2DArray.constoffset.minlod{{.*}}({{.*}}, <3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <2 x i32> <i32 2, i32 2>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTextureOffset_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTextureOffset_lit.frag
@@ -26,11 +26,11 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D.constoffset({{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>, <2 x i32> <i32 5, i32 5>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.bias.constoffset{{.*}}({{.*}}, float 1.000000e+00, float 0x3FD99999A0000000, i32 2, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D.constoffset{{.*}}({{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>, <2 x i32> <i32 5, i32 5>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/test/shaderdb/OpImageSampleImplicitLod_TestTexture_lit.frag
+++ b/test/shaderdb/OpImageSampleImplicitLod_TestTexture_lit.frag
@@ -27,11 +27,11 @@ void main()
 ; SHADERTEST: <4 x float> @spirv.image.sample.f32.2D({{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.1D.bias{{.*}}({{.*}}, float 1.000000e+00, float 0x3FD99999A0000000, {{.*}})
-; SHADERTEST: call <4 x i32>{{.*}}@llpc.call.load.sampler.desc.v4i32
-; SHADERTEST: call <8 x i32>{{.*}}@llpc.call.load.resource.desc.v8i32
+; SHADERTEST: call {{.*}} @"llpc.call.get.sampler.desc.ptr
+; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr
 ; SHADERTEST: call <4 x float> @llpc.image.sample.f32.2D{{.*}}({{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -124,13 +124,16 @@ namespace LlpcName
     const static char StreamOutBufferStore[]          = "llpc.streamoutbuffer.store";
 
     const static char DescriptorCallPrefix[]          = "llpc.descriptor.";
+    const static char DescriptorIndex[]               = "llpc.descriptor.index";
+    const static char DescriptorLoadFromPtr[]         = "llpc.descriptor.load.from.ptr";
     const static char DescriptorLoadPrefix[]          = "llpc.descriptor.load.";
-    const static char DescriptorLoadResource[]        = "llpc.descriptor.load.resource";
-    const static char DescriptorLoadSampler[]         = "llpc.descriptor.load.sampler";
-    const static char DescriptorLoadFmask[]           = "llpc.descriptor.load.fmask";
+    const static char DescriptorGetPtrPrefix[]        = "llpc.descriptor.get.";
+    const static char DescriptorGetResourcePtr[]      = "llpc.descriptor.get.resource.ptr";
+    const static char DescriptorGetSamplerPtr[]       = "llpc.descriptor.get.sampler.ptr";
+    const static char DescriptorGetFmaskPtr[]         = "llpc.descriptor.get.fmask.ptr";
     const static char DescriptorLoadBuffer[]          = "llpc.descriptor.load.buffer";
     const static char DescriptorLoadAddress[]         = "llpc.descriptor.load.address";
-    const static char DescriptorLoadTexelBuffer[]     = "llpc.descriptor.load.texelbuffer";
+    const static char DescriptorGetTexelBufferPtr[]   = "llpc.descriptor.get.texelbuffer.ptr";
     const static char DescriptorLoadSpillTable[]      = "llpc.descriptor.load.spilltable";
 
     const static char LaterCallPrefix[]               = "llpc.late.";


### PR DESCRIPTION
This commit separates a descriptor load into three parts:
1. Get pointer to descriptor
2. Optionally index it
3. Load the descriptor from the pointer.

This separation is done both in the builder interface and in the
llpc.descriptor.* calls lowered by PatchDescriptorLoad.

This only affects image-related descriptors (image, fmask, texel buffer,
fmask), not buffer descriptors.

I have done this to allow a future commit to change the SPIR-V reader to
use builder calls directly, instead of needing the LowerImageOp pass
afterwards. In most cases the SPIR-V reader would be able to trace back
from an image op to its descriptor's set, binding and index. But, in the
corner case of a pointer to (array of) descriptor being passed as a
function parameter, it is not possible for the SPIR-V reader to do that.

The implementation in PatchDescriptorLoad currently assumes that
everything is inlined by then, so it can trace back from the "descriptor
load from pointer" back to the "get pointer to descriptor", and
implement them together, including the case of optimizing a "dynamic
descriptor" (one that is in the top-level user data) or an immutable
sampler (constant data provided to the compiler). The plan is to remove
this assumption of inlining everything in a future commit.

Change-Id: I1275ecc1774afca4d7361479445cee0b900852f5
