### PR TITLE
Tag descriptor loads with !invariant.load

### DIFF
--- a/context/llpcContext.cpp
+++ b/context/llpcContext.cpp
@@ -129,6 +129,7 @@ Context::Context(
     m_metaIds.invariantLoad = getMDKindID("invariant.load");
     m_metaIds.range         = getMDKindID("range");
     m_metaIds.uniform       = getMDKindID("amdgpu.uniform");
+    m_metaIds.dereferenceable = getMDKindID("dereferenceable");
 
     // Load external LLVM libraries, in search order.
     if (pGpuWorkarounds->gfx9.treat1dImagesAs2d)

--- a/context/llpcContext.h
+++ b/context/llpcContext.h
@@ -123,6 +123,7 @@ public:
     uint32_t MetaIdInvariantLoad() const { return m_metaIds.invariantLoad; }
     uint32_t MetaIdRange() const { return m_metaIds.range; }
     uint32_t MetaIdUniform() const { return m_metaIds.uniform; }
+    uint32_t MetaIdDereferenceable() const { return m_metaIds.dereferenceable; }
 
     std::unique_ptr<llvm::Module> LoadLibary(const BinaryData* pLib);
 
@@ -337,6 +338,7 @@ private:
         uint32_t invariantLoad;   // "invariant.load"
         uint32_t range;           // "range"
         uint32_t uniform;         // "amdgpu.uniform"
+        uint32_t dereferenceable; // "dereferecenable"
     } m_metaIds;
 
     // GLSL emulation libraries

--- a/patch/llpcPatchCopyShader.cpp
+++ b/patch/llpcPatchCopyShader.cpp
@@ -711,6 +711,7 @@ Value* PatchCopyShader::LoadGsVsRingBufferDescriptor(
                                            "",
                                            pInsertPos);
     pGsVsRingBufDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
+    pGsVsRingBufDescPtr->setMetadata(m_pContext->MetaIdDereferenceable(), m_pContext->GetEmptyMetadataNode());
 
     auto pGsVsRingBufDesc = new LoadInst(pGsVsRingBufDescPtr, "", pInsertPos);
     pGsVsRingBufDesc->setMetadata(m_pContext->MetaIdInvariantLoad(), m_pContext->GetEmptyMetadataNode());

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -633,10 +633,8 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             auto pCastedDescPtr = CastInst::Create(Instruction::BitCast, pDescPtr, pDescPtrTy, "", pInsertPoint);
 
             // Load descriptor
-            MDNode *MD = m_pContext->GetEmptyMetadataNode();
-            pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), MD);
-            pCastedDescPtr->setMetadata(m_pContext->MetaIdInvariantLoad(), MD);
-
+            pCastedDescPtr->setMetadata(m_pContext->MetaIdInvariantLoad(), m_pContext->GetEmptyMetadataNode());
+            pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
             pDesc = new LoadInst(pCastedDescPtr, "", pInsertPoint);
             cast<LoadInst>(pDesc)->setAlignment(16);
         }

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -633,7 +633,10 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             auto pCastedDescPtr = CastInst::Create(Instruction::BitCast, pDescPtr, pDescPtrTy, "", pInsertPoint);
 
             // Load descriptor
-            pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
+            MDNode *MD = m_pContext->GetEmptyMetadataNode();
+            pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), MD);
+            pCastedDescPtr->setMetadata(m_pContext->MetaIdInvariantLoad(), MD);
+
             pDesc = new LoadInst(pCastedDescPtr, "", pInsertPoint);
             cast<LoadInst>(pDesc)->setAlignment(16);
         }


### PR DESCRIPTION
Adding !invariant.load metadata to descriptor loads, this should
help opts like -early-cse hoist these loads.