### PR TITLE
Fixed fast math flags on trig and exponent intrinsics

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -212,6 +212,27 @@ public:
     // -----------------------------------------------------------------------------------------------------------------
     // Base class operations
 
+    // Create a call to the specified intrinsic with one operand, mangled on its type.
+    // This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math
+    // flags from the Builder if none are specified by pFmfSource.
+    CallInst* CreateUnaryIntrinsic(
+        Intrinsic::ID id,                   // Intrinsic ID
+        Value*        pValue,               // [in] Input value
+        Instruction*  pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
+                                            //    from Builder
+        const Twine&  instName = "");       // [in] Name to give instruction
+
+    // Create a call to the specified intrinsic with two operands of the same type, mangled on that type.
+    // This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math
+    // flags from the Builder if none are specified by pFmfSource.
+    CallInst* CreateBinaryIntrinsic(
+        Intrinsic::ID id,                   // Intrinsic ID
+        Value*        pValue1,              // [in] Input value 1
+        Value*        pValue2,              // [in] Input value 2
+        Instruction*  pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
+                                            //    from Builder
+        const Twine&  name = "");           // [in] Name to give instruction
+
     // Create vector dot product operation. The two vectors must be the same floating point vector type.
     // Returns a value whose type is the element type of the vectors.
     virtual Value* CreateDotProduct(

--- a/test/shaderdb/OpExtInst_TestInverseSqrtDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInverseSqrtDouble_lit.frag
@@ -20,9 +20,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT:[^ ,]*]] = call double @llvm.sqrt.f64(double
+; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(double
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract double 1.000000e+00, %[[SQRT]]
-; SHADERTEST: %[[SQRT3:[^ ,]*]] = call <3 x double> @llvm.sqrt.v3f64(<3 x double>
+; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x double> @llvm.sqrt.v3f64(<3 x double>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <3 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>, %[[SQRT3]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestInverseSqrtFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInverseSqrtFloat_lit.frag
@@ -20,9 +20,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT:[^ ,]*]] = call float @llvm.sqrt.f32(float
+; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(float
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract float 1.000000e+00, %[[SQRT]]
-; SHADERTEST: %[[SQRT3:[^ ,]*]] = call <3 x float> @llvm.sqrt.v3f32(<3 x float>
+; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x float> @llvm.sqrt.v3f32(<3 x float>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %[[SQRT3]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestInverseSqrtVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInverseSqrtVec4Const_lit.frag
@@ -14,7 +14,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT4:[^ ,]*]] = call <4 x float> @llvm.sqrt.v4f32(<4 x float>
+; SHADERTEST: %[[SQRT4:[^ ,]*]] = call reassoc nnan nsz arcp contract <4 x float> @llvm.sqrt.v4f32(<4 x float>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %[[SQRT4]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestLog2Vec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLog2Vec4Const_lit.frag
@@ -14,13 +14,13 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call <4 x float> @llvm.log2.v4f32(<4 x float>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.log2.v4f32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call <4 x float> @llvm.log2.v4f32(<4 x float>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.log2.v4f32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLog2_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLog2_lit.frag
@@ -20,14 +20,14 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call <3 x float> @llvm.log2.v3f32(<3 x float>
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.log2.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call <3 x float> @llvm.log2.v3f32(<3 x float>
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.log2.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestLogVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLogVec4Const_lit.frag
@@ -18,10 +18,10 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ' SHADERTEST-LABEL: = call reassoc nnan nsz arcp contract <4 x float> (...) @llpc.call.log.v4f32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST-NOT: = call float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST-NOT: = call{{.*}} float @llvm.log2.f32(float
 ; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestLog_lit.frag
+++ b/test/shaderdb/OpExtInst_TestLog_lit.frag
@@ -26,9 +26,9 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract float (...) @llpc.call.log.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.log.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST: = call float @llvm.log2.f32(float
-; SHADERTEST-NOT: = call float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.log2.f32(float
+; SHADERTEST-NOT: = call{{.*}} @llvm.log2.f32(float
 ; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestPow2_lit.frag
+++ b/test/shaderdb/OpExtInst_TestPow2_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: = call float @llvm.amdgcn.frexp.mant.f32(float
 ; SHADERTEST: = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float
-; SHADERTEST: = call float @llvm.exp2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
@@ -17,12 +17,12 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> (...) @llpc.call.power.v4f32(<4 x float>
 ; SHADERTEST: store float 1.200000e+01, float addrspace(5)* %{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call <4 x float> @llvm.pow.v4f32(<4 x float>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.pow.v4f32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call float @llvm.pow.f32(float
-; SHADERTEST: = call float @llvm.pow.f32(float
-; SHADERTEST: = call float @llvm.pow.f32(float
-; SHADERTEST-NOT: = call float @llvm.pow.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
+; SHADERTEST-NOT: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
 ; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.200000e+01, float
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestPow_lit.frag
+++ b/test/shaderdb/OpExtInst_TestPow_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract float (...) @llpc.call.power.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.power.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestSinVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestSinVec4Const_lit.frag
@@ -13,14 +13,14 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call <4 x float> @llvm.sin.v4f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.sin.v4f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call <4 x float> @llvm.sin.v4f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.sin.v4f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: = call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: = call float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST-NOT: = call float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sin.f32(float %{{.*}})
+; SHADERTEST-NOT: = call{{.*}} float @llvm.sin.f32(float %{{.*}})
 ; SHADERTEST: ret void
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpExtInst_TestSin_lit.frag
+++ b/test/shaderdb/OpExtInst_TestSin_lit.frag
@@ -20,11 +20,11 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call float @llvm.sin.f32(
-; SHADERTEST: = call <3 x float> @llvm.sin.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sin.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.sin.v3f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call float @llvm.sin.f32(
-; SHADERTEST: = call <3 x float> @llvm.sin.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sin.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.sin.v3f32(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestSqrtDouble_lit.frag
+++ b/test/shaderdb/OpExtInst_TestSqrtDouble_lit.frag
@@ -20,11 +20,11 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call double @llvm.sqrt.f64(
-; SHADERTEST: = call <3 x double> @llvm.sqrt.v3f64(
+; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> @llvm.sqrt.v3f64(
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call double @llvm.sqrt.f64(
-; SHADERTEST: = call double @llvm.sqrt.f64(
+; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(
+; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestSqrtFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestSqrtFloat_lit.frag
@@ -20,11 +20,11 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call float @llvm.sqrt.f32(
-; SHADERTEST: = call <3 x float> @llvm.sqrt.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.sqrt.v3f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call float @llvm.sqrt.f32(
-; SHADERTEST: = call float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestSqrtVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestSqrtVec4Const_lit.frag
@@ -13,11 +13,11 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call <4 x float> @llvm.sqrt.v4f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.sqrt.v4f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call float @llvm.sqrt.f32(
-; SHADERTEST: = call float @llvm.sqrt.f32(
-; SHADERTEST: = call float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.sqrt.f32(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestTanVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTanVec4Const_lit.frag
@@ -15,8 +15,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> (...) @llpc.call.tan.v4f32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: = call <4 x float> @llvm.sin.v4f32(
-; SHADERTEST: = call <4 x float> @llvm.cos.v4f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.sin.v4f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x float> @llvm.cos.v4f32(
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <4 x float> <float 1.000000e+00,
 ; SHADERTEST: = fmul reassoc nnan nsz arcp contract <4 x float>
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/OpExtInst_TestTan_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTan_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract float (...) @llpc.call.tan.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.tan.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: %{{[0-9]*}} = call <3 x float> @llvm.sin.v3f32(<3 x float>
-; SHADERTEST: %{{[0-9]*}} = call <3 x float> @llvm.cos.v3f32(<3 x float>
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract <3 x float> @llvm.sin.v3f32(<3 x float>
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract <3 x float> @llvm.cos.v3f32(<3 x float>
 ; SHADERTEST: %{{[0-9]*}} = fdiv reassoc nnan nsz arcp contract <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>,
 ; SHADERTEST: %{{[0-9]*}} = fmul reassoc nnan nsz arcp contract <3 x float>
 ; SHADERTEST: %{{[0-9]*}} = fcmp one float %{{.*}}, %{{.*}}

--- a/test/shaderdb/OpExtInst_TestTanhFloat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTanhFloat_lit.frag
@@ -16,8 +16,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = fmul reassoc nnan nsz arcp contract float %{{.*}}, 0x3FF7154760000000
 ; SHADERTEST: %{{[0-9]*}} = fsub reassoc nnan nsz arcp contract float -0.000000e+00, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fsub reassoc nnan nsz arcp contract float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fadd reassoc nnan nsz arcp contract float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})

--- a/test/shaderdb/OpExtInst_TestTanh_lit.frag
+++ b/test/shaderdb/OpExtInst_TestTanh_lit.frag
@@ -25,15 +25,15 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = fmul reassoc nnan nsz arcp contract float %{{.*}}, 0x3FF7154760000000
 ; SHADERTEST: %{{[0-9]*}} = fsub reassoc nnan nsz arcp contract float -0.000000e+00,
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fsub reassoc nnan nsz arcp contract float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fadd reassoc nnan nsz arcp contract float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fmul reassoc nnan nsz arcp contract float %{{.*}}, 0x3FF7154760000000
 ; SHADERTEST: %{{[0-9]*}} = fsub reassoc nnan nsz arcp contract float -0.000000e+00, %{{.*}}
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract float @llvm.exp2.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = fsub reassoc nnan nsz arcp contract float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = fadd reassoc nnan nsz arcp contract float %{{.*}}, %{{.*}}
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.fdiv.fast(float %{{.*}}, float %{{.*}})

--- a/test/shaderdb/OpFwidth_TestFineCoarse_lit.frag
+++ b/test/shaderdb/OpFwidth_TestFineCoarse_lit.frag
@@ -17,18 +17,18 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.derivative.v3f32(<3 x float> %{{.*}}, i1 false, i1 false)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.derivative.v3f32(<3 x float> %{{.*}}, i1 true, i1 false)
-; SHADERTEST: = call <3 x float> @llvm.fabs.v3f32(
-; SHADERTEST: = call <3 x float> @llvm.fabs.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.fabs.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.fabs.v3f32(
 ; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x float>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.derivative.v3f32(<3 x float> %{{.*}}, i1 false, i1 true)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.derivative.v3f32(<3 x float> %{{.*}}, i1 true, i1 true)
-; SHADERTEST: = call <3 x float> @llvm.fabs.v3f32(
-; SHADERTEST: = call <3 x float> @llvm.fabs.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.fabs.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.fabs.v3f32(
 ; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x float>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.derivative.v3f32(<3 x float> %{{.*}}, i1 false, i1 false)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> (...) @llpc.call.derivative.v3f32(<3 x float> %{{.*}}, i1 true, i1 false)
-; SHADERTEST: = call <3 x float> @llvm.fabs.v3f32(
-; SHADERTEST: = call <3 x float> @llvm.fabs.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.fabs.v3f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x float> @llvm.fabs.v3f32(
 ; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/gfx9/ExtShaderFloat16_TestAngleTrigFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ExtShaderFloat16_TestAngleTrigFuncs_lit.frag
@@ -38,8 +38,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = fmul reassoc nnan nsz arcp contract <3 x half> %{{.*}}, <half 0xH2478, half 0xH2478, half 0xH2478>
 ; SHADERTEST: = fmul reassoc nnan nsz arcp contract <3 x half> %{{.*}}, <half 0xH5329, half 0xH5329, half 0xH5329>
-; SHADERTEST: = call <3 x half> @llvm.sin.v3f16(
-; SHADERTEST: = call <3 x half> @llvm.cos.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.sin.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.cos.v3f16(
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.tan.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.asin.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.acos.v3f16(<3 x half>
@@ -51,8 +51,8 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.acosh.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.atanh.v3f16(<3 x half>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST-COUNT-3: call half @llvm.sin.f16(half
-; SHADERTEST-COUNT-3: call half @llvm.cos.f16(half
+; SHADERTEST-COUNT-3: call reassoc nnan nsz arcp contract half @llvm.sin.f16(half
+; SHADERTEST-COUNT-3: call reassoc nnan nsz arcp contract half @llvm.cos.f16(half
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/gfx9/ExtShaderFloat16_TestDerivFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ExtShaderFloat16_TestDerivFuncs_lit.frag
@@ -38,18 +38,18 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 true, i1 false)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 false, i1 false)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 true, i1 false)
-; SHADERTEST: = call <3 x half> @llvm.fabs.v3f16(
-; SHADERTEST: = call <3 x half> @llvm.fabs.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.fabs.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.fabs.v3f16(
 ; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 false, i1 true)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 true, i1 true)
-; SHADERTEST: = call <3 x half> @llvm.fabs.v3f16(
-; SHADERTEST: = call <3 x half> @llvm.fabs.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.fabs.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.fabs.v3f16(
 ; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 false, i1 false)
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.derivative.v3f16(<3 x half> %{{.*}}, i1 true, i1 false)
-; SHADERTEST: = call <3 x half> @llvm.fabs.v3f16(
-; SHADERTEST: = call <3 x half> @llvm.fabs.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.fabs.v3f16(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.fabs.v3f16(
 ; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x half>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/gfx9/ExtShaderFloat16_TestExponentialFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ExtShaderFloat16_TestExponentialFuncs_lit.frag
@@ -36,10 +36,10 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.power.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.exp.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> (...) @llpc.call.log.v3f16(<3 x half>
-; SHADERTEST: = call <3 x half> @llvm.exp2.v3f16(<3 x half>
-; SHADERTEST: = call <3 x half> @llvm.log2.v3f16(<3 x half>
-; SHADERTEST: = call <3 x half> @llvm.sqrt.v3f16(<3 x half>
-; SHADERTEST: = call <3 x half> @llvm.sqrt.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.exp2.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.log2.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.sqrt.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x half> @llvm.sqrt.v3f16(<3 x half>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <3 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00>,
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -9364,13 +9364,11 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *ExtInst,
 
   case GLSLstd450Sin:
     // sin operation
-    return getBuilder()->CreateIntrinsic(Intrinsic::sin, Args[0]->getType(),
-                                       Args[0]);
+    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::sin, Args[0]);
 
   case GLSLstd450Cos:
     // cos operation
-    return getBuilder()->CreateIntrinsic(Intrinsic::cos, Args[0]->getType(),
-                                       Args[0]);
+    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::cos, Args[0]);
 
   case GLSLstd450Tan:
     // tan operation
@@ -9430,24 +9428,21 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *ExtInst,
 
   case GLSLstd450Exp2:
     // Base 2 exponent: 2^x
-    return getBuilder()->CreateIntrinsic(Intrinsic::exp2, Args[0]->getType(),
-                                       Args[0]);
+    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::exp2, Args[0]);
 
   case GLSLstd450Log2:
     // Base 2 logarithm: log2(x)
-    return getBuilder()->CreateIntrinsic(Intrinsic::log2, Args[0]->getType(),
-                                       Args[0]);
+    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::log2, Args[0]);
 
   case GLSLstd450Sqrt:
     // Square root
-    return getBuilder()->CreateIntrinsic(Intrinsic::sqrt, Args[0]->getType(),
-                                       Args[0]);
+    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::sqrt, Args[0]);
 
   case GLSLstd450InverseSqrt: {
     // Inverse square root
-    Value *Sqrt = getBuilder()->CreateIntrinsic(Intrinsic::sqrt,
-                                              Args[0]->getType(), Args[0]);
-    return getBuilder()->CreateFDiv(ConstantFP::get(Sqrt->getType(), 1.0), Sqrt);
+    Value *Sqrt = getBuilder()->CreateUnaryIntrinsic(Intrinsic::sqrt, Args[0]);
+    return getBuilder()->CreateFDiv(ConstantFP::get(Sqrt->getType(), 1.0),
+                                    Sqrt);
   }
 
   case GLSLstd450Determinant:


### PR DESCRIPTION
    1. Added Builder::CreateUnaryIntrinsic that is the same as the
       IRBuilder<>::CreateUnaryIntrinsic that it overrides, except that it
       honors Builder's FMF if none are explicitly provided.
    2. Switched the trig and exponent ops (and the fabs from OpFWidth) to
       use CreateUnaryIntrinsic, so they get FMF.
