### PR TITLE
Fix the pass-in parameter pModuleUsage of the class SPIRVToLLVM

### DIFF
--- a/lower/llpcSpirvLowerTranslator.cpp
+++ b/lower/llpcSpirvLowerTranslator.cpp
@@ -112,7 +112,7 @@ void SpirvLowerTranslator::TranslateSpirvToLlvm(
     Context* pContext = static_cast<Context*>(&pModule->getContext());
 
     if (readSpirv(pContext->GetBuilder(),
-                  pShaderInfo->pModuleData,
+                  &(pModuleData->usage),
                   spirvStream,
                   ConvertToExecModel(entryStage),
                   pShaderInfo->pEntryTarget,

--- a/translator/include/LLVMSPIRVLib.h
+++ b/translator/include/LLVMSPIRVLib.h
@@ -88,6 +88,7 @@ bool IsSPIRVBinary(std::string &Img);
 } // End namespace SPIRV
 
 namespace Llpc {
+struct ShaderModuleUsage;
 class Builder;
 } // End namespace Llpc
 
@@ -101,7 +102,7 @@ bool writeSpirv(llvm::Module *M, llvm::raw_ostream &OS, std::string &ErrMsg);
 /// \brief Load SPIRV from istream and translate to LLVM module.
 /// \returns true if succeeds.
 bool readSpirv(Llpc::Builder *Builder,
-               const void* ModuleData,
+               const Llpc::ShaderModuleUsage* ModuleData,
                std::istream &IS,
                spv::ExecutionModel EntryExecModel,
                const char *EntryName,

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -311,7 +311,7 @@ private:
 class SPIRVToLLVM {
 public:
   SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule,
-    const SPIRVSpecConstMap &TheSpecConstMap, Builder *pBuilder, const void* pModuleUsage)
+    const SPIRVSpecConstMap &TheSpecConstMap, Builder *pBuilder, const ShaderModuleUsage* pModuleUsage)
     :M(LLVMModule), m_pBuilder(pBuilder), BM(TheSPIRVModule), IsKernel(true),
     EnableXfb(false), EntryTarget(nullptr),
     SpecConstMap(TheSpecConstMap), DbgTran(BM, M),
@@ -10525,7 +10525,7 @@ SPIRVToLLVM::transLinkageType(const SPIRVValue *V) {
 
 } // namespace SPIRV
 
-bool llvm::readSpirv(Builder *Builder, const void *shaderInfo, std::istream &IS,
+bool llvm::readSpirv(Builder *Builder, const ShaderModuleUsage *shaderInfo, std::istream &IS,
                      spv::ExecutionModel EntryExecModel, const char *EntryName,
                      const SPIRVSpecConstMap &SpecConstMap, Module *M,
                      std::string &ErrMsg) {


### PR DESCRIPTION
Also change pModuleUsage type from void* to ShaderModuleUsage* to avoid
this problem in the future.