### PR TITLE
Add NGG support to GS

### DIFF
--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2285,7 +2285,31 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
 
     VGT_GS_OUTPRIM_TYPE gsOutputPrimitiveType = POINTLIST;
-    if (hasTs)
+    if (hasGs)
+    {
+        // GS present
+        if (gsInOutUsage.outputMapLocCount == 0)
+        {
+            gsOutputPrimitiveType = POINTLIST;
+        }
+        else if (gsBuiltInUsage.outputPrimitive == OutputPoints)
+        {
+            gsOutputPrimitiveType = POINTLIST;
+        }
+        else if (gsBuiltInUsage.outputPrimitive == OutputLineStrip)
+        {
+            gsOutputPrimitiveType = LINESTRIP;
+        }
+        else if (gsBuiltInUsage.outputPrimitive == OutputTriangleStrip)
+        {
+            gsOutputPrimitiveType = TRISTRIP;
+        }
+        else
+        {
+            LLPC_NEVER_CALLED();
+        }
+    }
+    else if (hasTs)
     {
         // With tessellation
         if (tesBuiltInUsage.pointMode)

--- a/patch/gfx9/llpcNggPrimShader.cpp
+++ b/patch/gfx9/llpcNggPrimShader.cpp
@@ -2223,6 +2223,9 @@ void NggPrimShader::ConstructPrimShaderWithGs(
         pOutVertCountInWavePhi->addIncoming(m_pBuilder->getInt32(0), pEndZeroOutVertCountBlock);
         pOutVertCountInWavePhi->addIncoming(pOutVertCountInWave, pBeginGsBlock);
         pOutVertCountInWave = pOutVertCountInWavePhi;
+        // NOTE: We promote GS output vertex count in wave to SGPR since it is treated as an uniform value. Otherwise,
+        // phi node resolving still treats it as VGPR, not as expected.
+        pOutVertCountInWave = m_pBuilder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, pOutVertCountInWave);
         pOutVertCountInWave->setName("outVertCountInWave");
 
         m_pBuilder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
@@ -3347,7 +3350,11 @@ Value* NggPrimShader::RunGsVariant(
     Argument* pArg = pSysValueStart;
 
     Value* pGsVsOffset = UndefValue::get(m_pBuilder->getInt32Ty()); // NOTE: For NGG, GS-VS offset is unused
-    Value* pGsWaveId   = m_nggFactor.pWaveIdInSubgroup;
+
+    // NOTE: This argument is expected to be GS wave ID, not wave ID in sub-group, for normal ES-GS merged shader.
+    // However, in NGG mode, GS wave ID, sent to GS_EMIT and GS_CUT messages, is no longer required because of NGG
+    // handling of such messages. Instead, wave ID in sub-group is required as the substitue.
+    auto pWaveId = m_nggFactor.pWaveIdInSubgroup;
 
     pArg += EsGsSpecialSysValueCount;
 
@@ -3456,7 +3463,7 @@ Value* NggPrimShader::RunGsVariant(
 
     // Set up system value SGPRs
     args.push_back(pGsVsOffset);
-    args.push_back(pGsWaveId);
+    args.push_back(pWaveId);
 
     // Set up system value VGPRs
     args.push_back(pEsGsOffset0);
@@ -3603,8 +3610,8 @@ Function* NggPrimShader::MutateGsToVariant(
                 LLPC_ASSERT(streamId < MaxGsStreams);
                 Value* pOutput = pCall->getOperand(3);
 
-                auto pEmitCounter = m_pBuilder->CreateLoad(emitCounterPtrs[streamId]);
-                ExportGsOutput(pOutput, location, compIdx, streamId, pEmitCounter, pThreadIdInWave);
+                auto pOutVertCounter = m_pBuilder->CreateLoad(outVertCounterPtrs[streamId]);
+                ExportGsOutput(pOutput, location, compIdx, streamId, pThreadIdInWave, pOutVertCounter);
 
                 removeCalls.push_back(pCall);
             }
@@ -3665,14 +3672,19 @@ Function* NggPrimShader::MutateGsToVariant(
     // NOTE: Only return vertex count info for rasterization stream.
     auto rasterStream = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.rasterStream;
     auto pOutVertCount = m_pBuilder->CreateLoad(outVertCounterPtrs[rasterStream]);
-    auto pInclusiveOutVertCount = DoSubgroupInclusiveAdd(pOutVertCount);
 
-    auto pOutVertCountInWave = m_pBuilder->CreateIntrinsic(Intrinsic::amdgcn_readlane,
-                                                           {},
-                                                           {
-                                                               pInclusiveOutVertCount,
-                                                               m_pBuilder->getInt32(waveSize - 1)
-                                                           });
+    Value* pOutVertCountInWave = nullptr;
+    auto pInclusiveOutVertCount = DoSubgroupInclusiveAdd(pOutVertCount, &pOutVertCountInWave);
+
+    // NOTE: We use the highest thread (MSB) to get GS output vertex count in this wave (after inclusive-add,
+    // the value of this thread stores this info)
+    pOutVertCountInWave = m_pBuilder->CreateIntrinsic(Intrinsic::amdgcn_readlane,
+                                                      {},
+                                                      {
+                                                          pOutVertCountInWave,
+                                                          m_pBuilder->getInt32(waveSize - 1)
+                                                      });
+
     Value* pResult = UndefValue::get(pResultTy);
     pResult = m_pBuilder->CreateInsertValue(pResult, pOutVertCount, 0);
     pResult = m_pBuilder->CreateInsertValue(pResult, pInclusiveOutVertCount, 1);
@@ -3784,7 +3796,7 @@ void NggPrimShader::ExportGsOutput(
     uint32_t     compIdx,           // Index used for vector element indexing
     uint32_t     streamId,          // ID of output vertex stream
     llvm::Value* pThreadIdInWave,   // [in] Thread ID in wave
-    Value*       pEmitCounter)      // [in] GS emit counter for this stream
+    Value*       pOutVertCounter)   // [in] GS output vertex counter for this stream
 {
     auto pResUsage = m_pContext->GetShaderResourceUsage(ShaderStageGeometry);
     if (pResUsage->inOutUsage.gs.rasterStream != streamId)
@@ -3814,13 +3826,13 @@ void NggPrimShader::ExportGsOutput(
     }
 
     // gsVsRingOffset = threadIdInWave * gsVsRingItemSize +
-    //                  emitCounter * vertexSize +
+    //                  outVertcounter * vertexSize +
     //                  location * 4 + compIdx (in DWORDS)
     const uint32_t gsVsRingItemSize = pResUsage->inOutUsage.gs.calcFactor.gsVsRingItemSize;
     Value* pGsVsRingOffset = m_pBuilder->CreateMul(pThreadIdInWave, m_pBuilder->getInt32(gsVsRingItemSize));
 
     const uint32_t vertexSize = pResUsage->inOutUsage.gs.outLocCount[streamId] * 4;
-    auto pVertexItemOffset = m_pBuilder->CreateMul(pEmitCounter, m_pBuilder->getInt32(vertexSize));
+    auto pVertexItemOffset = m_pBuilder->CreateMul(pOutVertCounter, m_pBuilder->getInt32(vertexSize));
 
     pGsVsRingOffset = m_pBuilder->CreateAdd(pGsVsRingOffset, pVertexItemOffset);
 
@@ -4042,10 +4054,10 @@ Function* NggPrimShader::CreateGsEmitHandler(
         // NOTE: Only calculate GS output primitive data and write it to LDS for rasterization stream.
         if (streamId == pResUsage->inOutUsage.gs.rasterStream)
         {
-            // vertexId = threadIdInSubgroup * outputVertices + emitCounter
+            // vertexId = threadIdInSubgroup * outputVertices + outVertCounter
             auto pvertexId = m_pBuilder->CreateMul(pThreadIdInSubgroup,
                 m_pBuilder->getInt32(pResUsage->builtInUsage.gs.outputVertices));
-            pvertexId = m_pBuilder->CreateAdd(pvertexId, pEmitCounter);
+            pvertexId = m_pBuilder->CreateAdd(pvertexId, pOutVertCounter);
 
             // vertexId0 = vertexId - outVertsPerPrim
             auto pVertexId0 = m_pBuilder->CreateSub(pvertexId, pOutVertsPerPrim);
@@ -6326,7 +6338,8 @@ Value* NggPrimShader::DoSubgroupBallot(
 // =====================================================================================================================
 // Output a subgroup inclusive-add (IAdd).
 Value* NggPrimShader::DoSubgroupInclusiveAdd(
-    Value* pValue) // [in] The value to do the exclusive-add on.
+    Value*   pValue,        // [in] The value to do the inclusive-add on
+    Value**  ppWwmResult)   // [out] Result in WWM section (optinal)
 {
     LLPC_ASSERT(pValue->getType()->isIntegerTy(32)); // Should be i32
 
@@ -6418,6 +6431,12 @@ Value* NggPrimShader::DoSubgroupInclusiveAdd(
     if (waveSize == 64)
     {
         pResult = m_pBuilder->CreateAdd(pResult, pMaskedBroadcast);
+    }
+
+    if (ppWwmResult != nullptr)
+    {
+        // Return the result in WWM section (optional)
+        *ppWwmResult = pResult;
     }
 
     // Finish the WWM section

--- a/patch/gfx9/llpcNggPrimShader.h
+++ b/patch/gfx9/llpcNggPrimShader.h
@@ -105,7 +105,7 @@ private:
                         uint32_t     compIdx,
                         uint32_t     streamId,
                         llvm::Value* pThreadIdInWave,
-                        llvm::Value* pEmitCounter);
+                        llvm::Value* pOutVertCounter);
 
     llvm::Value* ImportGsOutput(llvm::Type*  pOutputTy,
                                 uint32_t     location,
@@ -185,7 +185,7 @@ private:
     llvm::Function* CreateFetchCullingRegister(llvm::Module* pModule);
 
     llvm::Value* DoSubgroupBallot(llvm::Value* pValue);
-    llvm::Value* DoSubgroupInclusiveAdd(llvm::Value* pValue);
+    llvm::Value* DoSubgroupInclusiveAdd(llvm::Value* pValue, llvm::Value** ppWwmResult = nullptr);
     llvm::Value* DoDppUpdate(llvm::Value* pOldValue,
                              llvm::Value* pSrcValue,
                              uint32_t     dppCtrl,


### PR DESCRIPTION
Phase 3: Clear CTS issues for non culling mode.

- Misuse emitCounter to calculate primitive data, causing wrong vertex
  indices. EmitCounter will be adjusted dynamically when we lower GS_EMIT
  message. OutVertCounter is always incremented and represents the
  counting of GS output vertices.

- Return a value of WWM result of subgroupInclusiveAdd(). The highest
  thread has the value of GS output vertex count.

- Clarify the use of argument waveId in NGG. Originally, this value
  represents GS wave ID used in GS_EMIT/GS_CUT messages. Now, those GS
  messages are lowered in NGG. The value is actually  the ID of a wave
  in one NGG subgroup.

- Promote outVertCountInWave to SGPR. The value should be uniform in
  a wave,  but phi resolving leads it to be a VGPR. When GS threads
  are active, those threads take an uniform value, representing
  total number of GS output vertices in this wave. Otherwise, non GS
  threads take a value of zero. After we handle GS threads, we need
  a SGPR value from the first thread.

- The field OUTPRIM_TYPE of VGT_GS_OUT_PRIM_TYPE is incorrectly
  set. When GS is present, NGG should use GS output primitive type
  specified in shader.

Clear CTS test group: dEQP-VK.geometry.input.*