### PR TITLE
Add NGG support to GS

### DIFF
--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -1429,18 +1429,19 @@ Value* BuilderImplSubgroup::CreateThreadMask()
 {
     Value* pThreadId = CreateSubgroupMbcnt(getInt64(UINT64_MAX), "");
 
+    Value* pThreadMask = nullptr;
 #if LLPC_BUILD_GFX10
     if (GetShaderSubgroupSize() <= 32)
     {
-        pThreadId = CreateShl(getInt32(1), pThreadId);
+        pThreadMask = CreateShl(getInt32(1), pThreadId);
     }
     else
 #endif
     {
-        pThreadId = CreateShl(getInt64(1), CreateZExtOrTrunc(pThreadId, getInt64Ty()));
+        pThreadMask = CreateShl(getInt64(1), CreateZExtOrTrunc(pThreadId, getInt64Ty()));
     }
 
-    return pThreadId;
+    return pThreadMask;
 }
 
 // =====================================================================================================================

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2495,7 +2495,13 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     if (usePrimitiveId)
     {
         SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, true);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_PRIMITIVEID_EN, NGG_DISABLE_PROVOK_REUSE, true);
+
+        // NOTE: If primitive ID is used and there is no GS present, the field NGG_DISABLE_PROVOK_REUSE must be
+        // set to ensure provoking vertex reuse is disabled in the GE.
+        if (m_hasGs == false)
+        {
+            SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_PRIMITIVEID_EN, NGG_DISABLE_PROVOK_REUSE, true);
+        }
     }
 
     if (expCount == 0)

--- a/patch/gfx9/llpcNggLdsManager.h
+++ b/patch/gfx9/llpcNggLdsManager.h
@@ -72,11 +72,11 @@ enum NggLdsRegionType
 
     // LDS region for ES-GS
     LdsRegionEsGsRing,                  // ES-GS ring
-    LdsRegionGsOutPrimData,             // GS output primitive data
-    LdsRegionGsOutVertCountInWaves,     // GS output vertex count accumulated per wave (8 potential waves) and per
+    LdsRegionOutPrimData,               // GS output primitive data
+    LdsRegionOutVertCountInWaves,       // GS output vertex count accumulated per wave (8 potential waves) and per
                                         //   sub-group for each stream (4 GS streams)
-    LdsRegionGsVsRingItemOffset,        // GS-VS ring item offset of exported vertex data (overlapped with the region of
-                                        //   exported primitive data
+    LdsRegionOutVertOffset,             // GS output vertex (exported vertex data) offset in GS-VS ring
+                                        //   (overlapped with the region of exported primitive data, LDS reused)
     LdsRegionGsVsRing,                  // GS-VS ring
 
     LdsRegionGsBeginRange = LdsRegionEsGsRing,
@@ -118,7 +118,7 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    static uint32_t       LdsRegionSizes[LdsRegionCount];  // LDS sizes for all LDS region types (in BYTEs)
+    static const uint32_t LdsRegionSizes[LdsRegionCount];  // LDS sizes for all LDS region types (in BYTEs)
     static const char*    LdsRegionNames[LdsRegionCount];  // Name strings for all LDS region types
 
     Context*        m_pContext;     // LLPC context

--- a/patch/gfx9/llpcShaderMerger.cpp
+++ b/patch/gfx9/llpcShaderMerger.cpp
@@ -74,11 +74,12 @@ ShaderMerger::ShaderMerger(
 // =====================================================================================================================
 // Builds LLVM function for hardware primitive shader (NGG).
 Function* ShaderMerger::BuildPrimShader(
-    Function*  pEsEntryPoint,     // [in] Entry-point of hardware export shader (ES)
-    Function*  pGsEntryPoint)     // [in] Entry-point of hardware geometry shader (GS) (could be null)
+    Function*  pEsEntryPoint,           // [in] Entry-point of hardware export shader (ES) (could be null)
+    Function*  pGsEntryPoint,           // [in] Entry-point of hardware geometry shader (GS) (could be null)
+    Function*  pCopyShaderEntryPoint)   // [in] Entry-point of hardware vertex shader (VS, copy shader) (could be null)
 {
     NggPrimShader primShader(m_pContext);
-    return primShader.Generate(pEsEntryPoint, pGsEntryPoint);
+    return primShader.Generate(pEsEntryPoint, pGsEntryPoint, pCopyShaderEntryPoint);
 }
 #endif
 

--- a/patch/gfx9/llpcShaderMerger.h
+++ b/patch/gfx9/llpcShaderMerger.h
@@ -93,7 +93,9 @@ public:
     llvm::Function* GenerateLsHsEntryPoint(llvm::Function* pLsEntryPoint, llvm::Function* pHsEntryPoint);
     llvm::Function* GenerateEsGsEntryPoint(llvm::Function* pEsEntryPoint, llvm::Function* pGsEntryPoint);
 #if LLPC_BUILD_GFX10
-    llvm::Function* BuildPrimShader(llvm::Function* pEsEntryPoint, llvm::Function* pGsEntryPoint);
+    llvm::Function* BuildPrimShader(llvm::Function* pEsEntryPoint,
+                                    llvm::Function* pGsEntryPoint,
+                                    llvm::Function* pCopyShaderEntryPoint);
 #endif
 
 private:

--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -214,6 +214,7 @@ void Patch::AddPasses(
         passMgr.add(createAlwaysInlinerLegacyPass());
         passMgr.add(CreatePassDeadFuncRemove());
         passMgr.add(createGlobalDCEPass());
+        passMgr.add(createPromoteMemoryToRegisterPass());
         passMgr.add(createAggressiveDCEPass());
         passMgr.add(createInstructionCombiningPass(false));
         passMgr.add(createCFGSimplificationPass());

--- a/patch/llpcPatchPreparePipelineAbi.cpp
+++ b/patch/llpcPatchPreparePipelineAbi.cpp
@@ -242,7 +242,9 @@ void PatchPreparePipelineAbi::MergeShaderAndSetCallingConvs(
             {
                 if (pGsEntryPoint != nullptr)
                 {
-                    auto pPrimShaderEntryPoint = shaderMerger.BuildPrimShader(pEsEntryPoint, pGsEntryPoint);
+                    auto pCopyShaderEntryPoint = m_pPipelineShaders->GetEntryPoint(ShaderStageCopyShader);
+                    auto pPrimShaderEntryPoint =
+                        shaderMerger.BuildPrimShader(pEsEntryPoint, pGsEntryPoint, pCopyShaderEntryPoint);
                     pPrimShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
                 }
             }
@@ -281,7 +283,7 @@ void PatchPreparePipelineAbi::MergeShaderAndSetCallingConvs(
 
                 if (pEsEntryPoint != nullptr)
                 {
-                    auto pPrimShaderEntryPoint = shaderMerger.BuildPrimShader(pEsEntryPoint, nullptr);
+                    auto pPrimShaderEntryPoint = shaderMerger.BuildPrimShader(pEsEntryPoint, nullptr, nullptr);
                     pPrimShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
                 }
             }
@@ -302,7 +304,9 @@ void PatchPreparePipelineAbi::MergeShaderAndSetCallingConvs(
             {
                 if (pGsEntryPoint != nullptr)
                 {
-                    auto pPrimShaderEntryPoint = shaderMerger.BuildPrimShader(pEsEntryPoint, pGsEntryPoint);
+                    auto pCopyShaderEntryPoint = m_pPipelineShaders->GetEntryPoint(ShaderStageCopyShader);
+                    auto pPrimShaderEntryPoint =
+                        shaderMerger.BuildPrimShader(pEsEntryPoint, pGsEntryPoint, pCopyShaderEntryPoint);
                     pPrimShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
                 }
             }
@@ -328,7 +332,7 @@ void PatchPreparePipelineAbi::MergeShaderAndSetCallingConvs(
                 auto pEsEntryPoint = m_pPipelineShaders->GetEntryPoint(ShaderStageVertex);
                 if (pEsEntryPoint != nullptr)
                 {
-                    auto pPrimShaderEntryPoint = shaderMerger.BuildPrimShader(pEsEntryPoint, nullptr);
+                    auto pPrimShaderEntryPoint = shaderMerger.BuildPrimShader(pEsEntryPoint, nullptr, nullptr);
                     pPrimShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
                 }
             }

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -161,6 +161,11 @@ namespace LlpcName
     const static char NggGsEntryPoint[]               = "llpc.ngg.GS.main";
     const static char NggGsEntryVariant[]             = "llpc.ngg.GS.variant";
     const static char NggGsOutputExport[]             = "llpc.ngg.GS.output.export.";
+    const static char NggGsOutputImport[]             = "llpc.ngg.GS.output.import.";
+    const static char NggGsEmit[]                     = "llpc.ngg.GS.emit";
+    const static char NggGsCut[]                      = "llpc.ngg.GS.cut";
+
+    const static char NggCopyShaderEntryPoint[]       = "llpc.ngg.COPY.main";
     const static char NggPrimShaderEntryPoint[]       = "llpc.shader.PRIM.main";
 
     const static char NggCullingFetchReg[]            = "llpc.ngg.culling.fetchreg";


### PR DESCRIPTION
Phase 2: Implement NGG GS without culling.
- Handle GS_EMIT, GS_CUT.
- Add GS output vertex count calculation.
- Add GS primitive/vertex export.
- Add copy shader generation and merging.
- Correct some register settings.