### PR TITLE
Fixed check-amdllpc testing for non-standard dir structure

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -560,7 +560,7 @@ endif()
 ### Add Subdirectories #################################################################################################
 if(ICD_BUILD_LLPC)
 # SPVGEN
-set(XGL_SPVGEN_PATH ${PROJECT_SOURCE_DIR}/../../spvgen CACHE PATH "Specify the path to SPVGEN." FORCE)
+set(XGL_SPVGEN_PATH ${PROJECT_SOURCE_DIR}/../../spvgen CACHE PATH "Specify the path to SPVGEN.")
 
 if(EXISTS ${XGL_SPVGEN_PATH})
     add_subdirectory(${XGL_SPVGEN_PATH} ${CMAKE_BINARY_DIR}/spvgen EXCLUDE_FROM_ALL)


### PR DESCRIPTION
This fixes the use of the cmake variable XGL_SPVGEN_PATH when doing a
cmake build of check-amdllpc with a non-standard directory structure.

Change-Id: Ie07f39cf6e941e5754128138a3d7efcfaab657ca