### PR TITLE
Set default value 0xf to channelWriteMask

### DIFF
--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1081,6 +1081,7 @@ public:
         Section(m_addrTable, MemberCount, SectionTypeUnset, "colorBuffer")
     {
         memset(&m_state, 0, sizeof(m_state));
+        m_state.channelWriteMask = 0xF;
     }
 
     static void InitialAddrTable()


### PR DESCRIPTION
This change is to fix compatibility with the old dumped pipelines,
the channelWriteMask may not set in those pipelines, then the offline
compilation tools will not work properly.