### PR TITLE
Refactor buffer loads

### DIFF
--- a/test/shaderdb/ObjStorageBlock_TestAlign_lit.frag
+++ b/test/shaderdb/ObjStorageBlock_TestAlign_lit.frag
@@ -44,7 +44,7 @@ void main()
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
 ; SHADERTEST: call <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 24, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 256, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjStorageBlock_TestDouble_lit.frag
+++ b/test/shaderdb/ObjStorageBlock_TestDouble_lit.frag
@@ -26,12 +26,12 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{[0-9]*}}, i32 32
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{[0-9]*}}, i32 48
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> %{{[0-9]*}}, i32 8
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 32
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 48
+; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> %{{[0-9]*}}, i32 8
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> %{{[0-9]*}}, i32 8
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{[0-9]*}}, i32 64
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{[0-9]*}}, i32 80
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 64
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 80
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 96
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 112
 

--- a/test/shaderdb/ObjStorageBlock_TestMatrixInStruct_lit.vert
+++ b/test/shaderdb/ObjStorageBlock_TestMatrixInStruct_lit.vert
@@ -22,7 +22,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjStorageBlock_TestMemCpyInt16.comp
+++ b/test/shaderdb/ObjStorageBlock_TestMemCpyInt16.comp
@@ -19,7 +19,7 @@ void main() {
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.buffer.load.ushort(
+; SHADERTEST: call i16 @llvm.amdgcn.raw.buffer.load.i16(
 ; SHADERTEST: call void @llvm.amdgcn.buffer.store.short(
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
+++ b/test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
@@ -17,7 +17,7 @@ void main() {
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> %{{[0-9]*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjStorageBlock_TestMemCpyInt8.comp
+++ b/test/shaderdb/ObjStorageBlock_TestMemCpyInt8.comp
@@ -19,7 +19,7 @@ void main() {
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.buffer.load.ubyte(
+; SHADERTEST: call i8 @llvm.amdgcn.raw.buffer.load.i8(
 ; SHADERTEST: call void @llvm.amdgcn.buffer.store.byte(
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjStorageBlock_TestOffset_lit.frag
+++ b/test/shaderdb/ObjStorageBlock_TestOffset_lit.frag
@@ -42,7 +42,7 @@ void main()
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> %{{.*}}, <4 x i32> %{{[0-9]*}}, i32 128
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 256
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> %{{.*}}, <4 x i32> %{{[0-9]*}}, i32 512
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> %{{[0-9]*}}, i32 256
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 256
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/test/shaderdb/ObjStorageBlock_TestStoreBasicDouble_lit.vert
+++ b/test/shaderdb/ObjStorageBlock_TestStoreBasicDouble_lit.vert
@@ -22,16 +22,16 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 48, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
+; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 48, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 48, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 80, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 80, i32 0, i32 0)
 ; SHADERTEST: shufflevector <8 x i32> {{%[^,]+}}, <8 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
 ; SHADERTEST: shufflevector <8 x i32> {{%[^,]+}}, <8 x i32> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)

--- a/test/shaderdb/ObjStorageBlock_TestStoreBasicFloat_lit.vert
+++ b/test/shaderdb/ObjStorageBlock_TestStoreBasicFloat_lit.vert
@@ -22,15 +22,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
+; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 24, i32 0, i32 0)
+; SHADERTEST: call <3 x i32> @llvm.amdgcn.raw.buffer.load.v3i32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float %.i27, <4 x i32> {{%[^,]+}}, i32 24, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/ObjStorageBlock_TestStoreBasicInt_lit.vert
+++ b/test/shaderdb/ObjStorageBlock_TestStoreBasicInt_lit.vert
@@ -22,15 +22,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
+; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 24, i32 0, i32 0)
+; SHADERTEST: call <3 x i32> @llvm.amdgcn.raw.buffer.load.v3i32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 24, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/ObjStorageBlock_TestStoreBasicUint_lit.vert
+++ b/test/shaderdb/ObjStorageBlock_TestStoreBasicUint_lit.vert
@@ -22,15 +22,14 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
+; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 8, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.raw.buffer.load.v2f32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> {{%[^,]+}}, i32 24, i32 0, i32 0)
+; SHADERTEST: call <3 x i32> @llvm.amdgcn.raw.buffer.load.v3i32(<4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2f32(<2 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 16, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.f32(float {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 24, i32 0, i32 0)
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 32, i32 0, i32 0)
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/OpAtomicLoad_TestStorageBlock_lit.spvas
+++ b/test/shaderdb/OpAtomicLoad_TestStorageBlock_lit.spvas
@@ -6,7 +6,7 @@
 ; SHADERTEST: %{{.*}} = load atomic i32, i32 addrspace({{.*}})* {{.*}} monotonic
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST:  %{{.*}} = call float @llvm.amdgcn.raw.buffer.load.f32
+; SHADERTEST:  %{{.*}} = call i32 @llvm.amdgcn.raw.buffer.load.i32
 ; SHADERTEST: %{{.*}} = ptrtoint i32 addrspace({{.*}})* %{{.*}} to i32
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/test/shaderdb/OpCopyMemory_TestStruct_lit.spvas
+++ b/test/shaderdb/OpCopyMemory_TestStruct_lit.spvas
@@ -35,10 +35,10 @@
 ; SHADERTEST: store <4 x float>
 
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
-; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4f32
-; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4f32
-; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4f32
-; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4f32
+; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4i32
+; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4i32
+; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4i32
+; SHADERTEST: @llvm.amdgcn.raw.buffer.load.v4i32
 ; SHADERTEST: @llvm.amdgcn.raw.buffer.store.v4f32
 ; SHADERTEST: @llvm.amdgcn.raw.buffer.store.v4f32
 ; SHADERTEST: @llvm.amdgcn.raw.buffer.store.v4f32

--- a/test/shaderdb/PipelineCs_TestDynDescNoSpill_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestDynDescNoSpill_lit.pipe
@@ -4,7 +4,7 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@llpc.call.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0, i1 false,
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -39,5 +39,3 @@ userDataNode[1].offsetInDwords = 4
 userDataNode[1].sizeInDwords = 4
 userDataNode[1].set = 0
 userDataNode[1].binding = 1
-
-

--- a/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
+++ b/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
@@ -9,7 +9,7 @@
 ; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %{{.*}} to <16 x i32> {{.*}}
 ; SHADERTEST: %{{.*}} = load <16 x i32>, <16 x i32> {{.*}} %{{.*}}, align 64
 ; SHADERTEST: %{{.*}} = shufflevector <16 x i32> %{{.*}}, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; SHADERTEST: call <4 x float> @llvm.amdgcn.raw.buffer.load.v4f32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
+; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; END_SHADERTEST
 
 [CsGlsl]
@@ -56,5 +56,3 @@ userDataNode[2].next[0].offsetInDwords = 0
 userDataNode[2].next[0].sizeInDwords = 4
 userDataNode[2].next[0].set = 0
 userDataNode[2].next[0].binding = 2
-
-


### PR DESCRIPTION
Previously, buffer.load instructions were emitted for small loads but
raw buffer loads should be used instead.
This patch takes the chance and refactors the loading code.

Effect:
- Increase compilation speed by skipping unnecessary vector creations
- Use DWORDx3 loads when possible