### PR TITLE
Fixed typo in #238 timer change

### DIFF
--- a/util/llpcTimerProfiler.h
+++ b/util/llpcTimerProfiler.h
@@ -76,7 +76,7 @@ public:
     // -----------------------------------------------------------------------------------------------------------------
 
     static const uint32_t PipelineTimerEnableMask = ((1 << TimerCount) - 1);
-    static const uint32_t ShaderModuleTimerEnableMask = ((1 << TimerTranslate) || (1 << TimerLower));
+    static const uint32_t ShaderModuleTimerEnableMask = ((1 << TimerTranslate) | (1 << TimerLower));
 
 private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(TimerProfiler);


### PR DESCRIPTION
Apart from being wrong, this also gave me a compile error on clang.

Change-Id: Id04822201028938940fb137fcc8c309809c25b72