### PR TITLE
Add NGG support to GS

### DIFF
--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -450,7 +450,8 @@ struct ResourceUsage
                 uint32_t gsOnChipLdsSize;           // Total LDS size for GS on-chip mode.
                 uint32_t inputVertices;             // Number of GS input vertices
 #if LLPC_BUILD_GFX10
-                uint32_t primAmpFactor;             // GS primitive amplification factor
+                uint32_t primAmpFactor;             // GS primitive amplification factor (NGG)
+                bool     enableMaxVertOut;          // Whether to allow each GS instance to emit maximum vertices (NGG)
 #endif
             } calcFactor;
 

--- a/patch/gfx9/chip/llpcGfx9Chip.h
+++ b/patch/gfx9/chip/llpcGfx9Chip.h
@@ -200,6 +200,7 @@ namespace Llpc
 #if LLPC_BUILD_GFX10
 #define SET_REG_GFX10_FIELD(_stage, _reg, _field, _val)     (_stage)->_reg##_VAL.gfx10._field = (_val);
 #define SET_REG_GFX10_1_FIELD(_stage, _reg, _field, _val)   (_stage)->_reg##_VAL.gfx101._field = (_val);
+#define SET_REG_GFX10_1_PLUS_FIELD(_stage, _reg, _field, _val)  (_stage)->_reg##_VAL.gfx101Plus._field = (_val);
 #endif
 
 // Preferred number of GS primitives per ES thread.

--- a/patch/gfx9/llpcNggLdsManager.cpp
+++ b/patch/gfx9/llpcNggLdsManager.cpp
@@ -161,6 +161,8 @@ NggLdsManager::NggLdsManager(
     LLPC_OUTS("===============================================================================\n");
     LLPC_OUTS("// LLPC NGG LDS region info (in bytes)\n\n");
 
+    const auto& calcFactor = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor;
+
     if (hasGs)
     {
         //
@@ -172,7 +174,7 @@ NggLdsManager::NggLdsManager(
         //              | GS out vertex  offset |
         //              +-----------------------+
         //
-        const auto& calcFactor = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor;
+
         // NOTE: We round ES-GS LDS size to 4-DWORD alignment. This is for later LDS read/write operations of mutilple
         // DWORDs (such as DS128).
         const uint32_t esGsRingLdsSize = RoundUpToMultiple(calcFactor.esGsLdsSize, 4u) * SizeOfDword;
@@ -294,7 +296,8 @@ NggLdsManager::NggLdsManager(
         }
     }
 
-    LLPC_OUTS("\n");
+    LLPC_OUTS(format("%-40s :                  size = 0x%04" PRIX32,
+        static_cast<const char*>("LDS total"), calcFactor.gsOnChipLdsSize * SizeOfDword) << "\n\n");
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Phase 3: Clear CTS issues for non culling mode (clear CTS group:
dEQP-VK.geometry.*).

- Take GS instancing into account when calculating GS primitives per
  subgroup. Otherwise, the allocated GS-VS ring is too small.

  This fixes the CTS:
  dEQP-VK.geometry.layered.cube_array.invocation_per_layer

- Enable the register field EN_MAX_VERT_OUT_PER_GS_INSTANCE by adding a
  new flag enableMaxVertOut. This will restrict 1 input GS primitive per
  subgroup. If we have 4 GS instances and each emits 128 vertices, a
  subgroup couldn't hold the output GS primitives (>= 256).

  This fixes the CTS:
  dEQP-VK.geometry.basic.output_vary_by_attribute_instancing

- Force GS primitive amplification factor to be at least 1. Otherwise, the
  initialization of output primitive data in the block "initOutPrimData"
  will be wrong or be skipped. In the encountered case, the GS topology is
  line_strip while max_vertices is 1. Thus, the primitive amplification
  factor is: 1 - (2 - 1) = 0, which is unexpected.

  This fixes the CTS: dEQP-VK.geometry.emit.line_strip_emit_0_end_0