### PR TITLE
Initial code for reloctable shader elf

### DIFF
--- a/builder/llpcBuilderContext.h
+++ b/builder/llpcBuilderContext.h
@@ -107,6 +107,9 @@ public:
     // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
     void AddTargetPasses(Llpc::PassManager& passMgr, Timer* pCodeGenTimer, raw_pwrite_stream& outStream);
 
+    void SetBuildRelocatableElf(bool buildRelocatableElf) { m_buildRelocatableElf = buildRelocatableElf; }
+    bool BuildingRelocatableElf() { return m_buildRelocatableElf; }
+
 private:
     LLPC_DISALLOW_DEFAULT_CTOR(BuilderContext)
     LLPC_DISALLOW_COPY_AND_ASSIGN(BuilderContext)
@@ -114,9 +117,10 @@ private:
     BuilderContext(LLVMContext& context);
 
     // -----------------------------------------------------------------------------------------------------------------
-    LLVMContext&                    m_context;                  // LLVM context
-    TargetMachine*                  m_pTargetMachine = nullptr; // Target machine
-    TargetInfo*                     m_pTargetInfo = nullptr;    // Target info
+    LLVMContext&               m_context;                     // LLVM context
+    TargetMachine*             m_pTargetMachine = nullptr;    // Target machine
+    TargetInfo*                m_pTargetInfo = nullptr;       // Target info
+    bool                       m_buildRelocatableElf = false; // Flag indicating whether we are building relocatable ELF
 };
 
 } // Llpc

--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -28,6 +28,7 @@
  * @brief LLPC source file: implementation of Builder methods for shader input and output
  ***********************************************************************************************************************
  */
+#include "llpcBuilderContext.h"
 #include "llpcBuilderImpl.h"
 #include "llpcInternal.h"
 #include "llpcPipelineState.h"
@@ -348,10 +349,23 @@ void BuilderImplInOut::MarkGenericInputOutputUsage(
 
     if ((isOutput == false) || (m_shaderStage != ShaderStageGeometry))
     {
-        // Non-GS-output case.
-        for (uint32_t i = 0; i < locationCount; ++i)
+        bool keepAllLocations = false;
+        if (GetBuilderContext()->BuildingRelocatableElf())
         {
-            (*pInOutLocMap)[location + i] = InvalidValue;
+            if (m_shaderStage == ShaderStageVertex && isOutput)
+            {
+                keepAllLocations = true;
+            }
+            if (m_shaderStage == ShaderStageFragment && !isOutput)
+            {
+                keepAllLocations = true;
+            }
+        }
+        uint32_t startLocation = (keepAllLocations ? 0 : location);
+        // Non-GS-output case.
+        for (uint32_t i = startLocation; i < location + locationCount; ++i)
+        {
+            (*pInOutLocMap)[i] = InvalidValue;
         }
     }
     else

--- a/context/llpcCompiler.h
+++ b/context/llpcCompiler.h
@@ -119,15 +119,21 @@ public:
     virtual Result BuildComputePipeline(const ComputePipelineBuildInfo* pPipelineInfo,
                                         ComputePipelineBuildOut*        pPipelineOut,
                                         void*                           pPipelineDumpFile = nullptr);
-    Result BuildGraphicsPipelineInternal(GraphicsContext*                           pGraphicsContext,
-                                         llvm::ArrayRef<const PipelineShaderInfo*>  shaderInfo,
-                                         uint32_t                                   forceLoopUnrollCount,
-                                         ElfPackage*                                pPipelineElf);
+    Result BuildGraphicsPipelineInternal(GraphicsContext*                          pGraphicsContext,
+                                         llvm::ArrayRef<const PipelineShaderInfo*> shaderInfo,
+                                         uint32_t                                  forceLoopUnrollCount,
+                                         bool                                      buildingRelocatableElf,
+                                         ElfPackage*                               pPipelineElf);
 
     Result BuildComputePipelineInternal(ComputeContext*                 pComputeContext,
                                         const ComputePipelineBuildInfo* pPipelineInfo,
                                         uint32_t                        forceLoopUnrollCount,
                                         ElfPackage*                     pPipelineElf);
+
+    Result BuildPipelineWithRelocatableElf(Context*                                   pContext,
+                                           llvm::ArrayRef<const PipelineShaderInfo*>  shaderInfo,
+                                           uint32_t                                   forceLoopUnrollCount,
+                                           ElfPackage*                                pPipelineElf);
 
     Result BuildPipelineInternal(Context*                                   pContext,
                                  llvm::ArrayRef<const PipelineShaderInfo*>  shaderInfo,
@@ -184,6 +190,9 @@ private:
     void ReleaseContext(Context* pContext) const;
 
     bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule) const;
+    void LinkRelocatableShaderElf(ElfPackage *pShaderElfs, ElfPackage* pPipelineElf, Context* pContext);
+    bool CanUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo*>& shaderInfo) const;
+
     // -----------------------------------------------------------------------------------------------------------------
 
     std::vector<std::string>      m_options;          // Compilation options

--- a/context/llpcComputeContext.h
+++ b/context/llpcComputeContext.h
@@ -57,6 +57,9 @@ public:
     // Gets the mask of active shader stages bound to this pipeline
     virtual uint32_t GetShaderStageMask() const { return ShaderStageToMask(ShaderStageCompute); }
 
+    // Sets the mask of active shader stages bound to this pipeline
+    void SetShaderStageMask(uint32_t mask) { LLPC_ASSERT(mask == GetShaderStageMask()); }
+
     // Gets the count of active shader stages
     virtual uint32_t GetActiveShaderStageCount() const { return 1; }
 

--- a/context/llpcGraphicsContext.h
+++ b/context/llpcGraphicsContext.h
@@ -59,6 +59,9 @@ public:
     // Gets the mask of active shader stages bound to this pipeline
     virtual uint32_t GetShaderStageMask() const { return m_stageMask; }
 
+    // Gets the mask of active shader stages bound to this pipeline
+    void SetShaderStageMask(uint32_t mask) { m_stageMask = mask; }
+
     // Gets the count of active shader stages
     virtual uint32_t GetActiveShaderStageCount() const { return m_activeStageCount; }
 

--- a/context/llpcPipelineContext.h
+++ b/context/llpcPipelineContext.h
@@ -117,6 +117,9 @@ public:
     // Gets the mask of active shader stages bound to this pipeline
     virtual uint32_t GetShaderStageMask() const = 0;
 
+    // Sets the mask of active shader stages bound to this pipeline
+    virtual void SetShaderStageMask(uint32_t mask) = 0;
+
     // Gets the count of active shader stages
     virtual uint32_t GetActiveShaderStageCount() const = 0;
 

--- a/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2602,11 +2602,13 @@ Result ConfigBuilder::BuildPsRegConfig(
 
     for (uint32_t i = 0; i < pInterpInfo->size(); ++i)
     {
-        const auto& interpInfoElem = (*pInterpInfo)[i];
-        LLPC_ASSERT(((interpInfoElem.loc     == InvalidFsInterpInfo.loc) &&
-                     (interpInfoElem.flat    == InvalidFsInterpInfo.flat) &&
-                     (interpInfoElem.custom  == InvalidFsInterpInfo.custom) &&
-                     (interpInfoElem.is16bit == InvalidFsInterpInfo.is16bit)) == false);
+        auto interpInfoElem = (*pInterpInfo)[i];
+        if (((interpInfoElem.loc     == InvalidFsInterpInfo.loc) &&
+             (interpInfoElem.flat    == InvalidFsInterpInfo.flat) &&
+             (interpInfoElem.custom  == InvalidFsInterpInfo.custom) &&
+             (interpInfoElem.is16bit == InvalidFsInterpInfo.is16bit))) {
+          interpInfoElem.loc = i;
+        }
 
         regSPI_PS_INPUT_CNTL_0 spiPsInputCntl = {};
         spiPsInputCntl.bits.FLAT_SHADE = interpInfoElem.flat;

--- a/patch/llpcPatchInOutImportExport.cpp
+++ b/patch/llpcPatchInOutImportExport.cpp
@@ -37,6 +37,7 @@
 
 #include <unordered_set>
 #include "llpcBuilderBuiltIns.h"
+#include "llpcBuilderContext.h"
 #include "llpcBuilderImpl.h"
 #include "llpcFragColorExport.h"
 #include "llpcPatchInOutImportExport.h"
@@ -1536,6 +1537,22 @@ void PatchInOutImportExport::visitReturnInst(
                 ++inOutUsage.expCount;
             }
         }
+
+        if (m_pPipelineState->GetBuilderContext()->BuildingRelocatableElf())
+        {
+            // If we are building relocatable shaders, it is possible there are
+            // generic outputs that are not written to.  We need to count them in
+            // the export count.
+            auto pResUsage = m_pPipelineState->GetShaderResourceUsage(m_shaderStage);
+            for(auto locMap : pResUsage->inOutUsage.outputLocMap)
+            {
+                if (m_expLocs.count(locMap.second) != 0)
+                {
+                    continue;
+                }
+                ++inOutUsage.expCount;
+            }
+        }
     }
     else if (m_shaderStage == ShaderStageGeometry)
     {
@@ -2119,6 +2136,8 @@ void PatchInOutImportExport::PatchVsGenericOutputExport(
     Instruction* pInsertPos)     // [in] Where to insert the patch instruction
 {
     auto pOutputTy = pOutput->getType();
+
+    m_expLocs.insert(location);
 
     if (m_hasTs)
     {

--- a/patch/llpcPatchInOutImportExport.h
+++ b/patch/llpcPatchInOutImportExport.h
@@ -38,6 +38,8 @@
 #include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 
+#include <set>
+
 namespace Llpc
 {
 
@@ -344,6 +346,8 @@ private:
     std::vector<llvm::CallInst*> m_importCalls; // List of "call" instructions to import inputs
     std::vector<llvm::CallInst*> m_exportCalls; // List of "call" instructions to export outputs
     PipelineState*          m_pPipelineState = nullptr; // Pipeline state from PipelineStateWrapper pass
+
+    std::set<uint32_t>       m_expLocs; // The locations that already have an export instruction for the vertex shader.
 };
 
 } // Llpc

--- a/patch/llpcPatchNullFragShader.cpp
+++ b/patch/llpcPatchNullFragShader.cpp
@@ -36,6 +36,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
+#include "llpcBuilderContext.h"
 #include "llpcDebug.h"
 #include "llpcIntrinsDefs.h"
 #include "llpcInternal.h"
@@ -104,7 +105,9 @@ bool PatchNullFragShader::runOnModule(
 
     Patch::Init(&module);
 
-    if (cl::DisableNullFragShader)
+    auto pipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
+
+    if (cl::DisableNullFragShader || pipelineState->GetBuilderContext()->BuildingRelocatableElf())
     {
         // NOTE: If the option -disable-null-frag-shader is set to TRUE, we skip this pass. This is done by
         // standalone compiler.

--- a/test/shaderdb/gfx9/PipelineVsFs_TestRelocatableInOutMapping.pipe
+++ b/test/shaderdb/gfx9/PipelineVsFs_TestRelocatableInOutMapping.pipe
@@ -1,0 +1,114 @@
+; This test checks that the mapping for the outputs of the vertex shader
+; match the mapping for the inputs of the fragment shader.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -use-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: (VS) Output: loc = 0  =>  Mapped = [[loc0:[0-9]+]]
+; SHADERTEST: (VS) Output: loc = 1  =>  Mapped = [[loc1:[0-9]+]]
+; SHADERTEST: (VS) Output: loc = 3  =>  Mapped = [[loc3:[0-9]+]]
+; SHADERTEST: (VS) Output: loc = 4  =>  Mapped = [[loc4:[0-9]+]]
+; SHADERTEST: (FS) Input: loc = 0  =>  Mapped = [[loc0]]
+; SHADERTEST: (FS) Input: loc = 1  =>  Mapped = [[loc1]]
+; SHADERTEST: (FS) Input: loc = 3  =>  Mapped = [[loc3]]
+; SHADERTEST: (FS) Input: loc = 4  =>  Mapped = [[loc4]]
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+
+[Version]
+version = 38
+
+[VsSpirv]
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main" %2 %3 %4 %5 %6
+               OpSource GLSL 450
+               OpDecorate %2 Location 0
+               OpDecorate %3 Location 1
+               OpMemberDecorate %_struct_7 0 BuiltIn Position
+               OpMemberDecorate %_struct_7 1 BuiltIn PointSize
+               OpMemberDecorate %_struct_7 2 BuiltIn ClipDistance
+               OpMemberDecorate %_struct_7 3 BuiltIn CullDistance
+               OpDecorate %_struct_7 Block
+               OpDecorate %5 Location 4
+               OpDecorate %6 Location 3
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+          %2 = OpVariable %_ptr_Output_v3float Output
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%float_0_100000001 = OpConstant %float 0.100000001
+          %3 = OpVariable %_ptr_Output_v3float Output
+    %v4float = OpTypeVector %float 4
+        %int = OpTypeInt 32 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+  %_struct_7 = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output__struct_7 = OpTypePointer Output %_struct_7
+          %4 = OpVariable %_ptr_Output__struct_7 Output
+      %int_0 = OpConstant %int 0
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+         %22 = OpConstantComposite %v3float %float_0_100000001 %float_0_100000001 %float_0_100000001
+         %23 = OpConstantComposite %v4float %float_0_100000001 %float_0_100000001 %float_0_100000001 %float_0_100000001
+          %5 = OpVariable %_ptr_Output_v3float Output
+          %6 = OpVariable %_ptr_Output_v3float Output
+          %1 = OpFunction %void None %9
+         %24 = OpLabel
+         %25 = OpAccessChain %_ptr_Output_v4float %4 %int_0
+               OpStore %25 %23
+               OpStore %2 %22
+               OpStore %5 %22
+               OpStore %6 %22
+               OpStore %3 %22
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3 %4 %5 %6 %7
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_separate_shader_objects"
+               OpSourceExtension "GL_ARB_shading_language_420pack"
+               OpDecorate %3 Location 0
+               OpDecorate %4 Location 4
+               OpDecorate %5 Location 3
+               OpDecorate %6 Location 1
+               OpDecorate %7 Location 0
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+          %3 = OpVariable %_ptr_Input_v3float Input
+          %4 = OpVariable %_ptr_Input_v3float Input
+          %5 = OpVariable %_ptr_Input_v3float Input
+          %6 = OpVariable %_ptr_Input_v3float Input
+ %float_0_75 = OpConstant %float 0.75
+         %14 = OpConstantComposite %v3float %float_0_75 %float_0_75 %float_0_75
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %7 = OpVariable %_ptr_Output_v4float Output
+          %2 = OpFunction %void None %9
+         %17 = OpLabel
+         %18 = OpLoad %v3float %3
+         %19 = OpLoad %v3float %4
+         %20 = OpLoad %v3float %5
+         %21 = OpLoad %v3float %6
+         %22 = OpFAdd %v3float %18 %19
+         %23 = OpFAdd %v3float %20 %21
+         %24 = OpFAdd %v3float %22 %23
+         %25 = OpVectorShuffle %v4float %24 %14 0 1 2 3
+               OpStore %7 %25
+               OpReturn
+               OpFunctionEnd
+[FsInfo]
+entryPoint = main

--- a/test/shaderdb/gfx9/PipelineVsFs_TestRelocatableSeparateCompilation.pipe
+++ b/test/shaderdb/gfx9/PipelineVsFs_TestRelocatableSeparateCompilation.pipe
@@ -1,0 +1,114 @@
+; This test checks that pipeline patching is done for each shader separately.
+; It shows that the shaders were compiled individually and then linked.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -use-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST-EMPTY:
+; SHADERTEST-NEXT: ; ModuleID = 'llpcPipeline'
+; SHADERTEST-NEXT: source_filename = "llpcvertex
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST-EMPTY:
+; SHADERTEST-NEXT: ; ModuleID = 'llpcPipeline'
+; SHADERTEST-NEXT: source_filename = "llpcfragment
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+
+[Version]
+version = 38
+
+[VsSpirv]
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main" %2 %3 %4 %5 %6
+               OpSource GLSL 450
+               OpDecorate %2 Location 0
+               OpDecorate %3 Location 1
+               OpMemberDecorate %_struct_7 0 BuiltIn Position
+               OpMemberDecorate %_struct_7 1 BuiltIn PointSize
+               OpMemberDecorate %_struct_7 2 BuiltIn ClipDistance
+               OpMemberDecorate %_struct_7 3 BuiltIn CullDistance
+               OpDecorate %_struct_7 Block
+               OpDecorate %5 Location 4
+               OpDecorate %6 Location 3
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+          %2 = OpVariable %_ptr_Output_v3float Output
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%float_0_100000001 = OpConstant %float 0.100000001
+          %3 = OpVariable %_ptr_Output_v3float Output
+    %v4float = OpTypeVector %float 4
+        %int = OpTypeInt 32 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+  %_struct_7 = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output__struct_7 = OpTypePointer Output %_struct_7
+          %4 = OpVariable %_ptr_Output__struct_7 Output
+      %int_0 = OpConstant %int 0
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+         %22 = OpConstantComposite %v3float %float_0_100000001 %float_0_100000001 %float_0_100000001
+         %23 = OpConstantComposite %v4float %float_0_100000001 %float_0_100000001 %float_0_100000001 %float_0_100000001
+          %5 = OpVariable %_ptr_Output_v3float Output
+          %6 = OpVariable %_ptr_Output_v3float Output
+          %1 = OpFunction %void None %9
+         %24 = OpLabel
+         %25 = OpAccessChain %_ptr_Output_v4float %4 %int_0
+               OpStore %25 %23
+               OpStore %2 %22
+               OpStore %5 %22
+               OpStore %6 %22
+               OpStore %3 %22
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3 %4 %5 %6 %7
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_separate_shader_objects"
+               OpSourceExtension "GL_ARB_shading_language_420pack"
+               OpDecorate %3 Location 0
+               OpDecorate %4 Location 4
+               OpDecorate %5 Location 3
+               OpDecorate %6 Location 1
+               OpDecorate %7 Location 0
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+          %3 = OpVariable %_ptr_Input_v3float Input
+          %4 = OpVariable %_ptr_Input_v3float Input
+          %5 = OpVariable %_ptr_Input_v3float Input
+          %6 = OpVariable %_ptr_Input_v3float Input
+ %float_0_75 = OpConstant %float 0.75
+         %14 = OpConstantComposite %v3float %float_0_75 %float_0_75 %float_0_75
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %7 = OpVariable %_ptr_Output_v4float Output
+          %2 = OpFunction %void None %9
+         %17 = OpLabel
+         %18 = OpLoad %v3float %3
+         %19 = OpLoad %v3float %4
+         %20 = OpLoad %v3float %5
+         %21 = OpLoad %v3float %6
+         %22 = OpFAdd %v3float %18 %19
+         %23 = OpFAdd %v3float %20 %21
+         %24 = OpFAdd %v3float %22 %23
+         %25 = OpVectorShuffle %v4float %24 %14 0 1 2 3
+               OpStore %7 %25
+               OpReturn
+               OpFunctionEnd
+[FsInfo]
+entryPoint = main

--- a/util/llpcElfReader.cpp
+++ b/util/llpcElfReader.cpp
@@ -48,7 +48,8 @@ ElfReader<Elf>::ElfReader(
     m_header(),
     m_symSecIdx(InvalidValue),
     m_relocSecIdx(InvalidValue),
-    m_strtabSecIdx(InvalidValue)
+    m_strtabSecIdx(InvalidValue),
+    m_textSecIdx(InvalidValue)
 {
 }
 
@@ -151,6 +152,7 @@ Result ElfReader<Elf>::ReadFromBuffer(
     m_symSecIdx    = GetSectionIndex(SymTabName);
     m_relocSecIdx  = GetSectionIndex(RelocName);
     m_strtabSecIdx = GetSectionIndex(StrTabName);
+    m_textSecIdx   = GetSectionIndex(TextName);
 
     return result;
 }

--- a/util/llpcElfReader.h
+++ b/util/llpcElfReader.h
@@ -461,6 +461,10 @@ public:
     uint32_t GetSectionCount();
     Result GetSectionDataBySectionIndex(uint32_t secIdx, SectionBuffer** ppSectionData) const;
     Result GetSectionDataBySortingIndex(uint32_t sortIdx, uint32_t* pSecIdx, SectionBuffer** ppSectionData) const;
+    Result GetTextSectionData(SectionBuffer** ppSectionData) const
+    {
+        return GetSectionDataBySectionIndex(m_textSecIdx, ppSectionData);
+    }
 
     // Determine if a section with the specified name is present in this ELF.
     bool IsSectionPresent(const char* pName) const { return (m_map.find(pName) != m_map.end()); }
@@ -508,6 +512,7 @@ private:
     int32_t   m_symSecIdx;      // Index of symbol section
     int32_t   m_relocSecIdx;    // Index of relocation section
     int32_t   m_strtabSecIdx;   // Index of string table section
+    int32_t   m_textSecIdx;     // Index of string table section
 
     llvm::msgpack::Document      m_document;         // MsgPack document
     std::vector<MsgPackIterator> m_iteratorStack;    // MsgPack iterator stack

--- a/util/llpcElfWriter.h
+++ b/util/llpcElfWriter.h
@@ -95,6 +95,7 @@ public:
 
     void WriteToBuffer(ElfPackage* pElf);
 
+    Result LinkRelocatableElf(const llvm::ArrayRef<ElfReader<Elf>*>& relocatableElfs, Context *pContext);
 private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(ElfWriter);
 
@@ -107,6 +108,8 @@ private:
     void AssembleNotes();
 
     void AssembleSymbols();
+
+    void Reinitialize();
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/util/llpcPipelineDumper.h
+++ b/util/llpcPipelineDumper.h
@@ -82,7 +82,10 @@ public:
     static void DumpPipelineExtraInfo(PipelineDumpFile*             pBinaryFile,
                                       const std::string*            pStr);
 
-    static MetroHash::Hash GenerateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo* pPipeline, bool isCacheHash);
+    static MetroHash::Hash GenerateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo* pPipeline,
+                                                           bool                             isCacheHash,
+                                                           uint32_t                         stage = ShaderStageInvalid);
+
     static MetroHash::Hash GenerateHashForComputePipeline(const ComputePipelineBuildInfo* pPipeline, bool isCacheHash);
 
     static std::string GetPipelineInfoFileName(PipelineBuildInfo                pipelineInfo,


### PR DESCRIPTION
Part of https://github.com/GPUOpen-Drivers/llpc/issues/431.

This code will allows VsPs shader to have the two shader compiled
separetly and then be linked together.  It disables cross shader
optimizations like the removal of unused outputs from the vertex
shaders.