### PR TITLE
llpc: fix image/sample/sampledImage resource collection

### DIFF
--- a/lower/llpcSpirvLowerResourceCollect.h
+++ b/lower/llpcSpirvLowerResourceCollect.h
@@ -80,6 +80,8 @@ public:
     bool DetailUsageValid() { return m_detailUsageValid; }
 
     virtual bool runOnModule(llvm::Module& module);
+    void VisitCalls(Module& module);
+    Value* FindCallAndGetIndexValue(Module& module, CallInst* const pTargetCall);
 
     // -----------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
1. add array size for them
2. visit them in resource collection pass in spirv lower phase.

v2:
1. switch to use Function way
2. remove array size arg

v3: improve coding style

v4: fix function iterate

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>