### PR TITLE
Fix crash when input is LLVM IR

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -1074,7 +1074,7 @@ Result Compiler::BuildPipelineInternal(
     // NOTE: If input is LLVM IR, read it now. There is now only ever one IR module representing the
     // whole pipeline.
     bool IsLlvmBc = false;
-    const PipelineShaderInfo* pShaderInfo = shaderInfo[0];
+    const PipelineShaderInfo* pShaderInfo = (shaderInfo[0] != nullptr) ? shaderInfo[0] : shaderInfo.back();
     if (pShaderInfo != nullptr)
     {
         const ShaderModuleData* pModuleData = reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -1521,6 +1521,7 @@ static Result ProcessPipeline(
                 compileInfo.spirvBin[shaderStage].codeSize = bitcodeBuf.size();
                 compileInfo.spirvBin[shaderStage].pCode = pCode;
                 compileInfo.stageMask |= ShaderStageToMask(static_cast<ShaderStage>(shaderStage));
+                compileInfo.doAutoLayout = false;
             }
         }
         else


### PR DESCRIPTION
1. Disable auto-layout when input is LLVM IR, auto-layout only support SPIRV
2. Check both first and last shader stage for flag isLlvmBc in Compiler::BuildPipelineInternal, because compute shader is the last stage in input array