### PR TITLE
Created Builder::Generate to run middle- and back-end passes

### DIFF
--- a/lower/llpcSpirvLower.cpp
+++ b/lower/llpcSpirvLower.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Vectorize.h"
 
+#include "llpcBuilder.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
 #include "llpcPassManager.h"
@@ -85,7 +86,7 @@ void SpirvLower::AddPasses(
     uint32_t              forceLoopUnrollCount)   // 0 or force loop unroll count
 {
     // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-    AddTargetLibInfo(pContext, &passMgr);
+    pContext->GetBuilder()->PreparePassManager(&passMgr);
 
     // Start timer for lowering passes.
     if (pLowerTimer != nullptr)

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -258,14 +258,12 @@ void CodeGenManager::SetupTargetFeatures(
 
 // =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
-Result CodeGenManager::AddTargetPasses(
+void CodeGenManager::AddTargetPasses(
     Context*              pContext,      // [in] LLPC context
     PassManager&          passMgr,       // [in/out] pass manager to add passes to
-    llvm::Timer*          pCodeGenTimer, // [in] Timer to time target passes with, nullptr if not timing
+    Timer*                pCodeGenTimer, // [in] Timer to time target passes with, nullptr if not timing
     raw_pwrite_stream&    outStream)     // [out] Output stream
 {
-    Result result = Result::Success;
-
     // Start timer for codegen passes.
     if (pCodeGenTimer != nullptr)
     {
@@ -295,30 +293,16 @@ Result CodeGenManager::AddTargetPasses(
 
     auto pTargetMachine = pContext->GetTargetMachine();
 
-#if LLPC_ENABLE_EXCEPTION
-    try
-#endif
+    if (pTargetMachine->addPassesToEmitFile(passMgr, outStream, nullptr, FileType))
     {
-        if (pTargetMachine->addPassesToEmitFile(passMgr, outStream, nullptr, FileType))
-        {
-            LLPC_ERRS("Target machine cannot emit a file of this type\n");
-            result = Result::ErrorInvalidValue;
-        }
+        report_fatal_error("Target machine cannot emit a file of this type");
     }
-#if LLPC_ENABLE_EXCEPTION
-    catch (const char*)
-    {
-        result = Result::ErrorInvalidValue;
-    }
-#endif
 
     // Stop timer for codegen passes.
     if (pCodeGenTimer != nullptr)
     {
         passMgr.add(CreateStartStopTimer(pCodeGenTimer, false));
     }
-
-    return result;
 }
 
 } // Llpc

--- a/patch/llpcCodeGenManager.h
+++ b/patch/llpcCodeGenManager.h
@@ -83,10 +83,10 @@ public:
 
     static void SetupTargetFeatures(llvm::Module* pModule);
 
-    static Result AddTargetPasses(Context*                    pContext,
-                                  PassManager&                passMgr,
-                                  llvm::Timer*                pCodeGenTimer,
-                                  llvm::raw_pwrite_stream&    outStream);
+    static void AddTargetPasses(Context*                    pContext,
+                                PassManager&                passMgr,
+                                llvm::Timer*                pCodeGenTimer,
+                                llvm::raw_pwrite_stream&    outStream);
 
     static Result Run(llvm::Module*               pModule,
                       llvm::legacy::PassManager&  passMgr);

--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -96,8 +96,7 @@ void Patch::AddPasses(
     legacy::PassManager&  passMgr,       // [in/out] Pass manager to add passes to
     llvm::Timer*          pPatchTimer,   // [in] Timer to time patch passes with, nullptr if not timing
     llvm::Timer*          pOptTimer,     // [in] Timer to time LLVM optimization passes with, nullptr if not timing
-    std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>
-                          checkShaderCacheFunc)
+    Builder::CheckShaderCacheFunc  checkShaderCacheFunc)
                                          // Callback function to check shader cache
 {
     // Start timer for patching passes.

--- a/patch/llpcPatch.h
+++ b/patch/llpcPatch.h
@@ -33,6 +33,7 @@
 #include "llvm/Pass.h"
 
 #include "llpc.h"
+#include "llpcBuilder.h"
 #include "llpcContext.h"
 #include "llpcDebug.h"
 
@@ -130,8 +131,7 @@ public:
                           llvm::legacy::PassManager&  passMgr,
                           llvm::Timer*                pPatchTimer,
                           llvm::Timer*                pOptTimer,
-                          std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>
-                                                      checkShaderCacheFunc);
+                          Builder::CheckShaderCacheFunc checkShaderCacheFunc);
 
     static llvm::GlobalVariable* GetLdsVariable(llvm::Module* pModule);
 

--- a/patch/llpcPatchCheckShaderCache.h
+++ b/patch/llpcPatchCheckShaderCache.h
@@ -55,8 +55,7 @@ public:
     // any shader stages. The function takes the LLVM IR module and a per-shader-stage array of input/output
     // usage checksums, and it returns the shader stage mask with bits removed for shader stages that it wants
     // removed.
-    void SetCallbackFunction(
-        std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)> callbackFunc)
+    void SetCallbackFunction(Builder::CheckShaderCacheFunc callbackFunc)
     {
         m_callbackFunc = callbackFunc;
     }
@@ -70,7 +69,7 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>   m_callbackFunc;
+    Builder::CheckShaderCacheFunc   m_callbackFunc;
 };
 
 } // Llpc

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -748,30 +748,4 @@ bool IsIsaText(
     return (dataSize != 0) && ((reinterpret_cast<const char*>(pData))[0] == '\t');
 }
 
-// =====================================================================================================================
-// Manually add a target-aware TLI pass, so middle-end optimizations do not think that we have library functions.
-void AddTargetLibInfo(
-    Context*              pContext,   // [in] LLPC context
-    legacy::PassManager*  pPassMgr)   // [in/out] Pass manager
-{
-    TargetLibraryInfoImpl targetLibInfo(pContext->GetTargetMachine()->getTargetTriple());
-
-    // Adjust it to allow memcpy and memset.
-    // TODO: Investigate why the latter is necessary. I found that
-    // test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
-    // got unrolled far too much, and at too late a stage for the descriptor loads to be commoned up. It might
-    // be an unfortunate interaction between LoopIdiomRecognize and fat pointer laundering.
-    targetLibInfo.setAvailable(LibFunc_memcpy);
-    targetLibInfo.setAvailable(LibFunc_memset);
-
-    // Also disallow tan functions.
-    // TODO: This can be removed once we have LLVM fix D67406.
-    targetLibInfo.setUnavailable(LibFunc_tan);
-    targetLibInfo.setUnavailable(LibFunc_tanf);
-    targetLibInfo.setUnavailable(LibFunc_tanl);
-
-    auto pTargetLibInfoPass = new TargetLibraryInfoWrapperPass(targetLibInfo);
-    pPassMgr->add(pTargetLibInfoPass);
-}
-
 } // Llpc

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -32,9 +32,7 @@
 
 #include <unordered_set>
 
-#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 
 #include "spirvExt.h"
@@ -78,13 +76,6 @@ void initializePassDeadFuncRemovePass(PassRegistry&);
 void initializePassExternalLibLinkPass(PassRegistry&);
 void initializePipelineShadersPass(PassRegistry&);
 void initializeStartStopTimerPass(PassRegistry&);
-
-namespace legacy
-{
-
-class PassManager;
-
-} // legacy
 
 } // llvm
 
@@ -312,8 +303,5 @@ bool IsElfBinary(const void* pData, size_t dataSize);
 
 // Checks whether the output data is actually ISA assembler text
 bool IsIsaText(const void* pData, size_t dataSize);
-
-// Manually add a target-aware TLI pass, so middle-end optimizations do not think that we have library functions.
-void AddTargetLibInfo(Context* pContext, llvm::legacy::PassManager* pPassMgr);
 
 } // Llpc


### PR DESCRIPTION
    Part of the drive to clean up the interface from the front-end into the
    middle-end.
    
    The front-end now just calls Builder::Generate to run middle- and
    back-end passes and generate the ELF.
