### PR TITLE
llpc: refactor ShaderModuleData structure

### DIFF
--- a/context/llpcComputeContext.cpp
+++ b/context/llpcComputeContext.cpp
@@ -123,7 +123,7 @@ uint32_t ComputeContext::GetShaderWaveSize(
         const ShaderModuleData* pModuleData =
             reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
 
-        if ((pModuleData != nullptr) && pModuleData->moduleInfo.useSubgroupSize
+        if ((pModuleData != nullptr) && pModuleData->usage.useSubgroupSize
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
          && (m_pPipelineInfo->cs.options.allowVaryWaveSize == false)
 #endif

--- a/context/llpcGraphicsContext.cpp
+++ b/context/llpcGraphicsContext.cpp
@@ -1478,7 +1478,7 @@ uint32_t GraphicsContext::GetShaderWaveSize(
             const ShaderModuleData* pModuleData =
                 reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
 
-            if ((pModuleData != nullptr) && pModuleData->moduleInfo.useSubgroupSize
+            if ((pModuleData != nullptr) && pModuleData->usage.useSubgroupSize
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 31
              && (pShaderInfo->options.allowVaryWaveSize == false)
 #endif

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -63,23 +63,6 @@ enum class DescriptorType : uint32_t
     SubpassInput,         // Subpass input
 };
 
-// Enumerates basic type of vertex input.
-enum class BasicType : uint32_t
-{
-    Unknown = 0,          // Unknown
-    Float,                // Float
-    Double,               // Double
-    Int,                  // Signed integer
-    Uint,                 // Unsigned integer
-    Int64,                // 64-bit signed integer
-    Uint64,               // 64-bit unsigned integer
-    Float16,              // 16-bit floating-point
-    Int16,                // 16-bit signed integer
-    Uint16,               // 16-bit unsigned integer
-    Int8,                 // 8-bit signed integer
-    Uint8,                // 8-bit unsigned integer
-};
-
 // Represents floating-point control setting.
 struct FloatControl
 {

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -239,16 +239,76 @@ struct ShaderModuleBuildInfo
 #endif
 };
 
-/// Represents the header part of LLPC shader module data
-struct ShaderModuleDataHeader
+/// Represents the base data type
+enum class BasicType : uint32_t
 {
-    uint32_t hash[4];       // Shader hash code
+    Unknown = 0,          ///< Unknown
+    Float,                ///< Float
+    Double,               ///< Double
+    Int,                  ///< Signed integer
+    Uint,                 ///< Unsigned integer
+    Int64,                ///< 64-bit signed integer
+    Uint64,               ///< 64-bit unsigned integer
+    Float16,              ///< 16-bit floating-point
+    Int16,                ///< 16-bit signed integer
+    Uint16,               ///< 16-bit unsigned integer
+    Int8,                 ///< 8-bit signed integer
+    Uint8,                ///< 8-bit unsigned integer
+};
+
+/// Enumerates types of shader binary.
+enum class BinaryType : uint32_t
+{
+    Unknown = 0,  ///< Invalid type
+    Spirv,        ///< SPIR-V binary
+    LlvmBc,       ///< LLVM bitcode
+    MultiLlvmBc,  ///< Multiple LLVM bitcode
+    Elf,          ///< ELF
+};
+
+/// Represents the information of one shader entry in ShaderModuleExtraData
+struct ShaderModuleEntryData
+{
+    ShaderStage stage;              ///< Shader stage
+    void*       pShaderEntry;       ///< Private shader module entry info
+};
+
+/// Represents usage info of a shader module
+struct ShaderModuleUsage
+{
+    bool                  enableVarPtrStorageBuf;  ///< Whether to enable "VariablePointerStorageBuffer" capability
+    bool                  enableVarPtr;            ///< Whether to enable "VariablePointer" capability
+    bool                  useSubgroupSize;         ///< Whether gl_SubgroupSize is used
+    bool                  useHelpInvocation;       ///< Whether fragment shader has helper-invocation for subgroup
+    bool                  useSpecConstant;         ///< Whether specializaton constant is used
+    bool                  keepUnusedFunctions;     ///< Whether to keep unused function
+};
+
+/// Represents common part of shader module data
+struct ShaderModuleData
+{
+    uint32_t         hash[4];       ///< Shader hash code
+    BinaryType       binType;       ///< Shader binary type
+    BinaryData       binCode;       ///< Shader binary data
+    uint32_t         cacheHash[4];  ///< Hash code for calculate pipeline cache key
+    ShaderModuleUsage usage;        ///< Usage info of a shader module
+};
+
+/// Represents extended output of building a shader module (taking extra data info)
+struct ShaderModuleDataEx
+{
+    ShaderModuleData        common;        ///< Shader module common data
+    struct
+    {
+        uint32_t              entryCount;              ///< Shader entry count in the module
+        ShaderModuleEntryData entryDatas[1];           ///< Array of all shader entries in this module
+    } extra;                              ///< Represents extra part of shader module data
 };
 
 /// Represents output of building a shader module.
 struct ShaderModuleBuildOut
 {
-    void*                pModuleData;       ///< Output shader module data (opaque)
+    ShaderModuleData*   pModuleData;       ///< Output shader module data (opaque)
 };
 
 /// Represents the options for pipeline dump.

--- a/util/llpcPipelineDumper.cpp
+++ b/util/llpcPipelineDumper.cpp
@@ -78,8 +78,7 @@ std::ostream& operator<<(std::ostream& out, WaveBreakSize           waveBreakSiz
 
 template std::ostream& operator<<(std::ostream& out, ElfReader<Elf64>& reader);
 template raw_ostream& operator<<(raw_ostream& out, ElfReader<Elf64>& reader);
-constexpr size_t ShaderModuleCacheHashOffset =
-    offsetof(ShaderModuleData, moduleInfo) + offsetof(ShaderModuleInfo, cacheHash);
+constexpr size_t ShaderModuleCacheHashOffset = offsetof(ShaderModuleData, cacheHash);
 
 // =====================================================================================================================
 // Represents LLVM based mutex.
@@ -204,9 +203,8 @@ void VKAPI_CALL IPipelineDumper::DumpPipelineExtraInfo(
 uint64_t VKAPI_CALL IPipelineDumper::GetShaderHash(
     const void* pModuleData)   // [in] Pointer to the shader module data
 {
-    const ShaderModuleDataHeader* pModule =
-            reinterpret_cast<const ShaderModuleDataHeader*>(pModuleData);
-    return MetroHash::Compact64(reinterpret_cast<const MetroHash::Hash*>(&pModule->hash));
+    const ShaderModuleData* pShaderModuleData = reinterpret_cast<const ShaderModuleData*>(pModuleData);
+    return MetroHash::Compact64(reinterpret_cast<const MetroHash::Hash*>(&pShaderModuleData->hash));
 }
 
 // =====================================================================================================================
@@ -526,7 +524,7 @@ void PipelineDumper::DumpPipelineShaderInfo(
     const PipelineShaderInfo* pShaderInfo, // [in] Shader info of specified shader stage
     std::ostream&             dumpFile)    // [out] dump file
 {
-    const ShaderModuleDataHeader* pModuleData = reinterpret_cast<const ShaderModuleDataHeader*>(pShaderInfo->pModuleData);
+    const ShaderModuleData* pModuleData = reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
     auto pModuleHash = reinterpret_cast<const MetroHash::Hash*>(&pModuleData->hash[0]);
 
     // Output shader binary file
@@ -1117,8 +1115,7 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
 {
     if (pShaderInfo->pModuleData)
     {
-        const ShaderModuleDataHeader* pModuleData =
-            reinterpret_cast<const ShaderModuleDataHeader*>(pShaderInfo->pModuleData);
+        const ShaderModuleData* pModuleData = reinterpret_cast<const ShaderModuleData*>(pShaderInfo->pModuleData);
         pHasher->Update(stage);
         if (isCacheHash)
         {

--- a/util/llpcShaderModuleHelper.h
+++ b/util/llpcShaderModuleHelper.h
@@ -36,15 +36,6 @@
 namespace Llpc
 {
 
-// Enumerates types of shader binary.
-enum class BinaryType : uint32_t
-{
-    Unknown = 0,  // Invalid type
-    Spirv,        // SPIR-V binary
-    LlvmBc,       // LLVM bitcode
-    MultiLlvmBc,  // Multiple LLVM bitcode
-    Elf,          // ELF
-};
 
 // Represents the special header of SPIR-V token stream (the first DWORD).
 struct SpirvHeader
@@ -59,7 +50,6 @@ struct SpirvHeader
 // Represents the information of one shader entry in ShaderModuleData
 struct ShaderModuleEntry
 {
-    ShaderStage stage;              // Shader stage
     uint32_t    entryNameHash[4];   // Hash code of entry name
     uint32_t    entryOffset;        // Byte offset of the entry data in the binCode of ShaderModuleData
     uint32_t    entrySize;          // Byte size of the entry data
@@ -76,29 +66,6 @@ struct ShaderEntryName
     const char* pName;             // Entry name
 };
 
-// Represents the information of a shader module
-struct ShaderModuleInfo
-{
-    uint32_t              cacheHash[4];            // hash code for calculate pipeline cache key
-    uint32_t              debugInfoSize;           // Byte size of debug instructions
-    bool                  enableVarPtrStorageBuf;  // Whether to enable "VariablePointerStorageBuffer" capability
-    bool                  enableVarPtr;            // Whether to enable "VariablePointer" capability
-    bool                  useSubgroupSize;         // Whether gl_SubgroupSize is used
-    bool                  useHelpInvocation;       // Whether fragment shader has helper-invocation for subgroup
-    bool                  useSpecConstant;         // Whether specializaton constant is used
-    bool                  keepUnusedFunctions;     // Whether to keep unused function
-    uint32_t              entryCount;              // Entry count in the module
-    ShaderModuleEntry     entries[1];              // Array of all entries
-};
-
-// Represents output data of building a shader module.
-struct ShaderModuleData : public ShaderModuleDataHeader
-{
-    BinaryType       binType;                 // Shader binary type
-    BinaryData       binCode;                 // Shader binary data
-    ShaderModuleInfo moduleInfo;              // Shader module info
-};
-
 // =====================================================================================================================
 // Represents LLPC shader module helper class
 class ShaderModuleHelper
@@ -106,8 +73,9 @@ class ShaderModuleHelper
 public:
     static Result CollectInfoFromSpirvBinary(
         const BinaryData*             pSpvBinCode,
-        ShaderModuleInfo*             pShaderModuleInfo,
-        std::vector<ShaderEntryName>& shaderEntryNames);
+        ShaderModuleUsage*            pShaderModuleUsage,
+        std::vector<ShaderEntryName>& shaderEntryNames,
+        uint32_t*                     pDebugInfoSize);
 
     static void TrimSpirvDebugInfo(
         const BinaryData* pSpvBin,


### PR DESCRIPTION
No functionality changes.
This change is to easily export resource usage and fragnment shader output type.
The following patch will do these.

v2:
  1.New ShaderModuleEntry includes public and private parts.
  2.Rename struct OptShaderModuleData to ShaderModuleOptData.
  3.Rename struct ShaderModuleCaps to ShaderModuleAttribute.
v3:
  Fix Jenkins error.
v4:
  1.Improve coding style.
  2.Always evaluate entryCount for counting offset of data points,
     especially for data got from cache. Which fixes remaining Jenkins issue.
v5:
     make ShaderModuleExtraData inline in ShaderModuleDataEx.

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>