### PR TITLE
Pass color export state into Builder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,7 @@ if(ICD_BUILD_LLPC)
         patch/llpcFragColorExport.cpp
         patch/llpcPatch.cpp
         patch/llpcPatchBufferOp.cpp
+        patch/llpcPatchCheckShaderCache.cpp
         patch/llpcPatchCopyShader.cpp
         patch/llpcPatchDescriptorLoad.cpp
         patch/llpcPatchEntryPointMutate.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if(ICD_BUILD_LLPC)
 # llpc/builder
     target_sources(llpc PRIVATE
         builder/llpcBuilder.cpp
+        builder/llpcBuilderContext.cpp
         builder/llpcBuilderImpl.cpp
         builder/llpcBuilderImplArith.cpp
         builder/llpcBuilderImplDesc.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ if(ICD_BUILD_LLPC)
         builder/llpcBuilderRecorder.cpp
         builder/llpcBuilderReplayer.cpp
         builder/llpcPipelineState.cpp
+        builder/llpcTargetInfo.cpp
     )
 
 # llpc/context

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -104,6 +104,14 @@ Type* Builder::GetConditionallyVectorizedTy(
 }
 
 // =====================================================================================================================
+// Set the mask of shader stages that are present in the pipeline.
+void Builder::SetShaderStageMask(
+    uint32_t mask)  // Mask of shader stages
+{
+    GetPipelineState()->SetShaderStageMask(mask);
+}
+
+// =====================================================================================================================
 // Set the resource mapping nodes for the given shader stage.
 // This stores the nodes as IR metadata.
 void Builder::SetUserDataNodes(

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -122,6 +122,42 @@ void Builder::SetUserDataNodes(
 }
 
 // =====================================================================================================================
+// Set the device index.
+void Builder::SetDeviceIndex(
+    uint32_t    deviceIndex)        // Device index
+{
+    GetPipelineState()->SetDeviceIndex(deviceIndex);
+}
+
+// =====================================================================================================================
+// Set input-assembly state.
+// The client should always zero-initialize the struct before setting it up, in case future versions
+// add more fields. A local struct variable can be zero-initialized with " = {}".
+void Builder::SetInputAssemblyState(
+    const InputAssemblyState& iaState)    // [in] Input-assembly state
+{
+    GetPipelineState()->SetInputAssemblyState(iaState);
+}
+
+// =====================================================================================================================
+// Set viewport state.
+// The client should always zero-initialize the struct before setting it up, in case future versions
+// add more fields. A local struct variable can be zero-initialized with " = {}".
+void Builder::SetViewportState(
+    const ViewportState&      vpState)    // [in] Viewport state
+{
+    GetPipelineState()->SetViewportState(vpState);
+}
+
+// =====================================================================================================================
+// Set rasterizer state.
+void Builder::SetRasterizerState(
+    const RasterizerState&  rsState)    // [in] Rasterizer state
+{
+    GetPipelineState()->SetRasterizerState(rsState);
+}
+
+// =====================================================================================================================
 // Base implementation of linking shader modules into a pipeline module.
 Module* Builder::Link(
     ArrayRef<Module*> modules,               // Array of modules indexed by shader stage, with nullptr entry

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -49,45 +49,22 @@
 using namespace Llpc;
 using namespace llvm;
 
-// -use-builder-recorder
-static cl::opt<uint32_t> UseBuilderRecorder("use-builder-recorder",
-                                            cl::desc("Do lowering via recording and replaying LLPC builder:\n"
-                                                     "0: Generate IR directly; no recording\n"
-                                                     "1: Do lowering via recording and replaying LLPC builder (default)\n"
-                                                     "2: Do lowering via recording; no replaying"),
-                                            cl::init(1));
-
-// =====================================================================================================================
-// Create a Builder object
-// If -use-builder-recorder is 0, this creates a BuilderImpl. Otherwise, it creates a BuilderRecorder.
-Builder* Builder::Create(
-    LLVMContext& context) // [in] LLVM context
-{
-    if (UseBuilderRecorder == 0)
-    {
-        // -use-builder-recorder=0: generate LLVM IR directly without recording
-        return CreateBuilderImpl(context);
-    }
-    // -use-builder-recorder=1: record with BuilderRecorder and replay with BuilderReplayer
-    // -use-builder-recorder=2: record with BuilderRecorder and do not replay
-    return CreateBuilderRecorder(context, UseBuilderRecorder == 1 /*wantReplay*/);
-}
-
 // =====================================================================================================================
 // Create a BuilderImpl object
 Builder* Builder::CreateBuilderImpl(
-    LLVMContext& context) // [in] LLVM context
+    BuilderContext* pBuilderContext) // [in] Builder context
 {
-    return new BuilderImpl(context);
+    return new BuilderImpl(pBuilderContext);
 }
 
 // =====================================================================================================================
 Builder::Builder(
-    LLVMContext& context) // [in] LLPC context
+    BuilderContext* pBuilderContext) // [in] Builder context
     :
-    IRBuilder<>(context)
+    IRBuilder<>(pBuilderContext->GetContext()),
+    m_pBuilderContext(pBuilderContext)
 {
-    m_pPipelineState = new PipelineState(&context);
+    m_pPipelineState = new PipelineState(&getContext());
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -171,7 +171,7 @@ Module* Builder::Link(
         pPipelineModule->setModuleIdentifier("llpcPipeline");
 
         // Record pipeline state into IR metadata.
-        GetPipelineState()->RecordState(pPipelineModule);
+        GetPipelineState()->Flush(pPipelineModule);
     }
     else
     {
@@ -183,10 +183,7 @@ Module* Builder::Link(
         static_cast<Llpc::Context*>(&getContext())->SetModuleTargetMachine(pPipelineModule);
         Linker linker(*pPipelineModule);
 
-        if (m_pPipelineState != nullptr)
-        {
-            m_pPipelineState->RecordState(pPipelineModule);
-        }
+        GetPipelineState()->Flush(pPipelineModule);
 
         for (int32_t shaderIndex = 0; shaderIndex < modules.size(); ++shaderIndex)
         {
@@ -253,6 +250,9 @@ void Builder::Generate(
                      pPatchTimer,
                      pOptTimer,
                      checkShaderCacheFunc);
+
+    // Add pass to clear pipeline state from IR
+    patchPassMgr.add(CreatePipelineStateClearer());
 
     // Run the "whole pipeline" passes, excluding the target backend.
     patchPassMgr.run(*pipelineModule);

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -167,6 +167,17 @@ void Builder::SetRasterizerState(
 }
 
 // =====================================================================================================================
+// Set color export state.
+// The client should always zero-initialize the ColorExportState struct before setting it up, in case future
+// versions add more fields. A local struct variable can be zero-initialized with " = {}".
+void Builder::SetColorExportState(
+    ArrayRef<ColorExportFormat> formats,      // Array of ColorExportFormat structs
+    const ColorExportState&     exportState)  // [in] Color export flags
+{
+    GetPipelineState()->SetColorExportState(formats, exportState);
+}
+
+// =====================================================================================================================
 // Base implementation of linking shader modules into a pipeline module.
 Module* Builder::Link(
     ArrayRef<Module*> modules,               // Array of modules indexed by shader stage, with nullptr entry

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -130,6 +130,15 @@ void Builder::SetDeviceIndex(
 }
 
 // =====================================================================================================================
+// Set vertex input descriptions. Each location referenced in a call to CreateReadGenericInput in the
+// vertex shader must have a corresponding description provided here.
+void Builder::SetVertexInputDescriptions(
+    ArrayRef<VertexInputDescription>  inputs)   // Array of vertex input descriptions
+{
+    GetPipelineState()->SetVertexInputDescriptions(inputs);
+}
+
+// =====================================================================================================================
 // Set input-assembly state.
 // The client should always zero-initialize the struct before setting it up, in case future versions
 // add more fields. A local struct variable can be zero-initialized with " = {}".

--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -256,18 +256,12 @@ void Builder::Generate(
 
     // Run the "whole pipeline" passes, excluding the target backend.
     patchPassMgr.run(*pipelineModule);
-#if LLPC_BUILD_GFX10
-    // NOTE: Ideally, target feature setup should be added to the last pass in patching. But NGG is somewhat
-    // different in that it must involve extra LLVM optimization passes after preparing pipeline ABI. Thus,
-    // we do target feature setup here.
-#endif
-    CodeGenManager::SetupTargetFeatures(&*pipelineModule);
 
     // A separate "whole pipeline" pass manager for code generation.
     PassManager codeGenPassMgr(&passIndex);
 
     // Code generation.
-    CodeGenManager::AddTargetPasses(&getContext(), codeGenPassMgr, pCodeGenTimer, outStream);
+    GetBuilderContext()->AddTargetPasses(codeGenPassMgr, pCodeGenTimer, outStream);
 
     // Run the target backend codegen passes.
     codeGenPassMgr.run(*pipelineModule);

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -177,6 +177,96 @@ public:
         ArrayRef<ResourceMappingNode>   nodes,            // The resource mapping nodes
         ArrayRef<DescriptorRangeValue>  rangeValues);     // The descriptor range values
 
+    // Set the device index.
+    void SetDeviceIndex(
+        uint32_t    deviceIndex);       // Device index
+
+    // Primitive topology. These happen to have the same values as the corresponding Vulkan enum.
+    enum class PrimitiveTopology
+    {
+        PointList = 0,
+        LineList = 1,
+        LineStrip = 2,
+        TriangleList = 3,
+        TriangleStrip = 4,
+        TriangleFan = 5,
+        LineListWithAdjacency = 6,
+        LineStripWithAdjacency = 7,
+        TriangleListWithAdjacency = 8,
+        TriangleStripWithAdjacency = 9,
+        PatchList = 10,
+    };
+
+    // Struct to pass to SetInputAssemblyState
+    struct InputAssemblyState
+    {
+        PrimitiveTopology topology;           // Primitive topology
+        uint32_t          patchControlPoints; // Number of control points for PrimitiveTopology::PatchList
+        bool              disableVertexReuse; // Disable reusing vertex shader output for indexed draws
+        bool              switchWinding;      // Whether to reverse vertex ordering for tessellation
+        bool              enableMultiView;    // Whether to enable multi-view support
+    };
+
+    // Set input-assembly state, passing the struct above.
+    // The client should always zero-initialize the struct before setting it up, in case future versions
+    // add more fields. A local struct variable can be zero-initialized with " = {}".
+    void SetInputAssemblyState(
+        const InputAssemblyState& iaState);   // [in] Input-assembly state
+
+    // Struct to pass to SetViewportState
+    struct ViewportState
+    {
+        bool              depthClipEnable;    // Enable clipping based on Z coordinate
+    };
+
+    // Set viewport state, passing the struct above.
+    // The client should always zero-initialize the struct before setting it up, in case future versions
+    // add more fields. A local struct variable can be zero-initialized with " = {}".
+    void SetViewportState(
+        const ViewportState&      vpState);   // [in] Viewport state
+
+    // Polygon mode. These happen to have the same values as the corresponding Vulkan enum.
+    enum PolygonMode
+    {
+        PolygonModeFill = 0,
+        PolygonModeLine = 1,
+        PolygonModePoint = 2,
+    };
+
+    // Fragment cull mode flags. These happen to have the same values as the corresponding Vulkan enum.
+    enum CullModeFlags
+    {
+        CullModeNone = 0,
+        CullModeFront = 1,
+        CullModeBack = 2,
+        CullModeFrontAndBack = 3,
+    };
+
+    // Struct to pass to SetRasterizerState
+    struct RasterizerState
+    {
+        bool          rasterizerDiscardEnable;  // Kill all rasterized pixels. This is implicitly true if stream out
+                                                //  is enabled and no streams are rasterized
+        bool          innerCoverage;            // Related to conservative rasterization.  Must be false if
+                                                //  conservative rasterization is disabled.
+        bool          perSampleShading;         // Enable per sample shading
+        uint32_t      numSamples;               // Number of coverage samples used when rendering with this pipeline
+        uint32_t      samplePatternIdx;         // Index into the currently bound MSAA sample pattern table that
+                                                //  matches the sample pattern used by the rasterizer when rendering
+                                                //  with this pipeline.
+        uint8_t       usrClipPlaneMask;         // Mask to indicate the enabled user defined clip planes
+        PolygonMode   polygonMode;              // Polygon mode
+        CullModeFlags cullMode;                 // Fragment culling mode
+        bool          frontFaceClockwise;       // Front-facing triangle orientation: false=counter, true=clockwise
+        bool          depthBiasEnable;          // Whether to bias fragment depth values
+    };
+
+    // Set rasterizer state, passing the struct above.
+    // The client should always zero-initialize the struct before setting it up, in case future versions
+    // add more fields. A local struct variable can be zero-initialized with " = {}".
+    void SetRasterizerState(
+        const RasterizerState&  rsState);   // [in] Rasterizer state
+
     // -----------------------------------------------------------------------------------------------------------------
     // Methods to link and generate pipeline
 

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -102,6 +102,7 @@ inline static void InitializeBuilderPasses(
 //
 // 5. Call Builder::Link to link the shader IR modules into a pipeline IR module. (This needs to be
 //    done even if the pipeline only has a single shader, such as a compute pipeline.)
+//    if using BuilderRecorder, this also records the pipeline state into IR metadata.
 //
 // 6. Call Builder::Generate to run middle-end and back-end passes and generate the ELF.
 //    (Global options such as -filetype and -emit-llvm cause the output to be something other than ELF.)
@@ -200,7 +201,7 @@ public:
     // Output is written to outStream.
     // Like other Builder methods, on error, this calls report_fatal_error, which you can catch by setting
     // a diagnostic handler with LLVMContext::setDiagnosticHandler.
-    void Generate(
+    virtual void Generate(
         std::unique_ptr<Module>   pipelineModule,       // IR pipeline module
         raw_pwrite_stream&        outStream,            // [in/out] Stream to write ELF or IR disassembly output
         CheckShaderCacheFunc      checkShaderCacheFunc, // Function to check shader cache in graphics pipeline

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -181,6 +181,76 @@ public:
     void SetDeviceIndex(
         uint32_t    deviceIndex);       // Device index
 
+    // Data format of vertex buffer entry. For ones that exist in GFX9 hardware, these match the hardware
+    // encoding. But this also includes extra formats.
+    enum BufDataFormat
+    {
+        BufDataFormatInvalid                     = 0,
+        BufDataFormat8                           = 1,
+        BufDataFormat16                          = 2,
+        BufDataFormat8_8                         = 3,
+        BufDataFormat32                          = 4,
+        BufDataFormat16_16                       = 5,
+        BufDataFormat10_11_11                    = 6,
+        BufDataFormat11_11_10                    = 7,
+        BufDataFormat10_10_10_2                  = 8,
+        BufDataFormat2_10_10_10                  = 9,
+        BufDataFormat8_8_8_8                     = 10,
+        BufDataFormat32_32                       = 11,
+        BufDataFormat16_16_16_16                 = 12,
+        BufDataFormat32_32_32                    = 13,
+        BufDataFormat32_32_32_32                 = 14,
+        BufDataFormatReserved                    = 15,
+        // Extra formats not in GFX9 hardware encoding:
+        BufDataFormat8_8_8_8_BGRA,
+        BufDataFormat8_8_8,
+        BufDataFormat8_8_8_BGR,
+        BufDataFormat2_10_10_10_BGRA,
+        BufDataFormat64,
+        BufDataFormat64_64,
+        BufDataFormat64_64_64,
+        BufDataFormat64_64_64_64,
+    };
+
+    // Numeric format of vertex buffer entry. These match the GFX9 hardware encoding.
+    enum BufNumFormat
+    {
+        BufNumFormatUNORM                        = 0,
+        BufNumFormatSNORM                        = 1,
+        BufNumFormatUSCALED                      = 2,
+        BufNumFormatSSCALED                      = 3,
+        BufNumFormatUINT                         = 4,
+        BufNumFormatSINT                         = 5,
+        BufNumFormatSNORM_OGL                    = 6,
+        BufNumFormatFLOAT                        = 7,
+    };
+
+    // Rate of vertex input.
+    enum
+    {
+        VertexInputRateVertex = ~0,     // Vertex buffer has one element per vertex
+        VertexInputRateNone = 0,        // Vertex buffer has one element shared between all instances
+        VertexInputRateInstance = 1,    // Vertex buffer has one element per instance
+                                        // Other value N means vertex buffer has one element per N instances
+    };
+
+    // Structure for a vertex input
+    struct VertexInputDescription
+    {
+        uint32_t        location;       // Location of input, as provided to CreateReadGenericInput
+        uint32_t        binding;        // Index of the vertex buffer descriptor in the vertex buffer table
+        uint32_t        offset;         // Byte offset of the input in the binding's vertex buffer
+        uint32_t        stride;         // Byte stride of per-vertex/per-instance elements in the vertex buffer
+        BufDataFormat   dfmt;           // Data format of input; one of the BufDataFormat* values
+        BufNumFormat    nfmt;           // Numeric format of input; one of the BufNumFormat* values
+        uint32_t        inputRate;      // Vertex input rate for the binding
+    };
+
+    // Set vertex input descriptions. Each location referenced in a call to CreateReadGenericInput in the
+    // vertex shader must have a corresponding description provided here.
+    void SetVertexInputDescriptions(
+        ArrayRef<VertexInputDescription>  inputs);  // Array of vertex input descriptions
+
     // Primitive topology. These happen to have the same values as the corresponding Vulkan enum.
     enum class PrimitiveTopology
     {

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -1404,13 +1404,21 @@ protected:
     static Builder* CreateBuilderImpl(BuilderContext* pBuilderContext);
     static Builder* CreateBuilderRecorder(BuilderContext* pBuilderContext);
 
+    // Const version of GetPipelineState. This is used in BuilderImpl, and we know it does not need allocating.
+    PipelineState* GetPipelineState() const { return m_pPipelineState; }
+
+    // Get PipelineState, allocating if necessary. If it is allocated here (rather than passed in by
+    // BuilderImpl::SetPipelineState), then it is freed when the Builder is freed.
+    PipelineState* GetPipelineState();
+
     // Get a constant of FP or vector of FP type from the given APFloat, converting APFloat semantics where necessary
     Constant* GetFpConstant(Type* pTy, APFloat value);
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    ShaderStage     m_shaderStage     = ShaderStageInvalid; // Current shader stage being built.
-    PipelineState*  m_pPipelineState  = nullptr;            // Pipeline state
+    ShaderStage                     m_shaderStage = ShaderStageInvalid; // Current shader stage being built.
+    std::unique_ptr<PipelineState>  m_pAllocatedPipelineState;          // Pipeline state allocated by this Builder
+    PipelineState*                  m_pPipelineState = nullptr;         // Pipeline state to use in this Builder
 
     Type* GetTransposedMatrixTy(
         Type* const pMatrixType) const; // [in] The matrix type to tranpose
@@ -1432,8 +1440,5 @@ private:
 
     BuilderContext* m_pBuilderContext;      // Builder context
 };
-
-// Create BuilderReplayer pass
-ModulePass* CreateBuilderReplayer(Builder* pBuilder);
 
 } // Llpc

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -91,20 +91,22 @@ inline static void InitializeBuilderPasses(
 //    front-end decides whether to use BuilderImpl (generate IR directly) or BuilderRecorder (record
 //    Builder calls and replay them at the start of middle-end passes).
 //
-// 2. For a single compile, use BuilderContext::CreateBuilder to create the Builder object.
+// 2. Use BuilderContext::SetTargetMachine to specify which GPU we are compiling for.
 //
-// 3. Use Builder calls to specify the pipeline state:
+// 3. For a single compile, use BuilderContext::CreateBuilder to create the Builder object.
+//
+// 4. Use Builder calls to specify the pipeline state:
 //      Builder::SetUserDataNodes
 //    Setting pipeline state can be deferred to just before pipeline linking if using BuilderRecorder.
 //    If using BuilderImpl, it must be done here before any Builder calls that generate IR.
 //
-// 4. For each shader stage, create or process an IR module, using Builder calls to generate new IR.
+// 5. For each shader stage, create or process an IR module, using Builder calls to generate new IR.
 //
-// 5. Call Builder::Link to link the shader IR modules into a pipeline IR module. (This needs to be
+// 6. Call Builder::Link to link the shader IR modules into a pipeline IR module. (This needs to be
 //    done even if the pipeline only has a single shader, such as a compute pipeline.)
 //    if using BuilderRecorder, this also records the pipeline state into IR metadata.
 //
-// 6. Call Builder::Generate to run middle-end and back-end passes and generate the ELF.
+// 7. Call Builder::Generate to run middle-end and back-end passes and generate the ELF.
 //    (Global options such as -filetype and -emit-llvm cause the output to be something other than ELF.)
 //    The front-end can pass a call-back function into Builder::Generate to check a shader cache
 //    after input and output mapping, and elect to remove already-cached shaders from the pipeline.

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -162,6 +162,9 @@ public:
     // -----------------------------------------------------------------------------------------------------------------
     // Methods to set pipeline state
 
+    // Set the mask of shader stages that are present in the pipeline.
+    void SetShaderStageMask(uint32_t mask);
+
     // Set the resource mapping nodes for the pipeline. "nodes" describes the user data
     // supplied to the shader as a hierarchical table (max two levels) of descriptors.
     // "immutableDescs" contains descriptors (currently limited to samplers), whose values are hard

--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -210,9 +210,19 @@ public:
         BufDataFormat64_64,
         BufDataFormat64_64_64,
         BufDataFormat64_64_64_64,
+        BufDataFormat4_4,
+        BufDataFormat4_4_4_4,
+        BufDataFormat4_4_4_4_BGRA,
+        BufDataFormat5_6_5,
+        BufDataFormat5_6_5_BGR,
+        BufDataFormat5_6_5_1,
+        BufDataFormat5_6_5_1_BGRA,
+        BufDataFormat1_5_6_5,
+        BufDataFormat5_9_9_9,
     };
 
     // Numeric format of vertex buffer entry. These match the GFX9 hardware encoding.
+    // But this also includes extra formats.
     enum BufNumFormat
     {
         BufNumFormatUNORM                        = 0,
@@ -223,6 +233,9 @@ public:
         BufNumFormatSINT                         = 5,
         BufNumFormatSNORM_OGL                    = 6,
         BufNumFormatFLOAT                        = 7,
+        // Extra formats not in GFX9 hardware encoding:
+        BufNumFormatSRGB,
+        BufNumFormatOther,
     };
 
     // Rate of vertex input.
@@ -336,6 +349,30 @@ public:
     // add more fields. A local struct variable can be zero-initialized with " = {}".
     void SetRasterizerState(
         const RasterizerState&  rsState);   // [in] Rasterizer state
+
+    // A single color export format.
+    struct ColorExportFormat
+    {
+        BufDataFormat dfmt;                 // Data format
+        BufNumFormat  nfmt;                 // Numeric format
+        bool          blendEnable;          // Blend will be enabled for this target at draw time
+        bool          blendSrcAlphaToColor; // Whether source alpha is blended to color channels for this target
+                                            //  at draw time
+    };
+
+    // Struct to pass to SetColorExportState
+    struct ColorExportState
+    {
+        bool    alphaToCoverageEnable;          // Enable alpha to coverage
+        bool    dualSourceBlendEnable;          // Blend state bound at draw time will use a dual source blend mode
+    };
+
+    // Set color export state.
+    // The client should always zero-initialize the ColorExportState struct before setting it up, in case future
+    // versions add more fields. A local struct variable can be zero-initialized with " = {}".
+    void SetColorExportState(
+        ArrayRef<ColorExportFormat> formats,      // Array of ColorExportFormat structs
+        const ColorExportState&     exportState); // [in] Color export flags
 
     // -----------------------------------------------------------------------------------------------------------------
     // Methods to link and generate pipeline

--- a/builder/llpcBuilderContext.cpp
+++ b/builder/llpcBuilderContext.cpp
@@ -1,0 +1,58 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcBuilderContext.cpp
+ * @brief LLPC source file: implementation of llpc::BuilderContext class for creating and using Llpc::Builder
+ ***********************************************************************************************************************
+ */
+#include "llpcBuilderContext.h"
+#include "llpcBuilderImpl.h"
+#include "llpcBuilderRecorder.h"
+
+using namespace Llpc;
+using namespace llvm;
+
+// =====================================================================================================================
+BuilderContext::BuilderContext(
+    LLVMContext&  context,              // [in] LLVM context to give each Builder
+    bool          useBuilderRecorder)   // True to use BuilderRecorder, false to build directly
+    : m_context(context), m_useBuilderRecorder(useBuilderRecorder)
+{
+}
+
+// =====================================================================================================================
+// Create a Builder object
+Builder* BuilderContext::CreateBuilder()
+{
+    if (m_useBuilderRecorder == false)
+    {
+        // Generate LLVM IR directly without recording
+        return new BuilderImpl(this);
+    }
+    // Record with BuilderRecorder
+    return new BuilderRecorder(this);
+}
+

--- a/builder/llpcBuilderContext.cpp
+++ b/builder/llpcBuilderContext.cpp
@@ -56,3 +56,14 @@ Builder* BuilderContext::CreateBuilder()
     return new BuilderRecorder(this);
 }
 
+// =====================================================================================================================
+// Create a BuilderImpl object directly, passing in the PipelineState to use.
+Builder* BuilderContext::CreateBuilderImpl(
+    PipelineState*  pPipelineState)   // [in] PipelineState to use
+{
+    // Generate LLVM IR directly without recording
+    BuilderImpl* pBuilderImpl = new BuilderImpl(this);
+    pBuilderImpl->SetPipelineState(pPipelineState);
+    return pBuilderImpl;
+}
+

--- a/builder/llpcBuilderContext.h
+++ b/builder/llpcBuilderContext.h
@@ -46,6 +46,7 @@ namespace Llpc
 using namespace llvm;
 
 class Builder;
+class PipelineState;
 
 // =====================================================================================================================
 // BuilderContext class, used to create Builder objects. State shared between Builder objects is kept here.
@@ -59,6 +60,9 @@ public:
 
     // Create a Builder object
     Builder* CreateBuilder();
+
+    // Create a BuilderImpl object directly, passing in the PipelineState to use. This is used by BuilderReplayer.
+    Builder* CreateBuilderImpl(PipelineState* pPipelineState);
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(BuilderContext)

--- a/builder/llpcBuilderContext.h
+++ b/builder/llpcBuilderContext.h
@@ -1,0 +1,72 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcBuilderContext.h
+ * @brief LLPC header file: declaration of llpc::BuilderContext class for creating and using Llpc::Builder
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpc.h"
+#include "llpcDebug.h"
+
+namespace llvm
+{
+
+class LLVMContext;
+
+} // llvm
+
+namespace Llpc
+{
+
+using namespace llvm;
+
+class Builder;
+
+// =====================================================================================================================
+// BuilderContext class, used to create Builder objects. State shared between Builder objects is kept here.
+class BuilderContext
+{
+public:
+    BuilderContext(LLVMContext& context, bool useBuilderRecorder);
+
+    // Get LLVM context
+    LLVMContext& GetContext() const { return m_context; }
+
+    // Create a Builder object
+    Builder* CreateBuilder();
+
+private:
+    LLPC_DISALLOW_DEFAULT_CTOR(BuilderContext)
+    LLPC_DISALLOW_COPY_AND_ASSIGN(BuilderContext)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    LLVMContext&  m_context;              // LLVM context
+    bool          m_useBuilderRecorder;   // Whether to create BuilderRecorder or BuilderImpl
+};
+
+} // Llpc

--- a/builder/llpcBuilderImpl.cpp
+++ b/builder/llpcBuilderImpl.cpp
@@ -42,6 +42,16 @@ Context& BuilderImplBase::getContext() const
 }
 
 // =====================================================================================================================
+// Set PipelineState. This is used by BuilderReplayer to get its BuilderImpl to use the existing PipelineState,
+// rather than allocate its own new one.
+void BuilderImplBase::SetPipelineState(
+    PipelineState*  pPipelineState)   // [in] PipelineState to use
+{
+    LLPC_ASSERT(m_pAllocatedPipelineState == nullptr);
+    m_pPipelineState = pPipelineState;
+}
+
+// =====================================================================================================================
 // Create scalar from dot product of scalar or vector FP type. (The dot product of two scalars is their product.)
 Value* BuilderImplBase::CreateDotProduct(
     Value* const pVector1,            // [in] The float vector 1

--- a/builder/llpcBuilderImpl.cpp
+++ b/builder/llpcBuilderImpl.cpp
@@ -30,6 +30,7 @@
  */
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
+#include "llpcPipelineState.h"
 
 using namespace Llpc;
 using namespace llvm;
@@ -49,6 +50,14 @@ void BuilderImplBase::SetPipelineState(
 {
     LLPC_ASSERT(m_pAllocatedPipelineState == nullptr);
     m_pPipelineState = pPipelineState;
+}
+
+// =====================================================================================================================
+// Get the wave size for a shader stage
+uint32_t BuilderImplBase::GetShaderWaveSize(
+    ShaderStage stage) const    // Shader stage
+{
+    return m_pPipelineState->GetShaderWaveSize(stage);
 }
 
 // =====================================================================================================================
@@ -80,17 +89,17 @@ Value* BuilderImplBase::CreateDotProduct(
 // Get whether the context we are building in supports DPP operations.
 bool BuilderImplBase::SupportDpp() const
 {
-    return getContext().GetGfxIpVersion().major >= 8;
+    return GetPipelineState()->GetGfxIpVersion().major >= 8;
 }
 
 // =====================================================================================================================
 // Get whether the context we are building in support the bpermute operation.
 bool BuilderImplBase::SupportBPermute() const
 {
-    auto gfxIp = getContext().GetGfxIpVersion().major;
+    auto gfxIp = GetPipelineState()->GetGfxIpVersion().major;
     auto supportBPermute = (gfxIp == 8) || (gfxIp == 9);
 #if LLPC_BUILD_GFX10
-    auto waveSize = getContext().GetShaderWaveSize(GetShaderStageFromFunction(GetInsertBlock()->getParent()));
+    auto waveSize = GetShaderWaveSize(GetShaderStageFromFunction(GetInsertBlock()->getParent()));
     supportBPermute = supportBPermute || ((gfxIp == 10) && (waveSize == 32));
 #endif
     return supportBPermute;
@@ -101,7 +110,7 @@ bool BuilderImplBase::SupportBPermute() const
 // Get whether the context we are building in supports permute lane DPP operations.
 bool BuilderImplBase::SupportPermLaneDpp() const
 {
-    return getContext().GetGfxIpVersion().major >= 10;
+    return GetPipelineState()->GetGfxIpVersion().major >= 10;
 }
 #endif
 

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -42,7 +42,7 @@ using namespace llvm;
 class BuilderImplBase : public Builder
 {
 public:
-    BuilderImplBase(LLVMContext& context) : Builder(context) {}
+    BuilderImplBase(BuilderContext* pBuilderContext) : Builder(pBuilderContext) {}
 
     // Get the LLPC context. This overrides the IRBuilder method that gets the LLVM context.
     Llpc::Context& getContext() const;
@@ -100,7 +100,7 @@ private:
 class BuilderImplArith : virtual public BuilderImplBase
 {
 public:
-    BuilderImplArith(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplArith(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create calculation of 2D texture coordinates that would be used for accessing the selected cube map face for
     // the given cube map texture coordinates.
@@ -264,7 +264,7 @@ private:
 class BuilderImplDesc : virtual public BuilderImplBase
 {
 public:
-    BuilderImplDesc(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplDesc(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a load of a buffer descriptor.
     Value* CreateLoadBufferDesc(uint32_t      descSet,
@@ -324,7 +324,7 @@ private:
 class BuilderImplImage : virtual public BuilderImplBase
 {
 public:
-    BuilderImplImage(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplImage(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create an image load.
     Value* CreateImageLoad(Type*             pResultTy,
@@ -496,7 +496,7 @@ private:
 class BuilderImplInOut : virtual public BuilderImplBase
 {
 public:
-    BuilderImplInOut(llvm::LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplInOut(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a read of (part of) a user input value.
     Value* CreateReadGenericInput(Type*         pResultTy,
@@ -628,7 +628,7 @@ private:
 class BuilderImplMatrix : virtual public BuilderImplBase
 {
 public:
-    BuilderImplMatrix(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplMatrix(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a matrix transpose.
     Value* CreateTransposeMatrix(Value* const pMatrix,
@@ -685,7 +685,7 @@ private:
 class BuilderImplMisc : virtual public BuilderImplBase
 {
 public:
-    BuilderImplMisc(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplMisc(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // In the GS, emit the current values of outputs (as written by CreateWriteBuiltIn and CreateWriteOutput) to
     // the current output primitive in the specified output-primitive stream.
@@ -722,7 +722,7 @@ private:
 class BuilderImplSubgroup : virtual public BuilderImplBase
 {
 public:
-    BuilderImplSubgroup(LLVMContext& context) : BuilderImplBase(context) {}
+    BuilderImplSubgroup(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a get subgroup size query.
     Value* CreateGetSubgroupSize(const Twine& instName) override final;
@@ -954,14 +954,14 @@ class BuilderImpl final : public BuilderImplArith,
                                  BuilderImplSubgroup
 {
 public:
-    BuilderImpl(LLVMContext& context) : BuilderImplBase(context),
-                                        BuilderImplArith(context),
-                                        BuilderImplDesc(context),
-                                        BuilderImplImage(context),
-                                        BuilderImplInOut(context),
-                                        BuilderImplMatrix(context),
-                                        BuilderImplMisc(context),
-                                        BuilderImplSubgroup(context)
+    BuilderImpl(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext),
+                                                   BuilderImplArith(pBuilderContext),
+                                                   BuilderImplDesc(pBuilderContext),
+                                                   BuilderImplImage(pBuilderContext),
+                                                   BuilderImplInOut(pBuilderContext),
+                                                   BuilderImplMatrix(pBuilderContext),
+                                                   BuilderImplMisc(pBuilderContext),
+                                                   BuilderImplSubgroup(pBuilderContext)
     {}
     ~BuilderImpl() {}
 

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -94,6 +94,9 @@ protected:
                      Value*                                        pValue2,
                      std::function<Value*(Value*, Value*, Value*)> callback);
 
+    // Forwarding methods to PipelineState
+    uint32_t GetShaderWaveSize(ShaderStage stage) const;
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(BuilderImplBase)
     LLPC_DISALLOW_COPY_AND_ASSIGN(BuilderImplBase)

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -44,6 +44,10 @@ class BuilderImplBase : public Builder
 public:
     BuilderImplBase(BuilderContext* pBuilderContext) : Builder(pBuilderContext) {}
 
+    // Set PipelineState. This is used by BuilderReplayer to get its BuilderImpl to use the existing PipelineState,
+    // rather than allocate its own new one.
+    void SetPipelineState(PipelineState* pPipelineState);
+
     // Get the LLPC context. This overrides the IRBuilder method that gets the LLVM context.
     Llpc::Context& getContext() const;
 

--- a/builder/llpcBuilderImplArith.cpp
+++ b/builder/llpcBuilderImplArith.cpp
@@ -30,6 +30,7 @@
  */
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
+#include "llpcPipelineState.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-arith"
 
@@ -222,7 +223,7 @@ Value* BuilderImplArith::CreateSMod(
 {
 #if LLPC_BUILD_GFX10
     if (pDivisor->getType()->getScalarType()->isIntegerTy(32) &&
-        (getContext().GetGpuWorkarounds()->gfx10.disableI32ModToI16Mod))
+        (m_pPipelineState->GetGpuWorkarounds()->gfx10.disableI32ModToI16Mod))
     {
 
         // NOTE: On some hardware, when the divisor is a literal value and less than 0xFFFF, i32 mod will be
@@ -278,7 +279,7 @@ Value* BuilderImplArith::CreateFma(
     Value*        pC,         // [in] The value to add to the product of A and B
     const Twine&  instName)   // [in] Name to give instruction(s)
 {
-    if (getContext().GetGfxIpVersion().major <= 8)
+    if (GetPipelineState()->GetGfxIpVersion().major <= 8)
     {
         // Pre-GFX9 version: Use fmuladd.
         return CreateIntrinsic(Intrinsic::fmuladd, pA->getType(), { pA, pB, pC }, nullptr, instName);
@@ -945,7 +946,7 @@ Value* BuilderImplArith::CreateFClamp(
     // But we can only do this if we do not need NaN preservation.
     Value* pResult = nullptr;
     if (getFastMathFlags().noNaNs() && (pX->getType()->getScalarType()->isFloatTy() ||
-        ((getContext().GetGfxIpVersion().major >= 9) && pX->getType()->getScalarType()->isHalfTy())))
+        ((GetPipelineState()->GetGfxIpVersion().major >= 9) && pX->getType()->getScalarType()->isHalfTy())))
     {
         pResult = Scalarize(pX,
                             pMinVal,
@@ -970,7 +971,7 @@ Value* BuilderImplArith::CreateFClamp(
 
     // Before GFX9, fmed/fmin/fmax do not honor the hardware FP mode wanting flush denorms. So we need to
     // canonicalize the result here.
-    if (getContext().GetGfxIpVersion().major < 9)
+    if (GetPipelineState()->GetGfxIpVersion().major < 9)
     {
         pResult = Canonicalize(pResult);
     }
@@ -994,7 +995,7 @@ Value* BuilderImplArith::CreateFMin(
 
     // Before GFX9, fmed/fmin/fmax do not honor the hardware FP mode wanting flush denorms. So we need to
     // canonicalize the result here.
-    if (getContext().GetGfxIpVersion().major < 9)
+    if (GetPipelineState()->GetGfxIpVersion().major < 9)
     {
         pResult = Canonicalize(pResult);
     }
@@ -1018,7 +1019,7 @@ Value* BuilderImplArith::CreateFMax(
 
     // Before GFX9, fmed/fmin/fmax do not honor the hardware FP mode wanting flush denorms. So we need to
     // canonicalize the result here.
-    if (getContext().GetGfxIpVersion().major < 9)
+    if (GetPipelineState()->GetGfxIpVersion().major < 9)
     {
         pResult = Canonicalize(pResult);
     }
@@ -1045,7 +1046,7 @@ Value* BuilderImplArith::CreateFMin3(
 
     // Before GFX9, fmed/fmin/fmax do not honor the hardware FP mode wanting flush denorms. So we need to
     // canonicalize the result here.
-    if (getContext().GetGfxIpVersion().major < 9)
+    if (GetPipelineState()->GetGfxIpVersion().major < 9)
     {
         pResult = Canonicalize(pResult);
     }
@@ -1072,7 +1073,7 @@ Value* BuilderImplArith::CreateFMax3(
 
     // Before GFX9, fmed/fmin/fmax do not honor the hardware FP mode wanting flush denorms. So we need to
     // canonicalize the result here.
-    if (getContext().GetGfxIpVersion().major < 9)
+    if (GetPipelineState()->GetGfxIpVersion().major < 9)
     {
         pResult = Canonicalize(pResult);
     }
@@ -1095,7 +1096,7 @@ Value* BuilderImplArith::CreateFMid3(
     // But we can only do this if we do not need NaN preservation.
     Value* pResult = nullptr;
     if (getFastMathFlags().noNaNs() && (pValue1->getType()->getScalarType()->isFloatTy() ||
-        ((getContext().GetGfxIpVersion().major >= 9) && pValue1->getType()->getScalarType()->isHalfTy())))
+        ((GetPipelineState()->GetGfxIpVersion().major >= 9) && pValue1->getType()->getScalarType()->isHalfTy())))
     {
         pResult = Scalarize(pValue1,
                             pValue2,
@@ -1123,7 +1124,7 @@ Value* BuilderImplArith::CreateFMid3(
 
     // Before GFX9, fmed/fmin/fmax do not honor the hardware FP mode wanting flush denorms. So we need to
     // canonicalize the result here.
-    if (getContext().GetGfxIpVersion().major < 9)
+    if (GetPipelineState()->GetGfxIpVersion().major < 9)
     {
         pResult = Canonicalize(pResult);
     }

--- a/builder/llpcBuilderImplDesc.cpp
+++ b/builder/llpcBuilderImplDesc.cpp
@@ -31,6 +31,7 @@
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
+#include "llpcPipelineState.h"
 
 #include "llvm/IR/Intrinsics.h"
 
@@ -245,7 +246,7 @@ Value* BuilderImplDesc::ScalarizeIfUniform(
     if ((isNonUniform == false) && (isa<Constant>(pValue) == false))
     {
         // NOTE: GFX6 encounters GPU hang with this optimization enabled. So we should skip it.
-        if (getContext().GetGfxIpVersion().major > 6)
+        if (GetPipelineState()->GetGfxIpVersion().major > 6)
         {
             pValue = CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, pValue);
         }

--- a/builder/llpcBuilderImplImage.cpp
+++ b/builder/llpcBuilderImplImage.cpp
@@ -2370,9 +2370,7 @@ Value* BuilderImplImage::HandleFragCoordViewIndex(
     bool useViewIndex = false;
     if (flags & ImageFlagCheckMultiView)
     {
-        auto enableMultiView = reinterpret_cast<const GraphicsPipelineBuildInfo *>(
-                               getContext().GetPipelineBuildInfo())->iaState.enableMultiView;
-        if (enableMultiView)
+        if (GetPipelineState()->GetInputAssemblyState().enableMultiView)
         {
             useViewIndex = true;
             dim = Dim2DArray;

--- a/builder/llpcBuilderImplImage.cpp
+++ b/builder/llpcBuilderImplImage.cpp
@@ -31,6 +31,7 @@
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
+#include "llpcPipelineState.h"
 
 #include "llvm/IR/Intrinsics.h"
 
@@ -1337,7 +1338,7 @@ Value* BuilderImplImage::PreprocessIntegerImageGather(
     Value*&   pImageDesc, // [in/out] Image descriptor
     Value*&   pCoord)     // [in/out] Coordinate
 {
-    if (getContext().GetGfxIpVersion().major >= 9)
+    if (GetPipelineState()->GetGfxIpVersion().major >= 9)
     {
         // GFX9+: Workaround not needed.
         return nullptr;
@@ -1847,7 +1848,7 @@ Value* BuilderImplImage::CreateImageQuerySize(
         // Extract NUM_RECORDS (SQ_BUF_RSRC_WORD2)
         Value* pNumRecords = CreateExtractElement(pImageDesc, 2);
 
-        if (getContext().GetGfxIpVersion().major == 8)
+        if (GetPipelineState()->GetGfxIpVersion().major == 8)
         {
             // GFX8 only: extract STRIDE (SQ_BUF_RSRC_WORD1 [29:16]) and divide into NUM_RECORDS.
             Value* pStride = CreateIntrinsic(Intrinsic::amdgcn_ubfe,
@@ -1972,7 +1973,7 @@ Value* BuilderImplImage::CreateImageGetLod(
 uint32_t BuilderImplImage::Change1DTo2DIfNeeded(
     uint32_t                  dim)            // Image dimension
 {
-    if (getContext().GetGpuWorkarounds()->gfx9.treat1dImagesAs2d)
+    if (m_pPipelineState->GetGpuWorkarounds()->gfx9.treat1dImagesAs2d)
     {
         switch (dim)
         {
@@ -2333,7 +2334,7 @@ Value* BuilderImplImage::PatchCubeDescriptor(
     uint32_t  dim)    // Image dimensions
 {
     if (((dim != DimCube) && (dim != DimCubeArray)) ||
-        (getContext().GetGfxIpVersion().major >= 9))
+        (GetPipelineState()->GetGfxIpVersion().major >= 9))
     {
         return pDesc;
     }

--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -31,6 +31,7 @@
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
+#include "llpcPipelineState.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-inout"
 
@@ -618,7 +619,7 @@ Instruction* BuilderImplInOut::CreateWriteXfbOutput(
 
     // Ignore if not in last-vertex-stage shader (excluding copy shader).
     auto stagesAfterThisOneMask = -ShaderStageToMask(static_cast<ShaderStage>(m_shaderStage + 1));
-    if ((getContext().GetShaderStageMask() & ~ShaderStageToMask(ShaderStageFragment) &
+    if ((GetPipelineState()->GetShaderStageMask() & ~ShaderStageToMask(ShaderStageFragment) &
           ~ShaderStageToMask(ShaderStageCopyShader) & stagesAfterThisOneMask) != 0)
     {
         return nullptr;

--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -757,7 +757,7 @@ Value* BuilderImplInOut::ReadBuiltIn(
     {
         Value* pResult = nullptr;
         Value* pLocalInvocationId = ReadBuiltIn(false, BuiltInSubgroupLocalInvocationId, {}, nullptr, nullptr, "");
-        if (getContext().GetShaderWaveSize(m_shaderStage) == 64)
+        if (GetShaderWaveSize(m_shaderStage) == 64)
         {
             pLocalInvocationId = CreateZExt(pLocalInvocationId, getInt64Ty());
         }
@@ -784,7 +784,7 @@ Value* BuilderImplInOut::ReadBuiltIn(
         default:
             LLPC_NEVER_CALLED();
         }
-        if (getContext().GetShaderWaveSize(m_shaderStage) == 64)
+        if (GetShaderWaveSize(m_shaderStage) == 64)
         {
             pResult = CreateInsertElement(Constant::getNullValue(VectorType::get(getInt64Ty(), 2)),
                                           pResult,

--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -52,7 +52,7 @@ Value* BuilderImplSubgroup::CreateGetSubgroupSize(
 // Get the shader subgroup size for the current insertion block.
 uint32_t BuilderImplSubgroup::GetShaderSubgroupSize()
 {
-    return getContext().GetShaderWaveSize(GetShaderStageFromFunction(GetInsertBlock()->getParent()));
+    return GetShaderWaveSize(GetShaderStageFromFunction(GetInsertBlock()->getParent()));
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -349,8 +349,7 @@ Module* BuilderRecorder::Link(
 // This is a BuilderRecorder. Create the BuilderReplayer pass.
 ModulePass* BuilderRecorder::CreateBuilderReplayer()
 {
-    // Create a new BuilderImpl to replay the recorded Builder calls in.
-    return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(GetBuilderContext()));
+    return ::CreateBuilderReplayer(GetBuilderContext());
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -28,6 +28,7 @@
  * @brief LLPC source file: BuilderRecorder implementation
  ***********************************************************************************************************************
  */
+#include "llpcBuilderContext.h"
 #include "llpcBuilderRecorder.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
@@ -303,10 +304,16 @@ BuilderRecorderMetadataKinds::BuilderRecorderMetadataKinds(
 // =====================================================================================================================
 // Create a BuilderRecorder
 Builder* Builder::CreateBuilderRecorder(
-    LLVMContext&  context,    // [in] LLVM context
-    bool          wantReplay) // TRUE to make CreateBuilderReplayer return a replayer pass
+    BuilderContext* pBuilderContext)  // [in] Builder context
 {
-    return new BuilderRecorder(context, wantReplay);
+    return new BuilderRecorder(pBuilderContext);
+}
+
+// =====================================================================================================================
+BuilderRecorder::BuilderRecorder(
+    BuilderContext* pBuilderContext)  // [in] Builder context
+    : Builder(pBuilderContext), BuilderRecorderMetadataKinds(pBuilderContext->GetContext())
+{
 }
 
 #ifndef NDEBUG
@@ -339,15 +346,11 @@ Module* BuilderRecorder::Link(
 #endif
 
 // =====================================================================================================================
-// This is a BuilderRecorder. If it was created with wantReplay=true, create the BuilderReplayer pass.
+// This is a BuilderRecorder. Create the BuilderReplayer pass.
 ModulePass* BuilderRecorder::CreateBuilderReplayer()
 {
-    if (m_wantReplay)
-    {
-        // Create a new BuilderImpl to replay the recorded Builder calls in.
-        return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(getContext()));
-    }
-    return nullptr;
+    // Create a new BuilderImpl to replay the recorded Builder calls in.
+    return ::CreateBuilderReplayer(Builder::CreateBuilderImpl(GetBuilderContext()));
 }
 
 // =====================================================================================================================

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -210,9 +210,7 @@ public:
     // Given an opcode, get the call name (without the "llpc.call." prefix)
     static StringRef GetCallName(Opcode opcode);
 
-    BuilderRecorder(LLVMContext& context, bool wantReplay)
-        : Builder(context), BuilderRecorderMetadataKinds(context), m_wantReplay(wantReplay)
-    {}
+    BuilderRecorder(BuilderContext* pBuilderContext);
 
     ~BuilderRecorder() {}
 
@@ -223,7 +221,7 @@ public:
     Module* Link(ArrayRef<Module*> modules, bool linkNativeStages) override final;
 #endif
 
-    // If this is a BuilderRecorder created with wantReplay=true, create the BuilderReplayer pass.
+    // If this is a BuilderRecorder, create the BuilderReplayer pass.
     ModulePass* CreateBuilderReplayer() override;
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -668,8 +666,6 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
-    bool            m_wantReplay;                             // true to make CreateBuilderReplayer return a replayer
-                                                              //   pass
 #ifndef NDEBUG
     // Only used in a debug build to ensure SetShaderStage is being used consistently.
     std::vector<std::pair<WeakVH, ShaderStage>> m_funcShaderStageMap;       // Map from function to shader stage

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -674,4 +674,7 @@ private:
 #endif
 };
 
+// Create BuilderReplayer pass
+ModulePass* CreateBuilderReplayer(BuilderContext* pBuilderContext);
+
 } // Llpc

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -221,6 +221,12 @@ public:
     Module* Link(ArrayRef<Module*> modules, bool linkNativeStages) override final;
 #endif
 
+    // Generate pipeline module by running patch, middle-end optimization and backend codegen passes.
+    void Generate(std::unique_ptr<Module>   pipelineModule,
+                  raw_pwrite_stream&        outStream,
+                  CheckShaderCacheFunc      checkShaderCacheFunc,
+                  ArrayRef<Timer*>          timers) override final;
+
     // If this is a BuilderRecorder, create the BuilderReplayer pass.
     ModulePass* CreateBuilderReplayer() override;
 

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -112,9 +112,9 @@ bool BuilderReplayer::runOnModule(
 
     m_pModule = &module;
 
-    bool changed = false;
     // Set up the pipeline state from the specified linked IR module.
     PipelineState* pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(m_pModule);
+    pPipelineState->ReadState();
 
     // Create the BuilderImpl to replay into, passing it the PipelineState
     m_pBuilder.reset(m_pBuilderContext->CreateBuilderImpl(pPipelineState));
@@ -142,9 +142,6 @@ bool BuilderReplayer::runOnModule(
         const ConstantAsMetadata* const pMetaConst = cast<ConstantAsMetadata>(pFuncMeta->getOperand(0));
         uint32_t opcode = cast<ConstantInt>(pMetaConst->getValue())->getZExtValue();
 
-        // If we got here we are definitely changing the module.
-        changed = true;
-
         SmallVector<CallInst*, 8> callsToRemove;
 
         while (func.use_empty() == false)
@@ -165,7 +162,7 @@ bool BuilderReplayer::runOnModule(
         pFunc->eraseFromParent();
     }
 
-    return changed;
+    return true;
 }
 
 // =====================================================================================================================

--- a/builder/llpcPipelineState.cpp
+++ b/builder/llpcPipelineState.cpp
@@ -32,6 +32,7 @@
 
 #include "llpc.h"
 #include "llpcBuilderContext.h"
+#include "llpcContext.h"
 #include "llpcInternal.h"
 #include "llpcPipelineState.h"
 #include "llvm/IR/IRBuilder.h"
@@ -49,6 +50,34 @@ static const char* const UserDataMetadataName = "llpc.user.data.nodes";
 LLVMContext& PipelineState::GetContext() const
 {
     return GetBuilderContext()->GetContext();
+}
+
+// =====================================================================================================================
+// Get TargetInfo
+const TargetInfo& PipelineState::GetTargetInfo() const
+{
+    return GetBuilderContext()->GetTargetInfo();
+}
+
+// =====================================================================================================================
+// Get GfxIpVersion
+GfxIpVersion PipelineState::GetGfxIpVersion() const
+{
+    return GetTargetInfo().gfxIp;
+}
+
+// =====================================================================================================================
+// Get GpuProperty
+const GpuProperty* PipelineState::GetGpuProperty() const
+{
+    return &GetTargetInfo().gpuProperty;
+}
+
+// =====================================================================================================================
+// Get GpuWorkarounds
+const WorkaroundFlags* PipelineState::GetGpuWorkarounds() const
+{
+    return &GetTargetInfo().gpuWorkarounds;
 }
 
 // =====================================================================================================================
@@ -432,6 +461,16 @@ ArrayRef<MDString*> PipelineState::GetResourceTypeNames()
         }
     }
     return ArrayRef<MDString*>(m_resourceNodeTypeNames);
+}
+
+// =====================================================================================================================
+// Get wave size for the specified shader stage
+uint32_t PipelineState::GetShaderWaveSize(
+    ShaderStage stage)  // Shader stage
+{
+    // TODO: Move the logic of GetShaderWaveSize into here. But first we need to pass the pipeline build info
+    // into the middle-end in a clean way.
+    return reinterpret_cast<Context*>(&m_pModule->getContext())->GetShaderWaveSize(stage, *GetGpuProperty());
 }
 
 // =====================================================================================================================

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -89,12 +89,22 @@ class PipelineState
 {
 public:
     PipelineState()
-        : m_pContext(nullptr)
+        : m_pBuilderContext(nullptr)
     {}
 
-    PipelineState(llvm::LLVMContext* pContext)
-        : m_pContext(pContext)
+    PipelineState(BuilderContext* pBuilderContext)
+        : m_pBuilderContext(pBuilderContext)
     {}
+
+    // Get BuilderContext
+    BuilderContext* GetBuilderContext() const { return m_pBuilderContext; }
+
+    // Get LLVMContext
+    LLVMContext& GetContext() const;
+
+    // Accessors for pipeline module that this pipeline state is for.
+    void SetModule(Module* pModule) { m_pModule = pModule; }
+    Module* GetModule() const { return m_pModule; }
 
     // Set the resource mapping nodes for the pipeline.
     void SetUserDataNodes(ArrayRef<ResourceMappingNode>   nodes,
@@ -134,7 +144,8 @@ private:
     ResourceMappingNodeType GetResourceTypeFromName(MDString* pTypeName);
 
     // -----------------------------------------------------------------------------------------------------------------
-    llvm::LLVMContext*              m_pContext;                         // LLVM context
+    BuilderContext*                 m_pBuilderContext;                  // Builder context
+    Module*                         m_pModule = nullptr;                // Pipeline IR module
     std::unique_ptr<ResourceNode[]> m_allocUserDataNodes;               // Allocated buffer for user data
     ArrayRef<ResourceNode>          m_userDataNodes;                    // Top-level user data node table
     MDString*                       m_resourceNodeTypeNames[uint32_t(ResourceMappingNodeType::Count)] = {};
@@ -153,12 +164,15 @@ public:
     // Get the PipelineState from this wrapper pass.
     PipelineState* GetPipelineState(Module* pModule);
 
+    // Set the PipelineState. PipelineStateWrapper takes ownership of the PipelineState.
+    void SetPipelineState(std::unique_ptr<PipelineState> pPipelineState);
+
     // -----------------------------------------------------------------------------------------------------------------
 
     static char ID;   // ID of this pass
 
 private:
-    PipelineState* m_pPipelineState = nullptr;  // Cached pipeline state
+    std::unique_ptr<PipelineState> m_pPipelineState;  // Cached pipeline state
 };
 
 } // Llpc

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -165,6 +165,12 @@ public:
     void SetRasterizerState(const Builder::RasterizerState& vpState);
     const Builder::RasterizerState& GetRasterizerState();
 
+    // Accessors for color export state
+    void SetColorExportState(ArrayRef<Builder::ColorExportFormat> formats,
+                             const Builder::ColorExportState&     exportState);
+    const Builder::ColorExportFormat& GetColorExportFormat(uint32_t location);
+    const Builder::ColorExportState& GetColorExportState();
+
 private:
     // Type of immutable nodes map used in SetUserDataNodes
     typedef std::map<std::pair<uint32_t, uint32_t>, const DescriptorRangeValue*> ImmutableNodesMap;
@@ -204,6 +210,10 @@ private:
     void RecordRasterizerState(Module* pModule);
     void ReadRasterizerState();
 
+    // Color export state handling
+    void RecordColorExportState(Module* pModule);
+    void ReadColorExportState();
+
     // Utility functions to record and read an array of i32 values in metadata
     void SetNamedMetadataToArrayOfInt32(Module* pModule, ArrayRef<uint32_t> values, StringRef metaName);
     MDNode* GetArrayOfInt32MetaNode(ArrayRef<uint32_t> values, bool atLeastOneValue);
@@ -224,6 +234,9 @@ private:
     Builder::InputAssemblyState     m_inputAssemblyState = {};          // Input-assembly state
     Builder::ViewportState          m_viewportState = {};               // Viewport state
     Builder::RasterizerState        m_rasterizerState = {};             // Rasterizer state
+    SmallVector<Builder::ColorExportFormat, 8>
+                                    m_colorExportFormats;               // Color export formats
+    Builder::ColorExportState       m_colorExportState = {};            // Color export state
     bool                            m_clientStateDirty = false;         // Whether state provided by builder client
                                                                         //  (user data, vertex inputs, options) is dirty
                                                                         //  and needs writing to IR

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -122,6 +122,12 @@ public:
     // Clear the pipeline state IR metadata.
     void Clear(Module* pModule);
 
+    // Accessors for shader stage mask
+    void SetShaderStageMask(uint32_t mask) { m_stageMask = mask; }
+    uint32_t GetShaderStageMask() const { return m_stageMask; }
+    bool HasShaderStage(ShaderStage stage) const { return (GetShaderStageMask() >> stage) & 1; }
+    bool IsGraphics() const;
+
     // Record dirty pipeline state into IR metadata of specified module. Returns true if module modified.
     bool Flush(Module* pModule);
 
@@ -140,6 +146,9 @@ private:
     // Type of immutable nodes map used in SetUserDataNodes
     typedef std::map<std::pair<uint32_t, uint32_t>, const DescriptorRangeValue*> ImmutableNodesMap;
 
+    // Read shaderStageMask from IR
+    void ReadShaderStageMask();
+
     // User data nodes handling
     void SetUserDataNodesTable(ArrayRef<ResourceMappingNode>        nodes,
                                const ImmutableNodesMap&             immutableNodesMap,
@@ -155,6 +164,7 @@ private:
     // -----------------------------------------------------------------------------------------------------------------
     BuilderContext*                 m_pBuilderContext;                  // Builder context
     Module*                         m_pModule = nullptr;                // Pipeline IR module
+    uint32_t                        m_stageMask = 0;                    // Mask of active shader stages
     std::unique_ptr<ResourceNode[]> m_allocUserDataNodes;               // Allocated buffer for user data
     ArrayRef<ResourceNode>          m_userDataNodes;                    // Top-level user data node table
     MDString*                       m_resourceNodeTypeNames[uint32_t(ResourceMappingNodeType::Count)] = {};

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "llpc.h"
+#include "llpcBuilder.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include <map>
@@ -142,6 +144,22 @@ public:
     // Get wave size for the specified shader stage
     uint32_t GetShaderWaveSize(ShaderStage stage);
 
+    // Accessors for device index
+    void SetDeviceIndex(uint32_t deviceIndex);
+    uint32_t GetDeviceIndex() const;
+
+    // Accessors for input-assembly state.
+    void SetInputAssemblyState(const Builder::InputAssemblyState& iaState);
+    const Builder::InputAssemblyState& GetInputAssemblyState();
+
+    // Accessors for viewport state.
+    void SetViewportState(const Builder::ViewportState& vpState);
+    const Builder::ViewportState& GetViewportState();
+
+    // Accessors for rasterizer state.
+    void SetRasterizerState(const Builder::RasterizerState& vpState);
+    const Builder::RasterizerState& GetRasterizerState();
+
 private:
     // Type of immutable nodes map used in SetUserDataNodes
     typedef std::map<std::pair<uint32_t, uint32_t>, const DescriptorRangeValue*> ImmutableNodesMap;
@@ -161,6 +179,28 @@ private:
     MDString* GetResourceTypeName(ResourceMappingNodeType type);
     ResourceMappingNodeType GetResourceTypeFromName(MDString* pTypeName);
 
+    // Device index handling
+    void RecordDeviceIndex(Module* pModule);
+    void ReadDeviceIndex();
+
+    // Input-assembly state handling
+    void RecordInputAssemblyState(Module* pModule);
+    void ReadInputAssemblyState();
+
+    // Viewport state handling
+    void RecordViewportState(Module* pModule);
+    void ReadViewportState();
+
+    // Rasterizer state handling
+    void RecordRasterizerState(Module* pModule);
+    void ReadRasterizerState();
+
+    // Utility functions to record and read an array of i32 values in metadata
+    void SetNamedMetadataToArrayOfInt32(Module* pModule, ArrayRef<uint32_t> values, StringRef metaName);
+    MDNode* GetArrayOfInt32MetaNode(ArrayRef<uint32_t> values, bool atLeastOneValue);
+    uint32_t ReadNamedMetadataArrayOfInt32(StringRef metaName, MutableArrayRef<uint32_t> values);
+    uint32_t ReadArrayOfInt32MetaNode(MDNode* pMetaNode, MutableArrayRef<uint32_t> values);
+
     // -----------------------------------------------------------------------------------------------------------------
     BuilderContext*                 m_pBuilderContext;                  // Builder context
     Module*                         m_pModule = nullptr;                // Pipeline IR module
@@ -169,6 +209,10 @@ private:
     ArrayRef<ResourceNode>          m_userDataNodes;                    // Top-level user data node table
     MDString*                       m_resourceNodeTypeNames[uint32_t(ResourceMappingNodeType::Count)] = {};
                                                                         // Cached MDString for each resource node type
+    uint32_t                        m_deviceIndex = 0;                  // Device index
+    Builder::InputAssemblyState     m_inputAssemblyState = {};          // Input-assembly state
+    Builder::ViewportState          m_viewportState = {};               // Viewport state
+    Builder::RasterizerState        m_rasterizerState = {};             // Rasterizer state
     bool                            m_clientStateDirty = false;         // Whether state provided by builder client
                                                                         //  (user data, vertex inputs, options) is dirty
                                                                         //  and needs writing to IR

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -148,6 +148,11 @@ public:
     void SetDeviceIndex(uint32_t deviceIndex);
     uint32_t GetDeviceIndex() const;
 
+    // Accessors for vertex input descriptions.
+    void SetVertexInputDescriptions(ArrayRef<Builder::VertexInputDescription> inputs);
+    ArrayRef<Builder::VertexInputDescription> GetVertexInputDescriptions() const;
+    const Builder::VertexInputDescription* FindVertexInputDescription(uint32_t location) const;
+
     // Accessors for input-assembly state.
     void SetInputAssemblyState(const Builder::InputAssemblyState& iaState);
     const Builder::InputAssemblyState& GetInputAssemblyState();
@@ -183,6 +188,10 @@ private:
     void RecordDeviceIndex(Module* pModule);
     void ReadDeviceIndex();
 
+    // Vertex input descriptions handling
+    void RecordVertexInputDescriptions(Module* pModule);
+    void ReadVertexInputDescriptions();
+
     // Input-assembly state handling
     void RecordInputAssemblyState(Module* pModule);
     void ReadInputAssemblyState();
@@ -210,6 +219,8 @@ private:
     MDString*                       m_resourceNodeTypeNames[uint32_t(ResourceMappingNodeType::Count)] = {};
                                                                         // Cached MDString for each resource node type
     uint32_t                        m_deviceIndex = 0;                  // Device index
+    std::vector<Builder::VertexInputDescription>
+                                    m_vertexInputDescriptions;          // Vertex input descriptions
     Builder::InputAssemblyState     m_inputAssemblyState = {};          // Input-assembly state
     Builder::ViewportState          m_viewportState = {};               // Viewport state
     Builder::RasterizerState        m_rasterizerState = {};             // Rasterizer state

--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -54,7 +54,11 @@ namespace Llpc
 
 using namespace llvm;
 
+class BuilderContext;
+struct GpuProperty;
 class PipelineState;
+struct TargetInfo;
+struct WorkaroundFlags;
 
 ModulePass* CreatePipelineStateClearer();
 
@@ -109,6 +113,12 @@ public:
     void SetModule(Module* pModule) { m_pModule = pModule; }
     Module* GetModule() const { return m_pModule; }
 
+    // Accessors for TargetInfo and its contents
+    const TargetInfo& GetTargetInfo() const;
+    GfxIpVersion GetGfxIpVersion() const;
+    const GpuProperty* GetGpuProperty() const;
+    const WorkaroundFlags* GetGpuWorkarounds() const;
+
     // Clear the pipeline state IR metadata.
     void Clear(Module* pModule);
 
@@ -122,6 +132,9 @@ public:
     void SetUserDataNodes(ArrayRef<ResourceMappingNode>   nodes,
                           ArrayRef<DescriptorRangeValue>  rangeValues);
     ArrayRef<ResourceNode> GetUserDataNodes() const { return m_userDataNodes; }
+
+    // Get wave size for the specified shader stage
+    uint32_t GetShaderWaveSize(ShaderStage stage);
 
 private:
     // Type of immutable nodes map used in SetUserDataNodes

--- a/builder/llpcTargetInfo.cpp
+++ b/builder/llpcTargetInfo.cpp
@@ -1,0 +1,453 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcTargetInfo.cpp
+ * @brief LLPC source file: code to set up TargetInfo
+ ***********************************************************************************************************************
+ */
+#include "llpcTargetInfo.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace Llpc;
+using namespace llvm;
+
+#if LLPC_BUILD_GFX10
+namespace Llpc
+{
+
+// -native-wave-size: an option to override hardware native wave size, it will allow compiler to choose
+// final wave size base on it. Used in pre-silicon verification.
+cl::opt<int> NativeWaveSize("native-wave-size", cl::desc("Overrides hardware native wave size"), cl::init(0));
+
+} // Llpc
+#endif
+
+// =====================================================================================================================
+// Functions to set up TargetInfo for the various targets
+
+// gfx6+
+static void SetGfx6BaseInfo(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    // Initial settings (could be adjusted later according to graphics IP version info)
+    pTargetInfo->gpuProperty.waveSize = 64;
+
+    pTargetInfo->gpuProperty.ldsSizePerThreadGroup = 32 * 1024;
+    pTargetInfo->gpuProperty.numShaderEngines = 4;
+    pTargetInfo->gpuProperty.maxSgprsAvailable = 104;
+    pTargetInfo->gpuProperty.maxVgprsAvailable = 256;
+
+    //TODO: Setup gsPrimBufferDepth from hardware config option, will be done in another change.
+    pTargetInfo->gpuProperty.gsPrimBufferDepth = 0x100;
+
+    pTargetInfo->gpuProperty.maxUserDataCount = 16; // GFX6-8 value
+
+    pTargetInfo->gpuProperty.gsOnChipMaxLdsSize = 16384;
+
+    pTargetInfo->gpuProperty.tessOffChipLdsBufferSize = 32768;
+
+    // TODO: Accept gsOnChipDefaultPrimsPerSubgroup from panel option
+    pTargetInfo->gpuProperty.gsOnChipDefaultPrimsPerSubgroup   = 64;
+
+    pTargetInfo->gpuProperty.tessFactorBufferSizePerSe = 4096;
+
+    // TODO: Accept gsOnChipDefaultLdsSizePerSubgroup from panel option
+    pTargetInfo->gpuProperty.gsOnChipDefaultLdsSizePerSubgroup = 8192; // GFX6-8 value
+}
+
+// gfx6
+static void SetGfx6Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx6BaseInfo(pTargetInfo);
+    pTargetInfo->gpuProperty.ldsSizePerCu = 32768;
+    pTargetInfo->gpuProperty.ldsSizeDwordGranularityShift = 6;
+
+    // Hardware workarounds for GFX6 based GPU's:
+    pTargetInfo->gpuWorkarounds.gfx6.cbNoLt16BitIntClamp = 1;
+    pTargetInfo->gpuWorkarounds.gfx6.miscLoadBalancePerWatt = 1;
+    pTargetInfo->gpuWorkarounds.gfx6.shader8b16bLocalWriteCorruption = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx6.shaderReadlaneSmrd = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx6.shaderSpiCsRegAllocFragmentation = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx6.shaderVcczScalarReadBranchFailure = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx6.shaderMinMaxFlushDenorm = 1;
+
+    // NOTE: We only need workaround it in Tahiti, Pitcairn, Capeverde, to simplify the design, we set this
+    // flag for all gfxIp.major == 6
+    pTargetInfo->gpuWorkarounds.gfx6.shaderZExport = 1;
+}
+
+// gfx600
+static void SetGfx600Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx6Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 2;
+}
+
+// gfx601
+static void SetGfx601Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx6Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 1;
+}
+
+// gfx7+
+static void SetGfx7BaseInfo(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx6BaseInfo(pTargetInfo);
+    pTargetInfo->gpuProperty.ldsSizePerCu = 65536;
+    pTargetInfo->gpuProperty.ldsSizeDwordGranularityShift = 7;
+}
+
+// gfx7
+static void SetGfx7Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx7BaseInfo(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 1; // GFX7.0.2+ value
+
+    // Hardware workarounds for GFX7 based GPU's:
+    pTargetInfo->gpuWorkarounds.gfx6.shaderVcczScalarReadBranchFailure = 1;
+    pTargetInfo->gpuWorkarounds.gfx6.shaderMinMaxFlushDenorm = 1;
+}
+
+// gfx700
+static void SetGfx700Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx7Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 2;
+
+    // Hardware workarounds for GFX7.0.0
+    pTargetInfo->gpuWorkarounds.gfx6.cbNoLt16BitIntClamp = 1;
+    // NOTE: Buffer store + index mode are not used in vulkan, so we can skip this workaround in safe.
+    pTargetInfo->gpuWorkarounds.gfx6.shaderCoalesceStore = 1;
+}
+
+// gfx701
+static void SetGfx701Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx7Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 4;
+}
+
+// gfx703 and gfx704
+static void SetGfx703Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx7Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 4;
+
+    // Hardware workarounds for GFX7.0.3 / GFX7.0.4
+    pTargetInfo->gpuWorkarounds.gfx6.cbNoLt16BitIntClamp = 1;
+    pTargetInfo->gpuWorkarounds.gfx6.shaderCoalesceStore = 1;
+    pTargetInfo->gpuWorkarounds.gfx6.shaderSpiBarrierMgmt = 1;
+    pTargetInfo->gpuWorkarounds.gfx6.shaderSpiCsRegAllocFragmentation = 1;
+}
+
+// gfx8+
+static void SetGfx8BaseInfo(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx7BaseInfo(pTargetInfo);
+}
+
+// gfx8
+static void SetGfx8Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx8BaseInfo(pTargetInfo);
+
+    // Hardware workarounds for GFX8.x based GPU's:
+    pTargetInfo->gpuWorkarounds.gfx6.shaderMinMaxFlushDenorm = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx6.shaderSmemBufferAddrClamp = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx6.shaderEstimateRegisterUsage = 1;
+}
+
+// gfx800/gfx801
+static void SetGfx800Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx8Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 1;
+}
+
+// gfx802
+static void SetGfx802Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx8Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 4;
+
+    // Hardware workarounds
+    pTargetInfo->gpuWorkarounds.gfx6.miscSpiSgprsNum = 1;
+}
+
+// gfx803+
+static void SetGfx803Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx8Info(pTargetInfo);
+    // TODO: polaris11 and polaris12 is 2, but we can't identify them by GFX IP now.
+    pTargetInfo->gpuProperty.numShaderEngines = 4;
+}
+
+// gfx81
+static void SetGfx81Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx8Info(pTargetInfo);
+    pTargetInfo->gpuProperty.numShaderEngines = 1;
+}
+
+// gfx9+
+static void SetGfx9BaseInfo(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx8BaseInfo(pTargetInfo);
+    pTargetInfo->gpuProperty.maxUserDataCount = 32;
+    pTargetInfo->gpuProperty.gsOnChipDefaultLdsSizePerSubgroup = 0; // GFX9+ does not use this
+    pTargetInfo->gpuProperty.tessFactorBufferSizePerSe = 8192;
+    pTargetInfo->gpuProperty.numShaderEngines = 4;
+}
+
+// gfx9
+static void SetGfx9Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx9BaseInfo(pTargetInfo);
+
+    // TODO: Clean up code for all 1d texture patch
+    pTargetInfo->gpuWorkarounds.gfx9.treat1dImagesAs2d = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx9.shaderImageGatherInstFix = 1;
+
+    pTargetInfo->gpuWorkarounds.gfx9.fixCacheLineStraddling = 1;
+}
+
+// gfx900
+static void SetGfx900Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx9Info(pTargetInfo);
+    pTargetInfo->gpuWorkarounds.gfx9.fixLsVgprInput = 1;
+}
+
+#if LLPC_BUILD_GFX10
+// gfx10
+static void SetGfx10Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx9BaseInfo(pTargetInfo);
+
+    // Compiler is free to choose wave mode if forced wave size is not specified.
+    if (NativeWaveSize != 0)
+    {
+        LLPC_ASSERT((NativeWaveSize == 32) || (NativeWaveSize == 64));
+        pTargetInfo->gpuProperty.waveSize = NativeWaveSize;
+    }
+    else
+    {
+        pTargetInfo->gpuProperty.waveSize = 32;
+    }
+
+    pTargetInfo->gpuProperty.numShaderEngines = 2;
+    pTargetInfo->gpuProperty.supportShaderPowerProfiling = true;
+    pTargetInfo->gpuProperty.tessFactorBufferSizePerSe = 8192;
+    pTargetInfo->gpuProperty.supportSpiPrefPriority = true;
+
+    // Hardware workarounds for GFX10 based GPU's:
+    pTargetInfo->gpuWorkarounds.gfx10.disableI32ModToI16Mod = 1;
+}
+
+// gfx1010 (including gfx101E and gfx101F)
+static void SetGfx1010Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx10Info(pTargetInfo);
+
+    pTargetInfo->gpuWorkarounds.gfx10.waShaderInstPrefetch0 = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waDidtThrottleVmem = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waLdsVmemNotWaitingVmVsrc = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNsaAndClauseCanHang = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNsaCannotFollowWritelane = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waTessIncorrectRelativeIndex = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waSmemFollowedByVopc = 1;
+}
+
+// gfx101F
+static void SetGfx101FInfo(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx1010Info(pTargetInfo);
+    pTargetInfo->gpuProperty.tessFactorBufferSizePerSe = 0x80;
+
+    pTargetInfo->gpuWorkarounds.gfx10.waTessFactorBufferSizeLimitGeUtcl1Underflow = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waShaderInstPrefetch123   = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.nggTessDegeneratePrims    = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waThrottleInMultiDwordNsa = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNggCullingNoEmptySubgroups = 1;
+}
+
+#if LLPC_BUILD_NAVI12
+// gfx1011
+static void SetGfx1011Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx10Info(pTargetInfo);
+
+    pTargetInfo->gpuWorkarounds.gfx10.waShaderInstPrefetch0      = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waDidtThrottleVmem         = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waLdsVmemNotWaitingVmVsrc  = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNsaCannotFollowWritelane = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNsaAndClauseCanHang      = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waSmemFollowedByVopc       = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waShaderInstPrefetchFwd64  = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waWarFpAtomicDenormHazard  = 1;
+}
+
+#endif
+#if LLPC_BUILD_NAVI14
+// gfx1012
+static void SetGfx1012Info(
+    TargetInfo* pTargetInfo)    // [in/out] Target info
+{
+    SetGfx10Info(pTargetInfo);
+
+    pTargetInfo->gpuWorkarounds.gfx10.waShaderInstPrefetch0      = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waDidtThrottleVmem         = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waLdsVmemNotWaitingVmVsrc  = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNsaCannotFollowWritelane = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNsaAndClauseCanHang      = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waThrottleInMultiDwordNsa  = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waSmemFollowedByVopc       = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNggCullingNoEmptySubgroups = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waShaderInstPrefetchFwd64  = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waWarFpAtomicDenormHazard  = 1;
+    pTargetInfo->gpuWorkarounds.gfx10.waNggDisabled              = 1;
+}
+
+#endif
+#endif
+// =====================================================================================================================
+// Set TargetInfo. Returns false if the GPU name is not found or not supported.
+bool Llpc::SetTargetInfo(
+    StringRef     gpuName,      // LLVM GPU name, e.g. "gfx900"
+    TargetInfo*   pTargetInfo)  // [out] TargetInfo struct to set up
+{
+    *pTargetInfo = {};
+
+    struct GpuNameStringMap
+    {
+        const char* pGpuName;
+        void(*      pSetTargetInfoFunc)(TargetInfo* pTargetInfo);
+    };
+
+    static const GpuNameStringMap GpuNameMap[] =
+    {
+        { "gfx600",   &SetGfx600Info },   // gfx600, tahiti
+        { "gfx601",   &SetGfx601Info },   // gfx601, pitcairn, verde, oland, hainan
+        { "gfx700",   &SetGfx700Info },   // gfx700, kaveri
+        { "gfx701",   &SetGfx701Info },   // gfx701, hawaii
+        { "gfx702",   &SetGfx7Info },     // gfx702
+        { "gfx703",   &SetGfx703Info },   // gfx703, kabini, mullins
+        { "gfx704",   &SetGfx703Info },   // gfx704, bonaire
+        { "gfx800",   &SetGfx800Info },   // gfx800, iceland
+        { "gfx801",   &SetGfx800Info },   // gfx801, carrizo
+        { "gfx802",   &SetGfx802Info },   // gfx802, tonga
+        { "gfx803",   &SetGfx803Info },   // gfx803, fiji, polaris10, polaris11
+        { "gfx804",   &SetGfx803Info },   // gfx804
+        { "gfx810",   &SetGfx81Info },    // gfx810, stoney
+        { "gfx900",   &SetGfx900Info },   // gfx900
+        { "gfx901",   &SetGfx9Info },     // gfx901
+        { "gfx902",   &SetGfx900Info },   // gfx902
+        { "gfx903",   &SetGfx9Info },     // gfx903
+        { "gfx904",   &SetGfx9Info },     // gfx904, vega12
+#if LLPC_BUILD_VEGA20
+        { "gfx906",   &SetGfx9Info },     // gfx906, vega20
+#endif
+#if LLPC_BUILD_RAVEN2
+        { "gfx909",   &SetGfx9Info },     // gfx909, raven2
+#endif
+#if LLPC_BUILD_GFX10
+        { "gfx101F",  &SetGfx101FInfo },
+        { "gfx101E",  &SetGfx1010Info },
+        { "gfx1010",  &SetGfx1010Info },  // gfx1010
+#if LLPC_BUILD_NAVI12
+        { "gfx1011",  &SetGfx1011Info },  // gfx1011，navi12
+#endif
+#if LLPC_BUILD_NAVI14
+        { "gfx101D",  &SetGfx1012Info },
+        { "gfx1012",  &SetGfx1012Info },  // gfx1012, navi14
+#endif
+#if LLPC_BUILD_NAVI21
+        { "gfx1031",  &SetGfx10Info },    // gfx1031, navi21
+#endif
+#endif
+    };
+
+    void(* pSetTargetInfoFunc)(TargetInfo* pTargetInfo) = nullptr;
+    for (const GpuNameStringMap& mapEntry : ArrayRef<GpuNameStringMap>(GpuNameMap))
+    {
+        if (gpuName == mapEntry.pGpuName)
+        {
+            pSetTargetInfoFunc = mapEntry.pSetTargetInfoFunc;
+            break;
+        }
+    }
+    if (pSetTargetInfoFunc == nullptr)
+    {
+        return false;   // Target not supported
+    }
+
+    // Set up TargetInfo.gfxIp from the GPU name. This is the inverse of what happens to encode the
+    // GPU name in PipelineContext::GetGpuNameString. But longer term we should remove all the uses of
+    // TargetInfo.gfxIp in the middle-end and use specific feature bits instead.
+    gpuName.slice(3, gpuName.size() - 2).consumeInteger(10, pTargetInfo->gfxIp.major);
+    pTargetInfo->gfxIp.minor = gpuName[gpuName.size() - 2] - '0';
+    pTargetInfo->gfxIp.stepping = gpuName[gpuName.size() - 1] - '0';
+    if (pTargetInfo->gfxIp.stepping >= 10)
+    {
+        pTargetInfo->gfxIp.stepping = gpuName[gpuName.size() - 1] - 'A' + 0xFFFA;
+    }
+
+    // Set up the rest of TargetInfo.
+    (*pSetTargetInfoFunc)(pTargetInfo);
+
+    return true;
+}
+

--- a/builder/llpcTargetInfo.h
+++ b/builder/llpcTargetInfo.h
@@ -1,7 +1,7 @@
 /*
  ***********************************************************************************************************************
  *
- *  Copyright (c) 2017-2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -24,75 +24,33 @@
  **********************************************************************************************************************/
 /**
  ***********************************************************************************************************************
- * @file  llpcCodeGenManager.h
- * @brief LLPC header file: contains declaration of class Llpc::CodeGenManager.
+ * @file  llpcTargetInfo.h
+ * @brief LLPC header file: declaration of TargetInfo struct
  ***********************************************************************************************************************
  */
 #pragma once
 
-#include "llvm/IR/Module.h"
-#include "llvm/Support/raw_ostream.h"
-
-#include <string>
 #include "llpc.h"
-#include "llpcDebug.h"
-#include "llpcElfReader.h"
-
-namespace llvm
-{
-
-namespace legacy
-{
-
-class PassManager;
-
-} // legacy
-
-class Timer;
-
-} // llvm
+#include "llpcCompiler.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace Llpc
 {
 
-namespace Gfx6
-{
-    struct PipelineVsFsRegConfig;
-    struct PipelineCsRegConfig;
-}
-
-class Context;
-class PassManager;
-class PipelineState;
-
-// Represents data entry in a ELF section, including associated ELF symbols.
-struct ElfDataEntry
-{
-    const void* pData;           // Data in the section
-    uint32_t    offset;          // Offset of the data
-    uint32_t    size;            // Size of the data
-    uint32_t    padSize;         // Padding size of the data
-    const char* pSymName;        // Name of associated ELF symbol
-};
+using namespace llvm;
 
 // =====================================================================================================================
-// Represents the manager of GPU ISA code generation.
-class CodeGenManager
+// TargetInfo struct, representing features and workarounds for the particular selected target
+struct TargetInfo
 {
-public:
-    static void SetupTargetFeatures(PipelineState* pPipelineState);
-
-    static Result Run(llvm::Module*               pModule,
-                      llvm::legacy::PassManager&  passMgr);
-
-private:
-    LLPC_DISALLOW_DEFAULT_CTOR(CodeGenManager);
-    LLPC_DISALLOW_COPY_AND_ASSIGN(CodeGenManager);
-
-    static void DiagnosticHandler(const llvm::DiagnosticInfo& diagInfo, void* pContext);
-
-    static void FatalErrorHandler(void* userData, const std::string& reason, bool gen_crash_diag);
-
+    GfxIpVersion    gfxIp;          // major.minor.stepping
+    GpuProperty     gpuProperty;    // GPU properties
+    WorkaroundFlags gpuWorkarounds; // GPU workarounds
 };
+
+// Set TargetInfo. Returns false if the GPU name is not found or not supported.
+bool SetTargetInfo(
+    StringRef     gpuName,      // LLVM GPU name, e.g. "gfx900"
+    TargetInfo*   pTargetInfo); // [out] TargetInfo struct to set up
 
 } // Llpc

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -308,7 +308,7 @@ Result VKAPI_CALL ICompiler::Create(
 bool VKAPI_CALL ICompiler::IsVertexFormatSupported(
     VkFormat format)   // Vertex attribute format
 {
-    Builder::BufDataFormat dfmt = GraphicsContext::MapVkFormat(format).first;
+    Builder::BufDataFormat dfmt = GraphicsContext::MapVkFormat(format, false).first;
     return (dfmt != Builder::BufDataFormatInvalid);
 }
 

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -308,8 +308,8 @@ Result VKAPI_CALL ICompiler::Create(
 bool VKAPI_CALL ICompiler::IsVertexFormatSupported(
     VkFormat format)   // Vertex attribute format
 {
-    auto pInfo = VertexFetch::GetVertexFormatInfo(format);
-    return ((pInfo->dfmt == BUF_DATA_FORMAT_INVALID) && (pInfo->numChannels == 0)) ? false : true;
+    Builder::BufDataFormat dfmt = GraphicsContext::MapVkFormat(format).first;
+    return (dfmt != Builder::BufDataFormatInvalid);
 }
 
 // =====================================================================================================================

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -143,10 +143,6 @@ opt<bool> EnableShaderModuleOpt("enable-shader-module-opt",
 opt<bool> DisableLicm("disable-licm", desc("Disable LLVM LICM pass"), init(false));
 
 #if LLPC_BUILD_GFX10
-// -native-wave-size: an option to override hardware native wave size, it will allow compiler to choose
-// final wave size base on it. Used in pre-silicon verification.
-opt<int> NativeWaveSize("native-wave-size", cl::desc("Overrides hardware native wave size"), init(0));
-
 // -subgroup-size: sub-group size exposed via Vulkan API.
 opt<int> SubgroupSize("subgroup-size", cl::desc("Sub-group size exposed via Vulkan API"), init(64));
 #endif
@@ -171,6 +167,10 @@ extern opt<std::string> LogFileOuts;
 
 namespace Llpc
 {
+
+// -native-wave-size: an option to override hardware native wave size, it will allow compiler to choose
+// final wave size base on it. Used in pre-silicon verification.
+extern cl::opt<int> NativeWaveSize;
 
 llvm::sys::Mutex       Compiler::m_contextPoolMutex;
 std::vector<Context*>* Compiler::m_pContextPool = nullptr;
@@ -601,9 +601,6 @@ Compiler::Compiler(
 
     m_shaderCache = ShaderCacheManager::GetShaderCacheManager()->GetShaderCacheObject(&createInfo, &auxCreateInfo);
 
-    InitGpuProperty();
-    InitGpuWorkaround();
-
     ++m_instanceCount;
     ++m_outRedirectCount;
 }
@@ -809,8 +806,7 @@ Result Compiler::BuildShaderModule(
                 Context* pContext = AcquireContext();
 
                 pContext->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>());
-                pContext->CreateBuilder();
-                CodeGenManager::CreateTargetMachine(pContext, pPipelineOptions);
+                result = pContext->CreateBuilder(pPipelineOptions);
 
                 for (uint32_t i = 0; i < entryNames.size(); ++i)
                 {
@@ -991,9 +987,6 @@ Result Compiler::BuildPipelineInternal(
     TimerProfiler timerProfiler(pContext->GetPiplineHashCode(), "LLPC", TimerProfiler::PipelineTimerEnableMask);
 
     pContext->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>());
-
-    // Create the AMDGPU TargetMachine.
-    result = CodeGenManager::CreateTargetMachine(pContext, pContext->GetPipelineContext()->GetPipelineOptions());
 
     std::unique_ptr<Module> pipelineModule;
 
@@ -1422,9 +1415,12 @@ Result Compiler::BuildGraphicsPipelineInternal(
 {
     Context* pContext = AcquireContext();
     pContext->AttachPipelineContext(pGraphicsContext);
-    pContext->CreateBuilder();
+    Result result = pContext->CreateBuilder(pGraphicsContext->GetPipelineOptions());
 
-    Result result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
+    if (result == Result::Success)
+    {
+        result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
+    }
 
     ReleaseContext(pContext);
     return result;
@@ -1509,8 +1505,6 @@ Result Compiler::BuildGraphicsPipeline(
         uint32_t                      forceLoopUnrollCount = cl::ForceLoopUnrollCount;
 
         GraphicsContext graphicsContext(m_gfxIp,
-                                        &m_gpuProperty,
-                                        &m_gpuWorkarounds,
                                         pPipelineInfo,
                                         &pipelineHash,
                                         &cacheHash);
@@ -1564,19 +1558,22 @@ Result Compiler::BuildComputePipelineInternal(
 {
     Context* pContext = AcquireContext();
     pContext->AttachPipelineContext(pComputeContext);
-    pContext->CreateBuilder();
+    Result result = pContext->CreateBuilder(pComputeContext->GetPipelineOptions());
 
-    const PipelineShaderInfo* shaderInfo[ShaderStageNativeStageCount] =
+    if (result == Result::Success)
     {
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        &pPipelineInfo->cs,
-    };
+        const PipelineShaderInfo* shaderInfo[ShaderStageNativeStageCount] =
+        {
+            nullptr,
+            nullptr,
+            nullptr,
+            nullptr,
+            nullptr,
+            &pPipelineInfo->cs,
+        };
 
-    Result result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
+        result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
+    }
 
     ReleaseContext(pContext);
     return result;
@@ -1647,8 +1644,6 @@ Result Compiler::BuildComputePipeline(
         uint32_t                      forceLoopUnrollCount = cl::ForceLoopUnrollCount;
 
         ComputeContext computeContext(m_gfxIp,
-                                      &m_gpuProperty,
-                                      &m_gpuWorkarounds,
                                       pPipelineInfo,
                                       &pipelineHash,
                                       &cacheHash);
@@ -1985,244 +1980,6 @@ Result Compiler::CreateShaderCache(
 #endif
 
 // =====================================================================================================================
-// Initialize GPU property.
-void Compiler::InitGpuProperty()
-{
-    // Initial settings (could be adjusted later according to graphics IP version info)
-    memset(&m_gpuProperty, 0, sizeof(m_gpuProperty));
-    m_gpuProperty.waveSize = 64;
-
-#if LLPC_BUILD_GFX10
-    if (m_gfxIp.major == 10)
-    {
-        // Compiler is free to choose wave mode if forced wave size is not specified.
-        if (cl::NativeWaveSize != 0)
-        {
-            LLPC_ASSERT((cl::NativeWaveSize == 32) || (cl::NativeWaveSize == 64));
-            m_gpuProperty.waveSize = cl::NativeWaveSize;
-        }
-        else
-        {
-            m_gpuProperty.waveSize = 32;
-        }
-    }
-    else if (m_gfxIp.major > 10)
-    {
-        LLPC_NOT_IMPLEMENTED();
-    }
-#endif
-
-    m_gpuProperty.ldsSizePerCu = (m_gfxIp.major > 6) ? 65536 : 32768;
-    m_gpuProperty.ldsSizePerThreadGroup = 32 * 1024;
-    m_gpuProperty.numShaderEngines = 4;
-    m_gpuProperty.maxSgprsAvailable = 104;
-    m_gpuProperty.maxVgprsAvailable = 256;
-
-    //TODO: Setup gsPrimBufferDepth from hardware config option, will be done in another change.
-    m_gpuProperty.gsPrimBufferDepth = 0x100;
-
-    m_gpuProperty.maxUserDataCount = (m_gfxIp.major >= 9) ? 32 : 16;
-
-    m_gpuProperty.gsOnChipMaxLdsSize = 16384;
-
-    m_gpuProperty.tessOffChipLdsBufferSize = 32768;
-
-    // TODO: Accept gsOnChipDefaultPrimsPerSubgroup from panel option
-    m_gpuProperty.gsOnChipDefaultPrimsPerSubgroup   = 64;
-
-    m_gpuProperty.tessFactorBufferSizePerSe = 4096;
-
-    if (m_gfxIp.major <= 6)
-    {
-        m_gpuProperty.ldsSizeDwordGranularityShift = 6;
-    }
-    else
-    {
-        m_gpuProperty.ldsSizeDwordGranularityShift = 7;
-    }
-
-    if (m_gfxIp.major <= 8)
-    {
-        // TODO: Accept gsOnChipDefaultLdsSizePerSubgroup from panel option
-        m_gpuProperty.gsOnChipDefaultLdsSizePerSubgroup = 8192;
-    }
-
-    if (m_gfxIp.major == 6)
-    {
-        m_gpuProperty.numShaderEngines = (m_gfxIp.stepping == 0) ? 2 : 1;
-    }
-    else if (m_gfxIp.major == 7)
-    {
-        if (m_gfxIp.stepping == 0)
-        {
-            m_gpuProperty.numShaderEngines = 2;
-        }
-        else if (m_gfxIp.stepping == 1)
-        {
-            m_gpuProperty.numShaderEngines = 4;
-        }
-        else
-        {
-            m_gpuProperty.numShaderEngines = 1;
-        }
-    }
-    else if (m_gfxIp.major == 8)
-    {
-        // TODO: polaris11 and polaris12 is 2, but we can't identify them by GFX IP now.
-        m_gpuProperty.numShaderEngines = ((m_gfxIp.minor == 1) || (m_gfxIp.stepping <= 1)) ? 1 : 4;
-    }
-    else if (m_gfxIp.major == 9)
-    {
-        m_gpuProperty.tessFactorBufferSizePerSe = 8192;
-        if (m_gfxIp.stepping == 0)
-        {
-            m_gpuProperty.numShaderEngines = 4;
-        }
-    }
-#if LLPC_BUILD_GFX10
-    else if (m_gfxIp.major == 10)
-    {
-        m_gpuProperty.numShaderEngines = 2;
-        m_gpuProperty.supportShaderPowerProfiling = true;
-        m_gpuProperty.tessFactorBufferSizePerSe = 8192;
-
-        if (m_gfxIp.minor != 0)
-        {
-            m_gpuProperty.supportSpiPrefPriority = true; // For GFX10.1+
-        }
-
-        if ((m_gfxIp.minor == 1) && (m_gfxIp.stepping == 0xFFFF))
-        {
-            m_gpuProperty.tessFactorBufferSizePerSe = 0x80;
-        }
-    }
-#endif
-    else
-    {
-        LLPC_NOT_IMPLEMENTED();
-    }
-}
-
-// =====================================================================================================================
-// Initialize GPU workarounds.
-void Compiler::InitGpuWorkaround()
-{
-    memset(&m_gpuWorkarounds, 0, sizeof(m_gpuWorkarounds));
-    if (m_gfxIp.major == 6)
-    {
-        // Hardware workarounds for GFX6 based GPU's:
-        m_gpuWorkarounds.gfx6.cbNoLt16BitIntClamp = 1;
-        m_gpuWorkarounds.gfx6.miscLoadBalancePerWatt = 1;
-        m_gpuWorkarounds.gfx6.shader8b16bLocalWriteCorruption = 1;
-
-        m_gpuWorkarounds.gfx6.shaderReadlaneSmrd = 1;
-
-        m_gpuWorkarounds.gfx6.shaderSpiCsRegAllocFragmentation = 1;
-
-        m_gpuWorkarounds.gfx6.shaderVcczScalarReadBranchFailure = 1;
-
-        m_gpuWorkarounds.gfx6.shaderMinMaxFlushDenorm = 1;
-
-        // NOTE: We only need workaround it in Tahiti, Pitcairn, Capeverde, to simplify the design, we set this
-        // flag for all gfxIp.major == 6
-        m_gpuWorkarounds.gfx6.shaderZExport = 1;
-
-    }
-    else if (m_gfxIp.major == 7)
-    {
-        // Hardware workarounds for GFX7 based GPU's:
-        m_gpuWorkarounds.gfx6.shaderVcczScalarReadBranchFailure = 1;
-        m_gpuWorkarounds.gfx6.shaderMinMaxFlushDenorm = 1;
-
-        if (m_gfxIp.stepping == 0)
-        {
-            m_gpuWorkarounds.gfx6.cbNoLt16BitIntClamp = 1;
-
-            // NOTE: Buffer store + index mode are not used in vulkan, so we can skip this workaround in safe.
-            m_gpuWorkarounds.gfx6.shaderCoalesceStore = 1;
-        }
-        if ((m_gfxIp.stepping == 3) || (m_gfxIp.stepping == 4))
-        {
-            m_gpuWorkarounds.gfx6.cbNoLt16BitIntClamp = 1;
-            m_gpuWorkarounds.gfx6.shaderCoalesceStore = 1;
-            m_gpuWorkarounds.gfx6.shaderSpiBarrierMgmt = 1;
-            m_gpuWorkarounds.gfx6.shaderSpiCsRegAllocFragmentation = 1;
-        }
-    }
-    else if (m_gfxIp.major == 8)
-    {
-        // Hardware workarounds for GFX8.x based GPU's:
-        m_gpuWorkarounds.gfx6.shaderMinMaxFlushDenorm = 1;
-
-        m_gpuWorkarounds.gfx6.shaderSmemBufferAddrClamp = 1;
-
-        m_gpuWorkarounds.gfx6.shaderEstimateRegisterUsage = 1;
-
-        if (m_gfxIp.minor == 0 && m_gfxIp.stepping == 2)
-        {
-            m_gpuWorkarounds.gfx6.miscSpiSgprsNum = 1;
-        }
-    }
-    else if (m_gfxIp.major == 9)
-    {
-        // Hardware workarounds for GFX9 based GPU's:
-
-        // TODO: Clean up code for all 1d texture patch
-        m_gpuWorkarounds.gfx9.treat1dImagesAs2d = 1;
-
-        m_gpuWorkarounds.gfx9.shaderImageGatherInstFix = 1;
-
-        m_gpuWorkarounds.gfx9.fixCacheLineStraddling = 1;
-
-        if (m_gfxIp.stepping == 0 || m_gfxIp.stepping == 2)
-        {
-            m_gpuWorkarounds.gfx9.fixLsVgprInput = 1;
-        }
-    }
-#if LLPC_BUILD_GFX10
-    else if (m_gfxIp.major == 10)
-    {
-        // Hardware workarounds for GFX10 based GPU's:
-        m_gpuWorkarounds.gfx10.disableI32ModToI16Mod = 1;
-
-        if ((m_gfxIp.minor == 1) && (m_gfxIp.stepping == 0xFFFF))
-        {
-            m_gpuWorkarounds.gfx10.waTessFactorBufferSizeLimitGeUtcl1Underflow = 1;
-        }
-
-        if (m_gfxIp.minor == 1)
-        {
-            switch (m_gfxIp.stepping)
-            {
-            case 0:
-            case 0xFFFE:
-            case 0xFFFF:
-                m_gpuWorkarounds.gfx10.waShaderInstPrefetch0 = 1;
-                m_gpuWorkarounds.gfx10.waDidtThrottleVmem = 1;
-                m_gpuWorkarounds.gfx10.waLdsVmemNotWaitingVmVsrc = 1;
-                m_gpuWorkarounds.gfx10.waNsaAndClauseCanHang = 1;
-                m_gpuWorkarounds.gfx10.waNsaCannotFollowWritelane = 1;
-                m_gpuWorkarounds.gfx10.waTessIncorrectRelativeIndex = 1;
-                m_gpuWorkarounds.gfx10.waSmemFollowedByVopc = 1;
-
-                if (m_gfxIp.stepping == 0xFFFF)
-                {
-                    m_gpuWorkarounds.gfx10.waShaderInstPrefetch123   = 1;
-                    m_gpuWorkarounds.gfx10.nggTessDegeneratePrims    = 1;
-                    m_gpuWorkarounds.gfx10.waThrottleInMultiDwordNsa = 1;
-                    m_gpuWorkarounds.gfx10.waNggCullingNoEmptySubgroups = 1;
-                }
-                break;
-            default:
-                LLPC_NEVER_CALLED();
-                break;
-            }
-        }
-    }
-#endif
-
-}
-// =====================================================================================================================
 // Acquires a free context from context pool.
 Context* Compiler::AcquireContext() const
 {
@@ -2249,7 +2006,7 @@ Context* Compiler::AcquireContext() const
     if (pFreeContext == nullptr)
     {
         // Create a new one if we fail to find an available one
-        pFreeContext = new Context(m_gfxIp, &m_gpuWorkarounds);
+        pFreeContext = new Context(m_gfxIp);
         pFreeContext->SetInUse(true);
         m_pContextPool->push_back(pFreeContext);
     }

--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -809,7 +809,7 @@ Result Compiler::BuildShaderModule(
                 Context* pContext = AcquireContext();
 
                 pContext->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>());
-                pContext->SetBuilder(Builder::Create(*pContext));
+                pContext->CreateBuilder();
                 CodeGenManager::CreateTargetMachine(pContext, pPipelineOptions);
 
                 for (uint32_t i = 0; i < entryNames.size(); ++i)
@@ -1216,9 +1216,6 @@ Result Compiler::BuildPipelineInternal(
 #endif
     }
 
-    delete pContext->GetBuilder();
-    pContext->SetBuilder(nullptr);
-
     if (checkPerStageCache)
     {
         // For graphics, update shader caches with results of compile, and merge ELF outputs if necessary.
@@ -1425,12 +1422,10 @@ Result Compiler::BuildGraphicsPipelineInternal(
 {
     Context* pContext = AcquireContext();
     pContext->AttachPipelineContext(pGraphicsContext);
-    pContext->SetBuilder(Builder::Create(*pContext));
+    pContext->CreateBuilder();
 
     Result result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
 
-    delete pContext->GetBuilder();
-    pContext->SetBuilder(nullptr);
     ReleaseContext(pContext);
     return result;
 }
@@ -1569,7 +1564,7 @@ Result Compiler::BuildComputePipelineInternal(
 {
     Context* pContext = AcquireContext();
     pContext->AttachPipelineContext(pComputeContext);
-    pContext->SetBuilder(Builder::Create(*pContext));
+    pContext->CreateBuilder();
 
     const PipelineShaderInfo* shaderInfo[ShaderStageNativeStageCount] =
     {
@@ -1583,8 +1578,6 @@ Result Compiler::BuildComputePipelineInternal(
 
     Result result = BuildPipelineInternal(pContext, shaderInfo, forceLoopUnrollCount, pPipelineElf);
 
-    delete pContext->GetBuilder();
-    pContext->SetBuilder(nullptr);
     ReleaseContext(pContext);
     return result;
 }

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -254,7 +254,9 @@ public:
     static MetroHash::Hash GenerateHashForCompileOptions(uint32_t          optionCount,
                                                          const char*const* pOptions);
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     virtual Result CreateShaderCache(const ShaderCacheCreateInfo* pCreateInfo, IShaderCache** ppShaderCache);
+#endif
 
     static void TranslateSpirvToLlvm(const PipelineShaderInfo*    pShaderInfo,
                                      llvm::Module*                pModule);
@@ -287,7 +289,7 @@ private:
                                PipelineStatistics*     pPipelineStats) const;
 
     bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule) const;
-
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
                                         MetroHash::Hash*    pCacheHash,
                                         BinaryData*         pElfBin,
@@ -299,7 +301,15 @@ private:
                             ShaderCache**       ppShaderCache,
                             CacheEntryHandle*   phEntry,
                             uint32_t            shaderCacheCount);
+#else
+    ShaderEntryState LookUpShaderCache(MetroHash::Hash*    pCacheHash,
+                                       BinaryData*         pElfBin,
+                                       CacheEntryHandle*   phEntry);
 
+    void UpdateShaderCache(bool                bInsert,
+                           const BinaryData*   pElfBin,
+                           CacheEntryHandle   phEntry);
+#endif
     void BuildShaderCacheHash(Context* pContext, MetroHash::Hash* pFragmentHash, MetroHash::Hash* pNonFragmentHash);
 
     void MergeElfBinary(Context*          pContext,

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -42,6 +42,7 @@ namespace Llpc
 
 // Forward declaration
 class Builder;
+class Compiler;
 class ComputeContext;
 class Context;
 class GraphicsContext;
@@ -211,6 +212,55 @@ struct PipelineStatistics
 };
 
 // =====================================================================================================================
+// Object to manage checking and updating shader cache for graphics pipeline.
+class GraphicsShaderCacheChecker
+{
+public:
+    GraphicsShaderCacheChecker(Compiler* pCompiler, Context* pContext) :
+        m_pCompiler(pCompiler), m_pContext(pContext)
+    {}
+
+    // Check shader caches, returning mask of which shader stages we want to keep in this compile.
+    uint32_t Check(const llvm::Module*                     pModule,
+                   uint32_t                                stageMask,
+                   llvm::ArrayRef<llvm::ArrayRef<uint8_t>> stageHashes);
+
+    // Get cache results.
+    ShaderEntryState GetNonFragmentCacheEntryState() { return m_nonFragmentCacheEntryState; }
+    ShaderEntryState GetFragmentCacheEntryState() { return m_fragmentCacheEntryState; }
+
+    // Update shader caches with results of compile, and merge ELF outputs if necessary.
+    void UpdateAndMerge(Result result, ElfPackage* pPipelineElf);
+
+private:
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    static constexpr uint32_t ShaderCacheCount = 2;
+#endif
+    Compiler* m_pCompiler;
+    Context*  m_pContext;
+
+    ShaderEntryState m_nonFragmentCacheEntryState = ShaderEntryState::New;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    ShaderCache* m_pNonFragmentShaderCache[ShaderCacheCount] = {};
+    CacheEntryHandle m_hNonFragmentEntry[ShaderCacheCount] = {};
+#else
+    ShaderCache* m_pNonFragmentShaderCache = nullptr;
+    CacheEntryHandle m_hNonFragmentEntry = {};
+#endif
+    BinaryData m_nonFragmentElf = {};
+
+    ShaderEntryState m_fragmentCacheEntryState = ShaderEntryState::New;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    ShaderCache* m_pFragmentShaderCache[ShaderCacheCount] = {};
+    CacheEntryHandle m_hFragmentEntry[ShaderCacheCount] = {};
+#else
+    ShaderCache* m_pFragmentShaderCache = nullptr
+    CacheEntryHandle m_hFragmentEntry = {};
+#endif
+    BinaryData m_fragmentElf = {};
+};
+
+// =====================================================================================================================
 // Represents LLPC pipeline compiler.
 class Compiler: public ICompiler
 {
@@ -261,6 +311,38 @@ public:
     static void TranslateSpirvToLlvm(const PipelineShaderInfo*    pShaderInfo,
                                      llvm::Module*                pModule);
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+    ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
+                                        MetroHash::Hash*    pCacheHash,
+                                        BinaryData*         pElfBin,
+                                        ShaderCache**       ppShaderCache,
+                                        CacheEntryHandle*   phEntry);
+
+    static void UpdateShaderCaches(bool                insert,
+                                   const BinaryData*   pElfBin,
+                                   ShaderCache**       ppShaderCache,
+                                   CacheEntryHandle*   phEntry,
+                                   uint32_t            shaderCacheCount);
+#else
+    ShaderEntryState LookUpShaderCache(MetroHash::Hash*    pCacheHash,
+                                       BinaryData*         pElfBin,
+                                       CacheEntryHandle*   phEntry);
+
+    static void UpdateShaderCache(bool                insert,
+                                  const BinaryData*   pElfBin,
+                                  CacheEntryHandle    phEntry);
+#endif
+    static void BuildShaderCacheHash(Context*                                 pContext,
+                                     uint32_t                                 stageMask,
+                                     llvm::ArrayRef<llvm::ArrayRef<uint8_t>>  stageHashes,
+                                     MetroHash::Hash*                         pFragmentHash,
+                                     MetroHash::Hash*                         pNonFragmentHash);
+
+    void MergeElfBinary(Context*          pContext,
+                        const BinaryData* pFragmentElf,
+                        const BinaryData* pNonFragmentElf,
+                        ElfPackage*       pPipelineElf);
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(Compiler);
     LLPC_DISALLOW_COPY_AND_ASSIGN(Compiler);
@@ -289,33 +371,6 @@ private:
                                PipelineStatistics*     pPipelineStats) const;
 
     bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule) const;
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
-    ShaderEntryState LookUpShaderCaches(IShaderCache*       pAppPipelineCache,
-                                        MetroHash::Hash*    pCacheHash,
-                                        BinaryData*         pElfBin,
-                                        ShaderCache**       ppShaderCache,
-                                        CacheEntryHandle*   phEntry);
-
-    void UpdateShaderCaches(bool                bInsert,
-                            const BinaryData*   pElfBin,
-                            ShaderCache**       ppShaderCache,
-                            CacheEntryHandle*   phEntry,
-                            uint32_t            shaderCacheCount);
-#else
-    ShaderEntryState LookUpShaderCache(MetroHash::Hash*    pCacheHash,
-                                       BinaryData*         pElfBin,
-                                       CacheEntryHandle*   phEntry);
-
-    void UpdateShaderCache(bool                bInsert,
-                           const BinaryData*   pElfBin,
-                           CacheEntryHandle   phEntry);
-#endif
-    void BuildShaderCacheHash(Context* pContext, MetroHash::Hash* pFragmentHash, MetroHash::Hash* pNonFragmentHash);
-
-    void MergeElfBinary(Context*          pContext,
-                        const BinaryData* pFragmentElf,
-                        const BinaryData* pNonFragmentElf,
-                        ElfPackage*       pPipelineElf);
     // -----------------------------------------------------------------------------------------------------------------
 
     std::vector<std::string>      m_options;          // Compilation options

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -349,9 +349,6 @@ private:
 
     Result ValidatePipelineShaderInfo(ShaderStage shaderStage, const PipelineShaderInfo* pShaderInfo) const;
 
-    void InitGpuProperty();
-    void InitGpuWorkaround();
-
     Context* AcquireContext() const;
     void ReleaseContext(Context* pContext) const;
 
@@ -379,8 +376,6 @@ private:
     static uint32_t               m_instanceCount;    // The count of compiler instance
     static uint32_t               m_outRedirectCount; // The count of output redirect
     ShaderCachePtr                m_shaderCache;      // Shader cache
-    GpuProperty                   m_gpuProperty;      // GPU property
-    WorkaroundFlags               m_gpuWorkarounds;   // GPU workarounds;
     static llvm::sys::Mutex       m_contextPoolMutex; // Mutex for context pool access
     static std::vector<Context*>* m_pContextPool;      // Context pool
 };

--- a/context/llpcComputeContext.cpp
+++ b/context/llpcComputeContext.cpp
@@ -30,6 +30,7 @@
  */
 #define DEBUG_TYPE "llpc-compute-context"
 
+#include "llpcBuilder.h"
 #include "llpcComputeContext.h"
 #include "SPIRVInternal.h"
 
@@ -140,6 +141,15 @@ uint32_t ComputeContext::GetShaderWaveSize(
 #endif
     return waveSize;
 
+}
+
+// =====================================================================================================================
+// Set pipeline state in Builder
+void ComputeContext::SetBuilderPipelineState(
+    Builder*          pBuilder) const   // [in] The builder
+{
+    PipelineContext::SetBuilderPipelineState(pBuilder);
+    pBuilder->SetDeviceIndex(static_cast<const ComputePipelineBuildInfo*>(GetPipelineBuildInfo())->deviceIndex);
 }
 
 } // Llpc

--- a/context/llpcComputeContext.cpp
+++ b/context/llpcComputeContext.cpp
@@ -55,13 +55,11 @@ namespace Llpc
 // =====================================================================================================================
 ComputeContext::ComputeContext(
     GfxIpVersion                    gfxIp,            // Graphics Ip version info
-    const GpuProperty*              pGpuProp,         // [in] GPU Property
-    const WorkaroundFlags*          pGpuWorkarounds,  // [in] GPU workarounds
     const ComputePipelineBuildInfo* pPipelineInfo,    // [in] Compute pipeline build info
     MetroHash::Hash*                pPipelineHash,    // [in] Pipeline hash code
     MetroHash::Hash*                pCacheHash)       // [in] Cache hash code
     :
-    PipelineContext(gfxIp, pGpuProp, pGpuWorkarounds, pPipelineHash, pCacheHash),
+    PipelineContext(gfxIp, pPipelineHash, pCacheHash),
     m_pPipelineInfo(pPipelineInfo)
 {
     InitShaderResourceUsage(ShaderStageCompute, GetShaderResourceUsage(ShaderStageCompute));
@@ -101,9 +99,10 @@ const PipelineShaderInfo* ComputeContext::GetPipelineShaderInfo(
 //
 // NOTE: Need to be called after PatchResourceCollect pass, so usage of subgroupSize is confirmed.
 uint32_t ComputeContext::GetShaderWaveSize(
-    ShaderStage stage)  // Shader stage
+    ShaderStage         stage,        // Shader stage
+    const GpuProperty&  gpuProperty)  // [in] GPU properties
 {
-    uint32_t waveSize = m_pGpuProperty->waveSize;
+    uint32_t waveSize = gpuProperty.waveSize;
 #if LLPC_BUILD_GFX10
     LLPC_ASSERT(stage == ShaderStageCompute);
 

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -101,6 +101,9 @@ public:
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const { return &m_pPipelineInfo->options; }
 
+    // Set pipeline state in Builder
+    virtual void SetBuilderPipelineState(Builder* pBuilder) const;
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(ComputeContext);
     LLPC_DISALLOW_COPY_AND_ASSIGN(ComputeContext);

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -41,8 +41,6 @@ class ComputeContext: public PipelineContext
 {
 public:
     ComputeContext(GfxIpVersion                    gfxIp,
-                   const GpuProperty*              pGpuProp,
-                   const WorkaroundFlags*          pGpuWorkarounds,
                    const ComputePipelineBuildInfo* pPipelineInfo,
                    MetroHash::Hash*                pPipelineHash,
                    MetroHash::Hash*                pCacheHash);
@@ -68,7 +66,7 @@ public:
     virtual bool IsTessOffChip() const { LLPC_NEVER_CALLED(); return false; }
 
     // Determines whether GS on-chip mode is valid for this pipeline
-    virtual bool CheckGsOnChipValidity() { LLPC_NEVER_CALLED(); return false; }
+    virtual bool CheckGsOnChipValidity(PipelineState* pPipelineState) { LLPC_NEVER_CALLED(); return false; }
 
     // Checks whether GS on-chip mode is enabled
     virtual bool IsGsOnChip() const { LLPC_NEVER_CALLED(); return false; }
@@ -81,7 +79,7 @@ public:
 
 #if LLPC_BUILD_GFX10
     // Sets NGG control settings
-    virtual void SetNggControl() { LLPC_NEVER_CALLED(); }
+    virtual void SetNggControl(PipelineState* pPipelineState) { LLPC_NEVER_CALLED(); }
 
     // Gets NGG control settings
     virtual const NggControl* GetNggControl() const { LLPC_NEVER_CALLED(); return nullptr; }
@@ -98,7 +96,7 @@ public:
     virtual uint32_t GetVerticesPerPrimitive() const { LLPC_NEVER_CALLED(); return 0; }
 
     // Gets wave size for the specified shader stage
-    virtual uint32_t GetShaderWaveSize(ShaderStage stage);
+    virtual uint32_t GetShaderWaveSize(ShaderStage stage, const GpuProperty& gpuProperty);
 
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const { return &m_pPipelineInfo->options; }

--- a/context/llpcContext.h
+++ b/context/llpcContext.h
@@ -39,6 +39,7 @@
 #include <unordered_set>
 #include "spirvExt.h"
 
+#include "llpcBuilderContext.h"
 #include "llpcEmuLib.h"
 #include "llpcPipelineContext.h"
 
@@ -73,8 +74,8 @@ public:
         return m_pPipelineContext;
     }
 
-    // Sets LLPC builder
-    void SetBuilder(Builder* pBuilder) { m_pBuilder = pBuilder; }
+    // Create LLPC builder
+    void CreateBuilder();
 
     // Gets LLPC builder
     Builder* GetBuilder() const { return m_pBuilder; }
@@ -306,6 +307,7 @@ private:
     EmuLib                        m_glslEmuLib;        // LLVM library for GLSL emulation
     volatile  bool                m_isInUse;           // Whether this context is in use
     Builder*                      m_pBuilder = nullptr; // LLPC builder object
+    std::unique_ptr<BuilderContext> m_pBuilderContext;  // Builder context
 
     ResourceUsage*                m_pResUsage;          // External resource usage
 

--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -489,8 +489,8 @@ bool GraphicsContext::CheckGsOnChipValidity(
                                                                4 * pGsResUsage->inOutUsage.outputMapLocCount
                                                                  * pGsResUsage->builtInUsage.gs.outputVertices) : 0;
 
-            const uint32_t esExtraLdsSize = NggLdsManager::CalcEsExtraLdsSize(this) / 4; // In DWORDs
-            const uint32_t gsExtraLdsSize = NggLdsManager::CalcGsExtraLdsSize(this) / 4; // In DWORDs
+            const uint32_t esExtraLdsSize = NggLdsManager::CalcEsExtraLdsSize(pPipelineState) / 4; // In DWORDs
+            const uint32_t gsExtraLdsSize = NggLdsManager::CalcGsExtraLdsSize(pPipelineState) / 4; // In DWORDs
 
             // primAmpFactor = outputVertices - (outVertsPerPrim - 1)
             const uint32_t primAmpFactor =

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpcBuilder.h"
 #include "llpcPipelineContext.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -106,6 +107,9 @@ public:
 
     void InitShaderInfoForNullFs();
 
+    // Set pipeline state in Builder
+    virtual void SetBuilderPipelineState(Builder* pBuilder) const;
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(GraphicsContext);
     LLPC_DISALLOW_COPY_AND_ASSIGN(GraphicsContext);
@@ -115,6 +119,15 @@ private:
 #if LLPC_BUILD_GFX10
     void BuildNggCullingControlRegister();
 #endif
+
+    // Set input assembly state in builder
+    void SetInputAssemblyState(Builder* pBuilder) const;
+
+    // Set viewport state in builder
+    void SetViewportState(Builder* pBuilder) const;
+
+    // Set rasterizer state in builder
+    void SetRasterizerState(Builder* pBuilder) const;
 
     const GraphicsPipelineBuildInfo*    m_pPipelineInfo; // Info to build a graphics pipeline
 

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -112,7 +112,7 @@ public:
 
     // Map a VkFormat to a {Builder::BufDataFormat, Builder::BufNumFormat}. Returns BufDataFormatInvalid if the
     // VkFormat is not supported.
-    static std::pair<Builder::BufDataFormat, Builder::BufNumFormat> MapVkFormat(VkFormat format);
+    static std::pair<Builder::BufDataFormat, Builder::BufNumFormat> MapVkFormat(VkFormat format, bool isColorExport);
 
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(GraphicsContext);
@@ -135,6 +135,9 @@ private:
 
     // Set rasterizer state in builder
     void SetRasterizerState(Builder* pBuilder) const;
+
+    // Set color export state in builder
+    void SetColorExportState(Builder* pBuilder) const;
 
     const GraphicsPipelineBuildInfo*    m_pPipelineInfo; // Info to build a graphics pipeline
 

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -110,6 +110,10 @@ public:
     // Set pipeline state in Builder
     virtual void SetBuilderPipelineState(Builder* pBuilder) const;
 
+    // Map a VkFormat to a {Builder::BufDataFormat, Builder::BufNumFormat}. Returns BufDataFormatInvalid if the
+    // VkFormat is not supported.
+    static std::pair<Builder::BufDataFormat, Builder::BufNumFormat> MapVkFormat(VkFormat format);
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(GraphicsContext);
     LLPC_DISALLOW_COPY_AND_ASSIGN(GraphicsContext);
@@ -119,6 +123,9 @@ private:
 #if LLPC_BUILD_GFX10
     void BuildNggCullingControlRegister();
 #endif
+
+    // Set vertex input descriptions in Builder
+    void SetVertexInputDescriptions(Builder* pBuilder) const;
 
     // Set input assembly state in builder
     void SetInputAssemblyState(Builder* pBuilder) const;

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -43,8 +43,6 @@ class GraphicsContext: public PipelineContext
 {
 public:
     GraphicsContext(GfxIpVersion                     gfxIp,
-                    const GpuProperty*               pGpuProp,
-                    const WorkaroundFlags*           pGpuWorkarounds,
                     const GraphicsPipelineBuildInfo* pPipelineInfo,
                     MetroHash::Hash*                 pPipelineHash,
                     MetroHash::Hash*                 pCacheHash);
@@ -72,7 +70,7 @@ public:
     // Checks whether tessellation off-chip mode is enabled
     virtual bool IsTessOffChip() const { return m_tessOffchip; }
 
-    virtual bool CheckGsOnChipValidity();
+    virtual bool CheckGsOnChipValidity(PipelineState* pPipelineState);
 
     // Checks whether GS on-chip mode is enabled
 
@@ -88,7 +86,7 @@ public:
 
 #if LLPC_BUILD_GFX10
     // Sets NGG control settings
-    virtual void SetNggControl();
+    virtual void SetNggControl(PipelineState* pPipelineState);
 
     // Gets NGG control settings
     virtual const NggControl* GetNggControl() const { return &m_nggControl; }
@@ -101,7 +99,7 @@ public:
     virtual uint32_t GetVerticesPerPrimitive() const;
 
     // Gets wave size for the specified shader stage
-    virtual uint32_t GetShaderWaveSize(ShaderStage stage);
+    virtual uint32_t GetShaderWaveSize(ShaderStage stage, const GpuProperty& gpuProperty);
 
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const { return &m_pPipelineInfo->options; }

--- a/context/llpcPipelineContext.cpp
+++ b/context/llpcPipelineContext.cpp
@@ -47,16 +47,12 @@ namespace Llpc
 // =====================================================================================================================
 PipelineContext::PipelineContext(
     GfxIpVersion           gfxIp,           // Graphics IP version info
-    const GpuProperty*     pGpuProp,        // [in] GPU property
-    const WorkaroundFlags* pGpuWorkarounds, // [in] GPU workarounds
     MetroHash::Hash*       pPipelineHash,   // [in] Pipeline hash code
     MetroHash::Hash*       pCacheHash)      // [in] Cache hash code
     :
     m_gfxIp(gfxIp),
     m_pipelineHash(*pPipelineHash),
-    m_cacheHash(*pCacheHash),
-    m_pGpuProperty(pGpuProp),
-    m_pGpuWorkarounds(pGpuWorkarounds)
+    m_cacheHash(*pCacheHash)
 {
 
 }
@@ -68,59 +64,21 @@ PipelineContext::~PipelineContext()
 
 // =====================================================================================================================
 // Gets the name string of GPU target according to graphics IP version info.
-const char* PipelineContext::GetGpuNameString(
-    GfxIpVersion gfxIp)   // Graphics IP version info
+void PipelineContext::GetGpuNameString(
+    GfxIpVersion  gfxIp,    // Graphics IP version info
+    std::string&  gpuName)  // [out] LLVM GPU name
 {
-    struct GpuNameStringMap
+    gpuName.clear();
+    raw_string_ostream gpuNameStream(gpuName);
+    gpuNameStream << "gfx" << gfxIp.major << gfxIp.minor;
+    if (gfxIp.stepping >= 0xFFFA)
     {
-        GfxIpVersion gfxIp;
-        const char*  pNameString;
-    };
-
-    static const GpuNameStringMap GpuNameMap[] =
-    {   // Graphics IP  Target Name   Compatible Target Name
-        { { 6, 0, 0 }, "tahiti"   },  // [6.0.0] gfx600, tahiti
-        { { 6, 0, 1 }, "pitcairn" },  // [6.0.1] gfx601, pitcairn, verde, oland, hainan
-        { { 7, 0, 0 }, "kaveri"  },   // [7.0.0] gfx700, kaveri
-        { { 7, 0, 1 }, "hawaii"   },  // [7.0.1] gfx701, hawaii
-        { { 7, 0, 2 }, "gfx702"   },  // [7.0.2] gfx702
-        { { 7, 0, 3 }, "kabini"   },  // [7.0.3] gfx703, kabini, mullins
-        { { 7, 0, 4 }, "bonaire"  },  // [7.0.4] gfx704, bonaire
-        { { 8, 0, 0 }, "iceland"  },  // [8.0.0] gfx800, iceland
-        { { 8, 0, 1 }, "carrizo"  },  // [8.0.1] gfx801, carrizo
-        { { 8, 0, 2 }, "tonga"    },  // [8.0.2] gfx802, tonga
-        { { 8, 0, 3 }, "fiji"     },  // [8.0.3] gfx803, fiji, polaris10, polaris11
-        { { 8, 0, 4 }, "gfx804"   },  // [8.0.4] gfx804
-        { { 8, 1, 0 }, "stoney"   },  // [8.1.0] gfx810, stoney
-        { { 9, 0, 0 }, "gfx900"   },  // [9.0.0] gfx900
-        { { 9, 0, 1 }, "gfx901"   },  // [9.0.1] gfx901
-        { { 9, 0, 2 }, "gfx902"   },  // [9.0.2] gfx902
-        { { 9, 0, 3 }, "gfx903"   },  // [9.0.3] gfx903
-        { { 9, 0, 4 }, "gfx904"   },  // [9.0.4] gfx904, vega12
-        { { 9, 0, 6 }, "gfx906"   },  // [9.0.6] gfx906, vega20
-        { { 9, 0, 9 }, "gfx909"   },  // [9.0.9] gfx909, raven2
-#if LLPC_BUILD_GFX10
-        { { 10, 1, 0xFFFF }, "gfx101F" },
-        { { 10, 1, 0xFFFE }, "gfx101E" },
-        { { 10, 1, 0 }, "gfx1010" },  // [10.1.0] gfx1010
-#endif
-    };
-
-    const GpuNameStringMap* pNameMap = nullptr;
-    for (auto& nameMap : GpuNameMap)
-    {
-        if ((nameMap.gfxIp.major    == gfxIp.major) &&
-            (nameMap.gfxIp.minor    == gfxIp.minor) &&
-            (nameMap.gfxIp.stepping == gfxIp.stepping))
-        {
-            pNameMap = &nameMap;
-            break;
-        }
+        gpuNameStream << char(gfxIp.stepping - 0xFFFA + 'A');
     }
-
-    LLPC_ASSERT(pNameMap != nullptr);
-
-    return (pNameMap != nullptr) ? pNameMap->pNameString : "";
+    else
+    {
+        gpuNameStream << gfxIp.stepping;
+    }
 }
 
 // =====================================================================================================================

--- a/context/llpcPipelineContext.cpp
+++ b/context/llpcPipelineContext.cpp
@@ -240,10 +240,19 @@ ShaderHash PipelineContext::GetShaderHashCode(
 void PipelineContext::SetBuilderPipelineState(
     Builder*          pBuilder) const   // [in] The builder
 {
+    // Give the shader stage mask to Builder.
+    uint32_t stageMask = GetShaderStageMask();
+#if VKI_RAY_TRACING
+    if (HasRayTracingShaderStage(stageMask))
+    {
+        stageMask = 1 << ShaderStageCompute;
+    }
+#endif
+    pBuilder->SetShaderStageMask(stageMask);
+
     // Give the user data nodes and descriptor range values to the Builder.
     // The user data nodes have been merged so they are the same in each shader stage. Get them from
     // the first active stage.
-    uint32_t stageMask = GetShaderStageMask();
     const PipelineShaderInfo* pShaderInfo = nullptr;
     {
         pShaderInfo = GetPipelineShaderInfo(ShaderStage(countTrailingZeros(stageMask)));

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -807,7 +807,7 @@ public:
     virtual const PipelineOptions* GetPipelineOptions() const = 0;
 
     // Set pipeline state in Builder
-    void SetBuilderPipelineState(Builder* pBuilder) const;
+    virtual void SetBuilderPipelineState(Builder* pBuilder) const;
 
     static void InitShaderResourceUsage(ShaderStage shaderStage, ResourceUsage* pResUsage);
 

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -40,7 +40,7 @@
 #undef Bool
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 37
+#define LLPC_INTERFACE_MAJOR_VERSION 38
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -51,6 +51,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     38.0 | Removed CreateShaderCache in ICompiler and pShaderCache in pipeline build info                        |
 //* |     37.0 | Removed the -enable-dynamic-loop-unroll option                                                        |
 //* |     36.0 | Add 128 bit hash as clientHash in PipelineShaderOptions                                               |
 //* |     35.0 | Added disableLicm to PipelineShaderOptions                                                            |
@@ -448,7 +449,9 @@ struct GraphicsPipelineBuildInfo
     void*               pInstance;          ///< Vulkan instance object
     void*               pUserData;          ///< User data
     OutputAllocFunc     pfnOutputAlloc;     ///< Output buffer allocator
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     IShaderCache*       pShaderCache;       ///< Shader cache, used to search for the compiled shader data
+#endif
     PipelineShaderInfo  vs;                 ///< Vertex shader
     PipelineShaderInfo  tcs;                ///< Tessellation control shader
     PipelineShaderInfo  tes;                ///< Tessellation evaluation shader
@@ -519,7 +522,9 @@ struct ComputePipelineBuildInfo
     void*               pInstance;          ///< Vulkan instance object
     void*               pUserData;          ///< User data
     OutputAllocFunc     pfnOutputAlloc;     ///< Output buffer allocator
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     IShaderCache*       pShaderCache;       ///< Shader cache, used to search for the compiled shader data
+#endif
     uint32_t            deviceIndex;        ///< Device index for device group
     PipelineShaderInfo  cs;                 ///< Compute shader
     PipelineOptions     options;            ///< Per pipeline tuning options
@@ -756,6 +761,7 @@ public:
                                         ComputePipelineBuildOut*        pPipelineOut,
                                         void*                           pPipelineDumpFile = nullptr) = 0;
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     /// Creates a shader cache object with the requested properties.
     ///
     /// @param [in]  pCreateInfo    Create info of the shader cache.
@@ -765,6 +771,7 @@ public:
     virtual Result CreateShaderCache(
         const ShaderCacheCreateInfo* pCreateInfo,
         IShaderCache**               ppShaderCache) = 0;
+#endif
 
 protected:
     ICompiler() {}

--- a/lower/llpcSpirvLower.cpp
+++ b/lower/llpcSpirvLower.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Vectorize.h"
 
+#include "llpcBuilder.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"
 #include "llpcPassManager.h"
@@ -85,7 +86,7 @@ void SpirvLower::AddPasses(
     uint32_t              forceLoopUnrollCount)   // 0 or force loop unroll count
 {
     // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-    AddTargetLibInfo(pContext, &passMgr);
+    pContext->GetBuilder()->PreparePassManager(&passMgr);
 
     // Start timer for lowering passes.
     if (pLowerTimer != nullptr)

--- a/lower/llpcSpirvLowerInstMetaRemove.cpp
+++ b/lower/llpcSpirvLowerInstMetaRemove.cpp
@@ -76,6 +76,21 @@ bool SpirvLowerInstMetaRemove::runOnModule(
 
     visit(m_pModule);
 
+    // Remove any named metadata in the module that starts "spirv." or "opencl.".
+    SmallVector<NamedMDNode*, 8> nodesToRemove;
+    for (auto& namedMdNode : m_pModule->getNamedMDList())
+    {
+        if (namedMdNode.getName().startswith("spirv.") || namedMdNode.getName().startswith("opencl."))
+        {
+            nodesToRemove.push_back(&namedMdNode);
+        }
+    }
+    for (NamedMDNode* pNamedMdNode : nodesToRemove)
+    {
+        pNamedMdNode->eraseFromParent();
+        m_changed = true;
+    }
+
     return m_changed;
 }
 

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -79,7 +79,8 @@ ifeq ($(ICD_BUILD_LLPC), 1)
         llpcBuilderImplSubgroup.cpp         \
         llpcBuilderRecorder.cpp             \
         llpcBuilderReplayer.cpp             \
-        llpcPipelineState.cpp
+        llpcPipelineState.cpp               \
+        llpcTargetInfo.cpp
 
     # llpc/context
     CPPFILES +=                             \

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -124,6 +124,7 @@ endif
         llpcFragColorExport.cpp             \
         llpcPatch.cpp                       \
         llpcPatchBufferOp.cpp               \
+        llpcPatchCheckShaderCache.cpp       \
         llpcPatchCopyShader.cpp             \
         llpcPatchDescriptorLoad.cpp         \
         llpcPatchEntryPointMutate.cpp       \

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -68,6 +68,7 @@ ifeq ($(ICD_BUILD_LLPC), 1)
     # llpc/builder
     CPPFILES +=                             \
         llpcBuilder.cpp                     \
+        llpcBuilderContext.cpp              \
         llpcBuilderImpl.cpp                 \
         llpcBuilderImplArith.cpp            \
         llpcBuilderImplDesc.cpp             \

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -108,7 +108,7 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
 {
     Result result = Result::Success;
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
     ShaderHash hash = {};
@@ -170,7 +170,7 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
     size_t*             pConfigSize)      // [out] Size of register configuration
 {
     Result result = Result::Success;
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
     ShaderHash hash = {};
@@ -267,7 +267,7 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
 {
     Result result = Result::Success;
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
     ShaderHash hash = {};
@@ -347,7 +347,7 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
 {
     Result result = Result::Success;
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
     ShaderHash hash = {};
@@ -462,7 +462,7 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
 {
     Result result = Result::Success;
 
-    LLPC_ASSERT(pContext->GetShaderStageMask() == ShaderStageToMask(ShaderStageCompute));
+    LLPC_ASSERT(m_pPipelineState->GetShaderStageMask() == ShaderStageToMask(ShaderStageCompute));
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
     ShaderHash hash = {};
@@ -839,7 +839,7 @@ Result ConfigBuilder::BuildEsRegConfig(
     const auto pResUsage = pContext->GetShaderResourceUsage(shaderStage);
     const auto& builtInUsage = pResUsage->builtInUsage;
 
-    LLPC_ASSERT((pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
+    LLPC_ASSERT((m_pPipelineState->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
     const auto& calcFactor = pContext->GetShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor;
 
     uint32_t floatMode = SetupFloatingPointMode(pContext, shaderStage);

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -35,6 +35,7 @@
 #include "llpcContext.h"
 #include "llpcCodeGenManager.h"
 #include "llpcGfx6ConfigBuilder.h"
+#include "llpcPipelineState.h"
 
 namespace llvm
 {
@@ -523,8 +524,8 @@ Result ConfigBuilder::BuildVsRegConfig(
     if (shaderStage == ShaderStageCopyShader)
     {
         SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, Llpc::CopyShaderUserSgprCount);
-        SetNumAvailSgprs(Util::Abi::HardwareStage::Vs, pContext->GetGpuProperty()->maxSgprsAvailable);
-        SetNumAvailVgprs(Util::Abi::HardwareStage::Vs, pContext->GetGpuProperty()->maxVgprsAvailable);
+        SetNumAvailSgprs(Util::Abi::HardwareStage::Vs, m_pPipelineState->GetGpuProperty()->maxSgprsAvailable);
+        SetNumAvailVgprs(Util::Abi::HardwareStage::Vs, m_pPipelineState->GetGpuProperty()->maxVgprsAvailable);
 
         SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN,
             (pResUsage->inOutUsage.gs.outLocCount[0] > 0) && enableXfb);
@@ -850,14 +851,14 @@ Result ConfigBuilder::BuildEsRegConfig(
     SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC2_ES, TRAP_PRESENT, pShaderInfo->options.trapPresent);
     if (pContext->IsGsOnChip())
     {
-        LLPC_ASSERT(calcFactor.gsOnChipLdsSize <= pContext->GetGpuProperty()->gsOnChipMaxLdsSize);
+        LLPC_ASSERT(calcFactor.gsOnChipLdsSize <= m_pPipelineState->GetGpuProperty()->gsOnChipMaxLdsSize);
         LLPC_ASSERT((calcFactor.gsOnChipLdsSize %
-                     (1 << pContext->GetGpuProperty()->ldsSizeDwordGranularityShift)) == 0);
+                     (1 << m_pPipelineState->GetGpuProperty()->ldsSizeDwordGranularityShift)) == 0);
         SET_REG_FIELD(&pConfig->m_esRegs,
                       SPI_SHADER_PGM_RSRC2_ES,
                       LDS_SIZE__CI__VI,
                       (calcFactor.gsOnChipLdsSize >>
-                       pContext->GetGpuProperty()->ldsSizeDwordGranularityShift));
+                       m_pPipelineState->GetGpuProperty()->ldsSizeDwordGranularityShift));
     }
 
     uint32_t vgprCompCnt = 0;
@@ -944,7 +945,7 @@ Result ConfigBuilder::BuildLsRegConfig(
         ldsSizeInDwords = calcFactor.inPatchSize * calcFactor.patchCountPerThreadGroup;
     }
 
-    auto pGpuWorkarounds = pContext->GetGpuWorkarounds();
+    auto pGpuWorkarounds = m_pPipelineState->GetGpuWorkarounds();
 
     // Override the LDS size based on hardware workarounds.
     if (pGpuWorkarounds->gfx6.shaderSpiBarrierMgmt != 0)
@@ -964,7 +965,7 @@ Result ConfigBuilder::BuildLsRegConfig(
             pContext->GetShaderResourceUsage(ShaderStageTessControl)->builtInUsage.tcs.outputVertices;
 
         const uint32_t threadGroupSize = calcFactor.patchCountPerThreadGroup * outputVertices;
-        const uint32_t waveSize = pContext->GetGpuProperty()->waveSize;
+        const uint32_t waveSize = m_pPipelineState->GetGpuProperty()->waveSize;
         const uint32_t wavesPerThreadGroup = (threadGroupSize + waveSize - 1) / waveSize;
 
         if (wavesPerThreadGroup > 1)
@@ -978,7 +979,7 @@ Result ConfigBuilder::BuildLsRegConfig(
 
     // NOTE: On GFX6, granularity for the LDS_SIZE field is 64. The range is 0~128 which allocates 0 to 8K DWORDs.
     // On GFX7+, granularity for the LDS_SIZE field is 128. The range is 0~128 which allocates 0 to 16K DWORDs.
-    const uint32_t ldsSizeDwordGranularityShift = pContext->GetGpuProperty()->ldsSizeDwordGranularityShift;
+    const uint32_t ldsSizeDwordGranularityShift = m_pPipelineState->GetGpuProperty()->ldsSizeDwordGranularityShift;
     const uint32_t ldsSizeDwordGranularity = 1u << ldsSizeDwordGranularityShift;
     ldsSize = Pow2Align(ldsSizeInDwords, ldsSizeDwordGranularity) >> ldsSizeDwordGranularityShift;
 
@@ -1024,7 +1025,7 @@ Result ConfigBuilder::BuildGsRegConfig(
                                (builtInUsage.inputPrimitive == InputTrianglesAdjacency);
 
     // Maximum number of GS primitives per ES thread is capped by the hardware's GS-prim FIFO.
-    auto pGpuProp = pContext->GetGpuProperty();
+    auto pGpuProp = m_pPipelineState->GetGpuProperty();
     uint32_t maxGsPerEs = (pGpuProp->gsPrimBufferDepth + pGpuProp->waveSize);
 
     // This limit is halved if the primitive topology is adjacency-typed
@@ -1561,7 +1562,7 @@ Result ConfigBuilder::BuildUserDataConfig(
     uint32_t spillThreshold = UINT32_MAX;
     if (shaderStage != ShaderStageCopyShader)
     {
-        uint32_t maxUserDataCount = pContext->GetGpuProperty()->maxUserDataCount;
+        uint32_t maxUserDataCount = m_pPipelineState->GetGpuProperty()->maxUserDataCount;
         for (uint32_t i = 0; i < maxUserDataCount; ++i)
         {
             if (pIntfData->userDataMap[i] != InterfaceData::UserDataUnmapped)

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -573,12 +573,10 @@ Result ConfigBuilder::BuildVsRegConfig(
     }
     SET_REG(&pConfig->m_vsRegs, VGT_STRMOUT_BUFFER_CONFIG, streamBufferConfig);
 
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-
-    uint8_t usrClipPlaneMask = pPipelineInfo->rsState.usrClipPlaneMask;
-    bool depthClipDisable = (pPipelineInfo->vpState.depthClipEnable == false);
-    bool rasterizerDiscardEnable = pPipelineInfo->rsState.rasterizerDiscardEnable;
-    bool disableVertexReuse = pPipelineInfo->iaState.disableVertexReuse;
+    uint8_t usrClipPlaneMask = m_pPipelineState->GetRasterizerState().usrClipPlaneMask;
+    bool depthClipDisable = (m_pPipelineState->GetViewportState().depthClipEnable == false);
+    bool rasterizerDiscardEnable = m_pPipelineState->GetRasterizerState().rasterizerDiscardEnable;
+    bool disableVertexReuse = m_pPipelineState->GetInputAssemblyState().disableVertexReuse;
     SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
     SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
     SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
@@ -703,7 +701,7 @@ Result ConfigBuilder::BuildVsRegConfig(
 
     SET_REG_FIELD(&pConfig->m_vsRegs, VGT_VERTEX_REUSE_BLOCK_CNTL, VTX_REUSE_DEPTH, 14);
 
-    useLayer = useLayer || pPipelineInfo->iaState.enableMultiView;
+    useLayer = useLayer || m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     if (usePointSize || useLayer || useViewportIndex)
     {
@@ -809,8 +807,10 @@ Result ConfigBuilder::BuildHsRegConfig(
 
     // Set VGT_LS_HS_CONFIG
     SET_REG_FIELD(&pConfig->m_hsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-    SET_REG_FIELD(&pConfig->m_hsRegs, VGT_LS_HS_CONFIG, HS_NUM_INPUT_CP, pPipelineInfo->iaState.patchControlPoints);
+    SET_REG_FIELD(&pConfig->m_hsRegs,
+                  VGT_LS_HS_CONFIG,
+                  HS_NUM_INPUT_CP,
+                  m_pPipelineState->GetInputAssemblyState().patchControlPoints);
 
     auto hsNumOutputCp = builtInUsage.outputVertices;
     SET_REG_FIELD(&pConfig->m_hsRegs, VGT_LS_HS_CONFIG, HS_NUM_OUTPUT_CP, hsNumOutputCp);
@@ -1447,12 +1447,7 @@ Result ConfigBuilder::BuildUserDataConfig(
 {
     Result result = Result::Success;
 
-    bool enableMultiView = false;
-    if (pContext->IsGraphics())
-    {
-        enableMultiView = static_cast<const GraphicsPipelineBuildInfo*>(
-            pContext->GetPipelineBuildInfo())->iaState.enableMultiView;
-    }
+    bool enableMultiView = m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     const auto pIntfData = pContext->GetShaderInterfaceData(shaderStage);
     const auto pResUsage = pContext->GetShaderResourceUsage(shaderStage);
@@ -1650,8 +1645,7 @@ void ConfigBuilder::SetupVgtTfParam(
         topology = OUTPUT_TRIANGLE_CCW;
     }
 
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-    if (pPipelineInfo->iaState.switchWinding)
+    if (m_pPipelineState->GetInputAssemblyState().switchWinding)
     {
         if (topology == OUTPUT_TRIANGLE_CW)
         {

--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.h
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.h
@@ -38,6 +38,7 @@ namespace Llpc
 
 class Context;
 struct ElfDataEntry;
+class PipelineState;
 struct ResourceUsage;
 
 namespace Gfx6
@@ -48,7 +49,7 @@ namespace Gfx6
 class ConfigBuilder : public ConfigBuilderBase
 {
 public:
-    ConfigBuilder(llvm::Module* pModule) : ConfigBuilderBase(pModule) {}
+    ConfigBuilder(PipelineState* pPipelineState) : ConfigBuilderBase(pPipelineState) {}
 
     void BuildPalMetadata();
 

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -149,7 +149,7 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
     Result result = Result::Success;
     GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsFsRegConfig)];
     PipelineVsFsRegConfig* pConfig = reinterpret_cast<PipelineVsFsRegConfig*>(pAllocBuf);
@@ -256,7 +256,7 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
     Result result = Result::Success;
     GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsTsFsRegConfig)];
     PipelineVsTsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsFsRegConfig*>(pAllocBuf);
@@ -420,7 +420,7 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
     Result result = Result::Success;
     GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsGsFsRegConfig)];
     PipelineVsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsGsFsRegConfig*>(pAllocBuf);
@@ -557,7 +557,7 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
     Result result = Result::Success;
     GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineVsTsGsFsRegConfig)];
     PipelineVsTsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsGsFsRegConfig*>(pAllocBuf);
@@ -763,7 +763,7 @@ Result ConfigBuilder::BuildPipelineNggVsFsRegConfig(
     const auto pNggControl = pContext->GetNggControl();
     LLPC_ASSERT(pNggControl->enableNgg);
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineNggVsFsRegConfig)];
     PipelineNggVsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsFsRegConfig*>(pAllocBuf);
@@ -867,7 +867,7 @@ Result ConfigBuilder::BuildPipelineNggVsTsFsRegConfig(
     const auto pNggControl = pContext->GetNggControl();
     LLPC_ASSERT(pNggControl->enableNgg);
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineNggVsTsFsRegConfig)];
     PipelineNggVsTsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsTsFsRegConfig*>(pAllocBuf);
@@ -1014,7 +1014,7 @@ Result ConfigBuilder::BuildPipelineNggVsGsFsRegConfig(
     const auto pNggControl = pContext->GetNggControl();
     LLPC_ASSERT(pNggControl->enableNgg);
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineNggVsGsFsRegConfig)];
     PipelineNggVsGsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsGsFsRegConfig*>(pAllocBuf);
@@ -1128,7 +1128,7 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig(
     const auto pNggControl = pContext->GetNggControl();
     LLPC_ASSERT(pNggControl->enableNgg);
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     uint8_t* pAllocBuf = new uint8_t[sizeof(PipelineNggVsTsGsFsRegConfig)];
     PipelineNggVsTsGsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsTsGsFsRegConfig*>(pAllocBuf);
@@ -1295,7 +1295,7 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
     Result result = Result::Success;
     GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    LLPC_ASSERT(pContext->GetShaderStageMask() == ShaderStageToMask(ShaderStageCompute));
+    LLPC_ASSERT(m_pPipelineState->GetShaderStageMask() == ShaderStageToMask(ShaderStageCompute));
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
     ShaderHash hash = {};
@@ -1527,7 +1527,7 @@ Result ConfigBuilder::BuildVsRegConfig(
         cullDistanceCount = builtInUsage.gs.cullDistance;
 
         // NOTE: For ES-GS merged shader, the actual use of primitive ID should take both ES and GS into consideration.
-        const bool hasTs = ((pContext->GetShaderStageMask() & (ShaderStageToMask(ShaderStageTessControl) |
+        const bool hasTs = ((m_pPipelineState->GetShaderStageMask() & (ShaderStageToMask(ShaderStageTessControl) |
                                                                ShaderStageToMask(ShaderStageTessEval))) != 0);
         if (hasTs)
         {
@@ -1855,7 +1855,7 @@ Result ConfigBuilder::BuildEsGsRegConfig(
 
     GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
     const bool hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
                                       ShaderStageToMask(ShaderStageTessEval))) != 0);
 
@@ -2151,7 +2151,7 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     const auto pNggControl = pContext->GetNggControl();
     LLPC_ASSERT(pNggControl->enableNgg);
 
-    const uint32_t stageMask = pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
     const bool hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
                                       ShaderStageToMask(ShaderStageTessEval))) != 0);
     const bool hasGs = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -1434,12 +1434,10 @@ Result ConfigBuilder::BuildVsRegConfig(
     }
 #endif
 
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-
-    uint8_t usrClipPlaneMask = pPipelineInfo->rsState.usrClipPlaneMask;
-    bool depthClipDisable = (pPipelineInfo->vpState.depthClipEnable == false);
-    bool rasterizerDiscardEnable = pPipelineInfo->rsState.rasterizerDiscardEnable;
-    bool disableVertexReuse = pPipelineInfo->iaState.disableVertexReuse;
+    uint8_t usrClipPlaneMask = m_pPipelineState->GetRasterizerState().usrClipPlaneMask;
+    bool depthClipDisable = (m_pPipelineState->GetViewportState().depthClipEnable == false);
+    bool rasterizerDiscardEnable = m_pPipelineState->GetRasterizerState().rasterizerDiscardEnable;
+    bool disableVertexReuse = m_pPipelineState->GetInputAssemblyState().disableVertexReuse;
 
     SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
     SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
@@ -1597,7 +1595,7 @@ Result ConfigBuilder::BuildVsRegConfig(
 #endif
     SET_REG_FIELD(&pConfig->m_vsRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
 
-    useLayer = useLayer || pPipelineInfo->iaState.enableMultiView;
+    useLayer = useLayer || m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     if (usePointSize || useLayer || useViewportIndex)
     {
@@ -1788,8 +1786,10 @@ Result ConfigBuilder::BuildLsHsRegConfig(
 
     // Set VGT_LS_HS_CONFIG
     SET_REG_FIELD(&pConfig->m_lsHsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, VGT_LS_HS_CONFIG, HS_NUM_INPUT_CP, pPipelineInfo->iaState.patchControlPoints);
+    SET_REG_FIELD(&pConfig->m_lsHsRegs,
+                  VGT_LS_HS_CONFIG,
+                  HS_NUM_INPUT_CP,
+                  m_pPipelineState->GetInputAssemblyState().patchControlPoints);
 
     auto hsNumOutputCp = tcsBuiltInUsage.outputVertices;
     SET_REG_FIELD(&pConfig->m_lsHsRegs, VGT_LS_HS_CONFIG, HS_NUM_OUTPUT_CP, hsNumOutputCp);
@@ -2337,24 +2337,23 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     else
     {
         // Without tessellation
-        const auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-        const auto topology = pPipelineInfo->iaState.topology;
-        if (topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST)
+        const auto topology = m_pPipelineState->GetInputAssemblyState().topology;
+        if (topology == Builder::PrimitiveTopology::PointList)
         {
             gsOutputPrimitiveType = POINTLIST;
         }
-        else if ((topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY))
+        else if ((topology == Builder::PrimitiveTopology::LineList) ||
+                 (topology == Builder::PrimitiveTopology::LineStrip) ||
+                 (topology == Builder::PrimitiveTopology::LineListWithAdjacency) ||
+                 (topology == Builder::PrimitiveTopology::LineStripWithAdjacency))
         {
             gsOutputPrimitiveType = LINESTRIP;
         }
-        else if ((topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY) ||
-                 (topology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY))
+        else if ((topology == Builder::PrimitiveTopology::TriangleList) ||
+                 (topology == Builder::PrimitiveTopology::TriangleStrip) ||
+                 (topology == Builder::PrimitiveTopology::TriangleFan) ||
+                 (topology == Builder::PrimitiveTopology::TriangleListWithAdjacency) ||
+                 (topology == Builder::PrimitiveTopology::TriangleStripWithAdjacency))
         {
             gsOutputPrimitiveType = TRISTRIP;
         }
@@ -2404,12 +2403,10 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     //
     // Build VS specific configuration
     //
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-
-    uint8_t usrClipPlaneMask = pPipelineInfo->rsState.usrClipPlaneMask;
-    bool depthClipDisable = (pPipelineInfo->vpState.depthClipEnable == false);
-    bool rasterizerDiscardEnable = pPipelineInfo->rsState.rasterizerDiscardEnable;
-    bool disableVertexReuse = pPipelineInfo->iaState.disableVertexReuse;
+    uint8_t usrClipPlaneMask = m_pPipelineState->GetRasterizerState().usrClipPlaneMask;
+    bool depthClipDisable = (m_pPipelineState->GetViewportState().depthClipEnable == false);
+    bool rasterizerDiscardEnable = m_pPipelineState->GetRasterizerState().rasterizerDiscardEnable;
+    bool disableVertexReuse = m_pPipelineState->GetInputAssemblyState().disableVertexReuse;
 
     SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
     SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
@@ -2533,7 +2530,7 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
 
     SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
 
-    useLayer = useLayer || pPipelineInfo->iaState.enableMultiView;
+    useLayer = useLayer || m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     if (usePointSize || useLayer || useViewportIndex)
     {
@@ -2878,7 +2875,7 @@ Result ConfigBuilder::BuildPsRegConfig(
     SetPsUsesUavs(static_cast<uint32_t>(pResUsage->resourceWrite));
 #endif
 
-    if (pPipelineInfo->rsState.innerCoverage)
+    if (m_pPipelineState->GetRasterizerState().innerCoverage)
     {
         SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_INNER_COVERAGE);
     }
@@ -3054,8 +3051,7 @@ Result ConfigBuilder::BuildUserDataConfig(
     bool enableMultiView = false;
     if (pContext->IsGraphics())
     {
-        enableMultiView = static_cast<const GraphicsPipelineBuildInfo*>(
-            pContext->GetPipelineBuildInfo())->iaState.enableMultiView;
+        enableMultiView = m_pPipelineState->GetInputAssemblyState().enableMultiView;
     }
 
     bool enableXfb = false;
@@ -3360,8 +3356,7 @@ void ConfigBuilder::SetupVgtTfParam(
         topology = OUTPUT_TRIANGLE_CCW;
     }
 
-    auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-    if (pPipelineInfo->iaState.switchWinding)
+    if (m_pPipelineState->GetInputAssemblyState().switchWinding)
     {
         if (topology == OUTPUT_TRIANGLE_CW)
         {

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2642,9 +2642,6 @@ Result ConfigBuilder::BuildPsRegConfig(
 
     LLPC_ASSERT(shaderStage == ShaderStageFragment);
 
-    const GraphicsPipelineBuildInfo* pPipelineInfo =
-        static_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
-
     const auto pIntfData = pContext->GetShaderInterfaceData(shaderStage);
     const auto pShaderInfo = pContext->GetPipelineShaderInfo(shaderStage);
     const auto pResUsage = pContext->GetShaderResourceUsage(shaderStage);
@@ -2738,7 +2735,8 @@ Result ConfigBuilder::BuildPsRegConfig(
     SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
     SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
     SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE,
-                  (builtInUsage.sampleMask || (pPipelineInfo->cbState.alphaToCoverageEnable == false)));
+                  (builtInUsage.sampleMask ||
+                   (m_pPipelineState->GetColorExportState().alphaToCoverageEnable == false)));
     SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, builtInUsage.earlyFragmentTests);
     SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                   (builtInUsage.earlyFragmentTests && pResUsage->resourceWrite));

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.h
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.h
@@ -38,6 +38,7 @@ namespace Llpc
 
 class Context;
 struct ElfDataEntry;
+class PipelineState;
 struct ResourceUsage;
 
 namespace Gfx9
@@ -48,7 +49,7 @@ namespace Gfx9
 class ConfigBuilder : public ConfigBuilderBase
 {
 public:
-    ConfigBuilder(llvm::Module* pModule) : ConfigBuilderBase(pModule) {}
+    ConfigBuilder(PipelineState* pPipelineState) : ConfigBuilderBase(pPipelineState) {}
 
     void BuildPalMetadata();
 

--- a/patch/gfx9/llpcNggLdsManager.cpp
+++ b/patch/gfx9/llpcNggLdsManager.cpp
@@ -41,6 +41,7 @@
 #include "llpcGfx9Chip.h"
 #include "llpcNggLdsManager.h"
 #include "llpcPatch.h"
+#include "llpcPipelineState.h"
 
 using namespace llvm;
 
@@ -126,12 +127,12 @@ const char* NggLdsManager::LdsRegionNames[LdsRegionCount] =
 
 // =====================================================================================================================
 NggLdsManager::NggLdsManager(
-    Module*      pModule,    // [in] LLVM module
-    Context*     pContext,   // [in] LLPC context
-    IRBuilder<>* pBuilder)   // [in] LLVM IR builder
+    PipelineState*  pPipelineState, // [in] Pipeline state
+    Context*        pContext,       // [in] LLPC context
+    IRBuilder<>*    pBuilder)       // [in] LLVM IR builder
     :
     m_pContext(pContext),
-    m_waveCountInSubgroup(Gfx9::NggMaxThreadsPerSubgroup / pContext->GetGpuProperty()->waveSize),
+    m_waveCountInSubgroup(Gfx9::NggMaxThreadsPerSubgroup / pPipelineState->GetGpuProperty()->waveSize),
     m_pBuilder(pBuilder)
 {
     LLPC_ASSERT(pBuilder != nullptr);
@@ -147,7 +148,7 @@ NggLdsManager::NggLdsManager(
     //
     // Create global variable modeling LDS
     //
-    m_pLds = Patch::GetLdsVariable(pModule);
+    m_pLds = Patch::GetLdsVariable(pPipelineState);
 
     memset(&m_ldsRegionStart, InvalidValue, sizeof(m_ldsRegionStart)); // Initialized to invalid value (0xFFFFFFFF)
 

--- a/patch/gfx9/llpcNggLdsManager.h
+++ b/patch/gfx9/llpcNggLdsManager.h
@@ -42,6 +42,7 @@ namespace Llpc
 
 class Context;
 class GraphicsContext;
+class PipelineState;
 
 // Enumerates the types of LDS regions used in NGG.
 enum NggLdsRegionType
@@ -94,7 +95,7 @@ static const uint32_t SizeOfDword = sizeof(uint32_t);
 class NggLdsManager
 {
 public:
-    NggLdsManager(llvm::Module* pModule, Context* pContext, llvm::IRBuilder<>* pBuilder);
+    NggLdsManager(PipelineState* pPipelineState, Context* pContext, llvm::IRBuilder<>* pBuilder);
 
     static uint32_t CalcEsExtraLdsSize(GraphicsContext* pContext);
     static uint32_t CalcGsExtraLdsSize(GraphicsContext* pContext);

--- a/patch/gfx9/llpcNggLdsManager.h
+++ b/patch/gfx9/llpcNggLdsManager.h
@@ -97,8 +97,8 @@ class NggLdsManager
 public:
     NggLdsManager(PipelineState* pPipelineState, Context* pContext, llvm::IRBuilder<>* pBuilder);
 
-    static uint32_t CalcEsExtraLdsSize(GraphicsContext* pContext);
-    static uint32_t CalcGsExtraLdsSize(GraphicsContext* pContext);
+    static uint32_t CalcEsExtraLdsSize(PipelineState* pPipelineState);
+    static uint32_t CalcGsExtraLdsSize(PipelineState* pPipelineState);
 
     // Gets the LDS starting offset for the specified region
     uint32_t GetLdsRegionStart(NggLdsRegionType region) const
@@ -122,7 +122,8 @@ private:
     static const uint32_t LdsRegionSizes[LdsRegionCount];  // LDS sizes for all LDS region types (in BYTEs)
     static const char*    LdsRegionNames[LdsRegionCount];  // Name strings for all LDS region types
 
-    Context*        m_pContext;     // LLPC context
+    Context*        m_pContext;       // LLPC context
+    PipelineState*  m_pPipelineState; // Pipeline state
 
     llvm::GlobalValue*  m_pLds;     // Global variable to model NGG LDS
 

--- a/patch/gfx9/llpcNggPrimShader.cpp
+++ b/patch/gfx9/llpcNggPrimShader.cpp
@@ -72,11 +72,10 @@ NggPrimShader::NggPrimShader(
 
     memset(&m_nggFactor, 0, sizeof(m_nggFactor));
 
-    const uint32_t stageMask = m_pContext->GetShaderStageMask();
-    m_hasVs  = ((stageMask & ShaderStageToMask(ShaderStageVertex)) != 0);
-    m_hasTcs = ((stageMask & ShaderStageToMask(ShaderStageTessControl)) != 0);
-    m_hasTes = ((stageMask & ShaderStageToMask(ShaderStageTessEval)) != 0);
-    m_hasGs  = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);
+    m_hasVs = m_pPipelineState->HasShaderStage(ShaderStageVertex);
+    m_hasTcs = m_pPipelineState->HasShaderStage(ShaderStageTessControl);
+    m_hasTes = m_pPipelineState->HasShaderStage(ShaderStageTessEval);
+    m_hasGs = m_pPipelineState->HasShaderStage(ShaderStageGeometry);
 }
 
 // =====================================================================================================================

--- a/patch/gfx9/llpcNggPrimShader.h
+++ b/patch/gfx9/llpcNggPrimShader.h
@@ -41,6 +41,7 @@ namespace Llpc
 
 class Context;
 class NggLdsManager;
+class PipelineState;
 
 // Represents exported data used in "exp" instruction
 struct ExpData
@@ -56,7 +57,7 @@ struct ExpData
 class NggPrimShader
 {
 public:
-    NggPrimShader(Context* pContext);
+    NggPrimShader(PipelineState* pPipelineState, Context* pContext);
     ~NggPrimShader();
 
     llvm::Function* Generate(llvm::Function* pEsEntryPoint,
@@ -210,6 +211,7 @@ private:
 
     static const uint32_t NullPrim = (1u << 31); // Null primitive data (invalid)
 
+    PipelineState*  m_pPipelineState; // Pipeline state
     Context*        m_pContext; // LLPC context
     GfxIpVersion    m_gfxIp;    // Graphics IP version info
 

--- a/patch/gfx9/llpcShaderMerger.cpp
+++ b/patch/gfx9/llpcShaderMerger.cpp
@@ -66,11 +66,10 @@ ShaderMerger::ShaderMerger(
     LLPC_ASSERT(m_gfxIp.major >= 9);
     LLPC_ASSERT(m_pContext->IsGraphics());
 
-    const uint32_t stageMask = m_pContext->GetShaderStageMask();
-    m_hasVs  = ((stageMask & ShaderStageToMask(ShaderStageVertex)) != 0);
-    m_hasTcs = ((stageMask & ShaderStageToMask(ShaderStageTessControl)) != 0);
-    m_hasTes = ((stageMask & ShaderStageToMask(ShaderStageTessEval)) != 0);
-    m_hasGs  = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);
+    m_hasVs = m_pPipelineState->HasShaderStage(ShaderStageVertex);
+    m_hasTcs = m_pPipelineState->HasShaderStage(ShaderStageTessControl);
+    m_hasTes = m_pPipelineState->HasShaderStage(ShaderStageTessEval);
+    m_hasGs = m_pPipelineState->HasShaderStage(ShaderStageGeometry);
 }
 
 #if LLPC_BUILD_GFX10

--- a/patch/gfx9/llpcShaderMerger.h
+++ b/patch/gfx9/llpcShaderMerger.h
@@ -43,6 +43,7 @@ namespace Llpc
 {
 
 class Context;
+class PipelineState;
 
 // Enumerates special system values for the LS-HS merged shader (the assigned numeric values are identical to SGPR
 // numbers defined by hardware).
@@ -88,7 +89,7 @@ enum EsGsSpecialSysValue
 class ShaderMerger
 {
 public:
-    ShaderMerger(Context* pContext, PipelineShaders* pPipelineShaders);
+    ShaderMerger(PipelineState* pPipelineState, Context* pContext, PipelineShaders* pPipelineShaders);
 
     llvm::Function* GenerateLsHsEntryPoint(llvm::Function* pLsEntryPoint, llvm::Function* pHsEntryPoint);
     llvm::Function* GenerateEsGsEntryPoint(llvm::Function* pEsEntryPoint, llvm::Function* pGsEntryPoint);
@@ -107,6 +108,7 @@ private:
 
     // -----------------------------------------------------------------------------------------------------------------
 
+    PipelineState*    m_pPipelineState;     // Pipeline state
     Context*          m_pContext;           // LLPC context
     GfxIpVersion      m_gfxIp;              // Graphics IP version info
     PipelineShaders*  m_pPipelineShaders;   // API shaders in the pipeline

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -102,7 +102,7 @@ void CodeGenManager::SetupTargetFeatures(
              std::string targetFeatures(globalFeatures);
              AttrBuilder builder;
 
-             ShaderStage shaderStage = GetShaderStageFromCallingConv(pContext->GetShaderStageMask(),
+             ShaderStage shaderStage = GetShaderStageFromCallingConv(pPipelineState->GetShaderStageMask(),
                                                                      pFunc->getCallingConv());
 
             bool useSiScheduler = cl::EnableSiScheduler;

--- a/patch/llpcCodeGenManager.cpp
+++ b/patch/llpcCodeGenManager.cpp
@@ -258,14 +258,12 @@ void CodeGenManager::SetupTargetFeatures(
 
 // =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
-Result CodeGenManager::AddTargetPasses(
+void CodeGenManager::AddTargetPasses(
     Context*              pContext,      // [in] LLPC context
     PassManager&          passMgr,       // [in/out] pass manager to add passes to
-    llvm::Timer*          pCodeGenTimer, // [in] Timer to time target passes with, nullptr if not timing
+    Timer*                pCodeGenTimer, // [in] Timer to time target passes with, nullptr if not timing
     raw_pwrite_stream&    outStream)     // [out] Output stream
 {
-    Result result = Result::Success;
-
     // Start timer for codegen passes.
     if (pCodeGenTimer != nullptr)
     {
@@ -295,30 +293,16 @@ Result CodeGenManager::AddTargetPasses(
 
     auto pTargetMachine = pContext->GetTargetMachine();
 
-#if LLPC_ENABLE_EXCEPTION
-    try
-#endif
+    if (pTargetMachine->addPassesToEmitFile(passMgr, outStream, nullptr, FileType))
     {
-        if (pTargetMachine->addPassesToEmitFile(passMgr, outStream, nullptr, FileType))
-        {
-            LLPC_ERRS("Target machine cannot emit a file of this type\n");
-            result = Result::ErrorInvalidValue;
-        }
+        report_fatal_error("Target machine cannot emit a file of this type");
     }
-#if LLPC_ENABLE_EXCEPTION
-    catch (const char*)
-    {
-        result = Result::ErrorInvalidValue;
-    }
-#endif
 
     // Stop timer for codegen passes.
     if (pCodeGenTimer != nullptr)
     {
         passMgr.add(CreateStartStopTimer(pCodeGenTimer, false));
     }
-
-    return result;
 }
 
 } // Llpc

--- a/patch/llpcCodeGenManager.h
+++ b/patch/llpcCodeGenManager.h
@@ -83,10 +83,10 @@ public:
 
     static void SetupTargetFeatures(llvm::Module* pModule);
 
-    static Result AddTargetPasses(Context*                    pContext,
-                                  PassManager&                passMgr,
-                                  llvm::Timer*                pCodeGenTimer,
-                                  llvm::raw_pwrite_stream&    outStream);
+    static void AddTargetPasses(Context*                    pContext,
+                                PassManager&                passMgr,
+                                llvm::Timer*                pCodeGenTimer,
+                                llvm::raw_pwrite_stream&    outStream);
 
     static Result Run(llvm::Module*               pModule,
                       llvm::legacy::PassManager&  passMgr);

--- a/patch/llpcConfigBuilderBase.cpp
+++ b/patch/llpcConfigBuilderBase.cpp
@@ -52,10 +52,10 @@ ConfigBuilderBase::ConfigBuilderBase(
 {
     m_pContext = static_cast<Context*>(&m_pModule->getContext());
 
-    m_hasVs  = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)) != 0);
-    m_hasTcs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessControl)) != 0);
-    m_hasTes = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessEval)) != 0);
-    m_hasGs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
+    m_hasVs = m_pPipelineState->HasShaderStage(ShaderStageVertex);
+    m_hasTcs = m_pPipelineState->HasShaderStage(ShaderStageTessControl);
+    m_hasTes = m_pPipelineState->HasShaderStage(ShaderStageTessEval);
+    m_hasGs = m_pPipelineState->HasShaderStage(ShaderStageGeometry);
 
     m_gfxIp = m_pPipelineState->GetGfxIpVersion();
 

--- a/patch/llpcConfigBuilderBase.cpp
+++ b/patch/llpcConfigBuilderBase.cpp
@@ -36,26 +36,28 @@
 
 #include "llpcConfigBuilderBase.h"
 #include "llpcAbiMetadata.h"
+#include "llpcPipelineState.h"
 
 using namespace Llpc;
 using namespace llvm;
 
 // =====================================================================================================================
 ConfigBuilderBase::ConfigBuilderBase(
-    llvm::Module* pModule)  // [in/out] LLVM module
+    PipelineState*  pPipelineState) // [in] Pipeline state
     :
-    m_pModule(pModule),
+    m_pPipelineState(pPipelineState),
+    m_pModule(pPipelineState->GetModule()),
     m_userDataLimit(0),
     m_spillThreshold(UINT32_MAX)
 {
-    m_pContext = static_cast<Context*>(&pModule->getContext());
+    m_pContext = static_cast<Context*>(&m_pModule->getContext());
 
     m_hasVs  = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)) != 0);
     m_hasTcs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessControl)) != 0);
     m_hasTes = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessEval)) != 0);
     m_hasGs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
 
-    m_gfxIp = m_pContext->GetGfxIpVersion();
+    m_gfxIp = m_pPipelineState->GetGfxIpVersion();
 
 #if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 477
     // Only generate MsgPack PAL metadata for PAL client 477 onwards. PAL changed the .note record type

--- a/patch/llpcConfigBuilderBase.h
+++ b/patch/llpcConfigBuilderBase.h
@@ -36,12 +36,14 @@
 namespace Llpc
 {
 
+class PipelineState;
+
 // =====================================================================================================================
 // Register configuration builder base class.
 class ConfigBuilderBase
 {
 public:
-    ConfigBuilderBase(llvm::Module* pModule);
+    ConfigBuilderBase(PipelineState* pPipelineState);
     ~ConfigBuilderBase();
 
     void WritePalMetadata();
@@ -76,6 +78,7 @@ protected:
 
     // -----------------------------------------------------------------------------------------------------------------
 
+    PipelineState*                  m_pPipelineState;     // Pipeline state
     llvm::Module*                   m_pModule;            // LLVM module being processed
     Context*                        m_pContext;           // LLPC context
     uint8_t*                        m_pConfig = nullptr;  // Register/metadata configuration

--- a/patch/llpcFragColorExport.cpp
+++ b/patch/llpcFragColorExport.cpp
@@ -38,6 +38,7 @@
 #include "llpcDebug.h"
 #include "llpcFragColorExport.h"
 #include "llpcIntrinsDefs.h"
+#include "llpcPipelineState.h"
 
 using namespace llvm;
 
@@ -1168,11 +1169,12 @@ const ColorFormatInfo FragColorExport::m_colorFormatInfo[] =
 
 // =====================================================================================================================
 FragColorExport::FragColorExport(
-    Module* pModule) // [in] LLVM module
+    PipelineState*  pPipelineState) // [in] Pipeline state
     :
-    m_pModule(pModule),
-    m_pContext(static_cast<Context*>(&pModule->getContext())),
-    pPipelineInfo(static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo()))
+    m_pModule(pPipelineState->GetModule()),
+    m_pContext(static_cast<Context*>(&m_pModule->getContext())),
+    pPipelineInfo(static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo())),
+    m_pPipelineState(pPipelineState)
 {
 }
 
@@ -1644,8 +1646,8 @@ ExportFormat FragColorExport::ComputeExportFormat(
     // Start by assuming EXP_FORMAT_ZERO (no exports)
     ExportFormat expFmt = EXP_FORMAT_ZERO;
 
-    GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
-    auto pGpuWorkarounds = m_pContext->GetGpuWorkarounds();
+    GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
+    auto pGpuWorkarounds = m_pPipelineState->GetGpuWorkarounds();
 
     bool gfx8RbPlusEnable = false;
     if ((gfxIp.major == 8) && (gfxIp.minor == 1))

--- a/patch/llpcFragColorExport.cpp
+++ b/patch/llpcFragColorExport.cpp
@@ -45,1135 +45,12 @@ using namespace llvm;
 namespace Llpc
 {
 
-#define COLOR_FORMAT_UNDEFINED(_format) \
-{ \
-    _format, \
-    COLOR_NUM_FORMAT_FLOAT, \
-    COLOR_DATA_FORMAT_INVALID, \
-    1, \
-    {  8,  0,  0,  0, }, \
-    { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One }, \
-    ChannelMask::X, \
-}
-
-// Initializes info table of vertex format map
-const ColorFormatInfo FragColorExport::m_colorFormatInfo[] =
-{
-    // VK_FORMAT_UNDEFINED = 0
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_UNDEFINED),
-    // VK_FORMAT_R4G4_UNORM_PACK8 = 1
-    {
-        VK_FORMAT_R4G4_UNORM_PACK8,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_INVALID,
-        2,
-        {  4,  4,  0,  0, },
-        { ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R4G4B4A4_UNORM_PACK16 = 2
-    {
-        VK_FORMAT_R4G4B4A4_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_4_4_4_4,
-        4,
-        {  4,  4,  4,  4, },
-        { ChannelSwizzle::W, ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B4G4R4A4_UNORM_PACK16 = 3
-    {
-        VK_FORMAT_B4G4R4A4_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_4_4_4_4,
-        4,
-        {  4,  4,  4,  4, },
-        { ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W, ChannelSwizzle::X },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R5G6B5_UNORM_PACK16 = 4
-    {
-        VK_FORMAT_R5G6B5_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_5_6_5,
-        3,
-        {  5,  6,  5,  0, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_B5G6R5_UNORM_PACK16 = 5
-    {
-        VK_FORMAT_B5G6R5_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_5_6_5,
-        3,
-        {  5,  6,  5,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_R5G5B5A1_UNORM_PACK16 = 6
-    {
-        VK_FORMAT_R5G5B5A1_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_5_5_5_1,
-        4,
-        {  1,  5,  5,  5, },
-        { ChannelSwizzle::W, ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B5G5R5A1_UNORM_PACK16 = 7
-    {
-        VK_FORMAT_B5G5R5A1_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_5_5_5_1,
-        4,
-        {  1,  5,  5,  5, },
-        { ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W, ChannelSwizzle::X },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A1R5G5B5_UNORM_PACK16 = 8
-    {
-        VK_FORMAT_A1R5G5B5_UNORM_PACK16,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_1_5_5_5,
-        4,
-        {  5,  5,  5,  1, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8_UNORM = 9
-    {
-        VK_FORMAT_R8_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_8,
-        1,
-        {  8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8_SNORM = 10
-    {
-        VK_FORMAT_R8_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_8,
-        1,
-        {  8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8_USCALED = 11
-    {
-        VK_FORMAT_R8_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_8,
-        1,
-        {  8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8_SSCALED = 12
-    {
-        VK_FORMAT_R8_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_8,
-        1,
-        {  8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8_UINT = 13
-    {
-    VK_FORMAT_R8_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_8,
-        1,
-        { 8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8_SINT = 14
-    {
-        VK_FORMAT_R8_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_8,
-        1,
-        { 8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8_SRGB = 15
-    {
-        VK_FORMAT_R8_SRGB,
-        COLOR_NUM_FORMAT_SRGB,
-        COLOR_DATA_FORMAT_8,
-        1,
-        {  8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R8G8_UNORM = 16
-    {
-        VK_FORMAT_R8G8_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8_SNORM = 17
-    {
-        VK_FORMAT_R8G8_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8_USCALED = 18
-    {
-        VK_FORMAT_R8G8_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8_SSCALED = 19
-    {
-        VK_FORMAT_R8G8_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8_UINT = 20
-    {
-        VK_FORMAT_R8G8_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8_SINT = 21
-    {
-        VK_FORMAT_R8G8_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8_SRGB = 22
-    {
-        VK_FORMAT_R8G8_SRGB,
-        COLOR_NUM_FORMAT_SRGB,
-        COLOR_DATA_FORMAT_8_8,
-        2,
-        {  8,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R8G8B8_UNORM = 23
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_UNORM),
-    // VK_FORMAT_R8G8B8_SNORM = 24
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SNORM),
-    // VK_FORMAT_R8G8B8_USCALED = 25
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_USCALED),
-    // VK_FORMAT_R8G8B8_SSCALED = 26
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SSCALED),
-    // VK_FORMAT_R8G8B8_UINT = 27
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_UINT),
-    // VK_FORMAT_R8G8B8_SINT = 28
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SINT),
-    // VK_FORMAT_R8G8B8_SRGB = 29
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SRGB),
-    // VK_FORMAT_B8G8R8_UNORM = 30
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_UNORM),
-    // VK_FORMAT_B8G8R8_SNORM = 31
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SNORM),
-    // VK_FORMAT_B8G8R8_USCALED = 32
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_USCALED),
-    // VK_FORMAT_B8G8R8_SSCALED = 33
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SSCALED),
-    // VK_FORMAT_B8G8R8_UINT = 34
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_UINT),
-    // VK_FORMAT_B8G8R8_SINT = 35
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SINT),
-    // VK_FORMAT_B8G8R8_SRGB = 36
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SRGB),
-    // VK_FORMAT_R8G8B8A8_UNORM = 37
-    {
-        VK_FORMAT_R8G8B8A8_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8G8B8A8_SNORM = 38
-    {
-        VK_FORMAT_R8G8B8A8_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8G8B8A8_USCALED = 39
-    {
-        VK_FORMAT_R8G8B8A8_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8G8B8A8_SSCALED = 40
-    {
-        VK_FORMAT_R8G8B8A8_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8G8B8A8_UINT = 41
-    {
-        VK_FORMAT_R8G8B8A8_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8G8B8A8_SINT = 42
-    {
-        VK_FORMAT_R8G8B8A8_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R8G8B8A8_SRGB = 43
-    {
-        VK_FORMAT_R8G8B8A8_SRGB,
-        COLOR_NUM_FORMAT_SRGB,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_UNORM = 44
-    {
-        VK_FORMAT_B8G8R8A8_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_SNORM = 45
-    {
-        VK_FORMAT_B8G8R8A8_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_USCALED = 46
-    {
-        VK_FORMAT_B8G8R8A8_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_SSCALED = 47
-    {
-        VK_FORMAT_B8G8R8A8_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_UINT = 48
-    {
-        VK_FORMAT_B8G8R8A8_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_SINT = 49
-    {
-        VK_FORMAT_B8G8R8A8_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_B8G8R8A8_SRGB = 50
-    {
-        VK_FORMAT_B8G8R8A8_SRGB,
-        COLOR_NUM_FORMAT_SRGB,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_UNORM_PACK32 = 51
-    {
-        VK_FORMAT_A8B8G8R8_UNORM_PACK32,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_SNORM_PACK32 = 52
-    {
-        VK_FORMAT_A8B8G8R8_SNORM_PACK32,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_USCALED_PACK32 = 53
-    {
-        VK_FORMAT_A8B8G8R8_USCALED_PACK32,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_SSCALED_PACK32 = 54
-    {
-        VK_FORMAT_A8B8G8R8_SSCALED_PACK32,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_UINT_PACK32 = 55
-    {
-        VK_FORMAT_A8B8G8R8_UINT_PACK32,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_SINT_PACK32 = 56
-    {
-        VK_FORMAT_A8B8G8R8_SINT_PACK32,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A8B8G8R8_SRGB_PACK32 = 57
-    {
-        VK_FORMAT_A8B8G8R8_SRGB_PACK32,
-        COLOR_NUM_FORMAT_SRGB,
-        COLOR_DATA_FORMAT_8_8_8_8,
-        4,
-        {  8,  8,  8,  8, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2R10G10B10_UNORM_PACK32 = 58
-    {
-        VK_FORMAT_A2R10G10B10_UNORM_PACK32,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2R10G10B10_SNORM_PACK32 = 59
-    {
-        VK_FORMAT_A2R10G10B10_SNORM_PACK32,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2R10G10B10_USCALED_PACK32 = 60
-    {
-        VK_FORMAT_A2R10G10B10_USCALED_PACK32,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2R10G10B10_SSCALED_PACK32 = 61
-    {
-        VK_FORMAT_A2R10G10B10_SSCALED_PACK32,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2R10G10B10_UINT_PACK32 = 62
-    {
-        VK_FORMAT_A2R10G10B10_UINT_PACK32,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2R10G10B10_SINT_PACK32 = 63
-    {
-        VK_FORMAT_A2R10G10B10_SINT_PACK32,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::Z, ChannelSwizzle::Y, ChannelSwizzle::X, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2B10G10R10_UNORM_PACK32 = 64
-    {
-        VK_FORMAT_A2B10G10R10_UNORM_PACK32,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2B10G10R10_SNORM_PACK32 = 65
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_A2B10G10R10_SNORM_PACK32),
-    // VK_FORMAT_A2B10G10R10_USCALED_PACK32 = 66
-    {
-        VK_FORMAT_A2B10G10R10_USCALED_PACK32,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2B10G10R10_SSCALED_PACK32 = 67
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_A2B10G10R10_SSCALED_PACK32),
-    // VK_FORMAT_A2B10G10R10_UINT_PACK32 = 68
-    {
-        VK_FORMAT_A2B10G10R10_UINT_PACK32,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_2_10_10_10,
-        4,
-        { 10, 10, 10,  2, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_A2B10G10R10_SINT_PACK32 = 69
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_A2B10G10R10_SINT_PACK32),
-    // VK_FORMAT_R16_UNORM = 70
-    {
-        VK_FORMAT_R16_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16_SNORM = 71
-    {
-        VK_FORMAT_R16_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16_USCALED = 72
-    {
-        VK_FORMAT_R16_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16_SSCALED = 73
-    {
-        VK_FORMAT_R16_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16_UINT = 74
-    {
-        VK_FORMAT_R16_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16_SINT = 75
-    {
-        VK_FORMAT_R16_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16_SFLOAT = 76
-    {
-        VK_FORMAT_R16_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R16G16_UNORM = 77
-    {
-        VK_FORMAT_R16G16_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16_SNORM = 78
-    {
-        VK_FORMAT_R16G16_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16_USCALED = 79
-    {
-        VK_FORMAT_R16G16_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16_SSCALED = 80
-    {
-        VK_FORMAT_R16G16_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16_UINT = 81
-    {
-        VK_FORMAT_R16G16_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16_SINT = 82
-    {
-        VK_FORMAT_R16G16_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16_SFLOAT = 83
-    {
-        VK_FORMAT_R16G16_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_16_16,
-        2,
-        { 16, 16,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R16G16B16_UNORM = 84
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_UNORM),
-    // VK_FORMAT_R16G16B16_SNORM = 85
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SNORM),
-    // VK_FORMAT_R16G16B16_USCALED = 86
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_USCALED),
-    // VK_FORMAT_R16G16B16_SSCALED = 87
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SSCALED),
-    // VK_FORMAT_R16G16B16_UINT = 88
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_UINT),
-    // VK_FORMAT_R16G16B16_SINT = 89
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SINT),
-    // VK_FORMAT_R16G16B16_SFLOAT = 90
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SFLOAT),
-    // VK_FORMAT_R16G16B16A16_UNORM = 91
-    {
-        VK_FORMAT_R16G16B16A16_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R16G16B16A16_SNORM = 92
-    {
-        VK_FORMAT_R16G16B16A16_SNORM,
-        COLOR_NUM_FORMAT_SNORM,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R16G16B16A16_USCALED = 93
-    {
-        VK_FORMAT_R16G16B16A16_USCALED,
-        COLOR_NUM_FORMAT_USCALED,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R16G16B16A16_SSCALED = 94
-    {
-        VK_FORMAT_R16G16B16A16_SSCALED,
-        COLOR_NUM_FORMAT_SSCALED,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R16G16B16A16_UINT = 95
-    {
-        VK_FORMAT_R16G16B16A16_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R16G16B16A16_SINT = 96
-    {
-        VK_FORMAT_R16G16B16A16_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R16G16B16A16_SFLOAT = 97
-    {
-        VK_FORMAT_R16G16B16A16_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_16_16_16_16,
-        4,
-        { 16, 16, 16, 16, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R32_UINT = 98
-    {
-        VK_FORMAT_R32_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_32,
-        1,
-        { 32,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R32_SINT = 99
-    {
-        VK_FORMAT_R32_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_32,
-        1,
-        { 32,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R32_SFLOAT = 100
-    {
-        VK_FORMAT_R32_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_32,
-        1,
-        { 32,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_R32G32_UINT = 101
-    {
-        VK_FORMAT_R32G32_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_32_32,
-        2,
-        { 32, 32,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R32G32_SINT = 102
-    {
-        VK_FORMAT_R32G32_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_32_32,
-        2,
-        { 32, 32,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R32G32_SFLOAT = 103
-    {
-        VK_FORMAT_R32G32_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_32_32,
-        2,
-        { 32, 32,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_R32G32B32_UINT = 104
-    {
-        VK_FORMAT_R32G32B32_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_INVALID,
-        3,
-        { 32, 32, 32,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_R32G32B32_SINT = 105
-    {
-        VK_FORMAT_R32G32B32_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_INVALID,
-        3,
-        { 32, 32, 32,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_R32G32B32_SFLOAT = 106
-    {
-        VK_FORMAT_R32G32B32_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_INVALID,
-        3,
-        { 32, 32, 32,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_R32G32B32A32_UINT = 107
-    {
-        VK_FORMAT_R32G32B32A32_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_32_32_32_32,
-        3,
-        { 32, 32, 32, 32, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R32G32B32A32_SINT = 108
-    {
-        VK_FORMAT_R32G32B32A32_SINT,
-        COLOR_NUM_FORMAT_SINT,
-        COLOR_DATA_FORMAT_32_32_32_32,
-        3,
-        { 32, 32, 32, 32, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R32G32B32A32_SFLOAT = 109
-    {
-        VK_FORMAT_R32G32B32A32_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_32_32_32_32,
-        3,
-        { 32, 32, 32, 32, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::W },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z | ChannelMask::W,
-    },
-    // VK_FORMAT_R64_UINT = 110
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64_UINT),
-    // VK_FORMAT_R64_SINT = 111
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64_SINT),
-    // VK_FORMAT_R64_SFLOAT = 112
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64_SFLOAT),
-    // VK_FORMAT_R64G64_UINT = 113
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64_UINT),
-    // VK_FORMAT_R64G64_SINT = 114
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64_SINT),
-    // VK_FORMAT_R64G64_SFLOAT = 115
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64_SFLOAT),
-    // VK_FORMAT_R64G64B64_UINT = 116
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64B64_UINT),
-    // VK_FORMAT_R64G64B64_SINT = 117
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64B64_SINT),
-    // VK_FORMAT_R64G64B64_SFLOAT = 118
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64B64_SFLOAT),
-    // VK_FORMAT_R64G64B64A64_UINT = 119
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64B64A64_UINT),
-    // VK_FORMAT_R64G64B64A64_SINT = 120
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64B64A64_SINT),
-    // VK_FORMAT_R64G64B64A64_SFLOAT = 121
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_R64G64B64A64_SFLOAT),
-    // VK_FORMAT_B10G11R11_UFLOAT_PACK32 = 122
-    {
-        VK_FORMAT_B10G11R11_UFLOAT_PACK32,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_10_11_11,
-        3,
-        { 11, 11, 10,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 = 123
-    {
-        VK_FORMAT_E5B9G9R9_UFLOAT_PACK32,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_INVALID,
-        4,
-        {  9,  9,  9,  5, },
-        { ChannelSwizzle::X, ChannelSwizzle::Y, ChannelSwizzle::Z, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y | ChannelMask::Z,
-    },
-    // VK_FORMAT_D16_UNORM = 124
-    {
-        VK_FORMAT_D16_UNORM,
-        COLOR_NUM_FORMAT_UNORM,
-        COLOR_DATA_FORMAT_16,
-        1,
-        { 16,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_X8_D24_UNORM_PACK32 = 125
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_X8_D24_UNORM_PACK32),
-    // VK_FORMAT_D32_SFLOAT = 126
-    {
-        VK_FORMAT_D32_SFLOAT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_32,
-        1,
-        { 32,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_S8_UINT = 127
-    {
-        VK_FORMAT_S8_UINT,
-        COLOR_NUM_FORMAT_UINT,
-        COLOR_DATA_FORMAT_8,
-        1,
-        { 8,  0,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X,
-    },
-    // VK_FORMAT_D16_UNORM_S8_UINT = 128
-    {
-        VK_FORMAT_D16_UNORM_S8_UINT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_INVALID,
-        2,
-        { 16,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_D24_UNORM_S8_UINT = 129
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_D24_UNORM_S8_UINT),
-    // VK_FORMAT_D32_SFLOAT_S8_UINT = 130
-    {
-        VK_FORMAT_D32_SFLOAT_S8_UINT,
-        COLOR_NUM_FORMAT_FLOAT,
-        COLOR_DATA_FORMAT_INVALID,
-        2,
-        { 32,  8,  0,  0, },
-        { ChannelSwizzle::X, ChannelSwizzle::Zero, ChannelSwizzle::Zero, ChannelSwizzle::One },
-        ChannelMask::X | ChannelMask::Y,
-    },
-    // VK_FORMAT_BC1_RGB_UNORM_BLOCK = 131
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGB_UNORM_BLOCK),
-    // VK_FORMAT_BC1_RGB_SRGB_BLOCK = 132
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGB_SRGB_BLOCK),
-    // VK_FORMAT_BC1_RGBA_UNORM_BLOCK = 133
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGBA_UNORM_BLOCK),
-    // VK_FORMAT_BC1_RGBA_SRGB_BLOCK = 134
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGBA_SRGB_BLOCK),
-    // VK_FORMAT_BC2_UNORM_BLOCK = 135
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC2_UNORM_BLOCK),
-    // VK_FORMAT_BC2_SRGB_BLOCK = 136
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC2_SRGB_BLOCK),
-    // VK_FORMAT_BC3_UNORM_BLOCK = 137
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC3_UNORM_BLOCK),
-    // VK_FORMAT_BC3_SRGB_BLOCK = 138
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC3_SRGB_BLOCK),
-    // VK_FORMAT_BC4_UNORM_BLOCK = 139
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC4_UNORM_BLOCK),
-    // VK_FORMAT_BC4_SNORM_BLOCK = 140
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC4_SNORM_BLOCK),
-    // VK_FORMAT_BC5_UNORM_BLOCK = 141
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC5_UNORM_BLOCK),
-    // VK_FORMAT_BC5_SNORM_BLOCK = 142
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC5_SNORM_BLOCK),
-    // VK_FORMAT_BC6H_UFLOAT_BLOCK = 143
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC6H_UFLOAT_BLOCK),
-    // VK_FORMAT_BC6H_SFLOAT_BLOCK = 144
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC6H_SFLOAT_BLOCK),
-    // VK_FORMAT_BC7_UNORM_BLOCK = 145
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC7_UNORM_BLOCK),
-    // VK_FORMAT_BC7_SRGB_BLOCK = 146
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_BC7_SRGB_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK = 147
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK = 148
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK = 149
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK = 150
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK = 151
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK = 152
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK),
-    // VK_FORMAT_EAC_R11_UNORM_BLOCK = 153
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11_UNORM_BLOCK),
-    // VK_FORMAT_EAC_R11_SNORM_BLOCK = 154
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11_SNORM_BLOCK),
-    // VK_FORMAT_EAC_R11G11_UNORM_BLOCK = 155
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11G11_UNORM_BLOCK),
-    // VK_FORMAT_EAC_R11G11_SNORM_BLOCK = 156
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11G11_SNORM_BLOCK),
-    // VK_FORMAT_ASTC_4x4_UNORM_BLOCK = 157
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_4x4_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_4x4_SRGB_BLOCK = 158
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_4x4_SRGB_BLOCK),
-    // vK_FORMAT_ASTC_5x4_UNORM_BLOCK = 159
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x4_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_5x4_SRGB_BLOCK = 160
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x4_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_5x5_UNORM_BLOCK = 161
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_5x5_SRGB_BLOCK = 162
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_6x5_UNORM_BLOCK = 163
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_6x5_SRGB_BLOCK = 164
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_6x6_UNORM_BLOCK = 165
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x6_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_6x6_SRGB_BLOCK = 166
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x6_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_8x5_UNORM_BLOCK = 167
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_8x5_SRGB_BLOCK = 168
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_8x6_UNORM_BLOCK = 169
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x6_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_8x6_SRGB_BLOCK = 170
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x6_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_8x8_UNORM_BLOCK = 171
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x8_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_8x8_SRGB_BLOCK = 172
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x8_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x5_UNORM_BLOCK = 173
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x5_SRGB_BLOCK = 174
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x6_UNORM_BLOCK = 175
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x6_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x6_SRGB_BLOCK = 176
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x6_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x8_UNORM_BLOCK = 177
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x8_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x8_SRGB_BLOCK = 178
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x8_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x10_UNORM_BLOCK = 179
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x10_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x10_SRGB_BLOCK = 180
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x10_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_12x10_UNORM_BLOCK = 181
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x10_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_12x10_SRGB_BLOCK = 182
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x10_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_12x12_UNORM_BLOCK = 183
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x12_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_12x12_SRGB_BLOCK = 184
-    COLOR_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x12_SRGB_BLOCK),
-};
-
 // =====================================================================================================================
 FragColorExport::FragColorExport(
     PipelineState*  pPipelineState) // [in] Pipeline state
     :
     m_pModule(pPipelineState->GetModule()),
     m_pContext(static_cast<Context*>(&m_pModule->getContext())),
-    pPipelineInfo(static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo())),
     m_pPipelineState(pPipelineState)
 {
 }
@@ -1191,7 +68,7 @@ Value* FragColorExport::Run(
     const uint32_t origLoc = pResUsage->inOutUsage.fs.outputOrigLocs[location];
 
     ExportFormat expFmt = EXP_FORMAT_ZERO;
-    if (pPipelineInfo->cbState.dualSourceBlendEnable)
+    if (m_pPipelineState->GetColorExportState().dualSourceBlendEnable)
     {
         // Dual source blending is enabled
         expFmt= ComputeExportFormat(pOutputTy, 0);
@@ -1616,10 +493,8 @@ ExportFormat FragColorExport::ComputeExportFormat(
     uint32_t location    // Location of fragment data output
     ) const
 {
-    const auto pCbState = &pPipelineInfo->cbState;
-    const auto pTarget = &pCbState->target[location];
-
-    const VkFormat format = pTarget->format;
+    const auto pCbState = &m_pPipelineState->GetColorExportState();
+    const auto pTarget = &m_pPipelineState->GetColorExportFormat(location);
 
     const bool blendEnabled = pTarget->blendEnable;
 
@@ -1628,20 +503,26 @@ ExportFormat FragColorExport::ComputeExportFormat(
     // NOTE: Alpha-to-coverage only cares at the output from target #0.
     const bool enableAlphaToCoverage = (pCbState->alphaToCoverageEnable && (location == 0));
 
-    const bool isUnorm = IsUnorm(format);
-    const bool isSnorm = IsSnorm(format);
-    const bool isFloat = IsFloat(format);
-    const bool isUint  = IsUint(format);
-    const bool isSint  = IsSint(format);
-    const bool isSrgb  = IsSrgb(format);
+    const bool isUnorm = (pTarget->nfmt == Builder::BufNumFormatUNORM);
+    const bool isSnorm = (pTarget->nfmt == Builder::BufNumFormatSNORM);
+    bool isFloat = (pTarget->nfmt == Builder::BufNumFormatFLOAT);
+    const bool isUint = (pTarget->nfmt == Builder::BufNumFormatUINT);
+    const bool isSint = (pTarget->nfmt == Builder::BufNumFormatSINT);
+    const bool isSrgb = (pTarget->nfmt == Builder::BufNumFormatSRGB);
 
-    const uint32_t maxCompBitCount = GetMaxComponentBitCount(format);
+    if ((pTarget->dfmt == Builder::BufDataFormat8_8_8) || (pTarget->dfmt == Builder::BufDataFormat8_8_8_BGR))
+    {
+        // These three-byte formats are handled by pretending they are float.
+        isFloat = true;
+    }
 
-    const bool hasAlpha = HasAlpha(pTarget->format);
+    const uint32_t maxCompBitCount = GetMaxComponentBitCount(pTarget->dfmt);
+
+    const bool hasAlpha = HasAlpha(pTarget->dfmt);
     const bool alphaExport = (shaderExportsAlpha &&
                               (hasAlpha || pTarget->blendSrcAlphaToColor || enableAlphaToCoverage));
 
-    const CompSetting compSetting = ComputeCompSetting(format);
+    const CompSetting compSetting = ComputeCompSetting(pTarget->dfmt);
 
     // Start by assuming EXP_FORMAT_ZERO (no exports)
     ExportFormat expFmt = EXP_FORMAT_ZERO;
@@ -1655,7 +536,7 @@ ExportFormat FragColorExport::ComputeExportFormat(
         gfx8RbPlusEnable = true;
     }
 
-    if (format == VK_FORMAT_UNDEFINED)
+    if (pTarget->dfmt == Builder::BufDataFormatInvalid)
     {
         expFmt = EXP_FORMAT_ZERO;
     }
@@ -1733,205 +614,152 @@ ExportFormat FragColorExport::ComputeExportFormat(
 // =====================================================================================================================
 // This is the helper function for the algorithm to determine the shader export format.
 CompSetting FragColorExport::ComputeCompSetting(
-    VkFormat format // Color attachment color
+    Builder::BufDataFormat dfmt // Color attachment data format
     ) const
 {
     CompSetting compSetting = CompSetting::Invalid;
-
-    const ColorSwap colorSwap = ComputeColorSwap(format);
-    const uint32_t dfmt = GetColorFormatInfo(format)->dfmt;
-
-    switch (dfmt)
+    switch (GetNumChannels(dfmt))
     {
-    case COLOR_DATA_FORMAT_8:
-    case COLOR_DATA_FORMAT_16:
-    case COLOR_DATA_FORMAT_32:
-        if (colorSwap == COLOR_SWAP_STD)
-        {
-            compSetting = CompSetting::OneCompRed;
-        }
-        else if (colorSwap == COLOR_SWAP_ALT_REV)
-        {
-            compSetting = CompSetting::OneCompAlpha;
-        }
+    case 1:
+        compSetting = CompSetting::OneCompRed;
         break;
-    case COLOR_DATA_FORMAT_8_8:
-    case COLOR_DATA_FORMAT_16_16:
-    case COLOR_DATA_FORMAT_32_32:
-        if ((colorSwap == COLOR_SWAP_STD) || (colorSwap == COLOR_SWAP_STD_REV))
-        {
-            compSetting = CompSetting::TwoCompGreenRed;
-        }
-        else if ((colorSwap == COLOR_SWAP_ALT) || (colorSwap == COLOR_SWAP_ALT_REV))
-        {
-            compSetting = CompSetting::TwoCompAlphaRed;
-        }
-        break;
-    default:
-        compSetting = CompSetting::Invalid;
+    case 2:
+        compSetting = CompSetting::TwoCompGreenRed;
         break;
     }
-
     return compSetting;
 }
 
 // =====================================================================================================================
-// Determines the CB component swap mode according to color attachment format.
-ColorSwap FragColorExport::ComputeColorSwap(
-    VkFormat format // Color attachment format
+// Get the number of channels
+uint32_t FragColorExport::GetNumChannels(
+    Builder::BufDataFormat dfmt // Color attachment data format
     ) const
 {
-    ColorSwap colorSwap = COLOR_SWAP_STD;
-
-    const uint32_t numChannels = GetColorFormatInfo(format)->numChannels;
-    const auto& swizzle = GetColorFormatInfo(format)->channelSwizzle;
-
-    if (numChannels == 1)
+    switch (dfmt)
     {
-        if (swizzle.r == ChannelSwizzle::X)
-        {
-            colorSwap = COLOR_SWAP_STD;
-        }
-        else if (swizzle.a == ChannelSwizzle::X)
-        {
-            colorSwap = COLOR_SWAP_ALT_REV;
-        }
-        else
-        {
-            LLPC_NEVER_CALLED();
-        }
+    case Builder::BufDataFormatInvalid:
+    case Builder::BufDataFormatReserved:
+    case Builder::BufDataFormat8:
+    case Builder::BufDataFormat16:
+    case Builder::BufDataFormat32:
+    case Builder::BufDataFormat64:
+        return 1;
+    case Builder::BufDataFormat4_4:
+    case Builder::BufDataFormat8_8:
+    case Builder::BufDataFormat16_16:
+    case Builder::BufDataFormat32_32:
+    case Builder::BufDataFormat64_64:
+        return 2;
+    case Builder::BufDataFormat8_8_8:
+    case Builder::BufDataFormat8_8_8_BGR:
+    case Builder::BufDataFormat10_11_11:
+    case Builder::BufDataFormat11_11_10:
+    case Builder::BufDataFormat32_32_32:
+    case Builder::BufDataFormat64_64_64:
+    case Builder::BufDataFormat5_6_5:
+    case Builder::BufDataFormat5_6_5_BGR:
+        return 3;
+    case Builder::BufDataFormat10_10_10_2:
+    case Builder::BufDataFormat2_10_10_10:
+    case Builder::BufDataFormat8_8_8_8:
+    case Builder::BufDataFormat16_16_16_16:
+    case Builder::BufDataFormat32_32_32_32:
+    case Builder::BufDataFormat8_8_8_8_BGRA:
+    case Builder::BufDataFormat2_10_10_10_BGRA:
+    case Builder::BufDataFormat64_64_64_64:
+    case Builder::BufDataFormat4_4_4_4:
+    case Builder::BufDataFormat4_4_4_4_BGRA:
+    case Builder::BufDataFormat5_6_5_1:
+    case Builder::BufDataFormat5_6_5_1_BGRA:
+    case Builder::BufDataFormat1_5_6_5:
+    case Builder::BufDataFormat5_9_9_9:
+        return 4;
     }
-    else if (numChannels == 2)
-    {
-        if ((swizzle.r == ChannelSwizzle::X) && (swizzle.g == ChannelSwizzle::Y))
-        {
-            colorSwap = COLOR_SWAP_STD;
-        }
-        else if ((swizzle.r == ChannelSwizzle::X) && (swizzle.a == ChannelSwizzle::Y))
-        {
-            colorSwap = COLOR_SWAP_ALT;
-        }
-        else if ((swizzle.g == ChannelSwizzle::X) && (swizzle.r == ChannelSwizzle::Y))
-        {
-            colorSwap = COLOR_SWAP_STD_REV;
-        }
-        else if ((swizzle.a == ChannelSwizzle::X) && (swizzle.r == ChannelSwizzle::Y))
-        {
-            colorSwap = COLOR_SWAP_ALT_REV;
-        }
-        else
-        {
-            LLPC_NEVER_CALLED();
-        }
-    }
-    else if (numChannels == 3)
-    {
-        if ((swizzle.r == ChannelSwizzle::X) &&
-            (swizzle.g == ChannelSwizzle::Y) &&
-            (swizzle.b == ChannelSwizzle::Z))
-        {
-            colorSwap = COLOR_SWAP_STD;
-        }
-        else if ((swizzle.r == ChannelSwizzle::X) &&
-                 (swizzle.g == ChannelSwizzle::Y) &&
-                 (swizzle.a == ChannelSwizzle::Z))
-        {
-            colorSwap = COLOR_SWAP_ALT;
-        }
-        else if ((swizzle.b == ChannelSwizzle::X) &&
-                 (swizzle.g == ChannelSwizzle::Y) &&
-                 (swizzle.r == ChannelSwizzle::Z))
-        {
-            colorSwap = COLOR_SWAP_STD_REV;
-        }
-        else if ((swizzle.a == ChannelSwizzle::X) &&
-                 (swizzle.g == ChannelSwizzle::Y) &&
-                 (swizzle.r == ChannelSwizzle::Z))
-        {
-            colorSwap = COLOR_SWAP_ALT_REV;
-        }
-        else
-        {
-            LLPC_NEVER_CALLED();
-        }
-    }
-    else if (numChannels == 4)
-    {
-        if ((swizzle.r == ChannelSwizzle::X) &&
-            (swizzle.g == ChannelSwizzle::Y) &&
-            (swizzle.b == ChannelSwizzle::Z) &&
-            ((swizzle.a == ChannelSwizzle::W) || (swizzle.a == ChannelSwizzle::One)))
-        {
-            colorSwap = COLOR_SWAP_STD;
-        }
-        else if ((swizzle.b == ChannelSwizzle::X) &&
-                 (swizzle.g == ChannelSwizzle::Y) &&
-                 (swizzle.r == ChannelSwizzle::Z) &&
-                 ((swizzle.a == ChannelSwizzle::W) || (swizzle.a == ChannelSwizzle::One)))
-        {
-            colorSwap = COLOR_SWAP_ALT;
-        }
-        else if ((swizzle.a == ChannelSwizzle::X) &&
-                 (swizzle.b == ChannelSwizzle::Y) &&
-                 (swizzle.g == ChannelSwizzle::Z) &&
-                 (swizzle.r == ChannelSwizzle::W))
-        {
-            colorSwap = COLOR_SWAP_STD_REV;
-        }
-        else if ((swizzle.a == ChannelSwizzle::X) &&
-                 (swizzle.r == ChannelSwizzle::Y) &&
-                 (swizzle.g == ChannelSwizzle::Z) &&
-                 (swizzle.b == ChannelSwizzle::W))
-        {
-            colorSwap = COLOR_SWAP_ALT_REV;
-        }
-        else
-        {
-            LLPC_NEVER_CALLED();
-        }
-    }
-    else
-    {
-        LLPC_NEVER_CALLED();
-    }
-
-    return colorSwap;
-}
-
-// =====================================================================================================================
-// Gets info from table according to color attachment format.
-const ColorFormatInfo* FragColorExport::GetColorFormatInfo(
-    VkFormat format) // Color attachment format
-{
-    LLPC_ASSERT(format < VK_FORMAT_RANGE_SIZE);
-
-    const ColorFormatInfo* pFormatInfo = &m_colorFormatInfo[format];
-    LLPC_ASSERT(pFormatInfo->format == format);
-
-    return pFormatInfo;
+    return 0;
 }
 
 // =====================================================================================================================
 // Checks whether the alpha channel is present in the specified color attachment format.
 bool FragColorExport::HasAlpha(
-    VkFormat format // Color attachment foramt
+    Builder::BufDataFormat dfmt // Color attachment data format
     ) const
 {
-    const auto mask = GetColorFormatInfo(format)->channelMask;
-    const auto& swizzle = GetColorFormatInfo(format)->channelSwizzle;
-
-    return (((mask & ChannelMask::W) != 0) ||
-            ((swizzle.a != ChannelSwizzle::Zero) && (swizzle.a != ChannelSwizzle::One)));
+    switch (dfmt)
+    {
+    case Builder::BufDataFormat10_10_10_2:
+    case Builder::BufDataFormat2_10_10_10:
+    case Builder::BufDataFormat8_8_8_8:
+    case Builder::BufDataFormat16_16_16_16:
+    case Builder::BufDataFormat32_32_32_32:
+    case Builder::BufDataFormat8_8_8_8_BGRA:
+    case Builder::BufDataFormat2_10_10_10_BGRA:
+    case Builder::BufDataFormat64_64_64_64:
+    case Builder::BufDataFormat4_4_4_4:
+    case Builder::BufDataFormat4_4_4_4_BGRA:
+    case Builder::BufDataFormat5_6_5_1:
+    case Builder::BufDataFormat5_6_5_1_BGRA:
+    case Builder::BufDataFormat1_5_6_5:
+    case Builder::BufDataFormat5_9_9_9:
+        return true;
+    default:
+        return false;
+    }
 }
 
 // =====================================================================================================================
 // Gets the maximum bit-count of any component in specified color attachment format.
 uint32_t FragColorExport::GetMaxComponentBitCount(
-    VkFormat format // Color attachment foramt
+    Builder::BufDataFormat dfmt // Color attachment data format
     ) const
 {
-    auto& bitCount = GetColorFormatInfo(format)->bitCount;
-    return std::max(std::max(bitCount[0], bitCount[1]), std::max(bitCount[2], bitCount[3]));
+    switch (dfmt)
+    {
+    case Builder::BufDataFormatInvalid:
+    case Builder::BufDataFormatReserved:
+        return 0;
+    case Builder::BufDataFormat4_4:
+    case Builder::BufDataFormat4_4_4_4:
+    case Builder::BufDataFormat4_4_4_4_BGRA:
+        return 4;
+    case Builder::BufDataFormat5_6_5:
+    case Builder::BufDataFormat5_6_5_BGR:
+    case Builder::BufDataFormat5_6_5_1:
+    case Builder::BufDataFormat5_6_5_1_BGRA:
+    case Builder::BufDataFormat1_5_6_5:
+        return 6;
+    case Builder::BufDataFormat8:
+    case Builder::BufDataFormat8_8:
+    case Builder::BufDataFormat8_8_8:
+    case Builder::BufDataFormat8_8_8_BGR:
+    case Builder::BufDataFormat8_8_8_8:
+    case Builder::BufDataFormat8_8_8_8_BGRA:
+        return 8;
+    case Builder::BufDataFormat5_9_9_9:
+        return 9;
+    case Builder::BufDataFormat10_10_10_2:
+    case Builder::BufDataFormat2_10_10_10:
+    case Builder::BufDataFormat2_10_10_10_BGRA:
+        return 10;
+    case Builder::BufDataFormat10_11_11:
+    case Builder::BufDataFormat11_11_10:
+        return 11;
+    case Builder::BufDataFormat16:
+    case Builder::BufDataFormat16_16:
+    case Builder::BufDataFormat16_16_16_16:
+        return 16;
+    case Builder::BufDataFormat32:
+    case Builder::BufDataFormat32_32:
+    case Builder::BufDataFormat32_32_32:
+    case Builder::BufDataFormat32_32_32_32:
+        return 32;
+    case Builder::BufDataFormat64:
+    case Builder::BufDataFormat64_64:
+    case Builder::BufDataFormat64_64_64:
+    case Builder::BufDataFormat64_64_64_64:
+        return 64;
+    }
+    return 0;
 }
 
 // =====================================================================================================================

--- a/patch/llpcFragColorExport.h
+++ b/patch/llpcFragColorExport.h
@@ -37,6 +37,7 @@ namespace Llpc
 {
 
 class Context;
+class PipelineState;
 
 // Enumerates the source selection of each color channel in a color attachment format.
 enum class ChannelSwizzle : uint8_t
@@ -98,7 +99,7 @@ struct ColorFormatInfo
 class FragColorExport
 {
 public:
-    FragColorExport(llvm::Module* pModule);
+    FragColorExport(PipelineState* pPipelineState);
 
     llvm::Value* Run(llvm::Value* pOutput, uint32_t location, llvm::Instruction* pInsertPos);
 
@@ -134,7 +135,8 @@ private:
 
     static const ColorFormatInfo    m_colorFormatInfo[]; // Info table of fragment color format
 
-    const GraphicsPipelineBuildInfo* pPipelineInfo;   // Graphics pipeline build info
+    const GraphicsPipelineBuildInfo* pPipelineInfo;     // Graphics pipeline build info
+    PipelineState*                   m_pPipelineState;  // Pipeline state
 };
 
 } // Llpc

--- a/patch/llpcFragColorExport.h
+++ b/patch/llpcFragColorExport.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpcBuilder.h"
 #include "llpcInternal.h"
 #include "llpcIntrinsDefs.h"
 
@@ -38,26 +39,6 @@ namespace Llpc
 
 class Context;
 class PipelineState;
-
-// Enumerates the source selection of each color channel in a color attachment format.
-enum class ChannelSwizzle : uint8_t
-{
-    Zero = 0,       // Always 0 (ignore source)
-    One,            // Always 1 (ignore source)
-    X,              // X channel from the source
-    Y,              // Y channel from the source
-    Z,              // Z channel from the source
-    W,              // W channel from the source
-};
-
-// Enumerates the presence of each color channel in a color attachment format.
-enum ChannelMask : uint8_t
-{
-    X = 1,          // X channel is present
-    Y = 2,          // Y channel is present
-    Z = 4,          // Z channel is present
-    W = 8,          // W channel is present
-};
 
 // Enumerates component setting of color format. This is a "helper" enum used in the CB's algorithm for deriving
 // an ideal shader export format.
@@ -68,30 +49,6 @@ enum class CompSetting : uint32_t
     OneCompAlpha,       // Alpha
     TwoCompAlphaRed,    // Alpha, red
     TwoCompGreenRed     // Green, red
-};
-
-// Represents fragment color format info corresponding to color attachment format (VkFormat).
-struct ColorFormatInfo
-{
-    VkFormat        format;         // Color attachment format
-    ColorNumFormat  nfmt;           // Numeric format of fragment color
-    ColorDataFormat dfmt;           // Data format of fragment color
-    uint32_t        numChannels;    // Valid number of channels
-    uint32_t        bitCount[4];    // Number of bits for each channel
-
-    union
-    {
-        struct
-        {
-            ChannelSwizzle r;           // Red component swizzle
-            ChannelSwizzle g;           // Green component swizzle
-            ChannelSwizzle b;           // Blue component swizzle
-            ChannelSwizzle a;           // Alpha component swizzle
-        };
-        ChannelSwizzle     rgba[4];     // All four swizzles packed into one array
-    } channelSwizzle;
-
-    uint8_t    channelMask;    // Mask indicating which channel is valid
 };
 
 // =====================================================================================================================
@@ -108,22 +65,12 @@ private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(FragColorExport);
 
     ExportFormat ComputeExportFormat(llvm::Type* pOutputTy, uint32_t location) const;
-    CompSetting ComputeCompSetting(VkFormat format) const;
-    ColorSwap ComputeColorSwap(VkFormat format) const;
+    CompSetting ComputeCompSetting(Builder::BufDataFormat dfmt) const;
+    uint32_t GetNumChannels(Builder::BufDataFormat dfmt) const;
 
-    static const ColorFormatInfo* GetColorFormatInfo(VkFormat format);
+    bool HasAlpha(Builder::BufDataFormat dfmt) const;
 
-    // Checks whether numeric format of the specified color attachment format is as expected
-    bool IsUnorm(VkFormat format) const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_UNORM); }
-    bool IsSnorm(VkFormat format) const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SNORM); }
-    bool IsFloat(VkFormat format) const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_FLOAT); }
-    bool IsUint(VkFormat format)  const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_UINT);  }
-    bool IsSint(VkFormat format)  const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SINT);  }
-    bool IsSrgb(VkFormat format)  const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SRGB);  }
-
-    bool HasAlpha(VkFormat format) const;
-
-    uint32_t GetMaxComponentBitCount(VkFormat format) const;
+    uint32_t GetMaxComponentBitCount(Builder::BufDataFormat dfmt) const;
 
     llvm::Value* ConvertToFloat(llvm::Value* pValue, bool signedness, llvm::Instruction* pInsertPos) const;
     llvm::Value* ConvertToInt(llvm::Value* pValue, bool signedness, llvm::Instruction* pInsertPos) const;
@@ -133,9 +80,6 @@ private:
     llvm::Module*   m_pModule;          // LLVM module
     Context*        m_pContext;         // LLPC context
 
-    static const ColorFormatInfo    m_colorFormatInfo[]; // Info table of fragment color format
-
-    const GraphicsPipelineBuildInfo* pPipelineInfo;     // Graphics pipeline build info
     PipelineState*                   m_pPipelineState;  // Pipeline state
 };
 

--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -57,6 +57,7 @@
 #include "llpcPassManager.h"
 #include "llpcPatch.h"
 #include "llpcPatchCheckShaderCache.h"
+#include "llpcPipelineState.h"
 #include "SPIRVInternal.h"
 
 #define DEBUG_TYPE "llpc-patch"
@@ -368,8 +369,9 @@ void Patch::Init(
 // =====================================================================================================================
 // Get or create global variable for LDS.
 GlobalVariable* Patch::GetLdsVariable(
-    Module* pModule)  // [in/out] Module to get or create LDS in
+    PipelineState*  pPipelineState)   // [in] PipelineState
 {
+    Module* pModule = pPipelineState->GetModule();
     auto pContext = static_cast<Context*>(&pModule->getContext());
 
     // See if this module already has LDS.
@@ -381,7 +383,7 @@ GlobalVariable* Patch::GetLdsVariable(
     }
     // Now we can create LDS.
     // Construct LDS type: [ldsSize * i32], address space 3
-    auto ldsSize = pContext->GetGpuProperty()->ldsSizePerCu;
+    auto ldsSize = pPipelineState->GetGpuProperty()->ldsSizePerCu;
     auto pLdsTy = ArrayType::get(pContext->Int32Ty(), ldsSize / sizeof(uint32_t));
 
     auto pLds = new GlobalVariable(*pModule,

--- a/patch/llpcPatch.h
+++ b/patch/llpcPatch.h
@@ -133,7 +133,7 @@ public:
                           std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>
                                                       checkShaderCacheFunc);
 
-    static llvm::GlobalVariable* GetLdsVariable(llvm::Module* pModule);
+    static llvm::GlobalVariable* GetLdsVariable(PipelineState* pPipelineState);
 
 protected:
     void Init(llvm::Module* pModule);

--- a/patch/llpcPatchBufferOp.h
+++ b/patch/llpcPatchBufferOp.h
@@ -38,6 +38,8 @@
 namespace Llpc
 {
 
+class PipelineState;
+
 // =====================================================================================================================
 // Represents the pass of LLVM patching operations for buffer operations
 class PatchBufferOp final:
@@ -100,6 +102,7 @@ private:
     llvm::SmallVector<llvm::Instruction*, 16>       m_postVisitInsts;      // The post process instruction set.
     std::unique_ptr<llvm::IRBuilder<>>              m_pBuilder;            // The IRBuilder.
     Context*                                        m_pContext;            // The LLPC Context.
+    PipelineState*                                  m_pPipelineState;      // The pipeline state.
 
     static constexpr uint32_t MinMemOpLoopBytes = 256;
 };

--- a/patch/llpcPatchCheckShaderCache.cpp
+++ b/patch/llpcPatchCheckShaderCache.cpp
@@ -1,0 +1,164 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPatchCheckShaderCache.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::PatchCheckShaderCache.
+ ***********************************************************************************************************************
+ */
+#define DEBUG_TYPE "llpc-patch-check-shader-cache"
+
+#include "llvm/Support/Debug.h"
+
+#include "llpcPatchCheckShaderCache.h"
+#include "llpcPipelineShaders.h"
+
+using namespace llvm;
+using namespace Llpc;
+
+// =====================================================================================================================
+// Initializes static members.
+char PatchCheckShaderCache::ID = 0;
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Pass creator, creates the pass of LLVM patching operations for checking shader cache
+PatchCheckShaderCache* CreatePatchCheckShaderCache()
+{
+    return new PatchCheckShaderCache();
+}
+
+} // Llpc
+
+namespace
+{
+
+// =====================================================================================================================
+// Stream each map key and value for later inclusion in a hash
+template <class MapType>
+static void StreamMapEntries(MapType&     map,    // [in] Map to stream
+                             raw_ostream& stream) // [in/out] Stream to output map entries to
+{
+    size_t mapCount = map.size();
+    stream << StringRef(reinterpret_cast<const char*>(&mapCount), sizeof(mapCount));
+    for (auto mapIt : map)
+    {
+        stream << StringRef(reinterpret_cast<const char*>(&mapIt.first), sizeof(mapIt.first));
+        stream << StringRef(reinterpret_cast<const char*>(&mapIt.second), sizeof(mapIt.second));
+    }
+}
+
+} // anonymous
+
+// =====================================================================================================================
+PatchCheckShaderCache::PatchCheckShaderCache()
+    :
+    Patch(ID)
+{
+    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
+    initializePatchCheckShaderCachePass(*PassRegistry::getPassRegistry());
+}
+
+// =====================================================================================================================
+// Executes this LLVM patching pass on the specified LLVM module.
+bool PatchCheckShaderCache::runOnModule(
+    Module& module)  // [in,out] LLVM module to be run on
+{
+    LLVM_DEBUG(dbgs() << "Run the pass Patch-Check-Shader-Cache\n");
+
+    if (m_callbackFunc == nullptr)
+    {
+        // No shader cache in use.
+        return false;
+    }
+
+    Patch::Init(&module);
+
+    std::string inOutUsageStreams[ShaderStageGfxCount];
+    ArrayRef<uint8_t> inOutUsageValues[ShaderStageGfxCount];
+    auto stageMask = m_pContext->GetShaderStageMask();
+
+    // Build input/output layout hash per shader stage
+    for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1))
+    {
+        if ((stageMask & ShaderStageToMask(stage)) == 0)
+        {
+            continue;
+        }
+
+        auto pResUsage = m_pContext->GetShaderResourceUsage(stage);
+        raw_string_ostream stream(inOutUsageStreams[stage]);
+
+        // Update input/output usage
+        StreamMapEntries(pResUsage->inOutUsage.inputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.outputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchOutputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.builtInInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.builtInOutputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchBuiltInInputLocMap, stream);
+        StreamMapEntries(pResUsage->inOutUsage.perPatchBuiltInOutputLocMap, stream);
+
+        if (stage == ShaderStageGeometry)
+        {
+            // NOTE: For geometry shader, copy shader will use this special map info (from built-in outputs to
+            // locations of generic outputs). We have to add it to shader hash calculation.
+            StreamMapEntries(pResUsage->inOutUsage.gs.builtInOutLocs, stream);
+        }
+
+        // Store the result of the hash for this shader stage.
+        stream.flush();
+        inOutUsageValues[stage] = ArrayRef<uint8_t>(reinterpret_cast<const uint8_t*>(inOutUsageStreams[stage].data()),
+                                                    inOutUsageStreams[stage].size());
+    }
+
+    // Ask callback function if it wants to remove any shader stages.
+    uint32_t modifiedStageMask = m_callbackFunc(&module, stageMask, inOutUsageValues);
+    if (modifiedStageMask == stageMask)
+    {
+        return false;
+    }
+
+    // "Remove" a shader stage by making its entry-point function internal, so it gets removed later.
+    for (auto& func : module)
+    {
+        if ((func.empty() == false) && (func.getLinkage() != GlobalValue::InternalLinkage))
+        {
+            auto stage = GetShaderStageFromFunction(&func);
+            if ((stage != ShaderStageInvalid) && ((ShaderStageToMask(stage) & ~modifiedStageMask) != 0))
+            {
+                func.setLinkage(GlobalValue::InternalLinkage);
+            }
+        }
+    }
+    return true;
+}
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patch operations for checking shader cache
+INITIALIZE_PASS(PatchCheckShaderCache, DEBUG_TYPE,
+                "Patch LLVM for checking shader cache", false, false)

--- a/patch/llpcPatchCheckShaderCache.cpp
+++ b/patch/llpcPatchCheckShaderCache.cpp
@@ -100,7 +100,8 @@ bool PatchCheckShaderCache::runOnModule(
 
     std::string inOutUsageStreams[ShaderStageGfxCount];
     ArrayRef<uint8_t> inOutUsageValues[ShaderStageGfxCount];
-    auto stageMask = m_pContext->GetShaderStageMask();
+    PipelineState* pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
+    auto stageMask = pPipelineState->GetShaderStageMask();
 
     // Build input/output layout hash per shader stage
     for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1))

--- a/patch/llpcPatchCheckShaderCache.h
+++ b/patch/llpcPatchCheckShaderCache.h
@@ -1,0 +1,76 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPatchCheckShaderCache.h
+ * @brief LLPC header file: contains declaration of class Llpc::PatchCheckShaderCache
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcPatch.h"
+#include "llpcPipelineShaders.h"
+
+namespace Llpc
+{
+
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for checking shader cache
+class PatchCheckShaderCache:
+    public Patch
+{
+public:
+    PatchCheckShaderCache();
+
+    void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
+    {
+        analysisUsage.addRequired<PipelineShaders>();
+    }
+
+    virtual bool runOnModule(llvm::Module& module) override;
+
+    // Set the callback function that this pass uses to ask the front-end whether it wants to remove
+    // any shader stages. The function takes the LLVM IR module and a per-shader-stage array of input/output
+    // usage checksums, and it returns the shader stage mask with bits removed for shader stages that it wants
+    // removed.
+    void SetCallbackFunction(
+        std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)> callbackFunc)
+    {
+        m_callbackFunc = callbackFunc;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    static char ID;   // ID of this pass
+
+private:
+    LLPC_DISALLOW_COPY_AND_ASSIGN(PatchCheckShaderCache);
+
+    // -----------------------------------------------------------------------------------------------------------------
+
+    std::function<uint32_t(const Module*, uint32_t, ArrayRef<ArrayRef<uint8_t>>)>   m_callbackFunc;
+};
+
+} // Llpc

--- a/patch/llpcPatchCheckShaderCache.h
+++ b/patch/llpcPatchCheckShaderCache.h
@@ -32,6 +32,7 @@
 
 #include "llpcPatch.h"
 #include "llpcPipelineShaders.h"
+#include "llpcPipelineState.h"
 
 namespace Llpc
 {
@@ -46,6 +47,7 @@ public:
 
     void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
     {
+        analysisUsage.addRequired<PipelineStateWrapper>();
         analysisUsage.addRequired<PipelineShaders>();
     }
 

--- a/patch/llpcPatchCopyShader.cpp
+++ b/patch/llpcPatchCopyShader.cpp
@@ -308,6 +308,9 @@ bool PatchCopyShader::runOnModule(
     auto pExecModelMetaNode = MDNode::get(*m_pContext, pExecModelMeta);
     pEntryPoint->addMetadata(gSPIRVMD::ExecutionModel, *pExecModelMetaNode);
 
+    // Tell pipeline state there is a copy shader.
+    pPipelineState->SetShaderStageMask(pPipelineState->GetShaderStageMask() | (1U << ShaderStageCopyShader));
+
     return true;
 }
 

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -647,7 +647,7 @@ Value* PatchDescriptorLoad::BuildBufferCompactDesc(
                                         pInsertPoint);
 
     // DWORD3
-    const GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
+    const GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
     if (gfxIp.major < 10)
     {
         SqBufRsrcWord3 sqBufRsrcWord3 = {};

--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -109,7 +109,7 @@ bool PatchEntryPointMutate::runOnModule(
 
     m_pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
 
-    const uint32_t stageMask = m_pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
     m_hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
                              ShaderStageToMask(ShaderStageTessEval))) != 0);
     m_hasGs = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);
@@ -283,7 +283,7 @@ bool PatchEntryPointMutate::IsResourceNodeActive(
         // NOTE: For LS-HS/ES-GS merged shader, resource mapping nodes of the two shader stages are merged as a whole.
         // So we have to check activeness of both shader stages at the same time. Here, we determine the second shader
        // stage and get its resource usage accordingly.
-        uint32_t stageMask = m_pContext->GetShaderStageMask();
+        uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
         const bool hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
                                             ShaderStageToMask(ShaderStageTessEval))) != 0);
         const bool hasGs = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);
@@ -437,7 +437,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
             if (pNode->type == ResourceMappingNodeType::StreamOutTableVaPtr)
             {
                 // Only the last shader stage before fragment (ignoring copy shader) needs a stream out table.
-                if ((m_pContext->GetShaderStageMask() &
+                if ((m_pPipelineState->GetShaderStageMask() &
                      (ShaderStageToMask(ShaderStageFragment) - ShaderStageToMask(m_shaderStage))) ==
                     ShaderStageToMask(m_shaderStage))
                 {
@@ -510,7 +510,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
             auto pCurrResUsage = pResUsage;
             if ((m_pPipelineState->GetGfxIpVersion().major >= 9) &&
                 (m_shaderStage == ShaderStageTessControl) &&
-                (m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)))
+                (m_pPipelineState->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)))
             {
                 pCurrResUsage = m_pContext->GetShaderResourceUsage(ShaderStageVertex);
             }
@@ -785,7 +785,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
 
             if ((m_pPipelineState->GetGfxIpVersion().major >= 9) &&
                 (m_shaderStage == ShaderStageTessControl) &&
-                (m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)))
+                (m_pPipelineState->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)))
             {
                 pCurrIntfData = m_pContext->GetShaderInterfaceData(ShaderStageVertex);
                 pCurrResUsage = m_pContext->GetShaderResourceUsage(ShaderStageVertex);

--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -207,7 +207,7 @@ void PatchEntryPointMutate::ProcessShader()
         pResUsage->numVgprsAvailable = std::min(vgprLimit, pResUsage->numVgprsAvailable);
     }
     pResUsage->numVgprsAvailable = std::min(pResUsage->numVgprsAvailable,
-                                           m_pContext->GetGpuProperty()->maxVgprsAvailable);
+                                           m_pPipelineState->GetGpuProperty()->maxVgprsAvailable);
 
     if ((pShaderOptions->sgprLimit != 0) && (pShaderOptions->sgprLimit != UINT32_MAX))
     {
@@ -224,7 +224,7 @@ void PatchEntryPointMutate::ProcessShader()
         pResUsage->numSgprsAvailable = std::min(sgprLimit, pResUsage->numSgprsAvailable);
     }
     pResUsage->numSgprsAvailable = std::min(pResUsage->numSgprsAvailable,
-                                            m_pContext->GetGpuProperty()->maxSgprsAvailable);
+                                            m_pPipelineState->GetGpuProperty()->maxSgprsAvailable);
 
     if (pShaderOptions->maxThreadGroupsPerComputeUnit != 0)
     {
@@ -277,7 +277,7 @@ bool PatchEntryPointMutate::IsResourceNodeActive(
     const ResourceUsage* pResUsage1 = m_pContext->GetShaderResourceUsage(m_shaderStage);
     const ResourceUsage* pResUsage2 = nullptr;
 
-    const auto gfxIp = m_pContext->GetGfxIpVersion();
+    const auto gfxIp = m_pPipelineState->GetGfxIpVersion();
     if (gfxIp.major >= 9)
     {
         // NOTE: For LS-HS/ES-GS merged shader, resource mapping nodes of the two shader stages are merged as a whole.
@@ -398,7 +398,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
     entryArgIdxs.initialized = true;
 
     // Estimated available user data count
-    uint32_t maxUserDataCount = m_pContext->GetGpuProperty()->maxUserDataCount;
+    uint32_t maxUserDataCount = m_pPipelineState->GetGpuProperty()->maxUserDataCount;
     uint32_t availUserDataCount = maxUserDataCount - userDataIdx;
     uint32_t requiredRemappedUserDataCount = 0; // Maximum required user data
     uint32_t requiredUserDataCount = 0;         // Maximum required user data without remapping
@@ -421,7 +421,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
                 {
                     reserveVbTable = true;
                 }
-                else if (m_pContext->GetGfxIpVersion().major >= 9)
+                else if (m_pPipelineState->GetGfxIpVersion().major >= 9)
                 {
                     // On GFX9+, the shader stage that the vertex shader is merged in to needs a vertex buffer
                     // table, to ensure that the merged shader gets one.
@@ -443,7 +443,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
                 {
                     reserveStreamOutTable = true;
                 }
-                else if (m_pContext->GetGfxIpVersion().major >= 9)
+                else if (m_pPipelineState->GetGfxIpVersion().major >= 9)
                 {
                     // On GFX9+, the shader stage that the last shader is merged in to needs a stream out
                     // table, to ensure that the merged shader gets one.
@@ -508,7 +508,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
             // NOTE: On GFX9+, Vertex shader (LS) and tessellation control shader (HS) are merged into a single shader.
             // The user data count of tessellation control shader should be same as vertex shader.
             auto pCurrResUsage = pResUsage;
-            if ((m_pContext->GetGfxIpVersion().major >= 9) &&
+            if ((m_pPipelineState->GetGfxIpVersion().major >= 9) &&
                 (m_shaderStage == ShaderStageTessControl) &&
                 (m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)))
             {
@@ -527,7 +527,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
 
             // NOTE: Add a dummy "inreg" argument for ES-GS LDS size, this is to keep consistent
             // with PAL's GS on-chip behavior (VS is in NGG primitive shader).
-            const auto gfxIp = m_pContext->GetGfxIpVersion();
+            const auto gfxIp = m_pPipelineState->GetGfxIpVersion();
             if (((gfxIp.major >= 9) && (m_pContext->IsGsOnChip() && cl::InRegEsGsLdsSize))
 #if LLPC_BUILD_GFX10
                 || (enableNgg && (m_hasTs == false))
@@ -783,7 +783,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
             auto pCurrIntfData = pIntfData;
             auto pCurrResUsage = pResUsage;
 
-            if ((m_pContext->GetGfxIpVersion().major >= 9) &&
+            if ((m_pPipelineState->GetGfxIpVersion().major >= 9) &&
                 (m_shaderStage == ShaderStageTessControl) &&
                 (m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)))
             {

--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -471,13 +471,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
         }
     }
 
-    bool enableMultiView = false;
-    if (m_shaderStage != ShaderStageCompute)
-    {
-        enableMultiView = (static_cast<const GraphicsPipelineBuildInfo*>(
-            m_pContext->GetPipelineBuildInfo()))
-            ->iaState.enableMultiView;
-    }
+    auto enableMultiView = m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
 #if LLPC_BUILD_GFX10
     const bool enableNgg = m_pContext->IsGraphics() ? m_pContext->GetNggControl()->enableNgg : false;

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -112,7 +112,7 @@ bool PatchInOutImportExport::runOnModule(
     m_pipelineSysValues.Initialize(m_pPipelineState);
     m_gfxIp = m_pPipelineState->GetGfxIpVersion();
 
-    const uint32_t stageMask = m_pContext->GetShaderStageMask();
+    const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
     m_hasTs = ((stageMask & (ShaderStageToMask(ShaderStageTessControl) |
                              ShaderStageToMask(ShaderStageTessEval))) != 0);
     m_hasGs = ((stageMask & ShaderStageToMask(ShaderStageGeometry)) != 0);
@@ -222,7 +222,7 @@ void PatchInOutImportExport::ProcessShader()
     // Initialize calculation factors for tessellation shader
     if ((m_shaderStage == ShaderStageTessControl) || (m_shaderStage == ShaderStageTessEval))
     {
-        const uint32_t stageMask = m_pContext->GetShaderStageMask();
+        const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
         const bool hasTcs = ((stageMask & ShaderStageToMask(ShaderStageTessControl)) != 0);
 
         auto& calcFactor = m_pContext->GetShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor;
@@ -2618,7 +2618,7 @@ Value* PatchInOutImportExport::PatchTesBuiltInInputImport(
     case BuiltInPatchVertices:
         {
             uint32_t patchVertices = MaxTessPatchVertices;
-            const bool hasTcs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessControl)) != 0);
+            const bool hasTcs = m_pPipelineState->HasShaderStage(ShaderStageTessControl);
             if (hasTcs)
             {
                 const auto& tcsBuiltInUsage =
@@ -5406,7 +5406,7 @@ Value* PatchInOutImportExport::CalcEsGsRingOffsetForOutput(
     {
         // ringOffset = esGsOffset + threadId * esGsRingItemSize + location * 4 + compIdx
 
-        LLPC_ASSERT((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
+        LLPC_ASSERT(m_pPipelineState->HasShaderStage(ShaderStageGeometry));
         const auto& calcFactor = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor;
 
         pEsGsOffset = BinaryOperator::CreateLShr(pEsGsOffset,

--- a/patch/llpcPatchPreparePipelineAbi.cpp
+++ b/patch/llpcPatchPreparePipelineAbi.cpp
@@ -130,10 +130,10 @@ bool PatchPreparePipelineAbi::runOnModule(
     m_pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
     m_pPipelineShaders = &getAnalysis<PipelineShaders>();
 
-    m_hasVs  = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageVertex)) != 0);
-    m_hasTcs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessControl)) != 0);
-    m_hasTes = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageTessEval)) != 0);
-    m_hasGs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
+    m_hasVs = m_pPipelineState->HasShaderStage(ShaderStageVertex);
+    m_hasTcs = m_pPipelineState->HasShaderStage(ShaderStageTessControl);
+    m_hasTes = m_pPipelineState->HasShaderStage(ShaderStageTessEval);
+    m_hasGs = m_pPipelineState->HasShaderStage(ShaderStageGeometry);
 
     m_gfxIp = m_pPipelineState->GetGfxIpVersion();
 

--- a/patch/llpcPatchPreparePipelineAbi.cpp
+++ b/patch/llpcPatchPreparePipelineAbi.cpp
@@ -54,12 +54,10 @@ class PatchPreparePipelineAbi final : public Patch
 public:
     static char ID;
     PatchPreparePipelineAbi(
-        bool    onlySetCallingConvs = false,
-        uint32_t skipStageMask = 0)
+        bool    onlySetCallingConvs = false)
         :
         Patch(ID),
-        m_onlySetCallingConvs(onlySetCallingConvs),
-        m_skipStageMask(skipStageMask)
+        m_onlySetCallingConvs(onlySetCallingConvs)
     {
         initializePipelineShadersPass(*llvm::PassRegistry::getPassRegistry());
         initializePatchPreparePipelineAbiPass(*PassRegistry::getPassRegistry());
@@ -102,7 +100,6 @@ private:
     GfxIpVersion      m_gfxIp;               // Graphics IP version info
 
     const bool        m_onlySetCallingConvs; // Whether to only set the calling conventions
-    const uint32_t    m_skipStageMask;       // Mask indicating which shader stages should be skipped in processing
 };
 
 char PatchPreparePipelineAbi::ID = 0;
@@ -112,10 +109,9 @@ char PatchPreparePipelineAbi::ID = 0;
 // =====================================================================================================================
 // Create pass to prepare the pipeline ABI
 ModulePass* Llpc::CreatePatchPreparePipelineAbi(
-    bool     onlySetCallingConvs, // Should we only set the calling conventions, or do the full prepare.
-    uint32_t skipStageMask)       // Mask of stages to be skipped
+    bool     onlySetCallingConvs) // Should we only set the calling conventions, or do the full prepare.
 {
-    return new PatchPreparePipelineAbi(onlySetCallingConvs, skipStageMask);
+    return new PatchPreparePipelineAbi(onlySetCallingConvs);
 }
 
 // =====================================================================================================================
@@ -354,15 +350,7 @@ void PatchPreparePipelineAbi::SetCallingConv(
     auto pEntryPoint = m_pPipelineShaders->GetEntryPoint(shaderStage);
     if (pEntryPoint != nullptr)
     {
-        if (m_skipStageMask & ShaderStageToMask(shaderStage))
-        {
-            pEntryPoint->setLinkage(GlobalValue::InternalLinkage);
-            pEntryPoint->setCallingConv(CallingConv::C);
-        }
-        else
-        {
-            pEntryPoint->setCallingConv(callingConv);
-        }
+        pEntryPoint->setCallingConv(callingConv);
     }
 }
 

--- a/patch/llpcPatchResourceCollect.cpp
+++ b/patch/llpcPatchResourceCollect.cpp
@@ -162,27 +162,20 @@ void PatchResourceCollect::ProcessShader()
     else if (m_shaderStage == ShaderStageVertex)
     {
         // Collect resource usages from vertex input create info
-        auto pPipelineInfo = static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo());
-        auto pVertexInput = pPipelineInfo->pVertexInput;
-
         // TODO: In the future, we might check if the corresponding vertex attribute is active in vertex shader
         // and set the usage based on this info.
-        if (pVertexInput != nullptr)
+        for (const auto& vertexInput : m_pPipelineState->GetVertexInputDescriptions())
         {
-            for (uint32_t i = 0; i < pVertexInput->vertexBindingDescriptionCount; ++i)
+            if (vertexInput.inputRate == Builder::VertexInputRateVertex)
             {
-                auto pBinding = &pVertexInput->pVertexBindingDescriptions[i];
-                if (pBinding->inputRate == VK_VERTEX_INPUT_RATE_VERTEX)
-                {
-                    m_pResUsage->builtInUsage.vs.vertexIndex = true;
-                    m_pResUsage->builtInUsage.vs.baseVertex = true;
-                }
-                else
-                {
-                    //LLPC_ASSERT(pBinding->inputRate == VK_VERTEX_INPUT_RATE_INSTANCE);
-                    m_pResUsage->builtInUsage.vs.instanceIndex = true;
-                    m_pResUsage->builtInUsage.vs.baseInstance = true;
-                }
+                m_pResUsage->builtInUsage.vs.vertexIndex = true;
+                m_pResUsage->builtInUsage.vs.baseVertex = true;
+            }
+            else
+            {
+                // TODO: We probably don't need instanceIndex for VertexInputRateNone.
+                m_pResUsage->builtInUsage.vs.instanceIndex = true;
+                m_pResUsage->builtInUsage.vs.baseInstance = true;
             }
         }
     }

--- a/patch/llpcPatchResourceCollect.cpp
+++ b/patch/llpcPatchResourceCollect.cpp
@@ -101,7 +101,7 @@ bool PatchResourceCollect::runOnModule(
 #endif
 
         // Determine whether or not GS on-chip mode is valid for this pipeline
-        bool hasGs = ((m_pContext->GetShaderStageMask() & ShaderStageToMask(ShaderStageGeometry)) != 0);
+        bool hasGs = pPipelineState->HasShaderStage(ShaderStageGeometry);
 #if LLPC_BUILD_GFX10
         bool checkGsOnChip = hasGs || m_pContext->GetNggControl()->enableNgg;
 #else

--- a/patch/llpcPatchResourceCollect.h
+++ b/patch/llpcPatchResourceCollect.h
@@ -95,6 +95,7 @@ private:
     bool            m_hasDynIndexedOutput;      // Whether dynamic indices are used in generic output addressing (valid
                                                 // for tessellation control shader)
     ResourceUsage*  m_pResUsage;                // Pointer to shader resource usage
+    PipelineState*  m_pPipelineState;           // Pipeline state
 };
 
 } // Llpc

--- a/patch/llpcPatchResourceCollect.h
+++ b/patch/llpcPatchResourceCollect.h
@@ -35,6 +35,7 @@
 #include <unordered_set>
 #include "llpcPatch.h"
 #include "llpcPipelineShaders.h"
+#include "llpcPipelineState.h"
 
 namespace Llpc
 {
@@ -50,6 +51,7 @@ public:
 
     void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
     {
+        analysisUsage.addRequired<PipelineStateWrapper>();
         analysisUsage.addRequired<PipelineShaders>();
         analysisUsage.addPreserved<PipelineShaders>();
     }

--- a/patch/llpcPatchSetupTargetFeatures.cpp
+++ b/patch/llpcPatchSetupTargetFeatures.cpp
@@ -33,6 +33,7 @@
 
 #include "llpcCodeGenManager.h"
 #include "llpcPatch.h"
+#include "llpcPipelineState.h"
 
 #define DEBUG_TYPE "llpc-patch-setup-target-features"
 
@@ -50,7 +51,13 @@ public:
     static char ID;
     PatchSetupTargetFeatures() : Patch(ID)
     {
+        initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
         initializePatchSetupTargetFeaturesPass(*PassRegistry::getPassRegistry());
+    }
+
+    void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override
+    {
+        analysisUsage.addRequired<PipelineStateWrapper>();
     }
 
     bool runOnModule(Module& module) override;
@@ -79,7 +86,8 @@ bool PatchSetupTargetFeatures::runOnModule(
 
     Patch::Init(&module);
 
-    CodeGenManager::SetupTargetFeatures(&module);
+    PipelineState* pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
+    CodeGenManager::SetupTargetFeatures(pPipelineState);
 
     return true; // Modified the module.
 }

--- a/patch/llpcSystemValues.cpp
+++ b/patch/llpcSystemValues.cpp
@@ -95,7 +95,7 @@ Value* ShaderSystemValues::GetEsGsRingBufDesc()
 
         auto pDesc = LoadDescFromDriverTable(tableOffset);
         m_pEsGsRingBufDesc = pDesc;
-        if ((m_shaderStage != ShaderStageGeometry) && (m_pContext->GetGfxIpVersion().major >= 8))
+        if ((m_shaderStage != ShaderStageGeometry) && (m_pPipelineState->GetGfxIpVersion().major >= 8))
         {
             // NOTE: For GFX8+, we have to explicitly set DATA_FORMAT for GS-VS ring buffer descriptor for
             // VS/TES output.
@@ -341,7 +341,7 @@ Value* ShaderSystemValues::GetGsVsRingBufDesc(
                                             pInsertPos);
 
             m_gsVsRingBufDescs[streamId] = pDesc;
-            if (m_pContext->GetGfxIpVersion().major >= 8)
+            if (m_pPipelineState->GetGfxIpVersion().major >= 8)
             {
                 // NOTE: For GFX8+, we have to explicitly set DATA_FORMAT for GS-VS ring buffer descriptor.
                 m_gsVsRingBufDescs[streamId] = SetRingBufferDataFormat(m_gsVsRingBufDescs[streamId],

--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -36,6 +36,7 @@
 
 #include "llpcContext.h"
 #include "llpcDebug.h"
+#include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 #include "llpcVertexFetch.h"
 
@@ -1634,7 +1635,7 @@ uint32_t VertexFetch::MapVertexFormat(
     uint32_t format = 0;
 
 #if LLPC_BUILD_GFX10
-    GfxIpVersion gfxIp = m_pContext->GetGfxIpVersion();
+    GfxIpVersion gfxIp = m_pPipelineState->GetGfxIpVersion();
     if (gfxIp.major >= 10)
     {
         uint32_t index = (dfmt * 8) + nfmt;
@@ -1991,7 +1992,7 @@ bool VertexFetch::NeedPatchA2S(
     case VK_FORMAT_A2B10G10R10_SNORM_PACK32:
     case VK_FORMAT_A2B10G10R10_SSCALED_PACK32:
     case VK_FORMAT_A2B10G10R10_SINT_PACK32:
-        needPatch = (m_pContext->GetGfxIpVersion().major < 9);
+        needPatch = (m_pPipelineState->GetGfxIpVersion().major < 9);
         break;
     default:
         break;

--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -53,821 +53,6 @@ namespace Llpc
     0, \
 }
 
-// Initializes info table of vertex format map
-const VertexFormatInfo VertexFetch::m_vertexFormatInfo[] =
-{
-    // VK_FORMAT_UNDEFINED = 0
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_UNDEFINED),
-    // VK_FORMAT_R4G4_UNORM_PACK8 = 1
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R4G4_UNORM_PACK8),
-    // VK_FORMAT_R4G4B4A4_UNORM_PACK16 = 2
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R4G4B4A4_UNORM_PACK16),
-    // VK_FORMAT_B4G4R4A4_UNORM_PACK16 = 3
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B4G4R4A4_UNORM_PACK16),
-    // VK_FORMAT_R5G6B5_UNORM_PACK16 = 4
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R5G6B5_UNORM_PACK16),
-    // VK_FORMAT_B5G6R5_UNORM_PACK16 = 5
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B5G6R5_UNORM_PACK16),
-    // VK_FORMAT_R5G5B5A1_UNORM_PACK16 = 6
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R5G5B5A1_UNORM_PACK16),
-    // VK_FORMAT_B5G5R5A1_UNORM_PACK16 = 7
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B5G5R5A1_UNORM_PACK16),
-    // VK_FORMAT_A1R5G5B5_UNORM_PACK16 = 8
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_A1R5G5B5_UNORM_PACK16),
-    // VK_FORMAT_R8_UNORM = 9
-    {
-        VK_FORMAT_R8_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_8,
-        1
-    },
-    // VK_FORMAT_R8_SNORM = 10
-    {
-        VK_FORMAT_R8_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_8,
-        1
-    },
-    // VK_FORMAT_R8_USCALED = 11
-    {
-        VK_FORMAT_R8_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_8,
-        1
-    },
-    // VK_FORMAT_R8_SSCALED = 12
-    {
-        VK_FORMAT_R8_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_8,
-        1
-    },
-    // VK_FORMAT_R8_UINT = 13
-    {
-        VK_FORMAT_R8_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_8,
-        1
-    },
-    // VK_FORMAT_R8_SINT = 14
-    {
-        VK_FORMAT_R8_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_8,
-        1
-    },
-    // VK_FORMAT_R8_SRGB = 15
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8_SRGB),
-    // VK_FORMAT_R8G8_UNORM = 16
-    {
-        VK_FORMAT_R8G8_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_8_8,
-        2
-    },
-    // VK_FORMAT_R8G8_SNORM = 17
-    {
-        VK_FORMAT_R8G8_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_8_8,
-        2
-    },
-    // VK_FORMAT_R8G8_USCALED = 18
-    {
-        VK_FORMAT_R8G8_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_8_8,
-        2
-    },
-    // VK_FORMAT_R8G8_SSCALED = 19
-    {
-        VK_FORMAT_R8G8_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_8_8,
-        2
-    },
-    // VK_FORMAT_R8G8_UINT = 20
-    {
-        VK_FORMAT_R8G8_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_8_8,
-        2
-    },
-    // VK_FORMAT_R8G8_SINT = 21
-    {
-        VK_FORMAT_R8G8_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_8_8,
-        2
-    },
-    // VK_FORMAT_R8G8_SRGB = 22
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8_SRGB),
-    // VK_FORMAT_R8G8B8_UNORM = 23
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_UNORM),
-    // VK_FORMAT_R8G8B8_SNORM = 24
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SNORM),
-    // VK_FORMAT_R8G8B8_USCALED = 25
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_USCALED),
-    // VK_FORMAT_R8G8B8_SSCALED = 26
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SSCALED),
-    // VK_FORMAT_R8G8B8_UINT = 27
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_UINT),
-    // VK_FORMAT_R8G8B8_SINT = 28
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SINT),
-    // VK_FORMAT_R8G8B8_SRGB = 29
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8_SRGB),
-    // VK_FORMAT_B8G8R8_UNORM = 30
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_UNORM),
-    // VK_FORMAT_B8G8R8_SNORM = 31
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SNORM),
-    // VK_FORMAT_B8G8R8_USCALED = 32
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_USCALED),
-    // VK_FORMAT_B8G8R8_SSCALED = 33
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SSCALED),
-    // VK_FORMAT_B8G8R8_UINT = 34
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_UINT),
-    // VK_FORMAT_B8G8R8_SINT = 35
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SINT),
-    // VK_FORMAT_B8G8R8_SRGB = 36
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8_SRGB),
-    // VK_FORMAT_R8G8B8A8_UNORM = 37
-    {
-        VK_FORMAT_R8G8B8A8_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_R8G8B8A8_SNORM = 38
-    {
-        VK_FORMAT_R8G8B8A8_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_R8G8B8A8_USCALED = 39
-    {
-        VK_FORMAT_R8G8B8A8_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_R8G8B8A8_SSCALED = 40
-    {
-        VK_FORMAT_R8G8B8A8_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_R8G8B8A8_UINT = 41
-    {
-        VK_FORMAT_R8G8B8A8_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_R8G8B8A8_SINT = 42
-    {
-        VK_FORMAT_R8G8B8A8_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_R8G8B8A8_SRGB = 43
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R8G8B8A8_SRGB),
-    // VK_FORMAT_B8G8R8A8_UNORM = 44
-    {
-        VK_FORMAT_B8G8R8A8_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_B8G8R8A8_SNORM = 45
-    {
-        VK_FORMAT_B8G8R8A8_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_B8G8R8A8_USCALED = 46
-    {
-        VK_FORMAT_B8G8R8A8_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_B8G8R8A8_SSCALED = 47
-    {
-        VK_FORMAT_B8G8R8A8_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_B8G8R8A8_UINT = 48
-    {
-        VK_FORMAT_B8G8R8A8_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_B8G8R8A8_SINT = 49
-    {
-        VK_FORMAT_B8G8R8A8_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_B8G8R8A8_SRGB = 50
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_B8G8R8A8_SRGB),
-    // VK_FORMAT_A8B8G8R8_UNORM_PACK32 = 51
-    {
-        VK_FORMAT_A8B8G8R8_UNORM_PACK32,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_A8B8G8R8_SNORM_PACK32 = 52
-    {
-        VK_FORMAT_A8B8G8R8_SNORM_PACK32,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_A8B8G8R8_USCALED_PACK32 = 53
-    {
-        VK_FORMAT_A8B8G8R8_USCALED_PACK32,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_A8B8G8R8_SSCALED_PACK32 = 54
-    {
-        VK_FORMAT_A8B8G8R8_SSCALED_PACK32,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_A8B8G8R8_UINT_PACK32 = 55
-    {
-        VK_FORMAT_A8B8G8R8_UINT_PACK32,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_A8B8G8R8_SINT_PACK32 = 56
-    {
-        VK_FORMAT_A8B8G8R8_SINT_PACK32,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_8_8_8_8,
-        4
-    },
-    // VK_FORMAT_A8B8G8R8_SRGB_PACK32 = 57
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_A8B8G8R8_SRGB_PACK32),
-    // VK_FORMAT_A2R10G10B10_UNORM_PACK32 = 58
-    {
-        VK_FORMAT_A2R10G10B10_UNORM_PACK32,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2R10G10B10_SNORM_PACK32 = 59
-    {
-        VK_FORMAT_A2R10G10B10_SNORM_PACK32,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2R10G10B10_USCALED_PACK32 = 60
-    {
-        VK_FORMAT_A2R10G10B10_USCALED_PACK32,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2R10G10B10_SSCALED_PACK32 = 61
-    {
-        VK_FORMAT_A2R10G10B10_SSCALED_PACK32,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2R10G10B10_UINT_PACK32 = 62
-    {
-        VK_FORMAT_A2R10G10B10_UINT_PACK32,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2R10G10B10_SINT_PACK32 = 63
-    {
-        VK_FORMAT_A2R10G10B10_SINT_PACK32,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2B10G10R10_UNORM_PACK32 = 64
-    {
-        VK_FORMAT_A2B10G10R10_UNORM_PACK32,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2B10G10R10_SNORM_PACK32 = 65
-    {
-        VK_FORMAT_A2B10G10R10_SNORM_PACK32,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2B10G10R10_USCALED_PACK32 = 66
-    {
-        VK_FORMAT_A2B10G10R10_USCALED_PACK32,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2B10G10R10_SSCALED_PACK32 = 67
-    {
-        VK_FORMAT_A2B10G10R10_SSCALED_PACK32,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2B10G10R10_UINT_PACK32 = 68
-    {
-        VK_FORMAT_A2B10G10R10_UINT_PACK32,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_A2B10G10R10_SINT_PACK32 = 69
-    {
-        VK_FORMAT_A2B10G10R10_SINT_PACK32,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_2_10_10_10,
-        4
-    },
-    // VK_FORMAT_R16_UNORM = 70
-    {
-        VK_FORMAT_R16_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16_SNORM = 71
-    {
-        VK_FORMAT_R16_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16_USCALED = 72
-    {
-        VK_FORMAT_R16_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16_SSCALED = 73
-    {
-        VK_FORMAT_R16_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16_UINT = 74
-    {
-        VK_FORMAT_R16_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16_SINT = 75
-    {
-        VK_FORMAT_R16_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16_SFLOAT = 76
-    {
-        VK_FORMAT_R16_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_16,
-        1
-    },
-    // VK_FORMAT_R16G16_UNORM = 77
-    {
-        VK_FORMAT_R16G16_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16_SNORM = 78
-    {
-        VK_FORMAT_R16G16_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16_USCALED = 79
-    {
-        VK_FORMAT_R16G16_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16_SSCALED = 80
-    {
-        VK_FORMAT_R16G16_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16_UINT = 81
-    {
-        VK_FORMAT_R16G16_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16_SINT = 82
-    {
-        VK_FORMAT_R16G16_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16_SFLOAT = 83
-    {
-        VK_FORMAT_R16G16_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_16_16,
-        2
-    },
-    // VK_FORMAT_R16G16B16_UNORM = 84
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_UNORM),
-    // VK_FORMAT_R16G16B16_SNORM = 85
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SNORM),
-    // VK_FORMAT_R16G16B16_USCALED = 86
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_USCALED),
-    // VK_FORMAT_R16G16B16_SSCALED = 87
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SSCALED),
-    // VK_FORMAT_R16G16B16_UINT = 88
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_UINT),
-    // VK_FORMAT_R16G16B16_SINT = 89
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SINT),
-    // VK_FORMAT_R16G16B16_SFLOAT = 90
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_R16G16B16_SFLOAT),
-    // VK_FORMAT_R16G16B16A16_UNORM = 91
-    {
-        VK_FORMAT_R16G16B16A16_UNORM,
-        BUF_NUM_FORMAT_UNORM,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R16G16B16A16_SNORM = 92
-    {
-        VK_FORMAT_R16G16B16A16_SNORM,
-        BUF_NUM_FORMAT_SNORM,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R16G16B16A16_USCALED = 93
-    {
-        VK_FORMAT_R16G16B16A16_USCALED,
-        BUF_NUM_FORMAT_USCALED,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R16G16B16A16_SSCALED = 94
-    {
-        VK_FORMAT_R16G16B16A16_SSCALED,
-        BUF_NUM_FORMAT_SSCALED,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R16G16B16A16_UINT = 95
-    {
-        VK_FORMAT_R16G16B16A16_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R16G16B16A16_SINT = 96
-    {
-        VK_FORMAT_R16G16B16A16_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R16G16B16A16_SFLOAT = 97
-    {
-        VK_FORMAT_R16G16B16A16_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_16_16_16_16,
-        4
-    },
-    // VK_FORMAT_R32_UINT = 98
-    {
-        VK_FORMAT_R32_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32,
-        1
-    },
-    // VK_FORMAT_R32_SINT = 99
-    {
-        VK_FORMAT_R32_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32,
-        1
-    },
-    // VK_FORMAT_R32_SFLOAT = 100
-    {
-        VK_FORMAT_R32_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32,
-        1
-    },
-    // VK_FORMAT_R32G32_UINT = 101
-    {
-        VK_FORMAT_R32G32_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32,
-        2
-    },
-    // VK_FORMAT_R32G32_SINT = 102
-    {
-        VK_FORMAT_R32G32_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32,
-        2
-    },
-    // VK_FORMAT_R32G32_SFLOAT = 103
-    {
-        VK_FORMAT_R32G32_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32,
-        2
-    },
-    // VK_FORMAT_R32G32B32_UINT = 104
-    {
-        VK_FORMAT_R32G32B32_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32_32,
-        3
-    },
-    // VK_FORMAT_R32G32B32_SINT = 105
-    {
-        VK_FORMAT_R32G32B32_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32_32,
-        3
-    },
-    // VK_FORMAT_R32G32B32_SFLOAT = 106
-    {
-        VK_FORMAT_R32G32B32_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32_32,
-        3
-    },
-    // VK_FORMAT_R32G32B32A32_UINT = 107
-    {
-        VK_FORMAT_R32G32B32A32_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R32G32B32A32_SINT = 108
-    {
-        VK_FORMAT_R32G32B32A32_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R32G32B32A32_SFLOAT = 109
-    {
-        VK_FORMAT_R32G32B32A32_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64_UINT = 110
-    {
-        VK_FORMAT_R64_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32,
-        2
-    },
-    // VK_FORMAT_R64_SINT = 111
-    {
-        VK_FORMAT_R64_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32,
-        2
-    },
-    // VK_FORMAT_R64_SFLOAT = 112
-    {
-        VK_FORMAT_R64_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32,
-        2
-    },
-    // VK_FORMAT_R64G64_UINT = 113
-    {
-        VK_FORMAT_R64G64_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64_SINT = 114
-    {
-        VK_FORMAT_R64G64_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64_SFLOAT = 115
-    {
-        VK_FORMAT_R64G64_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64B64_UINT = 116
-    {
-        VK_FORMAT_R64G64B64_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64B64_SINT = 117
-    {
-        VK_FORMAT_R64G64B64_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64B64_SFLOAT = 118
-    {
-        VK_FORMAT_R64G64B64_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64B64A64_UINT = 119
-    {
-        VK_FORMAT_R64G64B64A64_UINT,
-        BUF_NUM_FORMAT_UINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64B64A64_SINT = 120
-    {
-        VK_FORMAT_R64G64B64A64_SINT,
-        BUF_NUM_FORMAT_SINT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_R64G64B64A64_SFLOAT = 121
-    {
-        VK_FORMAT_R64G64B64A64_SFLOAT,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_32_32_32_32,
-        4
-    },
-    // VK_FORMAT_B10G11R11_UFLOAT_PACK32 = 122
-    {
-        VK_FORMAT_B10G11R11_UFLOAT_PACK32,
-        BUF_NUM_FORMAT_FLOAT,
-        BUF_DATA_FORMAT_10_11_11,
-        3
-    },
-    // VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 = 123
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_E5B9G9R9_UFLOAT_PACK32),
-    // VK_FORMAT_D16_UNORM = 124
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_D16_UNORM),
-    // VK_FORMAT_X8_D24_UNORM_PACK32 = 125
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_X8_D24_UNORM_PACK32),
-    // VK_FORMAT_D32_SFLOAT = 126
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_D32_SFLOAT),
-    // VK_FORMAT_S8_UINT = 127
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_S8_UINT),
-    // VK_FORMAT_D16_UNORM_S8_UINT = 128
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_D16_UNORM_S8_UINT),
-    // VK_FORMAT_D24_UNORM_S8_UINT = 129
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_D24_UNORM_S8_UINT),
-    // VK_FORMAT_D32_SFLOAT_S8_UINT = 130
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_D32_SFLOAT_S8_UINT),
-    // VK_FORMAT_BC1_RGB_UNORM_BLOCK = 131
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGB_UNORM_BLOCK),
-    // VK_FORMAT_BC1_RGB_SRGB_BLOCK = 132
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGB_SRGB_BLOCK),
-    // VK_FORMAT_BC1_RGBA_UNORM_BLOCK = 133
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGBA_UNORM_BLOCK),
-    // VK_FORMAT_BC1_RGBA_SRGB_BLOCK = 134
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC1_RGBA_SRGB_BLOCK),
-    // VK_FORMAT_BC2_UNORM_BLOCK = 135
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC2_UNORM_BLOCK),
-    // VK_FORMAT_BC2_SRGB_BLOCK = 136
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC2_SRGB_BLOCK),
-    // VK_FORMAT_BC3_UNORM_BLOCK = 137
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC3_UNORM_BLOCK),
-    // VK_FORMAT_BC3_SRGB_BLOCK = 138
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC3_SRGB_BLOCK),
-    // VK_FORMAT_BC4_UNORM_BLOCK = 139
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC4_UNORM_BLOCK),
-    // VK_FORMAT_BC4_SNORM_BLOCK = 140
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC4_SNORM_BLOCK),
-    // VK_FORMAT_BC5_UNORM_BLOCK = 141
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC5_UNORM_BLOCK),
-    // VK_FORMAT_BC5_SNORM_BLOCK = 142
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC5_SNORM_BLOCK),
-    // VK_FORMAT_BC6H_UFLOAT_BLOCK = 143
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC6H_UFLOAT_BLOCK),
-    // VK_FORMAT_BC6H_SFLOAT_BLOCK = 144
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC6H_SFLOAT_BLOCK),
-    // VK_FORMAT_BC7_UNORM_BLOCK = 145
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC7_UNORM_BLOCK),
-    // VK_FORMAT_BC7_SRGB_BLOCK = 146
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_BC7_SRGB_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK = 147
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK = 148
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK = 149
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK = 150
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK = 151
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK),
-    // VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK = 152
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK),
-    // VK_FORMAT_EAC_R11_UNORM_BLOCK = 153
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11_UNORM_BLOCK),
-    // VK_FORMAT_EAC_R11_SNORM_BLOCK = 154
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11_SNORM_BLOCK),
-    // VK_FORMAT_EAC_R11G11_UNORM_BLOCK = 155
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11G11_UNORM_BLOCK),
-    // VK_FORMAT_EAC_R11G11_SNORM_BLOCK = 156
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_EAC_R11G11_SNORM_BLOCK),
-    // VK_FORMAT_ASTC_4x4_UNORM_BLOCK = 157
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_4x4_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_4x4_SRGB_BLOCK = 158
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_4x4_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_5x4_UNORM_BLOCK = 159
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x4_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_5x4_SRGB_BLOCK = 160
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x4_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_5x5_UNORM_BLOCK = 161
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_5x5_SRGB_BLOCK = 162
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_5x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_6x5_UNORM_BLOCK = 163
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_6x5_SRGB_BLOCK = 164
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_6x6_UNORM_BLOCK = 165
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x6_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_6x6_SRGB_BLOCK = 166
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_6x6_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_8x5_UNORM_BLOCK = 167
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_8x5_SRGB_BLOCK = 168
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_8x6_UNORM_BLOCK = 169
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x6_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_8x6_SRGB_BLOCK = 170
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x6_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_8x8_UNORM_BLOCK = 171
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x8_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_8x8_SRGB_BLOCK = 172
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_8x8_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x5_UNORM_BLOCK = 173
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x5_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x5_SRGB_BLOCK = 174
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x5_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x6_UNORM_BLOCK = 175
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x6_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x6_SRGB_BLOCK = 176
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x6_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x8_UNORM_BLOCK = 177
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x8_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x8_SRGB_BLOCK = 178
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x8_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_10x10_UNORM_BLOCK = 179
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x10_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_10x10_SRGB_BLOCK = 180
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_10x10_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_12x10_UNORM_BLOCK = 181
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x10_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_12x10_SRGB_BLOCK = 182
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x10_SRGB_BLOCK),
-    // VK_FORMAT_ASTC_12x12_UNORM_BLOCK = 183
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x12_UNORM_BLOCK),
-    // VK_FORMAT_ASTC_12x12_SRGB_BLOCK = 184
-    VERTEX_FORMAT_UNDEFINED(VK_FORMAT_ASTC_12x12_SRGB_BLOCK),
-};
-
 // Initializes info table of vertex component format map
 const VertexCompFormatInfo VertexFetch::m_vertexCompFormatInfo[] =
 {
@@ -1072,22 +257,13 @@ VertexFetch::VertexFetch(
     m_pModule(pEntryPoint->getParent()),
     m_pContext(static_cast<Context*>(&m_pModule->getContext())),
     m_pShaderSysValues(pShaderSysValues),
-    m_pPipelineState(pPipelineState),
-    m_pVertexInput(static_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo())->pVertexInput)
+    m_pPipelineState(pPipelineState)
 {
     LLPC_ASSERT(GetShaderStageFromFunction(pEntryPoint) == ShaderStageVertex); // Must be vertex shader
 
     auto& entryArgIdxs = m_pContext->GetShaderInterfaceData(ShaderStageVertex)->entryArgIdxs.vs;
     auto& builtInUsage = m_pContext->GetShaderResourceUsage(ShaderStageVertex)->builtInUsage.vs;
     auto pInsertPos = pEntryPoint->begin()->getFirstInsertionPt();
-
-    m_pVertexDivisor = nullptr;
-    if (m_pVertexInput != nullptr)
-    {
-        m_pVertexDivisor = FindVkStructInChain<VkPipelineVertexInputDivisorStateCreateInfoEXT>(
-            VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT,
-            m_pVertexInput->pNext);
-    }
 
     // VertexIndex = BaseVertex + VertexID
     if (builtInUsage.vertexIndex)
@@ -1198,65 +374,67 @@ Value* VertexFetch::Run(
 {
     Value* pVertex = nullptr;
 
-    const VkVertexInputBindingDescription*   pBinding = nullptr;
-    const VkVertexInputAttributeDescription* pAttrib  = nullptr;
-    const VkVertexInputBindingDivisorDescriptionEXT* pDivisor = nullptr;
-    ExtractVertexInputInfo(location, &pBinding, &pAttrib, &pDivisor);
+    // Get vertex input description for the given location
+    const Builder::VertexInputDescription* pDescription = m_pPipelineState->FindVertexInputDescription(location);
 
     // NOTE: If we could not find vertex input info matching this location, just return undefined value.
-    if (pBinding == nullptr)
+    if (pDescription == nullptr)
     {
         return UndefValue::get(pInputTy);
     }
 
-    auto pVbDesc = LoadVertexBufferDescriptor(pBinding->binding, pInsertPos);
+    auto pVbDesc = LoadVertexBufferDescriptor(pDescription->binding, pInsertPos);
 
     Value* pVbIndex = nullptr;
-    if (pBinding->inputRate == VK_VERTEX_INPUT_RATE_VERTEX)
+    if (pDescription->inputRate == Builder::VertexInputRateVertex)
     {
         pVbIndex = GetVertexIndex(); // Use vertex index
     }
     else
     {
-        LLPC_ASSERT(pBinding->inputRate == VK_VERTEX_INPUT_RATE_INSTANCE);
-        if (pDivisor != nullptr)
+        if (pDescription->inputRate == Builder::VertexInputRateNone)
         {
-            pVbIndex = BinaryOperator::CreateUDiv(m_pInstanceId,
-                                                  ConstantInt::get(m_pContext->Int32Ty(), pDivisor->divisor),
-                                                  "",
-                                                  pInsertPos);
-            pVbIndex = BinaryOperator::CreateAdd(pVbIndex, m_pBaseInstance, "", pInsertPos);
+            pVbIndex = m_pBaseInstance;
+        }
+        else if (pDescription->inputRate == Builder::VertexInputRateInstance)
+        {
+            pVbIndex = GetInstanceIndex(); // Use instance index
         }
         else
         {
-            pVbIndex = GetInstanceIndex(); // Use instance index
+            // There is a divisor.
+            pVbIndex = BinaryOperator::CreateUDiv(m_pInstanceId,
+                                                  ConstantInt::get(m_pContext->Int32Ty(), pDescription->inputRate),
+                                                  "",
+                                                  pInsertPos);
+            pVbIndex = BinaryOperator::CreateAdd(pVbIndex, m_pBaseInstance, "", pInsertPos);
         }
     }
 
     Value* vertexFetch[2] = {}; // Two vertex fetch operations might be required
     Value* pVertexFetch = nullptr; // Coalesced vector by combining the results of two vertex fetch operations
 
-    const VertexFormatInfo* pFormatInfo = GetVertexFormatInfo(pAttrib->format);
+    VertexFormatInfo formatInfo = GetVertexFormatInfo(pDescription);
 
     const bool is8bitFetch = (pInputTy->getScalarSizeInBits() == 8);
     const bool is16bitFetch = (pInputTy->getScalarSizeInBits() == 16);
 
     // Do the first vertex fetch operation
     AddVertexFetchInst(pVbDesc,
-                       pFormatInfo->numChannels,
+                       formatInfo.numChannels,
                        is16bitFetch,
                        pVbIndex,
-                       pAttrib->offset,
-                       pBinding->stride,
-                       pFormatInfo->dfmt,
-                       pFormatInfo->nfmt,
+                       pDescription->offset,
+                       pDescription->stride,
+                       formatInfo.dfmt,
+                       formatInfo.nfmt,
                        pInsertPos,
                        &vertexFetch[0]);
 
     // Do post-processing in certain cases
     std::vector<Constant*> shuffleMask;
-    bool postShuffle = NeedPostShuffle(pAttrib->format, shuffleMask);
-    bool patchA2S = NeedPatchA2S(pAttrib->format);
+    bool postShuffle = NeedPostShuffle(pDescription, shuffleMask);
+    bool patchA2S = NeedPatchA2S(pDescription);
     if (postShuffle || patchA2S)
     {
         if (postShuffle)
@@ -1281,7 +459,7 @@ Value* VertexFetch::Run(
                                                        "",
                                                        pInsertPos);
 
-            if (pFormatInfo->nfmt == BUF_NUM_FORMAT_SINT)
+            if (formatInfo.nfmt == BUF_NUM_FORMAT_SINT)
             {
                 // NOTE: For format "SINT 10_10_10_2", vertex fetches incorrectly return the alpha channel as
                 // unsigned. We have to manually sign-extend it here by doing a "shl" 30 then an "ashr" 30.
@@ -1298,7 +476,7 @@ Value* VertexFetch::Run(
                                                     "",
                                                     pInsertPos);
             }
-            else if (pFormatInfo->nfmt == BUF_NUM_FORMAT_SNORM)
+            else if (formatInfo.nfmt == BUF_NUM_FORMAT_SNORM)
             {
                 // NOTE: For format "SNORM 10_10_10_2", vertex fetches incorrectly return the alpha channel
                 // as unsigned. We have to somehow remap the values { 0.0, 0.33, 0.66, 1.00 } to { 0.0, 1.0,
@@ -1330,7 +508,7 @@ Value* VertexFetch::Run(
                 // %a = bitcast %a to i32
                 pAlpha = new BitCastInst(pAlpha, m_pContext->Int32Ty(), "", pInsertPos);
             }
-            else if (pFormatInfo->nfmt == BUF_NUM_FORMAT_SSCALED)
+            else if (formatInfo.nfmt == BUF_NUM_FORMAT_SSCALED)
             {
                 // NOTE: For format "SSCALED 10_10_10_2", vertex fetches incorrectly return the alpha channel
                 // as unsigned. We have to somehow remap the values { 0.0, 1.0, 2.0, 3.0 } to { 0.0, 1.0,
@@ -1376,15 +554,13 @@ Value* VertexFetch::Run(
     }
 
     // Do the second vertex fetch operation
-    const bool secondFetch = NeedSecondVertexFetch(pAttrib->format);
+    const bool secondFetch = NeedSecondVertexFetch(pDescription);
     if (secondFetch)
     {
-        uint32_t numChannels = pFormatInfo->numChannels;
-        uint32_t dfmt = pFormatInfo->dfmt;
+        uint32_t numChannels = formatInfo.numChannels;
+        uint32_t dfmt = formatInfo.dfmt;
 
-        if ((pAttrib->format == VK_FORMAT_R64G64B64_UINT) ||
-            (pAttrib->format == VK_FORMAT_R64G64B64_SINT) ||
-            (pAttrib->format == VK_FORMAT_R64G64B64_SFLOAT))
+        if (pDescription->dfmt == Builder::BufDataFormat64_64_64)
         {
             // Valid number of channels and data format have to be revised
             numChannels = 2;
@@ -1395,10 +571,10 @@ Value* VertexFetch::Run(
                            numChannels,
                            is16bitFetch,
                            pVbIndex,
-                           pAttrib->offset + SizeOfVec4,
-                           pBinding->stride,
+                           pDescription->offset + SizeOfVec4,
+                           pDescription->stride,
                            dfmt,
-                           pFormatInfo->nfmt,
+                           formatInfo.nfmt,
                            pInsertPos,
                            &vertexFetch[1]);
     }
@@ -1603,15 +779,55 @@ Value* VertexFetch::Run(
 
 // =====================================================================================================================
 // Gets info from table according to vertex attribute format.
-const VertexFormatInfo* VertexFetch::GetVertexFormatInfo(
-    VkFormat format) // Vertex attribute format
+VertexFormatInfo VertexFetch::GetVertexFormatInfo(
+    const Builder::VertexInputDescription* pInputDesc)    // [in] Vertex input description
 {
-    LLPC_ASSERT(format < VK_FORMAT_RANGE_SIZE);
-
-    const VertexFormatInfo* pFormatInfo = &m_vertexFormatInfo[format];
-    LLPC_ASSERT(pFormatInfo->format == format);
-
-    return pFormatInfo;
+    VertexFormatInfo info = {
+                                static_cast<BufNumFormat>(pInputDesc->nfmt),
+                                static_cast<BufDataFormat>(pInputDesc->dfmt),
+                                1
+                            };
+    switch (pInputDesc->dfmt)
+    {
+    case Builder::BufDataFormat8_8:
+    case Builder::BufDataFormat16_16:
+    case Builder::BufDataFormat32_32:
+        info.numChannels = 2;
+        break;
+    case Builder::BufDataFormat32_32_32:
+    case Builder::BufDataFormat10_11_11:
+    case Builder::BufDataFormat11_11_10:
+        info.numChannels = 3;
+        break;
+    case Builder::BufDataFormat8_8_8_8:
+    case Builder::BufDataFormat16_16_16_16:
+    case Builder::BufDataFormat32_32_32_32:
+    case Builder::BufDataFormat10_10_10_2:
+    case Builder::BufDataFormat2_10_10_10:
+        info.numChannels = 4;
+        break;
+    case Builder::BufDataFormat8_8_8_8_BGRA:
+        info.numChannels = 4;
+        info.dfmt = BUF_DATA_FORMAT_8_8_8_8;
+        break;
+    case Builder::BufDataFormat2_10_10_10_BGRA:
+        info.numChannels = 4;
+        info.dfmt = BUF_DATA_FORMAT_2_10_10_10;
+        break;
+    case Builder::BufDataFormat64:
+        info.numChannels = 2;
+        info.dfmt = BUF_DATA_FORMAT_32_32;
+        break;
+    case Builder::BufDataFormat64_64:
+    case Builder::BufDataFormat64_64_64:
+    case Builder::BufDataFormat64_64_64_64:
+        info.numChannels = 4;
+        info.dfmt = BUF_DATA_FORMAT_32_32_32_32;
+        break;
+    default:
+        break;
+    }
+    return info;
 }
 
 // =====================================================================================================================
@@ -1673,59 +889,6 @@ Value* VertexFetch::LoadVertexBufferDescriptor(
     pVbDesc->setAlignment(MaybeAlign(16));
 
     return pVbDesc;
-}
-
-// =====================================================================================================================
-// Extracts vertex input binding and attribute info based on the specified vertex input location.
-void VertexFetch::ExtractVertexInputInfo(
-    uint32_t                                          location,   // Location of vertex input
-    const VkVertexInputBindingDescription**           ppBinding,  // [out] Vertex binding
-    const VkVertexInputAttributeDescription**         ppAttrib,   // [out] Vertex attribute
-    const VkVertexInputBindingDivisorDescriptionEXT** ppDivisor   // [out] Vertex divisor
-    ) const
-{
-    LLPC_ASSERT((ppBinding != nullptr) && (ppAttrib != nullptr));
-
-    *ppBinding = nullptr;
-    *ppAttrib  = nullptr;
-    *ppDivisor = nullptr;
-
-    for (uint32_t i = 0; i < m_pVertexInput->vertexAttributeDescriptionCount; ++i)
-    {
-        auto pAttrib = &m_pVertexInput->pVertexAttributeDescriptions[i];
-        if (pAttrib->location == location)
-        {
-            *ppAttrib = pAttrib;
-            break;
-        }
-    }
-
-    if (*ppAttrib != nullptr) // Vertex attribute exists
-    {
-        for (uint32_t i = 0; i < m_pVertexInput->vertexBindingDescriptionCount; ++i)
-        {
-            auto pBinding = &m_pVertexInput->pVertexBindingDescriptions[i];
-            if (pBinding->binding == (*ppAttrib)->binding)
-            {
-                *ppBinding = pBinding;
-                break;
-            }
-        }
-        LLPC_ASSERT(*ppBinding != nullptr); // Vertex binding exists
-
-        if (m_pVertexDivisor != nullptr)
-        {
-            for (uint32_t i = 0;i < m_pVertexDivisor->vertexBindingDivisorCount; ++i)
-            {
-                auto pDivisor = &m_pVertexDivisor->pVertexBindingDivisors[i];
-                if (pDivisor->binding == (*ppAttrib)->binding)
-                {
-                    *ppDivisor = pDivisor;
-                    break;
-                }
-            }
-        }
-    }
 }
 
 // =====================================================================================================================
@@ -1943,26 +1106,16 @@ void VertexFetch::AddVertexFetchInst(
 // =====================================================================================================================
 // Checks whether post shuffle is required for vertex fetch oepration.
 bool VertexFetch::NeedPostShuffle(
-    VkFormat                format,     // Vertex attribute format
-    std::vector<Constant*>& shuffleMask // [out] Vector shuffle mask
+    const Builder::VertexInputDescription*  pInputDesc,   // [in] Vertex input description
+    std::vector<Constant*>&                 shuffleMask   // [out] Vector shuffle mask
     ) const
 {
     bool needShuffle = false;
 
-    switch (format)
+    switch (pInputDesc->dfmt)
     {
-    case VK_FORMAT_B8G8R8A8_UNORM:
-    case VK_FORMAT_B8G8R8A8_SNORM:
-    case VK_FORMAT_B8G8R8A8_USCALED:
-    case VK_FORMAT_B8G8R8A8_SSCALED:
-    case VK_FORMAT_B8G8R8A8_UINT:
-    case VK_FORMAT_B8G8R8A8_SINT:
-    case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
-    case VK_FORMAT_A2R10G10B10_SNORM_PACK32:
-    case VK_FORMAT_A2R10G10B10_USCALED_PACK32:
-    case VK_FORMAT_A2R10G10B10_SSCALED_PACK32:
-    case VK_FORMAT_A2R10G10B10_UINT_PACK32:
-    case VK_FORMAT_A2R10G10B10_SINT_PACK32:
+    case Builder::BufDataFormat8_8_8_8_BGRA:
+    case Builder::BufDataFormat2_10_10_10_BGRA:
         shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 2));
         shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
         shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));
@@ -1979,23 +1132,20 @@ bool VertexFetch::NeedPostShuffle(
 // =====================================================================================================================
 // Checks whether patching 2-bit signed alpha channel is required for vertex fetch operation.
 bool VertexFetch::NeedPatchA2S(
-    VkFormat format  // Vertex attribute format
+    const Builder::VertexInputDescription* pInputDesc    // [in] Vertex input description
     ) const
 {
     bool needPatch = false;
 
-    switch (format)
+    if ((pInputDesc->dfmt == Builder::BufDataFormat2_10_10_10) ||
+        (pInputDesc->dfmt == Builder::BufDataFormat2_10_10_10_BGRA))
     {
-    case VK_FORMAT_A2R10G10B10_SNORM_PACK32:
-    case VK_FORMAT_A2R10G10B10_SSCALED_PACK32:
-    case VK_FORMAT_A2R10G10B10_SINT_PACK32:
-    case VK_FORMAT_A2B10G10R10_SNORM_PACK32:
-    case VK_FORMAT_A2B10G10R10_SSCALED_PACK32:
-    case VK_FORMAT_A2B10G10R10_SINT_PACK32:
-        needPatch = (m_pPipelineState->GetGfxIpVersion().major < 9);
-        break;
-    default:
-        break;
+        if ((pInputDesc->nfmt == Builder::BufNumFormatSNORM) ||
+            (pInputDesc->nfmt == Builder::BufNumFormatSSCALED) ||
+            (pInputDesc->nfmt == Builder::BufNumFormatSINT))
+        {
+            needPatch = (m_pPipelineState->GetGfxIpVersion().major < 9);
+        }
     }
 
     return needPatch;
@@ -2004,15 +1154,11 @@ bool VertexFetch::NeedPatchA2S(
 // =====================================================================================================================
 // Checks whether the second vertex fetch operation is required (particularly for certain 64-bit typed formats).
 bool VertexFetch::NeedSecondVertexFetch(
-    VkFormat format // Vertex attribute format
+    const Builder::VertexInputDescription* pInputDesc    // [in] Vertex input description
     ) const
 {
-    return ((format == VK_FORMAT_R64G64B64_UINT)        ||
-            (format == VK_FORMAT_R64G64B64_SINT)        ||
-            (format == VK_FORMAT_R64G64B64_SFLOAT)      ||
-            (format == VK_FORMAT_R64G64B64A64_UINT)     ||
-            (format == VK_FORMAT_R64G64B64A64_SINT)     ||
-            (format == VK_FORMAT_R64G64B64A64_SFLOAT));
+    return ((pInputDesc->dfmt == Builder::BufDataFormat64_64_64) ||
+            (pInputDesc->dfmt == Builder::BufDataFormat64_64_64_64));
 }
 
 } // Llpc

--- a/patch/llpcVertexFetch.h
+++ b/patch/llpcVertexFetch.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpcBuilder.h"
 #include "llpcInternal.h"
 #include "llpcIntrinsDefs.h"
 
@@ -43,7 +44,6 @@ class ShaderSystemValues;
 // Represents vertex format info corresponding to vertex attribute format (VkFormat).
 struct VertexFormatInfo
 {
-    VkFormat        format;         // Vertex attribute format
     BufNumFormat    nfmt;           // Numeric format of vertex buffer
     BufDataFormat   dfmt;           // Data format of vertex buffer
     uint32_t        numChannels;    // Valid number of channels
@@ -69,7 +69,7 @@ class VertexFetch
 public:
     VertexFetch(llvm::Function* pEntrypoint, ShaderSystemValues* pShaderSysValues, PipelineState* pPipelineState);
 
-    static const VertexFormatInfo* GetVertexFormatInfo(VkFormat format);
+    static VertexFormatInfo GetVertexFormatInfo(const Builder::VertexInputDescription* pDescription);
 
     llvm::Value* Run(llvm::Type* pInputTy, uint32_t location, uint32_t compIdx, llvm::Instruction* pInsertPos);
 
@@ -89,11 +89,6 @@ private:
 
     llvm::Value* LoadVertexBufferDescriptor(uint32_t binding, llvm::Instruction* pInsertPos) const;
 
-    void ExtractVertexInputInfo(uint32_t                                          location,
-                                const VkVertexInputBindingDescription**           ppBinding,
-                                const VkVertexInputAttributeDescription**         ppAttrib,
-                                const VkVertexInputBindingDivisorDescriptionEXT** ppDivisor) const;
-
     void AddVertexFetchInst(llvm::Value*       pVbDesc,
                             uint32_t           numChannels,
                             bool               is16bitFetch,
@@ -105,11 +100,12 @@ private:
                             llvm::Instruction* pInsertPos,
                             llvm::Value**      ppFetch) const;
 
-    bool NeedPostShuffle(VkFormat format, std::vector<llvm::Constant*>& shuffleMask) const;
+    bool NeedPostShuffle(const Builder::VertexInputDescription* pInputDesc,
+                         std::vector<llvm::Constant*>&          shuffleMask) const;
 
-    bool NeedPatchA2S(VkFormat format) const;
+    bool NeedPatchA2S(const Builder::VertexInputDescription* pInputDesc) const;
 
-    bool NeedSecondVertexFetch(VkFormat format) const;
+    bool NeedSecondVertexFetch(const Builder::VertexInputDescription* pInputDesc) const;
 
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -118,15 +114,11 @@ private:
     ShaderSystemValues* m_pShaderSysValues; // ShaderSystemValues object for getting vertex buffer pointer from
     PipelineState*      m_pPipelineState;   // Pipeline state
 
-    const VkPipelineVertexInputStateCreateInfo*   m_pVertexInput; // Vertex input info
-    const VkPipelineVertexInputDivisorStateCreateInfoEXT* m_pVertexDivisor; // Vertex input divisor info
-
     llvm::Value*    m_pVertexIndex;     // Vertex index
     llvm::Value*    m_pInstanceIndex;   // Instance index
     llvm::Value*    m_pBaseInstance;    // Base instance
     llvm::Value*    m_pInstanceId;      // Instance ID
 
-    static const VertexFormatInfo       m_vertexFormatInfo[];       // Info table of vertex format
     static const VertexCompFormatInfo   m_vertexCompFormatInfo[];   // Info table of vertex component format
 #if LLPC_BUILD_GFX10
     static const BufFormat              m_vertexFormatMap[];        // Info table of vertex format mapping

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -94,10 +94,10 @@ using namespace Llpc;
 static cl::opt<std::string> GfxIp("gfxip",
                                   cl::desc("Graphics IP version"),
                                   cl::value_desc("major.minor.step"),
-                                  cl::init("8.0.0"));
+                                  cl::init("8.0.2"));
 
 // The GFXIP version parsed out of the -gfxip option before normal option processing occurs.
-static GfxIpVersion ParsedGfxIp = {8, 0, 0};
+static GfxIpVersion ParsedGfxIp = {8, 0, 2};
 
 // Input sources
 static cl::list<std::string> InFiles(cl::Positional, cl::OneOrMore, cl::ValueRequired,

--- a/util/llpcElfWriter.cpp
+++ b/util/llpcElfWriter.cpp
@@ -286,12 +286,14 @@ void ElfWriter<Elf>::MergeMetaNote(
     uint32_t regCount = 0;
     uint32_t psInputCntlBase = 0;
     uint32_t psUserDataBase = 0;
+    uint32_t psUserDataCount = 0;
     if (gfxIp.major < 9)
     {
         gfx6PsConfig.Init();
         pRegEntry = reinterpret_cast<Util::Abi::PalMetadataNoteEntry*>(&gfx6PsConfig);
         psInputCntlBase = gfx6PsConfig.GetPsInputCntlStart();
         psUserDataBase = gfx6PsConfig.GetPsUserDataStart();
+        psUserDataCount = 16;
         regCount = sizeof(gfx6PsConfig) / sizeof(Util::Abi::PalMetadataNoteEntry);
     }
     else
@@ -300,6 +302,7 @@ void ElfWriter<Elf>::MergeMetaNote(
         pRegEntry = reinterpret_cast<Util::Abi::PalMetadataNoteEntry*>(&gfx9PsConfig);
         psInputCntlBase = Gfx9::mmSPI_PS_INPUT_CNTL_0;
         psUserDataBase = Gfx9::mmSPI_SHADER_USER_DATA_PS_0;
+        psUserDataCount = 32;
         regCount = sizeof(gfx9PsConfig) / sizeof(Util::Abi::PalMetadataNoteEntry);
     }
 
@@ -317,7 +320,7 @@ void ElfWriter<Elf>::MergeMetaNote(
         MergeMapItem(destRegisters, srcRegisters, psInputCntlBase + i);
     }
 
-    for (uint32_t i = 0; i < pContext->GetGpuProperty()->maxUserDataCount; ++i)
+    for (uint32_t i = 0; i < psUserDataCount; ++i)
     {
         MergeMapItem(destRegisters, srcRegisters, psUserDataBase + i);
     }

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -267,7 +267,7 @@ ShaderStage GetShaderStageFromModule(
 // =====================================================================================================================
 // Gets the shader stage from the specified LLVM function. Returns ShaderStageInvalid if not shader entrypoint.
 ShaderStage GetShaderStageFromFunction(
-    Function* pFunc)  // [in] LLVM function
+    const Function* pFunc)  // [in] LLVM function
 {
     // First check for the metadata that is added by the builder. This works in the patch phase.
     MDNode* pStageMetaNode = pFunc->getMetadata(LlpcName::ShaderStageMetadata);

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -748,30 +748,4 @@ bool IsIsaText(
     return (dataSize != 0) && ((reinterpret_cast<const char*>(pData))[0] == '\t');
 }
 
-// =====================================================================================================================
-// Manually add a target-aware TLI pass, so middle-end optimizations do not think that we have library functions.
-void AddTargetLibInfo(
-    Context*              pContext,   // [in] LLPC context
-    legacy::PassManager*  pPassMgr)   // [in/out] Pass manager
-{
-    TargetLibraryInfoImpl targetLibInfo(pContext->GetTargetMachine()->getTargetTriple());
-
-    // Adjust it to allow memcpy and memset.
-    // TODO: Investigate why the latter is necessary. I found that
-    // test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
-    // got unrolled far too much, and at too late a stage for the descriptor loads to be commoned up. It might
-    // be an unfortunate interaction between LoopIdiomRecognize and fat pointer laundering.
-    targetLibInfo.setAvailable(LibFunc_memcpy);
-    targetLibInfo.setAvailable(LibFunc_memset);
-
-    // Also disallow tan functions.
-    // TODO: This can be removed once we have LLVM fix D67406.
-    targetLibInfo.setUnavailable(LibFunc_tan);
-    targetLibInfo.setUnavailable(LibFunc_tanf);
-    targetLibInfo.setUnavailable(LibFunc_tanl);
-
-    auto pTargetLibInfoPass = new TargetLibraryInfoWrapperPass(targetLibInfo);
-    pPassMgr->add(pTargetLibInfoPass);
-}
-
 } // Llpc

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -266,7 +266,7 @@ ShaderStage GetShaderStageFromModule(llvm::Module* pModule);
 void SetShaderStageToModule(llvm::Module* pModule, ShaderStage shaderStage);
 
 // Gets the shader stage from the specified LLVM function.
-ShaderStage GetShaderStageFromFunction(llvm::Function* pFunc);
+ShaderStage GetShaderStageFromFunction(const llvm::Function* pFunc);
 
 // Gets the shader stage from the specified calling convention.
 ShaderStage GetShaderStageFromCallingConv(uint32_t stageMask, llvm::CallingConv::ID callConv);

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -32,9 +32,7 @@
 
 #include <unordered_set>
 
-#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 
 #include "spirvExt.h"
@@ -78,13 +76,6 @@ void initializePassDeadFuncRemovePass(PassRegistry&);
 void initializePassExternalLibLinkPass(PassRegistry&);
 void initializePipelineShadersPass(PassRegistry&);
 void initializeStartStopTimerPass(PassRegistry&);
-
-namespace legacy
-{
-
-class PassManager;
-
-} // legacy
 
 } // llvm
 
@@ -312,8 +303,5 @@ bool IsElfBinary(const void* pData, size_t dataSize);
 
 // Checks whether the output data is actually ISA assembler text
 bool IsIsaText(const void* pData, size_t dataSize);
-
-// Manually add a target-aware TLI pass, so middle-end optimizations do not think that we have library functions.
-void AddTargetLibInfo(Context* pContext, llvm::legacy::PassManager* pPassMgr);
 
 } // Llpc


### PR DESCRIPTION
* Builder has a new method SetColorExportState for the front-end to
  pass the color export state in.
* The method forwards to PipelineState, where the state is stored.
* If using BuilderRecorder, PipelineState writes the state to IR
  metadata.
* The middle-end now accesses the above state by calling methods on
  PipelineState.
* This state in the middle-end no longer uses Vulkan enums.