### PR TITLE
Move DEBUG_TYPE after includes

### DIFF
--- a/llpc/builder/llpcPipelineState.cpp
+++ b/llpc/builder/llpcPipelineState.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PipelineState.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-pipeline-state"
-
 #include "llpc.h"
 #include "llpcBuilderContext.h"
 #include "llpcBuilderRecorder.h"
@@ -48,6 +46,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Target/TargetMachine.h"
+
+#define DEBUG_TYPE "llpc-pipeline-state"
 
 using namespace Llpc;
 using namespace llvm;

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::Compiler.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-compiler"
-
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/IR/IRPrintingPasses.h"
@@ -74,6 +72,8 @@
     #define SPVGEN_STATIC_LIB 1
     #include "spvgen.h"
 #endif
+
+#define DEBUG_TYPE "llpc-compiler"
 
 using namespace llvm;
 using namespace MetroHash;

--- a/llpc/context/llpcComputeContext.cpp
+++ b/llpc/context/llpcComputeContext.cpp
@@ -28,11 +28,11 @@
  * @brief LLPC source file: contains implementation of class Llpc::ComputeContext.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-compute-context"
-
 #include "llpcComputeContext.h"
 #include "llpcPipeline.h"
 #include "SPIRVInternal.h"
+
+#define DEBUG_TYPE "llpc-compute-context"
 
 using namespace llvm;
 

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::Context.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-context"
-
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Bitstream/BitstreamReader.h"
@@ -53,6 +51,8 @@
 #include "llpcPipelineContext.h"
 #include "llpcShaderCache.h"
 #include "llpcShaderCacheManager.h"
+
+#define DEBUG_TYPE "llpc-context"
 
 using namespace llvm;
 

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::GraphicsContext.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-graphics-context"
-
 #include "llvm/Support/Format.h"
 
 #include "SPIRVInternal.h"
@@ -39,6 +37,8 @@
 #include "llpcGfx9Chip.h"
 #include "llpcGraphicsContext.h"
 #include "llpcInternal.h"
+
+#define DEBUG_TYPE "llpc-graphics-context"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PipelineContext.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-pipeline-context"
-
 #include "llvm/IR/Module.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/CommandLine.h"
@@ -39,6 +37,8 @@
 #include "llpcCompiler.h"
 #include "llpcPipelineContext.h"
 #include "llpcPipeline.h"
+
+#define DEBUG_TYPE "llpc-pipeline-context"
 
 namespace llvm
 {

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -28,13 +28,13 @@
  @brief LLPC source file: contains implementation of class Llpc::ShaderCache.
  ***********************************************************************************************************************
 */
-#define DEBUG_TYPE "llpc-shader-cache"
-
 #include <string.h>
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llpcShaderCache.h"
 #include "llvm/Support/DJB.h"
+
+#define DEBUG_TYPE "llpc-shader-cache"
 
 using namespace llvm;
 

--- a/llpc/context/llpcShaderCacheManager.cpp
+++ b/llpc/context/llpcShaderCacheManager.cpp
@@ -28,10 +28,9 @@
  @brief LLPC source file: contains implementation of class Llpc::ShaderCacheManager.
  ***********************************************************************************************************************
 */
+#include "llpcShaderCacheManager.h"
 
 #define DEBUG_TYPE "llpc-shader-cache-manager"
-
-#include "llpcShaderCacheManager.h"
 
 using namespace llvm;
 

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -28,7 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::SpirvLowerGlobal.
  ***********************************************************************************************************************
  */
-
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Instructions.h"

--- a/llpc/patch/gfx6/chip/llpcGfx6Chip.cpp
+++ b/llpc/patch/gfx6/chip/llpcGfx6Chip.cpp
@@ -28,9 +28,9 @@
  * @brief LLPC header file: contains implementations for Gfx6 chips.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-gfx6-chip"
-
 #include "llpcGfx6Chip.h"
+
+#define DEBUG_TYPE "llpc-gfx6-chip"
 
 namespace Llpc
 {

--- a/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -28,14 +28,14 @@
  * @brief LLPC header file: contains implementation of class Llpc::Gfx6::ConfigBuilder.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-gfx6-config-builder"
-
 #include "llpcAbiMetadata.h"
 #include "llpcCodeGenManager.h"
 #include "llpcGfx6ConfigBuilder.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
 #include "llvm/Support/CommandLine.h"
+
+#define DEBUG_TYPE "llpc-gfx6-config-builder"
 
 namespace llvm
 {

--- a/llpc/patch/gfx9/chip/llpcGfx9Chip.cpp
+++ b/llpc/patch/gfx9/chip/llpcGfx9Chip.cpp
@@ -28,11 +28,11 @@
  * @brief LLPC header file: contains implementations for Gfx9 chips.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-gfx9-chip"
-
 #include <stdio.h>
 
 #include "llpcGfx9Chip.h"
+
+#define DEBUG_TYPE "llpc-gfx9-chip"
 
 namespace Llpc
 {

--- a/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -28,14 +28,14 @@
  * @brief LLPC header file: contains implementation of class Llpc::Gfx9::ConfigBuilder.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-gfx9-config-builder"
-
 #include "llpcCodeGenManager.h"
 #include "llpcElfReader.h"
 #include "llpcGfx9ConfigBuilder.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
 #include "llvm/Support/CommandLine.h"
+
+#define DEBUG_TYPE "llpc-gfx9-config-builder"
 
 namespace llvm
 {

--- a/llpc/patch/gfx9/llpcNggLdsManager.cpp
+++ b/llpc/patch/gfx9/llpcNggLdsManager.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::NggLdsManager.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-ngg-lds-manager"
-
 #include "llvm/Linker/Linker.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
@@ -42,6 +40,8 @@
 #include "llpcPatch.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-ngg-lds-manager"
 
 using namespace llvm;
 

--- a/llpc/patch/llpcCodeGenManager.cpp
+++ b/llpc/patch/llpcCodeGenManager.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::CodeGenManager.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-code-gen-manager"
-
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/IR/Metadata.h"
@@ -44,6 +42,8 @@
 #include "llpcPassManager.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-code-gen-manager"
 
 namespace llvm
 {

--- a/llpc/patch/llpcConfigBuilderBase.cpp
+++ b/llpc/patch/llpcConfigBuilderBase.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::ConfigBuilderBase.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-config-builder-base"
-
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
@@ -38,6 +36,8 @@
 #include "llpcAbiMetadata.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-config-builder-base"
 
 using namespace Llpc;
 using namespace llvm;

--- a/llpc/patch/llpcFragColorExport.cpp
+++ b/llpc/patch/llpcFragColorExport.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::FragColorExport.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-frag-color-export"
-
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
@@ -39,6 +37,8 @@
 #include "llpcIntrinsDefs.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-frag-color-export"
 
 using namespace llvm;
 

--- a/llpc/patch/llpcPatchBufferOp.cpp
+++ b/llpc/patch/llpcPatchBufferOp.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchBufferOp.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-buffer-op"
-
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Analysis/LegacyDivergenceAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
@@ -46,6 +44,8 @@
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-patch-buffer-op"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchCheckShaderCache.cpp
+++ b/llpc/patch/llpcPatchCheckShaderCache.cpp
@@ -28,12 +28,12 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchCheckShaderCache.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-check-shader-cache"
-
 #include "llvm/Support/Debug.h"
 
 #include "llpcPatchCheckShaderCache.h"
 #include "llpcPipelineShaders.h"
+
+#define DEBUG_TYPE "llpc-patch-check-shader-cache"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchCopyShader.cpp
+++ b/llpc/patch/llpcPatchCopyShader.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains declaration and implementation of class Llpc::PatchCopyShader.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-copy-shader"
-
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -44,6 +42,8 @@
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-patch-copy-shader"
 
 using namespace Llpc;
 using namespace llvm;

--- a/llpc/patch/llpcPatchDescriptorLoad.cpp
+++ b/llpc/patch/llpcPatchDescriptorLoad.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchDescriptorLoad.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-descriptor-load"
-
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -37,6 +35,8 @@
 
 #include "llpcPatchDescriptorLoad.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-patch-descriptor-load"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchEntryPointMutate.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-entry-point-mutate"
-
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -41,6 +39,8 @@
 #include "llpcPatchEntryPointMutate.h"
 #include "llpcPipelineShaders.h"
 #include "llpcTargetInfo.h"
+
+#define DEBUG_TYPE "llpc-patch-entry-point-mutate"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchInOutImportExport.cpp
+++ b/llpc/patch/llpcPatchInOutImportExport.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchInOutImportExport.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-in-out-import-export"
-
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/Support/Debug.h"
@@ -44,6 +42,8 @@
 #include "llpcPipelineShaders.h"
 #include "llpcTargetInfo.h"
 #include "llpcVertexFetch.h"
+
+#define DEBUG_TYPE "llpc-patch-in-out-import-export"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchLlvmIrInclusion.cpp
+++ b/llpc/patch/llpcPatchLlvmIrInclusion.cpp
@@ -28,13 +28,13 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchLlvmIrInclusion.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-llvm-ir-inclusion"
-
 #include "llvm/IR/Constants.h"
 
 #include "llpcPatchLlvmIrInclusion.h"
 #include "palPipelineAbi.h"
 #include "g_palPipelineAbiMetadata.h"
+
+#define DEBUG_TYPE "llpc-patch-llvm-ir-inclusion"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchLoadScalarizer.cpp
+++ b/llpc/patch/llpcPatchLoadScalarizer.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchLoadScalarizer.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-load-scalarizer"
-
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/Debug.h"
@@ -38,6 +36,8 @@
 #include "llpcPatchLoadScalarizer.h"
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
+
+#define DEBUG_TYPE "llpc-patch-load-scalarizer"
 
 using namespace Llpc;
 using namespace llvm;

--- a/llpc/patch/llpcPatchNullFragShader.cpp
+++ b/llpc/patch/llpcPatchNullFragShader.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains declaration and implementation of class Llpc::PatchNullFragShader.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-null-frag-shader"
-
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
@@ -42,6 +40,8 @@
 #include "llpcInternal.h"
 #include "llpcPatch.h"
 #include "llpcPipelineState.h"
+
+#define DEBUG_TYPE "llpc-patch-null-frag-shader"
 
 using namespace Llpc;
 using namespace llvm;

--- a/llpc/patch/llpcPatchPeepholeOpt.cpp
+++ b/llpc/patch/llpcPatchPeepholeOpt.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchPeepholeOpt.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-peephole-opt"
-
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
@@ -40,6 +38,8 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include "llpcPatchPeepholeOpt.h"
+
+#define DEBUG_TYPE "llpc-patch-peephole-opt"
 
 using namespace Llpc;
 using namespace llvm;

--- a/llpc/patch/llpcPatchPushConstOp.cpp
+++ b/llpc/patch/llpcPatchPushConstOp.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchPushConstOp.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-push-const"
-
 #include "llvm/IR/ValueMap.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -39,6 +37,8 @@
 #include "llpcPatchPushConstOp.h"
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
+
+#define DEBUG_TYPE "llpc-patch-push-const"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcPatchResourceCollect.cpp
+++ b/llpc/patch/llpcPatchResourceCollect.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::PatchResourceCollect.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-patch-resource-collect"
-
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -48,6 +46,8 @@
 #include "llpcTargetInfo.h"
 #include <algorithm>
 #include <functional>
+
+#define DEBUG_TYPE "llpc-patch-resource-collect"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/patch/llpcVertexFetch.cpp
+++ b/llpc/patch/llpcVertexFetch.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of class Llpc::VertexFetch.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-vertex-fetch"
-
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
@@ -39,6 +37,8 @@
 #include "llpcSystemValues.h"
 #include "llpcTargetInfo.h"
 #include "llpcVertexFetch.h"
+
+#define DEBUG_TYPE "llpc-vertex-fetch"
 
 using namespace llvm;
 

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of LLPC debug utility functions.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-debug"
-
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -45,6 +43,8 @@
 #include "llpcGfx9Chip.h"
 #include "llpcInternal.h"
 #include "llpcMetroHash.h"
+
+#define DEBUG_TYPE "llpc-debug"
 
 namespace llvm
 {

--- a/llpc/util/llpcElfReader.cpp
+++ b/llpc/util/llpcElfReader.cpp
@@ -28,11 +28,11 @@
  * @brief LLPC source file: contains implementation of LLPC ELF reading utilities.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-elf-reader"
-
 #include <algorithm>
 #include <string.h>
 #include "llpcElfReader.h"
+
+#define DEBUG_TYPE "llpc-elf-reader"
 
 using namespace llvm;
 

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of LLPC ELF writing utilities.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-elf-writer"
-
 #include <algorithm>
 #include <string.h>
 #include "llvm/ADT/SmallString.h"
@@ -39,6 +37,8 @@
 #include "llpcElfWriter.h"
 #include "llpcGfx6Chip.h"
 #include "llpcGfx9Chip.h"
+
+#define DEBUG_TYPE "llpc-elf-writer"
 
 using namespace llvm;
 

--- a/llpc/util/llpcFile.cpp
+++ b/llpc/util/llpcFile.cpp
@@ -28,11 +28,11 @@
  * @brief LLPC source file: contains implementation of utility collection class Llpc::File.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-file"
-
 #include "llpcFile.h"
 #include <stdarg.h>
 #include <sys/stat.h>
+
+#define DEBUG_TYPE "llpc-file"
 
 namespace Llpc
 {

--- a/llpc/util/llpcInternal.cpp
+++ b/llpc/util/llpcInternal.cpp
@@ -28,8 +28,6 @@
  * @brief LLPC source file: contains implementation of LLPC internal-use utility functions.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-internal"
-
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/raw_os_ostream.h"
 #include "spirvExt.h"
@@ -50,6 +48,8 @@
 #include "llpcDebug.h"
 #include "llpcElfReader.h"
 #include "llpcInternal.h"
+
+#define DEBUG_TYPE "llpc-internal"
 
 using namespace llvm;
 

--- a/llpc/util/llpcPassDeadFuncRemove.cpp
+++ b/llpc/util/llpcPassDeadFuncRemove.cpp
@@ -28,12 +28,12 @@
  * @brief LLPC source file: contains implementation of class Llpc::PassDeadFuncRemove.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-pass-dead-func-remove"
-
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "llpcPassDeadFuncRemove.h"
+
+#define DEBUG_TYPE "llpc-pass-dead-func-remove"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/util/llpcPipelineDumper.cpp
+++ b/llpc/util/llpcPipelineDumper.cpp
@@ -28,8 +28,6 @@
  * @breif LLPC source file: contains implementation of LLPC pipline dump utility.
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-pipeline-dumper"
-
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -48,6 +46,8 @@
 #include "llpcMetroHash.h"
 #include "llpcPipelineDumper.h"
 #include "llpcUtil.h"
+
+#define DEBUG_TYPE "llpc-pipeline-dumper"
 
 using namespace llvm;
 using namespace MetroHash;

--- a/llpc/util/llpcPipelineShaders.cpp
+++ b/llpc/util/llpcPipelineShaders.cpp
@@ -28,14 +28,14 @@
 * @brief LLPC source file: contains implementation of class Llpc::PipelineShaders
 ***********************************************************************************************************************
 */
-#define DEBUG_TYPE "llpc-pipeline-shaders"
-
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 
 #include "llpcInternal.h"
 #include "llpcPipelineShaders.h"
+
+#define DEBUG_TYPE "llpc-pipeline-shaders"
 
 using namespace llvm;
 using namespace Llpc;

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -29,8 +29,6 @@
  * (independent of LLVM use).
  ***********************************************************************************************************************
  */
-#define DEBUG_TYPE "llpc-util"
-
 #include "llpc.h"
 #include "llpcDebug.h"
 #include "llpcElfReader.h"
@@ -46,6 +44,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #endif
+
+#define DEBUG_TYPE "llpc-util"
 
 namespace Llpc
 {


### PR DESCRIPTION
It could be overwritten in includes, so we declare it afterwards as it
was already done for some files.