### PR TITLE
Turn off wgp for gfx10+

### DIFF
--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -203,12 +203,16 @@ void CodeGenManager::SetupTargetFeatures(
             }
 
 #if LLPC_BUILD_GFX10
-            // Setup wavefront size per shader stage
             if (gfxIp.major >= 10)
             {
+                // Setup wavefront size per shader stage
                 uint32_t waveSize = pContext->GetShaderWaveSize(shaderStage);
 
                 targetFeatures += ",+wavefrontsize" + std::to_string(waveSize);
+
+                // Allow driver setting for WGP by forcing backend to set 0
+                // which is then OR'ed with the driver set value
+                targetFeatures += ",+cumode";
             }
 #endif
 


### PR DESCRIPTION
LLPC requires that the driver sets the WGP or CUMODE bits. By default the
backend would override this with WGP on.

By setting the cumode sub target feature the backend will set 0 for the mode bit
- which is then OR'ed with whatever the driver has set initially. This means the
driver can control WGP or CUMODE.