### PR TITLE
Remove duplicate definitions of Llpc::{InvalidValue,SizeOfVec4}

### DIFF
--- a/llpc/builder/llpcBuilderImplInOut.cpp
+++ b/llpc/builder/llpcBuilderImplInOut.cpp
@@ -32,6 +32,7 @@
 #include "llpcBuilderImpl.h"
 #include "llpcInternal.h"
 #include "llpcPipelineState.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-inout"
 

--- a/llpc/builder/llpcPipelineState.cpp
+++ b/llpc/builder/llpcPipelineState.cpp
@@ -37,6 +37,7 @@
 #include "llpcPatch.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"

--- a/llpc/builder/llpcResourceUsage.h
+++ b/llpc/builder/llpcResourceUsage.h
@@ -88,7 +88,7 @@ struct FsInterpInfo
 };
 
 // Invalid interpolation info
-static const FsInterpInfo InvalidFsInterpInfo = { InvalidValue, false, false, false };
+static const FsInterpInfo InvalidFsInterpInfo = { ~0u, false, false, false };
 
 // Enumerate the workgroup layout options.
 enum class WorkgroupLayout : uint32_t
@@ -453,7 +453,7 @@ struct InterfaceData
     static const uint32_t MaxEsGsOffsetCount = 6;
     static const uint32_t MaxCsUserDataCount = 10;
     static const uint32_t CsStartUserData     = 2;
-    static const uint32_t UserDataUnmapped = InvalidValue;
+    static const uint32_t UserDataUnmapped = ~0u;
 
     uint32_t                    userDataCount;                    // User data count
     uint32_t                    userDataMap[MaxUserDataCount];    // User data map (from SGPR No. to API logical ID)

--- a/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -34,6 +34,7 @@
 #include "llpcGfx6ConfigBuilder.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "llpc-gfx6-config-builder"

--- a/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -33,6 +33,7 @@
 #include "llpcGfx9ConfigBuilder.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "llpc-gfx9-config-builder"

--- a/llpc/patch/gfx9/llpcNggLdsManager.h
+++ b/llpc/patch/gfx9/llpcNggLdsManager.h
@@ -35,6 +35,7 @@
 #include "llvm/IR/IRBuilder.h"
 
 #include "llpcInternal.h"
+#include "llpcUtil.h"
 
 namespace Llpc
 {

--- a/llpc/patch/llpcPatchCopyShader.cpp
+++ b/llpc/patch/llpcPatchCopyShader.cpp
@@ -40,6 +40,7 @@
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-copy-shader"
 

--- a/llpc/patch/llpcPatchDescriptorLoad.cpp
+++ b/llpc/patch/llpcPatchDescriptorLoad.cpp
@@ -35,6 +35,7 @@
 
 #include "llpcPatchDescriptorLoad.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-descriptor-load"
 

--- a/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -39,6 +39,7 @@
 #include "llpcPatchEntryPointMutate.h"
 #include "llpcPipelineShaders.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-entry-point-mutate"
 

--- a/llpc/patch/llpcPatchInOutImportExport.cpp
+++ b/llpc/patch/llpcPatchInOutImportExport.cpp
@@ -42,6 +42,7 @@
 #include "llpcPatchInOutImportExport.h"
 #include "llpcPipelineShaders.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llpcVertexFetch.h"
 
 #define DEBUG_TYPE "llpc-patch-in-out-import-export"

--- a/llpc/patch/llpcPatchNullFragShader.cpp
+++ b/llpc/patch/llpcPatchNullFragShader.cpp
@@ -39,6 +39,7 @@
 #include "llpcInternal.h"
 #include "llpcPatch.h"
 #include "llpcPipelineState.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-null-frag-shader"
 

--- a/llpc/patch/llpcPatchPushConstOp.cpp
+++ b/llpc/patch/llpcPatchPushConstOp.cpp
@@ -37,6 +37,7 @@
 #include "llpcPatchPushConstOp.h"
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-push-const"
 

--- a/llpc/patch/llpcSystemValues.cpp
+++ b/llpc/patch/llpcSystemValues.cpp
@@ -35,6 +35,7 @@
 #include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-system-values"
 

--- a/llpc/patch/llpcVertexFetch.cpp
+++ b/llpc/patch/llpcVertexFetch.cpp
@@ -35,6 +35,7 @@
 #include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llpcVertexFetch.h"
 
 #define DEBUG_TYPE "llpc-vertex-fetch"

--- a/llpc/util/llpcInternal.cpp
+++ b/llpc/util/llpcInternal.cpp
@@ -44,6 +44,7 @@
 
 #include "llpcBuilderBase.h"
 #include "llpcInternal.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-internal"
 

--- a/llpc/util/llpcInternal.h
+++ b/llpc/util/llpcInternal.h
@@ -55,12 +55,6 @@ void initializeStartStopTimerPass(PassRegistry&);
 namespace Llpc
 {
 
-// Invalid value
-static const uint32_t InvalidValue  = ~0u;
-
-// Size of vec4
-static const uint32_t SizeOfVec4 = sizeof(float) * 4;
-
 // Initialize helper passes
 inline static void InitializeUtilPasses(
     llvm::PassRegistry& passRegistry)   // Pass registry


### PR DESCRIPTION
There is a second set of definitions in llpcUtil.h, which could cause
conflicts going forward.