### PR TITLE
[CI] Do not build amdvlk on forks

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-push-amdvlk:
     name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
+    # Don't run on forks.
+    if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:


### PR DESCRIPTION
This should prevent the `build-amdvlk-docker` action on running and then failing on forks that do have the GCP credentials necessary to push the container repo.
