### PR TITLE
Wrong setting on SWITCH_ON_EOI and VGT_PRIMITIVEID_EN 

### DIFF
--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -366,7 +366,8 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     const auto& tesBuiltInUsage = m_pContext->GetShaderResourceUsage(ShaderStageTessEval)->builtInUsage.tes;
     const auto& gsBuiltInUsage = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->builtInUsage.gs;
 
-    if (tcsBuiltInUsage.primitiveId || tesBuiltInUsage.primitiveId || gsBuiltInUsage.primitiveId)
+    // With tessellation, SWITCH_ON_EOI and PARTIAL_ES_WAVE_ON must be set if primitive ID is used by either the TCS, TES, or GS.
+    if (tcsBuiltInUsage.primitiveId || tesBuiltInUsage.primitiveId || gsBuiltInUsage.primitiveIdIn)
     {
         iaMultiVgtParam.bits.PARTIAL_ES_WAVE_ON = true;
         iaMultiVgtParam.bits.SWITCH_ON_EOI = true;
@@ -567,7 +568,7 @@ Result ConfigBuilder::BuildVsRegConfig(
         LLPC_ASSERT(shaderStage == ShaderStageCopyShader);
 
         usePointSize      = builtInUsage.gs.pointSize;
-        usePrimitiveId    = builtInUsage.gs.primitiveIdIn;
+        usePrimitiveId    = builtInUsage.gs.primitiveId;
         useLayer          = builtInUsage.gs.layer;
         useViewportIndex  = builtInUsage.gs.viewportIndex;
         clipDistanceCount = builtInUsage.gs.clipDistance;

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -631,7 +631,8 @@ Result ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     const auto& tesBuiltInUsage = m_pContext->GetShaderResourceUsage(ShaderStageTessEval)->builtInUsage.tes;
     const auto& gsBuiltInUsage = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->builtInUsage.gs;
 
-    if (tcsBuiltInUsage.primitiveId || tesBuiltInUsage.primitiveId || gsBuiltInUsage.primitiveId)
+    // With tessellation, SWITCH_ON_EOI and PARTIAL_ES_WAVE_ON must be set if primitive ID is used by either the TCS, TES, or GS.
+    if (tcsBuiltInUsage.primitiveId || tesBuiltInUsage.primitiveId || gsBuiltInUsage.primitiveIdIn)
     {
         iaMultiVgtParam.bits.SWITCH_ON_EOI = true;
     }
@@ -1078,7 +1079,7 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig()
     const auto& tcsBuiltInUsage = m_pContext->GetShaderResourceUsage(ShaderStageTessControl)->builtInUsage.tcs;
     const auto& gsBuiltInUsage = m_pContext->GetShaderResourceUsage(ShaderStageGeometry)->builtInUsage.gs;
 
-    if (tcsBuiltInUsage.primitiveId || gsBuiltInUsage.primitiveId)
+    if (tcsBuiltInUsage.primitiveId || gsBuiltInUsage.primitiveIdIn)
     {
         iaMultiVgtParam.bits.SWITCH_ON_EOI = true;
     }
@@ -1308,7 +1309,7 @@ Result ConfigBuilder::BuildVsRegConfig(
         LLPC_ASSERT(shaderStage == ShaderStageCopyShader);
 
         usePointSize      = builtInUsage.gs.pointSize;
-        usePrimitiveId    = builtInUsage.gs.primitiveIdIn;
+        usePrimitiveId    = builtInUsage.gs.primitiveId;
         useLayer          = builtInUsage.gs.layer;
         useViewportIndex  = builtInUsage.gs.viewportIndex;
         clipDistanceCount = builtInUsage.gs.clipDistance;
@@ -2229,7 +2230,7 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     if (hasGs)
     {
         usePointSize      = gsBuiltInUsage.pointSize;
-        usePrimitiveId    = gsBuiltInUsage.primitiveIdIn;
+        usePrimitiveId    = gsBuiltInUsage.primitiveId;
         useLayer          = gsBuiltInUsage.layer;
         useViewportIndex  = gsBuiltInUsage.viewportIndex;
         clipDistanceCount = gsBuiltInUsage.clipDistance;


### PR DESCRIPTION
With tessellation, SWITCH_ON_EOI and PARTIAL_ES_WAVE_ON must be set if PrimID is used by either the API-HS, API-DS or API-GS, so what we should consider is whether gs uses the primitiveId as it's input not output.

Then the HW register VGT_PRIMITIVEID_EN should be determined by the next stage's state, not gs's state.