### PR TITLE
Change to use MaybeAlign variants of CreateAlignXXXX calls

### DIFF
--- a/patch/gfx9/llpcNggLdsManager.cpp
+++ b/patch/gfx9/llpcNggLdsManager.cpp
@@ -578,7 +578,7 @@ void NggLdsManager::WriteValueToLds(
             pStoreValue = pWriteValue;
         }
 
-        m_pBuilder->CreateAlignedStore(pStoreValue, pStorePtr, alignment);
+        m_pBuilder->CreateAlignedStore(pStoreValue, pStorePtr, MaybeAlign(alignment));
 
         if (compCount > 1)
         {

--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -754,7 +754,7 @@ void PatchBufferOp::visitMemMoveInst(
     LoadInst* const pSrcLoad = m_pBuilder->CreateAlignedLoad(pCastSrc, srcAlignment);
     CopyMetadata(pSrcLoad, &memMoveInst);
 
-    StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pSrcLoad, pCastDest, destAlignment);
+    StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pSrcLoad, pCastDest, MaybeAlign(destAlignment));
     CopyMetadata(pDestStore, &memMoveInst);
 
     // Record the memmove instruction so we remember to delete it later.
@@ -1193,7 +1193,7 @@ void PatchBufferOp::PostVisitMemCpyInst(
         LoadInst* const pSrcLoad = m_pBuilder->CreateAlignedLoad(pCastSrc, srcAlignment);
         CopyMetadata(pSrcLoad, &memCpyInst);
 
-        StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pSrcLoad, pCastDest, destAlignment);
+        StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pSrcLoad, pCastDest, MaybeAlign(destAlignment));
         CopyMetadata(pDestStore, &memCpyInst);
 
         // Visit the newly added instructions to turn them into fat pointer variants.
@@ -1368,7 +1368,7 @@ void PatchBufferOp::PostVisitMemSetInst(
             visitBitCastInst(*pCast);
         }
 
-        StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pNewValue, pCastDest, destAlignment);
+        StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pNewValue, pCastDest, MaybeAlign(destAlignment));
         CopyMetadata(pDestStore, &memSetInst);
         visitStoreInst(*pDestStore);
     }

--- a/patch/llpcPatchLoadScalarizer.cpp
+++ b/patch/llpcPatchLoadScalarizer.cpp
@@ -177,7 +177,7 @@ void PatchLoadScalarizer::visitLoadInst(
 
             loadComps[i] = m_pBuilder->CreateAlignedLoad(pCompTy,
                                                          pLoadCompPtr,
-                                                         compAlignment,
+                                                         MaybeAlign(compAlignment),
                                                          loadInst.getName() + ".ii" + Twine(i));
 
             for (auto metaNode : allMetaNodes)


### PR DESCRIPTION
The old variants are being deprecated and a future llvm change will stop the old
non-MaybeAlign variant from working.