### PR TITLE
PipelineState allocation changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,7 @@ if(ICD_BUILD_LLPC)
         patch/llpcFragColorExport.cpp
         patch/llpcPatch.cpp
         patch/llpcPatchBufferOp.cpp
+        patch/llpcPatchCheckShaderCache.cpp
         patch/llpcPatchCopyShader.cpp
         patch/llpcPatchDescriptorLoad.cpp
         patch/llpcPatchEntryPointMutate.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if(ICD_BUILD_LLPC)
 # llpc/builder
     target_sources(llpc PRIVATE
         builder/llpcBuilder.cpp
+        builder/llpcBuilderContext.cpp
         builder/llpcBuilderImpl.cpp
         builder/llpcBuilderImplArith.cpp
         builder/llpcBuilderImplDesc.cpp

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -49,45 +49,22 @@
 using namespace Llpc;
 using namespace llvm;
 
-// -use-builder-recorder
-static cl::opt<uint32_t> UseBuilderRecorder("use-builder-recorder",
-                                            cl::desc("Do lowering via recording and replaying LLPC builder:\n"
-                                                     "0: Generate IR directly; no recording\n"
-                                                     "1: Do lowering via recording and replaying LLPC builder (default)\n"
-                                                     "2: Do lowering via recording; no replaying"),
-                                            cl::init(1));
-
-// =====================================================================================================================
-// Create a Builder object
-// If -use-builder-recorder is 0, this creates a BuilderImpl. Otherwise, it creates a BuilderRecorder.
-Builder* Builder::Create(
-    LLVMContext& context) // [in] LLVM context
-{
-    if (UseBuilderRecorder == 0)
-    {
-        // -use-builder-recorder=0: generate LLVM IR directly without recording
-        return CreateBuilderImpl(context);
-    }
-    // -use-builder-recorder=1: record with BuilderRecorder and replay with BuilderReplayer
-    // -use-builder-recorder=2: record with BuilderRecorder and do not replay
-    return CreateBuilderRecorder(context, UseBuilderRecorder == 1 /*wantReplay*/);
-}
-
 // =====================================================================================================================
 // Create a BuilderImpl object
 Builder* Builder::CreateBuilderImpl(
-    LLVMContext& context) // [in] LLVM context
+    BuilderContext* pBuilderContext) // [in] Builder context
 {
-    return new BuilderImpl(context);
+    return new BuilderImpl(pBuilderContext);
 }
 
 // =====================================================================================================================
 Builder::Builder(
-    LLVMContext& context) // [in] LLPC context
+    BuilderContext* pBuilderContext) // [in] Builder context
     :
-    IRBuilder<>(context)
+    IRBuilder<>(pBuilderContext->GetContext()),
+    m_pBuilderContext(pBuilderContext)
 {
-    m_pPipelineState = new PipelineState(&context);
+    m_pPipelineState = new PipelineState(&getContext());
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -1404,13 +1404,21 @@ protected:
     static Builder* CreateBuilderImpl(BuilderContext* pBuilderContext);
     static Builder* CreateBuilderRecorder(BuilderContext* pBuilderContext);
 
+    // Const version of GetPipelineState. This is used in BuilderImpl, and we know it does not need allocating.
+    PipelineState* GetPipelineState() const { return m_pPipelineState; }
+
+    // Get PipelineState, allocating if necessary. If it is allocated here (rather than passed in by
+    // BuilderImpl::SetPipelineState), then it is freed when the Builder is freed.
+    PipelineState* GetPipelineState();
+
     // Get a constant of FP or vector of FP type from the given APFloat, converting APFloat semantics where necessary
     Constant* GetFpConstant(Type* pTy, APFloat value);
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    ShaderStage     m_shaderStage     = ShaderStageInvalid; // Current shader stage being built.
-    PipelineState*  m_pPipelineState  = nullptr;            // Pipeline state
+    ShaderStage                     m_shaderStage = ShaderStageInvalid; // Current shader stage being built.
+    std::unique_ptr<PipelineState>  m_pAllocatedPipelineState;          // Pipeline state allocated by this Builder
+    PipelineState*                  m_pPipelineState = nullptr;         // Pipeline state to use in this Builder
 
     Type* GetTransposedMatrixTy(
         Type* const pMatrixType) const; // [in] The matrix type to tranpose
@@ -1432,8 +1440,5 @@ private:
 
     BuilderContext* m_pBuilderContext;      // Builder context
 };
-
-// Create BuilderReplayer pass
-ModulePass* CreateBuilderReplayer(Builder* pBuilder);
 
 } // Llpc

--- a/builder/llpcBuilderContext.cpp
+++ b/builder/llpcBuilderContext.cpp
@@ -1,0 +1,58 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcBuilderContext.cpp
+ * @brief LLPC source file: implementation of llpc::BuilderContext class for creating and using Llpc::Builder
+ ***********************************************************************************************************************
+ */
+#include "llpcBuilderContext.h"
+#include "llpcBuilderImpl.h"
+#include "llpcBuilderRecorder.h"
+
+using namespace Llpc;
+using namespace llvm;
+
+// =====================================================================================================================
+BuilderContext::BuilderContext(
+    LLVMContext&  context,              // [in] LLVM context to give each Builder
+    bool          useBuilderRecorder)   // True to use BuilderRecorder, false to build directly
+    : m_context(context), m_useBuilderRecorder(useBuilderRecorder)
+{
+}
+
+// =====================================================================================================================
+// Create a Builder object
+Builder* BuilderContext::CreateBuilder()
+{
+    if (m_useBuilderRecorder == false)
+    {
+        // Generate LLVM IR directly without recording
+        return new BuilderImpl(this);
+    }
+    // Record with BuilderRecorder
+    return new BuilderRecorder(this);
+}
+

--- a/builder/llpcBuilderContext.cpp
+++ b/builder/llpcBuilderContext.cpp
@@ -56,3 +56,14 @@ Builder* BuilderContext::CreateBuilder()
     return new BuilderRecorder(this);
 }
 
+// =====================================================================================================================
+// Create a BuilderImpl object directly, passing in the PipelineState to use.
+Builder* BuilderContext::CreateBuilderImpl(
+    PipelineState*  pPipelineState)   // [in] PipelineState to use
+{
+    // Generate LLVM IR directly without recording
+    BuilderImpl* pBuilderImpl = new BuilderImpl(this);
+    pBuilderImpl->SetPipelineState(pPipelineState);
+    return pBuilderImpl;
+}
+

--- a/builder/llpcBuilderContext.h
+++ b/builder/llpcBuilderContext.h
@@ -46,6 +46,7 @@ namespace Llpc
 using namespace llvm;
 
 class Builder;
+class PipelineState;
 
 // =====================================================================================================================
 // BuilderContext class, used to create Builder objects. State shared between Builder objects is kept here.
@@ -59,6 +60,9 @@ public:
 
     // Create a Builder object
     Builder* CreateBuilder();
+
+    // Create a BuilderImpl object directly, passing in the PipelineState to use. This is used by BuilderReplayer.
+    Builder* CreateBuilderImpl(PipelineState* pPipelineState);
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(BuilderContext)

--- a/builder/llpcBuilderContext.h
+++ b/builder/llpcBuilderContext.h
@@ -1,0 +1,72 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcBuilderContext.h
+ * @brief LLPC header file: declaration of llpc::BuilderContext class for creating and using Llpc::Builder
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpc.h"
+#include "llpcDebug.h"
+
+namespace llvm
+{
+
+class LLVMContext;
+
+} // llvm
+
+namespace Llpc
+{
+
+using namespace llvm;
+
+class Builder;
+
+// =====================================================================================================================
+// BuilderContext class, used to create Builder objects. State shared between Builder objects is kept here.
+class BuilderContext
+{
+public:
+    BuilderContext(LLVMContext& context, bool useBuilderRecorder);
+
+    // Get LLVM context
+    LLVMContext& GetContext() const { return m_context; }
+
+    // Create a Builder object
+    Builder* CreateBuilder();
+
+private:
+    LLPC_DISALLOW_DEFAULT_CTOR(BuilderContext)
+    LLPC_DISALLOW_COPY_AND_ASSIGN(BuilderContext)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    LLVMContext&  m_context;              // LLVM context
+    bool          m_useBuilderRecorder;   // Whether to create BuilderRecorder or BuilderImpl
+};
+
+} // Llpc

--- a/builder/llpcBuilderImpl.cpp
+++ b/builder/llpcBuilderImpl.cpp
@@ -42,6 +42,16 @@ Context& BuilderImplBase::getContext() const
 }
 
 // =====================================================================================================================
+// Set PipelineState. This is used by BuilderReplayer to get its BuilderImpl to use the existing PipelineState,
+// rather than allocate its own new one.
+void BuilderImplBase::SetPipelineState(
+    PipelineState*  pPipelineState)   // [in] PipelineState to use
+{
+    LLPC_ASSERT(m_pAllocatedPipelineState == nullptr);
+    m_pPipelineState = pPipelineState;
+}
+
+// =====================================================================================================================
 // Create scalar from dot product of scalar or vector FP type. (The dot product of two scalars is their product.)
 Value* BuilderImplBase::CreateDotProduct(
     Value* const pVector1,            // [in] The float vector 1

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -42,7 +42,7 @@ using namespace llvm;
 class BuilderImplBase : public Builder
 {
 public:
-    BuilderImplBase(LLVMContext& context) : Builder(context) {}
+    BuilderImplBase(BuilderContext* pBuilderContext) : Builder(pBuilderContext) {}
 
     // Get the LLPC context. This overrides the IRBuilder method that gets the LLVM context.
     Llpc::Context& getContext() const;
@@ -100,7 +100,7 @@ private:
 class BuilderImplArith : virtual public BuilderImplBase
 {
 public:
-    BuilderImplArith(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplArith(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create calculation of 2D texture coordinates that would be used for accessing the selected cube map face for
     // the given cube map texture coordinates.
@@ -264,7 +264,7 @@ private:
 class BuilderImplDesc : virtual public BuilderImplBase
 {
 public:
-    BuilderImplDesc(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplDesc(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a load of a buffer descriptor.
     Value* CreateLoadBufferDesc(uint32_t      descSet,
@@ -324,7 +324,7 @@ private:
 class BuilderImplImage : virtual public BuilderImplBase
 {
 public:
-    BuilderImplImage(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplImage(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create an image load.
     Value* CreateImageLoad(Type*             pResultTy,
@@ -496,7 +496,7 @@ private:
 class BuilderImplInOut : virtual public BuilderImplBase
 {
 public:
-    BuilderImplInOut(llvm::LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplInOut(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a read of (part of) a user input value.
     Value* CreateReadGenericInput(Type*         pResultTy,
@@ -628,7 +628,7 @@ private:
 class BuilderImplMatrix : virtual public BuilderImplBase
 {
 public:
-    BuilderImplMatrix(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplMatrix(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a matrix transpose.
     Value* CreateTransposeMatrix(Value* const pMatrix,
@@ -685,7 +685,7 @@ private:
 class BuilderImplMisc : virtual public BuilderImplBase
 {
 public:
-    BuilderImplMisc(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplMisc(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // In the GS, emit the current values of outputs (as written by CreateWriteBuiltIn and CreateWriteOutput) to
     // the current output primitive in the specified output-primitive stream.
@@ -722,7 +722,7 @@ private:
 class BuilderImplSubgroup : virtual public BuilderImplBase
 {
 public:
-    BuilderImplSubgroup(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplSubgroup(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a get subgroup size query.
     Value* CreateGetSubgroupSize(const Twine& instName) override final;
@@ -954,14 +954,14 @@ class BuilderImpl final : public BuilderImplArith,
                                  BuilderImplSubgroup
 {
 public:
-    BuilderImpl(LLVMContext& context) : BuilderImplBase(context),
-                                        BuilderImplArith(context),
-                                        BuilderImplDesc(context),
-                                        BuilderImplImage(context),
-                                        BuilderImplInOut(context),
-                                        BuilderImplMatrix(context),
-                                        BuilderImplMisc(context),
-                                        BuilderImplSubgroup(context)
+    BuilderImpl(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext),
+                                                   BuilderImplArith(pBuilderContext),
+                                                   BuilderImplDesc(pBuilderContext),
+                                                   BuilderImplImage(pBuilderContext),
+                                                   BuilderImplInOut(pBuilderContext),
+                                                   BuilderImplMatrix(pBuilderContext),
+                                                   BuilderImplMisc(pBuilderContext),
+                                                   BuilderImplSubgroup(pBuilderContext)
     {}
     ~BuilderImpl() {}
 

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -44,6 +44,10 @@ class BuilderImplBase : public Builder
 public:
     BuilderImplBase(BuilderContext* pBuilderContext) : Builder(pBuilderContext) {}
 
+    // Set PipelineState. This is used by BuilderReplayer to get its BuilderImpl to use the existing PipelineState,
+    // rather than allocate its own new one.
+    void SetPipelineState(PipelineState* pPipelineState);
+
     // Get the LLPC context. This overrides the IRBuilder method that gets the LLVM context.
     Llpc::Context& getContext() const;
 

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -349,8 +349,7 @@ Module* BuilderRecorder::Link(
 // This is a BuilderRecorder. Create the BuilderReplayer pass.
 ModulePass* BuilderRecorder::CreateBuilderReplayer()
 {
-    // Create a new BuilderImpl to replay the recorded Builder calls in.
-    return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(GetBuilderContext()));
+    return ::CreateBuilderReplayer(GetBuilderContext());
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -28,6 +28,7 @@
  * @brief LLPC source file: BuilderRecorder implementation
  ***********************************************************************************************************************
  */
+#include "llpcBuilderContext.h"
 #include "llpcBuilderRecorder.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
@@ -303,10 +304,16 @@ BuilderRecorderMetadataKinds::BuilderRecorderMetadataKinds(
 // =====================================================================================================================
 // Create a BuilderRecorder
 Builder* Builder::CreateBuilderRecorder(
-    LLVMContext&  context,    // [in] LLVM context
-    bool          wantReplay) // TRUE to make CreateBuilderReplayer return a replayer pass
+    BuilderContext* pBuilderContext)  // [in] Builder context
 {
-    return new BuilderRecorder(context, wantReplay);
+    return new BuilderRecorder(pBuilderContext);
+}
+
+// =====================================================================================================================
+BuilderRecorder::BuilderRecorder(
+    BuilderContext* pBuilderContext)  // [in] Builder context
+    : Builder(pBuilderContext), BuilderRecorderMetadataKinds(pBuilderContext->GetContext())
+{
 }
 
 #ifndef NDEBUG
@@ -339,15 +346,11 @@ Module* BuilderRecorder::Link(
 #endif
 
 // =====================================================================================================================
-// This is a BuilderRecorder. If it was created with wantReplay=true, create the BuilderReplayer pass.
+// This is a BuilderRecorder. Create the BuilderReplayer pass.
 ModulePass* BuilderRecorder::CreateBuilderReplayer()
 {
-    if (m_wantReplay)
-    {
-        // Create a new BuilderImpl to replay the recorded Builder calls in.
-        return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(getContext()));
-    }
-    return nullptr;
+    // Create a new BuilderImpl to replay the recorded Builder calls in.
+    return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(GetBuilderContext()));
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -210,9 +210,7 @@ public:
     // Given an opcode, get the call name (without the "llpc.call." prefix)
     static StringRef GetCallName(Opcode opcode);
 
-    BuilderRecorder(LLVMContext& context, bool wantReplay)
-        : Builder(context), BuilderRecorderMetadataKinds(context), m_wantReplay(wantReplay)
-    {}
+    BuilderRecorder(BuilderContext* pBuilderContext);
 
     ~BuilderRecorder() {}
 
@@ -223,7 +221,7 @@ public:
     Module* Link(ArrayRef<Module*> modules, bool linkNativeStages) override final;
 #endif
 
-    // If this is a BuilderRecorder created with wantReplay=true, create the BuilderReplayer pass.
+    // If this is a BuilderRecorder, create the BuilderReplayer pass.
     ModulePass* CreateBuilderReplayer() override;
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -668,8 +666,6 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    bool            m_wantReplay;                             // true to make CreateBuilderReplayer return a replayer
-                                                              //   pass
 #ifndef NDEBUG
     // Only used in a debug build to ensure SetShaderStage is being used consistently.
     std::vector<std::pair<WeakVH, ShaderStage>> m_funcShaderStageMap;       // Map from function to shader stage

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -674,4 +674,7 @@ private:
 #endif
 };
 
+// Create BuilderReplayer pass
+ModulePass* CreateBuilderReplayer(BuilderContext* pBuilderContext);
+
 } // Llpc

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -89,12 +89,22 @@ class PipelineState
 {
 public:
     PipelineState()
-        : m_pContext(nullptr)
+        : m_pBuilderContext(nullptr)
     {}
 
-    PipelineState(llvm::LLVMContext* pContext)
-        : m_pContext(pContext)
+    PipelineState(BuilderContext* pBuilderContext)
+        : m_pBuilderContext(pBuilderContext)
     {}
+
+    // Get BuilderContext
+    BuilderContext* GetBuilderContext() const { return m_pBuilderContext; }
+
+    // Get LLVMContext
+    LLVMContext& GetContext() const;
+
+    // Accessors for pipeline module that this pipeline state is for.
+    void SetModule(Module* pModule) { m_pModule = pModule; }
+    Module* GetModule() const { return m_pModule; }
 
     // Set the resource mapping nodes for the pipeline.
     void SetUserDataNodes(ArrayRef<ResourceMappingNode>   nodes,
@@ -134,7 +144,8 @@ private:
     ResourceMappingNodeType GetResourceTypeFromName(MDString* pTypeName);
 
     // -----------------------------------------------------------------------------------------------------------------
-    llvm::LLVMContext*              m_pContext;                         // LLVM context
+    BuilderContext*                 m_pBuilderContext;                  // Builder context
+    Module*                         m_pModule = nullptr;                // Pipeline IR module
     std::unique_ptr<ResourceNode[]> m_allocUserDataNodes;               // Allocated buffer for user data
     ArrayRef<ResourceNode>          m_userDataNodes;                    // Top-level user data node table
     MDString*                       m_resourceNodeTypeNames[uint32_t(ResourceMappingNodeType::Count)] = {};
@@ -153,12 +164,15 @@ public:
     // Get the PipelineState from this wrapper pass.
     PipelineState* GetPipelineState(Module* pModule);
 
+    // Set the PipelineState. PipelineStateWrapper takes ownership of the PipelineState.
+    void SetPipelineState(std::unique_ptr<PipelineState> pPipelineState);
+
     // -----------------------------------------------------------------------------------------------------------------
 
     static char ID;   // ID of this pass
 
 private:
-    PipelineState* m_pPipelineState = nullptr;  // Cached pipeline state
+    std::unique_ptr<PipelineState> m_pPipelineState;  // Cached pipeline state
 };
 
 } // Llpc

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -809,7 +809,7 @@ Result Compiler::BuildShaderModule(
                 Context* pContext = AcquireContext();
 
                 pContext->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>());
-                pContext->SetBuilder(Builder::Create(*pContext));
+                pContext->CreateBuilder();
                 CodeGenManager::CreateTargetMachine(pContext, pPipelineOptions);
 
                 for (uint32_t i = 0; i < entryNames.size(); ++i)
@@ -1216,9 +1216,6 @@ Result Compiler::BuildPipelineInternal(
 #endif
     }
 
-    delete pContext->GetBuilder();
-    pContext->SetBuilder(nullptr);
-
     if (checkPerStageCache)
     {
         // For graphics, update shader caches with results of compile, and merge ELF outputs if necessary.
@@ -1425,12 +1422,10 @@ Result Compiler::BuildGraphicsPipelineInternal(
 {
     Context* pContext = AcquireContext();
     pContext->AttachPipelineContext(pGraphicsContext);
-    pContext->SetBuilder(Builder::Create(*pContext));
+    pContext->CreateBuilder();
 
     Result result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
 
-    delete pContext->GetBuilder();
-    pContext->SetBuilder(nullptr);
     ReleaseContext(pContext);
     return result;
 }
@@ -1569,7 +1564,7 @@ Result Compiler::BuildComputePipelineInternal(
 {
     Context* pContext = AcquireContext();
     pContext->AttachPipelineContext(pComputeContext);
-    pContext->SetBuilder(Builder::Create(*pContext));
+    pContext->CreateBuilder();
 
     const PipelineShaderInfo* shaderInfo[ShaderStageNativeStageCount] =
     {
@@ -1583,8 +1578,6 @@ Result Compiler::BuildComputePipelineInternal(
 
     Result result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
 
-    delete pContext->GetBuilder();
-    pContext->SetBuilder(nullptr);
     ReleaseContext(pContext);
     return result;
 }

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -254,7 +254,9 @@ public:
     static MetroHash::Hash GenerateHashForCompileOptions(uint32_t          optionCount,
                                                          const char*const* pOptions);
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     virtual Result CreateShaderCache(const ShaderCacheCreateInfo* pCreateInfo, IShaderCache** ppShaderCache);
+#endif
 
     static void TranslateSpirvToLlvm(const PipelineShaderInfo*    pShaderInfo,
                                      llvm::Module*                pModule);
@@ -287,7 +289,7 @@ private:
                                PipelineStatistics*     pPipelineStats) const;
 
     bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule) const;
-
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
                                         MetroHash::Hash*    pCacheHash,
                                         BinaryData*         pElfBin,
@@ -299,7 +301,15 @@ private:
                             ShaderCache**       ppShaderCache,
                             CacheEntryHandle*   phEntry,
                             uint32_t            shaderCacheCount);
+#else
+    ShaderEntryState LookUpShaderCache(MetroHash::Hash*    pCacheHash,
+                                       BinaryData*         pElfBin,
+                                       CacheEntryHandle*   phEntry);
 
+    void UpdateShaderCache(bool                bInsert,
+                           const BinaryData*   pElfBin,
+                           CacheEntryHandle   phEntry);
+#endif
     void BuildShaderCacheHash(Context* pContext, MetroHash::Hash* pFragmentHash, MetroHash::Hash* pNonFragmentHash);
 
     void MergeElfBinary(Context*          pContext,

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -42,6 +42,7 @@ namespace Llpc
 
 // Forward declaration
 class Builder;
+class Compiler;
 class ComputeContext;
 class Context;
 class GraphicsContext;
@@ -211,6 +212,55 @@ struct PipelineStatistics
 };
 
 // =====================================================================================================================
+// Object to manage checking and updating shader cache for graphics pipeline.
+class GraphicsShaderCacheChecker
+{
+public:
+    GraphicsShaderCacheChecker(Compiler* pCompiler, Context* pContext) :
+        m_pCompiler(pCompiler), m_pContext(pContext)
+    {}
+
+    // Check shader caches, returning mask of which shader stages we want to keep in this compile.
+    uint32_t Check(const llvm::Module*                     pModule,
+                   uint32_t                                stageMask,
+                   llvm::ArrayRef<llvm::ArrayRef<uint8_t>> stageHashes);
+
+    // Get cache results.
+    ShaderEntryState GetNonFragmentCacheEntryState() { return m_nonFragmentCacheEntryState; }
+    ShaderEntryState GetFragmentCacheEntryState() { return m_fragmentCacheEntryState; }
+
+    // Update shader caches with results of compile, and merge ELF outputs if necessary.
+    void UpdateAndMerge(Result result, ElfPackage* pPipelineElf);
+
+private:
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    static constexpr uint32_t ShaderCacheCount = 2;
+#endif
+    Compiler* m_pCompiler;
+    Context*  m_pContext;
+
+    ShaderEntryState m_nonFragmentCacheEntryState = ShaderEntryState::New;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    ShaderCache* m_pNonFragmentShaderCache[ShaderCacheCount] = {};
+    CacheEntryHandle m_hNonFragmentEntry[ShaderCacheCount] = {};
+#else
+    ShaderCache* m_pNonFragmentShaderCache = nullptr;
+    CacheEntryHandle m_hNonFragmentEntry = {};
+#endif
+    BinaryData m_nonFragmentElf = {};
+
+    ShaderEntryState m_fragmentCacheEntryState = ShaderEntryState::New;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    ShaderCache* m_pFragmentShaderCache[ShaderCacheCount] = {};
+    CacheEntryHandle m_hFragmentEntry[ShaderCacheCount] = {};
+#else
+    ShaderCache* m_pFragmentShaderCache = nullptr
+    CacheEntryHandle m_hFragmentEntry = {};
+#endif
+    BinaryData m_fragmentElf = {};
+};
+
+// =====================================================================================================================
 // Represents LLPC pipeline compiler.
 class Compiler: public ICompiler
 {
@@ -261,6 +311,38 @@ public:
     static void TranslateSpirvToLlvm(const PipelineShaderInfo*    pShaderInfo,
                                      llvm::Module*                pModule);
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
+                                        MetroHash::Hash*    pCacheHash,
+                                        BinaryData*         pElfBin,
+                                        ShaderCache**       ppShaderCache,
+                                        CacheEntryHandle*   phEntry);
+
+    static void UpdateShaderCaches(bool                insert,
+                                   const BinaryData*   pElfBin,
+                                   ShaderCache**       ppShaderCache,
+                                   CacheEntryHandle*   phEntry,
+                                   uint32_t            shaderCacheCount);
+#else
+    ShaderEntryState LookUpShaderCache(MetroHash::Hash*    pCacheHash,
+                                       BinaryData*         pElfBin,
+                                       CacheEntryHandle*   phEntry);
+
+    static void UpdateShaderCache(bool                insert,
+                                  const BinaryData*   pElfBin,
+                                  CacheEntryHandle    phEntry);
+#endif
+    static void BuildShaderCacheHash(Context*                                 pContext,
+                                     uint32_t                                 stageMask,
+                                     llvm::ArrayRef<llvm::ArrayRef<uint8_t>>  stageHashes,
+                                     MetroHash::Hash*                         pFragmentHash,
+                                     MetroHash::Hash*                         pNonFragmentHash);
+
+    void MergeElfBinary(Context*          pContext,
+                        const BinaryData* pFragmentElf,
+                        const BinaryData* pNonFragmentElf,
+                        ElfPackage*       pPipelineElf);
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(Compiler);
     LLPC_DISALLOW_COPY_AND_ASSIGN(Compiler);
@@ -289,33 +371,6 @@ private:
                                PipelineStatistics*     pPipelineStats) const;
 
     bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule) const;
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
-    ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
-                                        MetroHash::Hash*    pCacheHash,
-                                        BinaryData*         pElfBin,
-                                        ShaderCache**       ppShaderCache,
-                                        CacheEntryHandle*   phEntry);
-
-    void UpdateShaderCaches(bool                bInsert,
-                            const BinaryData*   pElfBin,
-                            ShaderCache**       ppShaderCache,
-                            CacheEntryHandle*   phEntry,
-                            uint32_t            shaderCacheCount);
-#else
-    ShaderEntryState LookUpShaderCache(MetroHash::Hash*    pCacheHash,
-                                       BinaryData*         pElfBin,
-                                       CacheEntryHandle*   phEntry);
-
-    void UpdateShaderCache(bool                bInsert,
-                           const BinaryData*   pElfBin,
-                           CacheEntryHandle   phEntry);
-#endif
-    void BuildShaderCacheHash(Context* pContext, MetroHash::Hash* pFragmentHash, MetroHash::Hash* pNonFragmentHash);
-
-    void MergeElfBinary(Context*          pContext,
-                        const BinaryData* pFragmentElf,
-                        const BinaryData* pNonFragmentElf,
-                        ElfPackage*       pPipelineElf);
     // -----------------------------------------------------------------------------------------------------------------
 
     std::vector<std::string>      m_options;          // Compilation options

--- a/context/llpcContext.h
+++ b/context/llpcContext.h
@@ -39,6 +39,7 @@
 #include <unordered_set>
 #include "spirvExt.h"
 
+#include "llpcBuilderContext.h"
 #include "llpcEmuLib.h"
 #include "llpcPipelineContext.h"
 
@@ -73,8 +74,8 @@ public:
         return m_pPipelineContext;
     }
 
-    // Sets LLPC builder
-    void SetBuilder(Builder* pBuilder) { m_pBuilder = pBuilder; }
+    // Create LLPC builder
+    void CreateBuilder();
 
     // Gets LLPC builder
     Builder* GetBuilder() const { return m_pBuilder; }
@@ -306,6 +307,7 @@ private:
     EmuLib                        m_glslEmuLib;        // LLVM library for GLSL emulation
     volatile  bool                m_isInUse;           // Whether this context is in use
     Builder*                      m_pBuilder = nullptr; // LLPC builder object
+    std::unique_ptr<BuilderContext> m_pBuilderContext;  // Builder context
 
     ResourceUsage*                m_pResUsage;          // External resource usage
 

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -40,7 +40,7 @@
 #undef Bool
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 37
+#define LLPC_INTERFACE_MAJOR_VERSION 38
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -51,6 +51,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     38.0 | Removed CreateShaderCache in ICompiler and pShaderCache in pipeline build info                        |
 //* |     37.0 | Removed the -enable-dynamic-loop-unroll option                                                        |
 //* |     36.0 | Add 128 bit hash as clientHash in PipelineShaderOptions                                               |
 //* |     35.0 | Added disableLicm to PipelineShaderOptions                                                            |
@@ -448,7 +449,9 @@ struct GraphicsPipelineBuildInfo
     void*               pInstance;          ///< Vulkan instance object
     void*               pUserData;          ///< User data
     OutputAllocFunc     pfnOutputAlloc;     ///< Output buffer allocator
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     IShaderCache*       pShaderCache;       ///< Shader cache, used to search for the compiled shader data
+#endif
     PipelineShaderInfo  vs;                 ///< Vertex shader
     PipelineShaderInfo  tcs;                ///< Tessellation control shader
     PipelineShaderInfo  tes;                ///< Tessellation evaluation shader
@@ -519,7 +522,9 @@ struct ComputePipelineBuildInfo
     void*               pInstance;          ///< Vulkan instance object
     void*               pUserData;          ///< User data
     OutputAllocFunc     pfnOutputAlloc;     ///< Output buffer allocator
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     IShaderCache*       pShaderCache;       ///< Shader cache, used to search for the compiled shader data
+#endif
     uint32_t            deviceIndex;        ///< Device index for device group
     PipelineShaderInfo  cs;                 ///< Compute shader
     PipelineOptions     options;            ///< Per pipeline tuning options
@@ -756,6 +761,7 @@ public:
                                         ComputePipelineBuildOut*        pPipelineOut,
                                         void*                           pPipelineDumpFile = nullptr) = 0;
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     /// Creates a shader cache object with the requested properties.
     ///
     /// @param [in]  pCreateInfo    Create info of the shader cache.
@@ -765,6 +771,7 @@ public:
     virtual Result CreateShaderCache(
         const ShaderCacheCreateInfo* pCreateInfo,
         IShaderCache**               ppShaderCache) = 0;
+#endif
 
 protected:
     ICompiler() {}

--- a/lower/llpcSpirvLower.cpp
+++ b/lower/llpcSpirvLower.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Vectorize.h"
 
+#include "llpcBuilder.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
 #include "llpcPassManager.h"
@@ -85,7 +86,7 @@ void SpirvLower::AddPasses(
     uint32_t              forceLoopUnrollCount)   // 0 or force loop unroll count
 {
     // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-    AddTargetLibInfo(pContext, &passMgr);
+    pContext->GetBuilder()->PreparePassManager(&passMgr);
 
     // Start timer for lowering passes.
     if (pLowerTimer != nullptr)

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -124,6 +124,7 @@ endif
         llpcFragColorExport.cpp             \
         llpcPatch.cpp                       \
         llpcPatchBufferOp.cpp               \
+        llpcPatchCheckShaderCache.cpp       \
         llpcPatchCopyShader.cpp             \
         llpcPatchDescriptorLoad.cpp         \
         llpcPatchEntryPointMutate.cpp       \

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -68,6 +68,7 @@ ifeq ($(ICD_BUILD_LLPC), 1)
     # llpc/builder
     CPPFILES +=                             \
         llpcBuilder.cpp                     \
+        llpcBuilderContext.cpp              \
         llpcBuilderImpl.cpp                 \
         llpcBuilderImplArith.cpp            \
         llpcBuilderImplDesc.cpp             \

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -258,14 +258,12 @@ void CodeGenManager::SetupTargetFeatures(
 
 // =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
-Result CodeGenManager::AddTargetPasses(
+void CodeGenManager::AddTargetPasses(
     Context*              pContext,      // [in] LLPC context
     PassManager&          passMgr,       // [in/out] pass manager to add passes to
-    llvm::Timer*          pCodeGenTimer, // [in] Timer to time target passes with, nullptr if not timing
+    Timer*                pCodeGenTimer, // [in] Timer to time target passes with, nullptr if not timing
     raw_pwrite_stream&    outStream)     // [out] Output stream
 {
-    Result result = Result::Success;
-
     // Start timer for codegen passes.
     if (pCodeGenTimer != nullptr)
     {
@@ -295,30 +293,16 @@ Result CodeGenManager::AddTargetPasses(
 
     auto pTargetMachine = pContext->GetTargetMachine();
 
-#if LLPC_ENABLE_EXCEPTION
-    try
-#endif
+    if (pTargetMachine->addPassesToEmitFile(passMgr, outStream, nullptr, FileType))
     {
-        if (pTargetMachine->addPassesToEmitFile(passMgr, outStream, nullptr, FileType))
-        {
-            LLPC_ERRS("Target machine cannot emit a file of this type\n");
-            result = Result::ErrorInvalidValue;
-        }
+        report_fatal_error("Target machine cannot emit a file of this type");
     }
-#if LLPC_ENABLE_EXCEPTION
-    catch (const char*)
-    {
-        result = Result::ErrorInvalidValue;
-    }
-#endif
 
     // Stop timer for codegen passes.
     if (pCodeGenTimer != nullptr)
     {
         passMgr.add(CreateStartStopTimer(pCodeGenTimer, false));
     }
-
-    return result;
 }
 
 } // Llpc

--- a/patch/llpcCodeGenManager.h
+++ b/patch/llpcCodeGenManager.h
@@ -83,10 +83,10 @@ public:
 
     static void SetupTargetFeatures(llvm::Module* pModule);
 
-    static Result AddTargetPasses(Context*                    pContext,
-                                  PassManager&                passMgr,
-                                  llvm::Timer*                pCodeGenTimer,
-                                  llvm::raw_pwrite_stream&    outStream);
+    static void AddTargetPasses(Context*                    pContext,
+                                PassManager&                passMgr,
+                                llvm::Timer*                pCodeGenTimer,
+                                llvm::raw_pwrite_stream&    outStream);
 
     static Result Run(llvm::Module*               pModule,
                       llvm::legacy::PassManager&  passMgr);

--- a/patch/llpcPatchCheckShaderCache.cpp
+++ b/patch/llpcPatchCheckShaderCache.cpp
@@ -1,0 +1,164 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPatchCheckShaderCache.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::PatchCheckShaderCache.
+ ***********************************************************************************************************************
+ */
+#define DEBUG_TYPE "llpc-patch-check-shader-cache"
+
+#include "llvm/Support/Debug.h"
+
+#include "llpcPatchCheckShaderCache.h"
+#include "llpcPipelineShaders.h"
+
+using namespace llvm;
+using namespace Llpc;
+
+// =====================================================================================================================
+// Initializes static members.
+char PatchCheckShaderCache::ID = 0;
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Pass creator, creates the pass of LLVM patching operations for checking shader cache
+PatchCheckShaderCache* CreatePatchCheckShaderCache()
+{
+    return new PatchCheckShaderCache();
+}
+
+} // Llpc
+
+namespace
+{
+
+// =====================================================================================================================
+// Stream each map key and value for later inclusion in a hash
+template <class MapType>
+static void StreamMapEntries(MapType&     map,    // [in] Map to stream
+                             raw_ostream& stream) // [in/out] Stream to output map entries to
+{
+    size_t mapCount = map.size();
+    stream << StringRef(reinterpret_cast<const char*>(&mapCount), sizeof(mapCount));
+    for (auto mapIt : map)
+    {
+        stream << StringRef(reinterpret_cast<const char*>(&mapIt.first), sizeof(mapIt.first));
+        stream << StringRef(reinterpret_cast<const char*>(&mapIt.second), sizeof(mapIt.second));
+    }
+}
+
+} // anonymous
+
+// =====================================================================================================================
+PatchCheckShaderCache::PatchCheckShaderCache()
+    :
+    Patch(ID)
+{
+    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
+    initializePatchCheckShaderCachePass(*PassRegistry::getPassRegistry());
+}
+
+// =====================================================================================================================
+// Executes this LLVM patching pass on the specified LLVM module.
+bool PatchCheckShaderCache::runOnModule(
+    Module& module)  // [in,out] LLVM module to be run on
+{
+    LLVM_DEBUG(dbgs() << "Run the pass Patch-Check-Shader-Cache\n");
+
+    if (m_callbackFunc == nullptr)
+    {
+        // No shader cache in use.
+        return false;
+    }
+
+    Patch::Init(&module);
+
+    std::string inOutUsageStreams[ShaderStageGfxCount];
+    ArrayRef<uint8_t> inOutUsageValues[ShaderStageGfxCount];
+    auto stageMask = m_pContext->GetShaderStageMask();
+
+    // Build input/output layout hash per shader stage
+    for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1))
+    {
+        if ((stageMask & ShaderStageToMask(stage)) == 0)
+        {
+            continue;
+        }
+
+        auto pResUsage = m_pContext->GetShaderResourceUsage(stage);
+        raw_string_ostream stream(inOutUsageStreams[stage]);
+
+        // Update input/output usage
+        StreamMapEntries(pResUsage->inOutUsage.inputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.outputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchOutputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.builtInInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.builtInOutputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchBuiltInInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchBuiltInOutputLocMap, stream);
+
+        if (stage == ShaderStageGeometry)
+        {
+            // NOTE: For geometry shader, copy shader will use this special map info (from built-in outputs to
+            // locations of generic outputs). We have to add it to shader hash calculation.
+            StreamMapEntries(pResUsage->inOutUsage.gs.builtInOutLocs, stream);
+        }
+
+        // Store the result of the hash for this shader stage.
+        stream.flush();
+        inOutUsageValues[stage] = ArrayRef<uint8_t>(reinterpret_cast<const uint8_t*>(inOutUsageStreams[stage].data()),
+                                                    inOutUsageStreams[stage].size());
+    }
+
+    // Ask callback function if it wants to remove any shader stages.
+    uint32_t modifiedStageMask = m_callbackFunc(&module, stageMask, inOutUsageValues);
+    if (modifiedStageMask == stageMask)
+    {
+        return false;
+    }
+
+    // "Remove" a shader stage by making its entry-point function internal, so it gets removed later.
+    for (auto& func : module)
+    {
+        if ((func.empty() == false) && (func.getLinkage() != GlobalValue::InternalLinkage))
+        {
+            auto stage = GetShaderStageFromFunction(&func);
+            if ((stage != ShaderStageInvalid) && ((ShaderStageToMask(stage) & ~modifiedStageMask) != 0))
+            {
+                func.setLinkage(GlobalValue::InternalLinkage);
+            }
+        }
+    }
+    return true;
+}
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patch operations for checking shader cache
+INITIALIZE_PASS(PatchCheckShaderCache, DEBUG_TYPE,
+                "Patch LLVM for checking shader cache", false, false)

--- a/patch/llpcPatchCheckShaderCache.h
+++ b/patch/llpcPatchCheckShaderCache.h
@@ -1,0 +1,76 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPatchCheckShaderCache.h
+ * @brief LLPC header file: contains declaration of class Llpc::PatchCheckShaderCache
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcPatch.h"
+#include "llpcPipelineShaders.h"
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for checking shader cache
+class PatchCheckShaderCache:
+    public Patch
+{
+public:
+    PatchCheckShaderCache();
+
+    void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
+    {
+        analysisUsage.addRequired<PipelineShaders>();
+    }
+
+    virtual bool runOnModule(llvm::Module& module) override;
+
+    // Set the callback function that this pass uses to ask the front-end whether it wants to remove
+    // any shader stages. The function takes the LLVM IR module and a per-shader-stage array of input/output
+    // usage checksums, and it returns the shader stage mask with bits removed for shader stages that it wants
+    // removed.
+    void SetCallbackFunction(
+        std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)> callbackFunc)
+    {
+        m_callbackFunc = callbackFunc;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    static char ID;   // ID of this pass
+
+private:
+    LLPC_DISALLOW_COPY_AND_ASSIGN(PatchCheckShaderCache);
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>   m_callbackFunc;
+};
+
+} // Llpc

--- a/patch/llpcPatchPreparePipelineAbi.cpp
+++ b/patch/llpcPatchPreparePipelineAbi.cpp
@@ -54,12 +54,10 @@ class PatchPreparePipelineAbi final : public Patch
 public:
     static char ID;
     PatchPreparePipelineAbi(
-        bool    onlySetCallingConvs = false,
-        uint32_t skipStageMask = 0)
+        bool    onlySetCallingConvs = false)
         :
         Patch(ID),
-        m_onlySetCallingConvs(onlySetCallingConvs),
-        m_skipStageMask(skipStageMask)
+        m_onlySetCallingConvs(onlySetCallingConvs)
     {
         initializePipelineShadersPass(*llvm::PassRegistry::getPassRegistry());
         initializePatchPreparePipelineAbiPass(*PassRegistry::getPassRegistry());
@@ -102,7 +100,6 @@ private:
     GfxIpVersion      m_gfxIp;               // Graphics IP version info
 
     const bool        m_onlySetCallingConvs; // Whether to only set the calling conventions
-    const uint32_t    m_skipStageMask;       // Mask indicating which shader stages should be skipped in processing
 };
 
 char PatchPreparePipelineAbi::ID = 0;
@@ -112,10 +109,9 @@ char PatchPreparePipelineAbi::ID = 0;
 // =====================================================================================================================
 // Create pass to prepare the pipeline ABI
 ModulePass* Llpc::CreatePatchPreparePipelineAbi(
-    bool     onlySetCallingConvs, // Should we only set the calling conventions, or do the full prepare.
-    uint32_t skipStageMask)       // Mask of stages to be skipped
+    bool     onlySetCallingConvs) // Should we only set the calling conventions, or do the full prepare.
 {
-    return new PatchPreparePipelineAbi(onlySetCallingConvs, skipStageMask);
+    return new PatchPreparePipelineAbi(onlySetCallingConvs);
 }
 
 // =====================================================================================================================
@@ -354,15 +350,7 @@ void PatchPreparePipelineAbi::SetCallingConv(
     auto pEntryPoint = m_pPipelineShaders->GetEntryPoint(shaderStage);
     if (pEntryPoint != nullptr)
     {
-        if (m_skipStageMask & ShaderStageToMask(shaderStage))
-        {
-            pEntryPoint->setLinkage(GlobalValue::InternalLinkage);
-            pEntryPoint->setCallingConv(CallingConv::C);
-        }
-        else
-        {
-            pEntryPoint->setCallingConv(callingConv);
-        }
+        pEntryPoint->setCallingConv(callingConv);
     }
 }
 

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -267,7 +267,7 @@ ShaderStage GetShaderStageFromModule(
 // =====================================================================================================================
 // Gets the shader stage from the specified LLVM function. Returns ShaderStageInvalid if not shader entrypoint.
 ShaderStage GetShaderStageFromFunction(
-    Function* pFunc)  // [in] LLVM function
+    const Function* pFunc)  // [in] LLVM function
 {
     // First check for the metadata that is added by the builder. This works in the patch phase.
     MDNode* pStageMetaNode = pFunc->getMetadata(LlpcName::ShaderStageMetadata);

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -748,30 +748,4 @@ bool IsIsaText(
     return (dataSize != 0) && ((reinterpret_cast<const char*>(pData))[0] == '\t');
 }
 
-// =====================================================================================================================
-// Manually add a target-aware TLI pass, so middle-end optimizations do not think that we have library functions.
-void AddTargetLibInfo(
-    Context*              pContext,   // [in] LLPC context
-    legacy::PassManager*  pPassMgr)   // [in/out] Pass manager
-{
-    TargetLibraryInfoImpl targetLibInfo(pContext->GetTargetMachine()->getTargetTriple());
-
-    // Adjust it to allow memcpy and memset.
-    // TODO: Investigate why the latter is necessary. I found that
-    // test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
-    // got unrolled far too much, and at too late a stage for the descriptor loads to be commoned up. It might
-    // be an unfortunate interaction between LoopIdiomRecognize and fat pointer laundering.
-    targetLibInfo.setAvailable(LibFunc_memcpy);
-    targetLibInfo.setAvailable(LibFunc_memset);
-
-    // Also disallow tan functions.
-    // TODO: This can be removed once we have LLVM fix D67406.
-    targetLibInfo.setUnavailable(LibFunc_tan);
-    targetLibInfo.setUnavailable(LibFunc_tanf);
-    targetLibInfo.setUnavailable(LibFunc_tanl);
-
-    auto pTargetLibInfoPass = new TargetLibraryInfoWrapperPass(targetLibInfo);
-    pPassMgr->add(pTargetLibInfoPass);
-}
-
 } // Llpc

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -266,7 +266,7 @@ ShaderStage GetShaderStageFromModule(llvm::Module* pModule);
 void SetShaderStageToModule(llvm::Module* pModule, ShaderStage shaderStage);
 
 // Gets the shader stage from the specified LLVM function.
-ShaderStage GetShaderStageFromFunction(llvm::Function* pFunc);
+ShaderStage GetShaderStageFromFunction(const llvm::Function* pFunc);
 
 // Gets the shader stage from the specified calling convention.
 ShaderStage GetShaderStageFromCallingConv(uint32_t stageMask, llvm::CallingConv::ID callConv);

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -32,9 +32,7 @@
 
 #include <unordered_set>
 
-#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 
 #include "spirvExt.h"
@@ -78,13 +76,6 @@ void initializePassDeadFuncRemovePass(PassRegistry&);
 void initializePassExternalLibLinkPass(PassRegistry&);
 void initializePipelineShadersPass(PassRegistry&);
 void initializeStartStopTimerPass(PassRegistry&);
-
-namespace legacy
-{
-
-class PassManager;
-
-} // legacy
 
 } // llvm
 
@@ -312,8 +303,5 @@ bool IsElfBinary(const void* pData, size_t dataSize);
 
 // Checks whether the output data is actually ISA assembler text
 bool IsIsaText(const void* pData, size_t dataSize);
-
-// Manually add a target-aware TLI pass, so middle-end optimizations do not think that we have library functions.
-void AddTargetLibInfo(Context* pContext, llvm::legacy::PassManager* pPassMgr);
 
 } // Llpc


### PR DESCRIPTION
    Part of the drive to clean up the interface from the front-end into the
    middle-end.
    
    Builder now only allocates a PipelineState if it was not given one via
    Builder::SetPipelineState. The inner BuilderImpl created by
    BuilderReplayer now has the outer PipelineState passed in to it.
    
    This commit also manually adds PipelineStateWrapper to the middle-end
    pass manager so it can give it the PipelineState it already has.
