### PR TITLE
Tidied SystemValues' use of PipelineState

### DIFF
--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -110,6 +110,7 @@ bool PatchInOutImportExport::runOnModule(
 
     m_gfxIp = m_pContext->GetGfxIpVersion();
     m_pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
+    m_pipelineSysValues.Initialize(m_pPipelineState);
 
     const uint32_t stageMask = m_pContext->GetShaderStageMask();
     m_hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
@@ -4487,7 +4488,7 @@ void PatchInOutImportExport::PatchXfbOutputExport(
                 (m_shaderStage == ShaderStageTessEval) ||
                 (m_shaderStage == ShaderStageCopyShader));
 
-    Value* pStreamOutBufDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetStreamOutBufDesc(m_pPipelineState, xfbBuffer);
+    Value* pStreamOutBufDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetStreamOutBufDesc(xfbBuffer);
 
     const auto& xfbStrides = m_pContext->GetShaderResourceUsage(m_shaderStage)->inOutUsage.xfbStrides;
     uint32_t xfbStride = xfbStrides[xfbBuffer];

--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -1663,7 +1663,7 @@ Value* VertexFetch::LoadVertexBufferDescriptor(
     idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), 0, false));
     idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), binding, false));
 
-    auto pVbTablePtr = m_pShaderSysValues->GetVertexBufTablePtr(m_pPipelineState);
+    auto pVbTablePtr = m_pShaderSysValues->GetVertexBufTablePtr();
     auto pVbDescPtr = GetElementPtrInst::Create(nullptr, pVbTablePtr, idxs, "", pInsertPos);
     pVbDescPtr->setMetadata(m_pContext->MetaIdUniform(), m_pContext->GetEmptyMetadataNode());
 


### PR DESCRIPTION
This tidies SystemValues so you don't need to pass PipelineState into
many of its methods.

Change-Id: I64dad6ee15d1fb773da28c241ae577be5559beb0