### PR TITLE
Memory leak in llpc

### DIFF
--- a/context/llpcCompiler.cpp
+++ b/context/llpcCompiler.cpp
@@ -529,7 +529,7 @@ Result Compiler::BuildShaderModule(
         // Trim debug info
         if (cl::TrimDebugInfo)
         {
-	        pTrimmedCode = new uint8_t[moduleDataEx.common.binCode.codeSize];
+            pTrimmedCode = new uint8_t[moduleDataEx.common.binCode.codeSize];
             ShaderModuleHelper::TrimSpirvDebugInfo(&pShaderInfo->shaderBin, moduleDataEx.common.binCode.codeSize, pTrimmedCode);
             moduleDataEx.common.binCode.pCode = pTrimmedCode;
         }


### PR DESCRIPTION
1.There are memory leak during vkCreateModule.
The root cause is that, when LLpc call Compiler::BuildShaderModule, it will create new array to store debug info trimed binary code,
and assign the pointer to the moduleDataEx, but after that, when copy the pCode from moduleDataEx to pModuleDataEx, our driver forget to release the pointer of moduleDataEx,
As result, the memory leaked.

2.When call ~Compiler(), the "return" will cause ShaderCache not been
destory.