### PR TITLE
Add EsGsLdsSize metadata for pre-GFX9 GPU when GS on-chip is enabled

### DIFF
--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -843,6 +843,7 @@ Result ConfigBuilder::BuildEsRegConfig(
                       LDS_SIZE__CI__VI,
                       (calcFactor.gsOnChipLdsSize >>
                        pContext->GetGpuProperty()->ldsSizeDwordGranularityShift));
+        SetEsGsLdsSize(calcFactor.esGsLdsSize * 4);
     }
 
     uint32_t vgprCompCnt = 0;


### PR DESCRIPTION
This metadata info is present on GFX9 and is useful for us to get the
usage info of ES-GS ring size. However, this metadata is missing for
pre-GFX9 GPU.