### PR TITLE
Set correct NULL value for LDS

### DIFF
--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5410,8 +5410,17 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpConstantNull: {
-    auto LT = transType(BV->getType());
-    return mapValue(BV, Constant::getNullValue(LT));
+    auto BTy = BV->getType();
+    auto NullPtrTy = transType(BTy);
+    Value *NullPtr = nullptr;
+    // For local memory space (LDS) the NULL value is 0xFFFFFFFF, not 0x0.
+    if (BTy->isTypePointer() && BTy->getPointerStorageClass() == spv::StorageClassWorkgroup) {
+      auto NullPtrAsInt = getBuilder()->getInt32(0xFFFFFFFF);
+      NullPtr = getBuilder()->CreateIntToPtr(NullPtrAsInt, NullPtrTy);
+    } else {
+      NullPtr = Constant::getNullValue(NullPtrTy);
+    }
+    return mapValue(BV, NullPtr);
   }
 
   case OpConstantComposite:


### PR DESCRIPTION
Set NULL value for LDS to 0xFFFFFFFF (previously it was 0x0).