### PR TITLE
Add extra header

### DIFF
--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -40,6 +40,9 @@
 #include "llpc.h"
 #include "llpcUtil.h"
 
+// TODO: Remove once LLVM has been updated with new intrinsics enums (D71320)
+#include "../lib/Target/AMDGPU/AMDGPU.h"
+
 namespace llvm { class CallInst; }
 namespace Llpc { class Context; }
 


### PR DESCRIPTION
Add an extra header inclusion to enable the LLVM upgrade
containing an incompatible change (https://reviews.llvm.org/D71320).

Starting from that commit, extra header "llvm/IR/IntrinsicsAMDGPU.h"
will need to be included for every file where amdgcn intrinsic is used.

After the next upgrade, when IntrinsicsAMDGPU.h is present,
I will remove AMDGPU.h inclusion and add IntrinsicsAMDGPU.h
inclusion instead.