### PR TITLE
Update for LLVM fneg instruction

### DIFF
--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -243,7 +243,7 @@ void SpirvLowerAlgebraTransform::visitBinaryOperator(
                               { pTrunc },
                               NoAttrib,
                               &binaryOp);
-            pTrunc = BinaryOperator::CreateFNeg(pTrunc, "", &binaryOp);
+            pTrunc = UnaryOperator::CreateFNeg(pTrunc, "", &binaryOp);
 
             // -trunc(x/y) * y + x
             auto pFRem = EmitCall("llvm.fmuladd." + GetTypeName(pDestTy),

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5214,7 +5214,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
   case OpFNegate: {
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
-    auto FNeg = BinaryOperator::CreateFNeg(transValue(BC->getOperand(0), F, BB),
+    // Implement -x as -0.0 - x.
+    Value *NegZero = ConstantFP::getNegativeZero(transType(BC->getType()));
+    auto FNeg = BinaryOperator::CreateFSub(NegZero,
+                                           transValue(BC->getOperand(0), F, BB),
                                            BV->getName(), BB);
     setFastMathFlags(FNeg);
     return mapValue(BV, FNeg);


### PR DESCRIPTION
LLVM introduced an fneg instruction and has recently removed
BinaryOperator::CreateFNeg in favour of UnaryInstruction::CreateFNeg.
Update LLPC and adjust the lit tests accordingly.