### PR TITLE
Revert "Make SubgroupBroadcastFirst input volatile"

### DIFF
--- a/builder/llpcBuilderImplSubgroup.cpp
+++ b/builder/llpcBuilderImplSubgroup.cpp
@@ -173,7 +173,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBroadcastFirst(
         return builder.CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, mappedArgs[0]);
     };
 
-    return CreateMapToInt32(pfnMapFunc, { CreateInlineAsmSideEffect(pValue) }, {});
+    return CreateMapToInt32(pfnMapFunc, pValue, {});
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The change exposes a bug elsewhere when handling large shaders
with many subgroup operations.
Revert while assessing the issue.

This reverts commit 2a817758dbacb56dcd95117987451b05ce494f35.