### PR TITLE
[CI] Revert fork detection changes in amdvlk cron build

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -21,14 +21,12 @@ jobs:
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git checkout ${GITHUB_SHA}
       - name: Setup Google Cloud CLI
-        if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '270.0.0'
           service_account_email: ${{ secrets.GCR_USER }}
           service_account_key: ${{ secrets.GCR_KEY }}
       - name: Setup Docker to use the GCR
-        if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
         run: |
           gcloud auth configure-docker
       - name: Build and Test AMDVLK with Docker
@@ -38,6 +36,5 @@ jobs:
                             --build-arg GENERATOR="${{ matrix.generator }}"
                             --tag ${{ matrix.base-image }}
       - name: Push the new image
-        if: ${GITHUB_REPOSITORY} == 'GPUOpen-Drivers/llpc'
         run: |
           docker push ${{ matrix.base-image }}


### PR DESCRIPTION
Recent commits to the workflow creating the base image for amdvlk did not work. This are seems to be undocumented, so I'm reverting all the changes for now and will reach out to github community forums and support.

For the context, I created a new private repo with actions and an equivalent setup to try out thoroughly. It seems there are 2 levels of workflow files validation: one that happens early and accepted the previous configurations, and a later one that runs just before executing a workflow. It is unclear to me when it is valid to use `github.repository` and `GITHUB_REPOSITORY`, how it composes with `if` statements and the expression evaluator. I tried all combinations of sytaxes I found online (`"VAR"`,`"$VAR"`, `${VAR}`, `${{ VAR }}`, `if {{ condition }}`, `if ${{ cond }}`, etc.), but nothing seems to work and evalute like I'd expect.