### PR TITLE
Temporary fixes to cope with llvm upstream changes

### DIFF
--- a/builder/llpcBuilder.h
+++ b/builder/llpcBuilder.h
@@ -288,7 +288,7 @@ public:
     virtual Value* CreateFpTruncWithRounding(
         Value*                                pValue,             // [in] Input value
         Type*                                 pDestTy,            // [in] Type to convert to
-        fp::RoundingMode  roundingMode,                           // Rounding mode
+        unsigned                              roundingMode,       // Rounding mode
         const Twine&                          instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create quantize operation: truncates float (or vector) value to a value that is representable by a half.

--- a/builder/llpcBuilderImpl.h
+++ b/builder/llpcBuilderImpl.h
@@ -113,7 +113,7 @@ public:
     // Create scalar or vector FP truncate operation with rounding mode.
     Value* CreateFpTruncWithRounding(Value*                                pValue,
                                      Type*                                 pDestTy,
-                                     fp::RoundingMode                      roundingMode,
+                                     unsigned                              roundingMode,
                                      const Twine&                          instName = "") override final;
 
     // Create quantize operation.

--- a/builder/llpcBuilderImplArith.cpp
+++ b/builder/llpcBuilderImplArith.cpp
@@ -84,7 +84,7 @@ Value* BuilderImplArith::CreateCubeFaceIndex(
 Value* BuilderImplArith::CreateFpTruncWithRounding(
     Value*            pValue,             // [in] Input value
     Type*             pDestTy,            // [in] Type to convert to
-    fp::RoundingMode  roundingMode,       // Rounding mode
+    unsigned          roundingMode,       // Rounding mode
     const Twine&      instName)           // [in] Name to give instruction(s)
 {
     if (pValue->getType()->getScalarType()->isDoubleTy())
@@ -101,7 +101,10 @@ Value* BuilderImplArith::CreateFpTruncWithRounding(
 
     // RTZ: Use cvt_pkrtz instruction.
     // TODO: We also use this for RTP and RTN for now.
-    if (roundingMode != fp::rmToNearest)
+    // TODO: Using a hard-coded value for rmToNearest due to flux in LLVM over
+    // the namespace for this value - this will be removed once it has settled
+    //if (roundingMode != fp::rmToNearest)
+    if (roundingMode != 1 /* rmToNearest */ )
     {
         Value* pResult = ScalarizeInPairs(pValue,
                                           [this](Value* pInVec2)

--- a/builder/llpcBuilderRecorder.cpp
+++ b/builder/llpcBuilderRecorder.cpp
@@ -806,7 +806,7 @@ Value* BuilderRecorder::CreateRefract(
 Value* BuilderRecorder::CreateFpTruncWithRounding(
     Value*            pValue,             // [in] Input value
     Type*             pDestTy,            // [in] Type to convert to
-    fp::RoundingMode  roundingMode,       // Rounding mode
+    unsigned          roundingMode,       // Rounding mode
     const Twine&      instName)           // [in] Name to give instruction(s)
 {
     return Record(Opcode::FpTruncWithRounding, pDestTy, { pValue, getInt32(roundingMode) }, instName);

--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -247,7 +247,7 @@ public:
     // Create scalar or vector FP truncate operation with rounding mode.
     Value* CreateFpTruncWithRounding(Value*            pValue,
                                      Type*             pDestTy,
-                                     fp::RoundingMode  roundingMode,
+                                     unsigned          roundingMode,
                                      const Twine&      instName = "") override final;
 
     // Create quantize operation.

--- a/builder/llpcBuilderReplayer.cpp
+++ b/builder/llpcBuilderReplayer.cpp
@@ -247,7 +247,7 @@ Value* BuilderReplayer::ProcessCall(
 
     case BuilderRecorder::FpTruncWithRounding:
         {
-            auto roundingMode = static_cast<fp::RoundingMode>(
+            auto roundingMode = static_cast<unsigned>(
                                   cast<ConstantInt>(args[1])->getZExtValue());
             return m_pBuilder->CreateFpTruncWithRounding(args[0], pCall->getType(), roundingMode);
         }

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -33,6 +33,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Type.h"
+#include "llvm/Support/CommandLine.h"
 
 #include <unordered_map>
 #include <unordered_set>

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6016,21 +6016,28 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         DestTy->getScalarType()->getPrimitiveSizeInBits())
       return mapValue(BV, getBuilder()->CreateFPExt(Val, DestTy));
 
-    fp::RoundingMode RM = fp::rmDynamic;
+    // TODO: use hardcoded values during namespace flux for llvm
+    //fp::RoundingMode RM = fp::rmDynamic;
+    unsigned RM = 0; // fp::rmDynamic
     SPIRVFPRoundingModeKind Rounding;
     if (BC->hasFPRoundingMode(&Rounding)) {
       switch (Rounding) {
       case FPRoundingModeRTE:
-        RM = fp::rmToNearest;
+        // TODO: use hardcoded values during namespace flux for llvm
+        //RM = fp::rmToNearest;
+        RM = 1;
         break;
       case FPRoundingModeRTZ:
-        RM = fp::rmTowardZero;
+        //RM = fp::rmTowardZero;
+        RM = 4;
         break;
       case FPRoundingModeRTP:
-        RM = fp::rmUpward;
+        //RM = fp::rmUpward;
+        RM = 3;
         break;
       case FPRoundingModeRTN:
-        RM = fp::rmDownward;
+        //RM = fp::rmDownward;
+        RM = 2;
         break;
       default:
         llvm_unreachable("");

--- a/util/llpcDebug.cpp
+++ b/util/llpcDebug.cpp
@@ -31,6 +31,7 @@
 #define DEBUG_TYPE "llpc-debug"
 
 #include "llvm/IR/Instructions.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Format.h"

--- a/util/llpcTimerProfiler.cpp
+++ b/util/llpcTimerProfiler.cpp
@@ -31,6 +31,7 @@
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 


### PR DESCRIPTION
The rounding mode enumeration is undergoing some flux in upstream LLVM at the
moment. These changes allow for this by using hard-coded values
temporarily. Once the upstream changes have settled, these will be reverted/or
changed to support the eventual solution.

Also includes some new headers that are now required for the CommandLine support
to work correctly in llpc.