### PR TITLE
Update test

### DIFF
--- a/test/shaderdb/ObjStorageBlock_TestDouble_lit.frag
+++ b/test/shaderdb/ObjStorageBlock_TestDouble_lit.frag
@@ -13,7 +13,7 @@ layout(location = 0) out vec4 output0;
 void main()
 {
     dvec4 dv4temp = dv4;
-    dv4temp.x = d;
+    dv4temp.x += d;
     d = dv4temp.y;
     output0 = vec4(dv4temp);
     dv4temp = dm2x4[0];


### PR DESCRIPTION
Update ObjStorageBlock_TestDouble_lit.frag so dv4.x is also used in
the shader.

This is needed because the pattern expects dv4.x to be loaded, but
there is a change planned to optimize unused components and with
the change the test would fail.