### PR TITLE
Group BuiltInTessLevel* stores together

### DIFF
--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -3938,6 +3938,8 @@ void PatchInOutImportExport::PatchTcsBuiltInOutputExport(
                 LLPC_ASSERT(perPatchBuiltInOutLocMap.find(builtInId) != perPatchBuiltInOutLocMap.end());
                 uint32_t loc = perPatchBuiltInOutLocMap[builtInId];
 
+                llvm::Instruction *pInsertAtEnd = pInsertPos->getParent()->getTerminator();
+
                 if (pElemIdx == nullptr)
                 {
                     // gl_TessLevelOuter[4] is treated as vec4
@@ -3947,18 +3949,18 @@ void PatchInOutImportExport::PatchTcsBuiltInOutputExport(
                     {
                         std::vector<uint32_t> idxs;
                         idxs.push_back(i);
-                        auto pElem = ExtractValueInst::Create(pOutput, idxs, "", pInsertPos);
+                        auto pElem = ExtractValueInst::Create(pOutput, idxs, "", pInsertAtEnd);
 
                         auto pElemIdx = ConstantInt::get(m_pContext->Int32Ty(), i);
                         auto pLdsOffset =
-                            CalcLdsOffsetForTcsOutput(pElem->getType(), loc, nullptr, pElemIdx, pVertexIdx, pInsertPos);
-                        WriteValueToLds(pElem, pLdsOffset, pInsertPos);
+                            CalcLdsOffsetForTcsOutput(pElem->getType(), loc, nullptr, pElemIdx, pVertexIdx, pInsertAtEnd);
+                        WriteValueToLds(pElem, pLdsOffset, pInsertAtEnd);
                     }
                 }
                 else
                 {
-                    auto pLdsOffset = CalcLdsOffsetForTcsOutput(pOutputTy, loc, nullptr, pElemIdx, nullptr, pInsertPos);
-                    WriteValueToLds(pOutput, pLdsOffset, pInsertPos);
+                    auto pLdsOffset = CalcLdsOffsetForTcsOutput(pOutputTy, loc, nullptr, pElemIdx, nullptr, pInsertAtEnd);
+                    WriteValueToLds(pOutput, pLdsOffset, pInsertAtEnd);
                 }
             }
             break;
@@ -4013,6 +4015,8 @@ void PatchInOutImportExport::PatchTcsBuiltInOutputExport(
                 LLPC_ASSERT(perPatchBuiltInOutLocMap.find(builtInId) != perPatchBuiltInOutLocMap.end());
                 uint32_t loc = perPatchBuiltInOutLocMap[builtInId];
 
+                llvm::Instruction *pInsertAtEnd = pInsertPos->getParent()->getTerminator();
+
                 if (pElemIdx == nullptr)
                 {
                     // gl_TessLevelInner[2] is treated as vec2
@@ -4022,18 +4026,18 @@ void PatchInOutImportExport::PatchTcsBuiltInOutputExport(
                     {
                         std::vector<uint32_t> idxs;
                         idxs.push_back(i);
-                        auto pElem = ExtractValueInst::Create(pOutput, idxs, "", pInsertPos);
+                        auto pElem = ExtractValueInst::Create(pOutput, idxs, "", pInsertAtEnd);
 
                         auto pElemIdx = ConstantInt::get(m_pContext->Int32Ty(), i);
                         auto pLdsOffset =
-                            CalcLdsOffsetForTcsOutput(pElem->getType(), loc, nullptr, pElemIdx, pVertexIdx, pInsertPos);
-                        WriteValueToLds(pElem, pLdsOffset, pInsertPos);
+                            CalcLdsOffsetForTcsOutput(pElem->getType(), loc, nullptr, pElemIdx, pVertexIdx, pInsertAtEnd);
+                        WriteValueToLds(pElem, pLdsOffset, pInsertAtEnd);
                     }
                 }
                 else
                 {
-                    auto pLdsOffset = CalcLdsOffsetForTcsOutput(pOutputTy, loc, nullptr, pElemIdx, nullptr, pInsertPos);
-                    WriteValueToLds(pOutput, pLdsOffset, pInsertPos);
+                    auto pLdsOffset = CalcLdsOffsetForTcsOutput(pOutputTy, loc, nullptr, pElemIdx, nullptr, pInsertAtEnd);
+                    WriteValueToLds(pOutput, pLdsOffset, pInsertAtEnd);
                 }
             }
 


### PR DESCRIPTION
Make the code of BuiltInTessLevelInner and BuiltInTessLevelOuter
more merge-friendly, by grouping stores generated in WriteValueToLds
at the end of block and keeping stores generated in StoreTessFactorToBuffer
where they were.

This helps in a common case, where stores to BuiltInTessLevelOuter (or
BuiltInTessLevelInner) are listed sequentially in the source, and the
generated instructions are intermingled.