### PR TITLE
Made PipelineState final to avoid clang-tidy error

### DIFF
--- a/builder/llpcPipelineState.h
+++ b/builder/llpcPipelineState.h
@@ -98,7 +98,7 @@ struct NggControl : NggState
 
 // =====================================================================================================================
 // The middle-end implementation of PipelineState, a subclass of Pipeline.
-class PipelineState : public Pipeline
+class PipelineState final : public Pipeline
 {
 public:
     PipelineState(BuilderContext* pBuilderContext)


### PR DESCRIPTION
A class has to be final if its destructor is final.

Change-Id: I3b09706464c88ca5788b7af5bb8013e229d4df79