### PR TITLE
Revert PR162 "PatchDescriptorLoad: extract buildBufferDescriptor"

### DIFF
--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -79,83 +79,6 @@ PatchDescriptorLoad::PatchDescriptorLoad()
 }
 
 // =====================================================================================================================
-// Create a non-strided, non-swizzled buffer descriptor.
-Value* PatchDescriptorLoad::BuildBufferDescriptor(
-    Value*       pBaseAddr,    // [in] Base address of the descriptor (top 16 bits are ignored); for convenience, an
-                               //      <N x i32> is also accepted (using the low 48 bits)
-    Value*       pBufSize,     // [in] Size of the referenced buffer in bytes
-    Instruction* pInsertPoint) // [in] Instructions are inserted before pInsertPoint
-{
-    IRBuilder<> builder(pInsertPoint);
-    Value* pBufDesc = UndefValue::get(m_pContext->Int32x4Ty());
-
-    Value* pElem0 = nullptr;
-    Value* pElem1 = nullptr;
-
-    if (pBaseAddr->getType() == m_pContext->Int64Ty())
-    {
-        pElem0 = builder.CreateTrunc(pBaseAddr, m_pContext->Int32Ty());
-        pElem1 = builder.CreateLShr(pBaseAddr, 32, "", true);
-        pElem1 = builder.CreateTrunc(pElem1, m_pContext->Int32Ty());
-    }
-    else
-    {
-        pElem0 = builder.CreateExtractElement(pBaseAddr, uint64_t(0));
-        pElem1 = builder.CreateExtractElement(pBaseAddr, 1);
-    }
-
-    // DWORD0
-    pBufDesc = builder.CreateInsertElement(pBufDesc, pElem0, uint64_t(0));
-
-    // DWORD1
-    pElem1 = builder.CreateAnd(pElem1, builder.getInt32(UINT16_MAX));
-    pBufDesc = builder.CreateInsertElement(pBufDesc, pElem1, 1);
-
-    // DWORD2
-    pBufDesc = builder.CreateInsertElement(pBufDesc, pBufSize, 2);
-
-    // DWORD3
-#if LLPC_BUILD_GFX10
-    const GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
-    if (gfxIp.major < 10)
-#endif
-    {
-        SqBufRsrcWord3 sqBufRsrcWord3 = {};
-        sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
-        sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
-        sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
-        sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
-        sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
-        sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
-        LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
-
-        pBufDesc = builder.CreateInsertElement(pBufDesc, builder.getInt32(sqBufRsrcWord3.u32All), 3);
-    }
-#if LLPC_BUILD_GFX10
-    else if (gfxIp.major == 10)
-    {
-        SqBufRsrcWord3 sqBufRsrcWord3 = {};
-        sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
-        sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
-        sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
-        sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
-        sqBufRsrcWord3.gfx10.FORMAT = BUF_FORMAT_32_UINT;
-        sqBufRsrcWord3.gfx10.RESOURCE_LEVEL = 1;
-        sqBufRsrcWord3.gfx10.OOB_SELECT = 2;
-        LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x21014FAC);
-
-        pBufDesc = builder.CreateInsertElement(pBufDesc, builder.getInt32(sqBufRsrcWord3.u32All), 3);
-    }
-    else
-    {
-        LLPC_NOT_IMPLEMENTED();
-    }
-#endif
-
-    return pBufDesc;
-}
-
-// =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM module.
 bool PatchDescriptorLoad::runOnModule(
     Module& module)  // [in,out] LLVM module to be run on
@@ -397,13 +320,13 @@ Value* PatchDescriptorLoad::LoadDescriptor(
         pDescRangeValue = GetDescriptorRangeValue(nodeType1, descSet, binding);
     }
 
-    IRBuilder<> builder(*m_pContext);
-    builder.SetInsertPoint(pInsertPoint);
-
     if (pDescRangeValue != nullptr)
     {
         // Descriptor range value (immutable sampler in Vulkan). pDescRangeValue is a constant array of
         // <4 x i32> descriptors.
+        IRBuilder<> builder(*m_pContext);
+        builder.SetInsertPoint(pInsertPoint);
+
         if (pDescRangeValue->getType()->getArrayNumElements() == 1)
         {
             // Immutable descriptor array is size 1, so we can assume index 0.
@@ -481,8 +404,101 @@ Value* PatchDescriptorLoad::LoadDescriptor(
                 // Extract compact buffer descriptor
                 if (descSizeInDword == DescriptorSizeBufferCompact / sizeof(uint32_t))
                 {
-                    pDesc = BuildBufferDescriptor(pDesc, builder.getInt32(UINT32_MAX), pInsertPoint);
+                    // Extract compact buffer descriptor
+                    Value* pDescElem0 = ExtractElementInst::Create(pDesc,
+                        ConstantInt::get(m_pContext->Int32Ty(), 0),
+                        "",
+                        pInsertPoint);
+
+                    Value* pDescElem1 = ExtractElementInst::Create(pDesc,
+                        ConstantInt::get(m_pContext->Int32Ty(), 1),
+                        "",
+                        pInsertPoint);
+
+                    // Build normal buffer descriptor
+                    auto pBufDescTy = m_pContext->Int32x4Ty();
+                    Value* pBufDesc = UndefValue::get(pBufDescTy);
+
+                    // DWORD0
+                    pBufDesc = InsertElementInst::Create(pBufDesc,
+                        pDescElem0,
+                        ConstantInt::get(m_pContext->Int32Ty(), 0),
+                        "",
+                        pInsertPoint);
+
+                    // DWORD1
+                    SqBufRsrcWord1 sqBufRsrcWord1 = {};
+                    sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
+
+                    pDescElem1 = BinaryOperator::CreateAnd(pDescElem1,
+                        ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord1.u32All),
+                        "",
+                        pInsertPoint);
+                    pBufDesc = InsertElementInst::Create(pBufDesc,
+                        pDescElem1,
+                        ConstantInt::get(m_pContext->Int32Ty(), 1),
+                        "",
+                        pInsertPoint);
+
+                    // DWORD2
+                    SqBufRsrcWord2 sqBufRsrcWord2 = {};
+                    sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
+
+                    pBufDesc = InsertElementInst::Create(pBufDesc,
+                        ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord2.u32All),
+                        ConstantInt::get(m_pContext->Int32Ty(), 2),
+                        "",
+                        pInsertPoint);
+
+                    // DWORD3
+#if LLPC_BUILD_GFX10
+                    const GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
+                    if (gfxIp.major < 10)
+#endif
+                    {
+                        SqBufRsrcWord3 sqBufRsrcWord3 = {};
+                        sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+                        sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+                        sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+                        sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+                        sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
+                        sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
+                        LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
+
+                        pBufDesc = InsertElementInst::Create(pBufDesc,
+                            ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
+                            ConstantInt::get(m_pContext->Int32Ty(), 3),
+                            "",
+                            &callInst);
+                    }
+#if LLPC_BUILD_GFX10
+                    else if (gfxIp.major == 10)
+                    {
+                        SqBufRsrcWord3 sqBufRsrcWord3 = {};
+                        sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+                        sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+                        sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+                        sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+                        sqBufRsrcWord3.gfx10.FORMAT = BUF_FORMAT_32_UINT;
+                        sqBufRsrcWord3.gfx10.RESOURCE_LEVEL = 1;
+                        sqBufRsrcWord3.gfx10.OOB_SELECT = 2;
+                        LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x21014FAC);
+
+                        pBufDesc = InsertElementInst::Create(pBufDesc,
+                            ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
+                            ConstantInt::get(m_pContext->Int32Ty(), 3),
+                            "",
+                            &callInst);
+                    }
+                    else
+                    {
+                        LLPC_NOT_IMPLEMENTED();
+                    }
+#endif
+
+                    pDesc = pBufDesc;
                 }
+
             }
             else
             {
@@ -522,10 +538,61 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             }
             else
             {
-                Value* pBaseAddr = builder.CreateInsertElement(pDescTableAddr, pDescElem0, (uint64_t)0);
-
                 // Build buffer descriptor from inline constant buffer address
-                pDesc = BuildBufferDescriptor(pBaseAddr, builder.getInt32(UINT32_MAX), pInsertPoint);
+                SqBufRsrcWord1 sqBufRsrcWord1 = {};
+                SqBufRsrcWord2 sqBufRsrcWord2 = {};
+                SqBufRsrcWord3 sqBufRsrcWord3 = {};
+
+                sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
+                sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
+
+                sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+                sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+                sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+                sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+                sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
+                sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
+                LLPC_ASSERT(sqBufRsrcWord3.u32All == 0x24FAC);
+
+                Value* pDescElem1 = ExtractElementInst::Create(pDescTableAddr,
+                    ConstantInt::get(m_pContext->Int32Ty(), 1),
+                    "",
+                    pInsertPoint);
+
+                auto pBufDescTy = m_pContext->Int32x4Ty();
+                pDesc = UndefValue::get(pBufDescTy);
+
+                // DWORD0
+                pDesc = InsertElementInst::Create(pDesc,
+                    pDescElem0,
+                    ConstantInt::get(m_pContext->Int32Ty(), 0),
+                    "",
+                    pInsertPoint);
+
+                // DWORD1
+                pDescElem1 = BinaryOperator::CreateAnd(pDescElem1,
+                    ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord1.u32All),
+                    "",
+                    pInsertPoint);
+                pDesc = InsertElementInst::Create(pDesc,
+                    pDescElem1,
+                    ConstantInt::get(m_pContext->Int32Ty(), 1),
+                    "",
+                    pInsertPoint);
+
+                // DWORD2
+                pDesc = InsertElementInst::Create(pDesc,
+                    ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord2.u32All),
+                    ConstantInt::get(m_pContext->Int32Ty(), 2),
+                    "",
+                    pInsertPoint);
+
+                // DWORD3
+                pDesc = InsertElementInst::Create(pDesc,
+                    ConstantInt::get(m_pContext->Int32Ty(), sqBufRsrcWord3.u32All),
+                    ConstantInt::get(m_pContext->Int32Ty(), 3),
+                    "",
+                    pInsertPoint);
             }
         }
         else

--- a/patch/llpcPatchDescriptorLoad.h
+++ b/patch/llpcPatchDescriptorLoad.h
@@ -89,8 +89,6 @@ private:
 
     void PatchWaterfallLastUseCalls();
 
-    llvm::Value* BuildBufferDescriptor(llvm::Value* pBaseAddr, llvm::Value* pBufSize, llvm::Instruction* pInsertPoint);
-
     // -----------------------------------------------------------------------------------------------------------------
 
     // Descriptor size

--- a/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -10,8 +10,8 @@
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to [4294967295 x i8]
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i64 0
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)
 ; SHADERTEST: bitcast <4 x i32> %{{.*}} to <2 x double>
 


### PR DESCRIPTION
This change was causing a hang in Navi10 testing. I am reverting it for
now, pending a proper investigation of the failure.

Change-Id: Iab5ec0ad543168f93029e9f587725b53d8698eaf