### PR TITLE
Make SubgroupBroadcastFirst input volatile

### DIFF
--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -173,7 +173,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBroadcastFirst(
         return builder.CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, mappedArgs[0]);
     };
 
-    return CreateMapToInt32(pfnMapFunc, pValue, {});
+    return CreateMapToInt32(pfnMapFunc, { CreateInlineAsmSideEffect(pValue) }, {});
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
SubgroupBroadcastFirst is implemented using readfirstlane.
As the exec mask is not modelled early in compilation it is
possible that the EarlyCSE pass may removed a readfirstlane
operation if it appears to be a duplicate of an earlier
readfirstlane.
In particular this can happen if the BroadcastFirst is in
a loop with branching control flow.
The resulting output produces incorrect results as intended
behaviour has been removed.

This patch mitigates the above issued by marking the input
operand of the readfirstlane as volatile using inline assembly
preventing EarlyCSE from removing the readfirstlane operations.