### PR TITLE
Implement Load YCbCr Sampler Descriptor

### DIFF
--- a/builder/llpcBuilderImplDesc.cpp
+++ b/builder/llpcBuilderImplDesc.cpp
@@ -146,6 +146,9 @@ Value* BuilderImplDesc::CreateLoadDescFromPtr(
                         (innerNode.set == descSet) &&
                         (innerNode.binding == binding))
                     {
+                        pGetSampleDescPtr->replaceAllUsesWith(UndefValue::get(pGetSampleDescPtr->getType()));
+                        pGetSampleDescPtr->dropAllReferences();
+                        pGetSampleDescPtr->eraseFromParent();
                         pImmutableValue = innerNode.pImmutableValue;
                     }
                 }
@@ -154,7 +157,10 @@ Value* BuilderImplDesc::CreateLoadDescFromPtr(
                      (node.set == descSet) &&
                      (node.binding == binding))
                  {
-                     pImmutableValue = node.pImmutableValue;
+                    pGetSampleDescPtr->replaceAllUsesWith(UndefValue::get(pGetSampleDescPtr->getType()));
+                    pGetSampleDescPtr->dropAllReferences();
+                    pGetSampleDescPtr->eraseFromParent();
+                    pImmutableValue = node.pImmutableValue;
                  }
         }
     }
@@ -323,4 +329,3 @@ Value* BuilderImplDesc::CreateGetBufferDescLength(
                     Attribute::ReadNone,
                     pInsertPos);
 }
-

--- a/patch/llpcPatchDescriptorLoad.cpp
+++ b/patch/llpcPatchDescriptorLoad.cpp
@@ -871,6 +871,19 @@ ResourceMappingNodeType PatchDescriptorLoad::CalcDescriptorOffsetAndSize(
 
                         break;
                     }
+                case ResourceMappingNodeType::DescriptorYCbCrSampler:
+                    {
+                        if ((pNode->set == descSet) &&
+                            (pNode->binding == binding) &&
+                            ((nodeType1 == ResourceMappingNodeType::DescriptorResource) ||
+                            (nodeType1 == ResourceMappingNodeType::DescriptorSampler)))
+                        {
+                            exist = true;
+                            foundNodeType = pNode->type;
+                        }
+
+                        break;
+                    }
                 default:
                     {
                         LLPC_NEVER_CALLED();


### PR DESCRIPTION
 - Handle ResourceMappingNodeType::DescriptorYCbCrSampler in Patch phase.
 - Remove llpc.descriptor.get.sampler.ptr if encountered with DescriptorYCbCrSampler
   in CreateLoadDescFromPtr function.