### PR TITLE
llpc: export resource node and fragment shader output during buildShaderModule

### DIFF
--- a/include/llpc.h
+++ b/include/llpc.h
@@ -266,11 +266,22 @@ enum class BinaryType : uint32_t
     Elf,          ///< ELF
 };
 
+/// Represents resource node data
+struct ResourceNodeData
+{
+    ResourceMappingNodeType type;       ///< Type of this resource mapping node
+    uint32_t                set;        ///< ID of descriptor set
+    uint32_t                binding;    ///< ID of descriptor binding
+    uint32_t                arraySize;  ///< Element count for arrayed binding
+};
+
 /// Represents the information of one shader entry in ShaderModuleExtraData
 struct ShaderModuleEntryData
 {
-    ShaderStage stage;              ///< Shader stage
-    void*       pShaderEntry;       ///< Private shader module entry info
+    ShaderStage             stage;              ///< Shader stage
+    void*                   pShaderEntry;       ///< Private shader module entry info
+    uint32_t                resNodeDataCount;  ///< Resource node data count
+    const ResourceNodeData* pResNodeDatas;     ///< Resource node data array
 };
 
 /// Represents usage info of a shader module
@@ -294,12 +305,27 @@ struct ShaderModuleData
     ShaderModuleUsage usage;        ///< Usage info of a shader module
 };
 
+/// Represents fragment shader output info
+struct FsOutInfo
+{
+    uint32_t    location;       ///< Output location in resource layout
+    uint32_t    index;          ///< Output index in resource layout
+    BasicType   basicType;      ///< Output data type
+    uint32_t    componentCount; ///< Count of components of output data
+};
+
 /// Represents extended output of building a shader module (taking extra data info)
 struct ShaderModuleDataEx
 {
-    ShaderModuleData        common;        ///< Shader module common data
+    ShaderModuleData        common;         ///< Shader module common data
+    uint32_t                codeOffset;     ///< Binary offset of binCode in ShaderModuleDataEx
+    uint32_t                entryOffset;    ///< Shader entry offset in ShaderModuleDataEx
+    uint32_t                resNodeOffset;  ///< Resource node offset in ShaderModuleDataEX
+    uint32_t                fsOutInfoOffset;///< FsOutInfo offset in ShaderModuleDataEX
     struct
     {
+        uint32_t              fsOutInfoCount;           ///< Count of fragment shader output
+        const FsOutInfo*      pFsOutInfos;              ///< Fragment output info array
         uint32_t              entryCount;              ///< Shader entry count in the module
         ShaderModuleEntryData entryDatas[1];           ///< Array of all shader entries in this module
     } extra;                              ///< Represents extra part of shader module data

--- a/lower/llpcSpirvLower.h
+++ b/lower/llpcSpirvLower.h
@@ -85,7 +85,7 @@ llvm::ModulePass* CreateSpirvLowerMemoryOp();
 llvm::ModulePass* CreateSpirvLowerGlobal();
 llvm::ModulePass* CreateSpirvLowerInstMetaRemove();
 llvm::ModulePass* CreateSpirvLowerLoopUnrollControl(uint32_t forceLoopUnrollCount);
-llvm::ModulePass* CreateSpirvLowerResourceCollect();
+llvm::ModulePass* CreateSpirvLowerResourceCollect(bool collectDetailUsage);
 llvm::ModulePass* CreateSpirvLowerTranslator(ShaderStage stage, const PipelineShaderInfo* pShaderInfo);
 
 // =====================================================================================================================

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7733,6 +7733,8 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *BV, Value *V) {
       ResMDs.push_back(
         ConstantAsMetadata::get(ConstantInt::get(Int32Ty, Binding)));
       ResMDs.push_back(
+        ConstantAsMetadata::get(ConstantInt::get(Int32Ty, BlockTy->getOpCode())));
+      ResMDs.push_back(
         ConstantAsMetadata::get(ConstantInt::get(Int32Ty, BlockType)));
       auto ResMDNode = MDNode::get(*Context, ResMDs);
       GV->addMetadata(gSPIRVMD::Resource, *ResMDNode);
@@ -7811,6 +7813,8 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *BV, Value *V) {
         ConstantAsMetadata::get(ConstantInt::get(Int32Ty, DescSet)));
       MDs.push_back(
         ConstantAsMetadata::get(ConstantInt::get(Int32Ty, Binding)));
+      MDs.push_back(
+        ConstantAsMetadata::get(ConstantInt::get(Int32Ty, OpaqueTy->getOpCode())));
       auto MDNode = MDNode::get(*Context, MDs);
       GV->addMetadata(gSPIRVMD::Resource, *MDNode);
 


### PR DESCRIPTION
Parse resource node usage and fragment shader output from llvm pass. and export it to next phase.
v2:
  1.Collect resource node in SPIRAS_Constant
  2.Add new parameter to control resource node collection behavior
  3.Get arraySize from LLVM type
  4.Using simple struct std::vector to return resource node data

v3:
  1.fix Jenkins test failures.
  2.switch to use std::set for resource node instead of std::map
  2.add new index member in FsOutVariable

v4: Some nitpick fix
v5: Coding style improvement
v6,v7: Further improve coding style