### PR TITLE
Move LLPC timer profile related code to utility class TimerProfiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ if(ICD_BUILD_LLPC)
         util/llpcPipelineDumper.cpp
         util/llpcPipelineShaders.cpp
         util/llpcStartStopTimer.cpp
+        util/llpcTimerProfiler.cpp
         util/llpcUtil.cpp
     )
 else()

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -65,6 +65,7 @@
 #include "llpcPatch.h"
 #include "llpcPipelineDumper.h"
 #include "llpcSpirvLower.h"
+#include "llpcTimerProfiler.h"
 #include "llpcVertexFetch.h"
 #include <mutex>
 #include <set>
@@ -227,34 +228,6 @@ class LlpcDiagnosticHandler : public llvm::DiagnosticHandler
         return true;
     }
 };
-
-// =====================================================================================================================
-// Gets dummy TimeRecords.
-static const StringMap<TimeRecord>& GetDummyTimeRecords()
-{
-    static StringMap<TimeRecord> dummyTimeRecords;
-    if (TimePassesIsEnabled && dummyTimeRecords.empty())
-    {
-        // NOTE: It is a workaround to get fixed layout in timer reports. Please remove it if we find a better solution.
-        // LLVM timer skips the field if it is zero in all timers, it causes the layout of the report isn't stable when
-        // compile multiple pipelines. so we add a dummy record to force all fields is shown.
-        // But LLVM TimeRecord can't be initialized explicitly. We have to use HackedTimeRecord to force update the vaule
-        // in TimeRecord.
-        TimeRecord timeRecord;
-        struct HackedTimeRecord
-        {
-            double t1;
-            double t2;
-            double t3;
-            ssize_t m1;
-        } hackedTimeRecord = { 1e-100, 1e-100, 1e-100, 0 };
-        static_assert(sizeof(timeRecord) == sizeof(hackedTimeRecord), "Unexpected Size!");
-        memcpy(&timeRecord, &hackedTimeRecord, sizeof(TimeRecord));
-        dummyTimeRecords["DUMMY"] = timeRecord;
-    }
-
-    return dummyTimeRecords;
-}
 
 // =====================================================================================================================
 // Creates LLPC compiler from the specified info.
@@ -747,22 +720,9 @@ Result Compiler::BuildShaderModule(
 
     memcpy(moduleData.hash, &hash, sizeof(hash));
 
-    std::string hashString;
-    raw_string_ostream ostream(hashString);
-    ostream << format("0x%016" PRIX64, MetroHash::Compact64(&hash));
-    ostream.flush();
-
-    TimerGroup timerGroupTotal("llpc", (Twine("LLPC ShaderModule") + hashString).str(), GetDummyTimeRecords());
-    Timer wholeTimer("llpc-total", (Twine("LLPC ShaderModule Total ") + hashString).str(), timerGroupTotal);
-
-    TimerGroup timerGroupPhases("llpc", (Twine("LLPC ShaderModule Phases ") + hashString).str(), GetDummyTimeRecords());
-    Timer translateTimer("llpc-translate", (Twine("LLPC ShaderModule Translate ") + hashString).str(), timerGroupPhases);
-    Timer lowerTimer("llpc-lower", (Twine("LLPC ShaderModule Lower ") + hashString).str(), timerGroupPhases);
-
-    if (TimePassesIsEnabled)
-    {
-        wholeTimer.startTimer();
-    }
+    TimerProfiler timerProfiler(MetroHash::Compact64(&hash),
+                                "LLPC ShaderModule",
+                                TimerProfiler::ShaderModuleTimerEnableMask);
 
     // Check the type of input shader binary
     if (IsSpirvBinary(&pShaderInfo->shaderBin))
@@ -878,10 +838,7 @@ Result Compiler::BuildShaderModule(
                     pContext->GetBuilder()->SetShaderStage(static_cast<ShaderStage>(entryNames[i].stage));
 
                     // Start timer for translate.
-                    if (TimePassesIsEnabled)
-                    {
-                        lowerPassMgr.add(CreateStartStopTimer(&translateTimer, true));
-                    }
+                    timerProfiler.AddTimerStartStopPass(&lowerPassMgr, TimerTranslate, true);
 
                     // SPIR-V translation, then dump the result.
                     PipelineShaderInfo shaderInfo = {};
@@ -899,18 +856,15 @@ Result Compiler::BuildShaderModule(
                     }
 
                     // Stop timer for translate.
-                    if (TimePassesIsEnabled)
-                    {
-                        lowerPassMgr.add(CreateStartStopTimer(&translateTimer, false));
-                    }
+                    timerProfiler.AddTimerStartStopPass(&lowerPassMgr, TimerTranslate, false);
 
                     // Per-shader SPIR-V lowering passes.
                     SpirvLower::AddPasses(pContext,
-                        static_cast<ShaderStage>(entryNames[i].stage),
-                        lowerPassMgr,
-                        TimePassesIsEnabled ? &lowerTimer : nullptr,
-                        cl::ForceLoopUnrollCount,
-                        nullptr);
+                                          static_cast<ShaderStage>(entryNames[i].stage),
+                                          lowerPassMgr,
+                                          timerProfiler.GetTimer(TimerLower),
+                                          cl::ForceLoopUnrollCount,
+                                          nullptr);
 
                     lowerPassMgr.add(createBitcodeWriterPass(moduleBinaryStream));
 
@@ -1018,11 +972,6 @@ Result Compiler::BuildShaderModule(
         }
     }
 
-    if (TimePassesIsEnabled)
-    {
-        wholeTimer.stopTimer();
-    }
-
     return result;
 }
 
@@ -1043,28 +992,7 @@ Result Compiler::BuildPipelineInternal(
     }
 
     uint32_t passIndex = 0;
-
-    // Create the timer group and timers for -time-passes.
-    std::string hash;
-    raw_string_ostream ostream(hash);
-    ostream << format("0x%016" PRIX64, pContext->GetPipelineContext()->GetPiplineHashCode());
-    ostream.flush();
-
-    TimerGroup timerGroupTotal("llpc", (Twine("LLPC ") + hash).str(), GetDummyTimeRecords());
-    Timer wholeTimer("llpc-total", (Twine("LLPC Total ") + hash).str(), timerGroupTotal);
-
-    TimerGroup timerGroupPhases("llpc", (Twine("LLPC Phases ") + hash).str(), GetDummyTimeRecords());
-    Timer translateTimer("llpc-translate", (Twine("LLPC Translate ") + hash).str(), timerGroupPhases);
-    Timer lowerTimer("llpc-lower", (Twine("LLPC Lower ") + hash).str(), timerGroupPhases);
-    Timer loadTimer("llpc-load", (Twine("LLPC Load ") + hash).str(), timerGroupPhases);
-    Timer patchTimer("llpc-patch", (Twine("LLPC Patch ") + hash).str(), timerGroupPhases);
-    Timer optTimer("llpc-opt", (Twine("LLPC Optimization ") + hash).str(), timerGroupPhases);
-    Timer codeGenTimer("llpc-codegen", (Twine("LLPC CodeGen ") + hash).str(), timerGroupPhases);
-
-    if (TimePassesIsEnabled)
-    {
-        wholeTimer.startTimer();
-    }
+    TimerProfiler timerProfiler(pContext->GetPiplineHashCode(), "LLPC", TimerProfiler::PipelineTimerEnableMask);
 
     pContext->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>());
 
@@ -1110,10 +1038,7 @@ Result Compiler::BuildPipelineInternal(
             Module* pModule = nullptr;
             if (pModuleData->binType == BinaryType::MultiLlvmBc)
             {
-                if (TimePassesIsEnabled)
-                {
-                    loadTimer.startTimer();
-                }
+                timerProfiler.StartStopTimer(TimerLoadBc, true);
 
                 MetroHash::Hash entryNameHash = {};
 
@@ -1153,10 +1078,7 @@ Result Compiler::BuildPipelineInternal(
                     result = Result::ErrorInvalidShader;
                 }
 
-                if (TimePassesIsEnabled)
-                {
-                    loadTimer.stopTimer();
-                }
+                 timerProfiler.StartStopTimer(TimerLoadBc, false);
             }
             else
             {
@@ -1188,10 +1110,7 @@ Result Compiler::BuildPipelineInternal(
             pContext->GetBuilder()->SetShaderStage(pShaderInfo->entryStage);
 
             // Start timer for translate.
-            if (TimePassesIsEnabled)
-            {
-                lowerPassMgr.add(CreateStartStopTimer(&translateTimer, true));
-            }
+            timerProfiler.AddTimerStartStopPass(&lowerPassMgr, TimerTranslate, true);
 
             // SPIR-V translation, then dump the result.
             lowerPassMgr.add(CreateSpirvLowerTranslator(pShaderInfo->entryStage, pShaderInfo));
@@ -1206,10 +1125,7 @@ Result Compiler::BuildPipelineInternal(
             }
 
             // Stop timer for translate.
-            if (TimePassesIsEnabled)
-            {
-                lowerPassMgr.add(CreateStartStopTimer(&translateTimer, false));
-            }
+            timerProfiler.AddTimerStartStopPass(&lowerPassMgr, TimerTranslate, false);
 
             // Run the passes.
             bool success = RunPasses(&lowerPassMgr, modules[shaderIndex]);
@@ -1235,11 +1151,11 @@ Result Compiler::BuildPipelineInternal(
             PassManager lowerPassMgr(&passIndex);
 
             SpirvLower::AddPasses(pContext,
-                                    pShaderInfo->entryStage,
-                                    lowerPassMgr,
-                                    TimePassesIsEnabled ? &lowerTimer : nullptr,
-                                    forceLoopUnrollCount,
-                                    pDynamicLoopUnroll);
+                                  pShaderInfo->entryStage,
+                                  lowerPassMgr,
+                                  timerProfiler.GetTimer(TimerLower),
+                                  forceLoopUnrollCount,
+                                  pDynamicLoopUnroll);
 
             // Run the passes.
             bool success = RunPasses(&lowerPassMgr, modules[shaderIndex]);
@@ -1264,9 +1180,7 @@ Result Compiler::BuildPipelineInternal(
     if (result == Result::Success)
     {
         // Patching.
-        Patch::AddPrePatchPasses(pContext,
-                                 prePatchPassMgr,
-                                 TimePassesIsEnabled ? &patchTimer : nullptr);
+        Patch::AddPrePatchPasses(pContext, prePatchPassMgr, timerProfiler.GetTimer(TimerPatch));
 
         bool success = RunPasses(&prePatchPassMgr, pPipelineModule);
         if (success == false)
@@ -1379,8 +1293,8 @@ Result Compiler::BuildPipelineInternal(
             Patch::AddPasses(pContext,
                              patchPassMgr,
                              skipStageMask,
-                             TimePassesIsEnabled ? &patchTimer : nullptr,
-                             TimePassesIsEnabled ? &optTimer : nullptr);
+                             timerProfiler.GetTimer(TimerPatch),
+                             timerProfiler.GetTimer(TimerOpt));
         }
 
         // At this point, we have finished with the Builder. No patch pass should be using Builder.
@@ -1412,18 +1326,11 @@ Result Compiler::BuildPipelineInternal(
 
         if (result == Result::Success)
         {
-            if (TimePassesIsEnabled)
-            {
-                codeGenPassMgr.add(CreateStartStopTimer(&codeGenTimer, true));
-            }
-
             // Code generation.
-            result = CodeGenManager::AddTargetPasses(pContext, codeGenPassMgr, elfStream);
-
-            if (TimePassesIsEnabled)
-            {
-                codeGenPassMgr.add(CreateStartStopTimer(&codeGenTimer, false));
-            }
+            result = CodeGenManager::AddTargetPasses(pContext,
+                                                     codeGenPassMgr,
+                                                     timerProfiler.GetTimer(TimerCodeGen),
+                                                     elfStream);
         }
 
         // Run the target backend codegen passes.
@@ -1511,11 +1418,6 @@ Result Compiler::BuildPipelineInternal(
     }
 
     pContext->setDiagnosticHandlerCallBack(nullptr);
-
-    if (TimePassesIsEnabled)
-    {
-        wholeTimer.stopTimer();
-    }
 
     delete pPipelineModule;
     pPipelineModule = nullptr;

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -190,6 +190,7 @@ endif
         llpcPipelineDumper.cpp              \
         llpcPipelineShaders.cpp             \
         llpcStartStopTimer.cpp              \
+        llpcTimerProfiler.cpp               \
         llpcUtil.cpp
 
     #if LLPC_BUILD_GFX10

--- a/patch/llpcCodeGenManager.h
+++ b/patch/llpcCodeGenManager.h
@@ -48,6 +48,8 @@ class PassManager;
 
 } // legacy
 
+class Timer;
+
 } // llvm
 
 namespace Llpc
@@ -83,6 +85,7 @@ public:
 
     static Result AddTargetPasses(Context*                    pContext,
                                   PassManager&                passMgr,
+                                  llvm::Timer*                pCodeGenTimer,
                                   llvm::raw_pwrite_stream&    outStream);
 
     static Result Run(llvm::Module*               pModule,

--- a/util/llpcTimerProfiler.cpp
+++ b/util/llpcTimerProfiler.cpp
@@ -1,0 +1,192 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+ /**
+  ***********************************************************************************************************************
+  * @file  llpcTimerProfiler.cpp
+  * @brief LLPC header file: contains the implementation of LLPC utility class TimerProfiler.
+  ***********************************************************************************************************************
+  */
+
+#include "llvm/ADT/Twine.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llpc.h"
+#include "llpcInternal.h"
+#include "llpcPassManager.h"
+#include "llpcTimerProfiler.h"
+
+using namespace llvm;
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+TimerProfiler::TimerProfiler(
+    uint64_t      hash64,              // Hash code
+    const char*   pDescriptionPrefix,  // [in] Profiler description prefix string
+    uint32_t      enableMask)           // Mask of enabled phase timers
+    :
+    m_total("", "", GetDummyTimeRecords()),
+    m_phases("", "", GetDummyTimeRecords())
+{
+    if (TimePassesIsEnabled)
+    {
+        std::string hashString;
+        raw_string_ostream ostream(hashString);
+        ostream << format("0x%016" PRIX64, hash64);
+        ostream.flush();
+
+        // Init whole timer
+        m_total.setName("llpc", (Twine(pDescriptionPrefix) + Twine(" ") + hashString).str());
+        m_wholeTimer.init("llpc-total", (Twine(pDescriptionPrefix) + Twine(" Total ") + hashString).str(), m_total);
+
+        // Init phase timers
+        m_phases.setName("llpc", (Twine(pDescriptionPrefix) + Twine(" Phases ") + hashString).str());
+        if (enableMask & (1 << TimerTranslate))
+        {
+            m_phaseTimers[TimerTranslate].init("llpc-translate",
+                                               (Twine(pDescriptionPrefix) +Twine(" Translate ") + hashString).str(),
+                                               m_phases);
+        }
+
+        if (enableMask & (1 << TimerLower))
+        {
+            m_phaseTimers[TimerLower].init("llpc-lower",
+                                           (Twine(pDescriptionPrefix) + Twine(" Lower ") + hashString).str(),
+                                           m_phases);
+        }
+        if (enableMask & (1 << TimerLoadBc))
+        {
+            m_phaseTimers[TimerLoadBc].init("llpc-load",
+                                            (Twine(pDescriptionPrefix) + Twine(" Load ") + hashString).str(),
+                                            m_phases);
+        }
+        if (enableMask & (1 << TimerPatch))
+        {
+            m_phaseTimers[TimerPatch].init("llpc-patch",
+                                           (Twine(pDescriptionPrefix) + Twine(" Patch ") + hashString).str(),
+                                           m_phases);
+        }
+        if (enableMask & (1 << TimerOpt))
+        {
+            m_phaseTimers[TimerOpt].init("llpc-opt",
+                                         (Twine(pDescriptionPrefix) + Twine(" Optimization ") + hashString).str(),
+                                         m_phases);
+        }
+
+        if (enableMask & (1 << TimerCodeGen))
+        {
+            m_phaseTimers[TimerCodeGen].init("llpc-codegen",
+                                             (Twine(pDescriptionPrefix) + Twine(" CodeGen ") + hashString).str(),
+                                             m_phases);
+        }
+
+        // Start whole timer
+        m_wholeTimer.startTimer();
+    }
+}
+
+// =====================================================================================================================
+TimerProfiler::~TimerProfiler()
+{
+    if (TimePassesIsEnabled)
+    {
+        // Stop whole timer
+        m_wholeTimer.stopTimer();
+    }
+}
+
+// =====================================================================================================================
+// Adds pass to start or stop timer in PassManager
+void TimerProfiler::AddTimerStartStopPass(
+    PassManager* pPassMgr,       // Pass Manager
+    TimerKind    timerKind,      // Kind of phase timer
+    bool         start)          // Start or  stop timer
+{
+    if (TimePassesIsEnabled)
+    {
+        pPassMgr->add(CreateStartStopTimer(&m_phaseTimers[timerKind], start));
+    }
+}
+
+// =====================================================================================================================
+// Starts or stop specified timer.
+void TimerProfiler::StartStopTimer(
+    TimerKind timerKind,         // Kind of phase timer
+    bool      start)             // Start or  stop timer
+{
+    if (TimePassesIsEnabled)
+    {
+        if (start)
+        {
+            m_phaseTimers[timerKind].startTimer();
+        }
+        else
+        {
+            m_phaseTimers[timerKind].stopTimer();
+        }
+    }
+}
+
+// =====================================================================================================================
+// Gets a specific timer. Returns nullptr if TimePassesIsEnabled isn't enabled.
+llvm::Timer* TimerProfiler::GetTimer(
+    TimerKind    timerKind)           // Kind of phase timer
+{
+    return TimePassesIsEnabled ? &m_phaseTimers[timerKind] : nullptr;
+}
+
+// =====================================================================================================================
+// Gets dummy TimeRecords.
+const StringMap<TimeRecord>& TimerProfiler::GetDummyTimeRecords()
+{
+    static StringMap<TimeRecord> dummyTimeRecords;
+    if (TimePassesIsEnabled && dummyTimeRecords.empty())
+    {
+        // NOTE: It is a workaround to get fixed layout in timer reports. Please remove it if we find a better solution.
+        // LLVM timer skips the field if it is zero in all timers, it causes the layout of the report isn't stable when
+        // compile multiple pipelines. so we add a dummy record to force all fields is shown.
+        // But LLVM TimeRecord can't be initialized explicitly. We have to use HackedTimeRecord to force update the vaule
+        // in TimeRecord.
+        TimeRecord timeRecord;
+        struct HackedTimeRecord
+        {
+            double t1;
+            double t2;
+            double t3;
+            ssize_t m1;
+        } hackedTimeRecord = { 1e-100, 1e-100, 1e-100, 0 };
+        static_assert(sizeof(timeRecord) == sizeof(hackedTimeRecord), "Unexpected Size!");
+        memcpy(&timeRecord, &hackedTimeRecord, sizeof(TimeRecord));
+        dummyTimeRecords["DUMMY"] = timeRecord;
+    }
+
+    return dummyTimeRecords;
+}
+
+} // Llpc
+

--- a/util/llpcTimerProfiler.h
+++ b/util/llpcTimerProfiler.h
@@ -1,0 +1,92 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+ /**
+  ***********************************************************************************************************************
+  * @file  llpcTimeProfiler.h
+  * @brief LLPC header file: contains the definition of LLPC utility class TimerProfiler.
+  ***********************************************************************************************************************
+  */
+
+#pragma once
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Timer.h"
+
+#include "llpc.h"
+#include "llpcDebug.h"
+
+namespace Llpc
+{
+
+class PassManager;
+
+// =====================================================================================================================
+// Enumerates the kinds of timer used to do profiling for LLPC compilation phases.
+enum TimerKind : uint32_t
+{
+    TimerTranslate,  // Timer for translator
+    TimerLower,      // Timer for SPIR-V lowering
+    TimerLoadBc,     // Timer for loading LLVM bitcode
+    TimerPatch,      // Timer for LLVM patching
+    TimerOpt,        // Timer for LLVM optimization
+    TimerCodeGen,    // Timer for backend code generation
+
+    TimerCount
+};
+
+// =====================================================================================================================
+// Represents a utility class for time profile, it wraps LLVM Timer and TimerGroup in internal.
+class TimerProfiler
+{
+public:
+    TimerProfiler(uint64_t hash64, const char* pDescriptionPrefix, uint32_t enableMask);
+
+    ~TimerProfiler();
+
+    void AddTimerStartStopPass(PassManager* pPassMgr, TimerKind timerKind, bool start);
+
+    void StartStopTimer(TimerKind name, bool start);
+
+    llvm::Timer* GetTimer(TimerKind timerKind);
+
+    static const llvm::StringMap<llvm::TimeRecord>& GetDummyTimeRecords();
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    static const uint32_t PipelineTimerEnableMask = ((1 << TimerCount) - 1);
+    static const uint32_t ShaderModuleTimerEnableMask = ((1 << TimerTranslate) || (1 << TimerLower));
+
+private:
+    LLPC_DISALLOW_COPY_AND_ASSIGN(TimerProfiler);
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    llvm::TimerGroup m_total;                // TimeGroup for total time
+    llvm::TimerGroup m_phases;               // TimeGroup for each phase
+    llvm::Timer m_wholeTimer;                // Whole timer
+    llvm::Timer m_phaseTimers[TimerCount];   // Phase timer
+};
+
+} // Llpc


### PR DESCRIPTION
TimerProfiler includes two timer groups
- Total Group: total time for all operations, it is equal with the lift time of TimerProfiler
- Phase Group: time for each phase, it can be enabled by enableMask in construct function.

Beside these, all timers in TimerProfiler are controlled by llvm flag TimePassesIsEnabled