### PR TITLE
Cleanup return block after SpirvLowerGlobal

### DIFF
--- a/lower/llpcSpirvLowerGlobal.cpp
+++ b/lower/llpcSpirvLowerGlobal.cpp
@@ -35,6 +35,7 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
 
 #include <unordered_set>
 #include "SPIRVInternal.h"
@@ -200,6 +201,8 @@ bool SpirvLowerGlobal::runOnModule(
 
     LowerBufferBlock();
     LowerPushConsts();
+
+    CleanupReturnBlock();
 
     return true;
 }
@@ -2357,6 +2360,22 @@ void SpirvLowerGlobal::LowerPushConsts()
     {
         pGlobal->dropAllReferences();
         pGlobal->eraseFromParent();
+    }
+}
+
+// =====================================================================================================================
+// Removes the created return block if it has a single predecessor. This is to avoid
+// scheduling future heavy-weight cleanup passes if we can trivially simplify the CFG here.
+void SpirvLowerGlobal::CleanupReturnBlock()
+{
+    if (m_pRetBlock == nullptr)
+    {
+        return;
+    }
+
+    if (MergeBlockIntoPredecessor(m_pRetBlock))
+    {
+        m_pRetBlock = nullptr;
     }
 }
 

--- a/lower/llpcSpirvLowerGlobal.h
+++ b/lower/llpcSpirvLowerGlobal.h
@@ -74,6 +74,8 @@ private:
     void LowerBufferBlock();
     void LowerPushConsts();
 
+    void CleanupReturnBlock();
+
     llvm::Value* AddCallInstForInOutImport(llvm::Type*        pInOutTy,
                                            uint32_t           addrSpace,
                                            llvm::Constant*    pInOutMeta,

--- a/test/shaderdb/OpImageDrefGather_TestTextureGather_lit.frag
+++ b/test/shaderdb/OpImageDrefGather_TestTextureGather_lit.frag
@@ -33,7 +33,7 @@ void main()
 ; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @llpc.call.image.gather.v4f32(i32 5, i32 0, {{.*}}, i32 545, <3 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, float 0.000000e+00, float 0x3FE99999A0000000)
 ; SHADERTEST: call { <8 x i32> addrspace(4)*, i32 } (...) @"llpc.call.get.image.desc.ptr.s[p4v8i32,i32]"(i32 0, i32 1)
 ; SHADERTEST: call { <4 x i32> addrspace(4)*, i32 } (...) @"llpc.call.get.sampler.desc.ptr.s[p4v4i32,i32]"(i32 0, i32 1)
-; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @llpc.call.image.gather.v4f32(i32 1, i32 0, <8 x i32> %19, <4 x i32> %18, i32 545, <2 x float> <float 1.000000e+00, float 1.000000e+00>, float 0.000000e+00, float 0x3FE6666660000000)
+; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @llpc.call.image.gather.v4f32(i32 1, i32 0, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <4 x i32> %{{[-0-9A-Za0z_.]+}}, i32 545, <2 x float> <float 1.000000e+00, float 1.000000e+00>, float 0.000000e+00, float 0x3FE6666660000000)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
 ; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.gather4.c.l.2d.v4f32.f32(i32 1, float 0x3FECCCCCC0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0.000000e+00, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <4 x i32> %{{[-0-9A-Za0z_.]+}}, i1 false, i32 0, i32 0)

--- a/test/shaderdb/OpVectorShuffle_TestVec_lit.frag
+++ b/test/shaderdb/OpVectorShuffle_TestVec_lit.frag
@@ -25,10 +25,8 @@ void main()
 ; SHADERTEST: %{{.*}} = extractelement <2 x float> %{{.*}}, i32 1
 ; SHADERTEST: %{{.*}} = insertelement <4 x float> %{{.*}}, float %{{.*}}, i32 3
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = extractelement <3 x float> %{{.*}}, i32 2
-; SHADERTEST: %{{.*}} = insertelement <4 x float> <float undef, float {{.*}}, float {{.*}}, float undef>, float %{{.*}}, i32 0
-; SHADERTEST: %{{.*}} = extractelement <3 x float> %{{.*}}, i32 1
-; SHADERTEST: %{{.*}} = insertelement <4 x float> %{{.*}}, float %{{.*}}, i32 3
+; SHADERTEST: [[VEC1:%.*]] = shufflevector <3 x float> %{{.*}}, <3 x float> undef, <4 x i32> <i32 undef, i32 1, i32 2, i32 undef>
+; SHADERTEST: [[VEC2:%.*]] = shufflevector <4 x float> <float undef, float 5.000000e-01, float 5.000000e-01, float undef>, <4 x float> [[VEC1]], <4 x i32> <i32 6, i32 1, i32 2, i32 5>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
This patch teaches the spirv globals lowering pass to clean up the created return block in the simplest case when the return block has a single predecessor.