### PR TITLE
Use specified wave size for varying subgroup size.

### DIFF
--- a/context/llpcComputeContext.cpp
+++ b/context/llpcComputeContext.cpp
@@ -123,18 +123,13 @@ uint32_t ComputeContext::GetShaderWaveSize(
         const ShaderModuleData* pModuleData =
             reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
 
-        if ((pModuleData != nullptr) && pModuleData->moduleInfo.useSubgroupSize)
-        {
+        if ((pModuleData != nullptr) && pModuleData->moduleInfo.useSubgroupSize
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
-            if (m_pPipelineInfo->cs.options.allowVaryWaveSize)
-            {
-                waveSize = m_pGpuProperty->waveSize;
-            }
-            else
+         && (m_pPipelineInfo->cs.options.allowVaryWaveSize == false)
 #endif
-            {
-                waveSize = cl::SubgroupSize;
-            }
+           )
+        {
+            waveSize = cl::SubgroupSize;
         }
 
         LLPC_ASSERT((waveSize == 32) || (waveSize == 64));

--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -1443,19 +1443,13 @@ uint32_t GraphicsContext::GetShaderWaveSize(
             const ShaderModuleData* pModuleData =
                 reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
 
-            if ((pModuleData != nullptr) && pModuleData->moduleInfo.useSubgroupSize)
-            {
+            if ((pModuleData != nullptr) && pModuleData->moduleInfo.useSubgroupSize
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
-                // NOTE: Hardware path for GS wave32 is not tested, use wave64 instead
-                if ((i != ShaderStageGeometry) && pShaderInfo->options.allowVaryWaveSize)
-                {
-                    waveSize = m_pGpuProperty->waveSize;
-                }
-                else
+             && (pShaderInfo->options.allowVaryWaveSize == false)
 #endif
-                {
-                    waveSize = cl::SubgroupSize;
-                }
+               )
+            {
+                waveSize = cl::SubgroupSize;
                 break;
             }
         }


### PR DESCRIPTION
Shader tuning wave size can now take effect if varying option is set.

Change-Id: I7c8e7ed9d794dbae4f30397450d4097719a9ccc2