### PR TITLE
Moved -enable-shadow-desc and -shadow-desc-table-ptr-high

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -132,14 +132,6 @@ static opt<std::string> ExecutableName("executable-name",
 // -enable-spirv-opt: enable optimization for SPIR-V binary
 opt<bool> EnableSpirvOpt("enable-spirv-opt", desc("Enable optimization for SPIR-V binary"), init(false));
 
-// -enable-shadow-desc: enable shadow desriptor table
-opt<bool> EnableShadowDescriptorTable("enable-shadow-desc", desc("Enable shadow descriptor table"), init(true));
-
-// -shadow-desc-table-ptr-high: high part of VA for shadow descriptor table pointer
-opt<uint32_t> ShadowDescTablePtrHigh("shadow-desc-table-ptr-high",
-                                     desc("High part of VA for shadow descriptor table pointer"),
-                                     init(2));
-
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 37
 // -enable-dynamic-loop-unroll: Enable dynamic loop unroll. (Deprecated)
 opt<bool> EnableDynamicLoopUnroll("enable-dynamic-loop-unroll", desc("Enable dynamic loop unroll (deprecated)"), init(false));
@@ -1764,8 +1756,6 @@ MetroHash::Hash Compiler::GenerateHashForCompileOptions(
         cl::EnableErrs.ArgStr,
         cl::LogFileDbgs.ArgStr,
         cl::LogFileOuts.ArgStr,
-        cl::EnableShadowDescriptorTable.ArgStr,
-        cl::ShadowDescTablePtrHigh.ArgStr,
         cl::ExecutableName.ArgStr
     };
 

--- a/llpc/patch/llpcPatchDescriptorLoad.cpp
+++ b/llpc/patch/llpcPatchDescriptorLoad.cpp
@@ -41,17 +41,10 @@
 using namespace llvm;
 using namespace Llpc;
 
-namespace llvm
-{
-
-namespace cl
-{
-
-extern opt<bool> EnableShadowDescriptorTable;
-
-} // cl
-
-} // llvm
+// -enable-shadow-desc: enable shadow desriptor table
+static cl::opt<bool> EnableShadowDescriptorTable("enable-shadow-desc",
+                                                 cl::desc("Enable shadow descriptor table"),
+                                                 cl::init(true));
 
 namespace Llpc
 {
@@ -533,7 +526,7 @@ Value* PatchDescriptorLoad::LoadDescriptor(
             {
                 pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalPerShaderTablePtr();
             }
-            else if ((cl::EnableShadowDescriptorTable) && (nodeType1 == ResourceMappingNodeType::DescriptorFmask))
+            else if ((EnableShadowDescriptorTable) && (nodeType1 == ResourceMappingNodeType::DescriptorFmask))
             {
                 pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetShadowDescTablePtr(descSet);
             }
@@ -726,7 +719,7 @@ ResourceMappingNodeType PatchDescriptorLoad::CalcDescriptorOffsetAndSize(
         exist = true;
     }
 
-    if (cl::EnableShadowDescriptorTable && (nodeType1 == ResourceMappingNodeType::DescriptorFmask))
+    if (EnableShadowDescriptorTable && (nodeType1 == ResourceMappingNodeType::DescriptorFmask))
     {
         // NOTE: When shadow descriptor table is enable, we need get F-Mask descriptor node from
         // associated multi-sampled texture resource node. So we have to change nodeType1 to

--- a/llpc/patch/llpcSystemValues.cpp
+++ b/llpc/patch/llpcSystemValues.cpp
@@ -41,17 +41,11 @@
 using namespace Llpc;
 using namespace llvm;
 
-namespace llvm
-{
-
-namespace cl
-{
-
-extern opt<uint32_t> ShadowDescTablePtrHigh;
-
-} // cl
-
-} // llvm
+// -shadow-desc-table-ptr-high: high part of VA for shadow descriptor table pointer
+// The default value 2 is a dummy value for use in offline compiling.
+static cl::opt<uint32_t> ShadowDescTablePtrHigh("shadow-desc-table-ptr-high",
+                                                cl::desc("High part of VA for shadow descriptor table pointer"),
+                                                cl::init(2));
 
 // =====================================================================================================================
 // Initialize this ShaderSystemValues if it was previously uninitialized.
@@ -405,7 +399,7 @@ Value* ShaderSystemValues::GetShadowDescTablePtr(
                                                     ADDR_SPACE_CONST);
             m_shadowDescTablePtrs[descSet] = GetExtendedResourceNodeValue(resNodeIdx,
                                                                           pDescTablePtrTy,
-                                                                          cl::ShadowDescTablePtrHigh);
+                                                                          ShadowDescTablePtrHigh);
         }
     }
     return m_shadowDescTablePtrs[descSet];


### PR DESCRIPTION
These options were still defined in the front-end in llpcCompiler.cpp.
This commit moves them to where they are used in LGC.

Change-Id: Ideb279b42d92939834a1ee203a1432d82f566c0f