### PR TITLE
Use char[] instead of char* for global string constants

### DIFF
--- a/builder/llpcBuilderRecorder.h
+++ b/builder/llpcBuilderRecorder.h
@@ -41,10 +41,10 @@ namespace Llpc
 using namespace llvm;
 
 // Prefix of all recorded calls.
-static const char* const BuilderCallPrefix = "llpc.call.";
+static const char BuilderCallPrefix[] = "llpc.call.";
 
 // LLPC call opcode metadata name.
-static const char* const BuilderCallOpcodeMetadataName = "llpc.call.opcode";
+static const char BuilderCallOpcodeMetadataName[] = "llpc.call.opcode";
 
 // =====================================================================================================================
 // A class that caches the metadata kind IDs used by BuilderRecorder and BuilderReplayer.

--- a/builder/llpcPipelineState.cpp
+++ b/builder/llpcPipelineState.cpp
@@ -41,7 +41,7 @@ using namespace Llpc;
 using namespace llvm;
 
 // User data nodes metadata name prefix
-static const char* const BuilderUserDataMetadataName = "llpc.user.data.nodes";
+static const char BuilderUserDataMetadataName[] = "llpc.user.data.nodes";
 
 // =====================================================================================================================
 // Set the resource mapping nodes for the pipeline.

--- a/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/translator/lib/SPIRV/SPIRVReader.cpp
@@ -119,7 +119,7 @@ cl::opt<bool> SPIRVWorkaroundBadSPIRV("spirv-workaround-bad-spirv",
 const char *KPlaceholderPrefix = "placeholder.";
 
 // Prefix for row major matrix helpers.
-static const char* const SpirvLaunderRowMajor = "spirv.launder.row_major";
+static const char SpirvLaunderRowMajor[] = "spirv.launder.row_major";
 
 static const SPIRVWord SPV_VERSION_1_0 = 0x00010000;
 


### PR DESCRIPTION
With char[], the compiler is not tempted to create the pointer as a real
object that would require a relocation by the runtime dynamic linker.

Most string constants already use char[], this change cleans up some places
that I found with a grep.