### PR TITLE
Fixed 'Reserve a descriptor type for future use'

### DIFF
--- a/include/lgc/Defs.h
+++ b/include/lgc/Defs.h
@@ -81,7 +81,10 @@ enum class ResourceMappingNodeType : uint32_t
     PushConst,                      ///< Push constant
     DescriptorBufferCompact,        ///< Compact buffer descriptor, only contains the buffer address
     StreamOutTableVaPtr,            ///< Stream-out buffer table VA pointer
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 40
     DescriptorReserved12,
+#elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 29
+#endif
     DescriptorYCbCrSampler,         ///< Generic descriptor: YCbCr sampler
     Count,                          ///< Count of resource mapping node types.
 };

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -41,10 +41,10 @@
 #undef Bool
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 38
+#define LLPC_INTERFACE_MAJOR_VERSION 40
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 0
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -64,6 +64,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     40.0 | Added DescriptorReserved12, which moves DescriptorYCbCrSampler down to 13                             |
 //* |     38.2 | Added scalarThreshold to PipelineShaderOptions                                                        |
 //* |     38.1 | Added unrollThreshold to PipelineShaderOptions                                                        |
 //* |     38.0 | Removed CreateShaderCache in ICompiler and pShaderCache in pipeline build info                        |

--- a/llpc/builder/llpcPipelineState.cpp
+++ b/llpc/builder/llpcPipelineState.cpp
@@ -1301,7 +1301,6 @@ const char* PipelineState::GetResourceMappingNodeTypeName(
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, PushConst)
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorBufferCompact)
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, StreamOutTableVaPtr)
-    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorReserved12)
         break;
     default:
         llvm_unreachable("Should never be called!");


### PR DESCRIPTION
The previous fix broke compatibility in some AMD internal builds.

Change-Id: Iec0ee5e489b2a15b8eb30add8ddadddeb0f20fad