### PR TITLE
llpc: fix Global type got incorrectly

### DIFF
--- a/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/lower/llpcSpirvLowerResourceCollect.cpp
@@ -220,7 +220,7 @@ bool SpirvLowerResourceCollect::runOnModule(
         case SPIRAS_Output:
             {
                 // Only collect FS out info when requested.
-                Type* pGlobalTy = pGlobal->getType();
+                Type* pGlobalTy = pGlobal->getType()->getContainedType(0);
                 if (m_collectDetailUsage == false || pGlobalTy->isSingleValueType() == false)
                 {
                     break;


### PR DESCRIPTION
It's a regression, caused by "Created ShaderModes to pass input
language shader modes into middle-end ".

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>