### PR TITLE
patch/llpcSystemValues: Refactor internal functions in terms of IRBuilder

### DIFF
--- a/patch/llpcSystemValues.h
+++ b/patch/llpcSystemValues.h
@@ -32,6 +32,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
 
 #include "llpcInternal.h"
 
@@ -129,12 +130,12 @@ private:
     llvm::Instruction* GetSpillTablePtr();
 
     // Load descriptor from driver table
-    llvm::Instruction* LoadDescFromDriverTable(uint32_t tableOffset);
+    llvm::Instruction* LoadDescFromDriverTable(uint32_t tableOffset, llvm::IRBuilder<>& builder);
 
     // Explicitly set the DATA_FORMAT of ring buffer descriptor.
     llvm::Value* SetRingBufferDataFormat(llvm::Value*       pBufDesc,
                                          uint32_t           dataFormat,
-                                         llvm::Instruction* pInsertPos) const;
+                                         llvm::IRBuilder<>& builder) const;
 
     // Find resource node by type
     const ResourceNode* FindResourceNodeByType(ResourceMappingNodeType type);


### PR DESCRIPTION
The main motivation behind this is to avoid awkward code that passes
Instructions around instead of Values and then attempts to insert
subsequent code just after those instructions.

In part the original code is inflexible in that it will fail if used on
instructions at the end of an incomplete basic block. More importantly,
using the IRBuilder is a more idiomatic use of LLVM and happens to make
the code much more readable by virtue of making it more concise.