### PR TITLE
Clean up temp header inclusion

### DIFF
--- a/builder/llpcBuilder.cpp
+++ b/builder/llpcBuilder.cpp
@@ -28,6 +28,8 @@
  * @brief LLPC source file: implementation of Llpc::Builder
  ***********************************************************************************************************************
  */
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 #include "llpcInternal.h"

--- a/builder/llpcBuilderImpl.cpp
+++ b/builder/llpcBuilderImpl.cpp
@@ -28,6 +28,8 @@
  * @brief LLPC source file: implementation of Llpc::BuilderImpl
  ***********************************************************************************************************************
  */
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 #include "llpcPipelineState.h"

--- a/builder/llpcBuilderImplArith.cpp
+++ b/builder/llpcBuilderImplArith.cpp
@@ -28,6 +28,8 @@
  * @brief LLPC source file: implementation of arithmetic Builder methods
  ***********************************************************************************************************************
  */
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 #include "llpcPipelineState.h"

--- a/builder/llpcBuilderImplDesc.cpp
+++ b/builder/llpcBuilderImplDesc.cpp
@@ -33,7 +33,7 @@
 #include "llpcInternal.h"
 #include "llpcTargetInfo.h"
 
-#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-desc"
 

--- a/builder/llpcBuilderImplImage.cpp
+++ b/builder/llpcBuilderImplImage.cpp
@@ -34,6 +34,7 @@
 #include "llpcTargetInfo.h"
 
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-image"
 

--- a/builder/llpcBuilderImplMisc.cpp
+++ b/builder/llpcBuilderImplMisc.cpp
@@ -31,8 +31,8 @@
 #include "llpcBuilderImpl.h"
 #include "llpcContext.h"
 
-#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-misc"
 

--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -35,6 +35,7 @@
 
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-subgroup"
 

--- a/patch/gfx9/llpcNggPrimShader.cpp
+++ b/patch/gfx9/llpcNggPrimShader.cpp
@@ -29,14 +29,15 @@
  ***********************************************************************************************************************
  */
 #include "SPIRVInternal.h"
-#include "llvm/Linker/Linker.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 

--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -30,11 +30,12 @@
  */
 #define DEBUG_TYPE "llpc-patch-buffer-op"
 
-#include "llvm/InitializePasses.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Analysis/LegacyDivergenceAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/InitializePasses.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"

--- a/patch/llpcPatchCopyShader.cpp
+++ b/patch/llpcPatchCopyShader.cpp
@@ -31,8 +31,9 @@
 #define DEBUG_TYPE "llpc-patch-copy-shader"
 
 #include "llvm/IR/Constants.h"
-#include "llvm/IR/Instructions.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #include "SPIRVInternal.h"
 #include "llpcBuilderImpl.h"

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -31,6 +31,7 @@
 #define DEBUG_TYPE "llpc-patch-in-out-import-export"
 
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/patch/llpcPatchPeepholeOpt.cpp
+++ b/patch/llpcPatchPeepholeOpt.cpp
@@ -33,6 +33,7 @@
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"

--- a/util/llpcInternal.h
+++ b/util/llpcInternal.h
@@ -40,9 +40,6 @@
 #include "llpc.h"
 #include "llpcUtil.h"
 
-// TODO: Remove once LLVM has been updated with new intrinsics enums (D71320)
-#include "../lib/Target/AMDGPU/AMDGPU.h"
-
 namespace llvm { class CallInst; }
 namespace Llpc { class Context; }
 


### PR DESCRIPTION
Remove a temporary header inclusion of AMDGPU.h introduced
in #399 and include IntrinsicsAMDGPU.h instead.