### PR TITLE
Subgroup vote execution modification

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -598,16 +598,19 @@ public:
     // Create a subgroup all.
     virtual llvm::Value* CreateSubgroupAll(
         llvm::Value* const pValue,             // [in] The value to compare
+        bool               wqm = false,        // Executed in WQM (whole quad mode)
         const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup any
     virtual llvm::Value* CreateSubgroupAny(
         llvm::Value* const pValue,             // [in] The value to compare
+        bool               wqm = false,        // Executed in WQM (whole quad mode)
         const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup all equal.
     virtual llvm::Value* CreateSubgroupAllEqual(
         llvm::Value* const pValue,             // [in] The value to compare
+        bool               wqm = false,        // Executed in WQM (whole quad mode)
         const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup broadcast.

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -354,14 +354,17 @@ public:
 
     // Create a subgroup all.
     llvm::Value* CreateSubgroupAll(llvm::Value* const pValue,
+                                   bool               wqm,
                                    const llvm::Twine& instName) override final;
 
     // Create a subgroup any
     llvm::Value* CreateSubgroupAny(llvm::Value* const pValue,
+                                   bool               wqm,
                                    const llvm::Twine& instName) override final;
 
     // Create a subgroup all equal.
     llvm::Value* CreateSubgroupAllEqual(llvm::Value* const pValue,
+                                        bool               wqm,
                                         const llvm::Twine& instName) override final;
 
     // Create a subgroup broadcast.

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -329,7 +329,7 @@ Value* BuilderRecorder::CreateIndexDescPtr(
 
 // =====================================================================================================================
 // Load image/sampler/texelbuffer/F-mask descriptor from pointer.
-// Returns <8 x i32> descriptor for image or F-mask, or <4 x i32> descriptor for sampler or texel buffer. 
+// Returns <8 x i32> descriptor for image or F-mask, or <4 x i32> descriptor for sampler or texel buffer.
 Value* BuilderRecorder::CreateLoadDescFromPtr(
     Value*        pDescPtr,           // [in] Descriptor pointer, as returned by CreateIndexDescPtr or one of
                                       //    the CreateGet*DescPtr methods
@@ -678,27 +678,30 @@ Value* BuilderRecorder::CreateSubgroupElect(
 // Create a subgroup all.
 Value* BuilderRecorder::CreateSubgroupAll(
     Value* const pValue,   // [in] The value to compare
+    bool         wqm,      // Executed in WQM (whole quad mode)
     const Twine& instName) // [in] Name to give instruction(s)
 {
-    return Record(Opcode::SubgroupAll, getInt1Ty(), pValue, instName);
+    return Record(Opcode::SubgroupAll, getInt1Ty(), { pValue,  getInt1(wqm) }, instName);
 }
 
 // =====================================================================================================================
 // Create a subgroup any
 Value* BuilderRecorder::CreateSubgroupAny(
     Value* const pValue,   // [in] The value to compare
+    bool         wqm,      // Executed in WQM (whole quad mode)
     const Twine& instName) // [in] Name to give instruction(s)
 {
-    return Record(Opcode::SubgroupAny, getInt1Ty(), pValue, instName);
+    return Record(Opcode::SubgroupAny, getInt1Ty(), { pValue,  getInt1(wqm) }, instName);
 }
 
 // =====================================================================================================================
 // Create a subgroup all equal.
 Value* BuilderRecorder::CreateSubgroupAllEqual(
     Value* const pValue,   // [in] The value to compare
+    bool         wqm,      // Executed in WQM (whole quad mode)
     const Twine& instName) // [in] Name to give instruction(s)
 {
-    return Record(Opcode::SubgroupAllEqual, getInt1Ty(), pValue, instName);
+    return Record(Opcode::SubgroupAllEqual, getInt1Ty(), { pValue,  getInt1(wqm) }, instName);
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -308,10 +308,13 @@ public:
     llvm::Value* CreateGetSubgroupSize(const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupElect(const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupAll(llvm::Value* const pValue,
+                                   bool               wqm,
                                    const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupAny(llvm::Value* const pValue,
+                                   bool               wqm,
                                    const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupAllEqual(llvm::Value* const pValue,
+                                        bool               wqm,
                                         const llvm::Twine& instName) override final;
     llvm::Value* CreateSubgroupBroadcast(llvm::Value* const pValue,
                                          llvm::Value* const pIndex,

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -542,15 +542,15 @@ Value* BuilderReplayer::ProcessCall(
         }
     case BuilderRecorder::Opcode::SubgroupAll:
         {
-            return m_pBuilder->CreateSubgroupAll(args[0]);
+            return m_pBuilder->CreateSubgroupAll(args[0], cast<ConstantInt>(args[1])->getZExtValue() != 0);
         }
     case BuilderRecorder::Opcode::SubgroupAny:
         {
-            return m_pBuilder->CreateSubgroupAny(args[0]);
+            return m_pBuilder->CreateSubgroupAny(args[0], cast<ConstantInt>(args[1])->getZExtValue() != 0);
         }
     case BuilderRecorder::Opcode::SubgroupAllEqual:
         {
-            return m_pBuilder->CreateSubgroupAllEqual(args[0]);
+            return m_pBuilder->CreateSubgroupAllEqual(args[0], cast<ConstantInt>(args[1])->getZExtValue() != 0);
         }
     case BuilderRecorder::Opcode::SubgroupBroadcast:
         {

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -1442,7 +1442,10 @@ void Compiler::TranslateSpirvToLlvm(
     Context* pContext = static_cast<Context*>(&pModule->getContext());
     pContext->SetModuleTargetMachine(pModule);
 
+    const PipelineShaderInfo* pShaderInfo = pContext->GetPipelineShaderInfo(shaderStage);
+
     if (readSpirv(pContext->GetBuilder(),
+                  pShaderInfo->pModuleData,
                   spirvStream,
                   static_cast<spv::ExecutionModel>(shaderStage),
                   pEntryTarget,
@@ -2047,6 +2050,23 @@ Result Compiler::CollectInfoFromSpirvBinary(
                 {
                     pShaderModuleInfo->useSubgroupSize = true;
                 }
+                break;
+            }
+        case spv::OpDPdx:
+        case spv::OpDPdy:
+        case spv::OpDPdxCoarse:
+        case spv::OpDPdyCoarse:
+        case spv::OpDPdxFine:
+        case spv::OpDPdyFine:
+        case spv::OpImageSampleImplicitLod:
+        case spv::OpImageSampleDrefImplicitLod:
+        case spv::OpImageSampleProjImplicitLod:
+        case spv::OpImageSampleProjDrefImplicitLod:
+        case spv::OpImageSparseSampleImplicitLod:
+        case spv::OpImageSparseSampleProjDrefImplicitLod:
+        case spv::OpImageSparseSampleProjImplicitLod:
+            {
+                pShaderModuleInfo->useHelpInvocation = true;
                 break;
             }
         case spv::OpString:

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -65,6 +65,7 @@ struct ShaderModuleInfo
     bool            enableVarPtrStorageBuf;  // Whether to enable "VariablePointerStorageBuffer" capability
     bool            enableVarPtr;            // Whether to enable "VariablePointer" capability
     bool            useSubgroupSize;         // Whether gl_SubgroupSize is used
+    bool            useHelpInvocation;       // Whether fragment shader has helper-invocation for subgroup
 };
 
 // Represents output data of building a shader module.

--- a/translator/include/LLVMSPIRVLib.h
+++ b/translator/include/LLVMSPIRVLib.h
@@ -127,6 +127,7 @@ bool writeSpirv(llvm::Module *M, llvm::raw_ostream &OS, std::string &ErrMsg);
 /// \brief Load SPIRV from istream and translate to LLVM module.
 /// \returns true if succeeds.
 bool readSpirv(Llpc::Builder *Builder,
+               const void* ModuleData,
                std::istream &IS,
                spv::ExecutionModel EntryExecModel,
                const char *EntryName,

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -49,6 +49,7 @@
 #include "SPIRVValue.h"
 
 #include "llpcBuilder.h"
+#include "llpcCompiler.h"
 #include "llpcContext.h"
 
 #include "llvm/ADT/DenseMap.h"
@@ -309,10 +310,11 @@ private:
 class SPIRVToLLVM {
 public:
   SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule,
-    const SPIRVSpecConstMap &TheSpecConstMap, Builder *pBuilder)
+    const SPIRVSpecConstMap &TheSpecConstMap, Builder *pBuilder, const void* pModuleData)
     :M(LLVMModule), m_pBuilder(pBuilder), BM(TheSPIRVModule), IsKernel(true),
     EnableXfb(false), EntryTarget(nullptr),
-    SpecConstMap(TheSpecConstMap), DbgTran(BM, M) {
+    SpecConstMap(TheSpecConstMap), DbgTran(BM, M),
+    ModuleData(reinterpret_cast<const ShaderModuleInfo*>(pModuleData)) {
     assert(M);
     Context = &M->getContext();
   }
@@ -488,6 +490,7 @@ private:
   RemappedTypeElementsMap RemappedTypeElements;
   DenseMap<Type *, bool> TypesWithPadMap;
   DenseMap<std::pair<SPIRVType*, uint32_t>, Type *> OverlappingStructTypeWorkaroundMap;
+  const ShaderModuleInfo* ModuleData;
 
   Type *mapType(SPIRVType *BT, Type *T) {
     SPIRVDBG(dbgs() << *T << '\n';)
@@ -3826,7 +3829,7 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformAll>(
     BasicBlock* const pBlock = m_pBuilder->GetInsertBlock();
     Function* const pFunc = m_pBuilder->GetInsertBlock()->getParent();
     Value* const pPredicate = transValue(spvOperands[1], pFunc, pBlock);
-    return m_pBuilder->CreateSubgroupAll(pPredicate);
+    return m_pBuilder->CreateSubgroupAll(pPredicate, ModuleData->useHelpInvocation);
 }
 
 // =====================================================================================================================
@@ -3841,7 +3844,7 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformAny>(
     BasicBlock* const pBlock = m_pBuilder->GetInsertBlock();
     Function* const pFunc = m_pBuilder->GetInsertBlock()->getParent();
     Value* const pPredicate = transValue(spvOperands[1], pFunc, pBlock);
-    return m_pBuilder->CreateSubgroupAny(pPredicate);
+    return m_pBuilder->CreateSubgroupAny(pPredicate, ModuleData->useHelpInvocation);
 }
 
 // =====================================================================================================================
@@ -3856,7 +3859,7 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformAllEqual>(
     BasicBlock* const pBlock = m_pBuilder->GetInsertBlock();
     Function* const pFunc = m_pBuilder->GetInsertBlock()->getParent();
     Value* const pValue = transValue(spvOperands[1], pFunc, pBlock);
-    return m_pBuilder->CreateSubgroupAllEqual(pValue);
+    return m_pBuilder->CreateSubgroupAllEqual(pValue, ModuleData->useHelpInvocation);
 }
 
 // =====================================================================================================================
@@ -4300,7 +4303,7 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpSubgroupAllKHR>(
     BasicBlock* const pBlock = m_pBuilder->GetInsertBlock();
     Function* const pFunc = m_pBuilder->GetInsertBlock()->getParent();
     Value* const pPredicate = transValue(spvOperands[0], pFunc, pBlock);
-    return m_pBuilder->CreateSubgroupAll(pPredicate);
+    return m_pBuilder->CreateSubgroupAll(pPredicate, ModuleData->useHelpInvocation);
 }
 
 // =====================================================================================================================
@@ -4314,7 +4317,7 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpSubgroupAnyKHR>(
     BasicBlock* const pBlock = m_pBuilder->GetInsertBlock();
     Function* const pFunc = m_pBuilder->GetInsertBlock()->getParent();
     Value* const pPredicate = transValue(spvOperands[0], pFunc, pBlock);
-    return m_pBuilder->CreateSubgroupAny(pPredicate);
+    return m_pBuilder->CreateSubgroupAny(pPredicate, ModuleData->useHelpInvocation);
 }
 
 // =====================================================================================================================
@@ -4328,7 +4331,7 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpSubgroupAllEqualKHR>(
     BasicBlock* const pBlock = m_pBuilder->GetInsertBlock();
     Function* const pFunc = m_pBuilder->GetInsertBlock()->getParent();
     Value* const pValue = transValue(spvOperands[0], pFunc, pBlock);
-    return m_pBuilder->CreateSubgroupAllEqual(pValue);
+    return m_pBuilder->CreateSubgroupAllEqual(pValue, ModuleData->useHelpInvocation);
 }
 
 // =====================================================================================================================
@@ -8662,7 +8665,7 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
 
 } // namespace SPIRV
 
-bool llvm::readSpirv(Builder *Builder, std::istream &IS,
+bool llvm::readSpirv(Builder *Builder, const void *shaderInfo, std::istream &IS,
                      spv::ExecutionModel EntryExecModel, const char *EntryName,
                      const SPIRVSpecConstMap &SpecConstMap, Module *M,
                      std::string &ErrMsg) {
@@ -8670,7 +8673,7 @@ bool llvm::readSpirv(Builder *Builder, std::istream &IS,
 
   IS >> *BM;
 
-  SPIRVToLLVM BTL(M, BM.get(), SpecConstMap, Builder);
+  SPIRVToLLVM BTL(M, BM.get(), SpecConstMap, Builder, shaderInfo);
   bool Succeed = true;
   if (!BTL.translate(EntryExecModel, EntryName)) {
     BM->getError(ErrMsg);


### PR DESCRIPTION
Helper invocations of whole quad mode should be incorporated into the
subgroup vote execution.