### PR TITLE
Removed reinstated extra llvm.amdgcn.wqm calls

### DIFF
--- a/builder/llpcBuilderImplMisc.cpp
+++ b/builder/llpcBuilderImplMisc.cpp
@@ -202,7 +202,6 @@ Value* BuilderImplMisc::CreateDerivative(
                                                                      getInt32(15),
                                                                      getTrue()
                                                                   });
-                               pFirstVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pFirstVal);
                                pFirstVal = CreateZExtOrTrunc(pFirstVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pFirstVal = CreateBitCast(pFirstVal, pValTy);
                                Value* pSecondVal = CreateIntrinsic(Intrinsic::amdgcn_mov_dpp,
@@ -214,10 +213,10 @@ Value* BuilderImplMisc::CreateDerivative(
                                                                       getInt32(15),
                                                                       getTrue()
                                                                    });
-                               pSecondVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pSecondVal);
                                pSecondVal = CreateZExtOrTrunc(pSecondVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pSecondVal = CreateBitCast(pSecondVal, pValTy);
-                               return CreateFSub(pFirstVal, pSecondVal);
+                               Value* pResult = CreateFSub(pFirstVal, pSecondVal);
+                               return CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pResult);
                             });
     }
     else
@@ -251,16 +250,15 @@ Value* BuilderImplMisc::CreateDerivative(
                                Value* pFirstVal = CreateIntrinsic(Intrinsic::amdgcn_ds_swizzle,
                                                                   {},
                                                                   { pValue, getInt32(perm1)});
-                               pFirstVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pFirstVal);
                                pFirstVal = CreateZExtOrTrunc(pFirstVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pFirstVal = CreateBitCast(pFirstVal, pValTy);
                                Value* pSecondVal = CreateIntrinsic(Intrinsic::amdgcn_ds_swizzle,
                                                                    {},
                                                                    { pValue, getInt32(perm2) });
-                               pSecondVal = CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pSecondVal);
                                pSecondVal = CreateZExtOrTrunc(pSecondVal, getIntNTy(pValTy->getPrimitiveSizeInBits()));
                                pSecondVal = CreateBitCast(pSecondVal, pValTy);
-                               return CreateFSub(pFirstVal, pSecondVal);
+                               Value* pResult = CreateFSub(pFirstVal, pSecondVal);
+                               return CreateUnaryIntrinsic(Intrinsic::amdgcn_wqm, pResult);
                             });
     }
     pResult->setName(instName);

--- a/test/shaderdb/ObjInput_TestIndexingInterpOfInputArray_lit.frag
+++ b/test/shaderdb/ObjInput_TestIndexingInterpOfInputArray_lit.frag
@@ -41,43 +41,43 @@ void main()
 ; SHADERTEST: = call <3 x float> @llpc.input.import.builtin.InterpPullMode.v3f32.i32(i32 268435459)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 245, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 160, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 245, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 160, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 245, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 160, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 238, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 68, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 238, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 68, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 238, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 68, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 4, i32 0, i32 0, i32 0, <2 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-2: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST: call float @llvm.amdgcn.interp.p2
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1

--- a/test/shaderdb/OpDPdx_TestFineCoarse_lit.frag
+++ b/test/shaderdb/OpDPdx_TestFineCoarse_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 85, i32 15, i32 15, i1 true)
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 0, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32(i32 %{{[0-9]+}})
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32(float %{{[0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpDPdy_TestFineCoarse_lit.frag
+++ b/test/shaderdb/OpDPdy_TestFineCoarse_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 170, i32 15, i32 15, i1 true)
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 0, i32 15, i32 15, i1 true)
-; SHADERTEST: call i32 @llvm.amdgcn.wqm.i32(i32 {{[%0-9]+}})
+; SHADERTEST: call float @llvm.amdgcn.wqm.f32(float {{[%0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Back in #219, I had to reinstate some surplus llvm.amdgcn.wqm calls in
derivative code, because it tickled the scheduler to give much worse
performance in one shader in one game. The scheduler problem is now
fixed in
https://reviews.llvm.org/D68338
so here I can remove the extra llvm.amdgcn.wqm calls.

Change-Id: I0faf80f59a6dd0b8d731a4c95ef137e93fcfd702