### PR TITLE
Add int64 image atomics support.

### DIFF
--- a/llpc/test/shaderdb/OpAtomicAnd_TestInt64ImageAtomicAnd.spvas
+++ b/llpc/test/shaderdb/OpAtomicAnd_TestInt64ImageAtomicAnd.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 8
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.and.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicAnd %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicCompareExchange_TestInt64ImageAtomicCompSwap.spvas
+++ b/llpc/test/shaderdb/OpAtomicCompareExchange_TestInt64ImageAtomicCompSwap.spvas
@@ -1,0 +1,63 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.compare.swap.i64(i32 1
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.cmpswap.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 30
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %21 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %22 = OpLoad %long %21
+         %26 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %28 = OpAtomicCompareExchange %long %26 %uint_1 %uint_0 %uint_0 %22 %20
+         %29 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %29 %28
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicExchange_TestInt64ImageAtomicExchange.spvas
+++ b/llpc/test/shaderdb/OpAtomicExchange_TestInt64ImageAtomicExchange.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 0
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.swap.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicExchange %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicIAdd_TestInt64ImageAtomicAdd.spvas
+++ b/llpc/test/shaderdb/OpAtomicIAdd_TestInt64ImageAtomicAdd.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 2
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.add.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicIAdd %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicIDecrement_TestInt64ImageAtomicDecrement.spvas
+++ b/llpc/test/shaderdb/OpAtomicIDecrement_TestInt64ImageAtomicDecrement.spvas
@@ -1,0 +1,63 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 3, {{.*}}, i64 1)
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.sub.2d.i64.i32(i64 1
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+      %int_1 = OpConstant %int 1
+   %int_2048 = OpConstant %int 2048
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+  %uint_2048 = OpConstant %uint 2048
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %23 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicIDecrement %long %23 %int_1 %uint_2048
+         %28 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %28 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicIIncrement_TestInt64ImageAtomicIncrement.spvas
+++ b/llpc/test/shaderdb/OpAtomicIIncrement_TestInt64ImageAtomicIncrement.spvas
@@ -1,0 +1,63 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 2, {{.*}}, i64 1)
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.add.2d.i64.i32(i64 1
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+      %int_1 = OpConstant %int 1
+   %int_2048 = OpConstant %int 2048
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+  %uint_2048 = OpConstant %uint 2048
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %23 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicIIncrement %long %23 %int_1 %uint_2048
+         %28 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %28 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicISub_TestInt64ImageAtomicSub.spvas
+++ b/llpc/test/shaderdb/OpAtomicISub_TestInt64ImageAtomicSub.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 3
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.sub.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicISub %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicLoad_TestInt64ImageAtomicLoad.spvas
+++ b/llpc/test/shaderdb/OpAtomicLoad_TestInt64ImageAtomicLoad.spvas
@@ -1,0 +1,63 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 2, {{.*}}, i64 0)
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.add.2d.i64.i32(i64 0
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+      %int_1 = OpConstant %int 1
+   %int_2048 = OpConstant %int 2048
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+  %uint_2048 = OpConstant %uint 2048
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %23 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicLoad %long %23 %int_1 %uint_2048
+         %28 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %28 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicOr_TestInt64ImageAtomicOr.spvas
+++ b/llpc/test/shaderdb/OpAtomicOr_TestInt64ImageAtomicOr.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 9
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.or.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicOr %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicSMax_TestInt64ImageAtomicMax.spvas
+++ b/llpc/test/shaderdb/OpAtomicSMax_TestInt64ImageAtomicMax.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 6
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.smax.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicSMax %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicSMin_TestInt64ImageAtomicMin.spvas
+++ b/llpc/test/shaderdb/OpAtomicSMin_TestInt64ImageAtomicMin.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 4
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.smin.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicSMin %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicStore_TestInt64ImageAtomicStore.spvas
+++ b/llpc/test/shaderdb/OpAtomicStore_TestInt64ImageAtomicStore.spvas
@@ -1,0 +1,62 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 0
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.swap.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 29
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %i642D "i642D"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+          %7 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_7 = OpTypePointer UniformConstant %7
+      %i642D = OpVariable %_ptr_UniformConstant_7 UniformConstant
+        %int = OpTypeInt 32 1
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %13 = OpConstantComposite %v2int %int_3 %int_3
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+      %int_1 = OpConstant %int 1
+   %int_2048 = OpConstant %int 2048
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+  %uint_2048 = OpConstant %uint 2048
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %26 = OpImageTexelPointer %_ptr_Image_long %i642D %13 %uint_0
+               OpAtomicStore %26 %int_1 %uint_2048 %20
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicUMax_TestInt64ImageAtomicMax.spvas
+++ b/llpc/test/shaderdb/OpAtomicUMax_TestInt64ImageAtomicMax.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 7
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.umax.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "u64"
+               OpName %_ ""
+               OpName %u642D "u642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %u642D DescriptorSet 0
+               OpDecorate %u642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %ulong = OpTypeInt 64 0
+        %Buf = OpTypeStruct %ulong
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %ulong 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %u642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_ulong = OpTypePointer Uniform %ulong
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_ulong = OpTypePointer Image %ulong
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_ulong %_ %int_0
+         %20 = OpLoad %ulong %19
+         %24 = OpImageTexelPointer %_ptr_Image_ulong %u642D %17 %uint_0
+         %26 = OpAtomicUMax %ulong %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_ulong %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicUMin_TestInt64ImageAtomicMin.spvas
+++ b/llpc/test/shaderdb/OpAtomicUMin_TestInt64ImageAtomicMin.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 5
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.umin.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "u64"
+               OpName %_ ""
+               OpName %u642D "u642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %u642D DescriptorSet 0
+               OpDecorate %u642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %ulong = OpTypeInt 64 0
+        %Buf = OpTypeStruct %ulong
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %ulong 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %u642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_ulong = OpTypePointer Uniform %ulong
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_ulong = OpTypePointer Image %ulong
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_ulong %_ %int_0
+         %20 = OpLoad %ulong %19
+         %24 = OpImageTexelPointer %_ptr_Image_ulong %u642D %17 %uint_0
+         %26 = OpAtomicUMin %ulong %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_ulong %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/OpAtomicXor_TestInt64ImageAtomicXor.spvas
+++ b/llpc/test/shaderdb/OpAtomicXor_TestInt64ImageAtomicXor.spvas
@@ -1,0 +1,61 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call i64 (...) @llpc.call.image.atomic.i64(i32 10
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i64 @llvm.amdgcn.image.atomic.xor.2d.i64.i32
+; SHADERTEST: AMDLLPC SUCCESS
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 8
+; Bound: 28
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int64
+               OpCapability Int64Atomics
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main"
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARB_gpu_shader_int64"
+               OpName %main "main"
+               OpName %Buf "Buf"
+               OpMemberName %Buf 0 "i64"
+               OpName %_ ""
+               OpName %i642D "i642D"
+               OpMemberDecorate %Buf 0 Offset 0
+               OpDecorate %Buf BufferBlock
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 1
+               OpDecorate %i642D DescriptorSet 0
+               OpDecorate %i642D Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %long = OpTypeInt 64 1
+        %Buf = OpTypeStruct %long
+%_ptr_Uniform_Buf = OpTypePointer Uniform %Buf
+          %_ = OpVariable %_ptr_Uniform_Buf Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %12 = OpTypeImage %long 2D 0 0 0 2 Unknown
+%_ptr_UniformConstant_12 = OpTypePointer UniformConstant %12
+      %i642D = OpVariable %_ptr_UniformConstant_12 UniformConstant
+      %v2int = OpTypeVector %int 2
+      %int_3 = OpConstant %int 3
+         %17 = OpConstantComposite %v2int %int_3 %int_3
+%_ptr_Uniform_long = OpTypePointer Uniform %long
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Image_long = OpTypePointer Image %long
+     %uint_1 = OpConstant %uint 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %19 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+         %20 = OpLoad %long %19
+         %24 = OpImageTexelPointer %_ptr_Image_long %i642D %17 %uint_0
+         %26 = OpAtomicXor %long %24 %uint_1 %uint_0 %20
+         %27 = OpAccessChain %_ptr_Uniform_long %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6379,15 +6379,15 @@ Value *SPIRVToLLVM::transSPIRVImageAtomicOpFromInst(SPIRVInstruction *BI,
     break;
   case OpAtomicLoad:
     AtomicOp = Llpc::Builder::ImageAtomicAdd;
-    InputData = getBuilder()->getInt32(0);
+    InputData = getBuilder()->getIntN(BIT->getType()->getBitWidth(), 0);
     break;
   case OpAtomicIIncrement:
     AtomicOp = Llpc::Builder::ImageAtomicAdd;
-    InputData = getBuilder()->getInt32(1);
+    InputData = getBuilder()->getIntN(BIT->getType()->getBitWidth(), 1);
     break;
   case OpAtomicIDecrement:
     AtomicOp = Llpc::Builder::ImageAtomicSub;
-    InputData = getBuilder()->getInt32(1);
+    InputData = getBuilder()->getIntN(BIT->getType()->getBitWidth(), 1);
     break;
   case OpAtomicIAdd:
     AtomicOp = Llpc::Builder::ImageAtomicAdd;


### PR DESCRIPTION
Most int64 image atomics have been supported already. Make some minor
changes in SPIR-V translator. We use image_atomic_add and image_atomic_sub
instructions to emulate SPIR-V AtomicLoad, AtomicIIncrement, and
AtomicIDecrement opcodes. Thus, the extra operands are assumed to be
int32 1. This is not true because we could have other non i32 types.

This commit add LIT tests for all int64 image atomics.