### PR TITLE
Add !invariant.load to load descriptor sets

### DIFF
--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -635,6 +635,8 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             // Load descriptor
             pCastedDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
             pDesc = new LoadInst(pCastedDescPtr, "", pInsertPoint);
+            if (LoadInst *LI = dyn_cast<LoadInst>(pDesc))
+              LI->setMetadata(m_pContext->MetaIdInvariantLoad(), m_pContext->GetEmptyMetadataNode());
             cast<LoadInst>(pDesc)->setAlignment(16);
         }
     }


### PR DESCRIPTION
This adds the !invariant.load metadata to load descriptor sets
in order for opts like cse to better optimize these loads