### PR TITLE
Define llpc options in just one place

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -3035,21 +3035,13 @@ void Compiler::BuildShaderCacheHash(
     if (stageMask & ShaderStageToMask(ShaderStageFragment))
     {
         // Add pipeline options to fragment hash
-        fragmentHasher.Update(pPipelineOptions->includeDisassembly);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
-        fragmentHasher.Update(pPipelineOptions->autoLayoutDesc);
-#endif
-        fragmentHasher.Update(pPipelineOptions->scalarBlockLayout);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-        fragmentHasher.Update(pPipelineOptions->reconfigWorkgroupLayout);
-#endif
-        fragmentHasher.Update(pPipelineOptions->includeIr);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
-        fragmentHasher.Update(pPipelineOptions->robustBufferAccess);
-#endif
-#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
-        fragmentHasher.Update(pPipelineOptions->includeIrBinary);
-#endif
+#define PIPELINE_OPT(type, field) fragmentHasher.Update(pPipelineOptions->field);
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
         PipelineDumper::UpdateHashForFragmentState(pPipelineInfo, &fragmentHasher);
         fragmentHasher.Finalize(pFragmentHash->bytes);
     }

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -192,26 +192,13 @@ struct BinaryData
 /// Represents per pipeline options.
 struct PipelineOptions
 {
-    bool includeDisassembly;       ///< If set, the disassembly for all compiled shaders will be included in
-                                   ///  the pipeline ELF.
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
-    bool autoLayoutDesc;           ///< If set, the LLPC standalone compiler is compiling individual shader(s)
-                                   ///  without pipeline info, so LLPC needs to do auto descriptor layout.
-#endif
-    bool scalarBlockLayout;        ///< If set, allows scalar block layout of types.
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-    bool reconfigWorkgroupLayout;  ///< If set, allows automatic workgroup reconfigure to take place on compute shaders.
-#endif
-    bool includeIr;                ///< If set, the IR for all compiled shaders will be included in the pipeline ELF.
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
-    bool robustBufferAccess;       ///< If set, out of bounds accesses to buffer or private array will be handled.
-                                   ///  for now this option is used by LLPC shader and affects only the private array,
-                                   ///  the out of bounds accesses will be skipped with this setting.
-#endif
-#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
-    bool includeIrBinary;          ///< If set, the IR binary for all compiled shaders will be included in the pipeline
-                                   ///  ELF.
-#endif
+#define PIPELINE_OPT(type, field) type field;
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.
@@ -261,60 +248,13 @@ struct PipelineDumpOptions
 /// Represents per shader stage options.
 struct PipelineShaderOptions
 {
-    bool   trapPresent;  ///< Indicates a trap handler will be present when this pipeline is executed,
-                         ///  and any trap conditions encountered in this shader should call the trap
-                         ///  handler. This could include an arithmetic exception, an explicit trap
-                         ///  request from the host, or a trap after every instruction when in debug
-                         ///  mode.
-    bool   debugMode;    ///< When set, this shader should cause the trap handler to be executed after
-                         ///  every instruction.  Only valid if trapPresent is set.
-    bool   enablePerformanceData; ///< Enables the compiler to generate extra instructions to gather
-                                  ///  various performance-related data.
-    bool   allowReZ;     ///< Allow the DB ReZ feature to be enabled.  This will cause an early-Z test
-                         ///  to potentially kill PS waves before launch, and also issues a late-Z test
-                         ///  in case the PS kills pixels.  Only valid for pixel shaders.
-    /// Maximum VGPR limit for this shader. The actual limit used by back-end for shader compilation is the smaller
-    /// of this value and whatever the target GPU supports. To effectively disable this limit, set this to UINT_MAX.
-    uint32_t  vgprLimit;
-
-    /// Maximum SGPR limit for this shader. The actual limit used by back-end for shader compilation is the smaller
-    /// of this value and whatever the target GPU supports. To effectively disable this limit, set this to UINT_MAX.
-    uint32_t  sgprLimit;
-
-    /// Overrides the number of CS thread-groups which the GPU will launch per compute-unit. This throttles the
-    /// shader, which can sometimes enable more graphics shader work to complete in parallel. A value of zero
-    /// disables limiting the number of thread-groups to launch. This field is ignored for graphics shaders.
-    uint32_t  maxThreadGroupsPerComputeUnit;
-
-#if LLPC_BUILD_GFX10
-    uint32_t      waveSize;      ///< Control the number of threads per wavefront (GFX10+)
-    bool          wgpMode;       ///< Whether to choose WGP mode or CU mode (GFX10+)
-    WaveBreakSize waveBreakSize; ///< Size of region to force the end of a wavefront (GFX10+).
-                                 ///  Only valid for fragment shaders.
-#endif
-
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-    /// Force loop unroll count. "0" means using default value; "1" means disabling loop unroll.
-    uint32_t  forceLoopUnrollCount;
-#endif
-
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
-    /// Enable LLPC load scalarizer optimization.
-    bool enableLoadScalarizer;
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
-    bool allowVaryWaveSize;      ///< If set, lets the pipeline vary the wave sizes.
-#elif VKI_EXT_SUBGROUP_SIZE_CONTROL
-    bool allowVaryWaveSize;      ///< If set, lets the pipeline vary the wave sizes.
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-    /// Use the LLVM backend's SI scheduler instead of the default scheduler.
-    bool      useSiScheduler;
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
-    /// Disable the the LLVM backend's LICM pass.
-    bool      disableLicm;
-#endif
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field) type field;
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 };
 
 /// Represents one node in a graph defining how the user data bound in a command buffer at draw/dispatch time maps to
@@ -392,34 +332,13 @@ struct GraphicsPipelineBuildOut
 /// Represents NGG tuning options
 struct NggState
 {
-    bool    enableNgg;                  ///< Enable NGG mode, use an implicit primitive shader
-    bool    enableGsUse;                ///< Enable NGG use on geometry shader
-    bool    forceNonPassthrough;        ///< Force NGG to run in non pass-through mode
-    bool    alwaysUsePrimShaderTable;   ///< Always use primitive shader table to fetch culling-control registers
-    NggCompactMode compactMode;         ///< Compaction mode after culling operations
-
-    bool    enableFastLaunch;           ///< Enable the hardware to launch subgroups of work at a faster rate
-    bool    enableVertexReuse;          ///< Enable optimization to cull duplicate vertices
-    bool    enableBackfaceCulling;      ///< Enable culling of primitives that don't meet facing criteria
-    bool    enableFrustumCulling;       ///< Enable discarding of primitives outside of view frustum
-    bool    enableBoxFilterCulling;     ///< Enable simpler frustum culler that is less accurate
-    bool    enableSphereCulling;        ///< Enable frustum culling based on a sphere
-    bool    enableSmallPrimFilter;      ///< Enable trivial sub-sample primitive culling
-    bool    enableCullDistanceCulling;  ///< Enable culling when "cull distance" exports are present
-
-    /// Following fields are used for NGG tuning
-    uint32_t backfaceExponent;          ///< Value from 1 to UINT32_MAX that will cause the backface culling
-                                        ///  algorithm to ignore area calculations that are less than
-                                        ///  (10 ^ -(backfaceExponent)) / abs(w0 * w1 * w2)
-                                        ///  Only valid if the NGG backface culler is enabled.
-                                        ///  A value of 0 will disable the threshold.
-
-    NggSubgroupSizingType subgroupSizing;   ///< NGG sub-group sizing type
-
-    uint32_t primsPerSubgroup;          ///< Preferred number of GS primitives to pack into a primitive shader
-                                        ///  sub-group
-
-    uint32_t vertsPerSubgroup;          ///< Preferred number of vertices consumed by a primitive shader sub-group
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field) type field;
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 };
 #endif
 

--- a/include/llpcOptions.h
+++ b/include/llpcOptions.h
@@ -1,0 +1,189 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Trade secret of Advanced Micro Devices, Inc.
+ *  Copyright (c) 2019, Advanced Micro Devices, Inc., (unpublished)
+ *
+ *  All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply
+ *  publication or any waiver of confidentiality. The year included in the foregoing notice is the year of creation of
+ *  the work.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcOptions.h
+ * @brief LLPC header file: contains LLPC options
+ ***********************************************************************************************************************
+ */
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Per pipeline options that make up PipelineOptions.
+
+// If set, the disassembly for all compiled shaders will be included in the pipeline ELF.
+PIPELINE_OPT(bool, includeDisassembly)
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
+// If set, the LLPC standalone compiler is compiling individual shader(s) without pipeline info, so LLPC needs
+// to do auto descriptor layout.
+PIPELINE_OPT(bool, autoLayoutDesc)
+#endif
+
+// If set, allows scalar block layout of types.
+PIPELINE_OPT(bool, scalarBlockLayout)
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
+// If set, allows automatic workgroup reconfigure to take place on compute shaders.
+PIPELINE_OPT(bool, reconfigWorkgroupLayout)
+#endif
+
+// If set, the IR for all compiled shaders will be included in the pipeline ELF.
+PIPELINE_OPT(bool, includeIr)
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
+// If set, out of bounds accesses to buffer or private array will be handled.
+//  for now this option is used by LLPC shader and affects only the private array,
+//  the out of bounds accesses will be skipped with this setting.
+PIPELINE_OPT(bool, robustBufferAccess)
+#endif
+
+#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
+// If set, the IR binary for all compiled shaders will be included in the pipeline ELF.
+PIPELINE_OPT(bool, includeIrBinary)
+#endif
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Per shader stage options that make up PipelineShaderOptions
+
+// Indicates a trap handler will be present when this pipeline is executed,
+// and any trap conditions encountered in this shader should call the trap
+// handler. This could include an arithmetic exception, an explicit trap
+// request from the host, or a trap after every instruction when in debug
+// mode.
+PIPELINESHADER_OPT(bool, trapPresent)
+
+// When set, this shader should cause the trap handler to be executed after
+// every instruction.  Only valid if trapPresent is set.
+PIPELINESHADER_OPT(bool, debugMode)
+
+// Enables the compiler to generate extra instructions to gather
+// various performance-related data.
+PIPELINESHADER_OPT(bool, enablePerformanceData)
+
+// Allow the DB ReZ feature to be enabled.  This will cause an early-Z test
+// to potentially kill PS waves before launch, and also issues a late-Z test
+// in case the PS kills pixels.  Only valid for pixel shaders.
+PIPELINESHADER_OPT(bool, allowReZ)
+
+// Maximum VGPR limit for this shader. The actual limit used by back-end for shader compilation is the smaller
+// of this value and whatever the target GPU supports. To effectively disable this limit, set this to UINT_MAX.
+PIPELINESHADER_OPT(uint32_t, vgprLimit)
+
+// Maximum SGPR limit for this shader. The actual limit used by back-end for shader compilation is the smaller
+// of this value and whatever the target GPU supports. To effectively disable this limit, set this to UINT_MAX.
+PIPELINESHADER_OPT(uint32_t, sgprLimit)
+
+// Overrides the number of CS thread-groups which the GPU will launch per compute-unit. This throttles the
+// shader, which can sometimes enable more graphics shader work to complete in parallel. A value of zero
+// disables limiting the number of thread-groups to launch. This field is ignored for graphics shaders.
+PIPELINESHADER_OPT(uint32_t, maxThreadGroupsPerComputeUnit)
+
+#if LLPC_BUILD_GFX10
+// Control the number of threads per wavefront (GFX10+)
+PIPELINESHADER_OPT(uint32_t, waveSize)
+
+// Whether to choose WGP mode or CU mode (GFX10+)
+PIPELINESHADER_OPT(bool, wgpMode)
+
+// Size of region to force the end of a wavefront (GFX10+).
+//  Only valid for fragment shaders.
+PIPELINESHADER_OPT(WaveBreakSize, waveBreakSize)
+#endif
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
+// Force loop unroll count. "0" means using default value; "1" means disabling loop unroll.
+PIPELINESHADER_OPT(uint32_t, forceLoopUnrollCount)
+#endif
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
+// Enable LLPC load scalarizer optimization.
+PIPELINESHADER_OPT(bool, enableLoadScalarizer)
+#endif
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
+// If set, lets the pipeline vary the wave sizes.
+PIPELINESHADER_OPT(bool, allowVaryWaveSize)
+#elif VKI_EXT_SUBGROUP_SIZE_CONTROL
+// If set, lets the pipeline vary the wave sizes.
+PIPELINESHADER_OPT(bool, allowVaryWaveSize)
+#endif
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
+// Use the LLVM backend's SI scheduler instead of the default scheduler.
+PIPELINESHADER_OPT(bool, useSiScheduler)
+#endif
+
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
+// Disable the the LLVM backend's LICM pass.
+PIPELINESHADER_OPT(bool, disableLicm)
+#endif
+
+#if LLPC_BUILD_GFX10
+// ---------------------------------------------------------------------------------------------------------------------
+// NGG tuning options that make up NggState
+
+// Enable NGG mode, use an implicit primitive shader
+NGGSTATE_OPT(bool, enableNgg)
+
+// Enable NGG use on geometry shader
+NGGSTATE_OPT(bool, enableGsUse)
+
+// Force NGG to run in non pass-through mode
+NGGSTATE_OPT(bool, forceNonPassthrough)
+
+// Always use primitive shader table to fetch culling-control registers
+NGGSTATE_OPT(bool, alwaysUsePrimShaderTable)
+
+// Compaction mode after culling operations
+NGGSTATE_OPT(NggCompactMode, compactMode)
+
+// Enable the hardware to launch subgroups of work at a faster rate
+NGGSTATE_OPT(bool, enableFastLaunch)
+
+// Enable optimization to cull duplicate vertices
+NGGSTATE_OPT(bool, enableVertexReuse)
+
+// Enable culling of primitives that don't meet facing criteria
+NGGSTATE_OPT(bool, enableBackfaceCulling)
+
+// Enable discarding of primitives outside of view frustum
+NGGSTATE_OPT(bool, enableFrustumCulling)
+
+// Enable simpler frustum culler that is less accurate
+NGGSTATE_OPT(bool, enableBoxFilterCulling)
+
+// Enable frustum culling based on a sphere
+NGGSTATE_OPT(bool, enableSphereCulling)
+
+// Enable trivial sub-sample primitive culling
+NGGSTATE_OPT(bool, enableSmallPrimFilter)
+
+// Enable culling when "cull distance" exports are present
+NGGSTATE_OPT(bool, enableCullDistanceCulling)
+
+// Value from 1 to UINT32_MAX that will cause the backface culling
+//  algorithm to ignore area calculations that are less than
+//  (10 ^ -(backfaceExponent)) / abs(w0 * w1 * w2)
+//  Only valid if the NGG backface culler is enabled.
+//  A value of 0 will disable the threshold.
+NGGSTATE_OPT(uint32_t, backfaceExponent)
+
+// NGG sub-group sizing type
+NGGSTATE_OPT(NggSubgroupSizingType, subgroupSizing)
+
+// Preferred number of GS primitives to pack into a primitive shader sub-group
+NGGSTATE_OPT(uint32_t, primsPerSubgroup)
+
+// Preferred number of vertices consumed by a primitive shader sub-group
+NGGSTATE_OPT(uint32_t, vertsPerSubgroup)
+
+#endif

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -115,6 +115,13 @@ enum MemberType : uint32_t
 #if VKI_BUILD_GFX10
     MemberTypeNggState,                      // VFX member type: SectionNggState
 #endif
+
+    // Aliases for use when including llpcOptions.h:
+    MemberType_bool = MemberTypeBool,
+    MemberType_uint32_t = MemberTypeInt,
+    MemberType_WaveBreakSize = MemberTypeEnum,
+    MemberType_NggCompactMode = MemberTypeEnum,
+    MemberType_NggSubgroupSizingType = MemberTypeEnum,
 };
 
 // =====================================================================================================================
@@ -1118,32 +1125,23 @@ public:
     static void InitialAddrTable()
     {
         StrToMemberAddr* pTableItem = m_addrTable;
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeDisassembly, MemberTypeBool, false);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, autoLayoutDesc, MemberTypeBool, false);
-#endif
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
-#endif
-#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIrBinary, MemberTypeBool, false);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
-#endif
+
+#define PIPELINE_OPT(type, field) \
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, field, MemberType_ ## type, false);
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
+
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);
     }
 
     void GetSubState(SubState& state) { state = m_state; };
 
 private:
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-    static const uint32_t  MemberCount = 7;
-#else
-    static const uint32_t  MemberCount = 6;
-#endif
+    static const uint32_t  MemberCount = 8;
     static StrToMemberAddr m_addrTable[MemberCount];
 
     SubState               m_state;
@@ -1165,34 +1163,15 @@ public:
     static void InitialAddrTable()
     {
         StrToMemberAddr* pTableItem = m_addrTable;
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, trapPresent, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, debugMode, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enablePerformanceData, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowReZ, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, vgprLimit, MemberTypeInt, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, sgprLimit, MemberTypeInt, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, maxThreadGroupsPerComputeUnit, MemberTypeInt, false);
-#if VKI_BUILD_GFX10
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveSize, MemberTypeInt, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, wgpMode, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveBreakSize, MemberTypeEnum, false);
-#endif
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
-#endif
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field) \
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, field, MemberType_ ## type, false);
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);
     }
@@ -1200,35 +1179,7 @@ public:
     void GetSubState(SubState& state) { state = m_state; };
 
 private:
-#if VKI_BUILD_GFX10
-    #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 34
-        static const uint32_t  MemberCount = 15;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
-         static const uint32_t  MemberCount = 14;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
-         static const uint32_t  MemberCount = 13;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-        static const uint32_t  MemberCount = 12;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-        static const uint32_t  MemberCount = 11;
-    #else
-        static const uint32_t  MemberCount = 10;
-    #endif
-#else
-    #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 34
-        static const uint32_t  MemberCount = 12;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
-        static const uint32_t  MemberCount = 11;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
-        static const uint32_t  MemberCount = 10;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-        static const uint32_t  MemberCount = 9;
-    #elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-        static const uint32_t  MemberCount = 8;
-    #else
-        static const uint32_t  MemberCount = 7;
-    #endif
-#endif
+    static const uint32_t  MemberCount = 17;
     static StrToMemberAddr m_addrTable[MemberCount];
 
     SubState               m_state;
@@ -1251,23 +1202,15 @@ public:
     static void InitialAddrTable()
     {
         StrToMemberAddr* pTableItem = m_addrTable;
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableNgg, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableGsUse, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceNonPassthrough, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, alwaysUsePrimShaderTable, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFastLaunch, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableVertexReuse, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBackfaceCulling, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFrustumCulling, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBoxFilterCulling, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSphereCulling, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSmallPrimFilter, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableCullDistanceCulling, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, backfaceExponent, MemberTypeInt, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, subgroupSizing, MemberTypeEnum, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, primsPerSubgroup, MemberTypeInt, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, vertsPerSubgroup, MemberTypeInt, false);
+
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field) \
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, field, MemberType_ ## type, false);
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);
     }

--- a/util/llpcPipelineDumper.cpp
+++ b/util/llpcPipelineDumper.cpp
@@ -617,31 +617,13 @@ void PipelineDumper::DumpPipelineShaderInfo(
     }
 
     // Output pipeline shader options
-    dumpFile << "options.trapPresent = " << pShaderInfo->options.trapPresent << "\n";
-    dumpFile << "options.debugMode = " << pShaderInfo->options.debugMode << "\n";
-    dumpFile << "options.enablePerformanceData = " << pShaderInfo->options.enablePerformanceData << "\n";
-    dumpFile << "options.allowReZ = " << pShaderInfo->options.allowReZ << "\n";
-    dumpFile << "options.vgprLimit = " << pShaderInfo->options.vgprLimit << "\n";
-    dumpFile << "options.sgprLimit = " << pShaderInfo->options.sgprLimit << "\n";
-    dumpFile << "options.maxThreadGroupsPerComputeUnit = " << pShaderInfo->options.maxThreadGroupsPerComputeUnit << "\n";
-#if LLPC_BUILD_GFX10
-    dumpFile << "options.waveSize = " << pShaderInfo->options.waveSize << "\n";
-    dumpFile << "options.wgpMode = " << pShaderInfo->options.wgpMode << "\n";
-    dumpFile << "options.waveBreakSize = " << pShaderInfo->options.waveBreakSize << "\n";
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-    dumpFile << "options.forceLoopUnrollCount = " << pShaderInfo->options.forceLoopUnrollCount << "\n";
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-    dumpFile << "options.useSiScheduler = " << pShaderInfo->options.useSiScheduler << "\n";
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
-    dumpFile << "options.enableLoadScalarizer = " << pShaderInfo->options.enableLoadScalarizer << "\n";
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
-    dumpFile << "options.disableLicm = " << pShaderInfo->options.disableLicm << "\n";
-#endif
-
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field) dumpFile << "options." #field " = " << pShaderInfo->options.field << "\n";
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
     dumpFile << "\n";
 }
 
@@ -739,22 +721,13 @@ void PipelineDumper::DumpPipelineOptions(
     const PipelineOptions*   pOptions,  // [in] Pipeline options
     std::ostream&            dumpFile)  // [out] dump file
 {
-    dumpFile << "options.includeDisassembly = " << pOptions->includeDisassembly << "\n";
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
-    dumpFile << "options.autoLayoutDesc = " << pOptions->autoLayoutDesc << "\n";
-#endif
-    dumpFile << "options.scalarBlockLayout = " << pOptions->scalarBlockLayout << "\n";
-    dumpFile << "options.includeIr = " << pOptions->includeIr << "\n";
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
-    dumpFile << "options.robustBufferAccess = " << pOptions->robustBufferAccess << "\n";
-#endif
-#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
-    dumpFile << "options.includeIrBinary = " << pOptions->includeIrBinary << "\n";
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-    dumpFile << "options.reconfigWorkgroupLayout = " << pOptions->reconfigWorkgroupLayout << "\n";
-#endif
-
+#define PIPELINE_OPT(type, field) dumpFile << "options." #field " = " << pOptions->field << "\n";
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 }
 
 // =====================================================================================================================
@@ -813,25 +786,14 @@ void PipelineDumper::DumpGraphicsStateInfo(
         }
     }
 
-#if LLPC_BUILD_GFX10
-    dumpFile << "nggState.enableNgg = " << pPipelineInfo->nggState.enableNgg << "\n";
-    dumpFile << "nggState.enableGsUse = " << pPipelineInfo->nggState.enableGsUse << "\n";
-    dumpFile << "nggState.forceNonPassthrough = " << pPipelineInfo->nggState.forceNonPassthrough << "\n";
-    dumpFile << "nggState.alwaysUsePrimShaderTable = " << pPipelineInfo->nggState.alwaysUsePrimShaderTable << "\n";
-    dumpFile << "nggState.compactMode = " << pPipelineInfo->nggState.compactMode << "\n";
-    dumpFile << "nggState.enableFastLaunch = " << pPipelineInfo->nggState.enableFastLaunch << "\n";
-    dumpFile << "nggState.enableVertexReuse = " << pPipelineInfo->nggState.enableVertexReuse << "\n";
-    dumpFile << "nggState.enableBackfaceCulling = " << pPipelineInfo->nggState.enableBackfaceCulling << "\n";
-    dumpFile << "nggState.enableFrustumCulling = " << pPipelineInfo->nggState.enableFrustumCulling << "\n";
-    dumpFile << "nggState.enableBoxFilterCulling = " << pPipelineInfo->nggState.enableBoxFilterCulling << "\n";
-    dumpFile << "nggState.enableSphereCulling = " << pPipelineInfo->nggState.enableSphereCulling << "\n";
-    dumpFile << "nggState.enableSmallPrimFilter = " << pPipelineInfo->nggState.enableSmallPrimFilter << "\n";
-    dumpFile << "nggState.enableCullDistanceCulling = " << pPipelineInfo->nggState.enableCullDistanceCulling << "\n";
-    dumpFile << "nggState.backfaceExponent = " << pPipelineInfo->nggState.backfaceExponent << "\n";
-    dumpFile << "nggState.subgroupSizing = " << pPipelineInfo->nggState.subgroupSizing << "\n";
-    dumpFile << "nggState.primsPerSubgroup = " << pPipelineInfo->nggState.primsPerSubgroup << "\n";
-    dumpFile << "nggState.vertsPerSubgroup = " << pPipelineInfo->nggState.vertsPerSubgroup << "\n";
-#endif
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field) dumpFile << "nggState." #field " = " << pPipelineInfo->nggState.field << "\n";
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
+
     DumpPipelineOptions(&pPipelineInfo->options, dumpFile);
     dumpFile << "\n\n";
 
@@ -939,18 +901,14 @@ MetroHash::Hash PipelineDumper::GenerateHashForComputePipeline(
 
     UpdateHashForPipelineShaderInfo(ShaderStageCompute, &pPipeline->cs, isCacheHash, &hasher);
     hasher.Update(pPipeline->deviceIndex);
-    hasher.Update(pPipeline->options.includeDisassembly);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
-    hasher.Update(pPipeline->options.autoLayoutDesc);
-#endif
-    hasher.Update(pPipeline->options.scalarBlockLayout);
-    hasher.Update(pPipeline->options.includeIr);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
-    hasher.Update(pPipeline->options.robustBufferAccess);
-#endif
-#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
-    hasher.Update(pPipeline->options.includeIrBinary);
-#endif
+
+#define PIPELINE_OPT(type, field) hasher.Update(pPipeline->options.field);
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 
     MetroHash::Hash hash = {};
     hasher.Finalize(hash.bytes);
@@ -1038,41 +996,21 @@ void PipelineDumper::UpdateHashForNonFragmentState(
 
     if (isCacheHash)
     {
-#if LLPC_BUILD_GFX10
-        pHasher->Update(pNggState->enableNgg);
-        pHasher->Update(pNggState->enableGsUse);
-        pHasher->Update(pNggState->forceNonPassthrough);
-        pHasher->Update(pNggState->alwaysUsePrimShaderTable);
-        pHasher->Update(pNggState->compactMode);
-        pHasher->Update(pNggState->enableFastLaunch);
-        pHasher->Update(pNggState->enableVertexReuse);
-        pHasher->Update(pNggState->enableBackfaceCulling);
-        pHasher->Update(pNggState->enableFrustumCulling);
-        pHasher->Update(pNggState->enableBoxFilterCulling);
-        pHasher->Update(pNggState->enableSphereCulling);
-        pHasher->Update(pNggState->enableSmallPrimFilter);
-        pHasher->Update(pNggState->enableCullDistanceCulling);
-        pHasher->Update(pNggState->backfaceExponent);
-        pHasher->Update(pNggState->subgroupSizing);
-        pHasher->Update(pNggState->primsPerSubgroup);
-        pHasher->Update(pNggState->vertsPerSubgroup);
-#endif
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field) pHasher->Update(pNggState->field);
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
 
-        pHasher->Update(pPipeline->options.includeDisassembly);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 30
-        pHasher->Update(pPipeline->options.autoLayoutDesc);
-#endif
-        pHasher->Update(pPipeline->options.scalarBlockLayout);
-        pHasher->Update(pPipeline->options.includeIr);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 23
-        pHasher->Update(pPipeline->options.robustBufferAccess);
-#endif
-#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 25) && (LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 27)
-        pHasher->Update(pPipeline->options.includeIrBinary);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-        pHasher->Update(pPipeline->options.reconfigWorkgroupLayout);
-#endif
+#define PIPELINE_OPT(type, field) pHasher->Update(pPipeline->options.field);
+#define PIPELINESHADER_OPT(type, field)
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
     }
 }
 
@@ -1183,30 +1121,13 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
         if (isCacheHash)
         {
             auto& options = pShaderInfo->options;
-            pHasher->Update(options.trapPresent);
-            pHasher->Update(options.debugMode);
-            pHasher->Update(options.enablePerformanceData);
-            pHasher->Update(options.allowReZ);
-            pHasher->Update(options.sgprLimit);
-            pHasher->Update(options.vgprLimit);
-            pHasher->Update(options.maxThreadGroupsPerComputeUnit);
-#if LLPC_BUILD_GFX10
-            pHasher->Update(options.waveSize);
-            pHasher->Update(options.wgpMode);
-            pHasher->Update(options.waveBreakSize);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 24
-            pHasher->Update(options.forceLoopUnrollCount);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 28
-            pHasher->Update(options.useSiScheduler);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
-            pHasher->Update(options.enableLoadScalarizer);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
-            pHasher->Update(options.disableLicm);
-#endif
+#define PIPELINE_OPT(type, field)
+#define PIPELINESHADER_OPT(type, field) pHasher->Update(options.field);
+#define NGGSTATE_OPT(type, field)
+#include "llpcOptions.h"
+#undef PIPELINE_OPT
+#undef PIPELINESHADER_OPT
+#undef NGGSTATE_OPT
         }
     }
 }


### PR DESCRIPTION
This commit adds llpcOptions.h, which is the single place to add a new
pipeline or shader or ngg option. All the other places (defining in
llpc.h, hashing in multiple places, dumping in llpcPipelineDumper,
reading the pipe file in vfx) now use the definitions in llpcOptions.h.

Change-Id: I4272f5e2cf12b503cb5c60cfc5668744e4053065