### PR TITLE
Make the LLPC_ASSERT macro variadic

### DIFF
--- a/util/llpcDebug.h
+++ b/util/llpcDebug.h
@@ -38,7 +38,7 @@
 #include <cassert>
 
 // Debug assertion: generic
-#define LLPC_ASSERT(_expr)      assert(_expr)
+#define LLPC_ASSERT(...)        assert(__VA_ARGS__)
 // Debug assertion: not implemented
 #define LLPC_NOT_IMPLEMENTED()  assert(0 && "Not implemented!")
 // Debug assertion: should never be called
@@ -48,7 +48,7 @@
 
 #else
 
-#define LLPC_ASSERT(_expr)            ((void)0)
+#define LLPC_ASSERT(...)              ((void)0)
 #define LLPC_NOT_IMPLEMENTED()        ((void)0)
 #define LLPC_NEVER_CALLED()           ((void)0)
 #define LLPC_NOT_TESTED()             ((void)0)


### PR DESCRIPTION
This patch introduces type punning utils. They replace a few most glaring strict aliasing violations.

In C++, memory is roughly 'dynamically strongly typed', i.e., each memory read must be of type compatible with the type of the last write (if any) -- known as the strict aliasing rules. An exception from this is the `char` type that can be used access any valid chunk of memory.

As a consequence, we have to be careful not to read memory using incompatible types. For example, we cannot perform pointer casts to load an int from a float variable.