### PR TITLE
Prepare for upstream LLVM changes in LLPC

### DIFF
--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -33,6 +33,7 @@
 #include "llpc.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Pass.h"
 #include <map>
 
 namespace llvm

--- a/patch/llpcPatchCopyShader.cpp
+++ b/patch/llpcPatchCopyShader.cpp
@@ -727,9 +727,10 @@ Value* PatchCopyShader::LoadValueFromGsVsRingBuffer(
         idxs.push_back(pRingOffset);
 
         Value* pLoadPtr = GetElementPtrInst::Create(nullptr, m_pLds, idxs, "", pInsertPos);
-        pLoadValue = new LoadInst(pLoadPtr, "", false, m_pLds->getAlignment(), pInsertPos);
+        auto pLoadInst = new LoadInst(pLoadPtr, "", false, pInsertPos);
+        pLoadInst->setAlignment(MaybeAlign(m_pLds->getAlignment()));
 
-        pLoadValue = new BitCastInst(pLoadValue, m_pContext->FloatTy(), "", pInsertPos);
+        pLoadValue = new BitCastInst(pLoadInst, m_pContext->FloatTy(), "", pInsertPos);
     }
     else
     {

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -5161,7 +5161,8 @@ void PatchInOutImportExport::StoreValueToEsGsRing(
             idxs.push_back(pRingOffset);
 
             Value* pStorePtr = GetElementPtrInst::Create(nullptr, m_pLds, idxs, "", pInsertPos);
-            new StoreInst(pStoreValue, pStorePtr, false, m_pLds->getAlignment(), pInsertPos);
+            auto pStoreInst = new StoreInst(pStoreValue, pStorePtr, false, pInsertPos);
+            pStoreInst->setAlignment(MaybeAlign(m_pLds->getAlignment()));
         }
         else
         {
@@ -5232,7 +5233,9 @@ Value* PatchInOutImportExport::LoadValueFromEsGsRing(
             idxs.push_back(pRingOffset);
 
             Value* pLoadPtr = GetElementPtrInst::Create(nullptr, m_pLds, idxs, "", pInsertPos);
-            pLoadValue = new LoadInst(pLoadPtr, "", false, m_pLds->getAlignment(), pInsertPos);
+            auto pLoadInst = new LoadInst(pLoadPtr, "", false, pInsertPos);
+            pLoadInst->setAlignment(MaybeAlign(m_pLds->getAlignment()));
+            pLoadValue = pLoadInst;
 
             if (bitWidth == 8)
             {
@@ -5351,7 +5354,8 @@ void PatchInOutImportExport::StoreValueToGsVsRingBuffer(
         idxs.push_back(pRingOffset);
 
         Value* pStorePtr = GetElementPtrInst::Create(nullptr, m_pLds, idxs, "", pInsertPos);
-        new StoreInst(pStoreValue, pStorePtr, false, m_pLds->getAlignment(), pInsertPos);
+        auto pStoreInst = new StoreInst(pStoreValue, pStorePtr, false, pInsertPos);
+        pStoreInst->setAlignment(MaybeAlign(m_pLds->getAlignment()));
     }
     else
     {
@@ -5655,7 +5659,9 @@ Value* PatchInOutImportExport::ReadValueFromLds(
             idxs.push_back(pLdsOffset);
 
             Value* pLoadPtr = GetElementPtrInst::Create(nullptr, m_pLds, idxs, "", pInsertPos);
-            loadValues[i] = new LoadInst(pLoadPtr, "", false, m_pLds->getAlignment(), pInsertPos);
+            auto pLoadInst = new LoadInst(pLoadPtr, "", false, pInsertPos);
+            pLoadInst->setAlignment(MaybeAlign(m_pLds->getAlignment()));
+            loadValues[i]=pLoadInst;
 
             if (bitWidth == 8)
             {
@@ -5787,7 +5793,9 @@ void PatchInOutImportExport::WriteValueToLds(
             idxs.push_back(pLdsOffset);
 
             Value* pStorePtr = GetElementPtrInst::Create(nullptr, m_pLds, idxs, "", pInsertPos);
-            new StoreInst(storeValues[i], pStorePtr, false, m_pLds->getAlignment(), pInsertPos);
+            auto pStoreInst = new StoreInst(storeValues[i], pStorePtr, false, pInsertPos);
+            pStoreInst->setAlignment(MaybeAlign(m_pLds->getAlignment()));
+
 
             pLdsOffset = BinaryOperator::CreateAdd(pLdsOffset, ConstantInt::get(m_pContext->Int32Ty(), 1), "", pInsertPos);
         }

--- a/translator/include/LLVMSPIRVLib.h
+++ b/translator/include/LLVMSPIRVLib.h
@@ -76,6 +76,7 @@ void initializeSPIRVLowerMemmovePass(PassRegistry&);
 }
 
 #include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
 
 namespace SPIRV {
 class SPIRVModule;


### PR DESCRIPTION
Changes in upstream LLVM require preparation in LLPC. The changes here are
compatible with both the current version of LLVM (to ensure that it still
continues to build and work), as well as the new scheme.

It is possible to implement the alignment changes more succinctly, but not in a
way that's compatible with current and future LLVM changes.