### PR TITLE
Reapply "Improve codegen for FMin and FMax"

### DIFF
--- a/patch/generate/glslArithOpEmu.ll
+++ b/patch/generate/glslArithOpEmu.ll
@@ -2698,10 +2698,10 @@ define i32 @llpc.umid3.i32(i32 %x, i32 %y, i32 %z)
 define float @llpc.fmin3.f32(float %x, float %y, float %z)
 {
     ; min(x, y)
-    %1 = call float @llvm.minnum.f32(float %x, float %y)
+    %1 = call nnan float @llvm.minnum.f32(float %x, float %y)
 
     ; min(min(x, y), z)
-    %2 = call float @llvm.minnum.f32(float %1, float %z)
+    %2 = call nnan float @llvm.minnum.f32(float %1, float %z)
 
     ret float %2
 }
@@ -2710,10 +2710,10 @@ define float @llpc.fmin3.f32(float %x, float %y, float %z)
 define float @llpc.fmax3.f32(float %x, float %y, float %z)
 {
     ; max(x, y)
-    %1 = call float @llvm.maxnum.f32(float %x, float %y)
+    %1 = call nnan float @llvm.maxnum.f32(float %x, float %y)
 
     ; max(max(x, y), z)
-    %2 = call float @llvm.maxnum.f32(float %1, float %z)
+    %2 = call nnan float @llvm.maxnum.f32(float %1, float %z)
 
     ret float %2
 }

--- a/patch/generate/glslArithOpEmuF16.ll
+++ b/patch/generate/glslArithOpEmuF16.ll
@@ -1070,8 +1070,8 @@ define half @llpc.nmax.f16(half %x, half %y) #0
 ; GLSL: float16_t clamp(float16_t, float16_t ,float16_t)
 define half @llpc.fclamp.f16(half %x, half %minVal, half %maxVal) #0
 {
-    %1 = call half @llvm.maxnum.f16(half %x, half %minVal)
-    %2 = call half @llvm.minnum.f16(half %1, half %maxVal)
+    %1 = call nnan half @llvm.maxnum.f16(half %x, half %minVal)
+    %2 = call nnan half @llvm.minnum.f16(half %1, half %maxVal)
 
     ret half %2
 }
@@ -2027,10 +2027,10 @@ define spir_func { <4 x half>, <4 x i32> } @_Z11frexpStructDv4_DhDv4_i(
 define half @llpc.fmin3.f16(half %x, half %y, half %z)
 {
     ; min(x, y)
-    %1 = call half @llvm.minnum.f16(half %x, half %y)
+    %1 = call nnan half @llvm.minnum.f16(half %x, half %y)
 
     ; min(min(x, y), z)
-    %2 = call half @llvm.minnum.f16(half %1, half %z)
+    %2 = call nnan half @llvm.minnum.f16(half %1, half %z)
 
     ret half %2
 }
@@ -2039,10 +2039,10 @@ define half @llpc.fmin3.f16(half %x, half %y, half %z)
 define half @llpc.fmax3.f16(half %x, half %y, half %z)
 {
     ; max(x, y)
-    %1 = call half @llvm.maxnum.f16(half %x, half %y)
+    %1 = call nnan half @llvm.maxnum.f16(half %x, half %y)
 
     ; max(max(x, y), z)
-    %2 = call half @llvm.maxnum.f16(half %1, half %z)
+    %2 = call nnan half @llvm.maxnum.f16(half %1, half %z)
 
     ret half %2
 }
@@ -2051,16 +2051,16 @@ define half @llpc.fmax3.f16(half %x, half %y, half %z)
 define half @llpc.fmid3.f16(half %x, half %y, half %z)
 {
     ; min(x, y)
-    %1 = call half @llvm.minnum.f16(half %x, half %y)
+    %1 = call nnan half @llvm.minnum.f16(half %x, half %y)
 
     ; max(x, y)
-    %2 = call half @llvm.maxnum.f16(half %x, half %y)
+    %2 = call nnan half @llvm.maxnum.f16(half %x, half %y)
 
     ; min(max(x, y), z)
-    %3 = call half @llvm.minnum.f16(half %2, half %z)
+    %3 = call nnan half @llvm.minnum.f16(half %2, half %z)
 
     ; max(min(x, y), min(max(x, y), z))
-    %4 = call half @llvm.maxnum.f16(half %1, half %3)
+    %4 = call nnan half @llvm.maxnum.f16(half %1, half %3)
 
     ret half %4
 }

--- a/patch/generate/glslArithOpEmuF64.ll
+++ b/patch/generate/glslArithOpEmuF64.ll
@@ -305,8 +305,8 @@ define double @llpc.nmax.f64(double %x, double %y) #0
 ; GLSL: double clamp(double, double ,double)
 define double @llpc.fclamp.f64(double %x, double %minVal, double %maxVal) #0
 {
-    %1 = call double @llvm.maxnum.f64(double %x, double %minVal)
-    %2 = call double @llvm.minnum.f64(double %1, double %maxVal)
+    %1 = call nnan double @llvm.maxnum.f64(double %x, double %minVal)
+    %2 = call nnan double @llvm.minnum.f64(double %1, double %maxVal)
     ret double %2
 }
 

--- a/test/shaderdb/OpExtInst_TestMaxBasic_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMaxBasic_lit.frag
@@ -21,10 +21,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x i32> @_Z4smaxDv4_iDv4_i(<4 x i32> %{{.*}}, <4 x i32> %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x i32> @_Z4umaxDv4_iDv4_i(<4 x i32> %{{.*}}, <4 x i32> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = icmp slt i32 %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = select i1 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = icmp slt i32 %{{.*}}, %{{.*}}

--- a/test/shaderdb/OpExtInst_TestMaxDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMaxDouble_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} double @_Z4fmaxdd(double %{{.*}}, double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x double> @_Z4fmaxDv3_dDv3_d(<3 x double> %{{.*}}, <3 x double> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call double @llvm.maxnum.f64(double %{{.*}}, double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call double @llvm.maxnum.f64(double %{{.*}}, double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan double @llvm.maxnum.f64(double %{{.*}}, double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan double @llvm.maxnum.f64(double %{{.*}}, double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestMaxFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMaxFloat_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @_Z4fmaxff(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x float> @_Z4fmaxDv3_fDv3_f(<3 x float> %{{.*}}, <3 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.maxnum.f32(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestMinBasic_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMinBasic_lit.frag
@@ -21,10 +21,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x i32> @_Z4sminDv4_iDv4_i(<4 x i32> %{{.*}}, <4 x i32> %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x i32> @_Z4uminDv4_iDv4_i(<4 x i32> %{{.*}}, <4 x i32> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = icmp slt i32 %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = select i1 %{{.*}}, i32 %{{.*}}, i32 %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = icmp slt i32 %{{.*}}, %{{.*}}

--- a/test/shaderdb/OpExtInst_TestMinDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMinDouble_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} double @_Z4fmindd(double %{{.*}}, double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x double> @_Z4fminDv3_dDv3_d(<3 x double> %{{.*}}, <3 x double> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call double @llvm.minnum.f64(double %{{.*}}, double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call double @llvm.minnum.f64(double %{{.*}}, double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan double @llvm.minnum.f64(double %{{.*}}, double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan double @llvm.minnum.f64(double %{{.*}}, double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestMinFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMinFloat_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @_Z4fminff(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x float> @_Z4fminDv3_fDv3_f(<3 x float> %{{.*}}, <3 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call nnan float @llvm.minnum.f32(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/gfx9/ExtShaderFloat16_TestCommonFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ExtShaderFloat16_TestCommonFuncs_lit.frag
@@ -58,9 +58,9 @@ void main()
 ; SHADERTEST: %{{.*}} = call half @_Z4fdivDhDh(half {{.*}}, half %{{.*}})
 ; SHADERTEST: %{{.*}} = call half @llvm.floor.f16(half %{{[0-9]*}})
 ; SHADERTEST-COUNT-3: %{{.*}} = call half @llvm.trunc.f16(half %{{.*}})
-; SHADERTEST-COUNT-3: %{{.*}} = call half @llvm.minnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
-; SHADERTEST: %{{.*}} = call half @llvm.maxnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
-; SHADERTEST: %{{.*}} = call half @llvm.minnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
+; SHADERTEST-COUNT-3: %{{.*}} = call nnan half @llvm.minnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
+; SHADERTEST: %{{.*}} = call nnan half @llvm.maxnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
+; SHADERTEST: %{{.*}} = call nnan half @llvm.minnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
 ; SHADERTEST-COUNT-3: %{{.*}} = call half @llvm.fmuladd.f16(half %{{.*}}, half %{{.*}}, half %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x half> @_Z10smoothStepDv3_DhDv3_DhDv3_Dh(<3 x half> %{{.*}}, <3 x half> %{{.*}}, <3 x half> %{{.*}})
 ; SHADERTEST: %{{.*}} = call {{.*}} <3 x i1> @_Z5isnanDv3_Dh(<3 x half> %{{.*}})
@@ -68,7 +68,7 @@ void main()
 ; SHADERTEST-COUNT-3: %{{.*}} = call half @llvm.fma.f16(half %{{.*}}, half %{{.*}}, half %{{.*}}) #0
 ; SHADERTEST: %{{[0-9]*}} = call { <3 x half>, <3 x i16> } @_Z11frexpStructDv3_DhDv3_s(<3 x half> %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <3 x half> @_Z5ldexpDv3_DhDv3_i(<3 x half> %{{.*}}, <3 x i32> %{{.*}})
-; SHADERTEST-COUNT-3: %{{.*}} = call half @llvm.maxnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
+; SHADERTEST-COUNT-3: %{{.*}} = call nnan half @llvm.maxnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/gfx9/ObjFloat16_TestTrinaryMinMaxFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ObjFloat16_TestTrinaryMinMaxFuncs_lit.frag
@@ -30,8 +30,8 @@ void main()
 ; SHADERTEST: <3 x half> @_Z8FMax3AMDDv3_DhDv3_DhDv3_Dh(<3 x half> %{{[0-9]*}}, <3 x half> %{{[0-9]*}}, <3 x half> %{{[0-9]*}})
 ; SHADERTEST: <3 x half> @_Z8FMid3AMDDv3_DhDv3_DhDv3_Dh(<3 x half> %{{[0-9]*}}, <3 x half> %{{[0-9]*}}, <3 x half> %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-COUNT-6: call half @llvm.minnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
-; SHADERTEST-COUNT-6: call half @llvm.maxnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
+; SHADERTEST-COUNT-6: call nnan half @llvm.minnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
+; SHADERTEST-COUNT-6: call nnan half @llvm.maxnum.f16(half %{{[0-9]*}}, half %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: AMDLLPC SUCCESS
 */


### PR DESCRIPTION
This reapplies 3366bbf11c674ec0e3baaed6c2588de4c7191147 which was
reverted in 6f222ab067eaba99ed6341f0d9dfc6960ca6fab4 "since it
introduces F12017 hang issue". Actually the hang was caused by a bug
in the driver which has been fixed by:
https://lists.freedesktop.org/archives/amd-gfx/2019-July/036598.html