### PR TITLE
SubgroupQuadSwap Horizontal Table and Vertical Table values.

### DIFF
--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -922,7 +922,7 @@ Value* BuilderImplSubgroup::CreateSubgroupQuadSwapHorizontal(
     }
     else
     {
-        return CreateDsSwizzle(pValue, GetDsSwizzleQuadMode(2, 3, 0, 1));
+        return CreateDsSwizzle(pValue, GetDsSwizzleQuadMode(1, 0, 3, 2));
     }
 }
 
@@ -938,7 +938,7 @@ Value* BuilderImplSubgroup::CreateSubgroupQuadSwapVertical(
     }
     else
     {
-        return CreateDsSwizzle(pValue, GetDsSwizzleQuadMode(1, 0, 3, 2));
+        return CreateDsSwizzle(pValue, GetDsSwizzleQuadMode(2, 3, 0, 1));
     }
 }
 


### PR DESCRIPTION
When chip not supportDpp, the SubgroupQuadSwap Horizontal Table should be (1, 0, 3, 2), and Vertical Table should be (2, 3, 0, 1).