### PR TITLE
Fix compile errors of spirv1.4 support for OpSelect and PartialCount

### DIFF
--- a/test/shaderdb/ObjSharedVariable_TestArrayCopy_lit.comp
+++ b/test/shaderdb/ObjSharedVariable_TestArrayCopy_lit.comp
@@ -30,10 +30,10 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @{{[0-9]}} = addrspace(3) global { i32, [16 x i32] }
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{[0-9]}}, i32 0, i32 1, i32 {{[0-9]*}})
-; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{[0-9]}}, i32 0, i32 1, i32 {{[0-9]*}})
-; SHADERTEST: %{{[0-9]*}} = getelementptr { i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{[0-9]}}, i32 0, i32 1, i32 %{{[0-9]*}}
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global { i32, [16 x i32] }
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @[[LDS]], i32 0, i32 1, i32 {{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @[[LDS]], i32 0, i32 1, i32 {{[0-9]*}})
+; SHADERTEST: %{{[0-9]*}} = getelementptr { i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @[[LDS]], i32 0, i32 1, i32 %{{[0-9]*}}
 ; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* %{{[0-9]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/ObjSharedVariable_TestArray_lit.comp
+++ b/test/shaderdb/ObjSharedVariable_TestArray_lit.comp
@@ -20,11 +20,11 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @{{[0-9]}} = addrspace(3) global [16 x i32] undef
-; SHADERTEST: %{{[0-9]*}} = getelementptr [16 x i32], [16 x i32] addrspace(3)* @{{[0-9]}}, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global [16 x i32] undef
+; SHADERTEST: %{{[0-9]*}} = getelementptr [16 x i32], [16 x i32] addrspace(3)* @[[LDS]], i32 0, i32 %{{[0-9]*}}
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* %{{[0-9]*}}
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds ([16 x i32], [16 x i32] addrspace(3)* @{{[0-9]}}, i32 0, i32 3)
-; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* getelementptr inbounds ([16 x i32], [16 x i32] addrspace(3)* @{{[0-9]}}, i32 0, i32 4)
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds ([16 x i32], [16 x i32] addrspace(3)* @[[LDS]], i32 0, i32 3)
+; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* getelementptr inbounds ([16 x i32], [16 x i32] addrspace(3)* @[[LDS]], i32 0, i32 4)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjSharedVariable_TestBasic_lit.comp
+++ b/test/shaderdb/ObjSharedVariable_TestBasic_lit.comp
@@ -23,9 +23,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @{{[0-9]}} = addrspace(3) global <4 x float> undef
-; SHADERTEST: store <4 x float> %{{[0-9]*}}, <4 x float> addrspace(3)* @{{[0-9]}}
-; SHADERTEST: %{{[0-9]*}} = load <4 x float>, <4 x float> addrspace(3)* @{{[0-9]}}
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global <4 x float> undef
+; SHADERTEST: store <4 x float> %{{[0-9]*}}, <4 x float> addrspace(3)* @[[LDS]]
+; SHADERTEST: %{{[0-9]*}} = load <4 x float>, <4 x float> addrspace(3)* @[[LDS]]
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjSharedVariable_TestMatrix_lit.comp
+++ b/test/shaderdb/ObjSharedVariable_TestMatrix_lit.comp
@@ -22,9 +22,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @{{[0-9]}} = addrspace(3) global [4 x <4 x float>] undef
-; SHADERTEST: store <4 x float> %{{[0-9]*}}, <4 x float> addrspace(3)* getelementptr inbounds ([4 x <4 x float>], [4 x <4 x float>] addrspace(3)* @{{[0-9]}}, i32 0, i32 {{[0-3]}})
-; SHADERTEST: %{{[0-9]*}} = load <4 x float>, <4 x float> addrspace(3)* getelementptr inbounds ([4 x <4 x float>], [4 x <4 x float>] addrspace(3)* @{{[0-9]}}, i32 0, i32 {{[0-3]}})
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global [4 x <4 x float>] undef
+; SHADERTEST: store <4 x float> %{{[0-9]*}}, <4 x float> addrspace(3)* getelementptr inbounds ([4 x <4 x float>], [4 x <4 x float>] addrspace(3)* @[[LDS]], i32 0, i32 {{[0-3]}})
+; SHADERTEST: %{{[0-9]*}} = load <4 x float>, <4 x float> addrspace(3)* getelementptr inbounds ([4 x <4 x float>], [4 x <4 x float>] addrspace(3)* @[[LDS]], i32 0, i32 {{[0-3]}})
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjSharedVariable_TestStruct_lit.comp
+++ b/test/shaderdb/ObjSharedVariable_TestStruct_lit.comp
@@ -24,11 +24,11 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @{{[0-9]}} = addrspace(3) global { i32, [16 x i32] }
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{[0-9]}}, i32 0, i32 0)
-; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{[0-9]}}, i32 0, i32 0)
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global { i32, [16 x i32] }
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @[[LDS]], i32 0, i32 0)
+; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* getelementptr inbounds ({ i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @[[LDS]], i32 0, i32 0)
 
-; SHADERTEST: %{{[0-9]*}} = getelementptr { i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{[0-9]}}, i32 0, i32 1, i32 %{{[0-9]*}}
+; SHADERTEST: %{{[0-9]*}} = getelementptr { i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @[[LDS]], i32 0, i32 1, i32 %{{[0-9]*}}
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* %{{[0-9]*}}
 ; SHADERTEST: %{{[0-9]*}} = getelementptr { i32, [16 x i32] }, { i32, [16 x i32] } addrspace(3)* @{{.*}}, i32 0, i32 1, i32 %{{[0-9]*}}
 ; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(3)* %{{[0-9]*}}

--- a/test/shaderdb/OpAtomicXXX_TestSharedVariable_lit.comp
+++ b/test/shaderdb/OpAtomicXXX_TestSharedVariable_lit.comp
@@ -63,8 +63,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: @{{.*}} = internal addrspace(3) global i32
-; SHADERTEST: @{{.*}} = internal addrspace(3) global [4 x i32]
+; SHADERTEST: @{{.*}} = addrspace(3) global i32
+; SHADERTEST: @{{.*}} = addrspace(3) global [4 x i32]
 ; SHADERTEST: atomicrmw add i32 addrspace(3)* @{{.*}}, i32 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw add i32 addrspace(3)* getelementptr inbounds ([4 x i32], [4 x i32] addrspace(3)* @{{.*}}, i32 0, i32 1), i32 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw min i32 addrspace(3)* @{{.*}}, i32 %{{[0-9]*}} monotonic


### PR DESCRIPTION
- Use int32 type for ‘llvm.loop.unroll.count’ Metadata instead of string type
- Give shared variable a name to skip "global optimize pass"