### PR TITLE
Fix the wrong order of ES arguments offChipLdsBase and isOffChip

### DIFF
--- a/patch/gfx9/llpcNggPrimShader.cpp
+++ b/patch/gfx9/llpcNggPrimShader.cpp
@@ -3076,7 +3076,7 @@ void NggPrimShader::RunEsOrEsVariant(
         if (m_pContext->IsTessOffChip())
         {
             args.push_back(m_hasGs ? pOffChipLdsBase : pIsOffChip);
-            args.push_back((m_hasGs == false) ? pIsOffChip : pOffChipLdsBase);
+            args.push_back(m_hasGs ? pIsOffChip : pOffChipLdsBase);
         }
 
         if (m_hasGs)


### PR DESCRIPTION
The issue causes CTS failure on GFX10:
dEQP-VK.pipeline.push_constant.graphics_pipeline.overlap_4_shaders_vert_tess_frag