### PR TITLE
Fix problems with gl_PointCoord when multisampling is enabled

### DIFF
--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -978,6 +978,7 @@ void BuilderImplInOut::MarkBuiltInInputUsage(
                               //    this function for this built-in might have different array sizes; we take the max)
 {
     auto& pUsage = getContext().GetShaderResourceUsage(m_shaderStage)->builtInUsage;
+    auto pPipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(getContext().GetPipelineBuildInfo());
     LLPC_ASSERT(((builtIn != BuiltInClipDistance) && (builtIn != BuiltInCullDistance)) || (arraySize != 0));
     switch (m_shaderStage)
     {
@@ -1083,7 +1084,14 @@ void BuilderImplInOut::MarkBuiltInInputUsage(
                 // NOTE: gl_PointCoord is emulated via a general input. Those qualifiers therefore have to
                 // be marked as used.
                 pUsage.fs.smooth = true;
-                pUsage.fs.center = true;
+                if (pPipelineInfo->rsState.perSampleShading)
+                {
+                    pUsage.fs.sample = true;
+                }
+                else
+                {
+                    pUsage.fs.center = true;
+                }
                 break;
             case BuiltInPrimitiveId: pUsage.fs.primitiveId = true; break;
             case BuiltInSampleId:

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -2861,13 +2861,16 @@ Value* PatchInOutImportExport::PatchFsBuiltInInputImport(
             interpInfo[loc] = { loc, false, false, false };
 
             // Emulation for "in vec2 gl_PointCoord"
+            const bool perSampleShading = static_cast<const GraphicsPipelineBuildInfo*>(
+                m_pContext->GetPipelineBuildInfo())->rsState.perSampleShading;
             pInput = PatchFsGenericInputImport(pInputTy,
                                                loc,
                                                nullptr,
                                                nullptr,
                                                nullptr,
                                                InOutInfo::InterpModeSmooth,
-                                               InOutInfo::InterpLocCenter,
+                                               perSampleShading ? InOutInfo::InterpLocSample :
+                                                                  InOutInfo::InterpLocCenter,
                                                pInsertPos);
             break;
         }

--- a/patch/llpcPatchResourceCollect.cpp
+++ b/patch/llpcPatchResourceCollect.cpp
@@ -1119,7 +1119,9 @@ void PatchResourceCollect::ProcessShader()
 
     if (m_shaderStage == ShaderStageFragment)
     {
-        if (m_pResUsage->builtInUsage.fs.fragCoord || m_pResUsage->builtInUsage.fs.sampleMaskIn)
+        if (m_pResUsage->builtInUsage.fs.fragCoord ||
+            m_pResUsage->builtInUsage.fs.pointCoord ||
+            m_pResUsage->builtInUsage.fs.sampleMaskIn)
         {
             const GraphicsPipelineBuildInfo* pPipelineInfo =
                 reinterpret_cast<const GraphicsPipelineBuildInfo*>(m_pContext->GetPipelineBuildInfo());


### PR DESCRIPTION
If perSampleShading is enable, the interpolation of gl_PointCoord should
use "smooth sample" interpolation qualifiers and enable runAtSampleRate.