### PR TITLE
llpc: quickly fix nullptr segfault

### DIFF
--- a/patch/llpcFragColorExport.cpp
+++ b/patch/llpcFragColorExport.cpp
@@ -52,7 +52,7 @@ FragColorExport::FragColorExport(
     :
     m_pPipelineState(pPipelineState),
     m_pModule(pModule),
-    m_pContext(&pModule->getContext())
+    m_pContext(pModule ? &pModule->getContext() : nullptr)
 {
 }
 


### PR DESCRIPTION
Caused by "Pass color export state into Builder".
In PipelineState::ComputeExportFormat, there is exactly nullptr passed into FragColorExport.

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>