### PR TITLE
Fix shaderdb tests

### DIFF
--- a/test/shaderdb/ObjInput_TestVsBasic_lit.vert
+++ b/test/shaderdb/ObjInput_TestVsBasic_lit.vert
@@ -21,7 +21,7 @@ void main()
 ; SHADERTEST-DAG: call i32 @llpc.input.import.generic{{.*}}
 ; SHADERTEST-DAG: call <4 x float> @llpc.input.import.generic.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST-COUNT-3: call <4 x i32> @llvm.amdgcn.struct.tbuffer.load.v4i32
+; SHADERTEST-COUNT-3: call {{.*}} @llvm.amdgcn.struct.tbuffer.load
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/ObjInput_TestVsCompSpecifier_lit.vert
+++ b/test/shaderdb/ObjInput_TestVsCompSpecifier_lit.vert
@@ -18,7 +18,7 @@ void main()
 ; SHADERTEST: call <2 x float> @llpc.input.import.generic.v2f32.i32.i32(i32 0, i32 1)
 ; SHADERTEST: call float @llpc.input.import.generic.f32.i32.i32(i32 0, i32 0)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call <4 x i32> @llvm.amdgcn.struct.tbuffer.load.v4i32
+; SHADERTEST: call {{.*}} @llvm.amdgcn.struct.tbuffer.load
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
There is no justification for requiring that a source variable
with fewer than 4 components is mapped to 4-component buffer
load (@llvm.amdgcn.struct.tbuffer.load.v4i32).