### PR TITLE
Stop SPIRV OpMemoryBarrier from causing cache flushes

### DIFF
--- a/test/shaderdb/OpMemoryBarrier_TestGroupMemoryBarrier_lit.comp
+++ b/test/shaderdb/OpMemoryBarrier_TestGroupMemoryBarrier_lit.comp
@@ -19,7 +19,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: fence syncscope("workgroup") acq_rel
+; SHADERTEST: fence syncscope("wavefront") acq_rel
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMemoryBarrier_TestMemoryBarrierBuffer_lit.frag
+++ b/test/shaderdb/OpMemoryBarrier_TestMemoryBarrierBuffer_lit.frag
@@ -17,7 +17,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: fence acq_rel
+; SHADERTEST: fence syncscope("wavefront") acq_rel
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMemoryBarrier_TestMemoryBarrierImage_lit.frag
+++ b/test/shaderdb/OpMemoryBarrier_TestMemoryBarrierImage_lit.frag
@@ -13,7 +13,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: fence acq_rel
+; SHADERTEST: fence syncscope("wavefront") acq_rel
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMemoryBarrier_TestMemoryBarrierShared_lit.comp
+++ b/test/shaderdb/OpMemoryBarrier_TestMemoryBarrierShared_lit.comp
@@ -16,7 +16,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: fence acq_rel
+; SHADERTEST: fence syncscope("wavefront") acq_rel
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMemoryBarrier_TestMemoryBarrier_lit.comp
+++ b/test/shaderdb/OpMemoryBarrier_TestMemoryBarrier_lit.comp
@@ -19,7 +19,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: fence acq_rel
+; SHADERTEST: fence syncscope("wavefront") acq_rel
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -9350,26 +9350,27 @@ Instruction *SPIRVToLLVM::transOCLMemFence(BasicBlock *BB, SPIRVWord MemSema,
         Ordering = AtomicOrdering::SequentiallyConsistent;
     }
 
-    SyncScope::ID Scope = SyncScope::System;
+    //SyncScope::ID Scope = SyncScope::System;
+    SyncScope::ID Scope = Context->getOrInsertSyncScopeID("wavefront");
 
-    switch (MemScope) {
-    case ScopeCrossDevice:
-    case ScopeDevice:
-    case ScopeQueueFamilyKHR:
-      Scope = SyncScope::System;
-      break;
-    case ScopeInvocation:
-      Scope = SyncScope::SingleThread;
-      break;
-    case ScopeWorkgroup:
-      Scope = Context->getOrInsertSyncScopeID("workgroup");
-      break;
-    case ScopeSubgroup:
-      Scope = Context->getOrInsertSyncScopeID("wavefront");
-      break;
-    default:
-      llvm_unreachable("Invalid scope");
-    }
+    // switch (MemScope) {
+    // case ScopeCrossDevice:
+    // case ScopeDevice:
+    // case ScopeQueueFamilyKHR:
+    //   Scope = SyncScope::System;
+    //   break;
+    // case ScopeInvocation:
+    //   Scope = SyncScope::SingleThread;
+    //   break;
+    // case ScopeWorkgroup:
+    //   Scope = Context->getOrInsertSyncScopeID("workgroup");
+    //   break;
+    // case ScopeSubgroup:
+    //   Scope = Context->getOrInsertSyncScopeID("wavefront");
+    //   break;
+    // default:
+    //   llvm_unreachable("Invalid scope");
+    // }
 
     return new FenceInst(*Context, Ordering, Scope, BB);
   } else if ((Ver > 0 && Ver <= kOCLVer::CL12)) {


### PR DESCRIPTION
OpMemoryBarrier can be implemented with waitcnt only if all non-private memory
accesses use GLC=1 (which I think they do).