### PR TITLE
Turn off deprecated-declarations warning-as-error

### DIFF
--- a/make/Makefile.llpc
+++ b/make/Makefile.llpc
@@ -272,7 +272,8 @@ endif
                     -Wno-sign-compare                  \
                     -Wno-delete-incomplete             \
                     -Wunused-function                  \
-                    -Wunused-variable
+                    -Wunused-variable                  \
+                    -Wno-error=deprecated-declarations
         ifeq ($(USING_CLANG),)
             LCXXOPTS += -Wno-maybe-uninitialized
         else

--- a/tool/Makefile.apillpctool
+++ b/tool/Makefile.apillpctool
@@ -87,7 +87,8 @@ LCXXOPTS +=                                \
 	    -Wno-error=sign-compare            \
 	    -Wno-error=parentheses             \
 	    -Wno-error=delete-non-virtual-dtor \
-	    -Wno-sign-compare
+	    -Wno-sign-compare                  \
+	    -Wno-error=deprecated-declarations
     ifeq ($(USING_CLANG),)
         LCXXOPTS += -Wno-error=maybe-uninitialized \
                     -fno-lto


### PR DESCRIPTION
LLVM is in the process of deprecating some IRBuilder functions. This particular
issue is for CreateMemCpy and CreateMemMove. During the transition period we
need to not treat these warnings as errors.

This change can be undone once transition has completed.