### PR TITLE
Fix CTS failure: dEQP-VK.draw.scissor.16*

### DIFF
--- a/patch/llpcPatchResourceCollect.h
+++ b/patch/llpcPatchResourceCollect.h
@@ -79,6 +79,8 @@ private:
 
     void ProcessShader();
 
+    bool IsVertexReuseDisabled();
+
     void ClearInactiveInput();
     void ClearInactiveOutput();
 


### PR DESCRIPTION
Take vertex reuse into consideration when calculating GS on-chip
parameters. Add a helper IsVertexReuseDisabled() to assist this.

If vertex reuse is off, the ES vertices will be multiplied by
GS instance count. Thus, the ES-GS LDS size is too small to accommodate so
many vertices, leading to out-of-range LDS ring writing and making GS-VS
ring data corrupted.