### PR TITLE
Use waterfall readlane for pre gfx8 asics for subgroup shuffle

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -1405,9 +1405,9 @@ protected:
     Type* GetTransposedMatrixTy(
         Type* const pMatrixType) const; // [in] The matrix type to tranpose
 
-    typedef Value* (*PFN_MapToInt32Func)(Builder&                     builder,
-                                               ArrayRef<Value*> mappedArgs,
-                                               ArrayRef<Value*> passthroughArgs);
+    typedef std::function<Value* (Builder& builder,
+                                  ArrayRef<Value*> mappedArgs,
+                                  ArrayRef<Value*> passthroughArgs)> PFN_MapToInt32Func;
 
     // Create a call that'll map the massage arguments to an i32 type (for functions that only take i32).
     Value* CreateMapToInt32(

--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -351,14 +351,15 @@ Value* BuilderImplSubgroup::CreateSubgroupShuffle(
     }
     else
     {
-        auto pfnMapFunc = [](Builder& builder, ArrayRef<Value*> mappedArgs, ArrayRef<Value*> passthroughArgs) -> Value*
+        auto pfnMapFunc = [this](Builder& builder, ArrayRef<Value*> mappedArgs, ArrayRef<Value*> passthroughArgs) -> Value*
         {
-            return builder.CreateIntrinsic(Intrinsic::amdgcn_readlane,
-                                           {},
-                                           {
-                                                mappedArgs[0],
-                                                passthroughArgs[0]
-                                           });
+            Value* const pReadlane = builder.CreateIntrinsic(Intrinsic::amdgcn_readlane,
+                                                             {},
+                                                             {
+                                                                 mappedArgs[0],
+                                                                 passthroughArgs[0]
+                                                             });
+            return CreateWaterfallLoop(cast<Instruction>(pReadlane), 1);
         };
 
         return CreateMapToInt32(pfnMapFunc, pValue, pIndex);


### PR DESCRIPTION
For subgroup - if permute is missing (pre gfx8) then use readlane/waterfall
instead
This previously relied on a backend exception for readlane that would
automatically waterfall if the readlane operands were not uniform. This
functionality is being removed and thus llpc must emit the correct waterfall
code itself.