### PR TITLE
Remove superfluous inits

### DIFF
--- a/llpc/builder/llpcBuilderReplayer.cpp
+++ b/llpc/builder/llpcBuilderReplayer.cpp
@@ -96,7 +96,6 @@ BuilderReplayer::BuilderReplayer(
     ModulePass(ID),
     BuilderRecorderMetadataKinds(static_cast<LLVMContext&>(pPipeline->GetContext()))
 {
-    initializeBuilderReplayerPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/builder/llpcPipelineState.cpp
+++ b/llpc/builder/llpcPipelineState.cpp
@@ -1325,7 +1325,6 @@ PipelineStateWrapper::PipelineStateWrapper(
     ImmutablePass(ID),
     m_pBuilderContext(pBuilderContext)
 {
-    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/builder/llpcPipelineState.h
+++ b/llpc/builder/llpcPipelineState.h
@@ -44,11 +44,7 @@ namespace llvm
 
 class MDString;
 class NamedMDNode;
-class PassRegistry;
 class Timer;
-
-void initializePipelineStateWrapperPass(PassRegistry&);
-void initializePipelineStateClearerPass(PassRegistry&);
 
 } // llvm
 

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -61,7 +61,6 @@ SpirvLowerAccessChain::SpirvLowerAccessChain()
     :
     SpirvLower(ID)
 {
-    initializeSpirvLowerAccessChainPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -76,7 +76,6 @@ SpirvLowerAlgebraTransform::SpirvLowerAlgebraTransform(
     m_enableFloatOpt(enableFloatOpt),
     m_changed(false)
 {
-    initializeSpirvLowerAlgebraTransformPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
@@ -62,7 +62,6 @@ SpirvLowerConstImmediateStore::SpirvLowerConstImmediateStore()
     :
     SpirvLower(ID)
 {
-    initializeSpirvLowerConstImmediateStorePass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -123,7 +123,6 @@ SpirvLowerGlobal::SpirvLowerGlobal()
     m_lowerInputInPlace(false),
     m_lowerOutputInPlace(false)
 {
-    initializeSpirvLowerGlobalPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerInstMetaRemove.cpp
+++ b/llpc/lower/llpcSpirvLowerInstMetaRemove.cpp
@@ -61,7 +61,6 @@ SpirvLowerInstMetaRemove::SpirvLowerInstMetaRemove()
     SpirvLower(ID),
     m_changed(false)
 {
-    initializeSpirvLowerInstMetaRemovePass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerLoopUnrollControl.cpp
+++ b/llpc/lower/llpcSpirvLowerLoopUnrollControl.cpp
@@ -77,7 +77,6 @@ SpirvLowerLoopUnrollControl::SpirvLowerLoopUnrollControl()
     m_forceLoopUnrollCount(0),
     m_disableLicm(false)
 {
-    initializeSpirvLowerLoopUnrollControlPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================
@@ -88,7 +87,6 @@ SpirvLowerLoopUnrollControl::SpirvLowerLoopUnrollControl(
     m_forceLoopUnrollCount(forceLoopUnrollCount),
     m_disableLicm(false)
 {
-    initializeSpirvLowerLoopUnrollControlPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -62,7 +62,6 @@ SpirvLowerMemoryOp::SpirvLowerMemoryOp()
     :
     SpirvLower(ID)
 {
-    initializeSpirvLowerMemoryOpPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -70,7 +70,6 @@ SpirvLowerResourceCollect::SpirvLowerResourceCollect(
     m_pushConstSize(0),
     m_detailUsageValid(false)
 {
-    initializeSpirvLowerResourceCollectPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerTranslator.h
+++ b/llpc/lower/llpcSpirvLowerTranslator.h
@@ -43,7 +43,6 @@ public:
     static char ID;
     SpirvLowerTranslator() : SpirvLower(ID)
     {
-        initializeSpirvLowerTranslatorPass(*llvm::PassRegistry::getPassRegistry());
     }
 
     SpirvLowerTranslator(
@@ -51,7 +50,6 @@ public:
         const PipelineShaderInfo*   pShaderInfo)  // [in] Shader info for this shader
         : SpirvLower(ID), m_shaderStage(stage), m_pShaderInfo(pShaderInfo)
     {
-        initializeSpirvLowerTranslatorPass(*llvm::PassRegistry::getPassRegistry());
     }
 
     bool runOnModule(llvm::Module& module) override;

--- a/llpc/patch/llpcPatchCheckShaderCache.cpp
+++ b/llpc/patch/llpcPatchCheckShaderCache.cpp
@@ -79,8 +79,6 @@ PatchCheckShaderCache::PatchCheckShaderCache()
     :
     Patch(ID)
 {
-    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
-    initializePatchCheckShaderCachePass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatchCopyShader.cpp
+++ b/llpc/patch/llpcPatchCopyShader.cpp
@@ -59,8 +59,6 @@ public:
     static char ID;
     PatchCopyShader() : Patch(ID)
     {
-        initializePipelineShadersPass(*PassRegistry::getPassRegistry());
-        initializePatchCopyShaderPass(*PassRegistry::getPassRegistry());
     }
 
     bool runOnModule(Module& module) override;

--- a/llpc/patch/llpcPatchDescriptorLoad.cpp
+++ b/llpc/patch/llpcPatchDescriptorLoad.cpp
@@ -72,9 +72,6 @@ PatchDescriptorLoad::PatchDescriptorLoad()
     :
     Patch(ID)
 {
-    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
-    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
-    initializePatchDescriptorLoadPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -82,9 +82,6 @@ PatchEntryPointMutate::PatchEntryPointMutate()
     m_hasTs(false),
     m_hasGs(false)
 {
-    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
-    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
-    initializePatchEntryPointMutatePass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatchInOutImportExport.cpp
+++ b/llpc/patch/llpcPatchInOutImportExport.cpp
@@ -70,10 +70,6 @@ PatchInOutImportExport::PatchInOutImportExport()
 {
     memset(&m_gfxIp, 0, sizeof(m_gfxIp));
     InitPerShader();
-
-    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
-    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
-    initializePatchInOutImportExportPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatchLlvmIrInclusion.cpp
+++ b/llpc/patch/llpcPatchLlvmIrInclusion.cpp
@@ -58,7 +58,6 @@ PatchLlvmIrInclusion::PatchLlvmIrInclusion()
     :
     Patch(ID)
 {
-    initializePatchLlvmIrInclusionPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatchLoadScalarizer.cpp
+++ b/llpc/patch/llpcPatchLoadScalarizer.cpp
@@ -61,7 +61,6 @@ PatchLoadScalarizer::PatchLoadScalarizer()
     :
     FunctionPass(ID)
 {
-    initializePatchLoadScalarizerPass(*PassRegistry::getPassRegistry());
     m_scalarThreshold = 0;
 }
 

--- a/llpc/patch/llpcPatchNullFragShader.cpp
+++ b/llpc/patch/llpcPatchNullFragShader.cpp
@@ -71,7 +71,6 @@ public:
     static char ID;
     PatchNullFragShader() : Patch(ID)
     {
-        initializePatchNullFragShaderPass(*PassRegistry::getPassRegistry());
     }
 
     void getAnalysisUsage(llvm::AnalysisUsage& analysisUsage) const override

--- a/llpc/patch/llpcPatchPeepholeOpt.cpp
+++ b/llpc/patch/llpcPatchPeepholeOpt.cpp
@@ -39,6 +39,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "llpcPatch.h"
 #include "llpcPatchPeepholeOpt.h"
 
 using namespace Llpc;
@@ -78,7 +79,6 @@ PatchPeepholeOpt::PatchPeepholeOpt(
     :
     FunctionPass(ID)
 {
-    initializePatchPeepholeOptPass(*PassRegistry::getPassRegistry());
     m_enableDiscardOpt = enableDiscardOpt;
 }
 

--- a/llpc/patch/llpcPatchPeepholeOpt.h
+++ b/llpc/patch/llpcPatchPeepholeOpt.h
@@ -38,14 +38,6 @@
 #include "llpcDebug.h"
 #include "llpcInternal.h"
 
-namespace llvm
-{
-
-class PassRegistry;
-void initializePatchPeepholeOptPass(PassRegistry&);
-
-} // llvm
-
 namespace Llpc
 {
 

--- a/llpc/patch/llpcPatchPreparePipelineAbi.cpp
+++ b/llpc/patch/llpcPatchPreparePipelineAbi.cpp
@@ -61,8 +61,6 @@ public:
         Patch(ID),
         m_onlySetCallingConvs(onlySetCallingConvs)
     {
-        initializePipelineShadersPass(*llvm::PassRegistry::getPassRegistry());
-        initializePatchPreparePipelineAbiPass(*PassRegistry::getPassRegistry());
     }
 
     bool runOnModule(Module& module) override;

--- a/llpc/patch/llpcPatchPushConstOp.cpp
+++ b/llpc/patch/llpcPatchPushConstOp.cpp
@@ -62,8 +62,6 @@ PatchPushConstOp::PatchPushConstOp()
     :
     Patch(ID)
 {
-    initializePipelineStateWrapperPass(*PassRegistry::getPassRegistry());
-    initializePatchPushConstOpPass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/patch/llpcPatchResourceCollect.cpp
+++ b/llpc/patch/llpcPatchResourceCollect.cpp
@@ -83,9 +83,6 @@ PatchResourceCollect::PatchResourceCollect()
     m_hasDynIndexedOutput(false),
     m_pResUsage(nullptr)
 {
-    initializePipelineShadersPass(*PassRegistry::getPassRegistry());
-    initializePatchResourceCollectPass(*PassRegistry::getPassRegistry());
-
     m_pLocationMapManager.reset(new InOutLocationMapManager);
 }
 

--- a/llpc/patch/llpcPatchSetupTargetFeatures.cpp
+++ b/llpc/patch/llpcPatchSetupTargetFeatures.cpp
@@ -51,7 +51,6 @@ public:
     static char ID;
     PatchSetupTargetFeatures() : Patch(ID)
     {
-        initializePatchSetupTargetFeaturesPass(*PassRegistry::getPassRegistry());
     }
 
     void getAnalysisUsage(AnalysisUsage& analysisUsage) const override

--- a/llpc/util/llpcInternal.h
+++ b/llpc/util/llpcInternal.h
@@ -57,8 +57,9 @@ class PassRegistry;
 class Timer;
 
 void initializePassDeadFuncRemovePass(PassRegistry&);
-void initializePassExternalLibLinkPass(PassRegistry&);
 void initializePipelineShadersPass(PassRegistry&);
+void initializePipelineStateClearerPass(PassRegistry&);
+void initializePipelineStateWrapperPass(PassRegistry&);
 void initializeStartStopTimerPass(PassRegistry&);
 
 } // llvm
@@ -75,6 +76,9 @@ inline static void InitializeUtilPasses(
 {
     initializePassDeadFuncRemovePass(passRegistry);
     initializePipelineShadersPass(passRegistry);
+    initializePipelineStateClearerPass(passRegistry);
+    initializePipelineStateWrapperPass(passRegistry);
+    initializeStartStopTimerPass(passRegistry);
 }
 
 namespace LlpcName

--- a/llpc/util/llpcPassDeadFuncRemove.cpp
+++ b/llpc/util/llpcPassDeadFuncRemove.cpp
@@ -57,7 +57,6 @@ PassDeadFuncRemove::PassDeadFuncRemove()
     :
     llvm::ModulePass(ID)
 {
-    initializePassDeadFuncRemovePass(*PassRegistry::getPassRegistry());
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcPassDeadFuncRemove.h
+++ b/llpc/util/llpcPassDeadFuncRemove.h
@@ -38,14 +38,6 @@
 #include "llpcDebug.h"
 #include "llpcInternal.h"
 
-namespace llvm
-{
-
-class PassRegistry;
-void initializePassDeadFuncRemovePass(PassRegistry&);
-
-} // llvm
-
 namespace Llpc
 {
 

--- a/llpc/util/llpcPipelineShaders.h
+++ b/llpc/util/llpcPipelineShaders.h
@@ -36,13 +36,6 @@
 
 #include "llpc.h"
 
-namespace llvm
-{
-
-void initializePipelineShadersPass(PassRegistry&);
-
-} // llvm
-
 namespace Llpc
 {
 
@@ -54,7 +47,6 @@ public:
     static char ID;
     PipelineShaders() : ModulePass(ID)
     {
-        initializePipelineShadersPass(*llvm::PassRegistry::getPassRegistry());
     }
 
     bool runOnModule(llvm::Module& module) override;

--- a/llpc/util/llpcStartStopTimer.cpp
+++ b/llpc/util/llpcStartStopTimer.cpp
@@ -50,7 +50,6 @@ public:
     StartStopTimer() : ModulePass(ID) {}
     StartStopTimer(Timer* pTimer, bool starting) : ModulePass(ID), m_pTimer(pTimer), m_starting(starting)
     {
-        initializeStartStopTimerPass(*llvm::PassRegistry::getPassRegistry());
     }
 
     bool runOnModule(Module& module) override;


### PR DESCRIPTION
Move all pass initialization calls to the creation of the
BuilderContext.