### PR TITLE
dEQP-VK.transform_feedback.fuzz* - some tests fail on Windows/LLPC on Gfx7

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -1092,7 +1092,7 @@ public:
         Value*        pValueToWrite,      // [in] Value to write
         bool          isBuiltIn,          // True for built-in, false for user output (ignored if not GS)
         uint32_t      location,           // Location (row) or built-in kind of output (ignored if not GS)
-        uint32_t      xfbBuffer,          // XFB buffer number
+        uint32_t      xfbBuffer,          // XFB buffer ID
         uint32_t      xfbStride,          // XFB stride
         Value*        pXfbOffset,         // [in] XFB byte offset
         InOutInfo     outputInfo) = 0;    // Extra output info (GS stream ID)

--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -605,7 +605,7 @@ Instruction* BuilderImplInOut::CreateWriteXfbOutput(
     Value*        pValueToWrite,      // [in] Value to write
     bool          isBuiltIn,          // True for built-in, false for user output (ignored if not GS)
     uint32_t      location,           // Location (row) or built-in kind of output (ignored if not GS)
-    uint32_t      xfbBuffer,          // XFB buffer number
+    uint32_t      xfbBuffer,          // XFB buffer ID
     uint32_t      xfbStride,          // XFB stride
     Value*        pXfbOffset,         // [in] XFB byte offset
     InOutInfo     outputInfo)         // Extra output info (GS stream ID)

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -1462,7 +1462,7 @@ Instruction* BuilderRecorder::CreateWriteXfbOutput(
     Value*        pValueToWrite,      // [in] Value to write
     bool          isBuiltIn,          // True for built-in, false for user output (ignored if not GS)
     uint32_t      location,           // Location (row) or built-in kind of output (ignored if not GS)
-    uint32_t      xfbBuffer,          // XFB buffer number
+    uint32_t      xfbBuffer,          // XFB buffer ID
     uint32_t      xfbStride,          // XFB stride
     Value*        pXfbOffset,         // [in] XFB byte offset
     InOutInfo     outputInfo)         // Extra output info (GS stream ID)

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -757,7 +757,7 @@ Value* BuilderReplayer::ProcessCall(
             return m_pBuilder->CreateWriteXfbOutput(args[0],                                    // Value to write
                                                     cast<ConstantInt>(args[1])->getZExtValue(), // IsBuiltIn
                                                     cast<ConstantInt>(args[2])->getZExtValue(), // Location/builtIn
-                                                    cast<ConstantInt>(args[3])->getZExtValue(), // XFB buffer number
+                                                    cast<ConstantInt>(args[3])->getZExtValue(), // XFB buffer ID
                                                     cast<ConstantInt>(args[4])->getZExtValue(), // XFB stride
                                                     args[5],                                    // XFB byte offset
                                                     outputInfo);

--- a/lower/llpcSpirvLowerGlobal.h
+++ b/lower/llpcSpirvLowerGlobal.h
@@ -91,6 +91,7 @@ private:
                                     llvm::Value*       pLocOffset,
                                     uint32_t           maxLocOffset,
                                     uint32_t           xfbLocOffset,
+                                    uint32_t           xfbBufferAdjust,
                                     llvm::Value*       pElemIdx,
                                     llvm::Value*       pVertexIdx,
                                     uint32_t           emitStreamId,

--- a/patch/llpcSystemValues.cpp
+++ b/patch/llpcSystemValues.cpp
@@ -579,7 +579,7 @@ Value* ShaderSystemValues::GetVertexBufTablePtr()
 // =====================================================================================================================
 // Get stream-out buffer descriptor
 Value* ShaderSystemValues::GetStreamOutBufDesc(
-    uint32_t        xfbBuffer)      // Transform feedback buffer number
+    uint32_t        xfbBuffer)      // Transform feedback buffer ID
 {
     if (m_streamOutBufDescs.size() <= xfbBuffer)
     {

--- a/translator/lib/SPIRV/SPIRVInternal.h
+++ b/translator/lib/SPIRV/SPIRVInternal.h
@@ -1183,11 +1183,13 @@ union ShaderInOutMetadata {
                                       // output (tessellation shader)
     uint64_t StreamId           : 2;  // ID of output stream (geometry shader)
     uint64_t IsXfb              : 1;  // Whether this is for transform feedback
+    uint64_t IsBlockArray       : 1;  // Whether we are handling block array
+
     uint64_t XfbBuffer          : 2;  // Transform feedback buffer ID
-    uint64_t XfbOffset          : 15; // Transform feedback offset
+    uint64_t XfbOffset          : 16; // Transform feedback offset
     uint64_t XfbStride          : 16; // Transform feedback stride
-    uint64_t XfbLoc             : 14; // Transform feedback location
-    uint64_t XfbLocStride       : 15; // Transform location stride
+    uint64_t XfbLoc             : 16; // Transform feedback location
+    uint64_t XfbArrayStride     : 16; // Transform feedback array stride
   };
   uint64_t U64All[2];
 };
@@ -1208,6 +1210,8 @@ struct ShaderInOutDecorate {
 
   bool           IsXfb;             // Whether this is a for transform feedback
 
+  bool           IsBlockArray;      // Whether we are handling a block array
+
   uint32_t       Component;         // Component offset of inputs and outputs
 
   bool           PerPatch;          // Whether this is a per-patch input/output
@@ -1223,7 +1227,7 @@ struct ShaderInOutDecorate {
   uint32_t       XfbOffset;          // Transform feedback offset
   uint32_t       XfbStride;          // Transform feedback stride
   uint32_t       XfbLoc;             // Transform feedback location
-  uint32_t       XfbLocStride;       // Transform feedback location stride
+  uint32_t       XfbArrayStride;     // Transform feedback array stride
   bool           contains64BitType;  // Whether contains 64-bit type
 };
 


### PR DESCRIPTION
Root cause: Block array corresponds to it owns capture buffer. Thus, Block
array index should be added to XFB buffer ID rather than XFB location.

- Change XfbLocStride to XfbArrayStride. For block array, it represents
  sub-array dimension. For non block array, it represents XFB location
  stride (in bytes).
- Change lower. Adjust XFB buffer ID for block array if necessary.
- Output XFB export info. This is easy to check the correctness similar
  to inout location info.
- Revise some comments.