### PR TITLE
Add missing initializePatchLlvmIrInclusionPass

### DIFF
--- a/llpc/patch/llpcPatch.h
+++ b/llpc/patch/llpcPatch.h
@@ -83,6 +83,7 @@ inline static void InitializePatchPasses(
   initializePatchDescriptorLoadPass(passRegistry);
   initializePatchEntryPointMutatePass(passRegistry);
   initializePatchInOutImportExportPass(passRegistry);
+  initializePatchLlvmIrInclusionPass(passRegistry);
   initializePatchLoadScalarizerPass(passRegistry);
   initializePatchNullFragShaderPass(passRegistry);
   initializePatchPeepholeOptPass(passRegistry);


### PR DESCRIPTION
All other passes are initialized so I guess this one missing is a bug.