### PR TITLE
update root descriptor offset after link/merge

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -239,6 +239,10 @@ struct PipelineShaderOptions
     bool allowVaryWaveSize;      ///< If set, lets the pipeline vary the wave sizes.
     /// Use the LLVM backend's SI scheduler instead of the default scheduler.
     bool      useSiScheduler;
+
+    // Whether update descriptor root offset in ELF
+    bool      updateDescInElf;
+
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
     /// Disable the the LLVM backend's LICM pass.
     bool      disableLicm;

--- a/llpc/builder/llpcPipeline.h
+++ b/llpc/builder/llpcPipeline.h
@@ -139,6 +139,9 @@ struct ShaderOptions
     // Use the LLVM backend's SI scheduler instead of the default scheduler.
     bool      useSiScheduler;
 
+    // Whether update descriptor root offset in ELF
+    bool      updateDescInElf;
+
     /// Default unroll threshold for LLVM.
     uint32_t  unrollThreshold;
 };

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -74,6 +74,7 @@ public:
 
     // Update shader caches with results of compile, and merge ELF outputs if necessary.
     void UpdateAndMerge(Result result, ElfPackage* pPipelineElf);
+    void UpdateRootUserDateOffset(ElfPackage* pPipelineElf);
 
 private:
     Compiler* m_pCompiler;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -358,6 +358,7 @@ void PipelineContext::SetOptionsInPipeline(
 #endif
 
             shaderOptions.useSiScheduler = EnableSiScheduler || pShaderInfo->options.useSiScheduler;
+            shaderOptions.updateDescInElf = pShaderInfo->options.updateDescInElf;
             shaderOptions.unrollThreshold = pShaderInfo->options.unrollThreshold;
 
             pPipeline->SetShaderOptions(static_cast<ShaderStage>(stage), shaderOptions);

--- a/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -1391,7 +1391,10 @@ void ConfigBuilder::BuildUserDataConfig(
             if (pIntfData->userDataMap[i] != InterfaceData::UserDataUnmapped)
             {
                 AppendConfig(startUserData + i, pIntfData->userDataMap[i]);
-                userDataLimit = std::max(userDataLimit, pIntfData->userDataMap[i] + 1);
+                if ((pIntfData->userDataMap[i] & DescRelocMagicMask) != DescRelocMagic)
+                {
+                    userDataLimit = std::max(userDataLimit, pIntfData->userDataMap[i] + 1);
+                }
             }
         }
 

--- a/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2839,7 +2839,11 @@ void ConfigBuilder::BuildUserDataConfig(
             if (pIntfData1->userDataMap[i] != InterfaceData::UserDataUnmapped)
             {
                 AppendConfig(startUserData + i, pIntfData1->userDataMap[i]);
-                userDataLimit = std::max(userDataLimit, pIntfData1->userDataMap[i] + 1);
+                if ((pIntfData1->userDataMap[i] & DescRelocMagicMask) != DescRelocMagic)
+                {
+                    userDataLimit = std::max(userDataLimit, pIntfData1->userDataMap[i] + 1);
+                }
+
             }
         }
 

--- a/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -673,7 +673,19 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
 
                     assert(pNode->sizeInDwords == 1);
 
-                    pIntfData->userDataMap[userDataIdx] = pNode->offsetInDwords;
+                    auto pShaderOptions = &m_pPipelineState->GetShaderOptions(m_shaderStage);
+                    if (pShaderOptions->updateDescInElf && (m_shaderStage == ShaderStageFragment))
+                    {
+                        // Put set number to register first, will update offset after merge ELFs
+                        // For partial pipeline compile, only fragment shader needs to adjust offset of root descriptor
+                        // If there are more individual shader compile in future, we can add more stages here
+                        pIntfData->userDataMap[userDataIdx] = DescRelocMagic | pNode->innerTable[0].set;
+                    }
+                    else
+                    {
+                        pIntfData->userDataMap[userDataIdx] = pNode->offsetInDwords;
+                    }
+
                     ++userDataIdx;
                     break;
                 }

--- a/llpc/tool/vfx/vfxSection.h
+++ b/llpc/tool/vfx/vfxSection.h
@@ -1163,6 +1163,7 @@ public:
 
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -68,8 +68,14 @@ public:
                               const ElfNote* pNote2,
                               ElfNote*       pNewNote);
 
+    static void UpdateMetaNote(Context*       pContext,
+                               const ElfNote* pNote,
+                               ElfNote*       pNewNote);
+
     Result ReadFromBuffer(const void* pBuffer, size_t bufSize);
     Result CopyFromReader(const ElfReader<Elf>& reader);
+
+    void UpdateElfBinary(Context* pContext, ElfPackage* pPipelineElf);
 
     void MergeElfBinary(Context*          pContext,
                         const BinaryData* pFragmentElf,

--- a/llpc/util/llpcInternal.h
+++ b/llpc/util/llpcInternal.h
@@ -167,6 +167,11 @@ static_assert(MaxGsStreams == MaxTransformFeedbackBuffers, "Unexpected value!");
 static const uint32_t InternalResourceTable  = 0x10000000;
 static const uint32_t InternalPerShaderTable = 0x10000001;
 
+// Descriptor offset reloc magic number
+static const uint32_t DescRelocMagic        = 0xA5A5A500;
+static const uint32_t DescRelocMagicMask    = 0xFFFFFF00;
+static const uint32_t DescSetMask           = 0x000000FF;
+
 // Internal resource table's virtual bindings
 static const uint32_t SI_DRV_TABLE_SCRATCH_GFX_SRD_OFFS = 0;
 static const uint32_t SI_DRV_TABLE_SCRATCH_CS_SRD_OFFS  = 1;

--- a/llpc/util/llpcPipelineDumper.cpp
+++ b/llpc/util/llpcPipelineDumper.cpp
@@ -606,6 +606,7 @@ void PipelineDumper::DumpPipelineShaderInfo(
     dumpFile << "options.waveBreakSize = " << pShaderInfo->options.waveBreakSize << "\n";
     dumpFile << "options.forceLoopUnrollCount = " << pShaderInfo->options.forceLoopUnrollCount << "\n";
     dumpFile << "options.useSiScheduler = " << pShaderInfo->options.useSiScheduler << "\n";
+    dumpFile << "options.updateDescInElf = " << pShaderInfo->options.updateDescInElf << "\n";
     dumpFile << "options.allowVaryWaveSize = " << pShaderInfo->options.allowVaryWaveSize << "\n";
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
     dumpFile << "options.enableLoadScalarizer = " << pShaderInfo->options.enableLoadScalarizer << "\n";
@@ -1171,6 +1172,7 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
             pHasher->Update(options.waveBreakSize);
             pHasher->Update(options.forceLoopUnrollCount);
             pHasher->Update(options.useSiScheduler);
+            pHasher->Update(options.updateDescInElf);
             pHasher->Update(options.allowVaryWaveSize);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
             pHasher->Update(options.enableLoadScalarizer);

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -44,6 +44,11 @@ static const uint32_t InvalidValue  = ~0u;
 // Size of vec4
 static const uint32_t SizeOfVec4 = sizeof(float) * 4;
 
+// Descriptor offset reloc magic number
+static const uint32_t DescRelocMagic        = 0xA5A5A500;
+static const uint32_t DescRelocMagicMask    = 0xFFFFFF00;
+static const uint32_t DescSetMask           = 0x000000FF;
+
 // Gets the name string of shader stage.
 const char* GetShaderStageName(ShaderStage shaderStage);
 


### PR DESCRIPTION
fill descriptor magic number and set number to USER_DATA registers,
accordingly update offset after link/merge
v2:
    a. fix cts failures(care userDataLimit).
    b. add option to decide if enable this feature.
    c. add mask to get Magic and set.
    d. improve coding style.

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>