### PR TITLE
Builder bit operations

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -346,6 +346,33 @@ public:
         Value*        pValue3,              // [in] Third value
         const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
+    // Create an "insert bitfield" operation for a (vector of) integer type.
+    // Returns a value where the "pCount" bits starting at bit "pOffset" come from the least significant "pCount"
+    // bits in "pInsert", and remaining bits come from "pBase". The result is undefined if "pCount"+"pOffset" is
+    // more than the number of bits (per vector element) in "pBase" and "pInsert".
+    // If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
+    // width. The scalar type of "pOffset" and "pCount" must be integer, but can be different to that of "pBase"
+    // and "pInsert" (and different to each other too).
+    virtual Value* CreateInsertBitField(
+        Value*        pBase,                // [in] Base value
+        Value*        pInsert,              // [in] Value to insert (same type as base)
+        Value*        pOffset,              // Bit number of least-significant end of bitfield
+        Value*        pCount,               // Count of bits in bitfield
+        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+
+    // Create an "extract bitfield " operation for a (vector of) i32.
+    // Returns a value where the least significant "pCount" bits come from the "pCount" bits starting at bit
+    // "pOffset" in "pBase", and that is zero- or sign-extended (depending on "isSigned") to the rest of the value.
+    // If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
+    // width. The scalar type of "pOffset" and "pCount" must be integer, but can be different to that of "pBase"
+    // (and different to each other too).
+    virtual Value* CreateExtractBitField(
+        Value*        pBase,                // [in] Base value
+        Value*        pOffset,              // Bit number of least-significant end of bitfield
+        Value*        pCount,               // Count of bits in bitfield
+        bool          isSigned,             // True for a signed int bitfield extract, false for unsigned
+        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+
     // -----------------------------------------------------------------------------------------------------------------
     // Descriptor operations
 

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -133,6 +133,20 @@ public:
     // Create "fmed3" operation, returning the middle one of three float values.
     Value* CreateFMed3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
 
+    // Create an "insert bitfield" operation for a (vector of) integer type.
+    Value* CreateInsertBitField(Value*        pBase,
+                                Value*        pInsert,
+                                Value*        pOffset,
+                                Value*        pCount,
+                                const Twine&  instName = "") override final;
+
+    // Create an "extract bitfield " operation for a (vector of) i32.
+    Value* CreateExtractBitField(Value*        pBase,
+                                 Value*        pOffset,
+                                 Value*        pCount,
+                                 bool          isSigned,
+                                 const Twine&  instName = "") override final;
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(BuilderImplArith)
     LLPC_DISALLOW_COPY_AND_ASSIGN(BuilderImplArith)

--- a/builder/llpcBuilderImplArith.cpp
+++ b/builder/llpcBuilderImplArith.cpp
@@ -612,3 +612,111 @@ Value* BuilderImplArith::CreateCallAmdgcnClass(
     return pResult;
 }
 
+// =====================================================================================================================
+// Create an "insert bitfield" operation for a (vector of) integer type.
+// Returns a value where the "pCount" bits starting at bit "pOffset" come from the least significant "pCount"
+// bits in "pInsert", and remaining bits come from "pBase". The result is undefined if "pCount"+"pOffset" is
+// more than the number of bits (per vector element) in "pBase" and "pInsert".
+// If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
+// width. The scalar type of "pOffset" and "pCount" must be integer, but can be different to that of "pBase"
+// and "pInsert" (and different to each other too).
+Value* BuilderImplArith::CreateInsertBitField(
+    Value*        pBase,                // [in] Base value
+    Value*        pInsert,              // [in] Value to insert (same type as base)
+    Value*        pOffset,              // Bit number of least-significant end of bitfield
+    Value*        pCount,               // Count of bits in bitfield
+    const Twine&  instName)             // [in] Name to give instruction(s)
+{
+    // Make pOffset and pCount vectors of the right integer type if necessary.
+    if (auto pVecTy = dyn_cast<VectorType>(pBase->getType()))
+    {
+        if (isa<VectorType>(pOffset->getType()) == false)
+        {
+            pOffset = CreateVectorSplat(pVecTy->getNumElements(), pOffset);
+        }
+        if (isa<VectorType>(pCount->getType()) == false)
+        {
+            pCount = CreateVectorSplat(pVecTy->getNumElements(), pCount);
+        }
+    }
+    pOffset = CreateZExtOrTrunc(pOffset, pBase->getType());
+    pCount = CreateZExtOrTrunc(pCount, pBase->getType());
+
+    Value* pBaseXorInsert = CreateXor(CreateShl(pInsert, pOffset), pBase);
+    Constant* pOne = ConstantInt::get(pCount->getType(), 1);
+    Value* pMask = CreateShl(CreateSub(CreateShl(pOne, pCount), pOne), pOffset);
+    Value* pResult = CreateXor(CreateAnd(pBaseXorInsert, pMask), pBase);
+    Value* pIsWholeField = CreateICmpEQ(pCount,
+                                        ConstantInt::get(pCount->getType(),
+                                                         pCount->getType()->getScalarType()->getPrimitiveSizeInBits()));
+    return CreateSelect(pIsWholeField, pInsert, pResult, instName);
+}
+
+// =====================================================================================================================
+// Create an "extract bitfield" operation for a (vector of) i32.
+// Returns a value where the least significant "pCount" bits come from the "pCount" bits starting at bit
+// "pOffset" in "pBase", and that is zero- or sign-extended (depending on "isSigned") to the rest of the value.
+// If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
+// width. The scalar type of "pOffset" and "pCount" must be integer, but can be different to that of "pBase"
+// (and different to each other too).
+Value* BuilderImplArith::CreateExtractBitField(
+    Value*        pBase,                // [in] Base value
+    Value*        pOffset,              // Bit number of least-significant end of bitfield
+    Value*        pCount,               // Count of bits in bitfield
+    bool          isSigned,             // True for a signed int bitfield extract, false for unsigned
+    const Twine&  instName)             // [in] Name to give instruction(s)
+{
+    // Make pOffset and pCount vectors of the right integer type if necessary.
+    if (auto pVecTy = dyn_cast<VectorType>(pBase->getType()))
+    {
+        if (isa<VectorType>(pOffset->getType()) == false)
+        {
+            pOffset = CreateVectorSplat(pVecTy->getNumElements(), pOffset);
+        }
+        if (isa<VectorType>(pCount->getType()) == false)
+        {
+            pCount = CreateVectorSplat(pVecTy->getNumElements(), pCount);
+        }
+    }
+    pOffset = CreateZExtOrTrunc(pOffset, pBase->getType());
+    pCount = CreateZExtOrTrunc(pCount, pBase->getType());
+
+    // For i32, we can use the amdgcn intrinsic and hence the instruction.
+    if (pBase->getType()->getScalarType()->isIntegerTy(32))
+    {
+        Value* pIsWholeField = CreateICmpEQ(
+                                    pCount,
+                                    ConstantInt::get(pCount->getType(),
+                                                     pCount->getType()->getScalarType()->getPrimitiveSizeInBits()));
+        Value* pResult = Scalarize(pBase,
+                                   pOffset,
+                                   pCount,
+                                   [this, isSigned](Value* pBase, Value* pOffset, Value* pCount)
+                                   {
+                                      return CreateIntrinsic(isSigned ? Intrinsic::amdgcn_sbfe : Intrinsic::amdgcn_ubfe,
+                                                             pBase->getType(),
+                                                             { pBase, pOffset, pCount });
+                                   });
+        pResult = CreateSelect(pIsWholeField, pBase, pResult);
+        Value* pIsEmptyField = CreateICmpEQ(pCount, Constant::getNullValue(pCount->getType()));
+        return CreateSelect(pIsEmptyField, Constant::getNullValue(pCount->getType()), pResult, instName);
+    }
+
+    // For other types, extract manually.
+    Value* pShiftDown = CreateSub(ConstantInt::get(pBase->getType(),
+                                                   pBase->getType()->getScalarType()->getPrimitiveSizeInBits()),
+                                  pCount);
+    Value* pShiftUp = CreateSub(pShiftDown, pOffset);
+    Value* pResult = CreateShl(pBase, pShiftUp);
+    if (isSigned)
+    {
+        pResult = CreateAShr(pResult, pShiftDown);
+    }
+    else
+    {
+        pResult = CreateLShr(pResult, pShiftDown);
+    }
+    Value* pIsZeroCount = CreateICmpEQ(pCount, Constant::getNullValue(pCount->getType()));
+    return CreateSelect(pIsZeroCount, pCount, pResult, instName);
+}
+

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -89,6 +89,10 @@ StringRef BuilderRecorder::GetCallName(
         return "inverse.sqrt";
     case Opcode::FMed3:
         return "fmed3";
+    case Opcode::InsertBitField:
+        return "insert.bit.field";
+    case Opcode::ExtractBitField:
+        return "extract.bit.field";
     case Opcode::LoadBufferDesc:
         return "load.buffer.desc";
     case Opcode::IndexDescPtr:
@@ -623,6 +627,39 @@ Value* BuilderRecorder::CreateFMed3(
     const Twine&  instName)             // [in] Name to give instruction(s)
 {
     return Record(Opcode::FMed3, pValue1->getType(), { pValue1, pValue2, pValue3 }, instName);
+}
+
+// =====================================================================================================================
+// Create an "insert bitfield" operation for a (vector of) integer type.
+// Returns a value where the "pCount" bits starting at bit "pOffset" come from the least significant "pCount"
+// bits in "pInsert", and remaining bits come from "pBase". The result is undefined if "pCount"+"pOffset" is
+// more than the number of bits (per vector element) in "pBase" and "pInsert".
+// If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
+// width.
+Value* BuilderRecorder::CreateInsertBitField(
+    Value*        pBase,                // [in] Base value
+    Value*        pInsert,              // [in] Value to insert (same type as base)
+    Value*        pOffset,              // Bit number of least-significant end of bitfield
+    Value*        pCount,               // Count of bits in bitfield
+    const Twine&  instName)             // [in] Name to give instruction(s)
+{
+    return Record(Opcode::InsertBitField, pBase->getType(), { pBase, pInsert, pOffset, pCount }, instName);
+}
+
+// =====================================================================================================================
+// Create an "extract bitfield " operation for a (vector of) i32.
+// Returns a value where the least significant "pCount" bits come from the "pCount" bits starting at bit
+// "pOffset" in "pBase", and that is zero- or sign-extended (depending on "isSigned") to the rest of the value.
+// If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
+// width.
+Value* BuilderRecorder::CreateExtractBitField(
+    Value*        pBase,                // [in] Base value
+    Value*        pOffset,              // Bit number of least-significant end of bitfield
+    Value*        pCount,               // Count of bits in bitfield
+    bool          isSigned,             // True for a signed int bitfield extract, false for unsigned
+    const Twine&  instName)             // [in] Name to give instruction(s)
+{
+    return Record(Opcode::ExtractBitField, pBase->getType(), { pBase, pOffset, pCount, getInt1(isSigned) }, instName);
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -94,6 +94,8 @@ public:
         Log,
         InverseSqrt,
         FMed3,
+        InsertBitField,
+        ExtractBitField,
 
         // Descriptor
         LoadBufferDesc,
@@ -244,6 +246,20 @@ public:
 
     // Create derivative calculation on float or vector of float or half
     Value* CreateDerivative(Value* pValue, bool isDirectionY, bool isFine, const Twine& instName = "") override final;
+
+    // Create an "insert bitfield" operation for a (vector of) integer type.
+    Value* CreateInsertBitField(Value*        pBase,
+                                Value*        pInsert,
+                                Value*        pOffset,
+                                Value*        pCount,
+                                const Twine&  instName = "") override final;
+
+    // Create an "extract bitfield " operation for a (vector of) i32.
+    Value* CreateExtractBitField(Value*        pBase,
+                                 Value*        pOffset,
+                                 Value*        pCount,
+                                 bool          isSigned,
+                                 const Twine&  instName = "") override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Descriptor operations

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -356,6 +356,19 @@ Value* BuilderReplayer::ProcessCall(
             return m_pBuilder->CreateFMed3(args[0], args[1], args[2]);
         }
 
+    case BuilderRecorder::Opcode::InsertBitField:
+        {
+            return m_pBuilder->CreateInsertBitField(args[0], args[1], args[2], args[3]);
+        }
+
+    case BuilderRecorder::Opcode::ExtractBitField:
+        {
+            return m_pBuilder->CreateExtractBitField(args[0],
+                                                     args[1],
+                                                     args[2],
+                                                     cast<ConstantInt>(args[3])->getZExtValue());
+        }
+
     // Replayer implementations of BuilderImplDesc methods
     case BuilderRecorder::Opcode::LoadBufferDesc:
         {

--- a/patch/generate/glslArithOpEmu.ll
+++ b/patch/generate/glslArithOpEmu.ll
@@ -1414,41 +1414,6 @@ define i32 @llpc.findSMsb.i32(i32 %value) #0
     ret i32 %end
 }
 
-; GLSL: int bitfieldInsert(int, int, int, int)
-define i32 @llpc.bitFieldInsert.i32(i32 %base, i32 %insert, i32 %offset, i32 %bits) #0
-{
-    %1 = shl i32 %insert, %offset
-    %2 = xor i32 %1, %base
-    %3 = shl i32 1, %bits
-    %4 = add i32 %3, -1
-    %5 = shl i32 %4, %offset
-    %6 = and i32 %2, %5
-    %7 = xor i32 %6, %base
-    %8 = icmp eq i32 %bits, 32
-    %9 = select i1 %8, i32 %insert, i32 %7
-    ret i32 %9
-}
-
-; GLSL: int bitfieldExtract(int, int ,int)
-define i32 @llpc.bitFieldSExtract.i32(i32 %value, i32 %offset, i32 %bits) #0
-{
-    %1 = icmp eq i32 %bits, 32
-    %2 = call i32 @llvm.amdgcn.sbfe.i32(i32 %value, i32 %offset, i32 %bits)
-    %3 = select i1 %1, i32 %value, i32 %2
-    ret i32 %3
-}
-
-; GLSL: uint bitfieldExtract(uint, uint ,uint)
-define i32 @llpc.bitFieldUExtract.i32(i32 %value, i32 %offset, i32 %bits) #0
-{
-    %1 = icmp eq i32 %bits, 32
-    %2 = call i32 @llvm.amdgcn.ubfe.i32(i32 %value, i32 %offset, i32 %bits)
-    %3 = select i1 %1, i32 %value, i32 %2
-    %4 = icmp eq i32 %bits, 0
-    %5 = select i1 %4, i32 0, i32 %3
-    ret i32 %5
-}
-
 ; =====================================================================================================================
 ; >>>  Vector Relational Functions
 ; =====================================================================================================================

--- a/patch/generate/script/genGlslArithOpEmuCode.txt
+++ b/patch/generate/script/genGlslArithOpEmuCode.txt
@@ -31,11 +31,6 @@ genType fma genType a genType b genType c : llpc.fma.f32 #0
 genType ldexp genType x genIType exp : llvm.amdgcn.ldexp.f32 #1
 
 # Integer Functions
-genIType BitFieldSExtract genIType value int offset int bits : llpc.bitFieldSExtract.i32 #0
-genUType BitFieldUExtract genUType value int offset int bits : llpc.bitFieldUExtract.i32 #0
-genIType BitFieldInsert genIType base genIType insert int offset int bits : llpc.bitFieldInsert.i32 #0
-genIType BitReverse genIType value : llvm.bitreverse.i32 #0
-genIType BitCount genIType value : llvm.ctpop.i32 #0
 genIType findILsb genUType value : llpc.findIlsb.i32 #0
 genIType findUMsb genUType value : llpc.findUMsb.i32 #0
 genIType findSMsb genIType value : llpc.findSMsb.i32 #0

--- a/test/shaderdb/OpBitFieldInsert_TestIntConst_lit.frag
+++ b/test/shaderdb/OpBitFieldInsert_TestIntConst_lit.frag
@@ -13,10 +13,10 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldInsert{{.*}}(i32 3, i32 6, i32 4, i32 5)
+; SHADERTEST: = call i32 (...) @llpc.call.insert.bit.field.i32(i32 3, i32 6, i32 4, i32 5)
 
-; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
-; SHADERTEST: call void @llpc.output.export.generic.i32.i32.v4f32({{.*}} <4 x float> <float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01>)
+; SHADERTEST-LABEL: {{^// LLPC.*}} pipeline patching results
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, i1 immarg true, i1 immarg true)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpBitFieldInsert_TestInt_lit.frag
+++ b/test/shaderdb/OpBitFieldInsert_TestInt_lit.frag
@@ -13,7 +13,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldInsert{{.*}}(i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: call i32 (...) @llpc.call.insert.bit.field.i32(i32
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpBitFieldInsert_TestIvec4_lit.frag
+++ b/test/shaderdb/OpBitFieldInsert_TestIvec4_lit.frag
@@ -13,7 +13,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} <4 x i32> {{.*}}BitFieldInsert{{.*}}(<4 x i32> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: call <4 x i32> (...) @llpc.call.insert.bit.field.v4i32(<4 x i32>
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpBitFieldInsert_TestUint_lit.frag
+++ b/test/shaderdb/OpBitFieldInsert_TestUint_lit.frag
@@ -22,8 +22,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldInsert{{.*}}(i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
-; SHADERTEST: call {{.*}} <3 x i32> {{.*}}BitFieldInsert{{.*}}(<3 x i32> %{{[0-9]*}}, <3 x i32> %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: call i32 (...) @llpc.call.insert.bit.field.i32(i32
+; SHADERTEST: call <3 x i32> (...) @llpc.call.insert.bit.field.v3i32(<3 x i32
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpBitFieldSExtract_TestGeneral_lit.frag
+++ b/test/shaderdb/OpBitFieldSExtract_TestGeneral_lit.frag
@@ -22,8 +22,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldSExtract{{.*}}(i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
-; SHADERTEST: call {{.*}} <3 x i32> {{.*}}BitFieldSExtract{{.*}}(<3 x i32> %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: call i32 (...) @llpc.call.extract.bit.field.i32(i32 {{.*}}, i1 true)
+; SHADERTEST: call <3 x i32> (...) @llpc.call.extract.bit.field.v3i32(<3 x i32> {{.*}}, i1 true)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-CONUT-2: call i32 @llvm.amdgcn.sbfe.i32

--- a/test/shaderdb/OpBitFieldSExtract_TestIntConst_lit.frag
+++ b/test/shaderdb/OpBitFieldSExtract_TestIntConst_lit.frag
@@ -13,8 +13,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldSExtract{{.*}}(i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldSExtract{{.*}}(i32 3423, i32 0, i32 32)
+; SHADERTEST: call i32 (...) @llpc.call.extract.bit.field.i32(i32 {{.*}}, i1 true)
+; SHADERTEST: call i32 (...) @llpc.call.extract.bit.field.i32(i32 3423, i32 0, i32 32, i1 true)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.sbfe.i32

--- a/test/shaderdb/OpBitFieldUExtract_TestGeneral_lit.frag
+++ b/test/shaderdb/OpBitFieldUExtract_TestGeneral_lit.frag
@@ -22,8 +22,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldUExtract{{.*}}(i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
-; SHADERTEST: call {{.*}} <3 x i32> {{.*}}BitFieldUExtract{{.*}}(<3 x i32> %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: call i32 (...) @llpc.call.extract.bit.field.i32(i32 {{.*}}, i1 false)
+; SHADERTEST: call <3 x i32> (...) @llpc.call.extract.bit.field.v3i32(<3 x i32> {{.*}}, i1 false)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-2: call i32 @llvm.amdgcn.ubfe.i32

--- a/test/shaderdb/OpBitFieldUExtract_TestUint_lit.frag
+++ b/test/shaderdb/OpBitFieldUExtract_TestUint_lit.frag
@@ -11,7 +11,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} i32 {{.*}}BitFieldUExtract{{.*}}(i32 %{{[0-9]*}}, i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: call i32 (...) @llpc.call.extract.bit.field.i32(i32 {{.*}}, i1 false)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.ubfe.i32

--- a/test/shaderdb/OpBitReverse_TestIntConst_lit.frag
+++ b/test/shaderdb/OpBitReverse_TestIntConst_lit.frag
@@ -9,7 +9,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: i32 {{.*}}BitReversei(i32 342)
+; SHADERTEST: call i32 @llvm.bitreverse.i32(i32 342)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpBitReverse_TestUint_lit.frag
+++ b/test/shaderdb/OpBitReverse_TestUint_lit.frag
@@ -20,8 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: i32 {{.*}}BitReversei(i32 %{{[0-9]*}})
-; SHADERTEST: <3 x i32> {{.*}}BitReverseDv3_i(<3 x i32> %{{[0-9]*}})
+; SHADERTEST: call i32 @llvm.bitreverse.i32(i32
+; SHADERTEST: call <3 x i32> @llvm.bitreverse.v3i32(<3 x i32>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Added builder methods for bitfield insert and extract, and switched
SPIR-V reader to use them. Also switched SPIR-V reader to use IRBuilder
methods with LLVM intrinsics for bit count and bit reverse.

Change-Id: I79f85754ced19d7f4a7d245091cef25615d00f66