### PR TITLE
Fixed a couple of problems in phi node fix

### DIFF
--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5622,7 +5622,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                                 Phi->getPairs().size() / 2, Phi->getName(), BB);
 
     auto LPhi = dyn_cast<PHINode>(mapValue(BV, PhiNode));
-    BasicBlock* ParentBB = LPhi->getParent();
 
 #ifndef NDEBUG
     SmallDenseSet<BasicBlock*, 4> SeenPredecessors;
@@ -5634,7 +5633,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       LPhi->addIncoming(TranslatedVal, TranslatedBB);
 
 #ifndef NDEBUG
-      assert(SeenPredecessors.count(TranslatedBB) != 0 &&
+      assert(SeenPredecessors.count(TranslatedBB) == 0 &&
              "SPIR-V requires phi entries to be unique for duplicate predecessor blocks.");
       SeenPredecessors.insert(TranslatedBB);
 #endif


### PR DESCRIPTION
1. The assert was the wrong way up, so many shaders failed to compile on
   a debug build. (It looks like none of our testing runs the llpc lit
   tests on a debug build.)
2. There was an unused variable that gave me an error on clang.

Change-Id: I528e3043d14ea95bbcda961167ce1bf9419dd1d6