### PR TITLE
Add SPV_KHR_non_semantic_info support

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4215,6 +4215,11 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpExtInst>(
     SPIRVValue* const pSpvValue) // [in] A SPIR-V value.
 {
     SPIRVExtInst* const pSpvExtInst = static_cast<SPIRVExtInst*>(pSpvValue);
+
+    // Just ignore this set of extended instructions
+    if (BM->getBuiltinSet(pSpvExtInst->getExtSetId()) == SPIRVEIS_NonSemanticInfo)
+        return nullptr;
+
     std::vector<SPIRVValue*> spvArgValues = pSpvExtInst->getArgumentValues();
 
     BasicBlock* const pBlock = getBuilder()->GetInsertBlock();

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -81,6 +81,7 @@ enum SPIRVExtInstSetKind {
   SPIRVEIS_ShaderExplicitVertexParameterAMD,
   SPIRVEIS_GcnShaderAMD,
   SPIRVEIS_ShaderTrinaryMinMaxAMD,
+  SPIRVEIS_NonSemanticInfo,
   SPIRVEIS_Count,
 };
 
@@ -113,6 +114,7 @@ template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
     "SPV_AMD_shader_explicit_vertex_parameter");
   add(SPIRVEIS_GcnShaderAMD, "SPV_AMD_gcn_shader");
   add(SPIRVEIS_ShaderTrinaryMinMaxAMD, "SPV_AMD_shader_trinary_minmax");
+  add(SPIRVEIS_NonSemanticInfo, "SPV_KHR_non_semantic_info");
 }
 typedef SPIRVMap<SPIRVExtInstSetKind, std::string> SPIRVBuiltinSetNameMap;
 

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -197,6 +197,9 @@ SPIRVMap<ShaderTrinaryMinMaxAMDExtOpKind, std::string>::init() {
 SPIRV_DEF_NAMEMAP(ShaderTrinaryMinMaxAMDExtOpKind,
   ShaderTrinaryMinMaxAMDExtOpMap)
 
+
+typedef uint32_t NonSemanticInfoExtOpKind;
+
 }
 
 #endif // SPIRV_LIBSPIRV_SPIRVEXTINST_H

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -120,8 +120,7 @@ void SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
 
     SPIRVInstruction *Inst =
         static_cast<SPIRVInstruction *>(Decoder.getEntry());
-    assert(Inst);
-    if (Inst->getOpCode() != OpUndef)
+    if ((Inst != nullptr) && Inst->getOpCode() != OpUndef)
       BB->addInstruction(Inst);
   }
   Decoder.setScope(this);

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1680,7 +1680,8 @@ public:
             ExtSetKind == SPIRVEIS_ShaderBallotAMD ||
             ExtSetKind == SPIRVEIS_ShaderExplicitVertexParameterAMD ||
             ExtSetKind == SPIRVEIS_GcnShaderAMD ||
-            ExtSetKind == SPIRVEIS_ShaderTrinaryMinMaxAMD) &&
+            ExtSetKind == SPIRVEIS_ShaderTrinaryMinMaxAMD ||
+            ExtSetKind == SPIRVEIS_NonSemanticInfo) &&
            "not supported");
   }
   void decode(std::istream &I) override {
@@ -1701,6 +1702,9 @@ public:
       break;
     case SPIRVEIS_ShaderTrinaryMinMaxAMD:
       getDecoder(I) >> ExtOpShaderTrinaryMinMaxAMD;
+      break;
+    case SPIRVEIS_NonSemanticInfo:
+      getDecoder(I) >> ExtOpNonSemanticInfo;
       break;
     default:
       assert(0 && "not supported");
@@ -1724,6 +1728,7 @@ protected:
       ExtOpShaderExplicitVertexParameterAMD;
     GcnShaderAMDExtOpKind ExtOpGcnShaderAMD;
     ShaderTrinaryMinMaxAMDExtOpKind ExtOpShaderTrinaryMinMaxAMD;
+    NonSemanticInfoExtOpKind ExtOpNonSemanticInfo;
   };
   SPIRVExtInstSetKind ExtSetKind;
 };

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -146,6 +146,7 @@ public:
   unsigned short getGeneratorId() const override { return GeneratorId; }
   unsigned short getGeneratorVer() const override { return GeneratorVer; }
   SPIRVWord getSPIRVVersion() const override { return SPIRVVersion; }
+  bool isNonSemanticInfoInstSet(llvm::StringRef setName) const;
 
   // Module changing functions
   bool importBuiltinSet(const std::string &, SPIRVId *) override;
@@ -633,11 +634,19 @@ bool SPIRVModuleImpl::importBuiltinSet(const std::string &BuiltinSetName,
   return true;
 }
 
+bool SPIRVModuleImpl::isNonSemanticInfoInstSet(llvm::StringRef setName) const {
+  return setName.startswith("NonSemantic.");
+}
+
 bool SPIRVModuleImpl::importBuiltinSetWithId(const std::string &BuiltinSetName,
                                              SPIRVId BuiltinSetId) {
   SPIRVExtInstSetKind BuiltinSet = SPIRVEIS_Count;
-  SPIRVCKRT(SPIRVBuiltinSetNameMap::rfind(BuiltinSetName, &BuiltinSet),
-            InvalidBuiltinSetName, "Actual is " + BuiltinSetName);
+
+  if (isNonSemanticInfoInstSet(BuiltinSetName))
+    BuiltinSet = SPIRVEIS_NonSemanticInfo;
+  else
+    SPIRVCKRT(SPIRVBuiltinSetNameMap::rfind(BuiltinSetName, &BuiltinSet),
+              InvalidBuiltinSetName, "Actual is " + BuiltinSetName);
   IdBuiltinMap[BuiltinSetId] = BuiltinSet;
   return true;
 }

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -116,7 +116,7 @@ SPIRVEntry *SPIRVDecoder::getEntry() {
   SPIRVEntry *Entry = SPIRVEntry::create(OpCode);
   assert(Entry);
   Entry->setModule(&M);
-  if (isModuleScopeAllowedOpCode(OpCode) && !Scope) {
+  if (!Scope && (isModuleScopeAllowedOpCode(OpCode) || OpCode == OpExtInst)) {
   } else
     Entry->setScope(Scope);
   Entry->setWordCount(WordCount);


### PR DESCRIPTION
We do not actually proccess the extension, instead, just ignore the instructions and let parser handle them silently.