### PR TITLE
Bound the number of InstCombine iterations

### DIFF
--- a/lower/llpcSpirvLower.cpp
+++ b/lower/llpcSpirvLower.cpp
@@ -230,7 +230,7 @@ void SpirvLower::AddPasses(
     passMgr.add(createGlobalDCEPass());
     passMgr.add(createPromoteMemoryToRegisterPass());
     passMgr.add(createAggressiveDCEPass());
-    passMgr.add(createInstructionCombiningPass(false));
+    passMgr.add(createInstructionCombiningPass(false, 3));
     passMgr.add(createCFGSimplificationPass());
     passMgr.add(createSROAPass());
     passMgr.add(createEarlyCSEPass());

--- a/patch/llpcPatch.cpp
+++ b/patch/llpcPatch.cpp
@@ -177,7 +177,7 @@ void Patch::AddPasses(
 
     // Patch buffer operations (must be after optimizations)
     passMgr.add(CreatePatchBufferOp());
-    passMgr.add(createInstructionCombiningPass(false));
+    passMgr.add(createInstructionCombiningPass(false, 2));
 
     // Fully prepare the pipeline ABI (must be after optimizations)
     passMgr.add(CreatePatchPreparePipelineAbi(/* onlySetCallingConvs = */ false));
@@ -257,7 +257,7 @@ void Patch::AddOptimizationPasses(
         passMgr.add(createCalledValuePropagationPass());
         passMgr.add(createGlobalOptimizerPass());
         passMgr.add(createPromoteMemoryToRegisterPass());
-        passMgr.add(createInstructionCombiningPass(expensiveCombines));
+        passMgr.add(createInstructionCombiningPass(expensiveCombines, 5));
         passMgr.add(CreatePatchPeepholeOpt());
         passMgr.add(createInstSimplifyLegacyPass());
         passMgr.add(createCFGSimplificationPass());
@@ -267,7 +267,7 @@ void Patch::AddOptimizationPasses(
         passMgr.add(createCorrelatedValuePropagationPass());
         passMgr.add(createCFGSimplificationPass());
         passMgr.add(createAggressiveInstCombinerPass());
-        passMgr.add(createInstructionCombiningPass(expensiveCombines));
+        passMgr.add(createInstructionCombiningPass(expensiveCombines, 3));
         passMgr.add(CreatePatchPeepholeOpt());
         passMgr.add(createInstSimplifyLegacyPass());
         passMgr.add(createCFGSimplificationPass());
@@ -275,7 +275,7 @@ void Patch::AddOptimizationPasses(
         passMgr.add(createLoopRotatePass());
         passMgr.add(createLICMPass());
         passMgr.add(createCFGSimplificationPass());
-        passMgr.add(createInstructionCombiningPass(expensiveCombines));
+        passMgr.add(createInstructionCombiningPass(expensiveCombines, 2));
         passMgr.add(createIndVarSimplifyPass());
         passMgr.add(createLoopIdiomPass());
         passMgr.add(createLoopDeletionPass());
@@ -288,7 +288,7 @@ void Patch::AddOptimizationPasses(
         passMgr.add(createGVNPass(disableGvnLoadPre));
         passMgr.add(createSCCPPass());
         passMgr.add(createBitTrackingDCEPass());
-        passMgr.add(createInstructionCombiningPass(expensiveCombines));
+        passMgr.add(createInstructionCombiningPass(expensiveCombines, 2));
         passMgr.add(CreatePatchPeepholeOpt());
         passMgr.add(createCorrelatedValuePropagationPass());
         passMgr.add(createAggressiveDCEPass());
@@ -300,7 +300,7 @@ void Patch::AddOptimizationPasses(
         passMgr.add(CreatePatchPeepholeOpt(true));
         passMgr.add(createInstSimplifyLegacyPass());
         passMgr.add(createLoopUnrollPass(optLevel));
-        passMgr.add(createInstructionCombiningPass(expensiveCombines));
+        passMgr.add(createInstructionCombiningPass(expensiveCombines, 2));
         passMgr.add(createLICMPass());
         passMgr.add(createStripDeadPrototypesPass());
         passMgr.add(createGlobalDCEPass());


### PR DESCRIPTION
By default, InstCombine iterates over a function until it keeps
changing. This causes the last iteration to always go to waste.
It is offen possible to predict the maximum number of itrations
necessary to reach a fixpoint and not run the additional iteration that
would detect it.

This patch bounds InstCombine passes in llpPatch and spirvLower with
conservatives numbers that should have minimal or no effect on the
generated code. On a database on 7400 real-world pipelines, this saves
about 4% of of InstCombine iterations. In the future it should be
possible to shave off more compilation times by making the thresholds
tighter at the expense of optimizing code less.