### PR TITLE
Fix issue with unused variable under some guarded conditions

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -1107,7 +1107,9 @@ uint32_t GraphicsShaderCacheChecker::Check(
         }
     }
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
     auto pPipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo());
+#endif
     if (stageMask & ShaderStageToMask(ShaderStageFragment))
     {
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38


### PR DESCRIPTION
Guarded code causing an unused variable definition error. Fix by adding the same
guard to the def of the variable as for the use.