### PR TITLE
Update shaderdb tests

### DIFF
--- a/test/shaderdb/OpImageQuerySizeLod_TestTextureSize_lit.frag
+++ b/test/shaderdb/OpImageQuerySizeLod_TestTextureSize_lit.frag
@@ -13,7 +13,8 @@ layout(location = 2) out ivec3 i3;
 
 void main()
 {
-    i3.xy  = textureSize(samp2D[index], 3);
+    i3 = ivec3(0);
+    i3.xy += textureSize(samp2D[index], 3);
     i3.xy += textureSize(samp2DShadow, 4);
     i3    += textureSize(samp3D, 5);
 }

--- a/test/shaderdb/OpImageQuerySize_TestBasic_lit.frag
+++ b/test/shaderdb/OpImageQuerySize_TestBasic_lit.frag
@@ -46,7 +46,7 @@ void main()
     oColor += vec4(sizeCubeS.x, sizeCubeS.y, 0, 0);
 
     ivec3 sizeCubeA = textureSize(sampCubeA, 0);
-    oColor += vec4(sizeCubeA.x, sizeCubeA.y, 0, 0);
+    oColor += vec4(sizeCubeA.x, sizeCubeA.y, sizeCubeA.z, 0);
 
     ivec3 sizeCubeAS = textureSize(sampCubeAS, 0);
     oColor += vec4(sizeCubeAS.x, sizeCubeAS.y, sizeCubeAS.z, 0);
@@ -118,8 +118,8 @@ void main()
 ; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.image.getresinfo.cube.v4f32.i32(i32 15, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.image.getresinfo.cube.v4f32.i32(i32 15, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.1darray.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)

--- a/test/shaderdb/OpImageQuerySize_TestImage_lit.comp
+++ b/test/shaderdb/OpImageQuerySize_TestImage_lit.comp
@@ -70,7 +70,7 @@ void main()
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.1darray.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darray.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.image.getresinfo.cube.v4f32.i32(i32 15, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/OpImageQuerySize_TestTextureSize_lit.frag
+++ b/test/shaderdb/OpImageQuerySize_TestTextureSize_lit.frag
@@ -14,7 +14,8 @@ layout(location = 0) out ivec3 i3;
 
 void main()
 {
-    i3.xy  = textureSize(samp2DRect);
+    i3 = ivec3(0);
+    i3.xy += textureSize(samp2DRect);
     i3.x  += textureSize(samp2DBuffer[index]);
     i3.xy += textureSize(samp2DMS);
     i3    += textureSize(samp2DMSArray[index]);


### PR DESCRIPTION
Update the following shaderdb tests:

* OpImageQuerySizeLod_TestTextureSize_lit.frag
* OpImageQuerySize_TestTextureSize_lit.frag
* OpImageQuerySize_TestBasic_lit.frag

Make sure that all returned values of textureSize() will be used
in the shader output value, and that value is not undef.

* OpImageQuerySize_TestBasic_lit.frag
* OpImageQuerySize_TestImage_lit.comp

Be more flexible in checking an intrinsic type after patching.
Currently in a few cases the type of @llvm.amdgcn.image.getresinfo.cube
to check against is a 4-element vector, but can theoretically be
a 3-element one.