### PR TITLE
[CI] Attempt to fix amdvlk builds

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   build-and-push-amdvlk:
     name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
-    # Don't run on forks.
-    if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
@@ -23,12 +21,14 @@ jobs:
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git checkout ${GITHUB_SHA}
       - name: Setup Google Cloud CLI
+        if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '270.0.0'
           service_account_email: ${{ secrets.GCR_USER }}
           service_account_key: ${{ secrets.GCR_KEY }}
       - name: Setup Docker to use the GCR
+        if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
         run: |
           gcloud auth configure-docker
       - name: Build and Test AMDVLK with Docker
@@ -38,5 +38,6 @@ jobs:
                             --build-arg GENERATOR="${{ matrix.generator }}"
                             --tag ${{ matrix.base-image }}
       - name: Push the new image
+        if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
         run: |
           docker push ${{ matrix.base-image }}


### PR DESCRIPTION
This attempts to fix the recent builds that fail with:

```
- Your workflow file was invalid: The pipeline is not valid. .github/workflows/build-amdvlk-docker.yml (Line: 11, Col: 9): Unexpected symbol: '${GITHUB_REPOSITORY}'. Located at position 1 within expression: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
```