### PR TITLE
Fixed internal build break

### DIFF
--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -61,12 +61,6 @@ bool EnableOuts();
 // Gets the value of option "enable-errs"
 bool EnableErrs();
 
-// Dumps ELF package to out stream
-template<class OStream, class Elf>
-OStream& operator<<(
-    OStream&         out,
-    ElfReader<Elf>&  reader);
-
 // Redirects the output of logs, It affects the behavior of llvm::outs(), dbgs() and errs().
 void RedirectLogOutput(
     bool              restoreToDefault,

--- a/llpc/util/llpcElfReader.h
+++ b/llpc/util/llpcElfReader.h
@@ -520,4 +520,10 @@ private:
     friend class ElfWriter<Elf>;
 };
 
+// Dumps ELF package to out stream
+template<class OStream, class Elf>
+OStream& operator<<(
+    OStream&         out,
+    ElfReader<Elf>&  reader);
+
 } // Llpc


### PR DESCRIPTION
My LGC move preparatory changes broke an AMD-internal build. Fixed.

Change-Id: I7dde8b9f802b3c382d327f84dc3ed2ed6253e88b