### PR TITLE
Remove trailing spaces and newlines

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -571,4 +571,3 @@ if(LLPC_BUILD_LIT)
     add_subdirectory(test)
 endif()
 endif()
-

--- a/llpc/builder/llpcPipelineState.cpp
+++ b/llpc/builder/llpcPipelineState.cpp
@@ -1339,4 +1339,3 @@ bool PipelineStateWrapper::doFinalization(
 // =====================================================================================================================
 // Initialize the pipeline state wrapper pass
 INITIALIZE_PASS(PipelineStateWrapper, DEBUG_TYPE, "LLPC pipeline state wrapper", false, true)
-

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1738,7 +1738,7 @@ Result Compiler::BuildComputePipeline(
     BinaryData elfBin = {};
 
     bool buildingRelocatableElf = CanUseRelocatableComputeShaderElf(&pPipelineInfo->cs);
-    
+
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 32
     // NOTE: It is to workaround the bug in Device::CreateInternalComputePipeline,
     // we forgot to set the entryStage in it. To keep backward compatibility, set the entryStage within LLPC.
@@ -2364,7 +2364,7 @@ void Compiler::LinkRelocatableShaderElf(
         }
         result = writer.LinkComputeRelocatableElf(csReader, pContext);
     }
-    
+
     if (result != Result::Success)
     {
         return;
@@ -2373,4 +2373,3 @@ void Compiler::LinkRelocatableShaderElf(
 }
 
 } // Llpc
-

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -23,10 +23,10 @@
  *
  **********************************************************************************************************************/
 /**
-***********************************************************************************************************************
-* @file  llpcSpirvLowerTranslator.cpp
-* @brief LLPC source file: contains implementation of Llpc::SpirvLowerTranslator
-***********************************************************************************************************************
+ ***********************************************************************************************************************
+ * @file  llpcSpirvLowerTranslator.cpp
+ * @brief LLPC source file: contains implementation of Llpc::SpirvLowerTranslator
+ ***********************************************************************************************************************
 */
 #include "llpcBuilder.h"
 #include "llpcCompiler.h"
@@ -167,4 +167,3 @@ void SpirvLowerTranslator::TranslateSpirvToLlvm(
 // =====================================================================================================================
 // Initializes the pass
 INITIALIZE_PASS(SpirvLowerTranslator, DEBUG_TYPE, "LLPC translate SPIR-V binary to LLVM IR", false, false)
-

--- a/llpc/patch/llpcPatchLoadScalarizer.cpp
+++ b/llpc/patch/llpcPatchLoadScalarizer.cpp
@@ -204,4 +204,3 @@ void PatchLoadScalarizer::visitLoadInst(
 // Initializes the pass of LLVM patching operations for load scarlarizer optimization.
 INITIALIZE_PASS(PatchLoadScalarizer, DEBUG_TYPE,
                 "Patch LLVM for load scarlarizer optimization", false, false)
-

--- a/llpc/patch/llpcPatchNullFragShader.cpp
+++ b/llpc/patch/llpcPatchNullFragShader.cpp
@@ -191,4 +191,3 @@ bool PatchNullFragShader::runOnModule(
 // =====================================================================================================================
 // Initializes the pass
 INITIALIZE_PASS(PatchNullFragShader, DEBUG_TYPE, "Patch LLVM for null fragment shader generation", false, false)
-

--- a/llpc/translator/lib/SPIRV/SPIRVUtil.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVUtil.cpp
@@ -37,7 +37,6 @@
 /// reader/writer.
 ///
 //===----------------------------------------------------------------------===//
-
 #include "SPIRVInternal.h"
 
 #define DEBUG_TYPE "spirv"

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -1105,7 +1105,7 @@ Result ElfWriter<Elf>::LinkComputeRelocatableElf(
 {
     // Currently nothing to do, just copy the elf.
     CopyFromReader(relocatableElf);
-    
+
     // Apply relocations
     // There are no relocations to apply yet.
 

--- a/llpc/util/llpcPipelineShaders.cpp
+++ b/llpc/util/llpcPipelineShaders.cpp
@@ -108,4 +108,3 @@ ShaderStage PipelineShaders::GetShaderStage(
 // =====================================================================================================================
 // Initializes the pass
 INITIALIZE_PASS(PipelineShaders, DEBUG_TYPE, "LLVM pass for getting pipeline shaders", false, true)
-


### PR DESCRIPTION
This still leaves a single \n at the end of every file.