### PR TITLE
Refine GraphicsShaderCacheChecker's implementation for LLPC version 38

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -1132,9 +1132,9 @@ uint32_t GraphicsShaderCacheChecker::Check(
                                                                        m_pNonFragmentShaderCache,
                                                                        m_hNonFragmentEntry);
 #else
-        m_fragmentCacheEntryState = m_pCompiler->LookUpShaderCache(&nonFragmentHash,
-                                                                   &m_nonFragmentElf,
-                                                                   &m_hNonFragmentEntry);
+        m_nonFragmentCacheEntryState = m_pCompiler->LookUpShaderCache(&nonFragmentHash,
+                                                                      &m_nonFragmentElf,
+                                                                      &m_hNonFragmentEntry);
 #endif
     }
 
@@ -1188,7 +1188,7 @@ void GraphicsShaderCacheChecker::UpdateAndMerge(
                                      m_hNonFragmentEntry,
                                      ShaderCacheCount);
 #else
-        Compiler::UpdateShaderCache(result == Result::Success, &pipelineElf, m_hNonFragmentEntry);
+        m_pCompiler->UpdateShaderCache(result == Result::Success, &pipelineElf, m_hNonFragmentEntry);
 #endif
     }
 
@@ -1223,7 +1223,7 @@ void GraphicsShaderCacheChecker::UpdateAndMerge(
                                      m_hFragmentEntry,
                                      ShaderCacheCount);
 #else
-        Compiler::UpdateShaderCache(result == Result::Success, &pipelineElf, m_hFragmentEntry);
+        m_pCompiler->UpdateShaderCache(result == Result::Success, &pipelineElf, m_hFragmentEntry);
 #endif
     }
 
@@ -1256,8 +1256,8 @@ void GraphicsShaderCacheChecker::UpdateAndMerge(
                                      m_hNonFragmentEntry,
                                      ShaderCacheCount);
 #else
-        Compiler::UpdateShaderCache(result == Result::Success, &pipelineElf, m_hFragmentEntry);
-        Compiler::UpdateShaderCache(result == Result::Success, &pipelineElf, m_hNonFragmentEntry);
+        m_pCompiler->UpdateShaderCache(result == Result::Success, &pipelineElf, m_hFragmentEntry);
+        m_pCompiler->UpdateShaderCache(result == Result::Success, &pipelineElf, m_hNonFragmentEntry);
 #endif
     }
 }
@@ -2155,14 +2155,17 @@ void Compiler::UpdateShaderCache(
     const BinaryData*                pElfBin,           // [in] Pointer to shader data
     CacheEntryHandle                 hEntry)            // [in] Handle of the shader caches entry
 {
-    if (insert)
+    if (hEntry != nullptr)
     {
-        LLPC_ASSERT(pElfBin->codeSize > 0);
-        m_shaderCache->InsertShader(hEntry, pElfBin->pCode, pElfBin->codeSize);
-    }
-    else
-    {
-        m_shaderCache->ResetShader(hEntry);
+        if (insert)
+        {
+            LLPC_ASSERT(pElfBin->codeSize > 0);
+            m_shaderCache->InsertShader(hEntry, pElfBin->pCode, pElfBin->codeSize);
+        }
+        else
+        {
+            m_shaderCache->ResetShader(hEntry);
+        }
     }
 }
 #endif

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -183,7 +183,6 @@ private:
     ShaderCache* m_pNonFragmentShaderCache[ShaderCacheCount] = {};
     CacheEntryHandle m_hNonFragmentEntry[ShaderCacheCount] = {};
 #else
-    ShaderCache* m_pNonFragmentShaderCache = nullptr;
     CacheEntryHandle m_hNonFragmentEntry = {};
 #endif
     BinaryData m_nonFragmentElf = {};
@@ -193,7 +192,6 @@ private:
     ShaderCache* m_pFragmentShaderCache[ShaderCacheCount] = {};
     CacheEntryHandle m_hFragmentEntry[ShaderCacheCount] = {};
 #else
-    ShaderCache* m_pFragmentShaderCache = nullptr
     CacheEntryHandle m_hFragmentEntry = {};
 #endif
     BinaryData m_fragmentElf = {};
@@ -267,9 +265,9 @@ public:
                                        BinaryData*         pElfBin,
                                        CacheEntryHandle*   phEntry);
 
-    static void UpdateShaderCache(bool                insert,
-                                  const BinaryData*   pElfBin,
-                                  CacheEntryHandle    phEntry);
+    void UpdateShaderCache(bool                insert,
+                           const BinaryData*   pElfBin,
+                           CacheEntryHandle    phEntry);
 #endif
     static void BuildShaderCacheHash(Context*                                 pContext,
                                      uint32_t                                 stageMask,


### PR DESCRIPTION
1. Remove m_pNonFragmentShaderCache and m_pFragmentShaderCache since we don't output shader cache pointer after LLPC version 38.
2. Change function UpdateShaderCache to non-static, since this function dependent on the class member m_shaderCache