### PR TITLE
Initialize core LLVM passes

### DIFF
--- a/llpc/builder/llpcBuilderContext.cpp
+++ b/llpc/builder/llpcBuilderContext.cpp
@@ -85,11 +85,22 @@ void BuilderContext::Initialize()
     LLVMInitializeAMDGPUAsmParser();
     LLVMInitializeAMDGPUDisassembler();
 
-    // Initialize special passes which are checked in PassManager
-    initializeJumpThreadingPass(passRegistry);
-    initializePrintModulePassWrapperPass(passRegistry);
+    // Initialize core LLVM passes so they can be referenced by -stop-before etc.
+    initializeCore(passRegistry);
+    initializeCodeGen(passRegistry);
+    initializeLoopStrengthReducePass(passRegistry);
+    initializeLowerIntrinsicsPass(passRegistry);
+    initializeEntryExitInstrumenterPass(passRegistry);
+    initializePostInlineEntryExitInstrumenterPass(passRegistry);
+    initializeUnreachableBlockElimLegacyPassPass(passRegistry);
+    initializeConstantHoistingLegacyPassPass(passRegistry);
+    initializeScalarOpts(passRegistry);
+    initializeVectorization(passRegistry);
+    initializeScalarizeMaskedMemIntrinPass(passRegistry);
+    initializeExpandReductionsPass(passRegistry);
+    initializeHardwareLoopsPass(passRegistry);
 
-    // Initialize passes so they can be referenced by -llpc-stop-before etc.
+    // Initialize LGC passes so they can be referenced by -stop-before etc.
     InitializeUtilPasses(passRegistry);
     initializeBuilderReplayerPass(passRegistry);
     InitializePatchPasses(passRegistry);


### PR DESCRIPTION
Initialize core LLVM passes so that command line options like
"amdllpc -print-before=greedy" work (to print MIR just before running
the LLVM greedy register allocator).

The list of passes to initialize is copied from LLVM's llc tool.