### PR TITLE
Add assertion when builder context creation failed

### DIFF
--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -93,6 +93,10 @@ BuilderContext* Context::GetBuilderContext()
         std::string gpuName;
         PipelineContext::GetGpuNameString(m_gfxIp, gpuName);
         m_builderContext.reset(BuilderContext::Create(*this, gpuName));
+        if (!m_builderContext)
+        {
+            report_fatal_error(Twine("Unknown target '") + Twine(gpuName) + Twine("'"));
+        }
     }
     return &*m_builderContext;
 }


### PR DESCRIPTION
This happens e.g. when using amdllpc with an invalid -gfxip option.
I hope this makes it easier to find out that the supplied gfxip does not
exist.