### PR TITLE
patch: Refactor the building of hardware_mapping PAL metadata

### DIFF
--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -119,12 +119,8 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
     PipelineVsFsRegConfig* pConfig = reinterpret_cast<PipelineVsFsRegConfig*>(pAllocBuf);
     pConfig->Init();
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderVs,
-                            0,
-                            0,
-                            0,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::VsPs);
 
@@ -181,12 +177,10 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
     PipelineVsTsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsFsRegConfig*>(pAllocBuf);
     pConfig->Init();
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderLs,
-                            Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderVs,
-                            0,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderLs);
+    AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessEval, Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::Tess);
 
@@ -278,12 +272,9 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
     PipelineVsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsGsFsRegConfig*>(pAllocBuf);
     pConfig->Init();
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderEs,
-                            0,
-                            0,
-                            Util::Abi::HwShaderGs | Util::Abi::HwShaderVs,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderEs);
+    AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs | Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::Gs);
 
@@ -358,12 +349,11 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
     PipelineVsTsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsGsFsRegConfig*>(pAllocBuf);
     pConfig->Init();
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderLs,
-                            Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderEs,
-                            Util::Abi::HwShaderGs | Util::Abi::HwShaderVs,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderLs);
+    AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessEval, Util::Abi::HwShaderEs);
+    AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs | Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::GsTess);
 
@@ -473,12 +463,7 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
     PipelineCsRegConfig* pConfig = reinterpret_cast<PipelineCsRegConfig*>(pAllocBuf);
     pConfig->Init();
 
-    BuildApiHwShaderMapping(0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            Util::Abi::HwShaderCs);
+    AddApiHwShaderMapping(ShaderStageCompute, Util::Abi::HwShaderCs);
 
     SetPipelineType(Util::Abi::PipelineType::Cs);
 

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -154,12 +154,8 @@ Result ConfigBuilder::BuildPipelineVsFsRegConfig(
     PipelineVsFsRegConfig* pConfig = reinterpret_cast<PipelineVsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderVs,
-                            0,
-                            0,
-                            0,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::VsPs);
 
@@ -261,12 +257,10 @@ Result ConfigBuilder::BuildPipelineVsTsFsRegConfig(
     PipelineVsTsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderVs,
-                            0,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessEval, Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::Tess);
 
@@ -425,12 +419,9 @@ Result ConfigBuilder::BuildPipelineVsGsFsRegConfig(
     PipelineVsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsGsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderGs,
-                            0,
-                            0,
-                            Util::Abi::HwShaderGs | Util::Abi::HwShaderVs,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs | Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::Gs);
 
@@ -562,12 +553,11 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig(
     PipelineVsTsGsFsRegConfig* pConfig = reinterpret_cast<PipelineVsTsGsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderGs,
-                            Util::Abi::HwShaderGs | Util::Abi::HwShaderVs,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessEval, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs | Util::Abi::HwShaderVs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::GsTess);
 
@@ -768,12 +758,8 @@ Result ConfigBuilder::BuildPipelineNggVsFsRegConfig(
     PipelineNggVsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderGs,
-                            0,
-                            0,
-                            0,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::Ngg);
 
@@ -872,12 +858,10 @@ Result ConfigBuilder::BuildPipelineNggVsTsFsRegConfig(
     PipelineNggVsTsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsTsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderGs,
-                            0,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessEval, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::NggTess);
 
@@ -1018,12 +1002,9 @@ Result ConfigBuilder::BuildPipelineNggVsGsFsRegConfig(
     PipelineNggVsGsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsGsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderGs,
-                            0,
-                            0,
-                            Util::Abi::HwShaderGs,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::Ngg);
 
@@ -1131,12 +1112,11 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig(
     PipelineNggVsTsGsFsRegConfig* pConfig = reinterpret_cast<PipelineNggVsTsGsFsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderHs,
-                            Util::Abi::HwShaderGs,
-                            Util::Abi::HwShaderGs,
-                            Util::Abi::HwShaderPs,
-                            0);
+    AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
+    AddApiHwShaderMapping(ShaderStageTessEval, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs);
+    AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
 
     SetPipelineType(Util::Abi::PipelineType::NggTess);
 
@@ -1304,12 +1284,7 @@ Result ConfigBuilder::BuildPipelineCsRegConfig(
     PipelineCsRegConfig* pConfig = reinterpret_cast<PipelineCsRegConfig*>(pAllocBuf);
     pConfig->Init(gfxIp);
 
-    BuildApiHwShaderMapping(0,
-                            0,
-                            0,
-                            0,
-                            0,
-                            Util::Abi::HwShaderCs);
+    AddApiHwShaderMapping(ShaderStageCompute, Util::Abi::HwShaderCs);
 
     SetPipelineType(Util::Abi::PipelineType::Cs);
 

--- a/patch/llpcConfigBuilderBase.cpp
+++ b/patch/llpcConfigBuilderBase.cpp
@@ -79,40 +79,22 @@ ConfigBuilderBase::~ConfigBuilderBase()
 }
 
 // =====================================================================================================================
-// Builds metadata API_HW_SHADER_MAPPING_HI/LO.
-void ConfigBuilderBase::BuildApiHwShaderMapping(
-    uint32_t           vsHwShader,    // Hardware shader mapping for vertex shader
-    uint32_t           tcsHwShader,   // Hardware shader mapping for tessellation control shader
-    uint32_t           tesHwShader,   // Hardware shader mapping for tessellation evaluation shader
-    uint32_t           gsHwShader,    // Hardware shader mapping for geometry shader
-    uint32_t           fsHwShader,    // Hardware shader mapping for fragment shader
-    uint32_t           csHwShader)    // Hardware shader mapping for compute shader
+/// Adds the .shaders.$(apiStage).hardware_mapping node to the PAL metadata.
+///
+/// @param [in] apiStage The API shader stage
+/// @param [in] hwStages The HW stage(s) that the API shader is mapped to, as a combination of
+///                      @ref Util::Abi::HardwareStageFlagBits.
+void ConfigBuilderBase::AddApiHwShaderMapping(
+    ShaderStage apiStage,
+    uint32_t hwStages)
 {
-    uint32_t hwStageMappings[] =
+    auto hwMappingNode = GetApiShaderNode(apiStage)[Util::Abi::ShaderMetadataKey::HardwareMapping]
+                            .getArray(true);
+    for (uint32_t hwStage = 0; hwStage < uint32_t(Util::Abi::HardwareStage::Count); ++hwStage)
     {
-        // In ShaderStage order:
-        vsHwShader,
-        tcsHwShader,
-        tesHwShader,
-        gsHwShader,
-        fsHwShader,
-        csHwShader
-    };
-
-    for (uint32_t apiStage = 0; apiStage < ShaderStageNativeStageCount; ++apiStage)
-    {
-        uint32_t hwStageMapping = hwStageMappings[apiStage];
-        if (hwStageMapping != 0)
+        if (hwStages & (1 << hwStage))
         {
-            auto hwMappingNode = GetApiShaderNode(apiStage)[Util::Abi::ShaderMetadataKey::HardwareMapping]
-                                    .getArray(true);
-            for (uint32_t hwStage = 0; hwStage < uint32_t(Util::Abi::HardwareStage::Count); ++hwStage)
-            {
-                if ((hwStageMapping & (1 << hwStage)) != 0)
-                {
-                    hwMappingNode.push_back(m_document->getNode(HwStageNames[hwStage]));
-                }
-            }
+            hwMappingNode.push_back(m_document->getNode(HwStageNames[hwStage]));
         }
     }
 }

--- a/patch/llpcConfigBuilderBase.h
+++ b/patch/llpcConfigBuilderBase.h
@@ -47,13 +47,7 @@ public:
     void WritePalMetadata();
 
 protected:
-    // Builds metadata API_HW_SHADER_MAPPING_HI/LO.
-    void BuildApiHwShaderMapping(uint32_t           vsHwShader,
-                                 uint32_t           tcsHwShader,
-                                 uint32_t           tesHwShader,
-                                 uint32_t           gsHwShader,
-                                 uint32_t           fsHwShader,
-                                 uint32_t           csHwShader);
+    void AddApiHwShaderMapping(ShaderStage apiStage, uint32_t hwStages);
 
     void SetShaderHash(ShaderStage apiStage, ShaderHash hash);
     void SetNumAvailSgprs(Util::Abi::HardwareStage hwStage, uint32_t value);


### PR DESCRIPTION
Use a common method for adding the mapping of a single API shader stage.
This helps us to avoid relying on the previously magic argument ordering
and can thereby streamline future changes.