### PR TITLE
Fix naming of LlvmIrSectionName

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -2963,7 +2963,7 @@ void Compiler::MergeElfBinary(
     }
 
     // Merge LLVM IR disassemble
-    const std::string LlvmIrSectionName = std::string(Util::Abi::AmdGpuCommentName) + ".llvmir";
+    const std::string LlvmIrSectionName = std::string(Util::Abi::AmdGpuCommentLlvmIrName);
     ElfSectionBuffer<Elf64::SectionHeader>* pFragmentLlvmIrSection = nullptr;
     const ElfSectionBuffer<Elf64::SectionHeader>* pNonFragmentLlvmIrSection = nullptr;
 


### PR DESCRIPTION
The current output is ".AMDGPU.comment..llvmir" (contains extra period).