### PR TITLE
Added extra -v dump before patching

### DIFF
--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -108,6 +108,13 @@ void Patch::AddPrePatchPasses(
         passMgr.add(pBuilderReplayer);
     }
 
+    if (EnableOuts())
+    {
+        passMgr.add(createPrintModulePass(outs(),
+                    "===============================================================================\n"
+                    "// LLPC pipeline before-patching results\n"));
+    }
+
     // Build null fragment shader if necessary
     passMgr.add(CreatePatchNullFragShader());
 


### PR DESCRIPTION
This will allow lit tests to test the result of Builder replaying,
before the IR is modified by any patching passes.

Change-Id: I0a26dfa456ffd81a8f490696cd479f205f3f7ba1