### PR TITLE
Revamped PatchDescriptorLoad

### DIFF
--- a/lgc/builder/llpcPipelineState.cpp
+++ b/lgc/builder/llpcPipelineState.cpp
@@ -762,6 +762,7 @@ void PipelineState::ReadUserDataNodes(
 // For nodeType == Unknown, the function finds any node of the given set,binding.
 // For nodeType == Resource, it matches Resource or CombinedTexture.
 // For nodeType == Sampler, it matches Sampler or CombinedTexture.
+// For nodeType == Buffer, it matches Buffer, BufferCompact or PushConst (the latter in an inner table only).
 // For other nodeType, only a node of the specified type is returned.
 // Returns {topNode, node} where "node" is the found user data node, and "topNode" is the top-level user data
 // node that contains it (or is equal to it).
@@ -780,6 +781,9 @@ std::pair<const ResourceNode*, const ResourceNode*> PipelineState::FindResourceN
                 if ((innerNode.set == descSet) && (innerNode.binding == binding))
                 {
                     if ((nodeType == ResourceNodeType::Unknown) || (nodeType == innerNode.type) ||
+                        (nodeType == ResourceNodeType::DescriptorBuffer &&
+                         (innerNode.type == ResourceNodeType::DescriptorBufferCompact ||
+                          innerNode.type == ResourceNodeType::PushConst)) ||
                         (innerNode.type == ResourceNodeType::DescriptorCombinedTexture &&
                          (nodeType == ResourceNodeType::DescriptorResource ||
                           nodeType == ResourceNodeType::DescriptorTexelBuffer ||
@@ -793,6 +797,8 @@ std::pair<const ResourceNode*, const ResourceNode*> PipelineState::FindResourceN
         else if ((node.set == descSet) && (node.binding == binding))
         {
             if ((nodeType == ResourceNodeType::Unknown) || (nodeType == node.type) ||
+                (nodeType == ResourceNodeType::DescriptorBuffer &&
+                 node.type == ResourceNodeType::DescriptorBufferCompact) ||
                 (node.type == ResourceNodeType::DescriptorCombinedTexture &&
                  (nodeType == ResourceNodeType::DescriptorResource ||
                   nodeType == ResourceNodeType::DescriptorTexelBuffer ||

--- a/lgc/include/lgc/llpcBuilder.h
+++ b/lgc/include/lgc/llpcBuilder.h
@@ -593,6 +593,21 @@ public:
 
     // -----------------------------------------------------------------------------------------------------------------
     // Descriptor operations
+    //
+    // The API here has two classes of descriptor, with different ways of handling the two classes:
+    //
+    // 1. A buffer descriptor is loaded in one step given its descriptor set, binding and index.
+    //    It is done this way because the implementation needs to be able to handle normal buffer
+    //    descriptors, compact buffer descriptors and inline buffers, without the input language (SPIR-V)
+    //    telling us which one it is.
+    //
+    // 2. An image/sampler/texelbuffer/F-mask descriptor has a three-step API:
+    //    a. Get a pointer to the descriptor or array of descriptors given the descriptor set and binding.
+    //    b. Zero or more calls to add on an array index.
+    //    c. Load the descriptor from its pointer.
+    //    SPIR-V allows a pointer to an image/sampler to be passed as a function arg (and maybe in other
+    //    ways). This API is formulated to allow the front-end to implement that. Step (c) can be
+    //    performed without needing to see the resource node used in (a).
 
     // Get the type of pointer returned by CreateLoadBufferDesc.
     PointerType* GetBufferDescTy(Type* pPointeeTy);
@@ -636,14 +651,10 @@ public:
 
     // Get the type of pointer to image or F-mask descriptor, as returned by CreateGetImageDescPtr.
     // The type is in fact a struct containing the actual pointer plus a stride in dwords.
-    // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
-    // set up the stride, and CreateIndexDescPtr will use it.
     Type* GetImageDescPtrTy();
 
     // Get the type of pointer to F-mask descriptor, as returned by CreateGetFmaskDescPtr.
     // The type is in fact a struct containing the actual pointer plus a stride in dwords.
-    // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
-    // set up the stride, and CreateIndexDescPtr will use it.
     Type* GetFmaskDescPtrTy();
 
     // Get the type of pointer to texel buffer descriptor, as returned by CreateGetTexelBufferDescPtr.

--- a/lgc/patch/llpcPatchDescriptorLoad.cpp
+++ b/lgc/patch/llpcPatchDescriptorLoad.cpp
@@ -25,7 +25,7 @@
 /**
  ***********************************************************************************************************************
  * @file  llpcPatchDescriptorLoad.cpp
- * @brief LLPC source file: contains implementation of class lgc::PatchDescriptorLoad.
+ * @brief LLPC source file: contains implementation of class Llpc::PatchDescriptorLoad.
  ***********************************************************************************************************************
  */
 #include "llvm/IR/IRBuilder.h"
@@ -38,8 +38,8 @@
 
 #define DEBUG_TYPE "llpc-patch-descriptor-load"
 
-using namespace llvm;
 using namespace lgc;
+using namespace llvm;
 
 // -enable-shadow-desc: enable shadow desriptor table
 static cl::opt<bool> EnableShadowDescriptorTable("enable-shadow-desc",
@@ -136,46 +136,283 @@ bool PatchDescriptorLoad::runOnModule(
 }
 
 // =====================================================================================================================
+// Process llpc.descriptor.get.{resource|sampler|fmask}.ptr call.
+// This generates code to build a {ptr,stride} struct.
+void PatchDescriptorLoad::ProcessDescriptorGetPtr(
+    CallInst* pDescPtrCall,     // [in] Call to llpc.descriptor.get.*.ptr
+    StringRef descPtrCallName)  // Name of that call
+{
+    m_pEntryPoint = pDescPtrCall->getFunction();
+    IRBuilder<> builder(*m_pContext);
+    builder.SetInsertPoint(pDescPtrCall);
+
+    // Find the resource node for the descriptor set and binding.
+    uint32_t descSet = cast<ConstantInt>(pDescPtrCall->getArgOperand(0))->getZExtValue();
+    uint32_t binding = cast<ConstantInt>(pDescPtrCall->getArgOperand(1))->getZExtValue();
+    auto resType = ResourceNodeType::DescriptorResource;
+    bool shadow = false;
+    if (descPtrCallName.startswith(lgcName::DescriptorGetTexelBufferPtr))
+    {
+        resType = ResourceNodeType::DescriptorTexelBuffer;
+    }
+    else if (descPtrCallName.startswith(lgcName::DescriptorGetSamplerPtr))
+    {
+        resType = ResourceNodeType::DescriptorSampler;
+    }
+    else if (descPtrCallName.startswith(lgcName::DescriptorGetFmaskPtr))
+    {
+        shadow = EnableShadowDescriptorTable;
+        resType = ResourceNodeType::DescriptorFmask;
+    }
+
+    // Find the descriptor node. For fmask with -enable-shadow-descriptor-table, if no fmask descriptor
+    // is found, look for a resource (image) one instead.
+    const ResourceNode* pTopNode = nullptr;
+    const ResourceNode* pNode = nullptr;
+    std::tie(pTopNode, pNode) = m_pPipelineState->FindResourceNode(resType, descSet, binding);
+    if ((pNode == nullptr) && (resType == ResourceNodeType::DescriptorFmask) && shadow)
+    {
+        std::tie(pTopNode, pNode) = m_pPipelineState->FindResourceNode(ResourceNodeType::DescriptorResource,
+                                                                       descSet,
+                                                                       binding);
+    }
+
+    Value* pDescPtrAndStride = nullptr;
+    if (pNode == nullptr)
+    {
+        // We did not find the resource node. Use an undef value.
+        pDescPtrAndStride = UndefValue::get(pDescPtrCall->getType());
+    }
+    else
+    {
+        // Get the descriptor pointer and stride as a struct.
+        pDescPtrAndStride = GetDescPtrAndStride(resType, descSet, binding, pTopNode, pNode, shadow, builder);
+    }
+    pDescPtrCall->replaceAllUsesWith(pDescPtrAndStride);
+    m_descLoadCalls.push_back(pDescPtrCall);
+    m_changed = true;
+}
+
+// =====================================================================================================================
+// Get a struct containing the pointer and byte stride for a descriptor
+Value* PatchDescriptorLoad::GetDescPtrAndStride(
+    ResourceNodeType        resType,    // Resource type
+    uint32_t                descSet,    // Descriptor set
+    uint32_t                binding,    // Binding
+    const ResourceNode*     pTopNode,   // Node in top-level descriptor table (TODO: nullptr for shader compilation)
+    const ResourceNode*     pNode,      // The descriptor node itself (TODO: nullptr for shader compilation)
+    bool                    shadow,     // Whether to load from shadow descriptor table
+    IRBuilder<>&            builder)    // [in/out] IRBuilder
+{
+    // Determine the stride if possible without looking at the resource node.
+    uint32_t byteSize = 0;
+    Value* pStride = nullptr;
+    switch (resType)
+    {
+    case ResourceNodeType::DescriptorBuffer:
+    case ResourceNodeType::DescriptorTexelBuffer:
+        byteSize = DescriptorSizeBuffer;
+        if ((pNode != nullptr) && (pNode->type == ResourceNodeType::DescriptorBufferCompact))
+        {
+            byteSize = DescriptorSizeBufferCompact;
+        }
+        pStride = builder.getInt32(byteSize / 4);
+        break;
+    case ResourceNodeType::DescriptorSampler:
+        byteSize = DescriptorSizeSampler;
+        break;
+    case ResourceNodeType::DescriptorResource:
+    case ResourceNodeType::DescriptorFmask:
+        byteSize = DescriptorSizeResource;
+        break;
+    default:
+        llvm_unreachable("");
+        break;
+    }
+
+    if (pStride == nullptr)
+    {
+        // Stride is not determinable just from the descriptor type requested by the Builder call.
+        if (pNode == nullptr)
+        {
+            // TODO: Shader compilation: Get byte stride using a reloc.
+            llvm_unreachable("");
+        }
+        else
+        {
+            // Pipeline compilation: Get the stride from the resource type in the node.
+            switch (pNode->type)
+            {
+            case ResourceNodeType::DescriptorSampler:
+                pStride = builder.getInt32(DescriptorSizeSampler / 4);
+                break;
+            case ResourceNodeType::DescriptorResource:
+            case ResourceNodeType::DescriptorFmask:
+                pStride = builder.getInt32(DescriptorSizeResource / 4);
+                break;
+            case ResourceNodeType::DescriptorCombinedTexture:
+                pStride = builder.getInt32((DescriptorSizeResource + DescriptorSizeSampler) / 4);
+                break;
+            default:
+                llvm_unreachable("Unexpected resource node type");
+                break;
+            }
+        }
+    }
+
+    Value* pDescPtr = nullptr;
+    if ((pNode != nullptr) && (pNode->pImmutableValue != nullptr) && (resType == ResourceNodeType::DescriptorSampler))
+    {
+        // This is an immutable sampler. Put the immutable value into a static variable and return a pointer
+        // to that. For a simple non-variably-indexed immutable sampler not passed through a function call
+        // or phi node, we rely on subsequent LLVM optimizations promoting the value back to a constant.
+        std::string globalName = (Twine("_immutable_sampler_") + Twine(pNode->set) +
+                                  " " + Twine(pNode->binding)).str();
+        pDescPtr = m_pModule->getGlobalVariable(globalName, /*AllowInternal=*/true);
+        if (pDescPtr == nullptr)
+        {
+            pDescPtr = new GlobalVariable(*m_pModule,
+                                          pNode->pImmutableValue->getType(),
+                                          /*isConstant=*/true,
+                                          GlobalValue::InternalLinkage,
+                                          pNode->pImmutableValue,
+                                          globalName,
+                                          nullptr,
+                                          GlobalValue::NotThreadLocal,
+                                          ADDR_SPACE_CONST);
+        }
+        pDescPtr = builder.CreateBitCast(pDescPtr, builder.getInt8Ty()->getPointerTo(ADDR_SPACE_CONST));
+
+        // We need to change the stride to 4 dwords. It would otherwise be incorrectly set to 12 dwords
+        // for a sampler in a combined texture.
+        pStride = builder.getInt32(DescriptorSizeSampler / 4);
+    }
+    else
+    {
+        // Get a pointer to the descriptor.
+        pDescPtr = GetDescPtr(resType, descSet, binding, pTopNode, pNode, shadow, builder);
+    }
+
+    // Cast the pointer to the right type and create and return the struct.
+    pDescPtr = builder.CreateBitCast(
+                            pDescPtr,
+                            VectorType::get(builder.getInt32Ty(), byteSize / 4)->getPointerTo(ADDR_SPACE_CONST));
+    Value* pDescPtrStruct = builder.CreateInsertValue(UndefValue::get(StructType::get(*m_pContext,
+                                                                                      { pDescPtr->getType(),
+                                                                                        builder.getInt32Ty() })),
+                                                      pDescPtr,
+                                                      0);
+    pDescPtrStruct = builder.CreateInsertValue(pDescPtrStruct, pStride, 1);
+    return pDescPtrStruct;
+}
+
+// =====================================================================================================================
+// Get a pointer to a descriptor, as a pointer to i32
+Value* PatchDescriptorLoad::GetDescPtr(
+    ResourceNodeType        resType,    // Resource type
+    uint32_t                descSet,    // Descriptor set
+    uint32_t                binding,    // Binding
+    const ResourceNode*     pTopNode,   // Node in top-level descriptor table (TODO: nullptr for shader compilation)
+    const ResourceNode*     pNode,      // The descriptor node itself (TODO: nullptr for shader compilation)
+    bool                    shadow,     // Whether to load from shadow descriptor table
+    IRBuilder<>&            builder)    // [in/out] IRBuilder
+{
+    Value* pDescPtr = nullptr;
+    // Get the descriptor table pointer.
+    auto pSysValues = m_pipelineSysValues.Get(builder.GetInsertPoint()->getFunction());
+    if ((pNode != nullptr) && (pNode == pTopNode))
+    {
+        // The descriptor is in the top-level table. Contrary to what used to happen, we just load from
+        // the spill table, so we can get a pointer to the descriptor. It gets returned as a pointer
+        // to array of i8.
+        pDescPtr = pSysValues->GetSpillTablePtr();
+    }
+    else if (shadow)
+    {
+        // Get pointer to descriptor set's descriptor table as pointer to i8.
+        pDescPtr = pSysValues->GetShadowDescTablePtr(descSet);
+    }
+    else
+    {
+        // Get pointer to descriptor set's descriptor table. This also gets returned as a pointer to
+        // array of i8.
+        pDescPtr = pSysValues->GetDescTablePtr(descSet);
+    }
+
+    // Add on the byte offset of the descriptor.
+    Value* pOffset = nullptr;
+    if (pNode == nullptr)
+    {
+        // TODO: Shader compilation: Get the offset for the descriptor using a reloc. The reloc symbol name
+        // needs to contain the descriptor set and binding, and, for image, fmask or sampler, whether it is
+        // a sampler.
+        llvm_unreachable("");
+    }
+    else
+    {
+        // Get the offset for the descriptor. Where we are getting the second part of a combined resource,
+        // add on the size of the first part.
+        uint32_t offsetInDwords = pNode->offsetInDwords;
+        if ((resType == ResourceNodeType::DescriptorSampler) &&
+            (pNode->type == ResourceNodeType::DescriptorCombinedTexture))
+        {
+            offsetInDwords += DescriptorSizeResource / 4;
+        }
+        pOffset = builder.getInt32(offsetInDwords);
+    }
+    pDescPtr = builder.CreateBitCast(pDescPtr, builder.getInt32Ty()->getPointerTo(ADDR_SPACE_CONST));
+    pDescPtr = builder.CreateGEP(builder.getInt32Ty(), pDescPtr, pOffset);
+
+    return pDescPtr;
+}
+
+// =====================================================================================================================
+// Process an llvm.descriptor.index : add an array index on to the descriptor pointer.
+// llvm.descriptor.index has two operands: the "descriptor pointer" (actually a struct containing the actual
+// pointer and an int giving the byte stride), and the index to add. It returns the updated "descriptor pointer".
+void PatchDescriptorLoad::ProcessDescriptorIndex(
+    CallInst* pCall)    // [in] llvm.descriptor.index call
+{
+    IRBuilder<> builder(*m_pContext);
+    builder.SetInsertPoint(pCall);
+
+    Value* pDescPtrStruct = pCall->getArgOperand(0);
+    Value* pIndex = pCall->getArgOperand(1);
+    Value* pStride = builder.CreateExtractValue(pDescPtrStruct, 1);
+    Value* pDescPtr = builder.CreateExtractValue(pDescPtrStruct, 0);
+
+    Value* pBytePtr = builder.CreateBitCast(pDescPtr, builder.getInt32Ty()->getPointerTo(ADDR_SPACE_CONST));
+    pIndex = builder.CreateMul(pIndex, pStride);
+    pBytePtr = builder.CreateGEP(builder.getInt32Ty(), pBytePtr, pIndex);
+    pDescPtr = builder.CreateBitCast(pBytePtr, pDescPtr->getType());
+
+    pDescPtrStruct = builder.CreateInsertValue(UndefValue::get(StructType::get(*m_pContext,
+                                                                               { pDescPtr->getType(),
+                                                                                 builder.getInt32Ty() })),
+                                                      pDescPtr,
+                                                      0);
+    pDescPtrStruct = builder.CreateInsertValue(pDescPtrStruct, pStride, 1);
+
+    pCall->replaceAllUsesWith(pDescPtrStruct);
+    m_descLoadCalls.push_back(pCall);
+    m_changed = true;
+}
+
+// =====================================================================================================================
 // Process "llpc.descriptor.load.from.ptr" call.
-// Currently we assume that everything is inlined, so here we can trace the pointer back through any
-// "llpc.descriptor.index" calls back to an "llpc.descriptor.point.*" call.
-// In the future, we want to remove the assumption that everything is inlined. To do that, we will need to
-// do some internal rearrangement to the descriptor load code. That will probably happen at the same time
-// as moving descriptor load code up into the builder.
 void PatchDescriptorLoad::ProcessLoadDescFromPtr(
     CallInst* pLoadFromPtr)   // [in] Call to llpc.descriptor.load.from.ptr
 {
-    m_pEntryPoint = pLoadFromPtr->getFunction();
     IRBuilder<> builder(*m_pContext);
     builder.SetInsertPoint(pLoadFromPtr);
-    Value* pIndex = builder.getInt32(0);
 
-    auto pLoadPtr = cast<CallInst>(pLoadFromPtr->getOperand(0));
-    while (pLoadPtr->getCalledFunction()->getName().startswith(lgcName::DescriptorIndex))
-    {
-        pIndex = builder.CreateAdd(pIndex, pLoadPtr->getOperand(1));
-        pLoadPtr = cast<CallInst>(pLoadPtr->getOperand(0));
-    }
-
-    assert(pLoadPtr->getCalledFunction()->getName().startswith(lgcName::DescriptorGetPtrPrefix));
-
-    uint32_t descSet = cast<ConstantInt>(pLoadPtr->getOperand(0))->getZExtValue();
-    uint32_t binding = cast<ConstantInt>(pLoadPtr->getOperand(1))->getZExtValue();
-    Value* pDesc = LoadDescriptor(*pLoadPtr, descSet, binding, pIndex, pLoadFromPtr);
+    Value* pDescPtrStruct = pLoadFromPtr->getArgOperand(0);
+    Value* pDescPtr = builder.CreateExtractValue(pDescPtrStruct, 0);
+    Value* pDesc = builder.CreateLoad(pLoadFromPtr->getType(), pDescPtr);
 
     pLoadFromPtr->replaceAllUsesWith(pDesc);
-
-    Instruction* pDeadInst = pLoadFromPtr;
-    while ((pDeadInst != nullptr) && pDeadInst->use_empty())
-    {
-        Instruction* pNextDeadInst = nullptr;
-        if ((isa<PHINode>(pDeadInst) == false) && (pDeadInst->getNumOperands() >= 1))
-        {
-            pNextDeadInst = dyn_cast<Instruction>(pDeadInst->getOperand(0));
-        }
-        pDeadInst->eraseFromParent();
-        pDeadInst = pNextDeadInst;
-    }
+    m_descLoadCalls.push_back(pLoadFromPtr);
+    m_changed = true;
 }
 
 // =====================================================================================================================
@@ -191,17 +428,15 @@ void PatchDescriptorLoad::visitCallInst(
 
     StringRef mangledName = pCallee->getName();
 
-    bool isDescLoad = mangledName.startswith(lgcName::DescriptorLoadPrefix);
-    if (isDescLoad == false)
+    if (mangledName.startswith(lgcName::DescriptorGetPtrPrefix))
     {
-        return; // Not descriptor load
+        ProcessDescriptorGetPtr(&callInst, mangledName);
+        return;
     }
 
-    if (mangledName.startswith(lgcName::DescriptorGetPtrPrefix) ||
-        mangledName.startswith(lgcName::DescriptorIndex))
+    if (mangledName.startswith(lgcName::DescriptorIndex))
     {
-        // Ignore llpc.descriptor.point.* calls and llpc.descriptor.index calls, as they
-        // get processed at llpc.descriptor.load.from.ptr.
+        ProcessDescriptorIndex(&callInst);
         return;
     }
 
@@ -211,382 +446,180 @@ void PatchDescriptorLoad::visitCallInst(
         return;
     }
 
-    // Descriptor loading should be inlined and stay in shader entry-point
-    assert(callInst.getParent()->getParent() == m_pEntryPoint);
-
-    m_changed = true;
-
-    // Create the descriptor load (unless the call has no uses).
-    if (callInst.use_empty() == false)
+    if (mangledName.startswith(lgcName::DescriptorLoadSpillTable))
     {
-        Value* pDesc = nullptr;
-        if (mangledName.startswith(lgcName::DescriptorLoadSpillTable))
+        // Descriptor loading should be inlined and stay in shader entry-point
+        assert(callInst.getParent()->getParent() == m_pEntryPoint);
+        m_changed = true;
+
+        if (callInst.use_empty() == false)
         {
-            pDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetSpilledPushConstTablePtr();
+            Value* pDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetSpilledPushConstTablePtr();
             if (pDesc->getType() != callInst.getType())
             {
                 pDesc = new BitCastInst(pDesc, callInst.getType(), "", &callInst);
             }
+            callInst.replaceAllUsesWith(pDesc);
         }
-        else
+        m_descLoadCalls.push_back(&callInst);
+        m_descLoadFuncs.insert(pCallee);
+        return;
+    }
+
+    if (mangledName.startswith(lgcName::DescriptorLoadBuffer))
+    {
+        // Descriptor loading should be inlined and stay in shader entry-point
+        assert(callInst.getParent()->getParent() == m_pEntryPoint);
+        m_changed = true;
+
+        if (callInst.use_empty() == false)
         {
             uint32_t descSet = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
             uint32_t binding = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
             Value* pArrayOffset = callInst.getOperand(2); // Offset for arrayed resource (index)
-            pDesc = LoadDescriptor(callInst, descSet, binding, pArrayOffset, &callInst);
+            Value* pDesc = LoadBufferDescriptor(descSet, binding, pArrayOffset, &callInst);
+            callInst.replaceAllUsesWith(pDesc);
         }
-
-        // Replace the call with the loaded descriptor.
-        callInst.replaceAllUsesWith(pDesc);
+        m_descLoadCalls.push_back(&callInst);
+        m_descLoadFuncs.insert(pCallee);
+        return;
     }
-
-    m_descLoadCalls.push_back(&callInst);
-    m_descLoadFuncs.insert(pCallee);
 }
 
 // =====================================================================================================================
-// Generate the code for the descriptor load
-Value* PatchDescriptorLoad::LoadDescriptor(
-    CallInst&     callInst,       // [in] The llpc.descriptor.load.* or llpc.descriptor.point.* call being replaced
+// Generate the code for a buffer descriptor load.
+// This is the handler for llpc.descriptor.load.buffer, which is also used for loading a descriptor
+// from the global table or the per-shader table.
+Value* PatchDescriptorLoad::LoadBufferDescriptor(
     uint32_t      descSet,        // Descriptor set
     uint32_t      binding,        // Binding
     Value*        pArrayOffset,   // [in] Index in descriptor array
     Instruction*  pInsertPoint)   // [in] Insert point
 {
-    StringRef mangledName = callInst.getCalledFunction()->getName();
-    Type* pDescPtrTy = nullptr;
-    ResourceNodeType nodeType1 = ResourceNodeType::Unknown;
-    ResourceNodeType nodeType2 = ResourceNodeType::Unknown;
+    IRBuilder<> builder(*m_pContext);
+    builder.SetInsertPoint(pInsertPoint);
 
-    // TODO: The address space ID 2 is a magic number. We have to replace it with defined LLPC address space ID.
-    if (mangledName == lgcName::DescriptorGetResourcePtr)
+    // Handle the special cases. First get a pointer to the global/per-shader table as pointer to i8.
+    Value* pDescPtr = nullptr;
+    if (descSet == InternalResourceTable)
     {
-        pDescPtrTy = VectorType::get(Type::getInt32Ty(*m_pContext), 8)->getPointerTo(ADDR_SPACE_CONST);
-        nodeType1 = ResourceNodeType::DescriptorResource;
-        nodeType2 = nodeType1;
+        pDescPtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalGlobalTablePtr();
     }
-    else if (mangledName == lgcName::DescriptorGetSamplerPtr)
+    else if (descSet == InternalPerShaderTable)
     {
-        pDescPtrTy = VectorType::get(Type::getInt32Ty(*m_pContext), 4)->getPointerTo(ADDR_SPACE_CONST);
-        nodeType1 = ResourceNodeType::DescriptorSampler;
-        nodeType2 = nodeType1;
+        pDescPtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalPerShaderTablePtr();
     }
-    else if (mangledName == lgcName::DescriptorGetFmaskPtr)
+    if (pDescPtr != nullptr)
     {
-        pDescPtrTy = VectorType::get(Type::getInt32Ty(*m_pContext), 8)->getPointerTo(ADDR_SPACE_CONST);
-        nodeType1 = ResourceNodeType::DescriptorFmask;
-        nodeType2 = nodeType1;
-    }
-    else if (mangledName == lgcName::DescriptorLoadBuffer)
-    {
-        pDescPtrTy = VectorType::get(Type::getInt32Ty(*m_pContext), 4)->getPointerTo(ADDR_SPACE_CONST);
-        nodeType1 = ResourceNodeType::DescriptorBuffer;
-        nodeType2 = ResourceNodeType::PushConst;
-    }
-    else if (mangledName == lgcName::DescriptorLoadAddress)
-    {
-        nodeType1 = ResourceNodeType::PushConst;
-        nodeType2 = nodeType1;
-    }
-    else if (mangledName == lgcName::DescriptorGetTexelBufferPtr)
-    {
-        pDescPtrTy = VectorType::get(Type::getInt32Ty(*m_pContext), 4)->getPointerTo(ADDR_SPACE_CONST);
-        nodeType1 = ResourceNodeType::DescriptorTexelBuffer;
-        nodeType2 = nodeType1;
-    }
-    else
-    {
-        llvm_unreachable("Should never be called!");
+        // "binding" gives the offset, in units of v4i32 descriptors.
+        // Add on the offset, giving pointer to i8.
+        pDescPtr = builder.CreateGEP(builder.getInt8Ty(), pDescPtr, builder.getInt32(binding * DescriptorSizeBuffer));
+        // Load the descriptor.
+        Type* pDescTy = VectorType::get(builder.getInt32Ty(), DescriptorSizeBuffer / 4);
+        pDescPtr = builder.CreateBitCast(pDescPtr, pDescTy->getPointerTo(ADDR_SPACE_CONST));
+        Instruction* pLoad = builder.CreateLoad(pDescTy, pDescPtr);
+        pLoad->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(pLoad->getContext(), {}));
+        return pLoad;
     }
 
-    assert(nodeType1 != ResourceNodeType::Unknown);
+    // Normal buffer descriptor load.
+    // Find the descriptor node, either a DescriptorBuffer or PushConst (inline buffer).
+    const ResourceNode* pTopNode = nullptr;
+    const ResourceNode* pNode = nullptr;
+    std::tie(pTopNode, pNode) = m_pPipelineState->FindResourceNode(ResourceNodeType::DescriptorBuffer,
+                                                                   descSet,
+                                                                   binding);
 
-    // Calculate descriptor offset (in bytes)
-    uint32_t descOffset = 0;
-    uint32_t descSize   = 0;
-    uint32_t dynDescIdx = InvalidValue;
-    Value*   pDesc = nullptr;
-    Constant* pDescRangeValue = nullptr;
-
-    if (nodeType1 == ResourceNodeType::DescriptorSampler)
+    if (pNode == nullptr)
     {
-        pDescRangeValue = GetDescriptorRangeValue(nodeType1, descSet, binding);
+        // We did not find the resource node. Use an undef value.
+        return UndefValue::get(VectorType::get(builder.getInt32Ty(), 4));
     }
 
-    if (pDescRangeValue != nullptr)
+    // Get a pointer to the descriptor, as a pointer to i32.
+    pDescPtr = GetDescPtr(ResourceNodeType::DescriptorBuffer,
+                          descSet,
+                          binding,
+                          pTopNode,
+                          pNode,
+                          /*shadow=*/false,
+                          builder);
+
+    if ((pNode != nullptr) && (pNode->type == ResourceNodeType::PushConst))
     {
-        // Descriptor range value (immutable sampler in Vulkan). pDescRangeValue is a constant array of
-        // <8 x i32> descriptors.
-        IRBuilder<> builder(*m_pContext);
-        builder.SetInsertPoint(pInsertPoint);
-
-        if (pDescRangeValue->getType()->getArrayNumElements() == 1)
-        {
-            // Immutable descriptor array is size 1, so we can assume index 0.
-            pDesc = builder.CreateExtractValue(pDescRangeValue, 0);
-        }
-        else if (auto pConstArrayOffset = dyn_cast<ConstantInt>(pArrayOffset))
-        {
-            // Array index is constant.
-            uint32_t index = pConstArrayOffset->getZExtValue();
-            pDesc = builder.CreateExtractValue(pDescRangeValue, {index});
-        }
-        else
-        {
-            // Array index is variable.
-            GlobalVariable* pDescs = new GlobalVariable(*m_pModule,
-                                                        pDescRangeValue->getType(),
-                                                        true, // isConstant
-                                                        GlobalValue::InternalLinkage,
-                                                        pDescRangeValue,
-                                                        "",
-                                                        nullptr,
-                                                        GlobalValue::NotThreadLocal,
-                                                        ADDR_SPACE_CONST);
-
-            auto pDescPtr = builder.CreateGEP(pDescs, {builder.getInt32(0), pArrayOffset});
-            pDesc = builder.CreateLoad(pDescPtr);
-        }
+        // Inline buffer.
+        return BuildInlineBufferDesc(pDescPtr, builder);
     }
 
-    if (pDesc == nullptr)
+    // Add on the index.
+    uint32_t dwordStride = DescriptorSizeBuffer / 4;
+    if ((pNode != nullptr) && (pNode->type == ResourceNodeType::DescriptorBufferCompact))
     {
-        auto foundNodeType = CalcDescriptorOffsetAndSize(nodeType1,
-                                                         nodeType2,
-                                                         descSet,
-                                                         binding,
-                                                         &descOffset,
-                                                         &descSize,
-                                                         &dynDescIdx);
-        if (foundNodeType == ResourceNodeType::PushConst)
-        {
-            // Handle the case of an inline const node when we were expecting a buffer descriptor.
-            nodeType1 = foundNodeType;
-        }
+        dwordStride = DescriptorSizeBufferCompact / 4;
+    }
+    pArrayOffset = builder.CreateMul(pArrayOffset, builder.getInt32(dwordStride));
+    pDescPtr = builder.CreateGEP(builder.getInt32Ty(), pDescPtr, pArrayOffset);
 
-        uint32_t descSizeInDword = descSize / sizeof(uint32_t);
-        if (dynDescIdx != InvalidValue)
-        {
-            // Dynamic descriptors
-            pDesc = m_pipelineSysValues.Get(m_pEntryPoint)->GetDynamicDesc(dynDescIdx);
-            if (pDesc != nullptr)
-            {
-                auto pDescTy = VectorType::get(Type::getInt32Ty(*m_pContext), descSizeInDword);
-                if (pDesc->getType() != pDescTy)
-                {
-                    // Array dynamic descriptor
-                    Value* pDynDesc = UndefValue::get(pDescTy);
-                    auto pDescStride = ConstantInt::get(Type::getInt32Ty(*m_pContext), descSizeInDword);
-                    auto pIndex = BinaryOperator::CreateMul(pArrayOffset, pDescStride, "", pInsertPoint);
-                    for (uint32_t i = 0; i < descSizeInDword; ++i)
-                    {
-                        auto pDescElem = ExtractElementInst::Create(pDesc, pIndex, "", pInsertPoint);
-                        pDynDesc = InsertElementInst::Create(pDynDesc,
-                                                             pDescElem,
-                                                             ConstantInt::get(Type::getInt32Ty(*m_pContext), i),
-                                                             "",
-                                                             pInsertPoint);
-                        pIndex = BinaryOperator::CreateAdd(pIndex,
-                                                           ConstantInt::get(Type::getInt32Ty(*m_pContext), 1),
-                                                           "",
-                                                           pInsertPoint);
-                    }
-                    pDesc = pDynDesc;
-                }
-
-                // Extract compact buffer descriptor
-                if (descSizeInDword == DescriptorSizeBufferCompact / sizeof(uint32_t))
-                {
-                    pDesc = BuildBufferCompactDesc(pDesc, pInsertPoint);
-                }
-
-            }
-            else
-            {
-                llvm_unreachable("Should never be called!");
-            }
-        }
-        else if (nodeType1 == ResourceNodeType::PushConst)
-        {
-            auto pDescTablePtr =
-                m_pipelineSysValues.Get(m_pEntryPoint)->GetDescTablePtr(descSet);
-
-            Value* pDescTableAddr = new PtrToIntInst(pDescTablePtr,
-                                                     Type::getInt64Ty(*m_pContext),
-                                                     "",
-                                                     pInsertPoint);
-
-            pDescTableAddr = new BitCastInst(pDescTableAddr,
-                                             VectorType::get(Type::getInt32Ty(*m_pContext), 2),
-                                             "",
-                                             pInsertPoint);
-
-            // Extract descriptor table address
-            Value* pDescElem0 = ExtractElementInst::Create(pDescTableAddr,
-                ConstantInt::get(Type::getInt32Ty(*m_pContext), 0),
-                "",
-                pInsertPoint);
-
-            auto pDescOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), descOffset);
-
-            pDescElem0 = BinaryOperator::CreateAdd(pDescElem0, pDescOffset, "", pInsertPoint);
-
-            if (pDescPtrTy == nullptr)
-            {
-                // Load the address of inline constant buffer
-                pDesc = InsertElementInst::Create(pDescTableAddr,
-                    pDescElem0,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), 0),
-                    "",
-                    pInsertPoint);
-            }
-            else
-            {
-                // Build buffer descriptor from inline constant buffer address
-                SqBufRsrcWord1 sqBufRsrcWord1 = {};
-                SqBufRsrcWord2 sqBufRsrcWord2 = {};
-                SqBufRsrcWord3 sqBufRsrcWord3 = {};
-
-                sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
-                sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
-
-                sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
-                sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
-                sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
-                sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
-                sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
-                sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
-                assert(sqBufRsrcWord3.u32All == 0x24FAC);
-
-                Value* pDescElem1 = ExtractElementInst::Create(pDescTableAddr,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), 1),
-                    "",
-                    pInsertPoint);
-
-                auto pBufDescTy = VectorType::get(Type::getInt32Ty(*m_pContext), 4);
-                pDesc = UndefValue::get(pBufDescTy);
-
-                // DWORD0
-                pDesc = InsertElementInst::Create(pDesc,
-                    pDescElem0,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), 0),
-                    "",
-                    pInsertPoint);
-
-                // DWORD1
-                pDescElem1 = BinaryOperator::CreateAnd(pDescElem1,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), sqBufRsrcWord1.u32All),
-                    "",
-                    pInsertPoint);
-                pDesc = InsertElementInst::Create(pDesc,
-                    pDescElem1,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), 1),
-                    "",
-                    pInsertPoint);
-
-                // DWORD2
-                pDesc = InsertElementInst::Create(pDesc,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), sqBufRsrcWord2.u32All),
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), 2),
-                    "",
-                    pInsertPoint);
-
-                // DWORD3
-                pDesc = InsertElementInst::Create(pDesc,
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), sqBufRsrcWord3.u32All),
-                    ConstantInt::get(Type::getInt32Ty(*m_pContext), 3),
-                    "",
-                    pInsertPoint);
-            }
-        }
-        else
-        {
-            auto pDescOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), descOffset);
-            auto pDescSize   = ConstantInt::get(Type::getInt32Ty(*m_pContext), descSize, 0);
-
-            Value* pOffset = BinaryOperator::CreateMul(pArrayOffset, pDescSize, "", pInsertPoint);
-            pOffset = BinaryOperator::CreateAdd(pOffset, pDescOffset, "", pInsertPoint);
-
-            pOffset = CastInst::CreateZExtOrBitCast(pOffset, Type::getInt64Ty(*m_pContext), "", pInsertPoint);
-
-            // Get descriptor address
-            Value* idxs[] = {
-                ConstantInt::get(Type::getInt64Ty(*m_pContext), 0, false),
-                pOffset
-            };
-
-            Value* pDescTablePtr = nullptr;
-
-            if (descSet == InternalResourceTable)
-            {
-                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalGlobalTablePtr();
-            }
-            else if (descSet == InternalPerShaderTable)
-            {
-                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetInternalPerShaderTablePtr();
-            }
-            else if ((EnableShadowDescriptorTable) && (nodeType1 == ResourceNodeType::DescriptorFmask))
-            {
-                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetShadowDescTablePtr(descSet);
-            }
-            else
-            {
-                pDescTablePtr = m_pipelineSysValues.Get(m_pEntryPoint)->GetDescTablePtr(descSet);
-            }
-            auto pDescPtr = GetElementPtrInst::Create(nullptr, pDescTablePtr, idxs, "", pInsertPoint);
-            auto pCastedDescPtr = CastInst::Create(Instruction::BitCast, pDescPtr, pDescPtrTy, "", pInsertPoint);
-
-            // Load descriptor
-            pCastedDescPtr->setMetadata(MetaNameUniform, MDNode::get(pCastedDescPtr->getContext(), {}));
-            auto pLoad = new LoadInst(pCastedDescPtr, "", pInsertPoint);
-            pLoad->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(pLoad->getContext(), {}));
-            pLoad->setAlignment(MaybeAlign(16));
-            pDesc = pLoad;
-
-            if (foundNodeType == ResourceNodeType::DescriptorBufferCompact)
-            {
-                assert(descSizeInDword == DescriptorSizeBufferCompact / sizeof(uint32_t));
-                pDesc = BuildBufferCompactDesc(pDesc, pInsertPoint);
-            }
-        }
+    if (dwordStride == DescriptorSizeBufferCompact / 4)
+    {
+        // Load compact buffer descriptor and convert it into a normal buffer descriptor.
+        Type* pDescTy = VectorType::get(builder.getInt32Ty(), DescriptorSizeBufferCompact / 4);
+        pDescPtr = builder.CreateBitCast(pDescPtr, pDescTy->getPointerTo(ADDR_SPACE_CONST));
+        Value* pDesc = builder.CreateLoad(pDescTy, pDescPtr);
+        return BuildBufferCompactDesc(pDesc, &*builder.GetInsertPoint());
     }
 
-    return pDesc;
+    // Load normal buffer descriptor.
+    Type* pDescTy = VectorType::get(builder.getInt32Ty(), DescriptorSizeBuffer / 4);
+    pDescPtr = builder.CreateBitCast(pDescPtr, pDescTy->getPointerTo(ADDR_SPACE_CONST));
+    Instruction* pLoad = builder.CreateLoad(pDescTy, pDescPtr);
+    pLoad->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(pLoad->getContext(), {}));
+    return pLoad;
 }
 
 // =====================================================================================================================
-// Gets the descriptor value of the specified descriptor.
-Constant* PatchDescriptorLoad::GetDescriptorRangeValue(
-    ResourceNodeType          nodeType,   // Type of the resource mapping node
-    uint32_t                  descSet,    // ID of descriptor set
-    uint32_t                  binding     // ID of descriptor binding
-    ) const
+// Calculate a buffer descriptor for an inline buffer
+Value* PatchDescriptorLoad::BuildInlineBufferDesc(
+    Value*        pDescPtr,   // [in] Pointer to inline buffer
+    IRBuilder<>&  builder)    // [in] Builder
 {
-    auto userDataNodes = m_pPipelineState->GetUserDataNodes();
-    for (const ResourceNode& node : userDataNodes)
-    {
-        if (node.type == ResourceNodeType::DescriptorTableVaPtr)
-        {
-            for (const ResourceNode& innerNode : node.innerTable)
-            {
-                if (((innerNode.type == ResourceNodeType::DescriptorSampler) ||
-                     (innerNode.type == ResourceNodeType::DescriptorCombinedTexture)) &&
-                    (innerNode.set == descSet) &&
-                    (innerNode.binding == binding))
-                {
-                    return innerNode.pImmutableValue;
-                }
-            }
-        }
-        else if (((node.type == ResourceNodeType::DescriptorSampler) ||
-                  (node.type == ResourceNodeType::DescriptorCombinedTexture)) &&
-                 (node.set == descSet) &&
-                 (node.binding == binding))
-        {
-            return node.pImmutableValue;
-        }
-    }
-    return nullptr;
+    // Bitcast the pointer to v2i32
+    pDescPtr = builder.CreatePtrToInt(pDescPtr, builder.getInt64Ty());
+    pDescPtr = builder.CreateBitCast(pDescPtr, VectorType::get(builder.getInt32Ty(), 2));
+
+    // Build descriptor words.
+    SqBufRsrcWord1 sqBufRsrcWord1 = {};
+    SqBufRsrcWord2 sqBufRsrcWord2 = {};
+    SqBufRsrcWord3 sqBufRsrcWord3 = {};
+
+    sqBufRsrcWord1.bits.BASE_ADDRESS_HI = UINT16_MAX;
+    sqBufRsrcWord2.bits.NUM_RECORDS = UINT32_MAX;
+
+    sqBufRsrcWord3.bits.DST_SEL_X = BUF_DST_SEL_X;
+    sqBufRsrcWord3.bits.DST_SEL_Y = BUF_DST_SEL_Y;
+    sqBufRsrcWord3.bits.DST_SEL_Z = BUF_DST_SEL_Z;
+    sqBufRsrcWord3.bits.DST_SEL_W = BUF_DST_SEL_W;
+    sqBufRsrcWord3.gfx6.NUM_FORMAT = BUF_NUM_FORMAT_UINT;
+    sqBufRsrcWord3.gfx6.DATA_FORMAT = BUF_DATA_FORMAT_32;
+    assert(sqBufRsrcWord3.u32All == 0x24FAC);
+
+    // DWORD0
+    Value* pDesc = UndefValue::get(VectorType::get(builder.getInt32Ty(), 4));
+    Value* pDescElem0 = builder.CreateExtractElement(pDescPtr, uint64_t(0));
+    pDesc = builder.CreateInsertElement(pDesc, pDescElem0, uint64_t(0));
+
+    // DWORD1
+    Value* pDescElem1 = builder.CreateExtractElement(pDescPtr, 1);
+    pDescElem1 = builder.CreateAnd(pDescElem1, builder.getInt32(sqBufRsrcWord1.u32All));
+    pDesc = builder.CreateInsertElement(pDesc, pDescElem1, 1);
+
+    // DWORD2
+    pDesc = builder.CreateInsertElement(pDesc, builder.getInt32(sqBufRsrcWord2.u32All), 2);
+
+    // DWORD3
+    pDesc = builder.CreateInsertElement(pDesc, builder.getInt32(sqBufRsrcWord3.u32All), 3);
+
+    return pDesc;
 }
 
 // =====================================================================================================================
@@ -687,209 +720,7 @@ Value* PatchDescriptorLoad::BuildBufferCompactDesc(
     return pBufDesc;
 }
 
-// =====================================================================================================================
-// Calculates the offset and size for the specified descriptor.
-//
-// Returns the type actually found, or ResourceNodeType::Unknown if not found.
-ResourceNodeType PatchDescriptorLoad::CalcDescriptorOffsetAndSize(
-    ResourceNodeType          nodeType1,      // The first resource node type for calculation
-    ResourceNodeType          nodeType2,      // The second resource node type for calculation (alternative)
-    uint32_t                  descSet,        // ID of descriptor set
-    uint32_t                  binding,        // ID of descriptor binding
-    uint32_t*                 pOffset,        // [out] Calculated offset of the descriptor
-    uint32_t*                 pSize,          // [out] Calculated size of the descriptor
-    uint32_t*                 pDynDescIdx     // [out] Calculated index of dynamic descriptor
-    ) const
-{
-    bool exist = false;
-    ResourceNodeType foundNodeType = ResourceNodeType::Unknown;
-
-    *pDynDescIdx = InvalidValue;
-    *pOffset = 0;
-    *pSize = 0;
-
-    uint32_t dynDescIdx = 0;
-
-    // Load descriptor from internal tables
-    if ((descSet == InternalResourceTable) || (descSet == InternalPerShaderTable))
-    {
-        *pOffset = binding * DescriptorSizeBuffer;
-        *pSize = DescriptorSizeBuffer;
-        exist = true;
-    }
-
-    if (EnableShadowDescriptorTable && (nodeType1 == ResourceNodeType::DescriptorFmask))
-    {
-        // NOTE: When shadow descriptor table is enable, we need get F-Mask descriptor node from
-        // associated multi-sampled texture resource node. So we have to change nodeType1 to
-        // DescriptorResource during the search.
-        nodeType1 = ResourceNodeType::DescriptorResource;
-    }
-
-    auto userDataNodes = m_pPipelineState->GetUserDataNodes();
-    for (uint32_t i = 0; (i < userDataNodes.size()) && (exist == false); ++i)
-    {
-        auto pSetNode = &userDataNodes[i];
-        if  ((pSetNode->type == ResourceNodeType::DescriptorResource) ||
-             (pSetNode->type == ResourceNodeType::DescriptorSampler) ||
-             (pSetNode->type == ResourceNodeType::DescriptorTexelBuffer) ||
-             (pSetNode->type == ResourceNodeType::DescriptorFmask) ||
-             (pSetNode->type == ResourceNodeType::DescriptorBuffer) ||
-             (pSetNode->type == ResourceNodeType::DescriptorBufferCompact))
-        {
-            if ((descSet == pSetNode->set) &&
-                (binding == pSetNode->binding) &&
-                ((nodeType1 == pSetNode->type) ||
-                 (nodeType2 == pSetNode->type) ||
-                 ((nodeType1 == ResourceNodeType::DescriptorBuffer) &&
-                 (pSetNode->type == ResourceNodeType::DescriptorBufferCompact))))
-            {
-                *pOffset = pSetNode->offsetInDwords;
-                if ((pSetNode->type == ResourceNodeType::DescriptorResource) ||
-                    (pSetNode->type == ResourceNodeType::DescriptorFmask))
-                {
-                    *pSize = DescriptorSizeResource;
-                }
-                else if (pSetNode->type == ResourceNodeType::DescriptorSampler)
-                {
-                    *pSize = DescriptorSizeSampler;
-                }
-                else if ((pSetNode->type == ResourceNodeType::DescriptorBuffer) ||
-                         (pSetNode->type == ResourceNodeType::DescriptorTexelBuffer))
-                {
-                    *pSize = DescriptorSizeBuffer;
-                }
-                else
-                {
-                    assert(pSetNode->type == ResourceNodeType::DescriptorBufferCompact);
-                    *pSize = DescriptorSizeBufferCompact;
-                }
-
-                *pDynDescIdx = dynDescIdx;
-                exist = true;
-                foundNodeType = pSetNode->type;
-            }
-            ++dynDescIdx;
-        }
-        else if (pSetNode->type == ResourceNodeType::DescriptorTableVaPtr)
-        {
-            for (uint32_t j = 0; (j < pSetNode->innerTable.size()) && (exist == false); ++j)
-            {
-                auto pNode = &pSetNode->innerTable[j];
-                switch (pNode->type)
-                {
-                case ResourceNodeType::DescriptorResource:
-                case ResourceNodeType::DescriptorSampler:
-                case ResourceNodeType::DescriptorFmask:
-                case ResourceNodeType::DescriptorTexelBuffer:
-                case ResourceNodeType::DescriptorBuffer:
-                case ResourceNodeType::PushConst:
-                case ResourceNodeType::DescriptorBufferCompact:
-                    {
-                        if ((pNode->set == descSet) &&
-                            (pNode->binding == binding) &&
-                            ((nodeType1 == pNode->type) ||
-                             (nodeType2 == pNode->type) ||
-                             ((nodeType1 == ResourceNodeType::DescriptorBuffer) &&
-                             (pNode->type == ResourceNodeType::DescriptorBufferCompact))))
-                        {
-                            exist = true;
-                            foundNodeType = pNode->type;
-
-                            if (pNode->type == ResourceNodeType::DescriptorResource)
-                            {
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize = DescriptorSizeResource;
-                            }
-                            else if (pNode->type == ResourceNodeType::DescriptorSampler)
-                            {
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize = DescriptorSizeSampler;
-                            }
-                            else if (pNode->type == ResourceNodeType::DescriptorFmask)
-                            {
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize = DescriptorSizeResource;
-                            }
-                            else if (pNode->type == ResourceNodeType::PushConst)
-                            {
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize = pNode->sizeInDwords * sizeof(uint32_t);
-                            }
-                            else if (pNode->type == ResourceNodeType::DescriptorBufferCompact)
-                            {
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize = pNode->sizeInDwords * sizeof(uint32_t);
-                            }
-                            else
-                            {
-                                assert((pNode->type == ResourceNodeType::DescriptorBuffer) ||
-                                             (pNode->type == ResourceNodeType::DescriptorTexelBuffer));
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize = DescriptorSizeBuffer;
-                            }
-                        }
-
-                        break;
-                    }
-                case ResourceNodeType::DescriptorCombinedTexture:
-                    {
-                        // TODO: Check descriptor binding in Vulkan API call to make sure sampler and texture are
-                        // bound in this way.
-                        if ((pNode->set == descSet) &&
-                            (pNode->binding == binding) &&
-                            ((nodeType1 == ResourceNodeType::DescriptorResource) ||
-                            (nodeType1 == ResourceNodeType::DescriptorSampler)))
-                        {
-                            exist = true;
-                            foundNodeType = pNode->type;
-
-                            if (nodeType1 == ResourceNodeType::DescriptorResource)
-                            {
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t);
-                                *pSize   = DescriptorSizeResource + DescriptorSizeSampler;
-                            }
-                            else
-                            {
-                                assert(nodeType1 == ResourceNodeType::DescriptorSampler);
-                                *pOffset = pNode->offsetInDwords * sizeof(uint32_t) + DescriptorSizeResource;
-                                *pSize   = DescriptorSizeResource + DescriptorSizeSampler;
-                            }
-                        }
-
-                        break;
-                    }
-                    case ResourceNodeType::DescriptorYCbCrSampler:
-                    {
-                        if ((pNode->set == descSet) &&
-                            (pNode->binding == binding) &&
-                            ((nodeType1 == ResourceNodeType::DescriptorResource) ||
-                            (nodeType1 == ResourceNodeType::DescriptorSampler)))
-                        {
-                            exist = true;
-                            foundNodeType = pNode->type;
-                        }
-
-                        break;
-                    }
-                default:
-                    {
-                        llvm_unreachable("Should never be called!");
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    // TODO: We haven't removed the dead code, so we might load inactive descriptors sometimes.
-    // Currently, disable this assert.
-    //assert(exist);
-
-    return foundNodeType;
-}
-
-} // lgc
+} // Llpc
 
 // =====================================================================================================================
 // Initializes the pass of LLVM patching opertions for descriptor load.

--- a/lgc/patch/llpcPatchDescriptorLoad.h
+++ b/lgc/patch/llpcPatchDescriptorLoad.h
@@ -68,28 +68,30 @@ private:
     PatchDescriptorLoad(const PatchDescriptorLoad&) = delete;
     PatchDescriptorLoad& operator=(const PatchDescriptorLoad&) = delete;
 
+    void ProcessDescriptorGetPtr(llvm::CallInst* pDescPtrCall, llvm::StringRef descPtrCallName);
+    llvm::Value* GetDescPtrAndStride(ResourceNodeType        resType,
+                                     uint32_t                descSet,
+                                     uint32_t                binding,
+                                     const ResourceNode*     pTopNode,
+                                     const ResourceNode*     pNode,
+                                     bool                    shadow,
+                                     llvm::IRBuilder<>&      builder);
+    llvm::Value* GetDescPtr(ResourceNodeType resType,
+                            uint32_t                descSet,
+                            uint32_t                binding,
+                            const ResourceNode*     pTopNode,
+                            const ResourceNode*     pNode,
+                            bool                    shadow,
+                            llvm::IRBuilder<>&      builder);
+
+    void ProcessDescriptorIndex(llvm::CallInst* pCall);
     void ProcessLoadDescFromPtr(llvm::CallInst* pLoadFromPtr);
+    llvm::Value* LoadBufferDescriptor(uint32_t            descSet,
+                                      uint32_t            binding,
+                                      llvm::Value*        pArrayOffset,
+                                      llvm::Instruction*  pInsertPoint);
 
-    llvm::Value* LoadDescriptor(llvm::CallInst&     callInst,
-                                uint32_t            descSet,
-                                uint32_t            binding,
-                                llvm::Value*        pArrayOffset,
-                                llvm::Instruction*  pInsertPoint);
-
-    ResourceNodeType CalcDescriptorOffsetAndSize(ResourceNodeType   nodeType1,
-                                                 ResourceNodeType   nodeType2,
-                                                 uint32_t           descSet,
-                                                 uint32_t           binding,
-                                                 uint32_t*          pOffset,
-                                                 uint32_t*          pStride,
-                                                 uint32_t*          pDynDescIdx) const;
-
-    llvm::Constant* GetDescriptorRangeValue(ResourceNodeType   nodeType,
-                                            uint32_t           descSet,
-                                            uint32_t           binding) const;
-
-    void PatchWaterfallLastUseCalls();
-
+    llvm::Value* BuildInlineBufferDesc(Value* pDescPtr, llvm::IRBuilder<>& builder);
     llvm::Value* BuildBufferCompactDesc(llvm::Value* pDesc, llvm::Instruction* pInsertPoint);
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/lgc/patch/llpcSystemValues.cpp
+++ b/lgc/patch/llpcSystemValues.cpp
@@ -406,53 +406,12 @@ Value* ShaderSystemValues::GetShadowDescTablePtr(
 }
 
 // =====================================================================================================================
-// Get dynamic descriptor
-Value* ShaderSystemValues::GetDynamicDesc(
-    uint32_t        dynDescIdx)     // Dynamic descriptor index
-{
-    if (dynDescIdx >= InterfaceData::MaxDynDescCount)
-    {
-        return nullptr;
-    }
-    if (m_dynDescs.size() <= dynDescIdx)
-    {
-        m_dynDescs.resize(dynDescIdx + 1);
-    }
-    if (m_dynDescs[dynDescIdx] == nullptr)
-    {
-        // Find the node.
-        uint32_t foundDynDescIdx = 0;
-        auto userDataNodes = m_pPipelineState->GetUserDataNodes();
-        for (uint32_t i = 0; i != userDataNodes.size(); ++i)
-        {
-            auto pNode = &userDataNodes[i];
-            if  ((pNode->type == ResourceNodeType::DescriptorResource) ||
-                 (pNode->type == ResourceNodeType::DescriptorSampler) ||
-                 (pNode->type == ResourceNodeType::DescriptorTexelBuffer) ||
-                 (pNode->type == ResourceNodeType::DescriptorFmask) ||
-                 (pNode->type == ResourceNodeType::DescriptorBuffer) ||
-                 (pNode->type == ResourceNodeType::DescriptorBufferCompact))
-            {
-                if (foundDynDescIdx == dynDescIdx)
-                {
-                    // Get the node value.
-                    m_dynDescs[dynDescIdx] = GetResourceNodeValue(i);
-                    break;
-                }
-                ++foundDynDescIdx;
-            }
-        }
-    }
-    return m_dynDescs[dynDescIdx];
-}
-
-// =====================================================================================================================
-// Get internal global table pointer
+// Get internal global table pointer as pointer to i8.
 Value* ShaderSystemValues::GetInternalGlobalTablePtr()
 {
     if (m_pInternalGlobalTablePtr == nullptr)
     {
-        auto pPtrTy = PointerType::get(ArrayType::get(Type::getInt8Ty(*m_pContext), UINT32_MAX), ADDR_SPACE_CONST);
+        auto pPtrTy = Type::getInt8Ty(*m_pContext)->getPointerTo(ADDR_SPACE_CONST);
         // Global table is always the first function argument
         m_pInternalGlobalTablePtr = MakePointer(GetFunctionArgument(m_pEntryPoint, 0, "globalTable"),
                                                 pPtrTy,
@@ -462,12 +421,12 @@ Value* ShaderSystemValues::GetInternalGlobalTablePtr()
 }
 
 // =====================================================================================================================
-// Get internal per shader table pointer
+// Get internal per shader table pointer as pointer to i8.
 Value* ShaderSystemValues::GetInternalPerShaderTablePtr()
 {
     if (m_pInternalPerShaderTablePtr == nullptr)
     {
-        auto pPtrTy = PointerType::get(ArrayType::get(Type::getInt8Ty(*m_pContext), UINT32_MAX), ADDR_SPACE_CONST);
+        auto pPtrTy = Type::getInt8Ty(*m_pContext)->getPointerTo(ADDR_SPACE_CONST);
         // Per shader table is always the second function argument
         m_pInternalPerShaderTablePtr = MakePointer(GetFunctionArgument(m_pEntryPoint, 1, "perShaderTable"),
                                                    pPtrTy,

--- a/lgc/patch/llpcSystemValues.h
+++ b/lgc/patch/llpcSystemValues.h
@@ -92,13 +92,10 @@ public:
     // Get shadow descriptor table pointer
     llvm::Value* GetShadowDescTablePtr(uint32_t descSet);
 
-    // Get dynamic descriptor
-    llvm::Value* GetDynamicDesc(uint32_t dynDescIdx);
-
-    // Get global internal table pointer
+    // Get global internal table pointer as pointer to i8.
     llvm::Value* GetInternalGlobalTablePtr();
 
-    // Get internal per shader table pointer
+    // Get internal per shader table pointer as pointer to i8.
     llvm::Value* GetInternalPerShaderTablePtr();
 
     // Get number of workgroups value
@@ -113,6 +110,9 @@ public:
     // Get stream-out buffer descriptor
     llvm::Value* GetStreamOutBufDesc(uint32_t xfbBuffer);
 
+    // Get spill table pointer
+    llvm::Instruction* GetSpillTablePtr();
+
 private:
     // Get stream-out buffer table pointer
     llvm::Instruction* GetStreamOutTablePtr();
@@ -125,9 +125,6 @@ private:
 
     // Get 32 bit resource node value
     llvm::Value* GetResourceNodeValue(uint32_t resNodeIdx);
-
-    // Get spill table pointer
-    llvm::Instruction* GetSpillTablePtr();
 
     // Load descriptor from driver table
     llvm::Instruction* LoadDescFromDriverTable(uint32_t tableOffset, BuilderBase& builder);
@@ -171,8 +168,6 @@ private:
                         m_descTablePtrs;                // Descriptor table pointers
     llvm::SmallVector<llvm::Value*, InterfaceData::MaxDescTableCount>
                         m_shadowDescTablePtrs;          // Shadow descriptor table pointers
-    llvm::SmallVector<llvm::Value*, InterfaceData::MaxDynDescCount>
-                        m_dynDescs;                     // Dynamic descriptors
     llvm::Value*        m_pInternalGlobalTablePtr = nullptr;
                                                         // Internal global table pointer
     llvm::Value*        m_pInternalPerShaderTablePtr = nullptr;

--- a/lgc/util/llpcInternal.h
+++ b/lgc/util/llpcInternal.h
@@ -105,7 +105,6 @@ namespace lgcName
     const static char DescriptorGetSamplerPtr[]       = "llpc.descriptor.get.sampler.ptr";
     const static char DescriptorGetFmaskPtr[]         = "llpc.descriptor.get.fmask.ptr";
     const static char DescriptorLoadBuffer[]          = "llpc.descriptor.load.buffer";
-    const static char DescriptorLoadAddress[]         = "llpc.descriptor.load.address";
     const static char DescriptorGetTexelBufferPtr[]   = "llpc.descriptor.get.texelbuffer.ptr";
     const static char DescriptorLoadSpillTable[]      = "llpc.descriptor.load.spilltable";
 

--- a/llpc/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
@@ -5,10 +5,9 @@
 ; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@llpc.call.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0, i1 false,
 ; SHADERTEST: load <4 x i32>, <4 x i32> addrspace(7)* %{{.*}}, align 16
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = getelementptr inbounds [512 x i8], [512 x i8] {{.*}} %{{.*}}, i64 0, i64 16
-; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %{{.*}} to <16 x i32> {{.*}}
-; SHADERTEST: %{{.*}} = load <16 x i32>, <16 x i32> {{.*}} %{{.*}}, align 64
-; SHADERTEST: %{{.*}} = shufflevector <16 x i32> %{{.*}}, <16 x i32> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; SHADERTEST: %{{.*}} = getelementptr{{.*}} i32, {{.*}} %{{.*}}, i64 4
+; SHADERTEST: %{{.*}} = bitcast i32 addrspace(4)* %{{.*}} to <4 x i32> {{.*}}
+; SHADERTEST: %{{.*}} = load <4 x i32>, <4 x i32> {{.*}} %{{.*}}, align 16
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -9,9 +9,9 @@
 ; SHADERTEST: load <2 x double>, <2 x double> addrspace(7)* %{{.*}}, align 16
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to [4294967295 x i8]
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i32 0
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 1
+; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to i32 addrspace(4)*
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i64 0
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)
 ; SHADERTEST: bitcast <4 x i32> %{{.*}} to <2 x double>
 


### PR DESCRIPTION
This commit changes the code to implement image and sampler descriptor
loading with the semantics intended by the separate Builder calls to
1. get the descriptor pointer
2. add an index to a descriptor pointer
3. load the descriptor from the pointer

Before this commit, the code relied on being able to scan back from (3)
to (1) to discover the descriptor set and binding. If we have
non-inlined subroutines in the future, that is no longer possible, as
SPIR-V allows the passing of a descriptor pointer as a call arg.

An immutable sampler is now handled by putting it into a read-only
global variable at (1), and relying on LLVM optimizations to promote it
back to a constant in the common case.

Change-Id: Ic37fcb2858dfbc0a84b065dd7987bd4a2746e0e3