### PR TITLE
Correct a latent issue when invoke GetPipelineShaderInfo()

### DIFF
--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -180,6 +180,12 @@ const PipelineShaderInfo* GraphicsContext::GetPipelineShaderInfo(
     ShaderStage shaderStage // Shader stage
     ) const
 {
+    if (shaderStage == ShaderStageCopyShader)
+    {
+        // Treat copy shader as part of geometry shader
+        shaderStage = ShaderStageGeometry;
+    }
+
     LLPC_ASSERT(shaderStage < ShaderStageGfxCount);
 
     const PipelineShaderInfo* pShaderInfo = nullptr;


### PR DESCRIPTION
Copy shader should be treated as part of geometry shader.