### PR TITLE
Fix IR modification during iteration bug in InstrinsicSimplify pass.

### DIFF
--- a/llpc/patch/llpcPatchIntrinsicSimplify.h
+++ b/llpc/patch/llpcPatchIntrinsicSimplify.h
@@ -78,6 +78,7 @@ private:
     llvm::Value* SimplifyImage(llvm::IntrinsicInst& intrinsicCall,
                                llvm::ArrayRef<uint32_t> coordOperandIndices) const;
     llvm::Value* SimplifyTrigonometric(llvm::IntrinsicInst& intrinsicCall) const;
+    bool CanSimplify(llvm::IntrinsicInst& intrinsicCall) const;
     llvm::Value* Simplify(llvm::IntrinsicInst& intrinsicCall) const;
 
     // -----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Use a worklist to avoid modifying the IR (particularly call list)
during iteration.  This was causing memory corruption.