### PR TITLE
Support translate & lower phase in shader module [Part 2]

### DIFF
--- a/context/llpcComputeContext.cpp
+++ b/context/llpcComputeContext.cpp
@@ -64,8 +64,8 @@ ComputeContext::ComputeContext(
     PipelineContext(gfxIp, pGpuProp, pGpuWorkarounds, pPipelineHash, pCacheHash),
     m_pPipelineInfo(pPipelineInfo)
 {
-    InitShaderResourceUsage(ShaderStageCompute);
-    InitShaderInterfaceData(ShaderStageCompute);
+    InitShaderResourceUsage(ShaderStageCompute, GetShaderResourceUsage(ShaderStageCompute));
+    InitShaderInterfaceData(GetShaderInterfaceData(ShaderStageCompute));
 }
 
 // =====================================================================================================================
@@ -146,49 +146,6 @@ uint32_t ComputeContext::GetShaderWaveSize(
 #endif
     return waveSize;
 
-}
-
-// =====================================================================================================================
-// Gets float control settings of the specified shader stage for the provide floating-point type.
-FloatControl ComputeContext::GetShaderFloatControl(
-    ShaderStage shaderStage,    // Shader stage
-    uint32_t    bitWidth        // Bit width of the floating-point type
-    ) const
-{
-    LLPC_ASSERT(shaderStage == ShaderStageCompute);
-
-    FloatControl floatControl = {};
-    const auto& commonUsage = m_resUsage.builtInUsage.common;
-
-    switch (bitWidth)
-    {
-    case 16:
-        floatControl.denormPerserve             = ((commonUsage.denormPerserve & SPIRVTW_16Bit) != 0);
-        floatControl.denormFlushToZero          = ((commonUsage.denormFlushToZero & SPIRVTW_16Bit) != 0);
-        floatControl.signedZeroInfNanPreserve   = ((commonUsage.signedZeroInfNanPreserve & SPIRVTW_16Bit) != 0);
-        floatControl.roundingModeRTE            = ((commonUsage.roundingModeRTE & SPIRVTW_16Bit) != 0);
-        floatControl.roundingModeRTZ            = ((commonUsage.roundingModeRTZ & SPIRVTW_16Bit) != 0);
-        break;
-    case 32:
-        floatControl.denormPerserve             = ((commonUsage.denormPerserve & SPIRVTW_32Bit) != 0);
-        floatControl.denormFlushToZero          = ((commonUsage.denormFlushToZero & SPIRVTW_32Bit) != 0);
-        floatControl.signedZeroInfNanPreserve   = ((commonUsage.signedZeroInfNanPreserve & SPIRVTW_32Bit) != 0);
-        floatControl.roundingModeRTE            = ((commonUsage.roundingModeRTE & SPIRVTW_32Bit) != 0);
-        floatControl.roundingModeRTZ            = ((commonUsage.roundingModeRTZ & SPIRVTW_32Bit) != 0);
-        break;
-    case 64:
-        floatControl.denormPerserve             = ((commonUsage.denormPerserve & SPIRVTW_64Bit) != 0);
-        floatControl.denormFlushToZero          = ((commonUsage.denormFlushToZero & SPIRVTW_64Bit) != 0);
-        floatControl.signedZeroInfNanPreserve   = ((commonUsage.signedZeroInfNanPreserve & SPIRVTW_64Bit) != 0);
-        floatControl.roundingModeRTE            = ((commonUsage.roundingModeRTE & SPIRVTW_64Bit) != 0);
-        floatControl.roundingModeRTZ            = ((commonUsage.roundingModeRTZ & SPIRVTW_64Bit) != 0);
-        break;
-    default:
-        LLPC_NEVER_CALLED();
-        break;
-    }
-
-    return floatControl;
 }
 
 } // Llpc

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -94,9 +94,6 @@ public:
     }
 #endif
 
-    // Gets float control settings of the specified shader stage for the provide floating-point type.
-    virtual FloatControl GetShaderFloatControl(ShaderStage shaderStage, uint32_t bitWidth) const;
-
     // Gets the count of vertices per primitive
     virtual uint32_t GetVerticesPerPrimitive() const { LLPC_NEVER_CALLED(); return 0; }
 

--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -133,8 +133,9 @@ GraphicsContext::GraphicsContext(
 
     for (uint32_t stage = 0; stage < ShaderStageGfxCount; ++stage)
     {
-        InitShaderResourceUsage(static_cast<ShaderStage>(stage));
-        InitShaderInterfaceData(static_cast<ShaderStage>(stage));
+        ShaderStage shaderStage = static_cast<ShaderStage>(stage);
+        InitShaderResourceUsage(shaderStage, GetShaderResourceUsage(shaderStage));
+        InitShaderInterfaceData(GetShaderInterfaceData(shaderStage));
     }
 }
 
@@ -1299,55 +1300,6 @@ bool GraphicsContext::GetShaderWgpMode(
     return wgpMode;
 }
 #endif
-
-// =====================================================================================================================
-// Gets float control settings of the specified shader stage for the provide floating-point type.
-FloatControl GraphicsContext::GetShaderFloatControl(
-    ShaderStage shaderStage,    // Shader stage
-    uint32_t    bitWidth        // Bit width of the floating-point type
-    ) const
-{
-    if (shaderStage == ShaderStageCopyShader)
-    {
-        // Treat copy shader as part of geometry shader
-        shaderStage = ShaderStageGeometry;
-    }
-
-    LLPC_ASSERT(shaderStage < ShaderStageGfxCount);
-
-    FloatControl floatControl = {};
-    const auto& commonUsage = m_resUsages[shaderStage].builtInUsage.common;
-
-    switch (bitWidth)
-    {
-    case 16:
-        floatControl.denormPerserve             = ((commonUsage.denormPerserve & SPIRVTW_16Bit) != 0);
-        floatControl.denormFlushToZero          = ((commonUsage.denormFlushToZero & SPIRVTW_16Bit) != 0);
-        floatControl.signedZeroInfNanPreserve   = ((commonUsage.signedZeroInfNanPreserve & SPIRVTW_16Bit) != 0);
-        floatControl.roundingModeRTE            = ((commonUsage.roundingModeRTE & SPIRVTW_16Bit) != 0);
-        floatControl.roundingModeRTZ            = ((commonUsage.roundingModeRTZ & SPIRVTW_16Bit) != 0);
-        break;
-    case 32:
-        floatControl.denormPerserve             = ((commonUsage.denormPerserve & SPIRVTW_32Bit) != 0);
-        floatControl.denormFlushToZero          = ((commonUsage.denormFlushToZero & SPIRVTW_32Bit) != 0);
-        floatControl.signedZeroInfNanPreserve   = ((commonUsage.signedZeroInfNanPreserve & SPIRVTW_32Bit) != 0);
-        floatControl.roundingModeRTE            = ((commonUsage.roundingModeRTE & SPIRVTW_32Bit) != 0);
-        floatControl.roundingModeRTZ            = ((commonUsage.roundingModeRTZ & SPIRVTW_32Bit) != 0);
-        break;
-    case 64:
-        floatControl.denormPerserve             = ((commonUsage.denormPerserve & SPIRVTW_64Bit) != 0);
-        floatControl.denormFlushToZero          = ((commonUsage.denormFlushToZero & SPIRVTW_64Bit) != 0);
-        floatControl.signedZeroInfNanPreserve   = ((commonUsage.signedZeroInfNanPreserve & SPIRVTW_64Bit) != 0);
-        floatControl.roundingModeRTE            = ((commonUsage.roundingModeRTE & SPIRVTW_64Bit) != 0);
-        floatControl.roundingModeRTZ            = ((commonUsage.roundingModeRTZ & SPIRVTW_64Bit) != 0);
-        break;
-    default:
-        LLPC_NEVER_CALLED();
-        break;
-    }
-
-    return floatControl;
-}
 
 // =====================================================================================================================
 // Gets the count of vertices per primitive

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -97,9 +97,6 @@ public:
     virtual bool GetShaderWgpMode(ShaderStage shaderStage) const;
 #endif
 
-    // Gets float control settings of the specified shader stage for the provide floating-point type.
-    virtual FloatControl GetShaderFloatControl(ShaderStage shaderStage, uint32_t bitWidth) const;
-
     // Gets the count of vertices per primitive
     virtual uint32_t GetVerticesPerPrimitive() const;
 

--- a/context/llpcPipelineContext.cpp
+++ b/context/llpcPipelineContext.cpp
@@ -68,7 +68,8 @@ PipelineContext::~PipelineContext()
 
 // =====================================================================================================================
 // Gets the name string of GPU target according to graphics IP version info.
-const char* PipelineContext::GetGpuNameString() const
+const char* PipelineContext::GetGpuNameString(
+    GfxIpVersion gfxIp)   // Graphics IP version info
 {
     struct GpuNameStringMap
     {
@@ -108,9 +109,9 @@ const char* PipelineContext::GetGpuNameString() const
     const GpuNameStringMap* pNameMap = nullptr;
     for (auto& nameMap : GpuNameMap)
     {
-        if ((nameMap.gfxIp.major    == m_gfxIp.major) &&
-            (nameMap.gfxIp.minor    == m_gfxIp.minor) &&
-            (nameMap.gfxIp.stepping == m_gfxIp.stepping))
+        if ((nameMap.gfxIp.major    == gfxIp.major) &&
+            (nameMap.gfxIp.minor    == gfxIp.minor) &&
+            (nameMap.gfxIp.stepping == gfxIp.stepping))
         {
             pNameMap = &nameMap;
             break;
@@ -124,10 +125,11 @@ const char* PipelineContext::GetGpuNameString() const
 
 // =====================================================================================================================
 // Gets the name string of the abbreviation for GPU target according to graphics IP version info.
-const char* PipelineContext::GetGpuNameAbbreviation() const
+const char* PipelineContext::GetGpuNameAbbreviation(
+    GfxIpVersion gfxIp)  // Graphics IP version info
 {
     const char* pNameAbbr = nullptr;
-    switch (m_gfxIp.major)
+    switch (gfxIp.major)
     {
     case 6:
         pNameAbbr = "SI";
@@ -152,10 +154,9 @@ const char* PipelineContext::GetGpuNameAbbreviation() const
 // =====================================================================================================================
 // Initializes resource usage of the specified shader stage.
 void PipelineContext::InitShaderResourceUsage(
-    ShaderStage shaderStage)    // Shader stage
+    ShaderStage    shaderStage,      // Shader stage
+    ResourceUsage* pResUsage)        // [out] Resource usage
 {
-    auto pResUsage = GetShaderResourceUsage(shaderStage);
-
     memset(&pResUsage->builtInUsage, 0, sizeof(pResUsage->builtInUsage));
 
     pResUsage->pushConstSizeInBytes = 0;
@@ -164,8 +165,8 @@ void PipelineContext::InitShaderResourceUsage(
     pResUsage->perShaderTable = false;
     pResUsage->globalConstant = false;
 
-    pResUsage->numSgprsAvailable = m_pGpuProperty->maxSgprsAvailable;
-    pResUsage->numVgprsAvailable = m_pGpuProperty->maxVgprsAvailable;
+    pResUsage->numSgprsAvailable = UINT32_MAX;
+    pResUsage->numVgprsAvailable = UINT32_MAX;
 
     pResUsage->inOutUsage.inputMapLocCount = 0;
     pResUsage->inOutUsage.outputMapLocCount = 0;
@@ -224,10 +225,8 @@ void PipelineContext::InitShaderResourceUsage(
 // =====================================================================================================================
 // Initializes interface data of the specified shader stage.
 void PipelineContext::InitShaderInterfaceData(
-    ShaderStage shaderStage)  // Shader stage
+    InterfaceData* pIntfData)  // [out] Interface data
 {
-    auto pIntfData = GetShaderInterfaceData(shaderStage);
-
     pIntfData->userDataCount = 0;
     memset(pIntfData->userDataMap, InterfaceData::UserDataUnmapped, sizeof(pIntfData->userDataMap));
 

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -166,7 +166,6 @@ union XfbOutInfo
 // NOTE: All fields must be initialized in InitShaderResourceUsage().
 struct ResourceUsage
 {
-    std::vector<DescriptorSet> descSets;              // Info array of descriptor sets and bindings
     std::unordered_set<uint64_t> descPairs;           // Pairs of descriptor set/binding
     uint32_t                   pushConstSizeInBytes;  // Push constant size (in bytes)
     bool                       resourceWrite;         // Whether shader does resource-write operations (UAV)
@@ -799,17 +798,14 @@ public:
     virtual bool GetShaderWgpMode(ShaderStage shaderStage) const = 0;
 #endif
 
-    // Gets float control settings of the specified shader stage for the provide floating-point type.
-    virtual FloatControl GetShaderFloatControl(ShaderStage shaderStage, uint32_t bitWidth) const = 0;
-
     // Gets the count of vertices per primitive
     virtual uint32_t GetVerticesPerPrimitive() const = 0;
 
     // Gets wave size for the specified shader stage
     virtual uint32_t GetShaderWaveSize(ShaderStage stage) = 0;
 
-    const char* GetGpuNameString() const;
-    const char* GetGpuNameAbbreviation() const;
+    static const char* GetGpuNameString(GfxIpVersion gfxIp);
+    static const char* GetGpuNameAbbreviation(GfxIpVersion gfxIp);
 
     // Gets graphics IP version info
     GfxIpVersion GetGfxIpVersion() const { return m_gfxIp; }
@@ -830,6 +826,9 @@ public:
     // Set pipeline state in Builder
     void SetBuilderPipelineState(Builder* pBuilder) const;
 
+    static void InitShaderResourceUsage(ShaderStage shaderStage, ResourceUsage* pResUsage);
+
+    static void InitShaderInterfaceData(InterfaceData* pIntfData);
 protected:
     // Gets dummy vertex input create info
     virtual VkPipelineVertexInputStateCreateInfo* GetDummyVertexInputInfo() { return nullptr; }
@@ -839,10 +838,6 @@ protected:
 
     // Gets dummy vertex attribute info
     virtual std::vector<VkVertexInputAttributeDescription>* GetDummyVertexAttributes() { return nullptr; }
-
-    void InitShaderResourceUsage(ShaderStage shaderStage);
-
-    void InitShaderInterfaceData(ShaderStage shaderStage);
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/lower/llpcSpirvLowerLoopUnrollControl.cpp
+++ b/lower/llpcSpirvLowerLoopUnrollControl.cpp
@@ -87,10 +87,13 @@ bool SpirvLowerLoopUnrollControl::runOnModule(
     SpirvLower::Init(&module);
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-    auto pShaderOptions = &(m_pContext->GetPipelineShaderInfo(m_shaderStage)->options);
-    if (pShaderOptions->forceLoopUnrollCount > 0)
+    if (m_pContext->GetPipelineContext() != nullptr)
     {
-        m_forceLoopUnrollCount = pShaderOptions->forceLoopUnrollCount;
+        auto pShaderOptions = &(m_pContext->GetPipelineShaderInfo(m_shaderStage)->options);
+        if (pShaderOptions->forceLoopUnrollCount > 0)
+        {
+            m_forceLoopUnrollCount = pShaderOptions->forceLoopUnrollCount;
+        }
     }
 #endif
 

--- a/lower/llpcSpirvLowerResourceCollect.h
+++ b/lower/llpcSpirvLowerResourceCollect.h
@@ -64,7 +64,6 @@ private:
     const llvm::Type* GetFlattenArrayElementType(const llvm::Type* pTy) const;
 
     void CollectExecutionModeUsage();
-    void CollectDescriptorUsage(uint32_t descSet, uint32_t binding, const DescriptorBinding* pBinding);
     void CollectInOutUsage(const llvm::Type* pInOutTy, llvm::Constant* pInOutMeta, SPIRAddressSpace addrSpace);
     void CollectGsOutputInfo(const Type* pOutputTy, uint32_t location, const ShaderInOutMetadata& outputMeta);
     void CollectXfbOutputInfo(const llvm::Type* pOutputTy, const ShaderInOutMetadata& inOutMeta);

--- a/lower/llpcSpirvLowerTranslator.cpp
+++ b/lower/llpcSpirvLowerTranslator.cpp
@@ -64,13 +64,7 @@ bool SpirvLowerTranslator::runOnModule(
     m_pContext = static_cast<Context*>(&module.getContext());
 
     // Translate SPIR-V binary to machine-independent LLVM module
-    const ShaderModuleData* pModuleData = reinterpret_cast<const ShaderModuleData*>(m_pShaderInfo->pModuleData);
-    LLPC_ASSERT(pModuleData->binType == BinaryType::Spirv);
-
-    Compiler::TranslateSpirvToLlvm(&pModuleData->binCode,
-                                   m_shaderStage,
-                                   m_pShaderInfo->pEntryTarget,
-                                   m_pShaderInfo->pSpecializationInfo,
+    Compiler::TranslateSpirvToLlvm(m_pShaderInfo,
                                    &module);
     return true;
 }

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -86,9 +86,9 @@ namespace Llpc
 // Creates the TargetMachine if not already created, and stores it in the context. It then persists as long as
 // the context.
 Result CodeGenManager::CreateTargetMachine(
-    Context*           pContext)  // [in/out] Pipeline context
+    Context*               pContext,          // [in/out] Pipeline context
+    const PipelineOptions* pPipelineOptions)  // [in] Pipeline options
 {
-    auto pPipelineOptions = pContext->GetPipelineContext()->GetPipelineOptions();
     if ((pContext->GetTargetMachine() != nullptr) &&
         (pPipelineOptions->includeDisassembly == pContext->GetTargetMachinePipelineOptions()->includeDisassembly) &&
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30

--- a/patch/llpcCodeGenManager.h
+++ b/patch/llpcCodeGenManager.h
@@ -77,7 +77,7 @@ struct ElfDataEntry
 class CodeGenManager
 {
 public:
-    static Result CreateTargetMachine(Context* pContext);
+    static Result CreateTargetMachine(Context* pContext, const PipelineOptions* pPipelineOptions);
 
     static void SetupTargetFeatures(llvm::Module* pModule);
 

--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -206,6 +206,8 @@ void PatchEntryPointMutate::ProcessShader()
         builder.addAttribute("amdgpu-num-vgpr", std::to_string(vgprLimit));
         pResUsage->numVgprsAvailable = std::min(vgprLimit, pResUsage->numVgprsAvailable);
     }
+    pResUsage->numVgprsAvailable = std::min(pResUsage->numVgprsAvailable,
+                                           m_pContext->GetGpuProperty()->maxVgprsAvailable);
 
     if ((pShaderOptions->sgprLimit != 0) && (pShaderOptions->sgprLimit != UINT32_MAX))
     {
@@ -221,6 +223,8 @@ void PatchEntryPointMutate::ProcessShader()
         builder.addAttribute("amdgpu-num-sgpr", std::to_string(sgprLimit));
         pResUsage->numSgprsAvailable = std::min(sgprLimit, pResUsage->numSgprsAvailable);
     }
+    pResUsage->numSgprsAvailable = std::min(pResUsage->numSgprsAvailable,
+                                            m_pContext->GetGpuProperty()->maxSgprsAvailable);
 
     if (pShaderOptions->maxThreadGroupsPerComputeUnit != 0)
     {

--- a/patch/llpcPatchResourceCollect.cpp
+++ b/patch/llpcPatchResourceCollect.cpp
@@ -161,6 +161,33 @@ void PatchResourceCollect::ProcessShader()
             }
         }
     }
+    else if (m_shaderStage == ShaderStageVertex)
+    {
+        // Collect resource usages from vertex input create info
+        auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo());
+        auto pVertexInput = pPipelineInfo->pVertexInput;
+
+        // TODO: In the future, we might check if the corresponding vertex attribute is active in vertex shader
+        // and set the usage based on this info.
+        if (pVertexInput != nullptr)
+        {
+            for (uint32_t i = 0; i < pVertexInput->vertexBindingDescriptionCount; ++i)
+            {
+                auto pBinding = &pVertexInput->pVertexBindingDescriptions[i];
+                if (pBinding->inputRate == VK_VERTEX_INPUT_RATE_VERTEX)
+                {
+                    m_pResUsage->builtInUsage.vs.vertexIndex = true;
+                    m_pResUsage->builtInUsage.vs.baseVertex = true;
+                }
+                else
+                {
+                    //LLPC_ASSERT(pBinding->inputRate == VK_VERTEX_INPUT_RATE_INSTANCE);
+                    m_pResUsage->builtInUsage.vs.instanceIndex = true;
+                    m_pResUsage->builtInUsage.vs.baseInstance = true;
+                }
+            }
+        }
+    }
 
     // Remove dead calls
     for (auto pCall : m_deadCalls)

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -1443,6 +1443,16 @@ static Result ProcessPipeline(
                         }
                     }
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 32
+                    bool isGraphics = (compileInfo.stageMask & ShaderStageToMask(ShaderStageCompute)) ? false : true;
+                    for (uint32_t i = 0; i < ShaderStageCount; ++i)
+                    {
+                        compileInfo.shaderInfo[i].options.pipelineOptions = isGraphics ?
+                                                                            compileInfo.gfxPipelineInfo.options :
+                                                                            compileInfo.compPipelineInfo.options;
+                    }
+#endif
+
                     fileNames += inFile;
                     fileNames += " ";
                     *pNextFile = i + 1;


### PR DESCRIPTION
1. Add new option -enable-shader-module-opt to support do translate, lower & potential opt pass in build shader module.
 - It is disabled in default.
2. Add ShdaerModuleOptions in ShaderModuleBuildInfo, it includes PipelineOptions and flag enableOpt
3. Modify function Compiler::BuildShaderModule to support translate & lower phase in it.
 - Internal shader cache is used if translate & lower phase is executed in build shader module
 - It do translate & lower for each entry point unless if specialized constant is used.
 - Result is serialized to BC code. (per current profile result, the cost of serialize and deserialize is acceptable)
 - Add functions to support store & load ResourceUsage
   ps: they should be removed once we store all these information in LLVM IR.
4. Modify lower & translate related code which dependent on PipelineContext, since PipelineContext isn't available in ShaderModule