### PR TITLE
[LLPC][Linux-Vulkan]: GPA Test Fails Randomly (1 out of 5times)

### DIFF
--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -315,16 +315,16 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    std::vector<std::string>     m_options;          // Compilation options
-    MetroHash::Hash              m_optionHash;       // Hash code of compilation options
-    GfxIpVersion                 m_gfxIp;            // Graphics IP version info
-    static uint32_t              m_instanceCount;    // The count of compiler instance
-    static uint32_t              m_outRedirectCount; // The count of output redirect
-    ShaderCachePtr               m_shaderCache;      // Shader cache
-    GpuProperty                  m_gpuProperty;      // GPU property
-    WorkaroundFlags              m_gpuWorkarounds;   // GPU workarounds;
-    static llvm::sys::Mutex      m_contextPoolMutex; // Mutex for context pool access
-    static std::vector<Context*> m_contextPool;      // Context pool
+    std::vector<std::string>      m_options;          // Compilation options
+    MetroHash::Hash               m_optionHash;       // Hash code of compilation options
+    GfxIpVersion                  m_gfxIp;            // Graphics IP version info
+    static uint32_t               m_instanceCount;    // The count of compiler instance
+    static uint32_t               m_outRedirectCount; // The count of output redirect
+    ShaderCachePtr                m_shaderCache;      // Shader cache
+    GpuProperty                   m_gpuProperty;      // GPU property
+    WorkaroundFlags               m_gpuWorkarounds;   // GPU workarounds;
+    static llvm::sys::Mutex       m_contextPoolMutex; // Mutex for context pool access
+    static std::vector<Context*>* m_pContextPool;      // Context pool
 };
 
 } // Llpc


### PR DESCRIPTION
RootCause:
Llpc::Compiler::m_contextPool is a global variable, it will be destroyed
by runtime C++ library at the end of main(), so  address of Llpc::Context
stored in m_contextPool is set to invalid memory address,after that,
~Compiler() is called in vkDestoryInstance():

delete pContext;

pContext is invalid memory address, so causing driver crash.

Solution:
allocate m_contextPool on heap, so that driver can control its' life.