### PR TITLE
Removed unused func CollectGsXfbOutputInfo

### DIFF
--- a/lower/llpcSpirvLowerGlobal.cpp
+++ b/lower/llpcSpirvLowerGlobal.cpp
@@ -2039,37 +2039,6 @@ void SpirvLowerGlobal::StoreOutputMember(
 }
 
 // =====================================================================================================================
-// Collects transform output info for geometry shader.
-void SpirvLowerGlobal::CollectGsXfbOutputInfo(
-    const llvm::Type *          pOutputTy,      // [in] Type of this output
-    uint32_t                    locOffset,      // Relative location array offset, passed from aggregate type
-    uint32_t                    xfbExtraOffset, // Transform feedback extra offset (for array type)
-    const ShaderInOutMetadata & outputMeta)     // [in] Metadata of this output
-{
-    LLPC_ASSERT(m_shaderStage == ShaderStageGeometry);
-    LLPC_ASSERT(outputMeta.IsXfb == true);
-    LLPC_ASSERT(outputMeta.IsBuiltIn == false);
-
-    auto pResUsage = m_pContext->GetShaderResourceUsage(ShaderStageGeometry);
-
-    uint32_t location = outputMeta.Value + outputMeta.Index + locOffset;
-
-    GsOutLocInfo outLocInfo = {};
-    outLocInfo.location = location;
-    outLocInfo.isBuiltIn = false;
-    outLocInfo.streamId = outputMeta.StreamId;
-
-    XfbOutInfo xfbOutInfo = {};
-
-    xfbOutInfo.xfbBuffer = outputMeta.XfbBuffer;
-    xfbOutInfo.xfbOffset = outputMeta.XfbOffset;
-    xfbOutInfo.is16bit = (pOutputTy->getScalarSizeInBits() == 16);
-    xfbOutInfo.xfbExtraOffset = xfbExtraOffset;
-
-    pResUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u32All] = xfbOutInfo.u32All;
-}
-
-// =====================================================================================================================
 // Lowers buffer blocks.
 void SpirvLowerGlobal::LowerBufferBlock()
 {

--- a/lower/llpcSpirvLowerGlobal.h
+++ b/lower/llpcSpirvLowerGlobal.h
@@ -118,11 +118,6 @@ private:
                            llvm::Value*                     pVertexIdx,
                            llvm::Instruction*               pInsertPos);
 
-    void CollectGsXfbOutputInfo(const llvm::Type*          pOutputTy,
-                                uint32_t                   locOffset,
-                                uint32_t                   xfbExtraOffset,
-                                const ShaderInOutMetadata& outputMeta);
-
     void InterpolateInputElement(uint32_t           interpLoc,
                                  llvm::Value*       pInterpInfo,
                                  llvm::CallInst&    callInst);


### PR DESCRIPTION
I think this got left behind when I did my Builder input/output change.

Change-Id: Ie4ff3da0a17ca6e7f3baf829c0611349ee8ae064