### PR TITLE
Support lower & translate phase in build shader module [Part1]

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -374,7 +374,8 @@ public:
         ImageFlagNonUniformSampler = 0x10,  // Whether the sampler descriptor is non-uniform
         ImageFlagAddFragCoord = 0x20,       // Add FragCoord (converted to signed int) on to coordinate x,y.
                                             // Image load, store and atomic only.
-        ImageFlagUseViewIndex = 0x40,       // Use ViewIndex as coordinate z. Image load, store and atomic only.
+        ImageFlagCheckMultiView = 0x40,     // If pipeline state enables multiview, use ViewIndex as coordinate z.
+                                            // Otherwise, acts the same as ImageFlagAddFragCoord
     };
 
     // Address array indices for image sample and gather methods. Where an optional entry is missing (either

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -290,7 +290,7 @@ private:
     Value* PatchCubeDescriptor(Value* pDesc, uint32_t dim);
 
     // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
-    Value* HandleFragCoordViewIndex(Value* pCoord, uint32_t flags);
+    Value* HandleFragCoordViewIndex(Value* pCoord, uint32_t flags, uint32_t& dim);
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/test/shaderdb/ExtMultiView_TestSubpassLoad_lit.pipe
+++ b/test/shaderdb/ExtMultiView_TestSubpassLoad_lit.pipe
@@ -3,7 +3,7 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x float> (...) @llpc.call.image.load.v4f32(i32 5, i32 96, <8 x i32>
+; SHADERTEST: call <4 x float> (...) @llpc.call.image.load.v4f32(i32 1, i32 96, <8 x i32>
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/test/shaderdb/OpImageRead_TestSubpassInput_lit.frag
+++ b/test/shaderdb/OpImageRead_TestSubpassInput_lit.frag
@@ -27,17 +27,17 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
 ; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 0) 
-; SHADERTEST: call {{.*}} @llpc.call.image.load.v4f32(i32 1, i32 32, {{.*}}, <2 x i32> zeroinitializer) 
+; SHADERTEST: call {{.*}} @llpc.call.image.load.v4f32(i32 1, i32 96, {{.*}}, <2 x i32> zeroinitializer) 
 ; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 1) 
-; SHADERTEST: call {{.*}} @llpc.call.image.load.with.fmask.v4f32(i32 6, i32 32, {{.*}}, {{.*}}, <2 x i32> zeroinitializer, i32 7) 
+; SHADERTEST: call {{.*}} @llpc.call.image.load.with.fmask.v4f32(i32 6, i32 96, {{.*}}, {{.*}}, <2 x i32> zeroinitializer, i32 7) 
 ; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 2) 
-; SHADERTEST: call {{.*}} @llpc.call.image.load.v4i32(i32 1, i32 36, {{.*}}, <2 x i32> zeroinitializer) 
+; SHADERTEST: call {{.*}} @llpc.call.image.load.v4i32(i32 1, i32 100, {{.*}}, <2 x i32> zeroinitializer) 
 ; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 3) 
-; SHADERTEST: call {{.*}} @llpc.call.image.load.with.fmask.v4i32(i32 6, i32 36, {{.*}}, {{.*}}, <2 x i32> zeroinitializer, i32 7) 
+; SHADERTEST: call {{.*}} @llpc.call.image.load.with.fmask.v4i32(i32 6, i32 100, {{.*}}, {{.*}}, <2 x i32> zeroinitializer, i32 7) 
 ; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 4) 
-; SHADERTEST: call {{.*}} @llpc.call.image.load.v4i32(i32 1, i32 32, {{.*}}, <2 x i32> zeroinitializer) 
+; SHADERTEST: call {{.*}} @llpc.call.image.load.v4i32(i32 1, i32 96, {{.*}}, <2 x i32> zeroinitializer) 
 ; SHADERTEST: call {{.*}} @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 5) 
-; SHADERTEST: call {{.*}} @llpc.call.image.load.with.fmask.v4i32(i32 6, i32 32, {{.*}}, {{.*}}, <2 x i32> zeroinitializer, i32 7) 
+; SHADERTEST: call {{.*}} @llpc.call.image.load.with.fmask.v4i32(i32 6, i32 96, {{.*}}, {{.*}}, <2 x i32> zeroinitializer, i32 7) 
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
 ; SHADERTEST: call <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15,{{.*}}, i32 0, i32 0)

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6908,9 +6908,6 @@ void SPIRVToLLVM::handleImageFetchReadWriteCoord(SPIRVInstruction *BI,
 
   if (ImageInfo->Desc->Dim == DimSubpassData) {
     // Modify coordinate for subpass data.
-    EnableMultiView &= reinterpret_cast<const GraphicsPipelineBuildInfo *>(
-                           m_pBuilder->getContext().GetPipelineBuildInfo())
-                           ->iaState.enableMultiView;
     if (!EnableMultiView) {
       // Subpass data without multiview: Add the x,y dimensions (converted to
       // signed int) of the fragment coordinate on to the texel coordate.
@@ -6918,11 +6915,8 @@ void SPIRVToLLVM::handleImageFetchReadWriteCoord(SPIRVInstruction *BI,
     } else {
       // Subpass data with multiview: Use the fragment coordinate as x,y, and
       // use ViewIndex as z. We need to pass in a (0,0,0) coordinate.
-      ImageInfo->Dim = Llpc::Builder::Dim2DArray;
       ImageInfo->Flags |= Llpc::Builder::ImageFlagAddFragCoord |
-                          Llpc::Builder::ImageFlagUseViewIndex;
-      Coord =
-          Constant::getNullValue(VectorType::get(m_pBuilder->getInt32Ty(), 3));
+                          Llpc::Builder::ImageFlagCheckMultiView;
     }
   }
 


### PR DESCRIPTION
Remove pipeline state dependency for LLPC builder interface
To support lower & translate phase in build shader module, we should not access any pipeline state in lower & translate. i.e we should not use any pipeline state when call builder interface, we can't access iaState.enableMultiView in SPIRVToLLVM::handleImageFetchReadWriteCoord.

Solution: Move related code to BuilderImplImage::HandleFragCoordViewIndex