### PR TITLE
Clean up unused codes for SPIR-V input

### DIFF
--- a/translator/include/LLVMSPIRVLib.h
+++ b/translator/include/LLVMSPIRVLib.h
@@ -85,24 +85,6 @@ typedef std::map<uint32_t, SPIRVSpecConstEntry> SPIRVSpecConstMap;
 /// \brief Check if a string contains SPIR-V binary.
 bool IsSPIRVBinary(std::string &Img);
 
-#ifdef _SPIRV_SUPPORT_TEXT_FMT
-/// \brief Convert SPIR-V between binary and internal textual formats.
-/// This function is not thread safe and should not be used in multi-thread
-/// applications unless guarded by a critical section.
-/// \returns true if succeeds.
-bool ConvertSPIRV(std::istream &IS, llvm::raw_ostream &OS,
-    std::string &ErrMsg, bool FromText, bool ToText);
-
-/// \brief Convert SPIR-V between binary and internel text formats.
-/// This function is not thread safe and should not be used in multi-thread
-/// applications unless guarded by a critical section.
-bool ConvertSPIRV(std::string &Input, std::string &Out,
-    std::string &ErrMsg, bool ToText);
-
-/// \brief Check if a string contains SPIR-V in internal text format.
-bool IsSPIRVText(std::string &Img);
-#endif
-
 } // End namespace SPIRV
 
 namespace Llpc {

--- a/translator/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/translator/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -130,17 +130,13 @@ void SPIRVLowerConstExpr::visit(Module *M) {
         auto Op = II->getOperand(OI);
 
         if (auto CE = dyn_cast<ConstantExpr>(Op)) {
-          SPIRVDBG(dbgs() << "[lowerConstantExpressions] " << *CE;)
           auto ReplInst = CE->getAsInstruction();
           auto InsPoint = II->getParent() == &*FBegin ? II : &FBegin->back();
           ReplInst->insertBefore(InsPoint);
-          SPIRVDBG(dbgs() << " -> " << *ReplInst << '\n';)
           WorkList.push_front(ReplInst);
           std::vector<Instruction *> Users;
           // Do not replace use during iteration of use. Do it in another loop
           for (auto U : CE->users()) {
-            SPIRVDBG(dbgs()
-                         << "[lowerConstantExpressions] Use: " << *U << '\n';)
             if (auto InstUser = dyn_cast<Instruction>(U)) {
               // Only replace users in scope of current function
               if (InstUser->getParent()->getParent() == &I)

--- a/translator/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/translator/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -158,7 +158,6 @@ bool SPIRVRegularizeLLVM::regularize() {
   std::string Err;
   raw_string_ostream ErrorOS(Err);
   if (verifyModule(*M, &ErrorOS)) {
-    SPIRVDBG(errs() << "Fails to verify module: " << ErrorOS.str();)
     return false;
   }
 

--- a/translator/lib/SPIRV/SPIRVUtil.cpp
+++ b/translator/lib/SPIRV/SPIRVUtil.cpp
@@ -68,19 +68,6 @@
 
 namespace SPIRV {
 
-#ifdef _SPIRV_SUPPORT_TEXT_FMT
-cl::opt<bool, true>
-    UseTextFormat("spirv-text",
-                  cl::desc("Use text format for SPIR-V for debugging purpose"),
-                  cl::location(SPIRVUseTextFormat));
-#endif
-
-#ifdef _SPIRVDBG
-cl::opt<bool, true> EnableDbgOutput("spirv-debug",
-                                    cl::desc("Enable SPIR-V debug output"),
-                                    cl::location(SPIRVDbgEnable));
-#endif
-
 void addFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr) {
   Call->addAttribute(AttributeList::FunctionIndex, Attr);
 }
@@ -104,7 +91,6 @@ void saveLLVMModule(Module *M, const std::string &OutputFile) {
   std::error_code EC;
   ToolOutputFile Out(OutputFile.c_str(), EC, sys::fs::F_None);
   if (EC) {
-    SPIRVDBG(errs() << "Fails to open output file: " << EC.message();)
     return;
   }
 

--- a/translator/lib/SPIRV/libSPIRV/SPIRVBasicBlock.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVBasicBlock.cpp
@@ -67,13 +67,7 @@ SPIRVInstruction *SPIRVBasicBlock::addInstruction(SPIRVInstruction *I) {
   return I;
 }
 
-void SPIRVBasicBlock::encodeChildren(spv_ostream &O) const {
-  O << SPIRVNL();
-  for (size_t I = 0, E = InstVec.size(); I != E; ++I)
-    O << *InstVec[I];
-}
-
-_SPIRV_IMP_ENCDEC1(SPIRVBasicBlock, Id)
+_SPIRV_IMP_DECODE1(SPIRVBasicBlock, Id)
 
 void SPIRVBasicBlock::setScope(SPIRVEntry *Scope) {
   assert(Scope && Scope->getOpCode() == OpFunction && "Invalid scope");

--- a/translator/lib/SPIRV/libSPIRV/SPIRVBasicBlock.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVBasicBlock.h
@@ -88,8 +88,7 @@ public:
   }
 
   void setAttr() { setHasNoType(); }
-  _SPIRV_DCL_ENCDEC
-  void encodeChildren(spv_ostream &) const override;
+  _SPIRV_DCL_DECODE
   void validate() const override {
     SPIRVValue::validate();
     assert(ParentF && "Invalid parent function");

--- a/translator/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
@@ -41,6 +41,5 @@
 
 using namespace SPIRV;
 
-bool SPIRV::SPIRVDbgEnable = false;
 bool SPIRV::SPIRVDbgAssertOnError = true;
 bool SPIRV::SPIRVDbgErrorMsgIncludesSourceInfo = true;

--- a/translator/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -51,14 +51,6 @@ namespace SPIRV {
 #define _SPIRVDBG
 #ifdef _SPIRVDBG
 
-#define SPIRVDBG(x)                                                            \
-  if (SPIRVDbgEnable) {                                                        \
-    x;                                                                         \
-  }
-
-// Enable debug output.
-extern bool SPIRVDbgEnable;
-
 // Include source file and line number in error message.
 extern bool SPIRVDbgErrorMsgIncludesSourceInfo;
 

--- a/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -112,13 +112,9 @@ public:
   iterator insert(const value_type& Dec) {
     auto ER = BaseType::equal_range(Dec);
     for (auto I = ER.first, E = ER.second; I != E; ++I) {
-      SPIRVDBG(spvdbgs() << "[compare decorate] " << *Dec << " vs " << **I
-                         << " : ");
       if (**I == *Dec)
         return I;
-      SPIRVDBG(spvdbgs() << " diff\n");
     }
-    SPIRVDBG(spvdbgs() << "[add decorate] " << *Dec << '\n');
     return BaseType::insert(Dec);
   }
 };
@@ -136,7 +132,7 @@ public:
   // Incomplete constructor
   SPIRVDecorate() : SPIRVDecorateGeneric(OC) {}
 
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void setWordCount(SPIRVWord) override;
   void validate() const override {
     SPIRVDecorateGeneric::validate();
@@ -165,31 +161,9 @@ public:
     return (SPIRVLinkageTypeKind)Literals.back();
   }
 
-  static void encodeLiterals(SPIRVEncoder &Encoder,
-                             const std::vector<SPIRVWord> &Literals) {
-#ifdef _SPIRV_SUPPORT_TEXT_FMT
-    if (SPIRVUseTextFormat) {
-      Encoder << getString(Literals.cbegin(), Literals.cend() - 1);
-      Encoder.OS << " ";
-      Encoder << (SPIRVLinkageTypeKind)Literals.back();
-    } else
-#endif
-      Encoder << Literals;
-  }
-
   static void decodeLiterals(SPIRVDecoder &Decoder,
                              std::vector<SPIRVWord> &Literals) {
-#ifdef _SPIRV_SUPPORT_TEXT_FMT
-    if (SPIRVUseTextFormat) {
-      std::string Name;
-      Decoder >> Name;
-      SPIRVLinkageTypeKind Kind;
-      Decoder >> Kind;
-      std::copy_n(getVec(Name).begin(), Literals.size() - 1, Literals.begin());
-      Literals.back() = Kind;
-    } else
-#endif
-      Decoder >> Literals;
+    Decoder >> Literals;
   }
 };
 
@@ -219,7 +193,7 @@ public:
     return std::make_pair(MemberNumber, Dec);
   }
 
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void setWordCount(SPIRVWord) override;
 
   void validate() const override {
@@ -244,8 +218,7 @@ public:
   };
   // Incomplete constructor
   SPIRVDecorationGroup() : SPIRVEntry(OC) {}
-  void encodeAll(spv_ostream &O) const override;
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   // Move the given decorates to the decoration group
   void takeDecorates(SPIRVDecorateSet &Decs) {
     for (auto &I:Decs) {
@@ -304,7 +277,7 @@ public:
     Targets.resize(WC - FixedWC);
   }
   virtual void decorateTargets() override;
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 };
 
 class SPIRVGroupMemberDecorate : public SPIRVGroupDecorateGeneric {
@@ -321,7 +294,7 @@ public:
     SPIRVEntryNoIdGeneric::setWordCount(WC);
   }
   virtual void decorateTargets() override;
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 protected:
   std::vector<SPIRVWord> MemberNumbers;
 };

--- a/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -65,71 +65,45 @@ class SPIRVLine;
 class SPIRVString;
 class SPIRVExtInst;
 
-// Add declaration of encode/decode functions to a class.
+// Add declaration of decode functions to a class.
 // Used inside class definition.
-#define _SPIRV_DCL_ENCDEC                                                      \
-  void encode(spv_ostream &O) const override;                                  \
+#define _SPIRV_DCL_DECODE                                                      \
   void decode(std::istream &I) override;
 
 #define _REQ_SPIRV_VER(Version)                                                \
   SPIRVWord getRequiredSPIRVVersion() const override { return Version; }
 
-// Add implementation of encode/decode functions to a class.
+// Add implementation of decode functions to a class.
 // Used out side of class definition.
-#define _SPIRV_IMP_ENCDEC0(Ty)                                                 \
-  void Ty::encode(spv_ostream &O) const {}                                     \
+#define _SPIRV_IMP_DECODE0(Ty)                                                 \
   void Ty::decode(std::istream &I) {}
-#define _SPIRV_IMP_ENCDEC1(Ty, x)                                              \
-  void Ty::encode(spv_ostream &O) const { getEncoder(O) << (x); }              \
+#define _SPIRV_IMP_DECODE1(Ty, x)                                              \
   void Ty::decode(std::istream &I) { getDecoder(I) >> (x); }
 #define _SPIRV_IMP_ENCDEC2(Ty, x, y)                                           \
-  void Ty::encode(spv_ostream &O) const { getEncoder(O) << (x) << (y); }       \
   void Ty::decode(std::istream &I) { getDecoder(I) >> (x) >> (y); }
-#define _SPIRV_IMP_ENCDEC3(Ty, x, y, z)                                        \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z);                                        \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE3(Ty, x, y, z)                                        \
   void Ty::decode(std::istream &I) { getDecoder(I) >> (x) >> (y) >> (z); }
-#define _SPIRV_IMP_ENCDEC4(Ty, x, y, z, u)                                     \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z) << (u);                                 \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE4(Ty, x, y, z, u)                                     \
   void Ty::decode(std::istream &I) {                                           \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u);                                 \
   }
-#define _SPIRV_IMP_ENCDEC5(Ty, x, y, z, u, v)                                  \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v);                          \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE5(Ty, x, y, z, u, v)                                  \
   void Ty::decode(std::istream &I) {                                           \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v);                          \
   }
-#define _SPIRV_IMP_ENCDEC6(Ty, x, y, z, u, v, w)                               \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w);                   \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE6(Ty, x, y, z, u, v, w)                               \
   void Ty::decode(std::istream &I) {                                           \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w);                   \
   }
-#define _SPIRV_IMP_ENCDEC7(Ty, x, y, z, u, v, w, r)                            \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w) << (r);            \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE7(Ty, x, y, z, u, v, w, r)                            \
   void Ty::decode(std::istream &I) {                                           \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w) >> (r);            \
   }
-#define _SPIRV_IMP_ENCDEC8(Ty, x, y, z, u, v, w, r, s)                         \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w) << (r) << (s);     \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE8(Ty, x, y, z, u, v, w, r, s)                         \
   void Ty::decode(std::istream &I) {                                           \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w) >> (r) >> (s);     \
   }
-#define _SPIRV_IMP_ENCDEC9(Ty, x, y, z, u, v, w, r, s, t)                      \
-  void Ty::encode(spv_ostream &O) const {                                      \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w) << (r) << (s)      \
-                  << (t);                                                      \
-  }                                                                            \
+#define _SPIRV_IMP_DECODE9(Ty, x, y, z, u, v, w, r, s, t)                      \
   void Ty::decode(std::istream &I) {                                           \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w) >> (r) >> (s) >>   \
         (t);                                                                   \
@@ -137,60 +111,35 @@ class SPIRVExtInst;
 
 // Add definition of encode/decode functions to a class.
 // Used inside class definition.
-#define _SPIRV_DEF_ENCDEC0                                                     \
-  void encode(spv_ostream &O) const override {}                                \
+#define _SPIRV_DEF_DECODE0                                                     \
   void decode(std::istream &I) override {}
-#define _SPIRV_DEF_ENCDEC1(x)                                                  \
-  void encode(spv_ostream &O) const override { getEncoder(O) << (x); }         \
+#define _SPIRV_DEF_DECODE1(x)                                                  \
   void decode(std::istream &I) override { getDecoder(I) >> (x); }
-#define _SPIRV_DEF_ENCDEC2(x, y)                                               \
-  void encode(spv_ostream &O) const override { getEncoder(O) << (x) << (y); }  \
+#define _SPIRV_DEF_DECODE2(x, y)                                               \
   void decode(std::istream &I) override { getDecoder(I) >> (x) >> (y); }
-#define _SPIRV_DEF_ENCDEC3(x, y, z)                                            \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z);                                        \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE3(x, y, z)                                            \
   void decode(std::istream &I) override { getDecoder(I) >> (x) >> (y) >> (z); }
-#define _SPIRV_DEF_ENCDEC4(x, y, z, u)                                         \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z) << (u);                                 \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE4(x, y, z, u)                                         \
   void decode(std::istream &I) override {                                      \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u);                                 \
   }
-#define _SPIRV_DEF_ENCDEC5(x, y, z, u, v)                                      \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v);                          \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE5(x, y, z, u, v)                                      \
   void decode(std::istream &I) override {                                      \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v);                          \
   }
-#define _SPIRV_DEF_ENCDEC6(x, y, z, u, v, w)                                   \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w);                   \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE6(x, y, z, u, v, w)                                   \
   void decode(std::istream &I) override {                                      \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w);                   \
   }
-#define _SPIRV_DEF_ENCDEC7(x, y, z, u, v, w, r)                                \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w) << (r);            \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE7(x, y, z, u, v, w, r)                                \
   void decode(std::istream &I) override {                                      \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w) >> (r);            \
   }
-#define _SPIRV_DEF_ENCDEC8(x, y, z, u, v, w, r, s)                             \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w) << (r) << (s);     \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE8(x, y, z, u, v, w, r, s)                             \
   void decode(std::istream &I) override {                                      \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w) >> (r) >> (s);     \
   }
-#define _SPIRV_DEF_ENCDEC9(x, y, z, u, v, w, r, s, t)                          \
-  void encode(spv_ostream &O) const override {                                 \
-    getEncoder(O) << (x) << (y) << (z) << (u) << (v) << (w) << (r) << (s)      \
-                  << (t);                                                      \
-  }                                                                            \
+#define _SPIRV_DEF_DECODE9(x, y, z, u, v, w, r, s, t)                          \
   void decode(std::istream &I) override {                                      \
     getDecoder(I) >> (x) >> (y) >> (z) >> (u) >> (v) >> (w) >> (r) >> (s) >>   \
         (t);                                                                   \
@@ -219,7 +168,7 @@ class SPIRVExtInst;
 ///    the table of the factory function SPIRVEntry::create().
 /// 2. Inherit from proper SPIRV class such as SPIRVType, SPIRVValue,
 ///    SPIRVInstruction, etc.
-/// 3. Implement virtual function encode(), decode(), validate().
+/// 3. Implement virtual function decode(), validate().
 /// 4. If the object has variable size, implement virtual function
 ///    setWordCount().
 /// 5. If the class has special attributes, e.g. having no id, or having no
@@ -277,7 +226,6 @@ public:
   std::vector<SPIRVType *> getValueTypes(const std::vector<SPIRVId> &) const;
 
   virtual SPIRVDecoder getDecoder(std::istream &);
-  virtual SPIRVEncoder getEncoder(spv_ostream &) const;
   SPIRVErrorLog &getErrorLog() const;
   SPIRVId getId() const {
     assert(hasId());
@@ -349,15 +297,7 @@ public:
   static std::unique_ptr<SPIRVExtInst> createUnique(SPIRVExtInstSetKind Set,
                                                     unsigned ExtOp);
 
-  friend spv_ostream &operator<<(spv_ostream &O, const SPIRVEntry &E);
   friend std::istream &operator>>(std::istream &I, SPIRVEntry &E);
-  virtual void encodeLine(spv_ostream &O) const;
-  virtual void encodeAll(spv_ostream &O) const;
-  virtual void encodeName(spv_ostream &O) const;
-  virtual void encodeChildren(spv_ostream &O) const;
-  virtual void encodeDecorate(spv_ostream &O) const;
-  virtual void encodeWordCountOpCode(spv_ostream &O) const;
-  virtual void encode(spv_ostream &O) const;
   virtual void decode(std::istream &I);
 
   friend class SPIRVDecoder;
@@ -436,7 +376,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC0
+  _SPIRV_DEF_DECODE0
   void validate() const override { assert(isValidId(SPIRVEntry::OpCode)); }
 };
 
@@ -478,7 +418,7 @@ public:
   std::pair<const SPIRVWord *, size_t> getInOuts() const {
     return { InOuts.data(), InOuts.size() };
   }
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 protected:
   SPIRVExecutionModelKind ExecModel;
   std::string Name;
@@ -493,7 +433,7 @@ public:
   SPIRVName() {}
 
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
 
   std::string Str;
@@ -513,7 +453,7 @@ public:
   SPIRVMemberName() : MemberNumber(SPIRVWORD_MAX) {}
 
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
   SPIRVWord MemberNumber;
   std::string Str;
@@ -528,7 +468,7 @@ public:
       : SPIRVEntry(M, FixedWC + getSizeInWords(TheStr), OC, TheId),
         Str(TheStr) {}
   SPIRVString() : SPIRVEntry(OC) {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   const std::string &getStr() const { return Str; }
 
 protected:
@@ -578,7 +518,7 @@ public:
   }
 
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
   SPIRVId FileName;
   SPIRVWord Line;
@@ -641,7 +581,7 @@ public:
     WordLiterals[0] |= EM->WordLiterals[0];
   }
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   SPIRVExecutionModeKind ExecMode;
   std::vector<SPIRVWord> WordLiterals;
 };
@@ -685,7 +625,7 @@ public:
   SPIRVExtInstImport() : SPIRVEntry(OC) {}
 
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
 
   std::string Str;
@@ -695,7 +635,7 @@ class SPIRVMemoryModel : public SPIRVEntryNoId<OpMemoryModel> {
 public:
   SPIRVMemoryModel(SPIRVModule *M) : SPIRVEntryNoId(M, 3) {}
   SPIRVMemoryModel() {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
 };
 
@@ -703,7 +643,7 @@ class SPIRVSource : public SPIRVEntryNoId<OpSource> {
 public:
   SPIRVSource(SPIRVModule *M) : SPIRVEntryNoId(M, 3) {}
   SPIRVSource() {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 private:
   SPIRVId File;
   std::string Source;
@@ -713,7 +653,7 @@ class SPIRVSourceContinued : public SPIRVEntryNoId<OpSourceContinued> {
 public:
   SPIRVSourceContinued(SPIRVModule *M, const std::string &SS);
   SPIRVSourceContinued() {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 private:
   std::string Str;
 };
@@ -722,7 +662,7 @@ class SPIRVSourceExtension : public SPIRVEntryNoId<OpSourceExtension> {
 public:
   SPIRVSourceExtension(SPIRVModule *M, const std::string &SS);
   SPIRVSourceExtension() {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 private:
   std::string S;
 };
@@ -731,7 +671,7 @@ class SPIRVExtension : public SPIRVEntryNoId<OpExtension> {
 public:
   SPIRVExtension(SPIRVModule *M, const std::string &SS);
   SPIRVExtension() {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 private:
   std::string S;
 };
@@ -740,7 +680,7 @@ class SPIRVCapability : public SPIRVEntryNoId<OpCapability> {
 public:
   SPIRVCapability(SPIRVModule *M, SPIRVCapabilityKind K);
   SPIRVCapability() : Kind(CapabilityMatrix) {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 
   SPIRVWord getRequiredSPIRVVersion() const override {
     switch (Kind) {
@@ -762,7 +702,7 @@ class SPIRVModuleProcessed : public SPIRVEntryNoId<OpModuleProcessed> {
 public:
   SPIRVModuleProcessed(SPIRVModule *M, const std::string &SS);
   SPIRVModuleProcessed() {}
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 private:
   std::string Str;
 };

--- a/translator/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -70,30 +70,10 @@ SPIRVDecoder SPIRVFunction::getDecoder(std::istream &IS) {
   return SPIRVDecoder(IS, *this);
 }
 
-void SPIRVFunction::encode(spv_ostream &O) const {
-  getEncoder(O) << Type << Id << FCtrlMask << FuncType;
-}
-
-void SPIRVFunction::encodeChildren(spv_ostream &O) const {
-  O << SPIRVNL();
-  for (auto &I : Parameters)
-    O << *I;
-  O << SPIRVNL();
-  for (auto &I : BBVec)
-    O << *I;
-  O << SPIRVFunctionEnd();
-}
-
-void SPIRVFunction::encodeExecutionModes(spv_ostream &O) const {
-  for (auto &I : ExecModes)
-    O << *I.second;
-}
-
 void SPIRVFunction::decode(std::istream &I) {
   SPIRVDecoder Decoder = getDecoder(I);
   Decoder >> Type >> Id >> FCtrlMask >> FuncType;
   Module->addFunction(this);
-  SPIRVDBG(spvdbgs() << "Decode function: " << Id << '\n');
 
   Decoder.getWordCountAndOpCode();
   while (!I.eof()) {
@@ -132,7 +112,6 @@ void SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
   SPIRVBasicBlock *BB = static_cast<SPIRVBasicBlock *>(Decoder.getEntry());
   assert(BB);
   addBasicBlock(BB);
-  SPIRVDBG(spvdbgs() << "Decode BB: " << BB->getId() << '\n');
 
   Decoder.setScope(BB);
   while (Decoder.getWordCountAndOpCode()) {

--- a/translator/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -75,7 +75,7 @@ protected:
     SPIRVValue::validate();
     assert(ParentFunc && "Invalid parent function");
   }
-  _SPIRV_DEF_ENCDEC2(Type, Id)
+  _SPIRV_DEF_DECODE2(Type, Id)
 private:
   SPIRVFunction *ParentFunc;
   unsigned ArgNo;
@@ -127,9 +127,7 @@ public:
     return BB;
   }
 
-  void encodeChildren(spv_ostream &) const override;
-  void encodeExecutionModes(spv_ostream &) const;
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override {
     SPIRVValue::validate();
     assert(FuncType && "Invalid func type");

--- a/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -343,14 +343,6 @@ public:
   void setHasVariableWordCount(bool VariWC) { HasVariWC = VariWC; }
 
 protected:
-  void encode(spv_ostream &O) const override {
-    auto E = getEncoder(O);
-    if (hasType())
-      E << Type;
-    if (hasId())
-      E << Id;
-    E << Ops;
-  }
   void decode(std::istream &I) override {
     auto D = getDecoder(I);
     if (hasType())
@@ -522,7 +514,7 @@ protected:
     SPIRVEntry::setWordCount(TheWordCount);
     Initializer.resize(WordCount - 4);
   }
-  _SPIRV_DEF_ENCDEC4(Type, Id, StorageClass, Initializer)
+  _SPIRV_DEF_DECODE4(Type, Id, StorageClass, Initializer)
 
   SPIRVStorageClassKind StorageClass;
   std::vector<SPIRVId> Initializer;
@@ -552,7 +544,7 @@ public:
   SPIRVValue *getSample() { return getValue(Sample); }
 
 protected:
-  _SPIRV_DEF_ENCDEC5(Type, Id, Image, Coordinate, Sample)
+  _SPIRV_DEF_DECODE5(Type, Id, Image, Coordinate, Sample)
   void validate()const override {
     SPIRVInstruction::validate();
     assert(Type->isTypePointer() &&
@@ -587,7 +579,7 @@ public:
 
   SPIRVValue *getResidentCode() { return getValue(ResidentCode); }
 protected:
-  _SPIRV_DEF_ENCDEC3(Type, Id, ResidentCode)
+  _SPIRV_DEF_DECODE3(Type, Id, ResidentCode)
 
   void validate()const override {
     assert(Type->isTypeBool() && Type->isTypeScalar());
@@ -639,9 +631,6 @@ protected:
   void setWordCount(SPIRVWord TheWordCount) override {
     SPIRVEntry::setWordCount(TheWordCount);
     MemoryAccess.resize(TheWordCount - FixedWords);
-  }
-  void encode(spv_ostream &O) const override {
-    getEncoder(O) << PtrId << ValId << MemoryAccess;
   }
 
   void decode(std::istream &I) override {
@@ -695,10 +684,6 @@ protected:
   void setWordCount(SPIRVWord TheWordCount) override {
     SPIRVEntry::setWordCount(TheWordCount);
     MemoryAccess.resize(TheWordCount - FixedWords);
-  }
-
-  void encode(spv_ostream &O) const override {
-    getEncoder(O) << Type << Id << PtrId << MemoryAccess;
   }
 
   void decode(std::istream &I) override {
@@ -846,7 +831,7 @@ protected:
     setHasNoId();
     setHasNoType();
   }
-  _SPIRV_DEF_ENCDEC0
+  _SPIRV_DEF_DECODE0
 };
 
 typedef SPIRVInstNoOperand<OpReturn> SPIRVReturn;
@@ -876,7 +861,7 @@ protected:
     setHasNoId();
     setHasNoType();
   }
-  _SPIRV_DEF_ENCDEC1(ReturnValueId)
+  _SPIRV_DEF_DECODE1(ReturnValueId)
   void validate() const override { SPIRVInstruction::validate(); }
   SPIRVId ReturnValueId;
 };
@@ -898,7 +883,7 @@ public:
   SPIRVValue *getTargetLabel() const { return getValue(TargetLabelId); }
 
 protected:
-  _SPIRV_DEF_ENCDEC1(TargetLabelId)
+  _SPIRV_DEF_DECODE1(TargetLabelId)
   void validate() const override {
     SPIRVInstruction::validate();
     assert(WordCount == 2);
@@ -946,7 +931,7 @@ protected:
     SPIRVEntry::setWordCount(TheWordCount);
     BranchWeights.resize(TheWordCount - 4);
   }
-  _SPIRV_DEF_ENCDEC4(ConditionId, TrueLabelId, FalseLabelId, BranchWeights)
+  _SPIRV_DEF_DECODE4(ConditionId, TrueLabelId, FalseLabelId, BranchWeights)
   void validate() const override {
     SPIRVInstruction::validate();
     assert(WordCount == 4 || WordCount == 6);
@@ -1016,7 +1001,7 @@ public:
     SPIRVEntry::setWordCount(TheWordCount);
     Pairs.resize(TheWordCount - FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC3(Type, Id, Pairs)
+  _SPIRV_DEF_DECODE3(Type, Id, Pairs)
   void validate() const override {
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
@@ -1181,7 +1166,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC5(Type, Id, Condition, Op1, Op2)
+  _SPIRV_DEF_DECODE5(Type, Id, Condition, Op1, Op2)
   void validate() const override {
     SPIRVInstruction::validate();
     if (getValue(Condition)->isForward() || getValue(Op1)->isForward() ||
@@ -1245,7 +1230,7 @@ public:
   SPIRVId getMergeBlock() { return MergeBlock; }
   SPIRVWord getSelectionControl() { return SelectionControl; }
 
-  _SPIRV_DEF_ENCDEC2(MergeBlock, SelectionControl)
+  _SPIRV_DEF_DECODE2(MergeBlock, SelectionControl)
 
 protected:
   SPIRVId MergeBlock;
@@ -1285,7 +1270,7 @@ public:
     SPIRVEntry::setWordCount(TheWordCount);
     LoopControlParameters.resize(TheWordCount - FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC4(MergeBlock, ContinueTarget, LoopControl,
+  _SPIRV_DEF_DECODE4(MergeBlock, ContinueTarget, LoopControl,
      LoopControlParameters)
 
 protected:
@@ -1353,7 +1338,7 @@ public:
     SPIRVEntry::setWordCount(TheWordCount);
     Pairs.resize(TheWordCount - FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC3(Select, Default, Pairs)
+  _SPIRV_DEF_DECODE3(Select, Default, Pairs)
   void validate() const override {
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
@@ -1399,7 +1384,7 @@ public:
   void setWordCount(SPIRVWord FixedWordCount) override {
     SPIRVEntry::setWordCount(FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC4(Type, Id, Dividend, Divisor)
+  _SPIRV_DEF_DECODE4(Type, Id, Dividend, Divisor)
   void validate() const override {
     SPIRVInstruction::validate();
     if (getValue(Dividend)->isForward() || getValue(Divisor)->isForward())
@@ -1441,7 +1426,7 @@ public:
   void setWordCount(SPIRVWord FixedWordCount) override {
     SPIRVEntry::setWordCount(FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC4(Type, Id, Vector, Scalar)
+  _SPIRV_DEF_DECODE4(Type, Id, Vector, Scalar)
   void validate() const override {
     SPIRVInstruction::validate();
     if (getValue(Vector)->isForward() || getValue(Scalar)->isForward())
@@ -1682,7 +1667,7 @@ public:
                     const std::vector<SPIRVWord> &TheArgs, SPIRVBasicBlock *BB);
   SPIRVFunctionCall() : FunctionId(SPIRVID_INVALID) {}
   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(FunctionId); }
-  _SPIRV_DEF_ENCDEC4(Type, Id, FunctionId, Args)
+  _SPIRV_DEF_DECODE4(Type, Id, FunctionId, Args)
   void validate() const override;
   bool isOperandLiteral(unsigned Index) const override { return false; }
 
@@ -1725,33 +1710,6 @@ public:
             ExtSetKind == SPIRVEIS_GcnShaderAMD ||
             ExtSetKind == SPIRVEIS_ShaderTrinaryMinMaxAMD) &&
            "not supported");
-  }
-  void encode(spv_ostream &O) const override {
-    getEncoder(O) << Type << Id << ExtSetId;
-    switch (ExtSetKind) {
-    case SPIRVEIS_OpenCL:
-      getEncoder(O) << ExtOpOCL;
-      break;
-    case SPIRVEIS_GLSL:
-      getEncoder(O) << ExtOpGLSL;
-      break;
-    case SPIRVEIS_ShaderBallotAMD:
-      getEncoder(O) << ExtOpShaderBallotAMD;
-      break;
-    case SPIRVEIS_ShaderExplicitVertexParameterAMD:
-      getEncoder(O) << ExtOpShaderExplicitVertexParameterAMD;
-      break;
-    case SPIRVEIS_GcnShaderAMD:
-      getEncoder(O) << ExtOpGcnShaderAMD;
-      break;
-    case SPIRVEIS_ShaderTrinaryMinMaxAMD:
-      getEncoder(O) << ExtOpShaderTrinaryMinMaxAMD;
-      break;
-    default:
-      assert(0 && "not supported");
-      getEncoder(O) << ExtOp;
-    }
-    getEncoder(O) << Args;
   }
   void decode(std::istream &I) override {
     getDecoder(I) >> Type >> Id >> ExtSetId;
@@ -1844,7 +1802,7 @@ protected:
     SPIRVEntry::setWordCount(TheWordCount);
     Constituents.resize(TheWordCount - FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC3(Type, Id, Constituents)
+  _SPIRV_DEF_DECODE3(Type, Id, Constituents)
   void validate() const override {
     SPIRVInstruction::validate();
     switch (getValueType(this->getId())->getOpCode()) {
@@ -1885,7 +1843,7 @@ protected:
     SPIRVEntry::setWordCount(TheWordCount);
     Indices.resize(TheWordCount - 4);
   }
-  _SPIRV_DEF_ENCDEC4(Type, Id, Composite, Indices)
+  _SPIRV_DEF_DECODE4(Type, Id, Composite, Indices)
   // ToDo: validate the result type is consistent with the base type and indices
   // need to trace through the base type for struct types
   void validate() const override {
@@ -1929,7 +1887,7 @@ protected:
     SPIRVEntry::setWordCount(TheWordCount);
     Indices.resize(TheWordCount - FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC5(Type, Id, Object, Composite, Indices)
+  _SPIRV_DEF_DECODE5(Type, Id, Object, Composite, Indices)
   // ToDo: validate the object type is consistent with the base type and indices
   // need to trace through the base type for struct types
   void validate() const override {
@@ -1963,7 +1921,7 @@ public:
   SPIRVValue *getOperand() { return getValue(Operand); }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Type, Id, Operand)
+  _SPIRV_DEF_DECODE3(Type, Id, Operand)
   SPIRVId Operand;
 };
 
@@ -2096,10 +2054,6 @@ protected:
     MemoryAccess.resize(TheWordCount - FixedWords);
   }
 
-  void encode(spv_ostream &O) const override {
-    getEncoder(O) << Target << Source << MemoryAccess;
-  }
-
   void decode(std::istream &I) override {
     getDecoder(I) >> Target >> Source >> MemoryAccess;
     memoryAccessUpdate(MemoryAccess);
@@ -2154,10 +2108,6 @@ protected:
     MemoryAccess.resize(TheWordCount - FixedWords);
   }
 
-  void encode(spv_ostream &O) const override {
-    getEncoder(O) << Target << Source << Size << MemoryAccess;
-  }
-
   void decode(std::istream &I) override {
     getDecoder(I) >> Target >> Source >> Size >> MemoryAccess;
     memoryAccessUpdate(MemoryAccess);
@@ -2192,7 +2142,7 @@ public:
   SPIRVValue *getIndex() const { return getValue(IndexId); }
 
 protected:
-  _SPIRV_DEF_ENCDEC4(Type, Id, VectorId, IndexId)
+  _SPIRV_DEF_DECODE4(Type, Id, VectorId, IndexId)
   void validate() const override {
     SPIRVInstruction::validate();
     if (getValue(VectorId)->isForward())
@@ -2227,7 +2177,7 @@ public:
   SPIRVValue *getComponent() { return getValue(ComponentId); }
 
 protected:
-  _SPIRV_DEF_ENCDEC5(Type, Id, VectorId, ComponentId, IndexId)
+  _SPIRV_DEF_DECODE5(Type, Id, VectorId, ComponentId, IndexId)
   void validate() const override {
     SPIRVInstruction::validate();
     if (getValue(VectorId)->isForward())
@@ -2275,7 +2225,7 @@ protected:
     SPIRVEntry::setWordCount(TheWordCount);
     Components.resize(TheWordCount - FixedWordCount);
   }
-  _SPIRV_DEF_ENCDEC5(Type, Id, Vector1, Vector2, Components)
+  _SPIRV_DEF_DECODE5(Type, Id, Vector1, Vector2, Components)
   void validate() const override {
     SPIRVInstruction::validate();
     assert(OpCode == OC);
@@ -2324,7 +2274,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(ExecScope, MemScope, MemSema)
+  _SPIRV_DEF_DECODE3(ExecScope, MemScope, MemSema)
   void validate() const override {
     assert(OpCode == OC);
     assert(WordCount == 4);
@@ -2358,7 +2308,7 @@ public:
     return getValues(Operands);
   }
 protected:
-  _SPIRV_DEF_ENCDEC4(Type, Id, Struct, MemberIndex)
+  _SPIRV_DEF_DECODE4(Type, Id, Struct, MemberIndex)
   void validate() const override {
     SPIRVInstruction::validate();
     assert(Type->isTypeInt() && Type->getBitWidth() == 32);
@@ -2402,7 +2352,7 @@ protected:
         !Module->hasCapability(CapabilityAddresses))
       assert(Size == 0 && "Size must be 0");
   }
-  _SPIRV_DEF_ENCDEC2(Object, Size)
+  _SPIRV_DEF_DECODE2(Object, Size)
   SPIRVId Object;
   SPIRVWord Size;
 };
@@ -2449,7 +2399,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC8(Type, Id, ExecScope, Destination, Source, NumElements,
+  _SPIRV_DEF_DECODE8(Type, Id, ExecScope, Destination, Source, NumElements,
                      Stride, Event)
   void validate() const override {
     assert(OpCode == OC);

--- a/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -465,24 +465,17 @@ void SPIRVModuleImpl::addLine(SPIRVEntry *E, SPIRVId FileNameId, SPIRVWord Line,
 // Creates decoration group and group decorates from decorates shared by
 // multiple targets.
 void SPIRVModuleImpl::optimizeDecorates() {
-  SPIRVDBG(spvdbgs() << "[optimizeDecorates] begin\n");
   for (auto I = DecorateSet.begin(), E = DecorateSet.end(); I != E;) {
     auto D = *I;
-    SPIRVDBG(spvdbgs() << "  check " << *D << '\n');
     if (D->getOpCode() == OpMemberDecorate) {
       ++I;
       continue;
     }
     auto ER = DecorateSet.equal_range(D);
-    SPIRVDBG(spvdbgs() << "  equal range " << **ER.first << " to ";
-             if (ER.second != DecorateSet.end()) spvdbgs() << **ER.second;
-             else spvdbgs() << "end"; spvdbgs() << '\n');
     if (std::distance(ER.first, ER.second) < 2) {
       I = ER.second;
-      SPIRVDBG(spvdbgs() << "  skip equal range \n");
       continue;
     }
-    SPIRVDBG(spvdbgs() << "  add deco group. erase equal range\n");
     auto G = add(new SPIRVDecorationGroup(this, getId()));
     std::vector<SPIRVId> Targets;
     Targets.push_back(D->getTargetId());
@@ -525,7 +518,6 @@ SPIRVValue *SPIRVModuleImpl::addPipeStorageConstant(SPIRVType *TheType,
 
 void SPIRVModuleImpl::addCapability(SPIRVCapabilityKind Cap) {
   addCapabilities(SPIRV::getCapability(Cap));
-  SPIRVDBG(spvdbgs() << "addCapability: " << Cap << '\n');
   if (hasCapability(Cap))
     return;
 
@@ -1297,8 +1289,6 @@ SPIRVModuleImpl::addDecorationGroup(SPIRVDecorationGroup *Group) {
   add(Group);
   Group->takeDecorates(DecorateSet);
   DecGroupVec.push_back(Group);
-  SPIRVDBG(spvdbgs() << "[addDecorationGroup] {" << *Group << "}\n";
-           spvdbgs() << "  Remaining DecorateSet: {" << DecorateSet << "}\n");
   return Group;
 }
 

--- a/translator/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -370,8 +370,7 @@ public:
                                                        SPIRVValue *,
                                                        SPIRVValue *,
                                                        SPIRVBasicBlock *) = 0;
-  // I/O functions
-  friend spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M);
+  // Input functions
   friend std::istream &operator>>(std::istream &I, SPIRVModule &M);
 
 protected:
@@ -391,21 +390,6 @@ private:
   const std::string ModuleFileStr;
   SPIRVModule *M;
 };
-
-#ifdef _SPIRV_SUPPORT_TEXT_FMT
-
-/// Convert SPIR-V between binary and internel text formats.
-/// This function is not thread safe and should not be used in multi-thread
-/// applications unless guarded by a critical section.
-bool ConvertSPIRV(std::istream &IS, spv_ostream &OS, std::string &ErrMsg,
-                  bool FromText, bool ToText);
-
-/// Convert SPIR-V between binary and internel text formats.
-/// This function is not thread safe and should not be used in multi-thread
-/// applications unless guarded by a critical section.
-bool ConvertSPIRV(std::string &Input, std::string &Out, std::string &ErrMsg,
-                  bool ToText);
-#endif
 } // namespace SPIRV
 
 #endif // SPIRV_LIBSPIRV_SPIRVMODULE_H

--- a/translator/lib/SPIRV/libSPIRV/SPIRVType.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVType.cpp
@@ -306,7 +306,7 @@ SPIRVConstant *SPIRVTypeArray::getLength() const {
   return get<SPIRVConstant>(Length);
 }
 
-_SPIRV_IMP_ENCDEC3(SPIRVTypeArray, Id, ElemType, Length)
+_SPIRV_IMP_DECODE3(SPIRVTypeArray, Id, ElemType, Length)
 
 SPIRVTypeRuntimeArray::SPIRVTypeRuntimeArray(SPIRVModule *M, SPIRVId TheId,
   SPIRVType *TheElemType)
@@ -321,10 +321,6 @@ SPIRVTypeRuntimeArray::validate()const {
 }
 
 _SPIRV_IMP_ENCDEC2(SPIRVTypeRuntimeArray, Id, ElemType)
-
-void SPIRVTypeForwardPointer::encode(spv_ostream &O) const {
-  getEncoder(O) << Pointer << SC;
-}
 
 void SPIRVTypeForwardPointer::decode(std::istream &I) {
   auto Decoder = getDecoder(I);

--- a/translator/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -120,7 +120,7 @@ public:
   SPIRVTypeVoid() : SPIRVType(OpTypeVoid) {}
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
 };
 
 class SPIRVTypeBool : public SPIRVType {
@@ -132,7 +132,7 @@ public:
   SPIRVTypeBool() : SPIRVType(OpTypeBool) {}
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
 };
 
 class SPIRVTypeInt : public SPIRVType {
@@ -169,7 +169,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Id, BitWidth, IsSigned)
+  _SPIRV_DEF_DECODE3(Id, BitWidth, IsSigned)
   void validate() const override {
     SPIRVEntry::validate();
     assert(BitWidth > 1 && BitWidth <= 64 && "Invalid bit width");
@@ -205,7 +205,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC2(Id, BitWidth)
+  _SPIRV_DEF_DECODE2(Id, BitWidth)
   void validate() const override {
     SPIRVEntry::validate();
     assert(BitWidth >= 16 && BitWidth <= 64 && "Invalid bit width");
@@ -247,7 +247,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Id, ElemStorageClass, ElemTypeId)
+  _SPIRV_DEF_DECODE3(Id, ElemStorageClass, ElemTypeId)
   void validate() const override {
     SPIRVEntry::validate();
     assert(isValid(ElemStorageClass));
@@ -270,7 +270,7 @@ public:
   void setPointer(SPIRVTypePointer *const P) { Pointer = P; }
   SPIRVStorageClassKind getStorageClass() const { return SC; }
 
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
 private:
   SPIRVTypePointer *Pointer;
   SPIRVStorageClassKind SC;
@@ -306,7 +306,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Id, CompType, CompCount)
+  _SPIRV_DEF_DECODE3(Id, CompType, CompCount)
   void validate() const override {
     SPIRVEntry::validate();
     CompType->validate();
@@ -346,7 +346,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Id, ColumnType, ColumnCount)
+  _SPIRV_DEF_DECODE3(Id, ColumnType, ColumnCount)
   void validate() const override {
     SPIRVEntry::validate();
     ColumnType->validate();
@@ -379,7 +379,7 @@ public:
   }
 
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
 
 private:
@@ -405,7 +405,7 @@ public:
   }
 
 protected:
-  _SPIRV_DCL_ENCDEC
+  _SPIRV_DCL_DECODE
   void validate() const override;
 private:
   SPIRVType *ElemType;                // Element Type
@@ -423,7 +423,7 @@ public:
   SPIRVTypeOpaque() : SPIRVType(OpTypeOpaque) {}
 
 protected:
-  _SPIRV_DEF_ENCDEC2(Id, Name)
+  _SPIRV_DEF_DECODE2(Id, Name)
   void validate() const override { SPIRVEntry::validate(); }
 };
 
@@ -525,7 +525,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC9(Id, SampledType, Desc.Dim, Desc.Depth, Desc.Arrayed,
+  _SPIRV_DEF_DECODE9(Id, SampledType, Desc.Dim, Desc.Depth, Desc.Arrayed,
                      Desc.MS, Desc.Sampled, Desc.Format, Acc)
   // The validation assumes OpenCL image or sampler type.
   void validate() const override {
@@ -560,7 +560,7 @@ public:
   SPIRVTypeSampler() : SPIRVType(OC) {}
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
   void validate() const override {
     assert(OpCode == OC);
     assert(WordCount == FixedWC);
@@ -587,7 +587,7 @@ public:
 
 protected:
   SPIRVTypeImage *ImgTy;
-  _SPIRV_DEF_ENCDEC2(Id, ImgTy)
+  _SPIRV_DEF_DECODE2(Id, ImgTy)
   void validate() const override {
     assert(OpCode == OC);
     assert(WordCount == FixedWC);
@@ -606,7 +606,7 @@ public:
   SPIRVTypePipeStorage() : SPIRVType(OC) {}
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
   void validate() const override {
     assert(OpCode == OC);
     assert(WordCount == FixedWC);
@@ -664,7 +664,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC2(Id, MemberTypeIdVec)
+  _SPIRV_DEF_DECODE2(Id, MemberTypeIdVec)
 
   void validate() const override { SPIRVEntry::validate(); }
 
@@ -696,7 +696,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Id, ReturnType, ParamTypeVec)
+  _SPIRV_DEF_DECODE3(Id, ReturnType, ParamTypeVec)
   void setWordCount(SPIRVWord WordCount) override {
     SPIRVType::setWordCount(WordCount);
     ParamTypeVec.resize(WordCount - 3);
@@ -728,7 +728,7 @@ public:
   SPIRVValue *getOperand() { return getValue(Opn); }
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
   void validate() const override { SPIRVEntry::validate(); }
   SPIRVId Opn;
 };
@@ -764,7 +764,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
   void validate() const override { SPIRVEntry::validate(); }
 };
 
@@ -784,7 +784,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
 };
 
 class SPIRVTypePipe : public SPIRVType {
@@ -812,7 +812,7 @@ public:
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC2(Id, AccessQualifier)
+  _SPIRV_DEF_DECODE2(Id, AccessQualifier)
   void validate() const override { SPIRVEntry::validate(); }
 
 private:

--- a/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -49,7 +49,6 @@ void SPIRVValue::setAlignment(SPIRVWord A) {
     return;
   }
   addDecorate(new SPIRVDecorate(DecorationAlignment, this, A));
-  SPIRVDBG(spvdbgs() << "Set alignment " << A << " for obj " << Id << "\n")
 }
 
 bool SPIRVValue::hasAlignment(SPIRVWord *Result) const {
@@ -64,8 +63,6 @@ void SPIRVValue::setVolatile(bool IsVolatile) {
     return;
   }
   addDecorate(new SPIRVDecorate(DecorationVolatile, this));
-  SPIRVDBG(spvdbgs() << "Set volatile "
-                     << " for obj " << Id << "\n")
 }
 
 bool SPIRVValue::isCoherent() { return hasDecorate(DecorationCoherent); }
@@ -76,8 +73,6 @@ void SPIRVValue::setCoherent(bool IsCoherent) {
     return;
   }
   addDecorate(new SPIRVDecorate(DecorationCoherent, this));
-  SPIRVDBG(spvdbgs() << "Set coherent "
-                     << " for obj " << Id << "\n")
 }
 
 } // namespace SPIRV

--- a/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -170,11 +170,6 @@ protected:
     SPIRVValue::validate();
     assert(NumWords >= 1 && NumWords <= 2 && "Invalid constant size");
   }
-  void encode(spv_ostream &O) const override {
-    getEncoder(O) << Type << Id;
-    for (unsigned I = 0; I < NumWords; ++I)
-      getEncoder(O) << Union.Words[I];
-  }
   void setWordCount(SPIRVWord WordCount) override {
     SPIRVValue::setWordCount(WordCount);
     NumWords = WordCount - 3;
@@ -207,7 +202,7 @@ public:
 
 protected:
   void validate() const override { SPIRVValue::validate(); }
-  _SPIRV_DEF_ENCDEC2(Type, Id)
+  _SPIRV_DEF_DECODE2(Type, Id)
 };
 
 template <Op OC> class SPIRVConstantBool : public SPIRVConstantEmpty<OC> {
@@ -296,7 +291,7 @@ protected:
     SPIRVEntry::setWordCount(WordCount);
     Elements.resize(WordCount - 3);
   }
-  _SPIRV_DEF_ENCDEC3(Type, Id, Elements)
+  _SPIRV_DEF_DECODE3(Type, Id, Elements)
 
   std::vector<SPIRVId> Elements;
 };
@@ -337,7 +332,7 @@ protected:
     assert(WordCount == WC);
     assert(Type->isTypeSampler());
   }
-  _SPIRV_DEF_ENCDEC5(Type, Id, AddrMode, Normalized, FilterMode)
+  _SPIRV_DEF_DECODE5(Type, Id, AddrMode, Normalized, FilterMode)
 };
 
 class SPIRVConstantPipeStorage : public SPIRVValue {
@@ -375,7 +370,7 @@ protected:
     assert(WordCount == WC);
     assert(Type->isTypePipeStorage());
   }
-  _SPIRV_DEF_ENCDEC5(Type, Id, PacketSize, PacketAlign, Capacity)
+  _SPIRV_DEF_DECODE5(Type, Id, PacketSize, PacketAlign, Capacity)
 };
 
 class SPIRVSpecConstantTrue : public SPIRVConstantBool<OpSpecConstantTrue> {
@@ -412,7 +407,7 @@ public:
       setType(TheTy);
   }
   SPIRVForward() : SPIRVValue(OC) { assert(0 && "should never be called"); }
-  _SPIRV_DEF_ENCDEC1(Id)
+  _SPIRV_DEF_DECODE1(Id)
   friend class SPIRVFunction;
 
 protected:


### PR DESCRIPTION
- Remove operator<< overload in SPIRVModule
- Remove convertSPIRV() for conversion between binary and internal textual formats