### PR TITLE
spirv: atomic loads need at least monotonic ordering

### DIFF
--- a/test/shaderdb/OpAtomicLoad_TestStorageBlock_lit.spvas
+++ b/test/shaderdb/OpAtomicLoad_TestStorageBlock_lit.spvas
@@ -3,7 +3,7 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = load atomic i32, i32 addrspace({{.*}})* {{.*}} unordered
+; SHADERTEST: %{{.*}} = load atomic i32, i32 addrspace({{.*}})* {{.*}} monotonic
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST:  %{{.*}} = call float @llvm.amdgcn.raw.buffer.load.f32

--- a/test/shaderdb/OpAtomicStore_TestStorageBlock_lit.spvas
+++ b/test/shaderdb/OpAtomicStore_TestStorageBlock_lit.spvas
@@ -3,7 +3,7 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: store atomic i32 %{{.*}}, i32 addrspace({{.*}}7)* %{{.*}} unordered
+; SHADERTEST: store atomic i32 %{{.*}}, i32 addrspace({{.*}}7)* %{{.*}} monotonic
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float %{{.*}}, <4 x i32> %{{.*}}, i32 %{{.*}}, i32 0, i32 1)

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3041,8 +3041,7 @@ static AtomicOrdering transMemorySemantics(
         return AtomicOrdering::Monotonic;
     }
 
-    // Atomic RMW have to at least be monotically ordered.
-    return isAtomicRMW ? AtomicOrdering::Monotonic : AtomicOrdering::Unordered;
+    return AtomicOrdering::Monotonic;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Unordered atomic loads are (incorrectly) hoisted out of loops. This is
a partial fix towards a test case under discussion for forward progress.