### PR TITLE
Fixed input/output packing to be entirely in the middle-end

### DIFF
--- a/context/llpcContext.h
+++ b/context/llpcContext.h
@@ -250,21 +250,6 @@ public:
     // Sets triple and data layout in specified module from the context's target machine.
     void SetModuleTargetMachine(llvm::Module* pModule);
 
-    bool CanPackInOut(ShaderStage shaderStage, bool isOutput) const
-    {
-        return m_pPipelineContext->CanPackInOut(shaderStage, isOutput);
-    }
-
-    bool IsPackInOutEnabled() const
-    {
-        return m_pPipelineContext->IsPackInOutEnabled();
-    }
-
-    void EnablePackInOut(bool packInOut)
-    {
-        m_pPipelineContext->EnablePackInOut(packInOut);
-    }
-
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(Context);
     LLPC_DISALLOW_COPY_AND_ASSIGN(Context);

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -63,6 +63,9 @@ public:
     // Gets the mask of active shader stages bound to this pipeline
     virtual uint32_t GetShaderStageMask() const { return m_stageMask; }
 
+    // Get the last vertex processing shader stage in this pipeline, or ShaderStageInvalid if none.
+    virtual ShaderStage GetLastVertexProcessingStage() const;
+
     // Gets the count of active shader stages
     virtual uint32_t GetActiveShaderStageCount() const { return m_activeStageCount; }
 
@@ -85,15 +88,6 @@ public:
     // Gets per pipeline options
     virtual const PipelineOptions* GetPipelineOptions() const { return &m_pPipelineInfo->options; }
 
-    // Checks whether the requirements of packing input/output is satisfied
-    virtual bool CanPackInOut(ShaderStage shaderStage, bool isOutput) const;
-
-    // Checks whether pack input/output is enabled
-    virtual bool IsPackInOutEnabled() const { return m_packInOut; }
-
-    // Enable/disable pack input/output
-    virtual void EnablePackInOut(bool packInOut) { m_packInOut = packInOut; }
-
     void InitShaderInfoForNullFs();
 
 private:
@@ -115,7 +109,6 @@ private:
     InterfaceData   m_intfData[ShaderStageGfxCount];    // Interface data of all graphics shader stages
 
     bool            m_gsOnChip;    // Whether to enable GS on-chip mode
-    bool            m_packInOut;    // Whether to enable/disable pack in/out
 
     llvm::SmallVector<std::unique_ptr<llvm::SmallVectorImpl<ResourceMappingNode>>, 4>
                     m_allocUserDataNodes;               // Allocated merged user data nodes

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -707,6 +707,9 @@ public:
     // Gets the mask of active shader stages bound to this pipeline
     virtual uint32_t GetShaderStageMask() const = 0;
 
+    // Get the final vertex processing shader stage in this pipeline, or ShaderStageInvalid if none.
+    virtual ShaderStage GetLastVertexProcessingStage() const { return ShaderStageInvalid; }
+
     // Gets the count of active shader stages
     virtual uint32_t GetActiveShaderStageCount() const = 0;
 
@@ -751,15 +754,6 @@ public:
 
     // Set pipeline state in Pipeline object for middle-end
     void SetPipelineState(Pipeline* pPipeline) const;
-
-    // Checks whether the requirements of packing input/output is satisfied
-    virtual bool CanPackInOut(ShaderStage shaderStage, bool isOutput) const { return false; }
-
-    // Checks whether pack input/output is enabled
-    virtual bool IsPackInOutEnabled() const { return false; }
-
-    // Enable/disable pack input/output
-    virtual void EnablePackInOut(bool packInOut) {}
 
     static void InitShaderResourceUsage(ShaderStage shaderStage, ResourceUsage* pResUsage);
 

--- a/patch/llpcPatchNullFragShader.cpp
+++ b/patch/llpcPatchNullFragShader.cpp
@@ -164,9 +164,6 @@ bool PatchNullFragShader::runOnModule(
     GraphicsContext* pGraphicsContext = static_cast<GraphicsContext*>(m_pContext->GetPipelineContext());
     pGraphicsContext->InitShaderInfoForNullFs();
 
-    // Disable pack input/output for null FS
-    pGraphicsContext->EnablePackInOut(false);
-
     return true;
 }
 

--- a/patch/llpcPatchResourceCollect.h
+++ b/patch/llpcPatchResourceCollect.h
@@ -93,8 +93,14 @@ private:
     void ReviseInputImportCalls();
     void ReassembleOutputExportCalls();
 
+    // Input/output scalarizing
+    void ScalarizeForInOutPacking(Module* pModule);
+    void ScalarizeGenericInput(CallInst* pCall);
+    void ScalarizeGenericOutput(CallInst* pCall);
+
     // -----------------------------------------------------------------------------------------------------------------
 
+    PipelineShaders*                m_pPipelineShaders;         // Pipeline shaders
     PipelineState*                  m_pPipelineState;           // Pipeline state
 
     std::unordered_set<llvm::CallInst*> m_deadCalls;            // Dead calls


### PR DESCRIPTION
The previous change to add input/output packing put some of the
implementation (the scalarizing) into the front-end, which causes
problems for the middle-end interface clean-up.

Also fixed to use InOutInfo::InterpMode* enum values.

Change-Id: Ifc5b0f26836a5d91f96883f4a88c7d87f208d135