### PR TITLE
Reinstate -enable-dynamic-loop-unroll option

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -127,6 +127,11 @@ opt<uint32_t> ShadowDescTablePtrHigh("shadow-desc-table-ptr-high",
                                      desc("High part of VA for shadow descriptor table pointer"),
                                      init(2));
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 37
+// -enable-dynamic-loop-unroll: Enable dynamic loop unroll. (Deprecated)
+opt<bool> EnableDynamicLoopUnroll("enable-dynamic-loop-unroll", desc("Enable dynamic loop unroll (deprecated)"), init(false));
+#endif
+
 // -force-loop-unroll-count: Force to set the loop unroll count.
 opt<int> ForceLoopUnrollCount("force-loop-unroll-count", cl::desc("Force loop unroll count"), init(0));
 

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -40,7 +40,7 @@
 #undef Bool
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 36
+#define LLPC_INTERFACE_MAJOR_VERSION 37
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -51,6 +51,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     37.0 | Removed the -enable-dynamic-loop-unroll option                                                        |
 //* |     36.0 | Add 128 bit hash as clientHash in PipelineShaderOptions                                               |
 //* |     35.0 | Added disableLicm to PipelineShaderOptions                                                            |
 //* |     33.0 | Add enableLoadScalarizer option into PipelineShaderOptions.                                           |


### PR DESCRIPTION
Bumped LLPC revision to 37, and reinstated the deprecated
-enable-dynamic-loop-unroll option for previous versions to
provide backwards compatibilty with older versions of xgl.

Note only the option is reinstated, and is a no-op.