### PR TITLE
llpc: compare pipeline state for auto layout

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -62,6 +62,7 @@
 #include "llpcElfReader.h"
 #include "llpcElfWriter.h"
 #include "llpcFile.h"
+#include "llpcFragColorExport.h"
 #include "llpcPassManager.h"
 #include "llpcPatch.h"
 #include "llpcPipelineDumper.h"
@@ -1259,6 +1260,23 @@ void GraphicsShaderCacheChecker::UpdateAndMerge(
         Compiler::UpdateShaderCache(result == Result::Success, &pipelineElf, m_hNonFragmentEntry);
 #endif
     }
+}
+
+// =====================================================================================================================
+// convert color buffer format to fragment shader export format
+uint32_t Compiler::ConvertColorBufferFormatToExportFormat(
+    const ColorTarget*          pTarget,                // [in] GraphicsPipelineBuildInfo
+    const bool                  enableAlphaToCoverage   // whether enalbe AlphaToCoverage
+    ) const
+{
+    ExportFormat exportFormat = FragColorExport::ConvertColorBufferFormatToExportFormat(
+            pTarget,
+            m_gfxIp,
+            &m_gpuWorkarounds,
+            pTarget->channelWriteMask,
+            enableAlphaToCoverage);
+
+    return static_cast<uint32_t>(exportFormat);
 }
 
 // =====================================================================================================================

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -212,6 +212,9 @@ public:
     virtual Result BuildShaderModule(const ShaderModuleBuildInfo* pShaderInfo,
                                      ShaderModuleBuildOut*        pShaderOut) const;
 
+    virtual uint32_t ConvertColorBufferFormatToExportFormat(const ColorTarget*  pTarget,
+                                                            const bool          enableAlphaToCoverage) const;
+
     virtual Result BuildGraphicsPipeline(const GraphicsPipelineBuildInfo* pPipelineInfo,
                                          GraphicsPipelineBuildOut*        pPipelineOut,
                                          void*                            pPipelineDumpFile = nullptr);

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -443,6 +443,16 @@ struct NggState
 };
 #endif
 
+/// Represents color target info
+struct ColorTarget
+{
+    bool            blendEnable;          ///< Blend will be enabled for this target at draw time
+    bool            blendSrcAlphaToColor; ///< Whether source alpha is blended to color channels for this target
+                                          ///  at draw time
+    uint8_t         channelWriteMask;     ///< Write mask to specify destination channels
+    VkFormat        format;               ///< Color attachment format
+};
+
 /// Represents info to build a graphics pipeline.
 struct GraphicsPipelineBuildInfo
 {
@@ -499,14 +509,8 @@ struct GraphicsPipelineBuildInfo
     {
         bool    alphaToCoverageEnable;          ///< Enable alpha to coverage
         bool    dualSourceBlendEnable;          ///< Blend state bound at draw time will use a dual source blend mode
-        struct
-        {
-            bool          blendEnable;          ///< Blend will be enabled for this target at draw time
-            bool          blendSrcAlphaToColor; ///< Whether source alpha is blended to color channels for this target
-                                                ///  at draw time
-           uint8_t        channelWriteMask;     ///< Write mask to specify destination channels
-           VkFormat       format;               ///< Color attachment format
-        } target[MaxColorTargets];              ///< Per-MRT color target info
+
+        ColorTarget target[MaxColorTargets];    ///< Per-MRT color target info
     } cbState;                                  ///< Color target state
 
 #if LLPC_BUILD_GFX10
@@ -731,6 +735,15 @@ public:
 
     /// Destroys the pipeline compiler.
     virtual void VKAPI_CALL Destroy() = 0;
+
+    /// Convert ColorBufferFormat to fragment shader export format
+    ///
+    /// param [in] pTarget                  Color target including color buffer format
+    /// param [in] enableAlphaToCoverage    Whether enable AlphaToCoverage
+    ///
+    /// @return uint32_t type casted from fragment shader export format.
+    virtual uint32_t ConvertColorBufferFormatToExportFormat(const ColorTarget*  pTarget,
+                                                            const bool          enableAlphaToCoverage) const = 0;
 
     /// Build shader module from the specified info.
     ///

--- a/patch/llpcFragColorExport.h
+++ b/patch/llpcFragColorExport.h
@@ -102,27 +102,34 @@ public:
 
     llvm::Value* Run(llvm::Value* pOutput, uint32_t location, llvm::Instruction* pInsertPos);
 
+    static ExportFormat ConvertColorBufferFormatToExportFormat(
+        const ColorTarget*          pTarget,
+        GfxIpVersion                gfxIp,
+        const WorkaroundFlags*      pGpuWorkarounds,
+        uint32_t                    outputMask,
+        const bool                  enableAlphaToCoverage);
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(FragColorExport);
     LLPC_DISALLOW_COPY_AND_ASSIGN(FragColorExport);
 
     ExportFormat ComputeExportFormat(llvm::Type* pOutputTy, uint32_t location) const;
-    CompSetting ComputeCompSetting(VkFormat format) const;
-    ColorSwap ComputeColorSwap(VkFormat format) const;
+    static CompSetting ComputeCompSetting(VkFormat format);
+    static ColorSwap ComputeColorSwap(VkFormat format);
 
     static const ColorFormatInfo* GetColorFormatInfo(VkFormat format);
 
     // Checks whether numeric format of the specified color attachment format is as expected
-    bool IsUnorm(VkFormat format) const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_UNORM); }
-    bool IsSnorm(VkFormat format) const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SNORM); }
-    bool IsFloat(VkFormat format) const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_FLOAT); }
-    bool IsUint(VkFormat format)  const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_UINT);  }
-    bool IsSint(VkFormat format)  const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SINT);  }
-    bool IsSrgb(VkFormat format)  const { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SRGB);  }
+    static bool IsUnorm(VkFormat format) { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_UNORM); }
+    static bool IsSnorm(VkFormat format) { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SNORM); }
+    static bool IsFloat(VkFormat format) { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_FLOAT); }
+    static bool IsUint(VkFormat format) { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_UINT);  }
+    static bool IsSint(VkFormat format) { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SINT);  }
+    static bool IsSrgb(VkFormat format) { return (GetColorFormatInfo(format)->nfmt == COLOR_NUM_FORMAT_SRGB);  }
 
-    bool HasAlpha(VkFormat format) const;
+    static bool HasAlpha(VkFormat format);
 
-    uint32_t GetMaxComponentBitCount(VkFormat format) const;
+    static uint32_t GetMaxComponentBitCount(VkFormat format);
 
     llvm::Value* ConvertToFloat(llvm::Value* pValue, bool signedness, llvm::Instruction* pInsertPos) const;
     llvm::Value* ConvertToInt(llvm::Value* pValue, bool signedness, llvm::Instruction* pInsertPos) const;

--- a/tool/amdllpc.cpp
+++ b/tool/amdllpc.cpp
@@ -969,7 +969,8 @@ static Result BuildShaderModules(
 // =====================================================================================================================
 // Check autolayout compatible.
 static Result CheckAutoLayoutCompatibleFunc(
-    CompileInfo*  pCompileInfo)     // [in,out] Compilation info of LLPC standalone tool
+    const ICompiler*    pCompiler,          // [in] LLPC compiler object
+    CompileInfo*        pCompileInfo)       // [in,out] Compilation info of LLPC standalone tool
 {
     Result result = Result::Success;
 
@@ -1014,15 +1015,16 @@ static Result CheckAutoLayoutCompatibleFunc(
             if (checkAutoLayoutCompatible)
             {
                 PipelineShaderInfo shaderInfo = *pShaderInfo;
+                GraphicsPipelineBuildInfo pipelineInfo = *pPipelineInfo;
                 DoAutoLayoutDesc(pCompileInfo->shaderModuleDatas[i].shaderStage,
                                  pCompileInfo->shaderModuleDatas[i].spirvBin,
-                                 pPipelineInfo,
+                                 &pipelineInfo,
                                  &shaderInfo,
                                  userDataOffset,
                                  true);
-                if (CheckShaderInfoComptible(pShaderInfo, shaderInfo.userDataNodeCount, shaderInfo.pUserDataNodes))
+                if (CheckShaderInfoComptible(pShaderInfo, shaderInfo.userDataNodeCount, shaderInfo.pUserDataNodes) &&
+                    CheckPipelineStateCompatible(pCompiler, pPipelineInfo, &pipelineInfo, ParsedGfxIp))
                 {
-                    // TODO: Pipeline state check
                     outs() << "Auto Layout fragment shader in " << pCompileInfo->pFileNames << " hitted\n";
                 }
                 else
@@ -1692,7 +1694,7 @@ static Result ProcessPipeline(
     if ((result == Result::Success) && (compileInfo.checkAutoLayoutCompatible == true))
     {
         compileInfo.pFileNames = fileNames.c_str();
-        result = CheckAutoLayoutCompatibleFunc(&compileInfo);
+        result = CheckAutoLayoutCompatibleFunc(pCompiler, &compileInfo);
     }
     else
     {

--- a/tool/amdllpc.h
+++ b/tool/amdllpc.h
@@ -45,3 +45,8 @@ void DoAutoLayoutDesc(Llpc::ShaderStage                 shaderStage,
 bool CheckShaderInfoComptible(Llpc::PipelineShaderInfo*        pShaderInfo,
                               uint32_t                         autoLayoutUserDataNodeCount,
                               const Llpc::ResourceMappingNode* pAutoLayoutUserDataNodes);
+
+bool CheckPipelineStateCompatible(const Llpc::ICompiler*            pCompiler,
+                                  Llpc::GraphicsPipelineBuildInfo*  pPipelineInfo,
+                                  Llpc::GraphicsPipelineBuildInfo*  pAutoLayoutPipelineInfo,
+                                  Llpc::GfxIpVersion                gfxIp);


### PR DESCRIPTION
compare Fragment shader export formate between input pipleline info and auto layout pipeline info
TODO: assign proper color format for autolayout per game.
v2: avoid directly to call into FragColorExport, using llpc interface instead.
v3:
    1. renmae it to CovnertColorBufferFormatToExportFormat
    2. bump LLPC version, and add it in new version
    3. remove gfxip, it is a part of icompiler
    4. use ColorTarget instead of pPipelineInfo
    5. remove location
    6. use outputMask instead of shaderExportsAlpha
    7. add export format in llpc.h, and use it as return type.
v4:
    remove export format definition in llpc.h and add version control
v5: update coding style

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>