### PR TITLE
Add relocatable-elf compilation path for compute pipelines

### DIFF
--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -128,6 +128,7 @@ public:
     Result BuildComputePipelineInternal(ComputeContext*                 pComputeContext,
                                         const ComputePipelineBuildInfo* pPipelineInfo,
                                         uint32_t                        forceLoopUnrollCount,
+                                        bool                            buildingRelocatableElf,
                                         ElfPackage*                     pPipelineElf);
 
     Result BuildPipelineWithRelocatableElf(Context*                                   pContext,
@@ -192,6 +193,7 @@ private:
     bool RunPasses(PassManager* pPassMgr, llvm::Module* pModule) const;
     void LinkRelocatableShaderElf(ElfPackage *pShaderElfs, ElfPackage* pPipelineElf, Context* pContext);
     bool CanUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo*>& shaderInfo) const;
+    bool CanUseRelocatableComputeShaderElf(const PipelineShaderInfo* pShaderInfo) const;
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -69,6 +69,7 @@ public:
                               ElfNote*       pNewNote);
 
     Result ReadFromBuffer(const void* pBuffer, size_t bufSize);
+    Result CopyFromReader(const ElfReader<Elf>& reader);
 
     void MergeElfBinary(Context*          pContext,
                         const BinaryData* pFragmentElf,
@@ -95,7 +96,9 @@ public:
 
     void WriteToBuffer(ElfPackage* pElf);
 
-    Result LinkRelocatableElf(const llvm::ArrayRef<ElfReader<Elf>*>& relocatableElfs, Context *pContext);
+    Result LinkGraphicsRelocatableElf(const llvm::ArrayRef<ElfReader<Elf>*>& relocatableElfs, Context *pContext);
+
+    Result LinkComputeRelocatableElf(const ElfReader<Elf>& relocatableElf, Context* pContext);
 private:
     LLPC_DISALLOW_COPY_AND_ASSIGN(ElfWriter);
 


### PR DESCRIPTION
This is a follow-up work that complements PR #438, which implements a relocatable-elf compilation path for vertex-fragment graphics pipelines. This PR contains the similar changes for compute pipelines.