### PR TITLE
Fixed gfx10 smod compile bug

### DIFF
--- a/builder/llpcBuilderImplArith.cpp
+++ b/builder/llpcBuilderImplArith.cpp
@@ -125,7 +125,7 @@ Value* BuilderImplArith::CreateSMod(
             if (pDivisorConst->getZExtValue() <= 0xFFFF)
             {
                 // Get a non-constant 0 value. (We know the top 17 bits of the 64-bit PC is always zero.)
-                Value* pPc = CreateIntrinsic(Intrinsic::amdgcn_s_getpc, getInt64Ty(), {});
+                Value* pPc = CreateIntrinsic(Intrinsic::amdgcn_s_getpc, {}, {});
                 Value* pPcHi = CreateExtractElement(CreateBitCast(pPc, VectorType::get(getInt32Ty(), 2)), 1);
                 Value* pNonConstantZero = CreateLShr(pPcHi, getInt32(15));
                 if (auto pVecTy = dyn_cast<VectorType>(pDivisor->getType()))


### PR DESCRIPTION
This bug was caused by my change "Builder: cube face, quantize, smod".

Change-Id: Ia86c9409914595a135c276508c4b2ffbe700eac2