### PR TITLE
Move LLPC timer profile related code to utility class TimerProfiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ if(ICD_BUILD_LLPC)
         util/llpcPipelineDumper.cpp
         util/llpcPipelineShaders.cpp
         util/llpcStartStopTimer.cpp
+        util/llpcTimerProfiler.cpp
         util/llpcUtil.cpp
     )
 else()

--- a/lower/llpcSpirvLower.h
+++ b/lower/llpcSpirvLower.h
@@ -61,6 +61,8 @@ void initializeSpirvLowerTranslatorPass(PassRegistry&);
 namespace Llpc
 {
 
+class TimerProfiler;
+
 // Initialize passes for SPIR-V lowering
 inline static void InitializeLowerPasses(
     llvm::PassRegistry& passRegistry)   // Pass registry
@@ -107,7 +109,7 @@ public:
     static void AddPasses(Context*                    pContext,
                           ShaderStage                 stage,
                           llvm::legacy::PassManager&  passMgr,
-                          llvm::Timer*                pLowerTimer,
+                          TimerProfiler*              pTimerProfiler,
                           uint32_t                    forceLoopUnrollCount,
                           bool*                       pNeedDynamicLoopUnroll);
 

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -190,6 +190,7 @@ endif
         llpcPipelineDumper.cpp              \
         llpcPipelineShaders.cpp             \
         llpcStartStopTimer.cpp              \
+        llpcTimerProfiler.cpp               \
         llpcUtil.cpp
 
     #if LLPC_BUILD_GFX10

--- a/util/llpcTimerProfiler.cpp
+++ b/util/llpcTimerProfiler.cpp
@@ -1,0 +1,191 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+ /**
+  ***********************************************************************************************************************
+  * @file  llpcTimerProfiler.cpp
+  * @brief LLPC header file: contains the implementation of LLPC utility class TimerProfiler.
+  ***********************************************************************************************************************
+  */
+#include "llvm/ADT/Twine.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "llpc.h"
+#include "llpcInternal.h"
+#include "llpcPassManager.h"
+#include "llpcTimerProfiler.h"
+
+using namespace llvm;
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+TimerProfiler::TimerProfiler(
+    uint64_t      hash64,              // Hash code
+    const char*   pDescriptionPrefix,  // [in] Profiler description prefix string
+    uint32_t      enableMask)           // Mask of enabled phase timers
+    :
+    m_total("", "", GetDummyTimeRecords()),
+    m_phases("", "", GetDummyTimeRecords())
+{
+    if (TimePassesIsEnabled)
+    {
+        std::string hashString;
+        raw_string_ostream ostream(hashString);
+        ostream << format("0x%016" PRIX64, hash64);
+        ostream.flush();
+
+        // Init whole timer
+        m_total.setName("llpc", (Twine(pDescriptionPrefix) + Twine(" ") + hashString).str());
+        m_wholeTimer.init("llpc-total", (Twine(pDescriptionPrefix) + Twine(" Total ") + hashString).str(), m_total);
+
+        // Init phase timers
+        m_phases.setName("llpc", (Twine(pDescriptionPrefix) + Twine(" Phases ") + hashString).str());
+        if (enableMask & (1 << TimerTranslate))
+        {
+            m_phaseTimers[TimerTranslate].init("llpc-translate",
+                                               (Twine(pDescriptionPrefix) +Twine(" Translate ") + hashString).str(),
+                                               m_phases);
+        }
+
+        if (enableMask & (1 << TimerLower))
+        {
+            m_phaseTimers[TimerLower].init("llpc-lower",
+                                           (Twine(pDescriptionPrefix) + Twine(" Lower ") + hashString).str(),
+                                           m_phases);
+        }
+        if (enableMask & (1 << TimerLoadBc))
+        {
+            m_phaseTimers[TimerLoadBc].init("llpc-load",
+                                            (Twine(pDescriptionPrefix) + Twine(" Load ") + hashString).str(),
+                                            m_phases);
+        }
+        if (enableMask & (1 << TimerPatch))
+        {
+            m_phaseTimers[TimerPatch].init("llpc-patch",
+                                           (Twine(pDescriptionPrefix) + Twine(" Patch ") + hashString).str(),
+                                           m_phases);
+        }
+        if (enableMask & (1 << TimerOpt))
+        {
+            m_phaseTimers[TimerOpt].init("llpc-opt",
+                                         (Twine(pDescriptionPrefix) + Twine(" Optimization ") + hashString).str(),
+                                         m_phases);
+        }
+
+        if (enableMask & (1 << TimerCodeGen))
+        {
+            m_phaseTimers[TimerCodeGen].init("llpc-codegen",
+                                             (Twine(pDescriptionPrefix) + Twine(" CodeGen ") + hashString).str(),
+                                             m_phases);
+        }
+
+        // Start whole timer
+        m_wholeTimer.startTimer();
+    }
+}
+
+// =====================================================================================================================
+TimerProfiler::~TimerProfiler()
+{
+    if (TimePassesIsEnabled)
+    {
+        // Stop whole timer
+        m_wholeTimer.stopTimer();
+    }
+}
+
+// =====================================================================================================================
+// Get a specific timer. Returns nullptr if !TimePassesIsEnabled.
+Timer* TimerProfiler::GetTimer(
+    TimerKind    name)           // Kind of phase timer
+{
+    return TimePassesIsEnabled ? &m_phaseTimers[name] : nullptr;
+}
+
+// =====================================================================================================================
+// Adds pass to start or stop timer in PassManager
+void TimerProfiler::AddTimerStartStopPass(
+    legacy::PassManager*  pPassMgr,       // Pass Manager
+    TimerKind             name,           // Kind of phase timer
+    bool                  start)          // Start or  stop timer
+{
+    if (TimePassesIsEnabled)
+    {
+        pPassMgr->add(CreateStartStopTimer(&m_phaseTimers[name], start));
+    }
+}
+
+// =====================================================================================================================
+// Starts or stop specified timer.
+void TimerProfiler::StartStopTimer(
+    TimerKind name,         // Kind of phase timer
+    bool      start)        // Start or  stop timer
+{
+    if (TimePassesIsEnabled)
+    {
+        if (start)
+        {
+            m_phaseTimers[name].startTimer();
+        }
+        else
+        {
+            m_phaseTimers[name].stopTimer();
+        }
+    }
+}
+
+// =====================================================================================================================
+// Gets dummy TimeRecords.
+const StringMap<TimeRecord>& TimerProfiler::GetDummyTimeRecords()
+{
+    static StringMap<TimeRecord> dummyTimeRecords;
+    if (TimePassesIsEnabled && dummyTimeRecords.empty())
+    {
+        // NOTE: It is a workaround to get fixed layout in timer reports. Please remove it if we find a better solution.
+        // LLVM timer skips the field if it is zero in all timers, it causes the layout of the report isn't stable when
+        // compile multiple pipelines. so we add a dummy record to force all fields is shown.
+        // But LLVM TimeRecord can't be initialized explicitly. We have to use HackedTimeRecord to force update the vaule
+        // in TimeRecord.
+        TimeRecord timeRecord;
+        struct HackedTimeRecord
+        {
+            double t1;
+            double t2;
+            double t3;
+            ssize_t m1;
+        } hackedTimeRecord = { 1e-100, 1e-100, 1e-100, 0 };
+        static_assert(sizeof(timeRecord) == sizeof(hackedTimeRecord), "Unexpected Size!");
+        memcpy(&timeRecord, &hackedTimeRecord, sizeof(TimeRecord));
+        dummyTimeRecords["DUMMY"] = timeRecord;
+    }
+
+    return dummyTimeRecords;
+}
+
+} // Llpc
+

--- a/util/llpcTimerProfiler.h
+++ b/util/llpcTimerProfiler.h
@@ -1,0 +1,103 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+ /**
+  ***********************************************************************************************************************
+  * @file  llpcTimeProfiler.h
+  * @brief LLPC header file: contains the definition of LLPC utility class TimerProfiler.
+  ***********************************************************************************************************************
+  */
+#pragma once
+
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Timer.h"
+
+#include "llpc.h"
+#include "llpcDebug.h"
+
+namespace llvm
+{
+namespace legacy
+{
+
+class PassManager;
+
+}
+}
+
+namespace Llpc
+{
+
+using namespace llvm;
+
+class PassManager;
+
+// =====================================================================================================================
+// Enumerates the kinds of timer used to do profiling for LLPC compilation phases.
+enum TimerKind : uint32_t
+{
+    TimerTranslate,  // Timer for translator
+    TimerLower,      // Timer for SPIR-V lowering
+    TimerLoadBc,     // Timer for loading LLVM bitcode
+    TimerPatch,      // Timer for LLVM patching
+    TimerOpt,        // Timer for LLVM optimization
+    TimerCodeGen,    // Timer for backend code generation
+
+    TimerCount
+};
+
+// =====================================================================================================================
+// Represents a utility class for time profile, it wraps LLVM Timer and TimerGroup in internal.
+class TimerProfiler
+{
+public:
+    TimerProfiler(uint64_t hash64, const char* pDescriptionPrefix, uint32_t enableMask);
+
+    ~TimerProfiler();
+
+    Timer* GetTimer(TimerKind name);
+
+    void AddTimerStartStopPass(legacy::PassManager* pPassMgr, TimerKind name, bool start);
+
+    void StartStopTimer(TimerKind name, bool start);
+
+    static const StringMap<TimeRecord>& GetDummyTimeRecords();
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    static const uint32_t PipelineTimerEnableMask = ((1 << TimerCount) - 1);
+    static const uint32_t ShaderModuleTimerEnableMask = ((1 << TimerTranslate) | (1 << TimerLower));
+
+private:
+    LLPC_DISALLOW_COPY_AND_ASSIGN(TimerProfiler);
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    TimerGroup m_total;                // TimeGroup for total time
+    TimerGroup m_phases;               // TimeGroup for each phase
+    Timer m_wholeTimer;                // Whole timer
+    Timer m_phaseTimers[TimerCount];   // Phase timer
+};
+
+} // Llpc


### PR DESCRIPTION
TimerProfiler includes two timer groups
- Total Group: total time for all operations, it is equal with the lift time of TimerProfiler
- Phase Group: time for each phase, it can be enabled by enableMask in construct function.

Beside these, all timers in TimerProfiler are controlled by llvm flag TimePassesIsEnabled

Change-Id: I646445ef414e2c10043353abd6be860659088cdb