### PR TITLE
[CI] Fix branch handling

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -2,16 +2,16 @@ name: Build AMDVLK for LLPC
 
 on:
   schedule:
-    - cron:  "0 */4 * * *"
+    - cron:  "0 */12 * * *"
 
 jobs:
   build-and-push-amdvlk:
-    name: Build AMDVLK branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
+    name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
         host-os:      ["ubuntu-latest"]
-        base-image:   ["gcr.io/stadia-open-source/amdvlk:nightly"]
+        base-image:   ["gcr.io/stadia-open-source/amdvlk_dev_release:nightly"]
         branch:       [dev]
         config:       [Release]
         generator:    [Ninja]

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -1,15 +1,20 @@
 name: LLPC Docker CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+  pull_request:
 
 jobs:
   build-and-test:
-    name: Test branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
+    name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
         host-os:      ["ubuntu-latest"]
-        base-image:   ["gcr.io/stadia-open-source/amdvlk:nightly"]
+        base-image:   ["gcr.io/stadia-open-source/amdvlk_dev_release:nightly"]
         branch:       [dev]
         config:       [Release]
         generator:    [Ninja]
@@ -17,7 +22,7 @@ jobs:
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
-          git fetch origin +${GITHUB_SHA}:${GITHUB_REF}
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
           git checkout ${GITHUB_SHA}
       - name: Fetch the latest prebuilt AMDVLK
         run: |

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -27,7 +27,7 @@ RUN cat /vulkandriver/build_info.txt \
     && (cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc)) \
     && rm -rf /vulkandriver/drivers/llpc \
     && git clone https://github.com/"$LLPC_REPO_NAME".git /vulkandriver/drivers/llpc \
-    && git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" \
+    && git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" --update-head-ok \
     && git -C /vulkandriver/drivers/llpc checkout "$LLPC_REPO_SHA"
 
 # Build LLPC.


### PR DESCRIPTION
This patch teaches github actions to run the CI workflow on new commits to branches (except master). 

As a preparation for handling more configurations in the future, the prebuilt image is renamed from `amdvlk:nightly` to `amdvlk_dev_release:nightly`. The base image is build twice a day instead of every 4 hours, which seemed excessive.