### PR TITLE
Adjustments to llpc lit tests for differences caused by upstream llvm…

### DIFF
--- a/llpc/test/shaderdb/ObjInput_TestIndexingInterpOfInputArray_lit.frag
+++ b/llpc/test/shaderdb/ObjInput_TestIndexingInterpOfInputArray_lit.frag
@@ -41,43 +41,43 @@ void main()
 ; SHADERTEST: = call <3 x float> @llpc.input.import.builtin.InterpPullMode.v3f32.i32(i32 268435459)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 245, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 160, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 245, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 160, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 245, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 160, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 238, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 68, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 238, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 68, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 238, i32 15, i32 15, i1 true)
 ; SHADERTEST: = call i32 @llvm.amdgcn.mov.dpp.i32(i32 %{{.*}}, i32 68, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call <4 x float> @llpc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 4, i32 0, i32 0, i32 0, <2 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-2: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST: call float @llvm.amdgcn.interp.p2
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1

--- a/llpc/test/shaderdb/OpDPdx_TestFineCoarse_lit.frag
+++ b/llpc/test/shaderdb/OpDPdx_TestFineCoarse_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 85, i32 15, i32 15, i1 true)
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 0, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32(float %{{[0-9]+}})
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32(float %{{[0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpDPdy_TestFineCoarse_lit.frag
+++ b/llpc/test/shaderdb/OpDPdy_TestFineCoarse_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 170, i32 15, i32 15, i1 true)
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32(i32 {{[%0-9]+}}, i32 0, i32 15, i32 15, i1 true)
-; SHADERTEST: call float @llvm.amdgcn.wqm.f32(float {{[%0-9]+}})
+; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32(float {{[%0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
… changes

Flags for wqm intrinsic calls are now more extensive in some cases
(e.g. reassoc nnan contract etc)
Adjust the matching regexs to cater for both the before and after cases