### PR TITLE
Refactor ES-GS and GS-VS ring load/store operations

### DIFF
--- a/patch/llpcPatchInOutImportExport.h
+++ b/patch/llpcPatchInOutImportExport.h
@@ -228,11 +228,11 @@ private:
                                        llvm::Value*        pVertexIdx,
                                        llvm::Instruction*  pInsertPos);
 
-    void StoreValueToGsVsRingBuffer(llvm::Value*        pStoreValue,
-                                    uint32_t            location,
-                                    uint32_t            compIdx,
-                                    uint32_t            streamId,
-                                    llvm::Instruction*  pInsertPos);
+    void StoreValueToGsVsRing(llvm::Value*        pStoreValue,
+                              uint32_t            location,
+                              uint32_t            compIdx,
+                              uint32_t            streamId,
+                              llvm::Instruction*  pInsertPos);
 
     llvm::Value* CalcEsGsRingOffsetForOutput(uint32_t           location,
                                              uint32_t           compIdx,


### PR DESCRIPTION
- Fix a small issue of i8 output of VS when GS is present. There is a
  missing assert: bitWidth == 8. And the store of i8 to ES-GS ring was not
  supported.

- Add array type to StoreValueToEsGsRing(), LoadValueFromEsGsRing(). This
  is to simplify the operations on ClipDistance and CullDistance.

- Rename StoreValueToGsVsRingBuffer to StoreValueToGsVsRing. Also, add
  array type to it and move NGG GS output export to it. This is to simplify
  operations on both GS generic outputs and GS builtin outputs.