### PR TITLE
PatchDescriptorLoad: extract buildBufferDescriptor

### DIFF
--- a/patch/llpcPatchDescriptorLoad.h
+++ b/patch/llpcPatchDescriptorLoad.h
@@ -89,6 +89,12 @@ private:
 
     void PatchWaterfallLastUseCalls();
 
+    // Create a non-strided, non-swizzled buffer descriptor with the given
+    // base address (64-bit integer) and size in bytes (32-bit integer).
+    llvm::Value* buildBufferDescriptor(llvm::Value* pBaseAddr,
+                                       llvm::Value* pBufSize,
+                                       llvm::Instruction* pInsertPoint);
+
     // -----------------------------------------------------------------------------------------------------------------
 
     // Descriptor size

--- a/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -10,8 +10,8 @@
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to [4294967295 x i8]
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i32 0
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 1
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i64 0
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)
 ; SHADERTEST: bitcast <4 x i32> %{{.*}} to <2 x double>
 


### PR DESCRIPTION
Increase code re-use and make the code more compact by using IRBuilder.

The test change is required because the canonical form of insertelement
uses i64 for the element index.