### PR TITLE
dEQP-VK.spirv_assembly.instruction.graphics.float_controls.fp32.input_args.denorm_mmulm_var_preserve_vert fail

### DIFF
--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -330,7 +330,8 @@ ShaderStage GetShaderStageFromCallingConv(
         shaderStage = hasTs ? ShaderStageTessEval : ShaderStageVertex;
         break;
     case CallingConv::AMDGPU_GS:
-        shaderStage = ShaderStageGeometry;
+        // NOTE: If GS is not present, this must be NGG.
+        shaderStage = hasGs ? ShaderStageGeometry : (hasTs ? ShaderStageTessEval : ShaderStageVertex);
         break;
     case CallingConv::AMDGPU_VS:
         shaderStage = hasGs ? ShaderStageCopyShader : (hasTs ? ShaderStageTessEval : ShaderStageVertex);


### PR DESCRIPTION
For NGG, the conversion from calling conversion to shader stage is wrong.
AMDGPU_GS could be VS or TES only (GS not present). The wrong shader stage
will report wrong float control info and fp32-denormals is not set
correctly.