### PR TITLE
Tuning option for loop unroll threshold

### DIFF
--- a/include/llpc.h
+++ b/include/llpc.h
@@ -43,7 +43,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 38
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 //**
 //**********************************************************************************************************************
@@ -51,6 +51,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     38.1 | Added unrollThreshold to PipelineShaderOptions                                                        |
 //* |     38.0 | Removed CreateShaderCache in ICompiler and pShaderCache in pipeline build info                        |
 //* |     37.0 | Removed the -enable-dynamic-loop-unroll option                                                        |
 //* |     36.0 | Add 128 bit hash as clientHash in PipelineShaderOptions                                               |
@@ -421,6 +422,8 @@ struct PipelineShaderOptions
     /// Disable the the LLVM backend's LICM pass.
     bool      disableLicm;
 #endif
+    /// Default unroll threshold for LLVM.
+    uint32_t  unrollThreshold;
 };
 
 /// Represents one node in a graph defining how the user data bound in a command buffer at draw/dispatch time maps to

--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -240,6 +240,11 @@ void PatchEntryPointMutate::ProcessShader()
         builder.addAttribute("amdgpu-waves-per-eu", wavesPerEu);
     }
 
+    if (pShaderOptions->unrollThreshold != 0)
+    {
+        builder.addAttribute("amdgpu-unroll-threshold", std::to_string(pShaderOptions->unrollThreshold));
+    }
+
     AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);
     pEntryPoint->addAttributes(attribIdx, builder);
 

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1190,13 +1190,15 @@ public:
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
 #endif
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
+
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);
     }
 
     void GetSubState(SubState& state) { state = m_state; };
 
 private:
-    static const uint32_t  MemberCount = 15;
+    static const uint32_t  MemberCount = 16;
     static StrToMemberAddr m_addrTable[MemberCount];
 
     SubState               m_state;

--- a/util/llpcPipelineDumper.cpp
+++ b/util/llpcPipelineDumper.cpp
@@ -640,6 +640,7 @@ void PipelineDumper::DumpPipelineShaderInfo(
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
     dumpFile << "options.disableLicm = " << pShaderInfo->options.disableLicm << "\n";
 #endif
+    dumpFile << "options.unrollThreshold = " << pShaderInfo->options.unrollThreshold << "\n";
 
     dumpFile << "\n";
 }
@@ -1208,6 +1209,7 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
             pHasher->Update(options.disableLicm);
 #endif
+            pHasher->Update(options.unrollThreshold);
         }
     }
 }


### PR DESCRIPTION
Add a shader tuning option "unrollThreshold" to allow the default loop unroll
threshold used by LLVM to be initialised to the specified value.
If a non-zero unrollThreshold is specified then it is passed to LLVM by use
of an attribute "amdgpu-unroll-threshold" that is attached to each function.
The unroll threshold used for each loop is then initialised to the specified
value before the target specific heuristics are applied, which may increase it.