### PR TITLE
Add const to some members of ElfReader

### DIFF
--- a/util/llpcElfReader.cpp
+++ b/util/llpcElfReader.cpp
@@ -181,7 +181,7 @@ Result ElfReader<Elf>::GetSectionData(
 // =====================================================================================================================
 // Gets the count of symbols in the symbol table section.
 template<class Elf>
-uint32_t ElfReader<Elf>::GetSymbolCount()
+uint32_t ElfReader<Elf>::GetSymbolCount() const
 {
     uint32_t symCount = 0;
     if (m_symSecIdx >= 0)
@@ -293,7 +293,8 @@ Result ElfReader<Elf>::GetSectionDataBySortingIndex(
 template<class Elf>
 void ElfReader<Elf>::GetSymbolsBySectionIndex(
     uint32_t                secIdx,         // Section index
-    std::vector<ElfSymbol>& secSymbols)     // [out] ELF symbols
+    std::vector<ElfSymbol>& secSymbols      // [out] ELF symbols
+    ) const
 {
     if ((secIdx < m_sections.size()) && (m_symSecIdx >= 0))
     {
@@ -355,9 +356,10 @@ bool ElfReader<Elf>::IsValidSymbol(
 // Gets note according to note type
 template<class Elf>
 ElfNote ElfReader<Elf>::GetNote(
-    Util::Abi::PipelineAbiNoteType noteType) // Note type
+    Util::Abi::PipelineAbiNoteType noteType // Note type
+    ) const
 {
-    uint32_t noteSecIdx = m_map[NoteName];
+    uint32_t noteSecIdx = m_map.at(NoteName);
     LLPC_ASSERT(noteSecIdx > 0);
 
     auto pNoteSection = m_sections[noteSecIdx];

--- a/util/llpcElfReader.h
+++ b/util/llpcElfReader.h
@@ -465,14 +465,14 @@ public:
     // Determine if a section with the specified name is present in this ELF.
     bool IsSectionPresent(const char* pName) const { return (m_map.find(pName) != m_map.end()); }
 
-    uint32_t GetSymbolCount();
+    uint32_t GetSymbolCount() const;
     void GetSymbol(uint32_t idx, ElfSymbol* pSymbol);
 
     bool IsValidSymbol(const char* pSymbolName);
 
-    ElfNote GetNote(Util::Abi::PipelineAbiNoteType noteType);
+    ElfNote GetNote(Util::Abi::PipelineAbiNoteType noteType) const;
 
-    void GetSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol>& secSymbols);
+    void GetSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol>& secSymbols) const;
 
     uint32_t GetRelocationCount();
     void GetRelocation(uint32_t idx, ElfReloc* pReloc);


### PR DESCRIPTION
A few of the functions in the ElfReader class do not change the class,
but are not marked as const.  This should be fixed so these functions
can be used in more places.