### PR TITLE
Changes for LLVM removal of LoadInst::setAlignment(unsigned) etc

### DIFF
--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -404,7 +404,7 @@ GlobalVariable* Patch::GetLdsVariable(
                                    nullptr,
                                    GlobalValue::NotThreadLocal,
                                    ADDR_SPACE_LOCAL);
-    pLds->setAlignment(sizeof(uint32_t));
+    pLds->setAlignment(MaybeAlign(sizeof(uint32_t)));
     return pLds;
 }
 

--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -656,7 +656,7 @@ void PatchBufferOp::visitLoadInst(
 
         LoadInst* const pNewLoad = m_pBuilder->CreateLoad(pLoadPointer);
         pNewLoad->setVolatile(loadInst.isVolatile());
-        pNewLoad->setAlignment(loadInst.getAlignment());
+        pNewLoad->setAlignment(MaybeAlign(loadInst.getAlignment()));
         pNewLoad->setOrdering(loadInst.getOrdering());
         pNewLoad->setSyncScopeID(loadInst.getSyncScopeID());
         CopyMetadata(pNewLoad, &loadInst);
@@ -1565,7 +1565,7 @@ Value* PatchBufferOp::ReplaceLoad(
 
         LoadInst* const pNewLoad = m_pBuilder->CreateLoad(pLoadPointer);
         pNewLoad->setVolatile(pLoadInst->isVolatile());
-        pNewLoad->setAlignment(pLoadInst->getAlignment());
+        pNewLoad->setAlignment(MaybeAlign(pLoadInst->getAlignment()));
         pNewLoad->setOrdering(pLoadInst->getOrdering());
         pNewLoad->setSyncScopeID(pLoadInst->getSyncScopeID());
         CopyMetadata(pNewLoad, pLoadInst);
@@ -1837,7 +1837,7 @@ void PatchBufferOp::ReplaceStore(
 
         StoreInst* const pNewStore = m_pBuilder->CreateStore(pStoreInst->getValueOperand(), pStorePointer);
         pNewStore->setVolatile(pStoreInst->isVolatile());
-        pNewStore->setAlignment(pStoreInst->getAlignment());
+        pNewStore->setAlignment(MaybeAlign(pStoreInst->getAlignment()));
         pNewStore->setOrdering(pStoreInst->getOrdering());
         pNewStore->setSyncScopeID(pStoreInst->getSyncScopeID());
         CopyMetadata(pNewStore, pStoreInst);

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -545,7 +545,7 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             pDesc = new LoadInst(pCastedDescPtr, "", pInsertPoint);
             if (LoadInst *LI = dyn_cast<LoadInst>(pDesc))
               LI->setMetadata(m_pContext->MetaIdInvariantLoad(), m_pContext->GetEmptyMetadataNode());
-            cast<LoadInst>(pDesc)->setAlignment(16);
+            cast<LoadInst>(pDesc)->setAlignment(MaybeAlign(16));
 
             if (foundNodeType == ResourceMappingNodeType::DescriptorBufferCompact)
             {

--- a/patch/llpcSystemValues.cpp
+++ b/patch/llpcSystemValues.cpp
@@ -610,7 +610,7 @@ Value* ShaderSystemValues::GetStreamOutBufDesc(
 
         auto pStreamOutBufDesc = new LoadInst(pStreamOutBufDescPtr, "", pInsertPos);
         pStreamOutBufDesc->setMetadata(m_pContext->MetaIdInvariantLoad(), m_pContext->GetEmptyMetadataNode());
-        pStreamOutBufDesc->setAlignment(16);
+        pStreamOutBufDesc->setAlignment(MaybeAlign(16));
 
         m_streamOutBufDescs[xfbBuffer] = pStreamOutBufDesc;
     }

--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -1669,7 +1669,7 @@ Value* VertexFetch::LoadVertexBufferDescriptor(
 
     auto pVbDesc = new LoadInst(pVbDescPtr, "", pInsertPos);
     pVbDesc->setMetadata(m_pContext->MetaIdInvariantLoad(), m_pContext->GetEmptyMetadataNode());
-    pVbDesc->setAlignment(16);
+    pVbDesc->setAlignment(MaybeAlign(16));
 
     return pVbDesc;
 }

--- a/translator/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/translator/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -96,7 +96,7 @@ public:
 
     auto *Alloca =
         Builder.CreateAlloca(SrcTy->getPointerElementType(), NumElements);
-    Alloca->setAlignment(Align);
+    Alloca->setAlignment(MaybeAlign(Align));
     Builder.CreateLifetimeStart(Alloca);
     Builder.CreateMemCpy(Alloca, Align, Src, Align, Length, Volatile);
     auto *SecondCpy = Builder.CreateMemCpy(Dest, I.getDestAlignment(), Alloca,

--- a/translator/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/translator/lib/SPIRV/SPIRVToOCL20.cpp
@@ -382,7 +382,8 @@ void SPIRVToOCL20::visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) {
                                     ->getParent()
                                     ->getEntryBlock()
                                     .getFirstInsertionPt()));
-          PExpected->setAlignment(CI->getType()->getScalarSizeInBits() / 8);
+          PExpected->setAlignment(
+              MaybeAlign(CI->getType()->getScalarSizeInBits() / 8));
           new StoreInst(Args[1], PExpected, PInsertBefore);
           Args[1] = PExpected;
           std::swap(Args[3], Args[4]);


### PR DESCRIPTION
This will be needed from LLVM 373195.

Change-Id: I39424d1f913caccf4f93cd8b7b4b65427f1a416b