### PR TITLE
llpcInternal: Refactor EmitCall in terms of the IRBuilder<> interface

### DIFF
--- a/test/shaderdb/ObjInput_TestFsCompSpecifier_lit.frag
+++ b/test/shaderdb/ObjInput_TestFsCompSpecifier_lit.frag
@@ -18,10 +18,10 @@ void main (void)
 ; SHADERTEST: call <2 x float> @llpc.input.import.generic.v2f32{{.*}}
 ; SHADERTEST: call float @llpc.input.import.generic.f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 1, i32 immarg 0, i32 %{{[0-9]*}})
-; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[0-9]*}}, i32 immarg 1, i32 immarg 0, i32 %{{[0-9]*}})
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 3, i32 immarg 0, i32 %{{[0-9]*}})
-; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[0-9]*}}, i32 immarg 3, i32 immarg 0, i32 %{{[0-9]*}})
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 1, i32 0, i32 %{{[0-9]*}})
+; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[0-9]*}}, i32 1, i32 0, i32 %{{[0-9]*}})
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 3, i32 0, i32 %{{[0-9]*}})
+; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[0-9]*}}, i32 3, i32 0, i32 %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpBitFieldInsert_TestIntConst_lit.frag
+++ b/test/shaderdb/OpBitFieldInsert_TestIntConst_lit.frag
@@ -16,7 +16,7 @@ void main()
 ; SHADERTEST: = call i32 (...) @llpc.call.insert.bit.field.i32(i32 3, i32 6, i32 4, i32 5)
 
 ; SHADERTEST-LABEL: {{^// LLPC.*}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, i1 immarg true, i1 immarg true)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 0, i32 15, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, i1 true, i1 true)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpEmitStreamVertex_TestGeneral_lit.geom
+++ b/test/shaderdb/OpEmitStreamVertex_TestGeneral_lit.geom
@@ -27,7 +27,7 @@ void main ( )
 ; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 290, i32 %{{[0-9]+}})
 ; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 290, i32 %{{[0-9]+}})
 ; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 274, i32 %{{[0-9]+}})
-; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 immarg 3, i32 %{{[0-9]+}})
+; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 3, i32 %{{[0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpEmitVertex_TestGeneral_lit.geom
+++ b/test/shaderdb/OpEmitVertex_TestGeneral_lit.geom
@@ -27,7 +27,7 @@ void main ( )
 ; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 34, i32 %{{[0-9]+}})
 ; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 34, i32 %{{[0-9]+}})
 ; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 18, i32 %{{[0-9]+}})
-; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 immarg 3, i32 %{{[0-9]+}})
+; SHADERTEST: call void @llvm.amdgcn.s.sendmsg(i32 3, i32 %{{[0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateAtCentroid_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateAtCentroid_lit.frag
@@ -23,10 +23,10 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.import.builtin.InterpPerspCentroid(i32 268435458)
 ; SHADERTEST: %{{[0-9]*}} = call <2 x float> @llpc.input.import.builtin.InterpPerspCentroid(i32 268435458)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 1, i32 immarg 1, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 1, i32 immarg 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 1, i32 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 1, i32 1, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateAtOffset_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateAtOffset_lit.frag
@@ -29,9 +29,9 @@ void main()
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32
 ; SHADERTEST: = call float @llpc.input.import.interpolant.f32{{.*}}v2f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.mov(i32 2, i32 immarg 1, i32 immarg 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.mov(i32 2, i32 1, i32 1, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestInterpolateAtSample_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInterpolateAtSample_lit.frag
@@ -31,9 +31,9 @@ void main()
 ; SHADERTEST-DAG: = call float @llpc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 0, i32 0, i32 0, i32 0, <2 x float>
 ; SHADERTEST-DAG: = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 1, i32 0, i32 0, i32 1, <2 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.mov(i32 2, i32 immarg 1, i32 immarg 1, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 0, i32 0, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.mov(i32 2, i32 1, i32 1, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
@@ -23,7 +23,7 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
 ; SHADERTEST-NOT: = call reassoc nnan nsz arcp contract float @llvm.pow.f32(float
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.200000e+01, float
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 0, i32 15, float 1.200000e+01, float
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
+++ b/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 0x3F9ACEEA00000000, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 immarg true, i1 immarg true)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 0, i32 15, float 0x3F9ACEEA00000000, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 true, i1 true)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpMatrixTimesScalar_TestMat4X2xConstFloat_lit.frag
+++ b/test/shaderdb/OpMatrixTimesScalar_TestMat4X2xConstFloat_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; SHADERTEST: [4 x <2 x float>] (...) @llpc.call.matrix.times.scalar.a4v2f32
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.000000e+00, float 5.000000e-01, float 0.000000e+00, float 0.000000e+00, i1 immarg true, i1 immarg true)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 0, i32 15, float 1.000000e+00, float 5.000000e-01, float 0.000000e+00, float 0.000000e+00, i1 true, i1 true)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/gfx9/ExtShaderInt8_TestVsInOut_lit.vert
+++ b/test/shaderdb/gfx9/ExtShaderInt8_TestVsInOut_lit.vert
@@ -21,7 +21,7 @@ void main (void)
 ; SHADERTEST: call void @llpc.output.export.generic.i32.i32.i8(i32 0, i32 0, i8 %{{[0-9]*}})
 ; SHADERTEST: call void @llpc.output.export.generic.i32.i32.v3i8(i32 1, i32 0, <3 x i8> %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 32, i32 immarg 1, float %{{[0-9]*}}, float undef, float undef, float undef, i1 immarg false, i1 immarg false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 32, i32 1, float %{{[0-9]*}}, float undef, float undef, float undef, i1 false, i1 false)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -34,6 +34,7 @@
 
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 
@@ -205,6 +206,14 @@ static const std::vector<llvm::Attribute::AttrKind>   NoAttrib;
 
 // Gets the entry point (valid for AMD GPU) of a LLVM module.
 llvm::Function* GetEntryPoint(llvm::Module* pModule);
+
+// Emits a LLVM function call using the given builder. The callee is built automically based on return
+// type and its parameters.
+llvm::CallInst* EmitCall(llvm::StringRef                           funcName,
+                         llvm::Type*                               pRetTy,
+                         llvm::ArrayRef<llvm::Value *>             args,
+                         llvm::ArrayRef<llvm::Attribute::AttrKind> attribs,
+                         llvm::IRBuilder<>&                        builder);
 
 // Emits a LLVM function call (inserted before the specified instruction), builds it automically based on return type
 // and its parameters.


### PR DESCRIPTION
Add a new variant of the EmitCall helper that takes an IRBuilder<>
reference, which is conveniently usable in all contexts that use a builder
and avoids the need to manually distinguish between an insertion point
in the middle vs. at the end of (an incomplete) basic block.

Further benefits of this refactoring include:

- Use a SmallVector for argTys to avoid a heap allocation in most cases.
- Use the builder interface for creating a function call instead of the
  manual Create method; this is the more idiomatic way.
- Do not set call instruction attributes redundantly.