### PR TITLE
Trinary min/max/mid changes

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -361,8 +361,28 @@ public:
         Value*        pX,                   // [in] Input value X
         const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
-    // Create "fmed3" operation, returning the middle one of three scalar or vector float or half values.
-    virtual Value* CreateFMed3(
+    // Create "fmin3" operation, returning the minimum of three scalar or vector float or half values.
+    // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
+    // It also honors the shader's FP mode being "flush denorm".
+    virtual Value* CreateFMin3(
+        Value*        pValue1,              // [in] First value
+        Value*        pValue2,              // [in] Second value
+        Value*        pValue3,              // [in] Third value
+        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+
+    // Create "fmax3" operation, returning the maximum of three scalar or vector float or half values.
+    // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
+    // It also honors the shader's FP mode being "flush denorm".
+    virtual Value* CreateFMax3(
+        Value*        pValue1,              // [in] First value
+        Value*        pValue2,              // [in] Second value
+        Value*        pValue3,              // [in] Third value
+        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+
+    // Create "fmid3" operation, returning the middle one of three scalar or vector float or half values.
+    // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
+    // It also honors the shader's FP mode being "flush denorm".
+    virtual Value* CreateFMid3(
         Value*        pValue1,              // [in] First value
         Value*        pValue2,              // [in] Second value
         Value*        pValue3,              // [in] Third value

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -130,8 +130,10 @@ public:
     Value* CreateInverseSqrt(Value* pX, const Twine& instName = "") override final;
     Value* CreateFSign(Value* pX, const Twine& instName = ""); // TODO add override final
 
-    // Create "fmed3" operation, returning the middle one of three float values.
-    Value* CreateFMed3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    // Methods for trinary min/max/mid.
+    Value* CreateFMin3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    Value* CreateFMax3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    Value* CreateFMid3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
 
     // Create an "insert bitfield" operation for a (vector of) integer type.
     Value* CreateInsertBitField(Value*        pBase,
@@ -211,6 +213,9 @@ private:
     {
         return ConstantFP::get(pTy, 0.000030517578125);
     }
+
+    // Ensure result is canonicalized if the shader's FP mode is flush denorms.
+    Value* Canonicalize(Value* pValue);
 };
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -87,8 +87,12 @@ StringRef BuilderRecorder::GetCallName(
         return "log";
     case InverseSqrt:
         return "inverse.sqrt";
-    case Opcode::FMed3:
-        return "fmed3";
+    case Opcode::FMin3:
+        return "fmin3";
+    case Opcode::FMax3:
+        return "fmax3";
+    case Opcode::FMid3:
+        return "fmid3";
     case Opcode::InsertBitField:
         return "insert.bit.field";
     case Opcode::ExtractBitField:
@@ -623,14 +627,36 @@ Value* BuilderRecorder::CreateDerivative(
 }
 
 // =====================================================================================================================
-// Create "fmed3" operation, returning the middle one of three float values.
-Value* BuilderRecorder::CreateFMed3(
+// Create "fmin3" operation, returning the minimum of three scalar or vector float or half values.
+Value* BuilderRecorder::CreateFMin3(
+    Value*        pValue1,    // [in] First value
+    Value*        pValue2,    // [in] Second value
+    Value*        pValue3,    // [in] Third value
+    const Twine&  instName)   // [in] Name to give instruction(s)
+{
+    return Record(Opcode::FMin3, pValue1->getType(), { pValue1, pValue2, pValue3 }, instName);
+}
+
+// =====================================================================================================================
+// Create "fmax3" operation, returning the maximum of three scalar or vector float or half values.
+Value* BuilderRecorder::CreateFMax3(
+    Value*        pValue1,    // [in] First value
+    Value*        pValue2,    // [in] Second value
+    Value*        pValue3,    // [in] Third value
+    const Twine&  instName)   // [in] Name to give instruction(s)
+{
+    return Record(Opcode::FMax3, pValue1->getType(), { pValue1, pValue2, pValue3 }, instName);
+}
+
+// =====================================================================================================================
+// Create "fmid3" operation, returning the middle one of three float values.
+Value* BuilderRecorder::CreateFMid3(
     Value*        pValue1,              // [in] First value
     Value*        pValue2,              // [in] Second value
     Value*        pValue3,              // [in] Third value
     const Twine&  instName)             // [in] Name to give instruction(s)
 {
-    return Record(Opcode::FMed3, pValue1->getType(), { pValue1, pValue2, pValue3 }, instName);
+    return Record(Opcode::FMid3, pValue1->getType(), { pValue1, pValue2, pValue3 }, instName);
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -93,7 +93,9 @@ public:
         Exp,
         Log,
         InverseSqrt,
-        FMed3,
+        FMin3,
+        FMax3,
+        FMid3,
         InsertBitField,
         ExtractBitField,
 
@@ -240,8 +242,10 @@ public:
     Value* CreateLog(Value* pX, const Twine& instName = "") override final;
     Value* CreateInverseSqrt(Value* pX, const Twine& instName = "") override final;
 
-    // Create fmed3 operation.
-    Value* CreateFMed3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    // Methods for trinary min/max/mid.
+    Value* CreateFMin3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    Value* CreateFMax3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    Value* CreateFMid3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
 
     // Create derivative calculation on float or vector of float or half
     Value* CreateDerivative(Value* pValue, bool isDirectionY, bool isFine, const Twine& instName = "") override final;

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -361,9 +361,19 @@ Value* BuilderReplayer::ProcessCall(
                                                 cast<ConstantInt>(args[2])->getZExtValue());  // isFine
         }
 
-    case BuilderRecorder::Opcode::FMed3:
+    case BuilderRecorder::Opcode::FMin3:
         {
-            return m_pBuilder->CreateFMed3(args[0], args[1], args[2]);
+            return m_pBuilder->CreateFMin3(args[0], args[1], args[2]);
+        }
+
+    case BuilderRecorder::Opcode::FMax3:
+        {
+            return m_pBuilder->CreateFMax3(args[0], args[1], args[2]);
+        }
+
+    case BuilderRecorder::Opcode::FMid3:
+        {
+            return m_pBuilder->CreateFMid3(args[0], args[1], args[2]);
         }
 
     case BuilderRecorder::Opcode::InsertBitField:

--- a/test/shaderdb/gfx9/ObjFloat16_TestTrinaryMinMaxFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ObjFloat16_TestTrinaryMinMaxFuncs_lit.frag
@@ -26,16 +26,14 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call nnan <3 x half> @llvm.minnum.v3f16(<3 x half>
-; SHADERTEST: = call nnan <3 x half> @llvm.minnum.v3f16(<3 x half>
-; SHADERTEST: = call nnan <3 x half> @llvm.maxnum.v3f16(<3 x half>
-; SHADERTEST: = call nnan <3 x half> @llvm.maxnum.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.fmed3.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.fmin3.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.fmax3.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.fmid3.v3f16(<3 x half>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: = call nnan <3 x half> @llvm.minnum.v3f16(<3 x half>
-; SHADERTEST: = call nnan <3 x half> @llvm.minnum.v3f16(<3 x half>
-; SHADERTEST: = call nnan <3 x half> @llvm.maxnum.v3f16(<3 x half>
-; SHADERTEST: = call nnan <3 x half> @llvm.maxnum.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.minnum.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.minnum.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.maxnum.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.maxnum.v3f16(<3 x half>
 ; SHADERTEST: = call half @llvm.amdgcn.fmed3.f16(half
 ; SHADERTEST: = call half @llvm.amdgcn.fmed3.f16(half
 ; SHADERTEST: = call half @llvm.amdgcn.fmed3.f16(half

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -9468,32 +9468,27 @@ Value *SPIRVToLLVM::transTrinaryMinMaxExtInst(SPIRVExtInst *ExtInst,
   switch (ExtInst->getExtOp()) {
 
   case FMin3AMD: {
-    // Minimum of three FP values. Undefined result if any NaNs.
-    FastMathFlags FMF;
+    // Middle of three FP values. Undefined result if any NaNs.
+    FastMathFlags FMF = getBuilder()->getFastMathFlags();
     FMF.setNoNaNs();
     getBuilder()->setFastMathFlags(FMF);
-    CallInst *Min1 = getBuilder()->CreateMinNum(Args[0], Args[1]);
-    setFastMathFlags(Min1);
-    CallInst *Min2 = getBuilder()->CreateMinNum(Min1, Args[2]);
-    setFastMathFlags(Min2);
-    return Min2;
+    return getBuilder()->CreateFMin3(Args[0], Args[1], Args[2]);
   }
 
   case FMax3AMD: {
-    // Maximum of three FP values. Undefined result if any NaNs.
-    FastMathFlags FMF;
+    // Middle of three FP values. Undefined result if any NaNs.
+    FastMathFlags FMF = getBuilder()->getFastMathFlags();
     FMF.setNoNaNs();
     getBuilder()->setFastMathFlags(FMF);
-    CallInst *Max1 = getBuilder()->CreateMaxNum(Args[0], Args[1]);
-    setFastMathFlags(Max1);
-    CallInst *Max2 = getBuilder()->CreateMaxNum(Max1, Args[2]);
-    setFastMathFlags(Max2);
-    return Max2;
+    return getBuilder()->CreateFMax3(Args[0], Args[1], Args[2]);
   }
 
   case FMid3AMD: {
     // Middle of three FP values. Undefined result if any NaNs.
-    return getBuilder()->CreateFMed3(Args[0], Args[1], Args[2]);
+    FastMathFlags FMF = getBuilder()->getFastMathFlags();
+    FMF.setNoNaNs();
+    getBuilder()->setFastMathFlags(FMF);
+    return getBuilder()->CreateFMid3(Args[0], Args[1], Args[2]);
   }
 
   case UMin3AMD: {


### PR DESCRIPTION
* Changed Builder::CreateFMed3 to CreateFMid3 to reflect the SPIR-V
  name, as it does not always use the fmed3 instruction.
* Added new CreateFMin3 and CreateFMax3, instead of generating the IR
  directly in the SPIR-V reader, because of wanting to add the
  functionality below.
* Made all three of them honor the fast math flags, in particular
  whether nnan is on, even though the SPIR-V reader always sets nnan for
  them.
* Made all three of them honor the shader's FP mode by canonicalizing
  the result on gfx8 and earlier if the FP mode wants denorm folding.

Change-Id: I8ce3cab27a016181d30d675a2fa3b4c8498318a9
