### PR TITLE
Reintroduce change to make SubgroupBroadcastFirst input volatile

### DIFF
--- a/llpc/builder/llpcBuilderImplSubgroup.cpp
+++ b/llpc/builder/llpcBuilderImplSubgroup.cpp
@@ -173,7 +173,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBroadcastFirst(
         return builder.CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, mappedArgs[0]);
     };
 
-    return CreateMapToInt32(pfnMapFunc, pValue, {});
+    return CreateMapToInt32(pfnMapFunc, { CreateInlineAsmSideEffect(pValue) }, {});
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatch.cpp
+++ b/llpc/patch/llpcPatch.cpp
@@ -296,7 +296,7 @@ void Patch::AddOptimizationPasses(
         passMgr.add(createInstSimplifyLegacyPass());
         passMgr.add(createFloat2IntPass());
         passMgr.add(createLoopRotatePass());
-        passMgr.add(createCFGSimplificationPass(1, true, true, false, true));
+        passMgr.add(createCFGSimplificationPass(1, true, true, true, true));
         passMgr.add(CreatePatchPeepholeOpt(true));
         passMgr.add(createInstSimplifyLegacyPass());
         passMgr.add(createLoopUnrollPass(optLevel));


### PR DESCRIPTION
Reintroduce previously reverted change to make SubgroupBroadcastFirst inputs volatile avoid problems with EarlyCSE.
As a prerequisite, CFG simplification behaviour must be changed to ensure keepLoops is true. Setting keepLoops false has negative interactions with the required subgroups change, and can produce other control flow not currently supported by the backend structurizer.