### PR TITLE
fix regression caused by PR488

### DIFF
--- a/llpc/tool/vfx/vfxSection.h
+++ b/llpc/tool/vfx/vfxSection.h
@@ -1180,7 +1180,7 @@ public:
     void GetSubState(SubState& state) { state = m_state; };
 
 private:
-    static const uint32_t  MemberCount = 17;
+    static const uint32_t  MemberCount = 18;
     static StrToMemberAddr m_addrTable[MemberCount];
 
     SubState               m_state;


### PR DESCRIPTION
when adding member to addrTable, we needs to increase the MemberCount.

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>