### PR TITLE
Add NGG support to GS

### DIFF
--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -303,7 +303,6 @@ bool GraphicsContext::CheckGsOnChipValidity()
     const bool hasGs = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);
 #endif
 
-    auto pEsResUsage = GetShaderResourceUsage(hasTs ? ShaderStageTessEval : ShaderStageVertex);
     auto pGsResUsage = GetShaderResourceUsage(ShaderStageGeometry);
 
     uint32_t inVertsPerPrim = 0;
@@ -355,7 +354,7 @@ bool GraphicsContext::CheckGsOnChipValidity()
     {
         uint32_t gsPrimsPerSubgroup = m_pGpuProperty->gsOnChipDefaultPrimsPerSubgroup;
 
-        const uint32_t esGsRingItemSize = 4 * std::max(1u, pEsResUsage->inOutUsage.outputMapLocCount);
+        const uint32_t esGsRingItemSize = 4 * std::max(1u, pGsResUsage->inOutUsage.inputMapLocCount);
         const uint32_t gsInstanceCount  = pGsResUsage->builtInUsage.gs.invocations;
         const uint32_t gsVsRingItemSize = 4 * std::max(1u,
                                                        (pGsResUsage->inOutUsage.outputMapLocCount *
@@ -647,7 +646,7 @@ bool GraphicsContext::CheckGsOnChipValidity()
                                                    GetShaderWaveSize(ShaderStageGeometry));
 
             // NOTE: Make esGsRingItemSize odd by "| 1", to optimize ES -> GS ring layout for LDS bank conflicts.
-            const uint32_t esGsRingItemSize = (4 * std::max(1u, pEsResUsage->inOutUsage.outputMapLocCount)) | 1;
+            const uint32_t esGsRingItemSize = (4 * std::max(1u, pGsResUsage->inOutUsage.inputMapLocCount)) | 1;
 
             const uint32_t gsVsRingItemSize = 4 * std::max(1u,
                                                            (pGsResUsage->inOutUsage.outputMapLocCount *

--- a/patch/gfx9/llpcNggPrimShader.h
+++ b/patch/gfx9/llpcNggPrimShader.h
@@ -70,11 +70,12 @@ private:
     llvm::FunctionType* GeneratePrimShaderEntryPointType(uint64_t* pInRegMask) const;
     llvm::Function* GeneratePrimShaderEntryPoint(llvm::Module* pModule);
 
+    void ConstructPrimShaderWithoutGs(llvm::Module* pModule);
     void ConstructPrimShaderWithGs(llvm::Module* pModule);
 
     void InitWaveThreadInfo(llvm::Value* pMergedGroupInfo, llvm::Value* pMergedWaveInfo);
 
-    llvm::Value* DoCulling(llvm::Module* pModule, llvm::BasicBlock* pInsertAtEnd);
+    llvm::Value* DoCulling(llvm::Module* pModule);
     void DoParamCacheAllocRequest();
     void DoPrimitiveExport(llvm::Value* pCullFlag = nullptr);
 
@@ -140,47 +141,39 @@ private:
                                    llvm::Value*      pCullFlag,
                                    llvm::Value*      pVertex0,
                                    llvm::Value*      pVertex1,
-                                   llvm::Value*      pVertex2,
-                                   llvm::BasicBlock* pInsertAtEnd);
+                                   llvm::Value*      pVertex2);
 
     llvm::Value* DoFrustumCulling(llvm::Module*     pModule,
                                   llvm::Value*      pCullFlag,
                                   llvm::Value*      pVertex0,
                                   llvm::Value*      pVertex1,
-                                  llvm::Value*      pVertex2,
-                                  llvm::BasicBlock* pInsertAtEnd);
+                                  llvm::Value*      pVertex2);
 
     llvm::Value* DoBoxFilterCulling(llvm::Module*     pModule,
                                     llvm::Value*      pCullFlag,
                                     llvm::Value*      pVertex0,
                                     llvm::Value*      pVertex1,
-                                    llvm::Value*      pVertex2,
-                                    llvm::BasicBlock* pInsertAtEnd);
+                                    llvm::Value*      pVertex2);
 
     llvm::Value* DoSphereCulling(llvm::Module*     pModule,
                                  llvm::Value*      pCullFlag,
                                  llvm::Value*      pVertex0,
                                  llvm::Value*      pVertex1,
-                                 llvm::Value*      pVertex2,
-                                 llvm::BasicBlock* pInsertAtEnd);
+                                 llvm::Value*      pVertex2);
 
     llvm::Value* DoSmallPrimFilterCulling(llvm::Module*     pModule,
                                           llvm::Value*      pCullFlag,
                                           llvm::Value*      pVertex0,
                                           llvm::Value*      pVertex1,
-                                          llvm::Value*      pVertex2,
-                                          llvm::BasicBlock* pInsertAtEnd);
+                                          llvm::Value*      pVertex2);
 
     llvm::Value* DoCullDistanceCulling(llvm::Module*     pModule,
                                        llvm::Value*      pCullFlag,
                                        llvm::Value*      pSignMask0,
                                        llvm::Value*      pSignMask1,
-                                       llvm::Value*      pSignMask2,
-                                       llvm::BasicBlock* pInsertAtEnd);
+                                       llvm::Value*      pSignMask2);
 
-    llvm::Value* FetchCullingControlRegister(llvm::Module*     pModule,
-                                             uint32_t          regOffset,
-                                             llvm::BasicBlock* pInsertAtEnd);
+    llvm::Value* FetchCullingControlRegister(llvm::Module* pModule, uint32_t regOffset);
 
     llvm::Function* CreateBackfaceCuller(llvm::Module* pModule);
     llvm::Function* CreateFrustumCuller(llvm::Module* pModule);


### PR DESCRIPTION
- Add the generation of ES-only primitive shader to a separate function.
- Remove redundant parameter pInsertAtEnd.
- Correct an issue of incorrect LDS offset value.
- Always use GS usage when calculate on-chip/off-chip GS parameters. This
  is for standalone compiler to handle GS-only shader without a complete
  pipeline.