### PR TITLE
Refine NGG implementation

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -1927,6 +1927,7 @@ void Compiler::InitGpuWorkaround()
                     m_gpuWorkarounds.gfx10.waShaderInstPrefetch123   = 1;
                     m_gpuWorkarounds.gfx10.nggTessDegeneratePrims    = 1;
                     m_gpuWorkarounds.gfx10.waThrottleInMultiDwordNsa = 1;
+                    m_gpuWorkarounds.gfx10.waNggCullingNoEmptySubgroups = 1;
                 }
                 break;
             default:

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -165,8 +165,11 @@ struct WorkaroundFlags
             uint32_t  waNsaCannotFollowWritelane : 1;
             uint32_t  waThrottleInMultiDwordNsa : 1;
             uint32_t  waSmemFollowedByVopc : 1;
+            uint32_t  waNggCullingNoEmptySubgroups : 1;
+            uint32_t  waShaderInstPrefetchFwd64 : 1;
+            uint32_t  waWarFpAtomicDenormHazard : 1;
             uint32_t  placeholder1 : 2;
-            uint32_t  reserved : 17;
+            uint32_t  reserved : 14;
         };
         uint32_t u32All;
     } gfx10;

--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -97,10 +97,14 @@ GraphicsContext::GraphicsContext(
 
 #if LLPC_BUILD_GFX10
     memset(&m_nggControl, 0, sizeof(m_nggControl));
-    // NOTE: All fields of NGG controls are determined by the pass of resource collecting in patching. Here, we still
-    // set NGG enablement early. The field is used when deciding if we need extra optimizations after NGG primitive
-    // shader creation. At that time, the pass of resource collecting has not been run.
-    m_nggControl.enableNgg = pPipelineInfo->nggState.enableNgg;
+
+    if (gfxIp.major >= 10)
+    {
+        // NOTE: All fields of NGG controls are determined by the pass of resource collecting in patching. Here, we still
+        // set NGG enablement early. The field is used when deciding if we need extra optimizations after NGG primitive
+        // shader creation. At that time, the pass of resource collecting has not been run.
+        m_nggControl.enableNgg = pPipelineInfo->nggState.enableNgg;
+    }
 #endif
 
     const PipelineShaderInfo* shaderInfo[ShaderStageGfxCount] =

--- a/patch/generate/gfx10/glslNggCullingOpEmu.ll
+++ b/patch/generate/gfx10/glslNggCullingOpEmu.ll
@@ -922,25 +922,25 @@ define i1 @llpc.ngg.culling.smallprimfilter(
     %59 = fmul float %58, %3
     %60 = fmul float %59, 2.0
 
-    ; minX = floor(min(scaledX0', scaledX1', scaledX2') - 0.000001)
+    ; minX = floor(min(scaledX0', scaledX1', scaledX2') - 1/256.0)
     %61 = call float @llpc.fmin3.f32(float %30, float %36, float %42)
-    %62 = fadd float %61, 0xBEB0C6F7A0000000
-    %63 = call float @llvm.floor.f32(float %62)
+    %62 = fadd float %61, -0.00390625
+    %63 = call float @llvm.rint.f32(float %62)
 
-    ; maxX = floor(max(scaledX0', scaledX1', scaledX2') + 0.000001)
+    ; maxX = floor(max(scaledX0', scaledX1', scaledX2') + 1/256.0)
     %64 = call float @llpc.fmax3.f32(float %30, float %36, float %42)
-    %65 = fadd float %64, 0x3EB0C6F7A0000000
-    %66 = call float @llvm.floor.f32(float %65)
+    %65 = fadd float %64, 0.00390625
+    %66 = call float @llvm.rint.f32(float %65)
 
-    ; minY = floor(min(scaledY0', scaledY1', scaledY2') - 0.000001)
+    ; minY = floor(min(scaledY0', scaledY1', scaledY2') - 1/256.0)
     %67 = call float @llpc.fmin3.f32(float %48, float %54, float %60)
-    %68 = fadd float %67, 0xBEB0C6F7A0000000
-    %69 = call float @llvm.floor.f32(float %68)
+    %68 = fadd float %67, -0.00390625
+    %69 = call float @llvm.rint.f32(float %68)
 
-    ; maxX = floor(max(scaledY0', scaledY1', scaledY2') + 0.000001)
+    ; maxX = floor(max(scaledY0', scaledY1', scaledY2') + 1/256.0)
     %70 = call float @llpc.fmax3.f32(float %48, float %54, float %60)
-    %71 = fadd float %70, 0x3EB0C6F7A0000000
-    %72 = call float @llvm.floor.f32(float %71)
+    %71 = fadd float %70, 0.00390625
+    %72 = call float @llvm.rint.f32(float %71)
 
     ; minX == maxX
     %73 = fcmp oeq float %63, %66
@@ -999,7 +999,7 @@ declare float @llvm.maxnum.f32(float, float) #0
 declare float @llvm.minnum.f32(float, float) #0
 declare <2 x half> @llvm.maxnum.v2f16(<2 x half>, <2 x half>) #0
 declare <2 x half> @llvm.minnum.v2f16(<2 x half>, <2 x half>) #0
-declare float @llvm.floor.f32(float) #0
+declare float @llvm.rint.f32(float) #0
 declare <2 x half> @llvm.amdgcn.cvt.pkrtz(float, float) #1
 declare half @llvm.fma.f16(half, half, half) #0
 declare <2 x half> @llvm.fma.v2f16(<2 x half>, <2 x half>, <2 x half>) #0

--- a/patch/gfx9/llpcNggLdsManager.cpp
+++ b/patch/gfx9/llpcNggLdsManager.cpp
@@ -287,7 +287,8 @@ uint32_t NggLdsManager::CalcLdsRegionTotalSize(
 // Reads value from LDS.
 Value* NggLdsManager::ReadValueFromLds(
     Type*        pReadTy,       // [in] Type of value read from LDS
-    Value*       pLdsOffset)    // [in] Start offset to do LDS read operations
+    Value*       pLdsOffset,    // [in] Start offset to do LDS read operations
+    bool         useDs128)      // Whether to use 128-bit LDS load, 16-byte alignment is guaranteed by caller
 {
     LLPC_ASSERT(m_pLds != nullptr);
     LLPC_ASSERT(pReadTy->isIntOrIntVectorTy() || pReadTy->isFPOrFPVectorTy());
@@ -296,11 +297,17 @@ Value* NggLdsManager::ReadValueFromLds(
 
     uint32_t bitWidth = 0;
     uint32_t compCount = 0;
+    uint32_t alignment = 4;
 
     if (readBits % 128 == 0)
     {
         bitWidth = 128;
         compCount = readBits / 128;
+
+        if (useDs128)
+        {
+            alignment = 16; // Set alignment to 16-byte to use 128-bit LDS load
+        }
     }
     else if (readBits % 64 == 0)
     {
@@ -324,7 +331,7 @@ Value* NggLdsManager::ReadValueFromLds(
         compCount = readBits / 8;
     }
 
-    Type* pCompTy = IntegerType::get(*m_pContext, bitWidth);
+    Type* pCompTy = m_pBuilder->getIntNTy(bitWidth);
     Value* pReadValue =  UndefValue::get((compCount > 1) ? VectorType::get(pCompTy, compCount) : pCompTy);
 
     // NOTE: LDS variable is defined as a pointer to i32 array. We cast it to a pointer to i8 array first.
@@ -336,11 +343,25 @@ Value* NggLdsManager::ReadValueFromLds(
         Value* pLoadPtr = m_pBuilder->CreateGEP(pLds, pLdsOffset);
         if (bitWidth != 8)
         {
-            pLoadPtr = m_pBuilder->CreateBitCast(pLoadPtr, PointerType::get(pCompTy, ADDR_SPACE_LOCAL));
+            if (useDs128 && (bitWidth == 128))
+            {
+                // NOTE: For single 128-bit LDS load, the friendly data type for backend compiler is <4 x i32>.
+                pLoadPtr =
+                    m_pBuilder->CreateBitCast(pLoadPtr, PointerType::get(m_pContext->Int32x4Ty(), ADDR_SPACE_LOCAL));
+            }
+            else
+            {
+                pLoadPtr = m_pBuilder->CreateBitCast(pLoadPtr, PointerType::get(pCompTy, ADDR_SPACE_LOCAL));
+            }
         }
 
         // NOTE: Use "volatile" for load to prevent optimization.
-        Value* pLoadValue = m_pBuilder->CreateAlignedLoad(pLoadPtr, m_pLds->getAlignment(), true);
+        Value* pLoadValue = m_pBuilder->CreateAlignedLoad(pLoadPtr, alignment, true);
+        if (useDs128 && (bitWidth == 128))
+        {
+            // Convert <4 x i32> to i128
+            pLoadValue = m_pBuilder->CreateBitCast(pLoadValue, m_pBuilder->getInt128Ty());
+        }
 
         if (compCount > 1)
         {
@@ -369,7 +390,8 @@ Value* NggLdsManager::ReadValueFromLds(
 // Writes value to LDS.
 void NggLdsManager::WriteValueToLds(
     Value*        pWriteValue,      // [in] Value written to LDS
-    Value*        pLdsOffset)       // [in] Start offset to do LDS write operations
+    Value*        pLdsOffset,       // [in] Start offset to do LDS write operations
+    bool          useDs128)         // Whether to use 128-bit LDS store, 16-byte alignment is guaranteed by caller
 {
     LLPC_ASSERT(m_pLds != nullptr);
 
@@ -380,11 +402,17 @@ void NggLdsManager::WriteValueToLds(
 
     uint32_t bitWidth = 0;
     uint32_t compCount = 0;
+    uint32_t alignment = 4;
 
     if (writeBits % 128 == 0)
     {
         bitWidth = 128;
         compCount = writeBits / 128;
+
+        if (useDs128)
+        {
+            alignment = 16; // Set alignment to 16-byte to use 128-bit LDS store
+        }
     }
     else if (writeBits % 64 == 0)
     {
@@ -408,7 +436,7 @@ void NggLdsManager::WriteValueToLds(
         compCount = writeBits / 8;
     }
 
-    Type* pCompTy = IntegerType::get(*m_pContext, bitWidth);
+    Type* pCompTy = m_pBuilder->getIntNTy(bitWidth);
     pWriteTy = (compCount > 1) ? VectorType::get(pCompTy, compCount) : pCompTy;
 
     if (pWriteValue->getType() != pWriteTy)
@@ -425,7 +453,16 @@ void NggLdsManager::WriteValueToLds(
         Value* pStorePtr = m_pBuilder->CreateGEP(pLds, pLdsOffset);
         if (bitWidth != 8)
         {
-            pStorePtr = m_pBuilder->CreateBitCast(pStorePtr, PointerType::get(pCompTy, ADDR_SPACE_LOCAL));
+            if (useDs128 && (bitWidth == 128))
+            {
+                // NOTE: For single 128-bit LDS store, the friendly data type for backend compiler is <4 x i32>.
+                pStorePtr =
+                    m_pBuilder->CreateBitCast(pStorePtr, PointerType::get(m_pContext->Int32x4Ty(), ADDR_SPACE_LOCAL));
+            }
+            else
+            {
+                pStorePtr = m_pBuilder->CreateBitCast(pStorePtr, PointerType::get(pCompTy, ADDR_SPACE_LOCAL));
+            }
         }
 
         Value* pStoreValue = nullptr;
@@ -438,8 +475,14 @@ void NggLdsManager::WriteValueToLds(
             pStoreValue = pWriteValue;
         }
 
+        if (useDs128 && (bitWidth == 128))
+        {
+            // Convert i128 to <4 x i32>
+            pStoreValue = m_pBuilder->CreateBitCast(pStoreValue, m_pContext->Int32x4Ty());
+        }
+
         // NOTE: Use "volatile" for store to prevent optimization.
-        m_pBuilder->CreateAlignedStore(pStoreValue, pStorePtr, m_pLds->getAlignment(), true);
+        m_pBuilder->CreateAlignedStore(pStoreValue, pStorePtr, alignment, true);
 
         if (compCount > 1)
         {

--- a/patch/gfx9/llpcNggLdsManager.h
+++ b/patch/gfx9/llpcNggLdsManager.h
@@ -92,8 +92,8 @@ public:
         return regionStart;
     }
 
-    llvm::Value* ReadValueFromLds(llvm::Type* pReadTy, llvm::Value* pLdsOffset);
-    void WriteValueToLds(llvm::Value* pWriteValue, llvm::Value* pLdsOffset);
+    llvm::Value* ReadValueFromLds(llvm::Type* pReadTy, llvm::Value* pLdsOffset, bool useDs128 = false);
+    void WriteValueToLds(llvm::Value* pWriteValue, llvm::Value* pLdsOffset, bool useDs128 = false);
 
     void AtomicOpWithLds(llvm::AtomicRMWInst::BinOp atomicOp, llvm::Value* pAtomicValue, llvm::Value* pLdsOffset);
 

--- a/patch/gfx9/llpcNggPrimShader.h
+++ b/patch/gfx9/llpcNggPrimShader.h
@@ -72,7 +72,7 @@ private:
     void DoParamCacheAllocRequest();
     void DoPrimitiveExport(llvm::Value* pCullFlag = nullptr);
 
-    llvm::BasicBlock* ConstructDummyExport(llvm::Module* pModule, llvm::Function* pEntryPoint);
+    void DoEarlyExit(uint32_t fullyCullThreadCount);
 
     void RunEsOrEsVariant(llvm::Module*         pModule,
                           llvm::StringRef       entryName,
@@ -176,7 +176,8 @@ private:
 
         llvm::Value*    pPrimitiveId;               // Primitive ID (for VS)
 
-        // System values (SGPRs)
+        // System values, not used in pass-through mode (SGPRs)
+        llvm::Value*    pMergedGroupInfo;           // Merged group info
         llvm::Value*    pPrimShaderTableAddrLow;    // Primitive shader table address low
         llvm::Value*    pPrimShaderTableAddrHigh;   // Primitive shader table address high
 

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -192,6 +192,18 @@ void CodeGenManager::SetupTargetFeatures(
                 builder.addAttribute("amdgpu-max-memory-clause", "1");
             }
 
+#if LLPC_BUILD_GFX10
+            if (pFunc->getCallingConv() == CallingConv::AMDGPU_GS)
+            {
+                // NOTE: For NGG primitive shader, enable 128-bit LDS load/store operations to optimize gvec4 data
+                // read/write. This usage must enable the feature of using CI+ additional instructions.
+                const auto pNggControl = pContext->GetNggControl();
+                if (pNggControl->enableNgg && (pNggControl->passthroughMode == false))
+                {
+                    targetFeatures += ",+ci-insts,+enable-ds128";
+                }
+            }
+#endif
             if (pFunc->getCallingConv() == CallingConv::AMDGPU_HS)
             {
                 // Force s_barrier to be present (ignore optimization)


### PR DESCRIPTION
- Add the workaround waNggCullingNoEmptySubgroups.
- Optimize the vertex compaction control flow for dummy export
- Use ds_read(write)_b128 instructions conditionally.
- When vertex culling is failed, avoid ds_read to fetch compacted vertex ID.
- Fix the culling of small primitive filter.