### PR TITLE
Fixed clang compile errors from 'Support translate and lower phase in…

### DIFF
--- a/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/lower/llpcSpirvLowerResourceCollect.cpp
@@ -127,11 +127,6 @@ bool SpirvLowerResourceCollect::runOnModule(
                 {
                     useImages = true;
 
-                    MDNode* pMetaNode = pGlobal->getMetadata(gSPIRVMD::Resource);
-
-                    auto descSet = mdconst::dyn_extract<ConstantInt>(pMetaNode->getOperand(0))->getZExtValue();
-                    auto binding = mdconst::dyn_extract<ConstantInt>(pMetaNode->getOperand(1))->getZExtValue();
-
                     // TODO: Will support separated texture resource/sampler.
                     DescriptorType descType = DescriptorType::Texture;
 
@@ -226,11 +221,11 @@ bool SpirvLowerResourceCollect::runOnModule(
         case SPIRAS_Uniform:
             {
                 // Buffer block
+#ifndef NDEBUG
                 MDNode* pMetaNode = pGlobal->getMetadata(gSPIRVMD::Resource);
-                auto descSet   = mdconst::dyn_extract<ConstantInt>(pMetaNode->getOperand(0))->getZExtValue();
-                auto binding   = mdconst::dyn_extract<ConstantInt>(pMetaNode->getOperand(1))->getZExtValue();
                 auto blockType = mdconst::dyn_extract<ConstantInt>(pMetaNode->getOperand(2))->getZExtValue();
                 LLPC_ASSERT((blockType == BlockTypeUniform) || (blockType == BlockTypeShaderStorage));
+#endif
                 break;
             }
         default:


### PR DESCRIPTION
… shader module [Part 2]'

- Fixed a few unused variables.
- Clang complained of ambiguity in calls to the BinaryStream set and map
  methods, so I separated BinaryStream into BinaryIStream and
  BinaryOStream.

Change-Id: I38af08d310fc7ef19b696e2af33d1a49aa31bb8c