### PR TITLE
Don't set defaults for -unroll-threshold or -unroll-partial-threshold

### DIFF
--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -377,8 +377,6 @@ static Result Init(
             // Name                                Option
             "-gfxip",                              "-gfxip=8.0.0",
             "-unroll-max-percent-threshold-boost", "-unroll-max-percent-threshold-boost=1000",
-            "-unroll-threshold",                   "-unroll-threshold=700",
-            "-unroll-partial-threshold",           "-unroll-partial-threshold=700",
             "-pragma-unroll-threshold",            "-pragma-unroll-threshold=1000",
             "-unroll-allow-partial",               "-unroll-allow-partial",
             "-simplifycfg-sink-common",            "-simplifycfg-sink-common=false",


### PR DESCRIPTION
After recent xgl commits, the driver no longer sets these options by
default for all apps, so it doesn't make sense for amdllpc to do so
either. It just causes unnecessary differences in code generation.

See xgl commit 8024f27f945:
* Replace use of unroll threshold option by shader tuning