### PR TITLE
Enable gcc error on unused function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ if(UNIX)
             -Wno-delete-incomplete
             -Wunused-variable
             -Werror=unused-variable
+            -Wunused-function
+            -Werror=unused-function
         )
 
         target_compile_options(llpc PRIVATE $<$<COMPILE_LANGUAGE:CXX>:
@@ -446,7 +448,7 @@ if(UNIX)
         target_compile_options(vfx PRIVATE -fno-strict-aliasing)
         target_compile_options(vfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-std=c++14 -fno-rtti>)
 
-        target_compile_options(vfx PRIVATE -Wno-unused-parameter -Wno-shift-negative-value -Wno-type-limits -Wno-error=switch -Wno-error=sign-compare -Wno-error=parentheses -Wno-error=maybe-uninitialized -Wno-error=delete-non-virtual-dtor -Wno-sign-compare -Wno-error -Wunused-variable -Werror=unused-variable)
+        target_compile_options(vfx PRIVATE -Wno-unused-parameter -Wno-shift-negative-value -Wno-type-limits -Wno-error=switch -Wno-error=sign-compare -Wno-error=parentheses -Wno-error=maybe-uninitialized -Wno-error=delete-non-virtual-dtor -Wno-sign-compare -Wno-error -Wunused-variable -Werror=unused-variable -Wunused-function -Werror=unused-function)
         target_compile_options(vfx PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers>)
 
         message(STATUS "Configured ${PROJECT_NAME} compiler options for GCC.")
@@ -528,7 +530,7 @@ if(UNIX)
         target_compile_options(amdllpc PRIVATE -fno-strict-aliasing)
         target_compile_options(amdllpc PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-std=c++14 -fno-rtti>)
 
-        target_compile_options(amdllpc PRIVATE -Wno-unused-parameter -Wno-shift-negative-value -Wno-type-limits -Wno-error=switch -Wno-error=sign-compare -Wno-error=parentheses -Wno-error=maybe-uninitialized -Wno-error=delete-non-virtual-dtor -Wno-sign-compare -Wno-error -Wunused-variable -Werror=unused-variable)
+        target_compile_options(amdllpc PRIVATE -Wno-unused-parameter -Wno-shift-negative-value -Wno-type-limits -Wno-error=switch -Wno-error=sign-compare -Wno-error=parentheses -Wno-error=maybe-uninitialized -Wno-error=delete-non-virtual-dtor -Wno-sign-compare -Wno-error -Wunused-variable -Werror=unused-variable -Wunused-function -Werror=unused-function)
         target_compile_options(amdllpc PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-missing-field-initializers>)
 
         message(STATUS "Configured ${PROJECT_NAME} compiler options for GCC.")

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -60,7 +60,6 @@ private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(BuilderReplayer);
 
     void ReplayCall(uint32_t opcode, CallInst* pCall);
-    void CheckCallAndReplay(Value* pValue);
 
     Value* ProcessCall(uint32_t opcode, CallInst* pCall);
 
@@ -203,28 +202,6 @@ void BuilderReplayer::ReplayCall(
         }
     }
     pCall->eraseFromParent();
-}
-
-// =====================================================================================================================
-// If the passed value is a recorded builder call, replay it now.
-// This is used in the waterfall loop workaround for not knowing the replay order.
-void BuilderReplayer::CheckCallAndReplay(
-    Value* pValue)    // [in] Value that might be a recorded call
-{
-    if (auto pCall = dyn_cast<CallInst>(pValue))
-    {
-        if (auto pFunc = pCall->getCalledFunction())
-        {
-            if (pFunc->getName().startswith(BuilderCallPrefix))
-            {
-                uint32_t opcode = cast<ConstantInt>(cast<ConstantAsMetadata>(
-                                      pFunc->getMetadata(m_opcodeMetaKindId)->getOperand(0))
-                                    ->getValue())->getZExtValue();
-
-                ReplayCall(opcode, pCall);
-            }
-        }
-    }
 }
 
 // =====================================================================================================================

--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -270,6 +270,7 @@ endif
                     -Wno-invalid-offsetof              \
                     -Wno-sign-compare                  \
                     -Wno-delete-incomplete             \
+                    -Wunused-function                  \
                     -Wunused-variable
         ifeq ($(USING_CLANG),)
             LCXXOPTS += -Wno-maybe-uninitialized


### PR DESCRIPTION
This will help to stop errors (like that fixed in PR345) creeping in
that break clang builds.

Change-Id: If218f365b029021ba8f179c50014084d9110554e