### PR TITLE
Use llvm.canonicalize with FNEG

### DIFF
--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.h
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.h
@@ -54,8 +54,10 @@ public:
 
     virtual bool runOnModule(llvm::Module& module);
     virtual void visitBinaryOperator(llvm::BinaryOperator& binaryOp);
+    virtual void visitUnaryOperator(llvm::UnaryOperator& unaryOp);
     virtual void visitCallInst(llvm::CallInst& callInst);
     virtual void visitFPTruncInst(llvm::FPTruncInst& fptruncInst);
+    void flushDenormIfNeeded(llvm::Instruction *pInst);
 
     // -----------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Use llvm.canonicalize with FNEG to force denorm flushing behaviour.

The equivalent mechanism is currenly used with FSUB (with 0).