### PR TITLE
Fixed breakage in non-fmed3 trinary fmid

### DIFF
--- a/builder/llpcBuilderImplArith.cpp
+++ b/builder/llpcBuilderImplArith.cpp
@@ -556,7 +556,7 @@ Value* BuilderImplArith::CreateFMed3(
     pMax1->setFastMathFlags(fastMathFlags);
     CallInst* pMin2 = CreateMinNum(pMax1, pValue3);
     pMin2->setFastMathFlags(fastMathFlags);
-    CallInst* pMax2 = CreateMinNum(pMin1, pMin2, instName);
+    CallInst* pMax2 = CreateMaxNum(pMin1, pMin2, instName);
     pMax2->setFastMathFlags(fastMathFlags);
     return pMax2;
 }


### PR DESCRIPTION
My change PR166 earlier today broke fmid from the AMD
ShaderTrinaryMinMax extension on half type on gfx8 and earlier. Fixed by
this commit.

Change-Id: I0942a2b7d93a9e88e76bcf91fd10ad9a41423e6f