### PR TITLE
Adjust to using explicit cast for StringRef to std::string

### DIFF
--- a/builder/llpcBuilderContext.cpp
+++ b/builder/llpcBuilderContext.cpp
@@ -119,7 +119,7 @@ BuilderContext* BuilderContext::Create(
 
     // Get the LLVM target and create the target machine. This should not fail, as we determined above
     // that we support the requested target.
-    StringRef triple = "amdgcn--amdpal";
+    const std::string triple = "amdgcn--amdpal";
     std::string errMsg;
     const Target* pTarget = TargetRegistry::lookupTarget(triple, errMsg);
     // Allow no signed zeros - this enables omod modifiers (div:2, mul:2)

--- a/builder/llpcBuilderImplInOut.cpp
+++ b/builder/llpcBuilderImplInOut.cpp
@@ -197,7 +197,7 @@ Value* BuilderImplInOut::ReadGenericInputOutput(
         break;
     }
 
-    std::string callName = baseCallName;
+    std::string callName(baseCallName);
     AddTypeMangling(pResultTy, args, callName);
     Value* pResult = EmitCall(callName,
                               pResultTy,

--- a/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/lower/llpcSpirvLowerResourceCollect.cpp
@@ -100,7 +100,7 @@ void SpirvLowerResourceCollect::CollectResourceNodeData(
             nodeType = ResourceMappingNodeType::DescriptorResource;
             // Image descriptor.
             Type* pImageType = pGlobalTy->getPointerElementType();
-            std::string imageTypeName = pImageType->getStructName();
+            const std::string imageTypeName(pImageType->getStructName());
             // Format of image opaque type: ...[.SampledImage.<date type><dim>]...
             if (imageTypeName.find(".SampledImage") != std::string::npos)
             {

--- a/translator/lib/SPIRV/SPIRVUtil.cpp
+++ b/translator/lib/SPIRV/SPIRVUtil.cpp
@@ -56,7 +56,7 @@ void removeFnAttr(LLVMContext *Context, CallInst *Call,
 Function *getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes,
                               StringRef Name, AttributeList *Attrs,
                               bool TakeName) {
-  std::string MangledName = Name;
+  const std::string MangledName(Name);
   bool IsVarArg = false;
   FunctionType *FT = FunctionType::get(RetTy, ArgTypes, IsVarArg);
   Function *F = M->getFunction(MangledName);


### PR DESCRIPTION
Prepare for a change in llvm where StringRef will no longer implicitly cast to
std::string due to this being an expensive operation.

Making all such conversions explicit in this code