### PR TITLE
Disable lto optimisation for gcc builds

### DIFF
--- a/tool/Makefile.apillpctool
+++ b/tool/Makefile.apillpctool
@@ -89,7 +89,8 @@ LCXXOPTS +=                                \
 	    -Wno-error=delete-non-virtual-dtor \
 	    -Wno-sign-compare
     ifeq ($(USING_CLANG),)
-        LCXXOPTS += -Wno-error=maybe-uninitialized
+        LCXXOPTS += -Wno-error=maybe-uninitialized \
+                    -fno-lto
     else
         LCXXOPTS += -Wno-error=conditional-uninitialized
     endif


### PR DESCRIPTION
Using LTO has been observed to cause link time errors when using gcc - disabling
for non-clang (gcc) builds.