### PR TITLE
Fix an issue of VK_EXT_vertex_attribute_disivor (divisor == 0)

### DIFF
--- a/patch/llpcVertexFetch.cpp
+++ b/patch/llpcVertexFetch.cpp
@@ -1181,11 +1181,19 @@ Value* VertexFetch::Run(
         LLPC_ASSERT(pBinding->inputRate == VK_VERTEX_INPUT_RATE_INSTANCE);
         if (pDivisor != nullptr)
         {
-            pVbIndex = BinaryOperator::CreateUDiv(m_pInstanceId,
-                                                  ConstantInt::get(m_pContext->Int32Ty(), pDivisor->divisor),
-                                                  "",
-                                                  pInsertPos);
-            pVbIndex = BinaryOperator::CreateAdd(pVbIndex, m_pBaseInstance, "", pInsertPos);
+            if (pDivisor->divisor == 0)
+            {
+                // All instances get the same VB record index
+                pVbIndex = m_pBaseInstance;
+            }
+            else
+            {
+                pVbIndex = BinaryOperator::CreateUDiv(m_pInstanceId,
+                                                      ConstantInt::get(m_pContext->Int32Ty(), pDivisor->divisor),
+                                                      "",
+                                                      pInsertPos);
+                pVbIndex = BinaryOperator::CreateAdd(pVbIndex, m_pBaseInstance, "", pInsertPos);
+            }
         }
         else
         {


### PR DESCRIPTION
In Vulkan spec, this case is valid. A value of 0 can be used for the
divisor if the feature flag vertexAttributeInstanceRateZeroDivisor is
enabled. In this case, the same vertex attribute will be applied to all
instances.