### PR TITLE
Add a space in error messages for readability

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -208,7 +208,7 @@ static void FatalErrorHandler(
     const std::string&  reason,         // Error reason
     bool                gen_crash_diag) // Whether diagnostic should be generated
 {
-    LLPC_ERRS("LLVM FATAL ERROR:" << reason << "\n");
+    LLPC_ERRS("LLVM FATAL ERROR: " << reason << "\n");
 #if LLPC_ENABLE_EXCEPTION
     throw("LLVM fatal error");
 #endif


### PR DESCRIPTION
Previously amdllpc reported errors like this:
    ERROR: LLVM FATAL ERROR:Broken function found, compilation aborted!
I think it looks better with a space after each colon.