### PR TITLE
Clarify the use of descriptor set indices in the PAL metadata

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -240,8 +240,9 @@ struct PipelineShaderOptions
     /// Use the LLVM backend's SI scheduler instead of the default scheduler.
     bool      useSiScheduler;
 
-    // Whether update descriptor root offset in ELF
-    bool      updateDescInElf;
+    /// Emit descriptor set indices instead of userdata table indices in the PAL userdata mapping metadata. For use with
+    /// pre-compilation: the userdata mapping must be adjusted later.
+    bool      emitDescriptorSetIndexInMetadata;
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
     /// Disable the the LLVM backend's LICM pass.

--- a/llpc/builder/llpcBuilderImplInOut.cpp
+++ b/llpc/builder/llpcBuilderImplInOut.cpp
@@ -32,6 +32,7 @@
 #include "llpcBuilderImpl.h"
 #include "llpcInternal.h"
 #include "llpcPipelineState.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-builder-impl-inout"
 

--- a/llpc/builder/llpcPipeline.h
+++ b/llpc/builder/llpcPipeline.h
@@ -139,8 +139,9 @@ struct ShaderOptions
     // Use the LLVM backend's SI scheduler instead of the default scheduler.
     bool      useSiScheduler;
 
-    // Whether update descriptor root offset in ELF
-    bool      updateDescInElf;
+    /// Emit descriptor set indices instead of userdata table indices in the PAL userdata mapping metadata. For use with
+    /// pre-compilation: the userdata mapping must be adjusted later.
+    bool      emitDescriptorSetIndexInMetadata;
 
     /// Default unroll threshold for LLVM.
     uint32_t  unrollThreshold;

--- a/llpc/builder/llpcPipelineState.cpp
+++ b/llpc/builder/llpcPipelineState.cpp
@@ -37,6 +37,7 @@
 #include "llpcPatch.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"

--- a/llpc/builder/llpcResourceUsage.h
+++ b/llpc/builder/llpcResourceUsage.h
@@ -88,7 +88,7 @@ struct FsInterpInfo
 };
 
 // Invalid interpolation info
-static const FsInterpInfo InvalidFsInterpInfo = { InvalidValue, false, false, false };
+static const FsInterpInfo InvalidFsInterpInfo = { ~0u, false, false, false };
 
 // Enumerate the workgroup layout options.
 enum class WorkgroupLayout : uint32_t
@@ -453,7 +453,7 @@ struct InterfaceData
     static const uint32_t MaxEsGsOffsetCount = 6;
     static const uint32_t MaxCsUserDataCount = 10;
     static const uint32_t CsStartUserData     = 2;
-    static const uint32_t UserDataUnmapped = InvalidValue;
+    static const uint32_t UserDataUnmapped = ~0u;
 
     uint32_t                    userDataCount;                    // User data count
     uint32_t                    userDataMap[MaxUserDataCount];    // User data map (from SGPR No. to API logical ID)

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -74,7 +74,6 @@ public:
 
     // Update shader caches with results of compile, and merge ELF outputs if necessary.
     void UpdateAndMerge(Result result, ElfPackage* pPipelineElf);
-    void UpdateRootUserDateOffset(ElfPackage* pPipelineElf);
 
 private:
     Compiler* m_pCompiler;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -358,7 +358,7 @@ void PipelineContext::SetOptionsInPipeline(
 #endif
 
             shaderOptions.useSiScheduler = EnableSiScheduler || pShaderInfo->options.useSiScheduler;
-            shaderOptions.updateDescInElf = pShaderInfo->options.updateDescInElf;
+            shaderOptions.emitDescriptorSetIndexInMetadata = pShaderInfo->options.emitDescriptorSetIndexInMetadata;
             shaderOptions.unrollThreshold = pShaderInfo->options.unrollThreshold;
 
             pPipeline->SetShaderOptions(static_cast<ShaderStage>(stage), shaderOptions);

--- a/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -34,6 +34,7 @@
 #include "llpcGfx6ConfigBuilder.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "llpc-gfx6-config-builder"

--- a/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/llpc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -1392,7 +1392,7 @@ void ConfigBuilder::BuildUserDataConfig(
             if (pIntfData->userDataMap[i] != InterfaceData::UserDataUnmapped)
             {
                 AppendConfig(startUserData + i, pIntfData->userDataMap[i]);
-                if ((pIntfData->userDataMap[i] & DescRelocMagicMask) != DescRelocMagic)
+                if (pIntfData->userDataMap[i] < VkDescriptorSetIndexLow)
                 {
                     userDataLimit = std::max(userDataLimit, pIntfData->userDataMap[i] + 1);
                 }

--- a/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -2840,7 +2840,7 @@ void ConfigBuilder::BuildUserDataConfig(
             if (pIntfData1->userDataMap[i] != InterfaceData::UserDataUnmapped)
             {
                 AppendConfig(startUserData + i, pIntfData1->userDataMap[i]);
-                if ((pIntfData1->userDataMap[i] & DescRelocMagicMask) != DescRelocMagic)
+                if (pIntfData1->userDataMap[i] < VkDescriptorSetIndexLow)
                 {
                     userDataLimit = std::max(userDataLimit, pIntfData1->userDataMap[i] + 1);
                 }

--- a/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/llpc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -33,6 +33,7 @@
 #include "llpcGfx9ConfigBuilder.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "llpc-gfx9-config-builder"

--- a/llpc/patch/gfx9/llpcNggLdsManager.h
+++ b/llpc/patch/gfx9/llpcNggLdsManager.h
@@ -35,6 +35,7 @@
 #include "llvm/IR/IRBuilder.h"
 
 #include "llpcInternal.h"
+#include "llpcUtil.h"
 
 namespace Llpc
 {

--- a/llpc/patch/llpcPatchCopyShader.cpp
+++ b/llpc/patch/llpcPatchCopyShader.cpp
@@ -40,6 +40,7 @@
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-copy-shader"
 

--- a/llpc/patch/llpcPatchDescriptorLoad.cpp
+++ b/llpc/patch/llpcPatchDescriptorLoad.cpp
@@ -35,6 +35,7 @@
 
 #include "llpcPatchDescriptorLoad.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-descriptor-load"
 

--- a/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -39,6 +39,7 @@
 #include "llpcPatchEntryPointMutate.h"
 #include "llpcPipelineShaders.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-entry-point-mutate"
 

--- a/llpc/patch/llpcPatchEntryPointMutate.cpp
+++ b/llpc/patch/llpcPatchEntryPointMutate.cpp
@@ -675,15 +675,17 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
                     assert(pNode->sizeInDwords == 1);
 
                     auto pShaderOptions = &m_pPipelineState->GetShaderOptions(m_shaderStage);
-                    if (pShaderOptions->updateDescInElf && (m_shaderStage == ShaderStageFragment))
+                    if (pShaderOptions->emitDescriptorSetIndexInMetadata && (m_shaderStage == ShaderStageFragment))
                     {
-                        // Put set number to register first, will update offset after merge ELFs
-                        // For partial pipeline compile, only fragment shader needs to adjust offset of root descriptor
-                        // If there are more individual shader compile in future, we can add more stages here
-                        pIntfData->userDataMap[userDataIdx] = DescRelocMagic | pNode->innerTable[0].set;
+                        // Record the descriptor set index into the mapping now instead of. This is used during partial
+                        // pipeline compile, when the final offset of descriptor set VA pointers within the PAL
+                        // userdata table are not yet known.
+                        assert(pNode->innerTable[0].set <= VkDescriptorSetIndexHigh - VkDescriptorSetIndexLow);
+                        pIntfData->userDataMap[userDataIdx] = VkDescriptorSetIndexLow + pNode->innerTable[0].set;
                     }
                     else
                     {
+                        // Record the offset into the PAL userdata table.
                         pIntfData->userDataMap[userDataIdx] = pNode->offsetInDwords;
                     }
 

--- a/llpc/patch/llpcPatchInOutImportExport.cpp
+++ b/llpc/patch/llpcPatchInOutImportExport.cpp
@@ -42,6 +42,7 @@
 #include "llpcPatchInOutImportExport.h"
 #include "llpcPipelineShaders.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llpcVertexFetch.h"
 
 #define DEBUG_TYPE "llpc-patch-in-out-import-export"

--- a/llpc/patch/llpcPatchNullFragShader.cpp
+++ b/llpc/patch/llpcPatchNullFragShader.cpp
@@ -39,6 +39,7 @@
 #include "llpcInternal.h"
 #include "llpcPatch.h"
 #include "llpcPipelineState.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-null-frag-shader"
 

--- a/llpc/patch/llpcPatchPushConstOp.cpp
+++ b/llpc/patch/llpcPatchPushConstOp.cpp
@@ -37,6 +37,7 @@
 #include "llpcPatchPushConstOp.h"
 #include "llpcPipelineShaders.h"
 #include "llpcPipelineState.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-patch-push-const"
 

--- a/llpc/patch/llpcSystemValues.cpp
+++ b/llpc/patch/llpcSystemValues.cpp
@@ -35,6 +35,7 @@
 #include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-system-values"
 

--- a/llpc/patch/llpcVertexFetch.cpp
+++ b/llpc/patch/llpcVertexFetch.cpp
@@ -35,6 +35,7 @@
 #include "llpcPipelineState.h"
 #include "llpcSystemValues.h"
 #include "llpcTargetInfo.h"
+#include "llpcUtil.h"
 #include "llpcVertexFetch.h"
 
 #define DEBUG_TYPE "llpc-vertex-fetch"

--- a/llpc/tool/vfx/vfxSection.h
+++ b/llpc/tool/vfx/vfxSection.h
@@ -1163,7 +1163,7 @@ public:
 
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
-        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, emitDescriptorSetIndexInMetadata, MemberTypeBool, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -64,20 +64,14 @@ public:
                              SectionBuffer*       pNewSection);
 
     static void MergeMetaNote(Context*       pContext,
-                              const ElfNote* pNote1,
-                              const ElfNote* pNote2,
+                              const ElfNote* pBaseNote,
+                              const ElfNote* pFragmentNote,
                               ElfNote*       pNewNote);
-
-    static void UpdateMetaNote(Context*       pContext,
-                               const ElfNote* pNote,
-                               ElfNote*       pNewNote);
 
     Result ReadFromBuffer(const void* pBuffer, size_t bufSize);
     Result CopyFromReader(const ElfReader<Elf>& reader);
 
-    void UpdateElfBinary(Context* pContext, ElfPackage* pPipelineElf);
-
-    void MergeElfBinary(Context*          pContext,
+    void MergeFragmentShader(Context*          pContext,
                         const BinaryData* pFragmentElf,
                         ElfPackage*       pPipelineElf);
 
@@ -108,8 +102,6 @@ public:
 private:
     ElfWriter(const ElfWriter&) = delete;
     ElfWriter& operator=(const ElfWriter&) = delete;
-
-    static void MergeMapItem(llvm::msgpack::MapDocNode& destMap, llvm::msgpack::MapDocNode& srcMap, uint32_t key);
 
     size_t GetRequiredBufferSizeBytes();
 

--- a/llpc/util/llpcInternal.cpp
+++ b/llpc/util/llpcInternal.cpp
@@ -44,6 +44,7 @@
 
 #include "llpcBuilderBase.h"
 #include "llpcInternal.h"
+#include "llpcUtil.h"
 
 #define DEBUG_TYPE "llpc-internal"
 

--- a/llpc/util/llpcInternal.h
+++ b/llpc/util/llpcInternal.h
@@ -55,12 +55,6 @@ void initializeStartStopTimerPass(PassRegistry&);
 namespace Llpc
 {
 
-// Invalid value
-static const uint32_t InvalidValue  = ~0u;
-
-// Size of vec4
-static const uint32_t SizeOfVec4 = sizeof(float) * 4;
-
 // Initialize helper passes
 inline static void InitializeUtilPasses(
     llvm::PassRegistry& passRegistry)   // Pass registry

--- a/llpc/util/llpcInternal.h
+++ b/llpc/util/llpcInternal.h
@@ -161,11 +161,6 @@ static_assert(MaxGsStreams == MaxTransformFeedbackBuffers, "Unexpected value!");
 static const uint32_t InternalResourceTable  = 0x10000000;
 static const uint32_t InternalPerShaderTable = 0x10000001;
 
-// Descriptor offset reloc magic number
-static const uint32_t DescRelocMagic        = 0xA5A5A500;
-static const uint32_t DescRelocMagicMask    = 0xFFFFFF00;
-static const uint32_t DescSetMask           = 0x000000FF;
-
 // Internal resource table's virtual bindings
 static const uint32_t SI_DRV_TABLE_SCRATCH_GFX_SRD_OFFS = 0;
 static const uint32_t SI_DRV_TABLE_SCRATCH_CS_SRD_OFFS  = 1;

--- a/llpc/util/llpcPipelineDumper.cpp
+++ b/llpc/util/llpcPipelineDumper.cpp
@@ -606,7 +606,8 @@ void PipelineDumper::DumpPipelineShaderInfo(
     dumpFile << "options.waveBreakSize = " << pShaderInfo->options.waveBreakSize << "\n";
     dumpFile << "options.forceLoopUnrollCount = " << pShaderInfo->options.forceLoopUnrollCount << "\n";
     dumpFile << "options.useSiScheduler = " << pShaderInfo->options.useSiScheduler << "\n";
-    dumpFile << "options.updateDescInElf = " << pShaderInfo->options.updateDescInElf << "\n";
+    dumpFile << "options.emitDescriptorSetIndexInMetadata = " << pShaderInfo->options.emitDescriptorSetIndexInMetadata
+             << "\n";
     dumpFile << "options.allowVaryWaveSize = " << pShaderInfo->options.allowVaryWaveSize << "\n";
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
     dumpFile << "options.enableLoadScalarizer = " << pShaderInfo->options.enableLoadScalarizer << "\n";
@@ -1172,7 +1173,7 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
             pHasher->Update(options.waveBreakSize);
             pHasher->Update(options.forceLoopUnrollCount);
             pHasher->Update(options.useSiScheduler);
-            pHasher->Update(options.updateDescInElf);
+            pHasher->Update(options.emitDescriptorSetIndexInMetadata);
             pHasher->Update(options.allowVaryWaveSize);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
             pHasher->Update(options.enableLoadScalarizer);

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -44,11 +44,6 @@ static const uint32_t InvalidValue  = ~0u;
 // Size of vec4
 static const uint32_t SizeOfVec4 = sizeof(float) * 4;
 
-// Descriptor offset reloc magic number
-static const uint32_t DescRelocMagic        = 0xA5A5A500;
-static const uint32_t DescRelocMagicMask    = 0xFFFFFF00;
-static const uint32_t DescSetMask           = 0x000000FF;
-
 // Gets the name string of shader stage.
 const char* GetShaderStageName(ShaderStage shaderStage);
 
@@ -174,5 +169,11 @@ inline const T* FindVkStructInChain(
     return reinterpret_cast<const T*>(pStructHeader);
 }
 
-} // Llpc
+// =====================================================================================================================
+// Descriptor set index userdata mappings.
+//
+// TODO: Replace this with a reference to palPipelineAbi.h Util::Abi::UserDataMapping eventually.
+static const uint32_t VkDescriptorSetIndexLow = 0x30000000;
+static const uint32_t VkDescriptorSetIndexHigh = 0x3000001F;
 
+} // Llpc


### PR DESCRIPTION
The PAL metadata contains a userdata mapping which tells PAL the data to
load into each loaded userdata SGPR. There are two kinds of values:
    
1. Indices into the userdata table maintained by the client driver via Pal::ICmdBuffer::CmdSetUserData
2. Special "system" values as listed in Util::Abi::UserDataMapping
    
Pointers to descriptor sets fall into the first category. The client driver
tells the compiler which location in the userdata table will contain the
pointer to each descriptor set (via the ResourceMappingNode part of the
pipeline build info).
    
When compiling a partial pipeline, the layout of the userdata table may not
be known yet. The compiler can already decide which SGPR will hold the
pointer to the descriptor set (the "key" part of the metadata), but 
does not yet know the final "value" part of the metadata.
    
To solve this problem, introduce a new kind of value, the
VkDescriptorSetIndex, which is emitted as part of the PAL metadata during
the initial compiler. It is resolved, when linking the different parts of a
pipeline together.
    
The emitDescriptorSetIndexInMetadata option instructs the compiler to
generate these VkDescriptorSetIndex mapping.
    
Resolving any such mappings during linking happens unconditionally while
merging the metadata.
    
This commit integrates the "updating" of the "meta note" into the merging
of the metadata, as this is conceptually one operation. Some method names
are updated to better reflect the asymmetry in what they do.
    
The updateDescInElf option is renamed to emitDescriptorSetIndexInMetadata
to better reflect the purpose of the option.
