### PR TITLE
SPIRVReader: Clarify the name of variable passed to transType

### DIFF
--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1131,16 +1131,17 @@ template<> Type *SPIRVToLLVM::transTypeWithOpcode<OpTypePointer>(
     }
 
     // Now non-image-related handling.
-    const bool isBufferBlockPointer = (storageClass == StorageClassStorageBuffer) ||
-                                      (storageClass == StorageClassUniform) ||
-                                      (storageClass == StorageClassPushConstant) ||
-                                      (storageClass == StorageClassPhysicalStorageBufferEXT);
+    const bool explicitlyLaidOut =
+        (storageClass == StorageClassStorageBuffer) ||
+        (storageClass == StorageClassUniform) ||
+        (storageClass == StorageClassPushConstant) ||
+        (storageClass == StorageClassPhysicalStorageBufferEXT);
 
     Type* const pPointeeType = transType(pSpvType->getPointerElementType(),
                                          matrixStride,
                                          isColumnMajor,
                                          true,
-                                         isBufferBlockPointer);
+                                         explicitlyLaidOut);
 
     return PointerType::get(pPointeeType, SPIRSPIRVAddrSpaceMap::rmap(storageClass));
 }


### PR DESCRIPTION
explicitlyLaidOut matches the name of the transType parameter and
captures more accurately what the flag means.