### PR TITLE
Fix ordering of erase instructions to prevent invalid pointers

### DIFF
--- a/llpc/patch/llpcPatchIntrinsicSimplify.cpp
+++ b/llpc/patch/llpcPatchIntrinsicSimplify.cpp
@@ -145,8 +145,8 @@ bool PatchIntrinsicSimplify::runOnFunction(
         changed = true;
 
         pIntrinsicCall->replaceAllUsesWith(pSimplifiedValue);
-        pIntrinsicCall->eraseFromParent();
         m_pScalarEvolution->eraseValueFromMap(pIntrinsicCall);
+        pIntrinsicCall->eraseFromParent();
     }
 
     return changed;


### PR DESCRIPTION
Slight fix to a previous change where erase ordering could have resulted in an
invalid pointer.