### PR TITLE
Make Descriptor Offsets Relocatable

### DIFF
--- a/lgc/include/lgc/util/Internal.h
+++ b/lgc/include/lgc/util/Internal.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "lgc/CommonDefs.h"
+#include "../interface/lgc/BuilderBase.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -74,6 +76,9 @@ llvm::CallInst *emitCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::Arra
 // type and its parameters.
 llvm::CallInst *emitCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
                          llvm::ArrayRef<llvm::Attribute::AttrKind> attribs, llvm::BasicBlock *insertAtEnd);
+
+// Emits a amdgcn.reloc.constant intrinsics that represents a relocatable value with the given symbol name.
+llvm::CallInst* emitRelocationConstant(llvm::IRBuilderBase *builder, const llvm::Twine &symbolName);
 
 // Adds LLVM-style type mangling suffix for the specified return type and args to the name.
 void addTypeMangling(llvm::Type *returnTy, llvm::ArrayRef<llvm::Value *> args, std::string &name);

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -41,6 +41,7 @@
 
 #include "lgc/BuilderBase.h"
 #include "lgc/util/Internal.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "llpc-internal"
 
@@ -80,6 +81,17 @@ CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, Arra
                    BasicBlock *insertAtEnd) {
   BuilderBase builder(insertAtEnd);
   return builder.createNamedCall(funcName, retTy, args, attribs);
+}
+
+// =====================================================================================================================
+// Emits a amdgcn.reloc.constant intrinsics that represents a relocatable value with the given symbol name.
+//
+// @param builder : [in,out] An IRBuilder for instruction insertion
+// @param symbolName : Name of the relocation symbol associated with this relocation
+llvm::CallInst *emitRelocationConstant(llvm::IRBuilderBase *builder, const llvm::Twine &symbolName) {
+  auto mdNode = llvm::MDNode::get(builder->getContext(), llvm::MDString::get(builder->getContext(), symbolName.str()));
+  return builder->CreateIntrinsic(llvm::Intrinsic::amdgcn_reloc_constant, {},
+                                  {llvm::MetadataAsValue::get(builder->getContext(), mdNode)});
 }
 
 // =====================================================================================================================

--- a/llpc/test/CMakeLists.txt
+++ b/llpc/test/CMakeLists.txt
@@ -35,7 +35,7 @@ project(shadertest
 
 if(DEFINED XGL_LLVM_SRC_PATH)
   # This is a build where LLPC lit testing is integrated into AMDVLK cmake files.
-  set(AMDLLPC_TEST_DEPS amdllpc spvgen FileCheck count not)
+  set(AMDLLPC_TEST_DEPS amdllpc spvgen FileCheck llvm-objdump count not)
   set(LLVM_DIR ${XGL_LLVM_SRC_PATH})
 endif()
 

--- a/llpc/test/lit.cfg.py
+++ b/llpc/test/lit.cfg.py
@@ -58,6 +58,6 @@ config.substitutions.append(('%spvgendir%', config.spvgen_dir))
 
 tool_dirs = [config.llvm_tools_dir, config.amdllpc_dir]
 
-tools = ['amdllpc']
+tools = ['amdllpc', 'llvm-objdump']
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/llpc/test/shaderdb/PipelineCs_RelocCombinedTextureSampler.pipe
+++ b/llpc/test/shaderdb/PipelineCs_RelocCombinedTextureSampler.pipe
@@ -1,0 +1,66 @@
+
+// This test case checks that two relocation entries are generated for a combined texture sampler descriptor,
+// one for the resource handle offset, and another for the sampler handle offset.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+  // Test that correct relocated offsets are in the linked texture fetching code.
+; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
+  // Matching the relocation entry for the resource descriptor
+; SHADERTEST-DAG: s_mov_b32 s[[RELOREG_RESOURCE:[0-9]+]], 16 //{{.*}}
+  // Matching the relocation entry for the sampler descriptor
+; SHADERTEST-DAG: s_mov_b32 s[[RELOREG_SAMPLER:[0-9]+]], 48 //{{.*}}
+  // Loading the resource descriptor
+; SHADERTEST-DAG: s_load_dwordx8 s[[RESOURCE_REG:\[[0-9]+:[0-9]+\]]], s[{{.*}}:{{.*}}], s[[RELOREG_RESOURCE]] //{{.*}}
+  // Loading the sampler descriptor
+; SHADERTEST-DAG: s_load_dwordx4 s[[SAMPLER_REG:\[[0-9]+:[0-9]+\]]], s[{{.*}}:{{.*}}], s[[RELOREG_SAMPLER]] //{{.*}}
+  // Sampling the texture
+; SHADERTEST: image_sample_lz v[0:3], v0, s[[RESOURCE_REG]], s[[SAMPLER_REG]] {{.*}}
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST1-DAG: ![[METADATANODE1:[0-9]+]] = !{!"doff_0_0_r"}
+; SHADERTEST1-DAG: ![[METADATANODE2:[0-9]+]] = !{!"doff_0_0_s"}
+; SHADERTEST1-DAG: %[[RELOCONST1:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE1]])
+; SHADERTEST1-DAG: %[[RELOCONST2:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE2]])
+; SHADERTEST1: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[CsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform sampler2D texSampler;
+
+layout(set = 1, binding = 0, std430) buffer OUT
+{
+    vec4 o;
+};
+
+layout(local_size_x = 2, local_size_y = 3) in;
+void main() {
+    o = texture(texSampler, vec2(0.0, 0.0));
+}
+
+
+[CsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorCombinedTexture
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 12
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].set = 1
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 16
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 1
+userDataNode[1].next[0].binding = 0

--- a/llpc/test/shaderdb/PipelineCs_RelocConst.pipe
+++ b/llpc/test/shaderdb/PipelineCs_RelocConst.pipe
@@ -1,0 +1,59 @@
+; This test case checks that descriptor offset relocation works for buffer descriptors in a compute pipeline.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
+; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 16 {{.*}}
+; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST1-DAG: ![[METADATANODE:[0-9]+]] = !{!"doff_0_0_b"}
+; SHADERTEST1-DAG: %[[RELOCONST:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE]])
+; SHADERTEST1: %[[RELOCONSTEXT:[0-9]+]] = zext i32 %[[RELOCONST]] to i64
+; SHADERTEST1: %[[BUFFFERDESCADDR:[0-9]+]] = add i64 %{{[0-9]+}}, %[[RELOCONSTEXT]]
+; SHADERTEST1: %[[BUFFERDESCPTR:[0-9]+]] = inttoptr i64 %[[BUFFFERDESCADDR]] {{.*}}
+; SHADERTEST1: %{{[0-9]+}} = load <4 x i32>, <4 x i32> addrspace(4)* %[[BUFFERDESCPTR]], align 16, !invariant.load !{{.*}}
+; SHADERTEST1: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[CsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform UniformBufferObject {
+    vec4 i;
+} ubo;
+
+layout(set = 1, binding = 0, std430) buffer OUT
+{
+    vec4 o;
+};
+
+layout(local_size_x = 2, local_size_y = 3) in;
+void main() {
+    o = ubo.i;
+}
+
+
+[CsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].set = 1
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 4
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 1
+userDataNode[1].next[0].binding = 0

--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -9,7 +9,7 @@
 ; SHADERTEST: load <2 x double>, <2 x double> addrspace(7)* %{{.*}}, align 16
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to i32 addrspace(4)*
+; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to <4 x i32> addrspace(4)*
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i64 0
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)

--- a/llpc/test/shaderdb/PipelineVsFs_RelocConst.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_RelocConst.pipe
@@ -1,0 +1,122 @@
+
+// This test case checks that descriptor offset relocation works for buffer descriptors in a vs/fs pipeline.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_vs_main>:
+; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 12 //{{.*}}
+; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
+; SHADERTEST: {{[0-9A-Za-z]+}} <_amdgpu_ps_main>:
+; SHADERTEST: s_mov_b32 s[[RELOREG1:[0-9]+]], 12 //{{.*}}
+; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG1]] //{{.*}}
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST1-DAG: ![[METADATANODE:[0-9]+]] = !{!"doff_0_0_b"}
+; SHADERTEST1-DAG: %[[RELOCONST:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE]])
+; SHADERTEST1: %[[RELOCONSTEXT:[0-9]+]] = zext i32 %[[RELOCONST]] to i64
+; SHADERTEST1: %[[BUFFFERDESCADDR:[0-9]+]] = add i64 %{{[0-9]+}}, %[[RELOCONSTEXT]]
+; SHADERTEST1: %[[BUFFERDESCPTR:[0-9]+]] = inttoptr i64 %[[BUFFFERDESCADDR]] {{.*}}
+; SHADERTEST1: %{{[0-9]+}} = load <4 x i32>, <4 x i32> addrspace(4)* %[[BUFFERDESCPTR]], align 16, !invariant.load !{{.*}}
+; SHADERTEST1: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[VsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform UniformBufferObject {
+    mat4 model;
+    mat4 view;
+    vec4 proj;
+} ubo;
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 1) in vec3 inColor;
+
+layout(location = 0) out vec3 fragColor;
+
+void main() {
+    gl_Position = ubo.proj;
+    fragColor = inColor;
+}
+
+
+[VsInfo]
+entryPoint = main
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 0
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 4
+userDataNode[1].set = 0
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 3
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 0
+userDataNode[1].next[0].binding = 0
+
+trapPresent = 0
+debugMode = 0
+enablePerformanceData = 0
+vgprLimit = 0
+sgprLimit = 0
+maxThreadGroupsPerComputeUnit = 0
+
+[FsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform UniformBufferObject {
+    mat4 model;
+    mat4 view;
+    vec4 proj;
+} ubo;
+
+layout(location = 0) in vec3 fragColor;
+layout(location = 0) out vec4 outputColor;
+void main() {
+    outputColor = vec4(fragColor, 1.0) + ubo.proj;
+}
+
+[FsInfo]
+entryPoint = main
+trapPresent = 0
+debugMode = 0
+enablePerformanceData = 0
+vgprLimit = 0
+sgprLimit = 0
+maxThreadGroupsPerComputeUnit = 0
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+patchControlPoints = 0
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 1
+numSamples = 8
+samplePatternIdx = 48
+usrClipPlaneMask = 0
+includeDisassembly = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 1
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 1
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 4
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 3
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -872,7 +872,7 @@ static Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *c
   // -filetype=asm.
   ElfReader<Elf64> reader(compileInfo->gfxIp);
   size_t readSize = 0;
-  if (reader.ReadFromBuffer(pipelineBin->pCode, &readSize) == Result::Success) {
+  if (reader.readFromBuffer(pipelineBin->pCode, &readSize) == Result::Success) {
     LLPC_OUTS("===============================================================================\n");
     LLPC_OUTS("// LLPC final ELF info\n");
     LLPC_OUTS(reader);

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -74,7 +74,7 @@ public:
 
   static void updateMetaNote(Context *context, const ElfNote *note, ElfNote *newNote);
 
-  Result ReadFromBuffer(const void *buffer, size_t bufSize);
+  Result readFromBuffer(const void *buffer, size_t bufSize);
   Result copyFromReader(const ElfReader<Elf> &reader);
 
   void updateElfBinary(Context *context, ElfPackage *pipelineElf);
@@ -82,7 +82,7 @@ public:
   void mergeElfBinary(Context *context, const BinaryData *fragmentElf, ElfPackage *pipelineElf);
 
   // Gets the section index for the specified section name.
-  int GetSectionIndex(const char *name) const {
+  int getSectionIndex(const char *name) const {
     auto entry = m_map.find(name);
     return entry != m_map.end() ? entry->second : InvalidValue;
   }
@@ -97,9 +97,19 @@ public:
 
   Result getSectionDataBySectionIndex(unsigned secIdx, const SectionBuffer **ppSectionData) const;
 
-  void GetSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol *> &secSymbols);
+  Result getSectionData(const char* pName, const void** ppData, size_t* pDataLength) const;
+
+  void getSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol *> &secSymbols);
 
   void writeToBuffer(ElfPackage *elf);
+
+  unsigned getSymbolCount() const;
+
+  void getSymbol(unsigned idx, ElfSymbol *symbol);
+
+  unsigned getRelocationCount();
+
+  void getRelocation(unsigned idx, ElfReloc *reloc);
 
   Result linkGraphicsRelocatableElf(const llvm::ArrayRef<ElfReader<Elf> *> &relocatableElfs, Context *context);
 
@@ -133,6 +143,7 @@ private:
 
   int m_textSecIdx;   // Section index of .text section
   int m_noteSecIdx;   // Section index of .note section
+  int m_relocSecIdx;  // Section index of relocation section
   int m_symSecIdx;    // Section index of symbol table section
   int m_strtabSecIdx; // Section index of string table section
 };

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -77,14 +77,16 @@ public:
   static void DumpPipelineExtraInfo(PipelineDumpFile *binaryFile, const std::string *str);
 
   static MetroHash::Hash generateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
-                                                         unsigned stage = ShaderStageInvalid);
+                                                        bool isRelocatableShader,
+                                                        unsigned stage = ShaderStageInvalid);
 
-  static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline, bool isCacheHash);
+  static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline,
+                                                        bool isRelocatableShader, bool isCacheHash);
 
   static std::string getPipelineInfoFileName(PipelineBuildInfo pipelineInfo, const MetroHash::Hash *hash);
 
   static void updateHashForPipelineShaderInfo(ShaderStage stage, const PipelineShaderInfo *shaderInfo, bool isCacheHash,
-                                              MetroHash64 *hasher);
+                                              MetroHash64 *hasher, bool isRelocatableShader);
 
   static void updateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo *vertexInput,
                                             MetroHash64 *hasher);
@@ -125,7 +127,7 @@ private:
   static void dumpPipelineOptions(const PipelineOptions *options, std::ostream &dumpFile);
 
   static void updateHashForResourceMappingNode(const ResourceMappingNode *userDataNode, bool isRootNode,
-                                               MetroHash64 *hasher);
+                                               MetroHash64 *hasher, bool isRelocatableShader);
 };
 
 } // namespace Vkgc

--- a/util/vkgcElfReader.h
+++ b/util/vkgcElfReader.h
@@ -149,7 +149,7 @@ static const char ShStrTabName[] = ".shstrtab"; // Name of ".shstrtab" section
 static const char StrTabName[] = ".strtab";     // Name of ".strtab" section
 static const char SymTabName[] = ".symtab";     // Name of ".symtab" section
 static const char NoteName[] = ".note";         // Name of ".note" section
-static const char RelocName[] = ".reloc";       // Name of ".reloc" section
+static const char RelocName[] = ".rel.text";    // Name of ".reloc" section
 static const char CommentName[] = ".comment";   // Name of ".comment" section
 
 static const uint32_t NT_AMD_AMDGPU_ISA = 11; // Note type of AMDGPU ISA version
@@ -355,6 +355,9 @@ struct ElfSymbol {
 struct ElfReloc {
   uint64_t offset; // Location
   uint32_t symIdx; // Index of this symbol in the symbol table
+  uint32_t type; // Type of this relocation
+  bool useExplicitAddend; // Whether an explicit addend is used
+  uint32_t addend; // The value of the explicit addend
 };
 
 // Represents info of ELF note
@@ -405,9 +408,9 @@ public:
   // Gets graphics IP version info (used by ELF dump only)
   GfxIpVersion getGfxIpVersion() const { return m_gfxIp; }
 
-  Result ReadFromBuffer(const void *pBuffer, size_t *bufSize);
+  Result readFromBuffer(const void *buffer, size_t *bufSize);
 
-  Result GetSectionData(const char *name, const void **ppData, size_t *dataLength) const;
+  Result getSectionData(const char *name, const void **ppData, size_t *dataLength) const;
 
   uint32_t getSectionCount();
   Result getSectionDataBySectionIndex(uint32_t secIdx, SectionBuffer **ppSectionData) const;
@@ -420,19 +423,19 @@ public:
   bool isSectionPresent(const char *name) const { return (m_map.find(name) != m_map.end()); }
 
   uint32_t getSymbolCount() const;
-  void getSymbol(uint32_t idx, ElfSymbol *symbol);
+  void getSymbol(uint32_t idx, ElfSymbol *symbol) const;
 
   bool isValidSymbol(const char *symbolName);
 
   ElfNote getNote(Util::Abi::PipelineAbiNoteType noteType) const;
 
-  void GetSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol> &secSymbols) const;
+  void getSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol> &secSymbols) const;
 
-  uint32_t getRelocationCount();
-  void getRelocation(uint32_t idx, ElfReloc *reloc);
+  uint32_t getRelocationCount() const;
+  void getRelocation(uint32_t idx, ElfReloc *reloc) const;
 
   // Gets the section index for the specified section name.
-  int32_t GetSectionIndex(const char *name) const {
+  int32_t getSectionIndex(const char *name) const {
     auto entry = m_map.find(name);
     return (entry != m_map.end()) ? entry->second : InvalidValue;
   }


### PR DESCRIPTION
This PR is based on PR #440.

The commit is based on the original changes made by s-perron
that emits a relocatable entry for each descriptor load, instead
of baking in a constant offset during initial compilation. The
compiler patches up the compiled binary with actual descriptor
offset at a later time when that info is available.