### PR TITLE
Fix Pipeline Dump Error when Handling Immutable Sampler

### DIFF
--- a/llpc/util/llpcPipelineDumper.cpp
+++ b/llpc/util/llpcPipelineDumper.cpp
@@ -574,7 +574,7 @@ void PipelineDumper::DumpPipelineShaderInfo(
 
                 for (uint32_t k = 0; k < DescriptorSizeInDw -1; ++k)
                 {
-                     dumpFile << pDescriptorRangeValue->pValue[i] << ", ";
+                     dumpFile << pDescriptorRangeValue->pValue[k] << ", ";
                 }
                 dumpFile << pDescriptorRangeValue->pValue[DescriptorSizeInDw - 1] << "\n";
             }


### PR DESCRIPTION
 - Use correct index when dumping immutable value

[Before]
```
[CsInfo]
entryPoint = main
descriptorRangeValue[0].type = DescriptorSampler
descriptorRangeValue[0].set = 1
descriptorRangeValue[0].binding = 0
descriptorRangeValue[0].arraySize = 1
descriptorRangeValue[0].uintData = 2147512466, 2147512466, 2147512466, 0
```

[After]
```
[CsInfo]
entryPoint = main
descriptorRangeValue[0].type = DescriptorYCbCrSampler
descriptorRangeValue[0].set = 1
descriptorRangeValue[0].binding = 0
descriptorRangeValue[0].arraySize = 1
descriptorRangeValue[0].uintData = 2147512466, 0, 3293577216, 0
```