### PR TITLE
LLVM IRBuilder::CreateMemSet has changed to use MaybeAlign

### DIFF
--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -1286,7 +1286,7 @@ void PatchBufferOp::PostVisitMemSetInst(
             Value* const pMemSet = m_pBuilder->CreateMemSet(pCastMemoryPointer,
                                                             pValue,
                                                             stride,
-                                                            1);
+                                                            Align::None());
             CopyMetadata(pMemSet, &memSetInst);
 
             pNewValue = m_pBuilder->CreateLoad(pMemoryPointer);
@@ -1348,7 +1348,7 @@ void PatchBufferOp::PostVisitMemSetInst(
             Value* const pMemSet = m_pBuilder->CreateMemSet(pCastMemoryPointer,
                                                             pValue,
                                                             pMemoryType->getVectorNumElements(),
-                                                            1);
+                                                            Align::None());
             CopyMetadata(pMemSet, &memSetInst);
 
             pNewValue = m_pBuilder->CreateLoad(pMemoryPointer);


### PR DESCRIPTION
This will be needed from upstream LLVM commit 1b2842bf902 "[Alignment][NFC] CreateMemSet use MaybeAlign"

Change-Id: Ie97a11100be6b7f6c547d54c743aeb14222078b7