### PR TITLE
Fixed Builder::CreateGetBufferDescLength bug

### DIFF
--- a/builder/llpcBuilderImplDesc.cpp
+++ b/builder/llpcBuilderImplDesc.cpp
@@ -262,9 +262,10 @@ Value* BuilderImplDesc::CreateGetBufferDescLength(
     // In future this should become a full LLVM intrinsic, but for now we patch in a late intrinsic that is cleaned up
     // in patch buffer op.
     Instruction* const pInsertPos = &*GetInsertPoint();
-
+    std::string callName = LlpcName::LateBufferLength;
+    AddTypeMangling(nullptr, pBufferDesc, callName);
     return EmitCall(pInsertPos->getModule(),
-                    LlpcName::LateBufferLength,
+                    callName,
                     getInt32Ty(),
                     pBufferDesc,
                     Attribute::ReadNone,

--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -486,7 +486,7 @@ void PatchBufferOp::visitCallInst(
             m_divergenceSet.insert(callInst.getArgOperand(0));
         }
     }
-    else if (callName.equals(LlpcName::LateBufferLength))
+    else if (callName.startswith(LlpcName::LateBufferLength))
     {
         Instruction* const pPointer = GetPointerOperandAsInst(callInst.getArgOperand(0));
 


### PR DESCRIPTION
This bug was shown up by the forthcoming builder input/output change,
giving a function type mismatch.

Change-Id: Ie30bf5588826cab265e04a608f3aa278b7a9f3b4