### PR TITLE
Use ElementCount in new API ConstantVector::getSplat()

### DIFF
--- a/llpc/builder/llpcBuilderImplSubgroup.cpp
+++ b/llpc/builder/llpcBuilderImplSubgroup.cpp
@@ -190,7 +190,8 @@ Value* BuilderImplSubgroup::CreateSubgroupBallot(
     // Ballot expects a <4 x i32> return, so we need to turn the i64 into that.
     pBallot = CreateBitCast(pBallot, VectorType::get(getInt32Ty(), 2));
 
-    return CreateShuffleVector(pBallot, ConstantVector::getSplat(2, getInt32(0)), { 0, 1, 2, 3 });
+    ElementCount elementCount = pBallot->getType()->getVectorElementCount();
+    return CreateShuffleVector(pBallot, ConstantVector::getSplat(elementCount, getInt32(0)), { 0, 1, 2, 3 });
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -248,9 +248,9 @@ void SpirvLowerAlgebraTransform::visitBinaryOperator(
             pBuilder->SetInsertPoint(&binaryOp);
 
             auto pOne = ConstantFP::get(Type::getHalfTy(*m_pContext), 1.0);
-            if (pDestTy->isVectorTy())
+            if (auto pVecTy = dyn_cast<VectorType>(pDestTy))
             {
-                pOne = ConstantVector::getSplat(pDestTy->getVectorNumElements(), pOne);
+                pOne = ConstantVector::getSplat(pVecTy->getElementCount(), pOne);
             }
 
             // -trunc(x * 1/y)

--- a/llpc/patch/gfx9/llpcNggPrimShader.cpp
+++ b/llpc/patch/gfx9/llpcNggPrimShader.cpp
@@ -1066,7 +1066,7 @@ void NggPrimShader::ConstructPrimShaderWithoutGs(
             auto pZero = m_pBuilder->getInt32(0);
 
             // Zero per-wave primitive/vertex count
-            auto pZeros = ConstantVector::getSplat(Gfx9::NggMaxWavesPerSubgroup, pZero);
+            auto pZeros = ConstantVector::getSplat({Gfx9::NggMaxWavesPerSubgroup, false}, pZero);
 
             auto pLdsOffset = m_pBuilder->getInt32(regionStart);
             m_pLdsManager->WriteValueToLds(pZeros, pLdsOffset);
@@ -2203,7 +2203,7 @@ void NggPrimShader::ConstructPrimShaderWithGs(
             if (i == rasterStream)
             {
                 // Zero per-wave GS output vertex count
-                auto pZeros = ConstantVector::getSplat(Gfx9::NggMaxWavesPerSubgroup, pZero);
+                auto pZeros = ConstantVector::getSplat({Gfx9::NggMaxWavesPerSubgroup, false}, pZero);
 
                 auto pLdsOffset =
                     m_pBuilder->getInt32(regionStart + i * SizeOfDword * (Gfx9::NggMaxWavesPerSubgroup + 1));

--- a/llpc/patch/llpcPatchBufferOp.cpp
+++ b/llpc/patch/llpcPatchBufferOp.cpp
@@ -1273,7 +1273,7 @@ void PatchBufferOp::PostVisitMemSetInst(
 
         if (Constant* const pConst = dyn_cast<Constant>(pValue))
         {
-            pNewValue = ConstantVector::getSplat(stride, pConst);
+            pNewValue = ConstantVector::getSplat({stride, false}, pConst);
             pNewValue = m_pBuilder->CreateBitCast(pNewValue, pCastDestType->getPointerElementType());
             CopyMetadata(pNewValue, &memSetInst);
         }
@@ -1337,7 +1337,7 @@ void PatchBufferOp::PostVisitMemSetInst(
 
         if (Constant* const pConst = dyn_cast<Constant>(pValue))
         {
-            pNewValue = ConstantVector::getSplat(pMemoryType->getVectorNumElements(), pConst);
+            pNewValue = ConstantVector::getSplat(pMemoryType->getVectorElementCount(), pConst);
         }
         else
         {


### PR DESCRIPTION
Update for D74386, where API for ConstantVector::getSplat()
was changed and now requires ElementCount.