### PR TITLE
Fixed VGT_STRMOUT_BUFFER_CONFIG for multiple xfb buffers in the same …

### DIFF
--- a/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/lower/llpcSpirvLowerResourceCollect.cpp
@@ -1742,7 +1742,7 @@ void SpirvLowerResourceCollect::CollectXfbOutputInfo(
     m_pResUsage->inOutUsage.enableXfb = (m_pResUsage->inOutUsage.enableXfb || (outputMeta.XfbStride > 0));
 
     LLPC_ASSERT(outputMeta.StreamId < MaxGsStreams);
-    m_pResUsage->inOutUsage.streamXfbBuffers[outputMeta.StreamId] = 1 << (outputMeta.XfbBuffer);
+    m_pResUsage->inOutUsage.streamXfbBuffers[outputMeta.StreamId] |= 1 << (outputMeta.XfbBuffer);
 }
 
 } // Llpc

--- a/test/shaderdb/ExtXfb_TestTesDoubleOutput_lit.tese
+++ b/test/shaderdb/ExtXfb_TestTesDoubleOutput_lit.tese
@@ -20,6 +20,7 @@ void main(void)
 ; SHADERTEST: call void @llpc.output.export.generic{{.*}}v3f64
 ; SHADERTEST: call void @llpc.output.export.xfb{{.*}}v2f64
 ; SHADERTEST: call void @llpc.output.export.generic{{.*}}v2f64
+; SHADERTEST: VGT_STRMOUT_BUFFER_CONFIG 0x{{0*}}3
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
…stream

I noticed that the test I have modified here was getting a
VGT_STRMOUT_BUFFER_CONFIG value of either 1 or 2 depending on what order
LowerResourceCollect happened to process the outputs with the XfbBuffer
decorations.

Change-Id: I87ad263e3ed6421c30733f488bc2f418571cf2f9