### PR TITLE
Allow for fast math flags in Matrix tests

### DIFF
--- a/test/shaderdb/OpExtInst_TestInverseMat4_lit.frag
+++ b/test/shaderdb/OpExtInst_TestInverseMat4_lit.frag
@@ -11,7 +11,7 @@ void main (void)
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call [4 x <4 x float>] (...) @llpc.call.matrix.inverse.a4v4f32([4 x <4 x float>] %
+; SHADERTEST: = call {{.*}}[4 x <4 x float>] (...) @llpc.call.matrix.inverse.a4v4f32([4 x <4 x float>] %
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestMatrixInverseDmat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMatrixInverseDmat_lit.frag
@@ -23,9 +23,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call [2 x <2 x double>] (...) @llpc.call.matrix.inverse.a2v2f64([2 x <2 x double>] %
-; SHADERTEST: = call [3 x <3 x double>] (...) @llpc.call.matrix.inverse.a3v3f64([3 x <3 x double>] %
-; SHADERTEST: = call [4 x <4 x double>] (...) @llpc.call.matrix.inverse.a4v4f64([4 x <4 x double>] %
+; SHADERTEST: = call {{.*}}[2 x <2 x double>] (...) @llpc.call.matrix.inverse.a2v2f64([2 x <2 x double>] %
+; SHADERTEST: = call {{.*}}[3 x <3 x double>] (...) @llpc.call.matrix.inverse.a3v3f64([3 x <3 x double>] %
+; SHADERTEST: = call {{.*}}[4 x <4 x double>] (...) @llpc.call.matrix.inverse.a4v4f64([4 x <4 x double>] %
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestMatrixInverseMat_lit.frag
+++ b/test/shaderdb/OpExtInst_TestMatrixInverseMat_lit.frag
@@ -23,9 +23,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call [2 x <2 x float>] (...) @llpc.call.matrix.inverse.a2v2f32([2 x <2 x float>] %
-; SHADERTEST: = call [3 x <3 x float>] (...) @llpc.call.matrix.inverse.a3v3f32([3 x <3 x float>] %
-; SHADERTEST: = call [4 x <4 x float>] (...) @llpc.call.matrix.inverse.a4v4f32([4 x <4 x float>] %
+; SHADERTEST: = call {{.*}}[2 x <2 x float>] (...) @llpc.call.matrix.inverse.a2v2f32([2 x <2 x float>] %
+; SHADERTEST: = call {{.*}}[3 x <3 x float>] (...) @llpc.call.matrix.inverse.a3v3f32([3 x <3 x float>] %
+; SHADERTEST: = call {{.*}}[4 x <4 x float>] (...) @llpc.call.matrix.inverse.a4v4f32([4 x <4 x float>] %
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpExtInst_TestinverseMat2-lit.frag
+++ b/test/shaderdb/OpExtInst_TestinverseMat2-lit.frag
@@ -11,7 +11,7 @@ void main (void)
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call [2 x <2 x float>] (...) @llpc.call.matrix.inverse.a2v2f32([2 x <2 x float>] %
+; SHADERTEST: = call {{.*}}[2 x <2 x float>] (...) @llpc.call.matrix.inverse.a2v2f32([2 x <2 x float>] %
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/test/shaderdb/OpMatrixTimesMatrix_TestDmat2xDmat2_lit.frag
+++ b/test/shaderdb/OpMatrixTimesMatrix_TestDmat2xDmat2_lit.frag
@@ -24,8 +24,8 @@ void main()
 ; SHADERTEST: [2 x <2 x double>] (...) @llpc.call.matrix.times.matrix.a2v2f64([2 x <2 x double>] %{{[^, ]*}}, [2 x <2 x double>] %{{[^, ]*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul double %{{[^, ]*}}, %{{[^, ]*}}
-; SHADERTEST: fadd double %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}double %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fadd {{.*}}double %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesMatrix_TestDmat4X3xDmat3X4_lit.frag
+++ b/test/shaderdb/OpMatrixTimesMatrix_TestDmat4X3xDmat3X4_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: [3 x <3 x double>] (...) @llpc.call.matrix.times.matrix.a3v3f64
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul double %{{[^, ]*}}, %{{[^, ]*}}
-; SHADERTEST: fadd double %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}double %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fadd {{.*}}double %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesMatrix_TestMat2X3xMat4X3_lit.frag
+++ b/test/shaderdb/OpMatrixTimesMatrix_TestMat2X3xMat4X3_lit.frag
@@ -23,8 +23,8 @@ void main()
 ; SHADERTEST: [4 x <3 x float>] (...) @llpc.call.matrix.times.matrix.a4v3f32
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul float %{{[^, ]*}}, %{{[^, ]*}}
-; SHADERTEST: fadd float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fadd {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesMatrix_TestMat2xMat2_lit.frag
+++ b/test/shaderdb/OpMatrixTimesMatrix_TestMat2xMat2_lit.frag
@@ -21,8 +21,8 @@ void main()
 ; SHADERTEST: [2 x <2 x float>] (...) @llpc.call.matrix.times.matrix.a2v2f32
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul float %{{.*}}, %{{[^, ]*}}
-; SHADERTEST: fadd float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}float %{{.*}}, %{{[^, ]*}}
+; SHADERTEST: fadd {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesMatrix_TestMat3xMat3_lit.frag
+++ b/test/shaderdb/OpMatrixTimesMatrix_TestMat3xMat3_lit.frag
@@ -24,8 +24,8 @@ void main()
 ; SHADERTEST: [3 x <3 x float>] (...) @llpc.call.matrix.times.matrix.a3v3f32
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul float %{{[^, ]*}}, %{{[^, ]*}}
-; SHADERTEST: fadd float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fadd {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesMatrix_TestMat4xMat4_lit.frag
+++ b/test/shaderdb/OpMatrixTimesMatrix_TestMat4xMat4_lit.frag
@@ -29,8 +29,8 @@ void main()
 ; SHADERTEST: [4 x <4 x float>] (...) @llpc.call.matrix.times.matrix.a4v4f32
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul float %{{[^, ]*}}, %{{[^, ]*}}
-; SHADERTEST: fadd float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fadd {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesScalar_TestDmat3xDouble_lit.frag
+++ b/test/shaderdb/OpMatrixTimesScalar_TestDmat3xDouble_lit.frag
@@ -20,10 +20,10 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call [3 x <3 x double>] (...) @llpc.call.matrix.times.scalar.a3v3f64
+; SHADERTEST: call {{.*}}[3 x <3 x double>] (...) @llpc.call.matrix.times.scalar.a3v3f64
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: fmul double %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}double %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpMatrixTimesScalar_TestDoublexDmat4_bit.frag
+++ b/test/shaderdb/OpMatrixTimesScalar_TestDoublexDmat4_bit.frag
@@ -20,7 +20,7 @@ void main()
 ; SHADERTEST: [4 x <4 x double>] (...) @llpc.call.matrix.times.scalar.a4v4f64
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: fmul double %{{[^, ]*}}, %{{[^, ]*}}
+; SHADERTEST: fmul {{.*}}double %{{[^, ]*}}, %{{[^, ]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/OpOuterProduct_TestDvec3xDvec2_lit.frag
+++ b/test/shaderdb/OpOuterProduct_TestDvec3xDvec2_lit.frag
@@ -18,7 +18,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call [2 x <3 x double>] (...) @llpc.call.outer.product.a2v3f64
+; SHADERTEST: call {{.*}}[2 x <3 x double>] (...) @llpc.call.outer.product.a2v3f64
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/gfx9/ExtShaderFloat16_TestMatrixFuncs_lit.frag
+++ b/test/shaderdb/gfx9/ExtShaderFloat16_TestMatrixFuncs_lit.frag
@@ -39,14 +39,14 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call [2 x <3 x half>] (...) @llpc.call.outer.product.a2v3f16(<3 x half> %{{.*}}, <2 x half> %{{.*}})
-; SHADERTEST: %{{[^, ]*}} = call [3 x <2 x half>] {{.*}}@llpc.call.transpose.matrix.a3v2f16([2 x <3 x half>] %{{[^, ]*}})
+; SHADERTEST: = call {{.*}}[2 x <3 x half>] (...) @llpc.call.outer.product.a2v3f16(<3 x half> %{{.*}}, <2 x half> %{{.*}})
+; SHADERTEST: %{{[^, ]*}} = call {{.*}}[3 x <2 x half>] {{.*}}@llpc.call.transpose.matrix.a3v2f16([2 x <3 x half>] %{{[^, ]*}})
 ; SHADERTEST: = call reassoc nnan nsz arcp contract half (...) @llpc.call.determinant.f16([2 x <2 x half>] %
 ; SHADERTEST: = call reassoc nnan nsz arcp contract half (...) @llpc.call.determinant.f16([3 x <3 x half>] %
 ; SHADERTEST: = call reassoc nnan nsz arcp contract half (...) @llpc.call.determinant.f16([4 x <4 x half>] %
-; SHADERTEST: = call [2 x <2 x half>] (...) @llpc.call.matrix.inverse.a2v2f16([2 x <2 x half>] %
-; SHADERTEST: = call [3 x <3 x half>] (...) @llpc.call.matrix.inverse.a3v3f16([3 x <3 x half>] %
-; SHADERTEST: = call [4 x <4 x half>] (...) @llpc.call.matrix.inverse.a4v4f16([4 x <4 x half>] %
+; SHADERTEST: = call {{.*}}[2 x <2 x half>] (...) @llpc.call.matrix.inverse.a2v2f16([2 x <2 x half>] %
+; SHADERTEST: = call {{.*}}[3 x <3 x half>] (...) @llpc.call.matrix.inverse.a3v3f16([3 x <3 x half>] %
+; SHADERTEST: = call {{.*}}[4 x <4 x half>] (...) @llpc.call.matrix.inverse.a4v4f16([4 x <4 x half>] %
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
There are upstream changes in flight for LLVM that will end up adding more fast
math flags to matrix operations (calls and operations). These changes allow for
checking with and without these extra flags.