### PR TITLE
llpc: export more variables to shader module data

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -599,6 +599,7 @@ Result Compiler::BuildShaderModule(
 
                     moduleEntryData.pShaderEntry = &moduleEntry;
                     moduleEntryData.stage = entryNames[i].stage;
+                    moduleEntryData.pEntryName = entryNames[i].pName;
                     moduleEntry.entryOffset = moduleBinary.size();
                     MetroHash::Hash entryNamehash = {};
                     MetroHash64::Hash(reinterpret_cast<const uint8_t*>(entryNames[i].pName),
@@ -632,7 +633,8 @@ Result Compiler::BuildShaderModule(
                     shaderInfo.pEntryTarget = entryNames[i].pName;
                     lowerPassMgr->add(CreateSpirvLowerTranslator(static_cast<ShaderStage>(entryNames[i].stage),
                                                                 &shaderInfo));
-                    bool collectDetailUsage = (entryNames[i].stage == ShaderStageFragment) ? true : false;
+                    bool collectDetailUsage = ((entryNames[i].stage == ShaderStageFragment) ||
+                                               (entryNames[i].stage == ShaderStageCompute)) ? true : false;
                     auto pResCollectPass = static_cast<SpirvLowerResourceCollect*>(
                                            CreateSpirvLowerResourceCollect(collectDetailUsage));
                     lowerPassMgr->add(pResCollectPass);
@@ -682,8 +684,9 @@ Result Compiler::BuildShaderModule(
                             entryResourceNodeDatas[i].push_back(data);
                         }
 
-                        auto& fsOutInfos = pResCollectPass->GetFsOutInfos();
-                        for (auto& fsOutInfo : fsOutInfos)
+                        moduleEntryData.pushConstSize = pResCollectPass->GetPushConstSize();
+                        auto& fsOutInfosFromPass = pResCollectPass->GetFsOutInfos();
+                        for (auto& fsOutInfo : fsOutInfosFromPass)
                         {
                             fsOutInfos.push_back(fsOutInfo);
                         }

--- a/include/llpc.h
+++ b/include/llpc.h
@@ -291,9 +291,11 @@ struct ResourceNodeData
 struct ShaderModuleEntryData
 {
     ShaderStage             stage;              ///< Shader stage
+    const char*             pEntryName;         ///< Shader entry name
     void*                   pShaderEntry;       ///< Private shader module entry info
-    uint32_t                resNodeDataCount;  ///< Resource node data count
-    const ResourceNodeData* pResNodeDatas;     ///< Resource node data array
+    uint32_t                resNodeDataCount;   ///< Resource node data count
+    const ResourceNodeData* pResNodeDatas;      ///< Resource node data array
+    uint32_t                pushConstSize;      ///< Push constant size in byte
 };
 
 /// Represents usage info of a shader module

--- a/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/lower/llpcSpirvLowerResourceCollect.cpp
@@ -66,6 +66,7 @@ SpirvLowerResourceCollect::SpirvLowerResourceCollect(
     :
     SpirvLower(ID),
     m_collectDetailUsage(collectDetailUsage),
+    m_pushConstSize(0),
     m_detailUsageValid(false)
 {
     initializeSpirvLowerResourceCollectPass(*PassRegistry::getPassRegistry());
@@ -193,7 +194,13 @@ bool SpirvLowerResourceCollect::runOnModule(
         {
         case SPIRAS_Constant:
             {
-                if (pGlobal->hasMetadata(gSPIRVMD::PushConst) == false)
+                if (pGlobal->hasMetadata(gSPIRVMD::PushConst))
+                {
+                    // Push constant
+                    MDNode* pMetaNode = pGlobal->getMetadata(gSPIRVMD::PushConst);
+                    m_pushConstSize = mdconst::dyn_extract<ConstantInt>(pMetaNode->getOperand(0))->getZExtValue();
+                }
+                else
                 {
                     // Only collect resource node data when requested
                     if (m_collectDetailUsage == true)

--- a/lower/llpcSpirvLowerResourceCollect.h
+++ b/lower/llpcSpirvLowerResourceCollect.h
@@ -47,10 +47,10 @@ union ResourceNodeDataKey
 {
     struct
     {
-        uint64_t set        :   16;  // Resource set
-        uint64_t binding    :   16;  // Resource binding
-        uint64_t arraySize  :   16;  // Resource array size
         uint64_t reserved   :   16;
+        uint64_t arraySize  :   16;  // Resource array size
+        uint64_t binding    :   16;  // Resource binding
+        uint64_t set        :   16;  // Resource set
     } value;
     uint64_t u64All;
 };
@@ -75,6 +75,7 @@ public:
     {
         return m_resNodeDatas;
     }
+    auto GetPushConstSize() {return m_pushConstSize; }
     auto& GetFsOutInfos() { return m_fsOutInfos; }
     bool DetailUsageValid() { return m_detailUsageValid; }
 
@@ -99,6 +100,7 @@ private:
     bool m_collectDetailUsage;      // If enabled, collect detailed usages of resource node datas and FS output infos
     std::map<ResourceNodeDataKey, ResourceMappingNodeType, ResNodeDataSortingComparer> m_resNodeDatas; // Resource
                                                                                                        // node data
+    uint32_t m_pushConstSize;        // Push constant size in byte
     std::vector<FsOutInfo> m_fsOutInfos;   // FS output info array
     bool m_detailUsageValid; // Indicate whether detailed usages (resource node datas
                              // or fragment shader output infos) are valid


### PR DESCRIPTION
1. export entry name and pushConstant size
2. fix issue when getting fsOutInfo
3. reverse set/binding/arraysize order in std::set
4. collect compute pipeline layout

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>