### PR TITLE
Add 128-bit Client hash to PipelineShaderOptions

### DIFF
--- a/context/llpcContext.h
+++ b/context/llpcContext.h
@@ -281,7 +281,7 @@ public:
         return m_pPipelineContext->GetCacheHashCode();
     }
 
-    uint64_t GetShaderHashCode(ShaderStage shaderStage) const
+    ShaderHash GetShaderHashCode(ShaderStage shaderStage) const
     {
         return m_pPipelineContext->GetShaderHashCode(shaderStage);
     }

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -806,7 +806,7 @@ public:
     uint64_t GetPiplineHashCode() const { return MetroHash::Compact64(&m_pipelineHash); }
     uint64_t GetCacheHashCode() const { return MetroHash::Compact64(&m_cacheHash); }
 
-    virtual uint64_t GetShaderHashCode(ShaderStage stage) const;
+    virtual ShaderHash GetShaderHashCode(ShaderStage stage) const;
 
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const = 0;

--- a/context/llpcShaderCache.cpp
+++ b/context/llpcShaderCache.cpp
@@ -253,7 +253,7 @@ Result ShaderCache::Merge(
 
         for (auto it : pSrcCache->m_shaderIndexMap)
         {
-            ShaderHash key = it.first;
+            uint64_t key = it.first;
 
             auto indexMap = m_shaderIndexMap.find(key);
             if (indexMap == m_shaderIndexMap.end())
@@ -464,7 +464,7 @@ ShaderEntryState ShaderCache::FindShader(
 
     bool readOnlyLock = (allocateOnMiss == false);
     LockCacheMap(readOnlyLock);
-    ShaderHash hashKey = MetroHash::Compact64(&hash);
+    uint64_t hashKey = MetroHash::Compact64(&hash);
     auto indexMap = m_shaderIndexMap.find(hashKey);
     if (indexMap != m_shaderIndexMap.end())
     {

--- a/context/llpcShaderCache.h
+++ b/context/llpcShaderCache.h
@@ -48,7 +48,7 @@ namespace Llpc
 // Header data that is stored with each shader in the cache.
 struct ShaderHeader
 {
-    ShaderHash  key;    // Compacted hash key used to identify shaders
+    uint64_t    key;    // Compacted hash key used to identify shaders
     uint64_t    crc;    // CRC of the shader cache entry, used to detect data corruption.
     size_t      size;   // Total size of the shader data in the storage file
 };
@@ -81,7 +81,8 @@ struct ShaderIndex
     void*                       pDataBlob;   // Serialized data blob representing a cached RelocatableShader object.
 };
 
-typedef std::unordered_map<ShaderHash, ShaderIndex*> ShaderIndexMap;
+// The key in hash map is a 64-bit compacted Shader Hash
+typedef std::unordered_map<uint64_t, ShaderIndex*> ShaderIndexMap;
 
 // Specifies auxiliary info necessary to create a shader cache object.
 struct ShaderCacheAuxCreateInfo

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -109,7 +109,11 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
 
     const uint32_t stageMask = pContext->GetShaderStageMask();
 
-    uint64_t hash64 = 0;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    ShaderHash hash = {};
+#else
+    ShaderHash hash = 0;
+#endif
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsFsRegConfig)];
     PipelineVsFsRegConfig* pConfig = reinterpret_cast<PipelineVsFsRegConfig*>(pAllocBuf);
@@ -130,16 +134,16 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_REAL);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageFragment)))
     {
         result = BuildPsRegConfig<PipelineVsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
     }
 
     // Set up IA_MULTI_VGT_PARAM
@@ -167,7 +171,11 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
     Result result = Result::Success;
     const uint32_t stageMask = pContext->GetShaderStageMask();
 
-    uint64_t hash64 = 0;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    ShaderHash hash = {};
+#else
+    ShaderHash hash = 0;
+#endif
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsTsFsRegConfig)];
     PipelineVsTsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsFsRegConfig*>(pAllocBuf);
@@ -188,8 +196,8 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, LS_EN, LS_STAGE_ON);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageTessControl)))
@@ -198,8 +206,8 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageTessControl);
-        SetShaderHash(ShaderStageTessControl, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageTessControl);
+        SetShaderHash(ShaderStageTessControl, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageTessEval)))
@@ -208,16 +216,16 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_DS);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageTessEval);
-        SetShaderHash(ShaderStageTessEval, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageTessEval);
+        SetShaderHash(ShaderStageTessEval, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageFragment)))
     {
         result = BuildPsRegConfig<PipelineVsTsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
     }
 
     if (pContext->IsTessOffChip())
@@ -260,7 +268,11 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
 
     const uint32_t stageMask = pContext->GetShaderStageMask();
 
-    uint64_t hash64 = 0;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    ShaderHash hash = {};
+#else
+    ShaderHash hash = 0;
+#endif
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsGsFsRegConfig)];
     PipelineVsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsGsFsRegConfig*>(pAllocBuf);
@@ -281,8 +293,8 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_REAL);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageGeometry)))
@@ -291,16 +303,16 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageGeometry);
-        SetShaderHash(ShaderStageGeometry, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageGeometry);
+        SetShaderHash(ShaderStageGeometry, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageFragment)))
     {
         result = BuildPsRegConfig<PipelineVsGsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageCopyShader)))
@@ -336,7 +348,11 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
 
     const uint32_t stageMask = pContext->GetShaderStageMask();
 
-    uint64_t hash64 = 0;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    ShaderHash hash = {};
+#else
+    ShaderHash hash = 0;
+#endif
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsTsGsFsRegConfig)];
     PipelineVsTsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsGsFsRegConfig*>(pAllocBuf);
@@ -357,8 +373,8 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, LS_EN, LS_STAGE_ON);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageTessControl)))
@@ -367,8 +383,8 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageTessControl);
-        SetShaderHash(ShaderStageTessControl, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageTessControl);
+        SetShaderHash(ShaderStageTessControl, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageTessEval)))
@@ -377,8 +393,8 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_DS);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageTessEval);
-        SetShaderHash(ShaderStageTessEval, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageTessEval);
+        SetShaderHash(ShaderStageTessEval, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageGeometry)))
@@ -387,16 +403,16 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
 
         SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageGeometry);
-        SetShaderHash(ShaderStageGeometry, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageGeometry);
+        SetShaderHash(ShaderStageGeometry, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageFragment)))
     {
         result = BuildPsRegConfig<PipelineVsTsGsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageCopyShader)))
@@ -447,7 +463,11 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
 
     LLPC_ASSERT(pContext->GetShaderStageMask() == ShaderStageToMask(ShaderStageCompute));
 
-    uint64_t hash64 = 0;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    ShaderHash hash = {};
+#else
+    ShaderHash hash = 0;
+#endif
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineCsRegConfig)];
     PipelineCsRegConfig* pConfig = reinterpret_cast<PipelineCsRegConfig*>(pAllocBuf);
@@ -464,8 +484,8 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
 
     result = BuildCsRegConfig(pContext, ShaderStageCompute, pConfig);
 
-    hash64 = pContext->GetShaderHashCode(ShaderStageCompute);
-    SetShaderHash(ShaderStageCompute, hash64);
+    hash = pContext->GetShaderHashCode(ShaderStageCompute);
+    SetShaderHash(ShaderStageCompute, hash);
 
     LLPC_ASSERT((ppConfig != nullptr) && (pConfigSize != nullptr));
     *ppConfig = pAllocBuf;

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -185,14 +185,14 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
 #endif
 #endif
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, hash);
         SET_REG(pConfig, VGT_GS_ONCHIP_CNTL, 0);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_CHKSUM_VS, CHECKSUM, checksum);
         }
 #endif
@@ -202,13 +202,13 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineVsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
 #endif
@@ -287,16 +287,23 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
                                                              hasTcs ? ShaderStageTessControl : ShaderStageInvalid,
                                                              pConfig);
 
-        uint64_t vsHash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, vsHash64);
+        ShaderHash vsHash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, vsHash);
 
-        uint64_t tcsHash64 = pContext->GetShaderHashCode(ShaderStageTessControl);
-        SetShaderHash(ShaderStageTessControl, tcsHash64);
+        ShaderHash tcsHash = pContext->GetShaderHashCode(ShaderStageTessControl);
+        SetShaderHash(ShaderStageTessControl, tcsHash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(vsHash64 ^ tcsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = vsHash.upper ^ tcsHash.upper;
+            hash.lower = vsHash.lower ^ tcsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(vsHash ^ tcsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 #endif
@@ -340,13 +347,13 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
 #endif
 #endif
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageTessEval);
-        SetShaderHash(ShaderStageTessEval, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageTessEval);
+        SetShaderHash(ShaderStageTessEval, hash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_CHKSUM_VS, CHECKSUM, checksum);
         }
 #endif
@@ -356,13 +363,13 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineVsTsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
 #endif
@@ -439,16 +446,23 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
                                                              hasGs ? ShaderStageGeometry : ShaderStageInvalid,
                                                              pConfig);
 
-        uint64_t vsHash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, vsHash64);
+        ShaderHash vsHash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, vsHash);
 
-        uint64_t gsHash64 = pContext->GetShaderHashCode(ShaderStageGeometry);
-        SetShaderHash(ShaderStageGeometry, gsHash64);
+        ShaderHash gsHash = pContext->GetShaderHashCode(ShaderStageGeometry);
+        SetShaderHash(ShaderStageGeometry, gsHash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(vsHash64 ^ gsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = vsHash.upper ^ gsHash.upper;
+            hash.lower = vsHash.lower ^ gsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(vsHash ^ gsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 #endif
@@ -475,13 +489,13 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineVsGsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
 #endif
@@ -569,16 +583,23 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
                                                                hasTcs ? ShaderStageTessControl : ShaderStageInvalid,
                                                                pConfig);
 
-        uint64_t vsHash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, vsHash64);
+        ShaderHash vsHash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, vsHash);
 
-        uint64_t tcsHash64 = pContext->GetShaderHashCode(ShaderStageTessControl);
-        SetShaderHash(ShaderStageTessControl, tcsHash64);
+        ShaderHash tcsHash = pContext->GetShaderHashCode(ShaderStageTessControl);
+        SetShaderHash(ShaderStageTessControl, tcsHash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(vsHash64 ^ tcsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = vsHash.upper ^ tcsHash.upper;
+            hash.lower = vsHash.lower ^ tcsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(vsHash ^ tcsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 #endif
@@ -615,16 +636,23 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
                                                                hasGs ? ShaderStageGeometry : ShaderStageInvalid,
                                                                pConfig);
 
-        uint64_t tesHash64 = pContext->GetShaderHashCode(ShaderStageTessEval);
-        SetShaderHash(ShaderStageTessEval, tesHash64);
+        ShaderHash tesHash = pContext->GetShaderHashCode(ShaderStageTessEval);
+        SetShaderHash(ShaderStageTessEval, tesHash);
 
-        uint64_t gsHash64 = pContext->GetShaderHashCode(ShaderStageGeometry);
-        SetShaderHash(ShaderStageGeometry, gsHash64);
+        ShaderHash gsHash = pContext->GetShaderHashCode(ShaderStageGeometry);
+        SetShaderHash(ShaderStageGeometry, gsHash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(tesHash64 ^ gsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = tesHash.upper ^ gsHash.upper;
+            hash.lower = tesHash.lower ^ gsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(tesHash ^ gsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 #endif
@@ -654,13 +682,13 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineVsTsGsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
 #if LLPC_BUILD_GFX10
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
 #endif
@@ -779,12 +807,12 @@ Result ConfigBuilder::BuildPipelineNggVsFsRegConfig(
 #endif
 #endif
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, hash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
     }
@@ -793,12 +821,12 @@ Result ConfigBuilder::BuildPipelineNggVsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineNggVsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
@@ -869,15 +897,22 @@ Result ConfigBuilder::BuildPipelineNggVsTsFsRegConfig(
                                                                 hasTcs ? ShaderStageTessControl : ShaderStageInvalid,
                                                                 pConfig);
 
-        uint64_t vsHash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, vsHash64);
+        ShaderHash vsHash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, vsHash);
 
-        uint64_t tcsHash64 = pContext->GetShaderHashCode(ShaderStageTessControl);
-        SetShaderHash(ShaderStageTessControl, tcsHash64);
+        ShaderHash tcsHash = pContext->GetShaderHashCode(ShaderStageTessControl);
+        SetShaderHash(ShaderStageTessControl, tcsHash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(vsHash64 ^ tcsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = vsHash.upper ^ tcsHash.upper;
+            hash.lower = vsHash.lower ^ tcsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(vsHash ^ tcsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 
@@ -922,12 +957,12 @@ Result ConfigBuilder::BuildPipelineNggVsTsFsRegConfig(
 #endif
 #endif
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageTessEval);
-        SetShaderHash(ShaderStageTessEval, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageTessEval);
+        SetShaderHash(ShaderStageTessEval, hash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
     }
@@ -936,12 +971,12 @@ Result ConfigBuilder::BuildPipelineNggVsTsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineNggVsTsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
@@ -1012,15 +1047,22 @@ Result ConfigBuilder::BuildPipelineNggVsGsFsRegConfig(
                                                                       hasGs ? ShaderStageGeometry : ShaderStageInvalid,
                                                                       pConfig);
 
-        uint64_t vsHash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, vsHash64);
+        ShaderHash vsHash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, vsHash);
 
-        uint64_t gsHash64 = pContext->GetShaderHashCode(ShaderStageGeometry);
-        SetShaderHash(ShaderStageGeometry, gsHash64);
+        ShaderHash gsHash = pContext->GetShaderHashCode(ShaderStageGeometry);
+        SetShaderHash(ShaderStageGeometry, gsHash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(vsHash64 ^ gsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = vsHash.upper ^ gsHash.upper;
+            hash.lower = vsHash.lower ^ gsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(vsHash ^ gsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 
@@ -1047,12 +1089,12 @@ Result ConfigBuilder::BuildPipelineNggVsGsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineNggVsGsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
@@ -1119,15 +1161,22 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig(
                                                                   hasTcs ? ShaderStageTessControl : ShaderStageInvalid,
                                                                   pConfig);
 
-        uint64_t vsHash64 = pContext->GetShaderHashCode(ShaderStageVertex);
-        SetShaderHash(ShaderStageVertex, vsHash64);
+        ShaderHash vsHash = pContext->GetShaderHashCode(ShaderStageVertex);
+        SetShaderHash(ShaderStageVertex, vsHash);
 
-        uint64_t tcsHash64 = pContext->GetShaderHashCode(ShaderStageTessControl);
-        SetShaderHash(ShaderStageTessControl, tcsHash64);
+        ShaderHash tcsHash = pContext->GetShaderHashCode(ShaderStageTessControl);
+        SetShaderHash(ShaderStageTessControl, tcsHash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(vsHash64 ^ tcsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = vsHash.upper ^ tcsHash.upper;
+            hash.lower = vsHash.lower ^ tcsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(vsHash ^ tcsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 
@@ -1159,15 +1208,22 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig(
                                                                    hasGs ? ShaderStageGeometry : ShaderStageInvalid,
                                                                    pConfig);
 
-        uint64_t tesHash64 = pContext->GetShaderHashCode(ShaderStageTessEval);
-        SetShaderHash(ShaderStageTessEval, tesHash64);
+        ShaderHash tesHash = pContext->GetShaderHashCode(ShaderStageTessEval);
+        SetShaderHash(ShaderStageTessEval, tesHash);
 
-        uint64_t gsHash64 = pContext->GetShaderHashCode(ShaderStageGeometry);
-        SetShaderHash(ShaderStageGeometry, gsHash64);
+        ShaderHash gsHash = pContext->GetShaderHashCode(ShaderStageGeometry);
+        SetShaderHash(ShaderStageGeometry, gsHash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(tesHash64 ^ gsHash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+            ShaderHash hash = {};
+            hash.upper = tesHash.upper ^ gsHash.upper;
+            hash.lower = tesHash.lower ^ gsHash.lower;
+            uint32_t checksum = MetroHash::Compact32(hash);
+#else
+            uint32_t checksum = MetroHash::Compact32(tesHash ^ gsHash);
+#endif
             SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 
@@ -1195,12 +1251,12 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig(
     {
         result = BuildPsRegConfig<PipelineNggVsTsGsFsRegConfig>(pContext, ShaderStageFragment, pConfig);
 
-        uint64_t hash64 = pContext->GetShaderHashCode(ShaderStageFragment);
-        SetShaderHash(ShaderStageFragment, hash64);
+        ShaderHash hash = pContext->GetShaderHashCode(ShaderStageFragment);
+        SetShaderHash(ShaderStageFragment, hash);
 
         if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
         {
-            uint32_t checksum = MetroHash::Compact32(hash64);
+            uint32_t checksum = MetroHash::Compact32(hash);
             SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
@@ -1241,7 +1297,11 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
 
     LLPC_ASSERT(pContext->GetShaderStageMask() == ShaderStageToMask(ShaderStageCompute));
 
-    uint64_t hash64 = 0;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    ShaderHash hash = {};
+#else
+    ShaderHash hash = 0;
+#endif
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineCsRegConfig)];
     PipelineCsRegConfig* pConfig = reinterpret_cast<PipelineCsRegConfig*>(pAllocBuf);
@@ -1258,13 +1318,13 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
 
     result = BuildCsRegConfig(pContext, ShaderStageCompute, pConfig);
 
-    hash64 = pContext->GetShaderHashCode(ShaderStageCompute);
-        SetShaderHash(ShaderStageCompute, hash64);
+    hash = pContext->GetShaderHashCode(ShaderStageCompute);
+    SetShaderHash(ShaderStageCompute, hash);
 
 #if LLPC_BUILD_GFX10
     if (pContext->GetGpuProperty()->supportShaderPowerProfiling)
     {
-        uint32_t checksum = MetroHash::Compact32(hash64);
+        uint32_t checksum = MetroHash::Compact32(hash);
         SET_REG_FIELD(&pConfig->m_csRegs, COMPUTE_SHADER_CHKSUM, CHECKSUM, checksum);
     }
 #endif

--- a/patch/llpcConfigBuilderBase.cpp
+++ b/patch/llpcConfigBuilderBase.cpp
@@ -147,12 +147,19 @@ msgpack::MapDocNode ConfigBuilderBase::GetHwShaderNode(
 // =====================================================================================================================
 // Set an API shader's hash in metadata
 void ConfigBuilderBase::SetShaderHash(
-    ShaderStage apiStage, // API shader stage
-    uint64_t    hash64)   // Its hash
+    ShaderStage   apiStage, // API shader stage
+    ShaderHash    hash)     // Its hash
 {
     auto hashNode = GetApiShaderNode(uint32_t(apiStage))[Util::Abi::ShaderMetadataKey::ApiShaderHash].getArray(true);
-    hashNode[0] = hashNode.getDocument()->getNode(hash64);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+    // 128-bit hash
+    hashNode[0] = hashNode.getDocument()->getNode(hash.lower);
+    hashNode[1] = hashNode.getDocument()->getNode(hash.upper);
+#else
+    // 64-bit hash
+    hashNode[0] = hashNode.getDocument()->getNode(hash);
     hashNode[1] = hashNode.getDocument()->getNode(0U);
+#endif
 }
 
 // =====================================================================================================================
@@ -163,7 +170,6 @@ void ConfigBuilderBase::SetNumAvailSgprs(
 {
     auto hwShaderNode = GetHwShaderNode(hwStage);
     hwShaderNode[Util::Abi::HardwareStageMetadataKey::SgprLimit] = hwShaderNode.getDocument()->getNode(value);
- 
 }
 
 // =====================================================================================================================

--- a/patch/llpcConfigBuilderBase.h
+++ b/patch/llpcConfigBuilderBase.h
@@ -55,7 +55,7 @@ protected:
                                  uint32_t           fsHwShader,
                                  uint32_t           csHwShader);
 
-    void SetShaderHash(ShaderStage apiStage, uint64_t hash64);
+    void SetShaderHash(ShaderStage apiStage, ShaderHash hash);
     void SetNumAvailSgprs(Util::Abi::HardwareStage hwStage, uint32_t value);
     void SetNumAvailVgprs(Util::Abi::HardwareStage hwStage, uint32_t value);
     void SetUsesViewportArrayIndex(bool useViewportIndex);

--- a/util/llpcMetroHash.h
+++ b/util/llpcMetroHash.h
@@ -77,5 +77,18 @@ inline uint32_t Compact32(uint64_t hash)
     return static_cast<uint32_t>(hash) ^ static_cast<uint32_t>(hash >> 32);
 }
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
+// Compacts a 128-bit hash into a 32-bit one by XOR'ing each 32-bit chunk together.
+//
+// Takes input parameter ShaderHash, which is a struct consisting of 2 quad words to be compacted.
+//
+// Returns 32-bit hash value based on the input 128-bit hash.
+inline uint32_t Compact32(Llpc::ShaderHash hash)
+{
+    return (static_cast<uint32_t>(hash.lower) ^ static_cast<uint32_t>(hash.lower >> 32)
+        ^ static_cast<uint32_t>(hash.upper) ^ static_cast<uint32_t>(hash.upper >> 32));
+}
+#endif
+
 } // MetroHash
 


### PR DESCRIPTION
This enables LLPC Vulkan driver tuning. The 128-bit client hash is required in pipeline dumps.