### PR TITLE
Mark stores to ring buffers as operating on swizzled buffer

### DIFF
--- a/patch/llpcIntrinsDefs.h
+++ b/patch/llpcIntrinsDefs.h
@@ -605,10 +605,11 @@ union CoherentFlag
         uint32_t slc    :  1;   // System level coherence
 #if LLPC_BUILD_GFX10
         uint32_t dlc    :  1;   // Device level coherence
-        uint32_t        :  29;
 #else
-        uint32_t        :  30;
+        uint32_t        :  1;
 #endif
+        uint32_t swz    :  1;   // Swizzled buffer
+        uint32_t        :  28;
     } bits;
 
     uint32_t u32All;


### PR DESCRIPTION
Set "swz" bit on store buffer intrinsics used for GS-VS and ES-GS ring write accesses.
Ring read accesses do not need that option set.

Setting "swz" on the intrinsic will ensure that TBUFFER_STORE instructions are not
merged in the backend. Merging of TBUFFER_LOAD and TBUFFER_STORE instructions
will be done imminently (currently not performed).