### PR TITLE
Fix non gfx10 build

### DIFF
--- a/patch/gfx9/chip/llpcGfx9Chip.cpp
+++ b/patch/gfx9/chip/llpcGfx9Chip.cpp
@@ -30,6 +30,8 @@
  */
 #define DEBUG_TYPE "llpc-gfx9-chip"
 
+#include <stdio.h>
+
 #include "llpcGfx9Chip.h"
 
 namespace Llpc

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -665,6 +665,7 @@ Value* PatchDescriptorLoad::BuildBufferCompactDesc(
                                             "",
                                             pInsertPoint);
     }
+#ifdef LLPC_BUILD_GFX10
     else if (gfxIp.major == 10)
     {
         SqBufRsrcWord3 sqBufRsrcWord3 = {};
@@ -683,6 +684,7 @@ Value* PatchDescriptorLoad::BuildBufferCompactDesc(
                                             "",
                                             pInsertPoint);
     }
+#endif
     else
     {
         LLPC_NOT_IMPLEMENTED();

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -4235,8 +4235,8 @@ void PatchInOutImportExport::PatchGsBuiltInOutputExport(
         EmitCall(callName, m_pContext->VoidTy(), args, NoAttrib, pInsertPos);
     }
     else
-    {
 #endif
+    {
         switch (builtInId)
         {
         case BuiltInPosition:


### PR DESCRIPTION
This adds extra guards around code that is only valid when building with
GFX10 enabled.

Tested with GFX10 support disabled and GFX10 support enabled.

Note that this requires changes in the other drivers as well.