### PR TITLE
Update alignment arguments to use MaybeAlign

### DIFF
--- a/patch/gfx9/llpcNggLdsManager.cpp
+++ b/patch/gfx9/llpcNggLdsManager.cpp
@@ -473,7 +473,7 @@ Value* NggLdsManager::ReadValueFromLds(
             pLoadPtr = m_pBuilder->CreateBitCast(pLoadPtr, PointerType::get(pCompTy, ADDR_SPACE_LOCAL));
         }
 
-        Value* pLoadValue = m_pBuilder->CreateAlignedLoad(pLoadPtr, alignment);
+        Value* pLoadValue = m_pBuilder->CreateAlignedLoad(pLoadPtr, MaybeAlign(alignment));
 
         if (compCount > 1)
         {

--- a/patch/gfx9/llpcNggPrimShader.cpp
+++ b/patch/gfx9/llpcNggPrimShader.cpp
@@ -6605,7 +6605,7 @@ Function* NggPrimShader::CreateFetchCullingRegister(
         auto pLoadPtr = m_pBuilder->CreateGEP(pPrimShaderTablePtr, { m_pBuilder->getInt32(0), pRegOffset });
         cast<Instruction>(pLoadPtr)->setMetadata(MetaNameUniform, MDNode::get(m_pBuilder->getContext(), {}));
 
-        auto pRegValue = m_pBuilder->CreateAlignedLoad(pLoadPtr, 4);
+        auto pRegValue = m_pBuilder->CreateAlignedLoad(pLoadPtr, MaybeAlign(4));
         pRegValue->setVolatile(true);
         pRegValue->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(m_pBuilder->getContext(), {}));
 

--- a/patch/llpcPatchBufferOp.cpp
+++ b/patch/llpcPatchBufferOp.cpp
@@ -751,7 +751,7 @@ void PatchBufferOp::visitMemMoveInst(
     Value* const pCastSrc = m_pBuilder->CreateBitCast(pSrc, pCastSrcType);
     CopyMetadata(pCastSrc, &memMoveInst);
 
-    LoadInst* const pSrcLoad = m_pBuilder->CreateAlignedLoad(pCastSrc, srcAlignment);
+    LoadInst* const pSrcLoad = m_pBuilder->CreateAlignedLoad(pCastSrc, MaybeAlign(srcAlignment));
     CopyMetadata(pSrcLoad, &memMoveInst);
 
     StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pSrcLoad, pCastDest, MaybeAlign(destAlignment));
@@ -1190,7 +1190,7 @@ void PatchBufferOp::PostVisitMemCpyInst(
         Value* const pCastSrc = m_pBuilder->CreateBitCast(pSrc, pCastSrcType);
         CopyMetadata(pCastSrc, &memCpyInst);
 
-        LoadInst* const pSrcLoad = m_pBuilder->CreateAlignedLoad(pCastSrc, srcAlignment);
+        LoadInst* const pSrcLoad = m_pBuilder->CreateAlignedLoad(pCastSrc, MaybeAlign(srcAlignment));
         CopyMetadata(pSrcLoad, &memCpyInst);
 
         StoreInst* const pDestStore = m_pBuilder->CreateAlignedStore(pSrcLoad, pCastDest, MaybeAlign(destAlignment));
@@ -1290,7 +1290,7 @@ void PatchBufferOp::PostVisitMemSetInst(
             Value* const pMemSet = m_pBuilder->CreateMemSet(pCastMemoryPointer,
                                                             pValue,
                                                             stride,
-                                                            Align::None());
+                                                            Align());
             CopyMetadata(pMemSet, &memSetInst);
 
             pNewValue = m_pBuilder->CreateLoad(pMemoryPointer);
@@ -1352,7 +1352,7 @@ void PatchBufferOp::PostVisitMemSetInst(
             Value* const pMemSet = m_pBuilder->CreateMemSet(pCastMemoryPointer,
                                                             pValue,
                                                             pMemoryType->getVectorNumElements(),
-                                                            Align::None());
+                                                            Align());
             CopyMetadata(pMemSet, &memSetInst);
 
             pNewValue = m_pBuilder->CreateLoad(pMemoryPointer);

--- a/patch/llpcPatchCopyShader.cpp
+++ b/patch/llpcPatchCopyShader.cpp
@@ -540,7 +540,7 @@ Value* PatchCopyShader::LoadValueFromGsVsRing(
         pLoadPtr = builder.CreateBitCast(
             pLoadPtr, PointerType::get(pLoadTy, m_pLds->getType()->getPointerAddressSpace()));
 
-        return builder.CreateAlignedLoad(pLoadPtr, m_pLds->getAlignment());
+        return builder.CreateAlignedLoad(pLoadPtr, MaybeAlign(m_pLds->getAlignment()));
     }
     else
     {


### PR DESCRIPTION
More MaybeAlign changes. The old implicit conversion is being deprecated so we
need to use MaybeAlign to enable llvm updates.