### PR TITLE
Added support to lower OpAtomicLoad to raw_atomic_buffer_load

### DIFF
--- a/llpc/patch/llpcPatchBufferOp.cpp
+++ b/llpc/patch/llpcPatchBufferOp.cpp
@@ -1756,7 +1756,10 @@ Value* PatchBufferOp::ReplaceLoadStore(
             }
             else
             {
-                pPart = m_pBuilder->CreateIntrinsic(Intrinsic::amdgcn_raw_buffer_load,
+                uint32_t intrinsicID = Intrinsic::amdgcn_raw_buffer_load;
+                if (ordering != AtomicOrdering::NotAtomic)
+                    intrinsicID = Intrinsic::amdgcn_raw_atomic_buffer_load;
+                pPart = m_pBuilder->CreateIntrinsic(intrinsicID,
                                                     pIntAccessType,
                                                     {
                                                         pBufferDesc,

--- a/llpc/test/shaderdb/OpAtomicLoad_TestStorageBlock_lit.spvas
+++ b/llpc/test/shaderdb/OpAtomicLoad_TestStorageBlock_lit.spvas
@@ -6,7 +6,7 @@
 ; SHADERTEST: %{{.*}} = load atomic i32, i32 addrspace({{.*}})* {{.*}} monotonic
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST:  %{{.*}} = call i32 @llvm.amdgcn.raw.buffer.load.i32
+; SHADERTEST:  %{{.*}} = call i32 @llvm.amdgcn.raw.atomic.buffer.load.i32
 ; SHADERTEST: %{{.*}} = ptrtoint i32 addrspace({{.*}})* %{{.*}} to i32
 
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
There were issues with llvm opts hoisting atomic loads and changing program correctness. raw_atomic_buffer_load intrinsic has been created to deal with this and OpAtomicLoad should now be lowered to this.