### PR TITLE
Fixed comment typos in 'trinary min/max/mid changes'

### DIFF
--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -9608,7 +9608,7 @@ Value *SPIRVToLLVM::transTrinaryMinMaxExtInst(SPIRVExtInst *ExtInst,
   switch (ExtInst->getExtOp()) {
 
   case FMin3AMD: {
-    // Middle of three FP values. Undefined result if any NaNs.
+    // Minimum of three FP values. Undefined result if any NaNs.
     FastMathFlags FMF = getBuilder()->getFastMathFlags();
     FMF.setNoNaNs();
     getBuilder()->setFastMathFlags(FMF);
@@ -9616,7 +9616,7 @@ Value *SPIRVToLLVM::transTrinaryMinMaxExtInst(SPIRVExtInst *ExtInst,
   }
 
   case FMax3AMD: {
-    // Middle of three FP values. Undefined result if any NaNs.
+    // Maximum of three FP values. Undefined result if any NaNs.
     FastMathFlags FMF = getBuilder()->getFastMathFlags();
     FMF.setNoNaNs();
     getBuilder()->setFastMathFlags(FMF);


### PR DESCRIPTION
Change-Id: I257adbc7928c08f6a765219ad77172fd6317b369