### PR TITLE
Pack In/Out for VS-FS pipeline

### DIFF
--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -351,23 +351,27 @@ void BuilderImplInOut::MarkGenericInputOutputUsage(
         }
     }
 
-    if ((isOutput == false) || (m_shaderStage != ShaderStageGeometry))
+    // Don't fill pInOutLocMap if we need pack this variable
+    if (getContext().CheckPackInOutValidity(m_shaderStage, isOutput) == false)
     {
-        // Non-GS-output case.
-        for (uint32_t i = 0; i < locationCount; ++i)
+        if ((isOutput == false) || (m_shaderStage != ShaderStageGeometry))
         {
-            (*pInOutLocMap)[location + i] = InvalidValue;
+            // Non-GS-output case.
+            for (uint32_t i = 0; i < locationCount; ++i)
+            {
+                (*pInOutLocMap)[location + i] = InvalidValue;
+            }
         }
-    }
-    else
-    {
-        // GS output. We include the stream ID with the location in the map key.
-        for (uint32_t i = 0; i < locationCount; ++i)
+        else
         {
-            GsOutLocInfo outLocInfo = {};
-            outLocInfo.location = location + i;
-            outLocInfo.streamId = inOutInfo.GetStreamId();
-            (*pInOutLocMap)[outLocInfo.u32All] = InvalidValue;
+            // GS output. We include the stream ID with the location in the map key.
+            for (uint32_t i = 0; i < locationCount; ++i)
+            {
+                GsOutLocInfo outLocInfo = {};
+                outLocInfo.location = location + i;
+                outLocInfo.streamId = inOutInfo.GetStreamId();
+                (*pInOutLocMap)[outLocInfo.u32All] = InvalidValue;
+            }
         }
     }
 

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -103,6 +103,19 @@ public:
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const { return &m_pPipelineInfo->options; }
 
+    // Checks whether pack in/out is valid for VS-FS pipeline
+    virtual bool CheckPackInOutValidity(ShaderStage shaderStage, bool isOutput) const 
+    { 
+        LLPC_NEVER_CALLED();
+        return false; 
+    }
+
+    // Checks whether pack in/out is enabled
+    virtual bool IsPackInOut() const { LLPC_NEVER_CALLED(); return false; }
+
+    // Sets pack in/out in
+    virtual void SetPackInOut(bool packInOut) { LLPC_NEVER_CALLED(); }
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(ComputeContext);
     LLPC_DISALLOW_COPY_AND_ASSIGN(ComputeContext);

--- a/context/llpcContext.h
+++ b/context/llpcContext.h
@@ -294,6 +294,21 @@ public:
         m_pResUsage = pResUsage;
     }
 
+    bool CheckPackInOutValidity(ShaderStage shaderStage, bool isOutput) const
+    {
+        return m_pPipelineContext->CheckPackInOutValidity(shaderStage, isOutput);
+    }
+
+    bool IsPackInOut() const
+    {
+        return m_pPipelineContext->IsPackInOut();
+    }
+
+    void SetPackInOut(bool packInOut)
+    {
+        m_pPipelineContext->SetPackInOut(packInOut);
+    }
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(Context);
     LLPC_DISALLOW_COPY_AND_ASSIGN(Context);

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -106,6 +106,15 @@ public:
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const { return &m_pPipelineInfo->options; }
 
+    // Checks whether pack input/output is valid. Current VS output and FS input in VS-FS pipeline is packable
+    virtual bool CheckPackInOutValidity(ShaderStage shaderStage, bool isOutput) const;
+
+    // Checks whether pack in/out is enabled
+    virtual bool IsPackInOut() const { return m_packInOut; }
+
+    // Sets pack in/out in
+    virtual void SetPackInOut(bool packInOut) { m_packInOut = packInOut; }
+
     void InitShaderInfoForNullFs();
 
 private:
@@ -132,6 +141,8 @@ private:
 #if LLPC_BUILD_GFX10
     NggControl      m_nggControl;   // NGG control settings
 #endif
+
+    bool            m_packInOut;    // Whether to enable pack in/out
 
     llvm::SmallVector<std::unique_ptr<llvm::SmallVectorImpl<ResourceMappingNode>>, 4>
                     m_allocUserDataNodes;               // Allocated merged user data nodes

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -398,8 +398,11 @@ struct ResourceUsage
     // Usage of generic input/output
     struct
     {
-        // Map from shader specified locations to tightly packed locations
+        // Map from shader specified locations to tightly packed locations.
+        // Pack in/out reuses the two maps to obtain tightly packed locations when pack condition is satified
+        // FS' inputLocMap uses all fields of InOutPackInfo.u32All as key
         std::map<uint32_t, uint32_t> inputLocMap;
+        // VS' outputLocMap uses three fields of InOutPackInfo.u32All (compIdx, location and channelMask) as key
         std::map<uint32_t, uint32_t> outputLocMap;
 
         std::map<uint32_t, uint32_t> perPatchInputLocMap;
@@ -810,6 +813,15 @@ public:
 
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const = 0;
+
+    // Checks whether pack in/out is valid for VS-FS pipeline
+    virtual bool CheckPackInOutValidity(ShaderStage shaderStage, bool isOutput) const { return false; }
+
+    // Checks whether pack in/out is enabled
+    virtual bool IsPackInOut() const { return false; };
+
+    // Sets pack in/out in
+    virtual void SetPackInOut(bool packInOut) {}
 
     // Set pipeline state in Builder
     void SetBuilderPipelineState(Builder* pBuilder) const;

--- a/patch/llpcPatchNullFragShader.cpp
+++ b/patch/llpcPatchNullFragShader.cpp
@@ -164,6 +164,9 @@ bool PatchNullFragShader::runOnModule(
     GraphicsContext* pGraphicsContext = static_cast<GraphicsContext*>(m_pContext->GetPipelineContext());
     pGraphicsContext->InitShaderInfoForNullFs();
 
+    // Disable pack in/out for null FS
+    pGraphicsContext->SetPackInOut(false);
+
     return true;
 }
 

--- a/patch/llpcPatchResourceCollect.h
+++ b/patch/llpcPatchResourceCollect.h
@@ -39,6 +39,8 @@
 namespace Llpc
 {
 
+typedef std::map<uint32_t, uint32_t>::iterator LocMapIterator; // Iterator of the map from uint32_t to uint32_t
+
 // =====================================================================================================================
 // Represents the pass of LLVM patching opertions for resource collecting
 class PatchResourceCollect:
@@ -64,6 +66,48 @@ public:
 private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(PatchResourceCollect);
 
+    // Enumerates bit width
+    enum BitWidth: uint32_t
+    {
+        BitWidth8,
+        BitWidth16,
+        BitWidth32,
+        BitWidth64,
+    };
+
+    // The infos used to partition ordered call indices into a pack group
+    // The non-64-bit and 64-bit are packed respectively in a pack group
+    struct PackGroup
+    {
+        uint32_t scalarizedCallCount; // The scalarized call count in a pack group
+        bool     is64Bit;             // Wether is 64-bits
+    };
+
+    // Represents pack info of input or output
+    union InOutPackInfo
+    {
+        struct
+        {
+            uint32_t compIdx              : 2;  // Component index of output vector
+            uint32_t location             : 16; // Location of the output
+            uint32_t channelMask          : 4;  // The channel mask of packed VS output
+        } vs;
+
+        struct
+        {
+            uint32_t compIdx              : 2;  // Component index of input vector
+            uint32_t location             : 16; // Location of the input
+            uint32_t bitWidth             : 2;  // Correspond to enumerants of BitWidth
+            uint32_t interpMode           : 2;  // Interpolation mode: 0-Smooth, 1-Flat, 2-NoPersp, 3-Custom
+            uint32_t interpLoc            : 3;  // Interpolation location: 0-Unknown, 1-Center, 2-Centroid,
+                                                // 3-Smaple, 4-Custom
+            uint32_t interpolantCompCount : 3;  // The component count of interpolant
+            uint32_t isInterpolant        : 1;  // Whether it is interpolant input
+        } fs;
+
+        uint32_t u32All;
+    };
+
     void ProcessShader();
 
     void ClearInactiveInput();
@@ -76,6 +120,29 @@ private:
     void MapGsGenericOutput(GsOutLocInfo outLocInfo);
     void MapGsBuiltInOutput(uint32_t builtInId, uint32_t elemCount);
 
+    bool CheckValidityForInOutPack() const;
+    void ProcessCallForInOutPack(CallInst* pCall);
+    void MatchGenericInOutWithPack();
+    void MapBuiltInToGenericInOutWithPack();
+    void PackGenericInOut();
+    void PrepareForInOutPack(SmallVector<PackGroup, 4>&         packGroups,
+                             std::vector<uint32_t>&             orderedOutputCallIndices);
+    void CreatePackedGenericInOut(const SmallVector<PackGroup, 4>& packGroups,
+                                  const std::vector<uint32_t>&     orderedOutputCallIndices,
+                                  uint32_t&                        inputPackLoc,
+                                  uint32_t&                        outputPackLoc);
+    void CreateInterpolateInOut(uint32_t& inputPackLoc,
+                                uint32_t& outputPackLoc);
+    LocMapIterator CreatePackedGenericInput(bool            is64Bit,
+                                            uint32_t        inputCallCount,
+                                            uint32_t&       locId,
+                                            LocMapIterator  locMapIt);
+    void CreatePackedGenericOutput(const std::vector<uint32_t>& orderedOutputCallIndices,
+                                   bool                         is64Bit,
+                                   uint32_t                     outputCallCount,
+                                   uint32_t&                    callIndexPos,
+                                   uint32_t&                    packLoc);
+
     // -----------------------------------------------------------------------------------------------------------------
 
     std::unordered_set<llvm::CallInst*> m_deadCalls;            // Dead calls
@@ -87,11 +154,15 @@ private:
     std::unordered_set<uint32_t>    m_importedOutputLocs;       // Locations of imported generic outputs
     std::unordered_set<uint32_t>    m_importedOutputBuiltIns;   // IDs of imported built-in outputs
 
+    std::vector<llvm::CallInst*>    m_importedCalls;            // Imported calls
+    std::vector<llvm::CallInst*>    m_exportedCalls;            // Exported calls
+
     bool            m_hasPushConstOp;           // Whether push constant is active
     bool            m_hasDynIndexedInput;       // Whether dynamic indices are used in generic input addressing (valid
                                                 // for tessellation shader, fragment shader with input interpolation)
     bool            m_hasDynIndexedOutput;      // Whether dynamic indices are used in generic output addressing (valid
                                                 // for tessellation control shader)
+    bool            m_hasInterpolantInput;      // Whether interpolant funtions are used
     ResourceUsage*  m_pResUsage;                // Pointer to shader resource usage
 };
 


### PR DESCRIPTION
The workflow of pack in/out for VS-FS pipeline
1. In lower global pass, split a vector-based call from VS' output or FS' generic input into multiple scalar-based calls.
2. Patch resource collecting, merge scalar-based calls into tightly packed vector-based call for VS and create new scalar-based call with corresponding component index for FS
- Collect the pack info for each scalar-based call by reusing VS' outputLocMap and FS' inputLocMap but changing the key as new defined InOutPackInfo. (see ProcessCallForInOutPack())
- Core function of packing in/out (see PackGenericInOut())
  - Build a unified rule for both VS and FS to group their scalar-based calls into pack groups. The union of interpMod, interpLoc and bitWidth from FS' pack info is used as grouping metric. Add all scalar-based calls to dead call set. (see PrepareForInOutPack())
  - Create new generic input/output calls (CreateGenericInOut())
     - For VS output, scalar-based calls in the same pack group are used to generate four channels occupied vector-based calls as many as possible. The union of location, component index and channel mask is used as the key of outputLocMap and the location argument to map the new call with the final packed and continus location. (see CreateGenericOutput())
     - For FS input, scalar-based calls in the same pack group are recreated with packed component index. Use the key of inputLocMap as the location argument to map the new call with the final packed and continus location.(see CreateGenericInput())
  - Create new input/output calls for interpolant usage with non-pack (CreateInterpolantInOut())
     - For VS output, the scalar-based calls related to an interpolant call are restored to the vector without splitting. Use the key of inputLocMap as the location argument to map the new call with the final packed and continus location.
     - For FS interpolant input, the call is recreated with the key of inputLocMap as the location argument to map it with the final packed and continus location

NOTE: 
1. Use cl::PackInOut option to turn on/off the feature which is enabled by default. Use GraphicsContext::m_packInOut to disable pack for non-supported cases (e.g. VS + null FS)
2. The current pack in/out is for VS-FS pipeline.