### PR TITLE
Add NGG support to GS

### DIFF
--- a/llpc/patch/gfx9/llpcNggPrimShader.h
+++ b/llpc/patch/gfx9/llpcNggPrimShader.h
@@ -121,7 +121,8 @@ private:
                         llvm::Value* pEmitCounterPtr,
                         llvm::Value* pOutVertCounterPtr,
                         llvm::Value* pOutPrimCounterPtr,
-                        llvm::Value* pOutstandingVertCounterPtr);
+                        llvm::Value* pOutstandingVertCounterPtr,
+                        llvm::Value* pFlipVertOrderPtr);
 
     void ProcessGsCut(llvm::Module*  pModule,
                       uint32_t       streamId,
@@ -129,7 +130,8 @@ private:
                       llvm::Value*   pEmitCounterPtr,
                       llvm::Value*   pOutVertCounterPtr,
                       llvm::Value*   pOutPrimCounterPtr,
-                      llvm::Value*   pOutstandingVertCounterPtr);
+                      llvm::Value*   pOutstandingVertCounterPtr,
+                      llvm::Value*   pFlipVertOrderPtr);
 
     llvm::Function* CreateGsEmitHandler(llvm::Module* pModule, uint32_t streamId);
     llvm::Function* CreateGsCutHandler(llvm::Module* pModule, uint32_t streamId);


### PR DESCRIPTION
Fix an issue of vertex ordering for triangle strip.

Previously, we use index parity of the first vertex to decide vertex
ordering of the output triangle strip primitive. This is not incorrect
because of the inserted CUT operations. See this example:

Vertices: 0, 1, 2, CUT, 3, 4, 5, 6
Primitives (incorrect): <0, 1, 2>, <null prim>, <3, 5, 4>, <4, 5, 6>
Primitives (correct): <0, 1, 2>, <null prim>, <3, 4, 5>, <4, 6, 5>

We now use flag flipVertOrder to explicitly indicate whether to flip
vertex ordering. This flag is NOT-ed once a primitive is completed. It
will be cleared once a CUT operation is encountered. This flag is used
only for triangle strip. For other output primitive type, nothing is done.

Also, previous handling is based on subgroup-view vertex indices.
Rather,it should be based on thread-view vertex indices.