### PR TITLE
Mark subgroup votes as soft WQM

### DIFF
--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -77,7 +77,7 @@ Value* BuilderImplSubgroup::CreateSubgroupAll(
     if (wqm)
     {
         pResult = CreateZExt(pResult, getInt32Ty());
-        pResult = CreateIntrinsic(Intrinsic::amdgcn_wqm, { getInt32Ty() }, { pResult });
+        pResult = CreateIntrinsic(Intrinsic::amdgcn_softwqm, { getInt32Ty() }, { pResult });
         pResult = CreateTrunc(pResult, getInt1Ty());
     }
     return pResult;
@@ -97,7 +97,7 @@ Value* BuilderImplSubgroup::CreateSubgroupAny(
     if (wqm)
     {
         pResult = CreateZExt(pResult, getInt32Ty());
-        pResult = CreateIntrinsic(Intrinsic::amdgcn_wqm, { getInt32Ty() }, { pResult });
+        pResult = CreateIntrinsic(Intrinsic::amdgcn_softwqm, { getInt32Ty() }, { pResult });
         pResult = CreateTrunc(pResult, getInt1Ty());
     }
     return pResult;


### PR DESCRIPTION
By marking the votes as soft WQM they will only be executed in WQM
if the shader contains other WQM computation.