### PR TITLE
Fix sampledimage containing buffer passed to function problem

### DIFF
--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1111,7 +1111,12 @@ template<> Type *SPIRVToLLVM::transTypeWithOpcode<OpTypePointer>(
                 // Pointer to sampled image is represented by a struct containing pointer to image and pointer to
                 // sampler. But if the image is multisampled, then it itself is another struct, as above.
                 Type* pImagePtrTy = getBuilder()->GetImageDescPtrTy();
-                if (static_cast<SPIRVTypeSampledImage*>(pSpvElementType)->getImageType()->getDescriptor().MS)
+                SPIRVTypeImage* pSpvImageTy = static_cast<SPIRVTypeSampledImage*>(pSpvElementType)->getImageType();
+                if (pSpvImageTy->getDescriptor().Dim == DimBuffer)
+                {
+                    pImagePtrTy = getBuilder()->GetTexelBufferDescPtrTy();
+                }
+                else if (pSpvImageTy->getDescriptor().MS)
                 {
                     pImagePtrTy = StructType::get(*Context,
                                                   { getBuilder()->GetImageDescPtrTy(), getBuilder()->GetFmaskDescPtrTy() });


### PR DESCRIPTION
The spir-v reader was not correctly translating the type for
"sampledimage containing buffer", and that caused an assert when passing
a value of that type into a function. Fixed.

Change-Id: I22c1c792bbad50f53fe85d2096d20a6783270812