### PR TITLE
Google Chrome/ANGLE failure in Vulkan driver: dEQP test failures with odd vertex strides and offsets

### DIFF
--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -1746,7 +1746,9 @@ void VertexFetch::AddVertexFetchInst(
 
     // NOTE: If the vertex attribute offset and stride are aligned on data format boundaries, we can do a vertex fetch
     // operation to read the whole vertex. Otherwise, we have to do vertex per-component fetch operations.
-    if ((((offset % pFormatInfo->vertexByteSize) == 0) && ((stride % pFormatInfo->vertexByteSize) == 0)) ||
+    if ((((offset % pFormatInfo->vertexByteSize) == 0) &&
+         ((stride % pFormatInfo->vertexByteSize) == 0) &&
+         (dfmt != BUF_DATA_FORMAT_8_8)) || // Format 8_8 has to be per-component fetch because of alignment problem
         (pFormatInfo->compDfmt == dfmt))
     {
         // NOTE: If the vertex attribute offset is greater than vertex attribute stride, we have to adjust both vertex


### PR DESCRIPTION
For format 8_8, the fetch must be per-component. Otherwise, the misaligned
vertex buffer binding offset will cause vertex fetch failure.