### PR TITLE
SPIRVReader: Handle MemberDecorate of Component correctly

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7913,7 +7913,7 @@ Constant * SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *BT,
       SPIRVWord MemberComponent = SPIRVID_INVALID;
       if (BT->hasMemberDecorate(
             MemberIdx, DecorationComponent, 0, &MemberComponent))
-        MemberDec.Component = Component;
+        MemberDec.Component = MemberComponent;
 
       if (BT->hasMemberDecorate(MemberIdx, DecorationFlat))
         MemberDec.Interp.Mode = InterpModeFlat;


### PR DESCRIPTION
Apparently this is not tested by CTS at the moment, but there is a related
Khronos-internal issue (vulkan/vulkan#2025) with a sample that exposes
this problem.