### PR TITLE
Fix a typo in llpcGfxNConfigBuilder.cpp.

### DIFF
--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -1113,7 +1113,7 @@ Result ConfigBuilder::BuildGsRegConfig(
     {
         gsOutputPrimitiveType = POINTLIST;
     }
-    else if (builtInUsage.outputPrimitive == LINESTRIP)
+    else if (builtInUsage.outputPrimitive == OutputLineStrip)
     {
         gsOutputPrimitiveType = LINESTRIP;
     }

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2013,7 +2013,7 @@ Result ConfigBuilder::BuildEsGsRegConfig(
     {
         gsOutputPrimitiveType = POINTLIST;
     }
-    else if (gsBuiltInUsage.outputPrimitive == LINESTRIP)
+    else if (gsBuiltInUsage.outputPrimitive == OutputLineStrip)
     {
         gsOutputPrimitiveType = LINESTRIP;
     }


### PR DESCRIPTION
We have to use the enumerant OutputLineStrip rather than LINESTRIP.