### PR TITLE
Support llvm.amdgcn.raw.buffer.atomic.* 64bit operation

### DIFF
--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -302,8 +302,8 @@ void PatchBufferOp::visitAtomicRMWInst(
     Value* const pBaseIndex = m_pBuilder->CreatePtrToInt(m_replacementMap[pPointer].second, m_pBuilder->getInt32Ty());
     CopyMetadata(pBaseIndex, &atomicRmwInst);
 
-    // If our buffer descriptor is divergent or is not a 32-bit integer, need to handle it differently.
-    if ((m_divergenceSet.count(pBufferDesc) > 0) || (pStoreType->isIntegerTy(32) == false))
+    // If our buffer descriptor is divergent, need to handle it differently.
+    if (m_divergenceSet.count(pBufferDesc) > 0)
     {
         Value* const pBaseAddr = GetBaseAddressFromBufferDesc(pBufferDesc);
 
@@ -387,7 +387,7 @@ void PatchBufferOp::visitAtomicRMWInst(
         }
 
         Value* const pAtomicCall = m_pBuilder->CreateIntrinsic(intrinsic,
-                                                               m_pBuilder->getInt32Ty(),
+                                                               cast<IntegerType>(pStoreType),
                                                                {
                                                                    atomicRmwInst.getValOperand(),
                                                                    pBufferDesc,

--- a/test/shaderdb/OpAtomicXXX_TestStorageBlockAndSharedWithData64_lit.comp
+++ b/test/shaderdb/OpAtomicXXX_TestStorageBlockAndSharedWithData64_lit.comp
@@ -83,8 +83,7 @@ void main ()
 // BEGIN_SHADERTEST
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
-
-; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: atomicrmw umin i64 addrspace({{.*}})* %{{[0-9]*}}, i64 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw umax i64 addrspace({{.*}})* %{{[0-9]*}}, i64 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw and i64 addrspace({{.*}})* %{{[0-9]*}}, i64 %{{[0-9]*}} monotonic
@@ -97,6 +96,31 @@ void main ()
 ; SHADERTEST: atomicrmw xor i64 addrspace({{.*}})* %{{[0-9]*}}, i64 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw add i64 addrspace({{.*}})* %{{[0-9]*}}, i64 %{{[0-9]*}} monotonic
 ; SHADERTEST: cmpxchg i64 addrspace({{.*}})* %{{[0-9]*}}, i64 78187493520, i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw umin i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 0), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw umax i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 1), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw and i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 2), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw or i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 3), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw xor i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 4), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw min i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 5), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw max i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 6), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw and i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 7), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw or i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 8), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw xor i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 9), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: atomicrmw add i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 10), i64 %{{[0-9]*}} monotonic
+; SHADERTEST: cmpxchg i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 12), i64 78187493520, i64 %{{[0-9]*}} monotonic
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.umin.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.umax.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 8, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.and.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 16, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.or.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 24, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.xor.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 32, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.smin.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 40, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.smax.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 48, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.and.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 56, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.or.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 64, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.xor.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 72, i32 0, i32 0)
+; SHADERTEST: call i64 @llvm.amdgcn.raw.buffer.atomic.add.i64(i64 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 80, i32 0, i32 0)
 ; SHADERTEST: atomicrmw umin i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 0), i64 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw umax i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 1), i64 %{{[0-9]*}} monotonic
 ; SHADERTEST: atomicrmw and i64 addrspace(3)* getelementptr inbounds ({ i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 }, { i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 } addrspace(3)* @{{.*}}, i32 0, i32 2), i64 %{{[0-9]*}} monotonic


### PR DESCRIPTION
- Directly call llvm.amdgcn.raw.buffer.atomic.*.i64 intrisinc
- Add OpAtomicXXXi64_TestStorageBlock_lit.frag to shaderdb