### PR TITLE
Set default unroll threshold attribute value

### DIFF
--- a/patch/llpcPatchEntryPointMutate.cpp
+++ b/patch/llpcPatchEntryPointMutate.cpp
@@ -206,6 +206,11 @@ void PatchEntryPointMutate::ProcessShader()
     {
         builder.addAttribute("amdgpu-unroll-threshold", std::to_string(pShaderOptions->unrollThreshold));
     }
+    else
+    {
+        // use a default unroll threshold of 700
+        builder.addAttribute("amdgpu-unroll-threshold", "700");
+    }
 
     AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);
     pEntryPoint->addAttributes(attribIdx, builder);


### PR DESCRIPTION
Use a default value of 700 for the amdgpu-unroll-threshold attribute if no explicit value was specified by the unrollThreshold shader option.