### PR TITLE
Add NGG support to GS

### DIFF
--- a/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -566,7 +566,7 @@ Result ConfigBuilder::BuildVsRegConfig(
         LLPC_ASSERT(shaderStage == ShaderStageCopyShader);
 
         usePointSize      = builtInUsage.gs.pointSize;
-        usePrimitiveId    = builtInUsage.gs.primitiveId;
+        usePrimitiveId    = builtInUsage.gs.primitiveIdIn;
         useLayer          = builtInUsage.gs.layer;
         useViewportIndex  = builtInUsage.gs.viewportIndex;
         clipDistanceCount = builtInUsage.gs.clipDistance;

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -929,7 +929,6 @@ Result ConfigBuilder::BuildPipelineNggVsGsFsRegConfig()
         }
 #endif
 #endif
-        // TODO: Set Gfx10::mmGE_NGG_SUBGRP_CNTL and Gfx10::mmGE_MAX_OUTPUT_PER_SUBGROUP
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageFragment)))
@@ -1056,8 +1055,6 @@ Result ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig()
         }
 #endif
 #endif
-
-        // TODO: Set Gfx10::mmGE_NGG_SUBGRP_CNTL and Gfx10::mmGE_MAX_OUTPUT_PER_SUBGROUP
     }
 
     if ((result == Result::Success) && (stageMask & ShaderStageToMask(ShaderStageFragment)))
@@ -2234,11 +2231,14 @@ Result ConfigBuilder::BuildPrimShaderRegConfig(
     if (hasGs)
     {
         usePointSize      = gsBuiltInUsage.pointSize;
-        usePrimitiveId    = gsBuiltInUsage.primitiveId;
+        usePrimitiveId    = gsBuiltInUsage.primitiveIdIn;
         useLayer          = gsBuiltInUsage.layer;
         useViewportIndex  = gsBuiltInUsage.viewportIndex;
         clipDistanceCount = gsBuiltInUsage.clipDistance;
         cullDistanceCount = gsBuiltInUsage.cullDistance;
+#if VKI_3RD_PARTY_IP_PROPERTY_ID
+        usePropertyId     = gsBuiltInUsage.propertyId;
+#endif
 
         expCount = pGsResUsage->inOutUsage.expCount;
 

--- a/patch/gfx9/llpcNggPrimShader.h
+++ b/patch/gfx9/llpcNggPrimShader.h
@@ -106,7 +106,7 @@ private:
                         uint32_t     location,
                         uint32_t     compIdx,
                         uint32_t     streamId,
-                        llvm::Value* pThreadIdInWave,
+                        llvm::Value* pThreadIdInSubgroup,
                         llvm::Value* pOutVertCounter);
 
     llvm::Value* ImportGsOutput(llvm::Type*  pOutputTy,


### PR DESCRIPTION
Phase 3: Clear CTS issues for non culling mode (clear CTS group other than
dEQP-VK.geometry.*).

- According to GE-SPI interface spec, GS instance ID is stored in v3[7:0]
  in NGG mode. Extract it with a mask 0xFF.

  This fixes the CTS failure: dEQP-VK.draw.scissor.16_static_scissors

- Vertex orientation is wrong when we generate primitive connectivity
  data. This is because we revise this data in later phase (not in GS_EMIT
  handling, and the vertex indices are always 0, 1, 2). The correction
  should be made when we revise primitive connectivity data.

- Fix an issue of GS-VS ring write operation. When calculating the LDS
  address offset, we have to use threadIdInSubroup rather than
  threadIdInWave. It is different from traditiinal GS because of the lack
  of gsVsOffset.

  This fixes the CTS failure:
  dEQP-VK.glsl.builtin.function.common.sign.int_mediump_geometry

- 16-bit data is not well exported to GS-VS ring. We don't pack them by
  default. Thus, the exporting should follow what non-NGG mode does with
  high 16 bits padded by zeros.

  This fixes the CTS failure:
  dEQP-VK.spirv_assembly.instruction.graphics.16bit_storage.input_output_
  float_64_to_16.vector1_rte_geom

- Correct the register settings of VGT_PRIMITIVEID_EN.

- Skip the revising of primitive connectivity data if the adjusted vertex
  index is 0.