### PR TITLE
Reunited pre-patch and patch pass managers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,7 @@ if(ICD_BUILD_LLPC)
         patch/llpcFragColorExport.cpp
         patch/llpcPatch.cpp
         patch/llpcPatchBufferOp.cpp
+        patch/llpcPatchCheckShaderCache.cpp
         patch/llpcPatchCopyShader.cpp
         patch/llpcPatchDescriptorLoad.cpp
         patch/llpcPatchEntryPointMutate.cpp

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -124,6 +124,7 @@ endif
         llpcFragColorExport.cpp             \
         llpcPatch.cpp                       \
         llpcPatchBufferOp.cpp               \
+        llpcPatchCheckShaderCache.cpp       \
         llpcPatchCopyShader.cpp             \
         llpcPatchDescriptorLoad.cpp         \
         llpcPatchEntryPointMutate.cpp       \

--- a/patch/llpcPatchCheckShaderCache.cpp
+++ b/patch/llpcPatchCheckShaderCache.cpp
@@ -1,0 +1,164 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPatchCheckShaderCache.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::PatchCheckShaderCache.
+ ***********************************************************************************************************************
+ */
+#define DEBUG_TYPE "llpc-patch-check-shader-cache"
+
+#include "llvm/Support/Debug.h"
+
+#include "llpcPatchCheckShaderCache.h"
+#include "llpcPipelineShaders.h"
+
+using namespace llvm;
+using namespace Llpc;
+
+// =====================================================================================================================
+// Initializes static members.
+char PatchCheckShaderCache::ID = 0;
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Pass creator, creates the pass of LLVM patching operations for checking shader cache
+PatchCheckShaderCache* CreatePatchCheckShaderCache()
+{
+    return new PatchCheckShaderCache();
+}
+
+} // Llpc
+
+namespace
+{
+
+// =====================================================================================================================
+// Stream each map key and value for later inclusion in a hash
+template <class MapType>
+static void StreamMapEntries(MapType&     map,    // [in] Map to stream
+                             raw_ostream& stream) // [in/out] Stream to output map entries to
+{
+    size_t mapCount = map.size();
+    stream << StringRef(reinterpret_cast<const char*>(&mapCount), sizeof(mapCount));
+    for (auto mapIt : map)
+    {
+        stream << StringRef(reinterpret_cast<const char*>(&mapIt.first), sizeof(mapIt.first));
+        stream << StringRef(reinterpret_cast<const char*>(&mapIt.second), sizeof(mapIt.second));
+    }
+}
+
+} // anonymous
+
+// =====================================================================================================================
+PatchCheckShaderCache::PatchCheckShaderCache()
+    :
+    Patch(ID)
+{
+    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
+    initializePatchCheckShaderCachePass(*PassRegistry::getPassRegistry());
+}
+
+// =====================================================================================================================
+// Executes this LLVM patching pass on the specified LLVM module.
+bool PatchCheckShaderCache::runOnModule(
+    Module& module)  // [in,out] LLVM module to be run on
+{
+    LLVM_DEBUG(dbgs() << "Run the pass Patch-Check-Shader-Cache\n");
+
+    if (m_callbackFunc == nullptr)
+    {
+        // No shader cache in use.
+        return false;
+    }
+
+    Patch::Init(&module);
+
+    std::string inOutUsageStreams[ShaderStageGfxCount];
+    ArrayRef<uint8_t> inOutUsageValues[ShaderStageGfxCount];
+    auto stageMask = m_pContext->GetShaderStageMask();
+
+    // Build input/output layout hash per shader stage
+    for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1))
+    {
+        if ((stageMask & ShaderStageToMask(stage)) == 0)
+        {
+            continue;
+        }
+
+        auto pResUsage = m_pContext->GetShaderResourceUsage(stage);
+        raw_string_ostream stream(inOutUsageStreams[stage]);
+
+        // Update input/output usage
+        StreamMapEntries(pResUsage->inOutUsage.inputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.outputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchOutputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.builtInInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.builtInOutputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchBuiltInInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchBuiltInOutputLocMap, stream);
+
+        if (stage == ShaderStageGeometry)
+        {
+            // NOTE: For geometry shader, copy shader will use this special map info (from built-in outputs to
+            // locations of generic outputs). We have to add it to shader hash calculation.
+            StreamMapEntries(pResUsage->inOutUsage.gs.builtInOutLocs, stream);
+        }
+
+        // Store the result of the hash for this shader stage.
+        stream.flush();
+        inOutUsageValues[stage] = ArrayRef<uint8_t>(reinterpret_cast<const uint8_t*>(inOutUsageStreams[stage].data()),
+                                                    inOutUsageStreams[stage].size());
+    }
+
+    // Ask callback function if it wants to remove any shader stages.
+    uint32_t modifiedStageMask = m_callbackFunc(&module, stageMask, inOutUsageValues);
+    if (modifiedStageMask == stageMask)
+    {
+        return false;
+    }
+
+    // "Remove" a shader stage by making its entry-point function internal, so it gets removed later.
+    for (auto& func : module)
+    {
+        if ((func.empty() == false) && (func.getLinkage() != GlobalValue::InternalLinkage))
+        {
+            auto stage = GetShaderStageFromFunction(&func);
+            if ((stage != ShaderStageInvalid) && ((ShaderStageToMask(stage) & ~modifiedStageMask) != 0))
+            {
+                func.setLinkage(GlobalValue::InternalLinkage);
+            }
+        }
+    }
+    return true;
+}
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patch operations for checking shader cache
+INITIALIZE_PASS(PatchCheckShaderCache, DEBUG_TYPE,
+                "Patch LLVM for checking shader cache", false, false)

--- a/patch/llpcPatchCheckShaderCache.h
+++ b/patch/llpcPatchCheckShaderCache.h
@@ -1,0 +1,76 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPatchCheckShaderCache.h
+ * @brief LLPC header file: contains declaration of class Llpc::PatchCheckShaderCache
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcPatch.h"
+#include "llpcPipelineShaders.h"
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for checking shader cache
+class PatchCheckShaderCache:
+    public Patch
+{
+public:
+    PatchCheckShaderCache();
+
+    void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
+    {
+        analysisUsage.addRequired<PipelineShaders>();
+    }
+
+    virtual bool runOnModule(llvm::Module& module) override;
+
+    // Set the callback function that this pass uses to ask the front-end whether it wants to remove
+    // any shader stages. The function takes the LLVM IR module and a per-shader-stage array of input/output
+    // usage checksums, and it returns the shader stage mask with bits removed for shader stages that it wants
+    // removed.
+    void SetCallbackFunction(
+        std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)> callbackFunc)
+    {
+        m_callbackFunc = callbackFunc;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    static char ID;   // ID of this pass
+
+private:
+    LLPC_DISALLOW_COPY_AND_ASSIGN(PatchCheckShaderCache);
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>   m_callbackFunc;
+};
+
+} // Llpc

--- a/patch/llpcPatchPreparePipelineAbi.cpp
+++ b/patch/llpcPatchPreparePipelineAbi.cpp
@@ -54,12 +54,10 @@ class PatchPreparePipelineAbi final : public Patch
 public:
     static char ID;
     PatchPreparePipelineAbi(
-        bool    onlySetCallingConvs = false,
-        uint32_t skipStageMask = 0)
+        bool    onlySetCallingConvs = false)
         :
         Patch(ID),
-        m_onlySetCallingConvs(onlySetCallingConvs),
-        m_skipStageMask(skipStageMask)
+        m_onlySetCallingConvs(onlySetCallingConvs)
     {
         initializePipelineShadersPass(*llvm::PassRegistry::getPassRegistry());
         initializePatchPreparePipelineAbiPass(*PassRegistry::getPassRegistry());
@@ -102,7 +100,6 @@ private:
     GfxIpVersion      m_gfxIp;               // Graphics IP version info
 
     const bool        m_onlySetCallingConvs; // Whether to only set the calling conventions
-    const uint32_t    m_skipStageMask;       // Mask indicating which shader stages should be skipped in processing
 };
 
 char PatchPreparePipelineAbi::ID = 0;
@@ -112,10 +109,9 @@ char PatchPreparePipelineAbi::ID = 0;
 // =====================================================================================================================
 // Create pass to prepare the pipeline ABI
 ModulePass* Llpc::CreatePatchPreparePipelineAbi(
-    bool     onlySetCallingConvs, // Should we only set the calling conventions, or do the full prepare.
-    uint32_t skipStageMask)       // Mask of stages to be skipped
+    bool     onlySetCallingConvs) // Should we only set the calling conventions, or do the full prepare.
 {
-    return new PatchPreparePipelineAbi(onlySetCallingConvs, skipStageMask);
+    return new PatchPreparePipelineAbi(onlySetCallingConvs);
 }
 
 // =====================================================================================================================
@@ -354,15 +350,7 @@ void PatchPreparePipelineAbi::SetCallingConv(
     auto pEntryPoint = m_pPipelineShaders->GetEntryPoint(shaderStage);
     if (pEntryPoint != nullptr)
     {
-        if (m_skipStageMask & ShaderStageToMask(shaderStage))
-        {
-            pEntryPoint->setLinkage(GlobalValue::InternalLinkage);
-            pEntryPoint->setCallingConv(CallingConv::C);
-        }
-        else
-        {
-            pEntryPoint->setCallingConv(callingConv);
-        }
+        pEntryPoint->setCallingConv(callingConv);
     }
 }
 

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -267,7 +267,7 @@ ShaderStage GetShaderStageFromModule(
 // =====================================================================================================================
 // Gets the shader stage from the specified LLVM function. Returns ShaderStageInvalid if not shader entrypoint.
 ShaderStage GetShaderStageFromFunction(
-    Function* pFunc)  // [in] LLVM function
+    const Function* pFunc)  // [in] LLVM function
 {
     // First check for the metadata that is added by the builder. This works in the patch phase.
     MDNode* pStageMetaNode = pFunc->getMetadata(LlpcName::ShaderStageMetadata);

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -266,7 +266,7 @@ ShaderStage GetShaderStageFromModule(llvm::Module* pModule);
 void SetShaderStageToModule(llvm::Module* pModule, ShaderStage shaderStage);
 
 // Gets the shader stage from the specified LLVM function.
-ShaderStage GetShaderStageFromFunction(llvm::Function* pFunc);
+ShaderStage GetShaderStageFromFunction(const llvm::Function* pFunc);
 
 // Gets the shader stage from the specified calling convention.
 ShaderStage GetShaderStageFromCallingConv(uint32_t stageMask, llvm::CallingConv::ID callConv);


### PR DESCRIPTION
Part of the drive to clean up the interface from the front-end into the
middle-end.

Ultimately we want the whole of the middle- and back-ends to run in the
same pass manager. This is the first half of that.

The change includes factoring out shader cache checking in the graphics
pipeline. That remains in the front-end, in a lambda that is passed in
to the patch phase to run part way through it.

Change-Id: I1b71c042f2f4c95d2b24510143aaaf730492f019