### PR TITLE
Reinstated extra llvm.amdgcn.wqm in derivative code

### DIFF
--- a/builder/llpcBuilderImplMisc.cpp
+++ b/builder/llpcBuilderImplMisc.cpp
@@ -174,6 +174,7 @@ Value* BuilderImplMisc::CreateDerivative(
                                                                      getInt32(15),
                                                                      getTrue()
                                                                   });
+                               pFirstVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pFirstVal);
                                pFirstVal = CreateZExtOrTrunc(pFirstVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pFirstVal = CreateBitCast(pFirstVal, pValTy);
                                Value* pSecondVal = CreateIntrinsic(Intrinsic::amdgcn_mov_dpp,
@@ -185,10 +186,10 @@ Value* BuilderImplMisc::CreateDerivative(
                                                                       getInt32(15),
                                                                       getTrue()
                                                                    });
+                               pSecondVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pSecondVal);
                                pSecondVal = CreateZExtOrTrunc(pSecondVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pSecondVal = CreateBitCast(pSecondVal, pValTy);
-                               Value* pResult = CreateFSub(pFirstVal, pSecondVal);
-                               return CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pResult);
+                               return CreateFSub(pFirstVal, pSecondVal);
                             });
     }
     else
@@ -222,15 +223,16 @@ Value* BuilderImplMisc::CreateDerivative(
                                Value* pFirstVal = CreateIntrinsic(Intrinsic::amdgcn_ds_swizzle,
                                                                   {},
                                                                   { pValue, getInt32(perm1)});
+                               pFirstVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pFirstVal);
                                pFirstVal = CreateZExtOrTrunc(pFirstVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pFirstVal = CreateBitCast(pFirstVal, pValTy);
                                Value* pSecondVal = CreateIntrinsic(Intrinsic::amdgcn_ds_swizzle,
                                                                    {},
                                                                    { pValue, getInt32(perm2) });
+                               pSecondVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pSecondVal);
                                pSecondVal = CreateZExtOrTrunc(pSecondVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pSecondVal = CreateBitCast(pSecondVal, pValTy);
-                               Value* pResult = CreateFSub(pFirstVal, pSecondVal);
-                               return CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pResult);
+                               return CreateFSub(pFirstVal, pSecondVal);
                             });
     }
     pResult->setName(instName);

--- a/test/shaderdb/OpDPdx_TestFineCoarse_lit.frag
+++ b/test/shaderdb/OpDPdx_TestFineCoarse_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 85, i32 15, i32 15, i1 true)
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 0, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32(float %{{[0-9]+}})
+; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32(i32 %{{[0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpDPdy_TestFineCoarse_lit.frag
+++ b/test/shaderdb/OpDPdy_TestFineCoarse_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 170, i32 15, i32 15, i1 true)
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 0, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32(float {{[%0-9]+}})
+; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32(i32 {{[%0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
In PR #157 "Derivative operations in Builder", I also removed what I
believe is an extra unnecessary llvm.amdgcn.wqm call in the middle of a
derivative calculation. However that caused much worse performance in
one pipeline in a particular game because it started doing lots of sgpr
spilling. Possibly having fewer wqm intrinsics and fewer bitcasts
allowed some pass more freedom to move other code around, which
accidetntally increased sgpr pressure.

This commit reinstates the extra llvm.amdgcn.wqm, to get the same final
ISA as before the above change.

Change-Id: I83467c4f05f42ab6626f13f5c586b43c2244ef12