### PR TITLE
Use array initializers instead of dynamic containers

### DIFF
--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -487,30 +487,31 @@ Value* BuilderImplInOut::ModifyAuxInterpValue(
     {
         // Add intrinsic to calculate I/J for interpolation function
         std::string evalInstName;
-        std::vector<Value*> evalArgs;
         auto pResUsage = getContext().GetShaderResourceUsage(ShaderStageFragment);
 
         if (inputInfo.GetInterpLoc() == InOutInfo::InterpLocCentroid)
         {
+            Value* evalArg = nullptr;
+
             evalInstName = LlpcName::InputImportBuiltIn;
             if (inputInfo.GetInterpMode() == InOutInfo::InterpModeNoPersp)
             {
                 evalInstName += "InterpLinearCentroid";
-                evalArgs.push_back(getInt32(spv::BuiltInInterpLinearCentroid));
+                evalArg = getInt32(spv::BuiltInInterpLinearCentroid);
                 pResUsage->builtInUsage.fs.noperspective = true;
                 pResUsage->builtInUsage.fs.centroid = true;
             }
             else
             {
                 evalInstName += "InterpPerspCentroid";
-                evalArgs.push_back(getInt32(spv::BuiltInInterpPerspCentroid));
+                evalArg = getInt32(spv::BuiltInInterpPerspCentroid);
                 pResUsage->builtInUsage.fs.smooth = true;
                 pResUsage->builtInUsage.fs.centroid = true;
             }
 
             pAuxInterpValue = EmitCall(evalInstName,
                                        VectorType::get(getFloatTy(), 2),
-                                       evalArgs,
+                                       { evalArg },
                                        Attribute::ReadOnly,
                                        &*GetInsertPoint());
         }

--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -1476,14 +1476,12 @@ Value* BuilderImplSubgroup::CreateGroupBallot(
     // The not equal predicate for the icmp intrinsic is 33.
     Constant* const pPredicateNE = getInt32(33);
 
-    SmallVector<Type*, 2> types;
-
     // icmp has a new signature (requiring the return type as the first type).
-    types.push_back(getIntNTy(GetShaderSubgroupSize()));
-    types.push_back(getInt32Ty());
-
     Value* pResult = CreateIntrinsic(Intrinsic::amdgcn_icmp,
-                                     types,
+                                     {
+                                          getIntNTy(GetShaderSubgroupSize()),
+                                          getInt32Ty()
+                                     },
                                      {
                                           pValueAsInt32,
                                           getInt32(0),

--- a/context/llpcContext.cpp
+++ b/context/llpcContext.cpp
@@ -67,8 +67,7 @@ Context::Context(
     m_gfxIp(gfxIp),
     m_glslEmuLib(this)
 {
-    std::vector<Metadata*> emptyMeta;
-    m_pEmptyMetaNode = MDNode::get(*this, emptyMeta);
+    m_pEmptyMetaNode = MDNode::get(*this, {});
 
     // Initialize pre-constructed LLVM derived types
     m_tys.pBoolTy     = Type::getInt1Ty(*this);

--- a/lower/llpcSpirvLowerGlobal.cpp
+++ b/lower/llpcSpirvLowerGlobal.cpp
@@ -501,10 +501,7 @@ void SpirvLowerGlobal::visitLoadInst(
                                                             InterpLocUnknown,
                                                             nullptr,
                                                             &loadInst);
-
-                std::vector<uint32_t> idxs;
-                idxs.push_back(i);
-                pLoadValue = InsertValueInst::Create(pLoadValue, pElemValue, idxs, "", &loadInst);
+                pLoadValue = InsertValueInst::Create(pLoadValue, pElemValue, { i }, "", &loadInst);
             }
         }
         else
@@ -680,10 +677,7 @@ void SpirvLowerGlobal::visitStoreInst(
             const uint32_t elemCount = pOutputy->getArrayNumElements();
             for (uint32_t i = 0; i < elemCount; ++i)
             {
-                std::vector<uint32_t> idxs;
-                idxs.push_back(i);
-                auto pElemValue = ExtractValueInst::Create(pStoreValue, idxs, "", &storeInst);
-
+                auto pElemValue = ExtractValueInst::Create(pStoreValue, { i }, "", &storeInst);
                 Value* pVertexIdx = ConstantInt::get(m_pContext->Int32Ty(), i);
                 AddCallInstForOutputExport(pElemValue,
                                            pElemMeta,
@@ -1219,10 +1213,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                            interpLoc,
                                                            pAuxInterpValue,
                                                            pInsertPos);
-
-                    std::vector<uint32_t> idxs;
-                    idxs.push_back(elemIdx);
-                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, idxs, "", pInsertPos);
+                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { elemIdx }, "", pInsertPos);
                 }
             }
             else
@@ -1273,10 +1264,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                            InterpLocUnknown,
                                                            nullptr,
                                                            pInsertPos);
-
-                    std::vector<uint32_t> idxs;
-                    idxs.push_back(elemIdx);
-                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, idxs, "", pInsertPos);
+                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { elemIdx }, "", pInsertPos);
                 }
             }
             else
@@ -1308,10 +1296,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                            InterpLocUnknown,
                                                            nullptr,
                                                            pInsertPos);
-
-                    std::vector<uint32_t> idxs;
-                    idxs.push_back(elemIdx);
-                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, idxs, "", pInsertPos);
+                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { elemIdx }, "", pInsertPos);
                 }
             }
         }
@@ -1338,15 +1323,11 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                      InterpLocUnknown,
                                                      nullptr,
                                                      pInsertPos);
-
-            std::vector<uint32_t> idxs;
-            idxs.push_back(memberIdx);
-            pInOutValue = InsertValueInst::Create(pInOutValue, pMember, idxs, "", pInsertPos);
+            pInOutValue = InsertValueInst::Create(pInOutValue, pMember, { memberIdx }, "", pInsertPos);
         }
     }
     else
     {
-        std::vector<Value*> args;
         Constant* pInOutMetaConst = cast<Constant>(pInOutMeta);
         inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaConst->getOperand(0))->getZExtValue();
         inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaConst->getOperand(1))->getZExtValue();
@@ -1521,9 +1502,7 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
                 for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
                 {
                     // Handle array elements recursively
-                    std::vector<uint32_t> idxs;
-                    idxs.push_back(elemIdx);
-                    auto pElem = ExtractValueInst::Create(pOutputValue, idxs, "", pInsertPos);
+		  auto pElem = ExtractValueInst::Create(pOutputValue, { elemIdx }, "", pInsertPos);
 
                     auto pXfbOffset = m_pBuilder->getInt32(outputMeta.XfbOffset +
                                                            outputMeta.XfbExtraOffset +
@@ -1568,9 +1547,7 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
             for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
             {
                 // Handle array elements recursively
-                std::vector<uint32_t> idxs;
-                idxs.push_back(elemIdx);
-                Value* pElem = ExtractValueInst::Create(pOutputValue, idxs, "", pInsertPos);
+	      Value* pElem = ExtractValueInst::Create(pOutputValue, { elemIdx }, "", pInsertPos);
 
                 Value* pElemLocOffset = nullptr;
                 ConstantInt* pLocOffsetConst = dyn_cast<ConstantInt>(pLocOffset);
@@ -1617,11 +1594,7 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
         {
             // Handle structure member recursively
             auto pMemberMeta = cast<Constant>(pOutputMeta->getOperand(memberIdx));
-
-            std::vector<uint32_t> idxs;
-            idxs.push_back(memberIdx);
-            Value* pMember = ExtractValueInst::Create(pOutputValue, idxs, "", pInsertPos);
-
+            Value* pMember = ExtractValueInst::Create(pOutputValue, { memberIdx }, "", pInsertPos);
             AddCallInstForOutputExport(pMember,
                                        pMemberMeta,
                                        pLocOffset,
@@ -1637,7 +1610,6 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
     else
     {
         // Normal scalar or vector type
-        std::vector<Value*> args;
         m_pBuilder->SetInsertPoint(pInsertPos);
         Constant* pInOutMetaConst = cast<Constant>(pOutputMeta);
         outputMeta.U64All[0] = cast<ConstantInt>(pInOutMetaConst->getOperand(0))->getZExtValue();

--- a/lower/llpcSpirvLowerLoopUnrollControl.cpp
+++ b/lower/llpcSpirvLowerLoopUnrollControl.cpp
@@ -147,11 +147,12 @@ bool SpirvLowerLoopUnrollControl::runOnModule(
                 // one operand pointing to itself, meaning that the SPIR-V did not
                 // have an unroll or don't-unroll directive, so we can add the force
                 // unroll count metadata.
-                SmallVector<llvm::Metadata*, 2> opUnrollCountMeta;
-                opUnrollCountMeta.push_back(MDString::get(*m_pContext, "llvm.loop.unroll.count"));
-                opUnrollCountMeta.push_back(ConstantAsMetadata::get(
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), m_forceLoopUnrollCount)));
-                MDNode* pLoopUnrollCountMetaNode = MDNode::get(*m_pContext, opUnrollCountMeta);
+                llvm::Metadata* unrollCountMeta[] = {
+                    MDString::get(*m_pContext, "llvm.loop.unroll.count"),
+                    ConstantAsMetadata::get(
+                        ConstantInt::get(Type::getInt32Ty(*m_pContext), m_forceLoopUnrollCount))
+                };
+                MDNode* pLoopUnrollCountMetaNode = MDNode::get(*m_pContext, unrollCountMeta);
                 pLoopMetaNode = MDNode::concatenate(pLoopMetaNode,
                                                     MDNode::get(*m_pContext, pLoopUnrollCountMetaNode));
 

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -515,9 +515,10 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             pOffset = CastInst::CreateZExtOrBitCast(pOffset, m_pContext->Int64Ty(), "", pInsertPoint);
 
             // Get descriptor address
-            std::vector<Value*> idxs;
-            idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), 0, false));
-            idxs.push_back(pOffset);
+            Value* idxs[] = {
+                ConstantInt::get(m_pContext->Int64Ty(), 0, false),
+                pOffset
+            };
 
             Value* pDescTablePtr = nullptr;
 

--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -1105,54 +1105,25 @@ VertexFetch::VertexFetch(
     }
 
     // Initialize default fetch values
-    std::vector<Constant*> defaults;
     auto pZero = ConstantInt::get(m_pContext->Int32Ty(), 0);
+    auto pOne = ConstantInt::get(m_pContext->Int32Ty(), 1);
 
     // Int8 (0, 0, 0, 1)
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
-    m_fetchDefaults.pInt8 = ConstantVector::get(defaults);
+    m_fetchDefaults.pInt8 = ConstantVector::get({ pZero, pZero, pZero, pOne });
 
     // Int16 (0, 0, 0, 1)
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
-    m_fetchDefaults.pInt16 = ConstantVector::get(defaults);
+    m_fetchDefaults.pInt16 = ConstantVector::get({ pZero, pZero, pZero, pOne });
 
     // Int (0, 0, 0, 1)
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
-    m_fetchDefaults.pInt = ConstantVector::get(defaults);
+    m_fetchDefaults.pInt = ConstantVector::get({ pZero, pZero, pZero, pOne });
 
     // Int64 (0, 0, 0, 1)
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
-    m_fetchDefaults.pInt64 = ConstantVector::get(defaults);
+    m_fetchDefaults.pInt64 = ConstantVector::get({ pZero, pZero, pZero, pZero, pZero, pZero, pZero, pOne });
 
     // Float16 (0, 0, 0, 1.0)
     const uint16_t float16One = 0x3C00;
-
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), float16One));
-    m_fetchDefaults.pFloat16 = ConstantVector::get(defaults);
+    auto pFloat16One = ConstantInt::get(m_pContext->Int32Ty(), float16One);
+    m_fetchDefaults.pFloat16 = ConstantVector::get({ pZero, pZero, pZero, pFloat16One });
 
     // Float (0.0, 0.0, 0.0, 1.0)
     union
@@ -1160,13 +1131,8 @@ VertexFetch::VertexFetch(
         float    f;
         uint32_t u32;
     } floatOne = { 1.0f };
-
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), floatOne.u32));
-    m_fetchDefaults.pFloat = ConstantVector::get(defaults);
+    auto pFloatOne = ConstantInt::get(m_pContext->Int32Ty(), floatOne.u32);
+    m_fetchDefaults.pFloat = ConstantVector::get({ pZero, pZero, pZero, pFloatOne });
 
     // Double (0.0, 0.0, 0.0, 1.0)
     union
@@ -1174,17 +1140,12 @@ VertexFetch::VertexFetch(
         double   d;
         uint32_t u32[2];
     } doubleOne = { 1.0 };
-
-    defaults.clear();
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(pZero);
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), doubleOne.u32[0]));
-    defaults.push_back(ConstantInt::get(m_pContext->Int32Ty(), doubleOne.u32[1]));
-    m_fetchDefaults.pDouble = ConstantVector::get(defaults);
+    auto pDoubleOne0 = ConstantInt::get(m_pContext->Int32Ty(), doubleOne.u32[0]);
+    auto pDoubleOne1 = ConstantInt::get(m_pContext->Int32Ty(), doubleOne.u32[1]);
+    m_fetchDefaults.pDouble = ConstantVector::get({ pZero, pZero,
+                                                    pZero, pZero,
+                                                    pZero, pZero,
+                                                    pDoubleOne0, pDoubleOne1 });
 }
 
 // =====================================================================================================================
@@ -1419,11 +1380,12 @@ Value* VertexFetch::Run(
             // the same types.
 
             // %vf1 = shufflevector %vf1, %vf1, <0, 1, undef, undef>
-            shuffleMask.clear();
-            shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));
-            shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
-            shuffleMask.push_back(UndefValue::get(m_pContext->Int32Ty()));
-            shuffleMask.push_back(UndefValue::get(m_pContext->Int32Ty()));
+            Constant* shuffleMask[] = {
+                ConstantInt::get(m_pContext->Int32Ty(), 0),
+                ConstantInt::get(m_pContext->Int32Ty(), 1),
+                UndefValue::get(m_pContext->Int32Ty()),
+                UndefValue::get(m_pContext->Int32Ty())
+            };
             vertexFetch[1] = new ShuffleVectorInst(vertexFetch[1],
                                                    vertexFetch[1],
                                                    ConstantVector::get(shuffleMask),
@@ -1659,9 +1621,10 @@ Value* VertexFetch::LoadVertexBufferDescriptor(
     Instruction* pInsertPos     // [in] Where to insert instructions
     ) const
 {
-    std::vector<Value*> idxs;
-    idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), 0, false));
-    idxs.push_back(ConstantInt::get(m_pContext->Int64Ty(), binding, false));
+    Value* idxs[] = {
+        ConstantInt::get(m_pContext->Int64Ty(), 0, false),
+        ConstantInt::get(m_pContext->Int64Ty(), binding, false)
+    };
 
     auto pVbTablePtr = m_pShaderSysValues->GetVertexBufTablePtr();
     auto pVbDescPtr = GetElementPtrInst::Create(nullptr, pVbTablePtr, idxs, "", pInsertPos);
@@ -1761,13 +1724,14 @@ void VertexFetch::AddVertexFetchInst(
         }
 
         // Do vertex fetch
-        std::vector<Value*> args;
-        args.push_back(pVbDesc);                                                              // rsrc
-        args.push_back(pVbIndex);                                                             // vindex
-        args.push_back(ConstantInt::get(m_pContext->Int32Ty(), offset));                      // offset
-        args.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));                           // soffset
-        args.push_back(ConstantInt::get(m_pContext->Int32Ty(), MapVertexFormat(dfmt, nfmt))); // dfmt, nfmt
-        args.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));                           // glc, slc
+        Value* args[] = {
+            pVbDesc,                                                                // rsrc
+            pVbIndex,                                                               // vindex
+            ConstantInt::get(m_pContext->Int32Ty(), offset),                        // offset
+            ConstantInt::get(m_pContext->Int32Ty(), 0),                             // soffset
+            ConstantInt::get(m_pContext->Int32Ty(), MapVertexFormat(dfmt, nfmt)),   // dfmt, nfmt
+            ConstantInt::get(m_pContext->Int32Ty(), 0)                              // glc, slc
+        };
 
         StringRef suffix = "";
         Type* pFetchTy = nullptr;
@@ -1846,10 +1810,11 @@ void VertexFetch::AddVertexFetchInst(
         {
             // NOTE: If valid number of channels is 3, the actual fetch type should be revised from <4 x i32>
             // to <3 x i32>.
-            std::vector<Constant*> shuffleMask;
-            shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));
-            shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 1));
-            shuffleMask.push_back(ConstantInt::get(m_pContext->Int32Ty(), 2));
+            Constant* shuffleMask[] = {
+                ConstantInt::get(m_pContext->Int32Ty(), 0),
+                ConstantInt::get(m_pContext->Int32Ty(), 1),
+                ConstantInt::get(m_pContext->Int32Ty(), 2)
+            };
             *ppFetch = new ShuffleVectorInst(pFetch, pFetch, ConstantVector::get(shuffleMask), "", pInsertPos);
         }
         else
@@ -1895,14 +1860,15 @@ void VertexFetch::AddVertexFetchInst(
         // Do vertex per-component fetches
         for (uint32_t i = 0; i < pFormatInfo->compCount; ++i)
         {
-            std::vector<Value*> args;
-            args.push_back(pVbDesc);                                                        // rsrc
-            args.push_back(compVbIndices[i]);                                               // vindex
-            args.push_back(ConstantInt::get(m_pContext->Int32Ty(), compOffsets[i]));        // offset
-            args.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));                     // soffset
-            args.push_back(ConstantInt::get(m_pContext->Int32Ty(),
-                                            MapVertexFormat(pFormatInfo->compDfmt, nfmt))); // dfmt, nfmt
-            args.push_back(ConstantInt::get(m_pContext->Int32Ty(), 0));                     // glc, slc
+            Value* args[] = {
+                pVbDesc,                                                        // rsrc
+                compVbIndices[i],                                               // vindex
+                ConstantInt::get(m_pContext->Int32Ty(), compOffsets[i]),        // offset
+                ConstantInt::get(m_pContext->Int32Ty(), 0),                     // soffset
+                ConstantInt::get(m_pContext->Int32Ty(),
+                                 MapVertexFormat(pFormatInfo->compDfmt, nfmt)), // dfmt, nfmt
+                ConstantInt::get(m_pContext->Int32Ty(), 0)                      // glc, slc
+            };
 
             Value* pCompFetch = nullptr;
             if (is16bitFetch)

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2896,7 +2896,7 @@ Constant* SPIRVToLLVM::buildConstStoreRecursively(
         for (uint32_t i = 0, memberCount = pSpvType->getStructMemberCount(); i < memberCount; i++)
         {
             const uint32_t memberIndex = needsPad ? lookupRemappedTypeElements(pSpvType, i) : i;
-            const std::array<Constant*, 2> indices = { pZero, getBuilder()->getInt32(memberIndex) };
+            Constant* indices[] = { pZero, getBuilder()->getInt32(memberIndex) };
             Type* const pMemberStoreType = GetElementPtrInst::getIndexedType(pStoreType, indices);
             constMembers[memberIndex] = buildConstStoreRecursively(pSpvType->getStructMemberType(i),
                                                                    pMemberStoreType->getPointerTo(addrSpace),

--- a/util/llpcInternal.cpp
+++ b/util/llpcInternal.cpp
@@ -295,8 +295,7 @@ void SetShaderStageToModule(
     LLVMContext& context = pModule->getContext();
     Function* pFunc = GetEntryPoint(pModule);
     auto execModel = ConvertToExecModel(shaderStage);
-    std::vector<Metadata*> execModelMeta =
-    {
+    Metadata* execModelMeta[] = {
         ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(context), execModel))
     };
     auto pExecModelMetaNode = MDNode::get(context, execModelMeta);


### PR DESCRIPTION
This usually makes the code simpler, and it removes dynamic memory
allocation which can be expensive.