### PR TITLE
Do some NGG renaming

### DIFF
--- a/llpc/patch/gfx9/llpcNggLdsManager.cpp
+++ b/llpc/patch/gfx9/llpcNggLdsManager.cpp
@@ -68,7 +68,7 @@ const uint32_t NggLdsManager::LdsRegionSizes[LdsRegionCount] =
     // 1 DWORD (uint32_t) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,                     // LdsRegionCullDistance
     // 1 BYTE (uint8_t) per thread
-    Gfx9::NggMaxThreadsPerSubgroup,                                   // LdsRegionCompactThreadIdInSubgroup
+    Gfx9::NggMaxThreadsPerSubgroup,                                   // LdsRegionVertThreadIdMap
     // 1 DWORD (uint32_t) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,                     // LdsRegionCompactVertexId
     // 1 DWORD (uint32_t) per thread
@@ -109,7 +109,7 @@ const char* NggLdsManager::LdsRegionNames[LdsRegionCount] =
     "Primitive count in waves",             // LdsRegionPrimCountInWaves
     "Vertex count in waves",                // LdsRegionVertCountInWaves
     "Cull distance",                        // LdsRegionCullDistance
-    "Compacted thread ID in sub-group",     // LdsRegionCompactThreadIdInSubgroup
+    "Vertex thread ID map",                 // LdsRegionVertThreadIdMap
     "Compacted vertex ID (VS)",             // LdsRegionCompactVertexId
     "Compacted instance ID (VS)",           // LdsRegionCompactInstanceId
     "Compacted primitive ID (VS)",          // LdsRegionCompactPrimId
@@ -120,9 +120,9 @@ const char* NggLdsManager::LdsRegionNames[LdsRegionCount] =
 
     // LDS region name for ES-GS
     "ES-GS ring",                           // LdsRegionEsGsRing
-    "GS output primitive data",             // LdsRegionOutPrimData
-    "GS output vertex count in waves",      // LdsRegionOutVertCountInWaves
-    "GS output vertex offset",              // LdsRegionOutVertOffset
+    "GS out primitive data",                // LdsRegionOutPrimData
+    "GS out vertex count in waves",         // LdsRegionOutVertCountInWaves
+    "GS out vertex offset",                 // LdsRegionOutVertOffset
     "GS-VS ring",                           // LdsRegionGsVsRing
 };
 
@@ -238,12 +238,12 @@ NggLdsManager::NggLdsManager(
             // | Distributed primitive ID |           | Primitive count (in waves) |
             // +--------------------------+           +----------------------------+
             //
-            //     | =============== Compacted data region (for vertex compaction) ================ |
-            //     +------------------+-------------+-------------+-------------+
-            // >>> | Vertex thread ID | Vertex ID   | Instance ID | Primtive ID |                     (VS)
-            //     +------------------+-------------+-------------+-------------+-------------------+
-            //                        | Tesscoord X | Tesscoord Y | Patch ID    | Relative patch ID | (TES)
-            //                        +-------------+-------------+-------------+-------------------+
+            //                            | ====== Compacted data region (for vertex compaction) ====== |
+            //     +----------------------+-------------+-------------+-------------+
+            // >>> | Vertex thread ID map | Vertex ID   | Instance ID | Primtive ID |                     (VS)
+            //     +----------------------+-------------+-------------+-------------+-------------------+
+            //                            | Tesscoord X | Tesscoord Y | Patch ID    | Relative patch ID | (TES)
+            //                            +-------------+-------------+-------------+-------------------+
             //
             uint32_t ldsRegionStart = 0;
             for (uint32_t region = LdsRegionEsBeginRange; region <= LdsRegionEsEndRange; ++region)

--- a/llpc/patch/gfx9/llpcNggLdsManager.h
+++ b/llpc/patch/gfx9/llpcNggLdsManager.h
@@ -48,12 +48,12 @@ enum NggLdsRegionType
     LdsRegionDistribPrimId = 0,         // Distributed primitive ID (a special region, overlapped with the region of
                                         //   position data in NGG non pass-through mode)
     LdsRegionPosData,                   // Position data to export
-    LdsRegionDrawFlag,                  // Draw flag indicating whether the primitive survives
+    LdsRegionDrawFlag,                  // Draw flag indicating whether the vertex survives
     LdsRegionPrimCountInWaves,          // Primitive count accumulated per wave (8 potential waves) and per sub-group
     LdsRegionVertCountInWaves,          // Vertex count accumulated per wave (8 potential waves) and per sub-group
     LdsRegionCullDistance,              // Aggregated sign value of cull distance (bitmask)
     // Below regions are for vertex compaction
-    LdsRegionCompactThreadIdInSubgroup, // Thread ID in sub-group to export primitive data
+    LdsRegionVertThreadIdMap,           // Vertex thread ID map (uncompacted -> compacted)
     LdsRegionCompactVertexId,           // Vertex ID (VS only)
     LdsRegionCompactInstanceId,         // Instance ID (VS only)
     LdsRegionCompactPrimId,             // Primitive ID (VS only)
@@ -62,7 +62,7 @@ enum NggLdsRegionType
     LdsRegionCompactPatchId,            // Patch ID (TES only)
     LdsRegionCompactRelPatchId,         // Relative patch ID (TES only)
 
-    LdsRegionCompactBeginRange = LdsRegionCompactThreadIdInSubgroup,
+    LdsRegionCompactBeginRange = LdsRegionVertThreadIdMap,
     LdsRegionCompactEndRange = LdsRegionCompactRelPatchId,
 
     LdsRegionEsBeginRange = LdsRegionDistribPrimId,

--- a/llpc/patch/gfx9/llpcNggPrimShader.cpp
+++ b/llpc/patch/gfx9/llpcNggPrimShader.cpp
@@ -1504,35 +1504,24 @@ void NggPrimShader::ConstructPrimShaderWithoutGs(
                 // Write thread ID in sub-group to LDS
                 Value* pCompactThreadId =
                     m_pBuilder->CreateTrunc(pCompactThreadIdInSubrgoup, m_pBuilder->getInt8Ty());
-                WriteCompactDataToLds(pCompactThreadId,
-                                      m_nggFactor.pThreadIdInSubgroup,
-                                      LdsRegionCompactThreadIdInSubgroup);
+                WritePerThreadDataToLds(pCompactThreadId, m_nggFactor.pThreadIdInSubgroup, LdsRegionVertThreadIdMap);
 
                 if (hasTs)
                 {
                     // Write X/Y of tessCoord (U/V) to LDS
                     if (pResUsage->builtInUsage.tes.tessCoord)
                     {
-                        WriteCompactDataToLds(pTessCoordX,
-                                              pCompactThreadIdInSubrgoup,
-                                              LdsRegionCompactTessCoordX);
-
-                        WriteCompactDataToLds(pTessCoordY,
-                                              pCompactThreadIdInSubrgoup,
-                                              LdsRegionCompactTessCoordY);
+                        WritePerThreadDataToLds(pTessCoordX, pCompactThreadIdInSubrgoup, LdsRegionCompactTessCoordX);
+                        WritePerThreadDataToLds(pTessCoordY, pCompactThreadIdInSubrgoup, LdsRegionCompactTessCoordY);
                     }
 
                     // Write relative patch ID to LDS
-                    WriteCompactDataToLds(pRelPatchId,
-                                          pCompactThreadIdInSubrgoup,
-                                          LdsRegionCompactRelPatchId);
+                    WritePerThreadDataToLds(pRelPatchId, pCompactThreadIdInSubrgoup, LdsRegionCompactRelPatchId);
 
                     // Write patch ID to LDS
                     if (pResUsage->builtInUsage.tes.primitiveId)
                     {
-                        WriteCompactDataToLds(pPatchId,
-                                              pCompactThreadIdInSubrgoup,
-                                              LdsRegionCompactPatchId);
+                        WritePerThreadDataToLds(pPatchId, pCompactThreadIdInSubrgoup, LdsRegionCompactPatchId);
                     }
                 }
                 else
@@ -1540,26 +1529,22 @@ void NggPrimShader::ConstructPrimShaderWithoutGs(
                     // Write vertex ID to LDS
                     if (pResUsage->builtInUsage.vs.vertexIndex)
                     {
-                        WriteCompactDataToLds(pVertexId,
-                                              pCompactThreadIdInSubrgoup,
-                                              LdsRegionCompactVertexId);
+                        WritePerThreadDataToLds(pVertexId, pCompactThreadIdInSubrgoup, LdsRegionCompactVertexId);
                     }
 
                     // Write instance ID to LDS
                     if (pResUsage->builtInUsage.vs.instanceIndex)
                     {
-                        WriteCompactDataToLds(pInstanceId,
-                                              pCompactThreadIdInSubrgoup,
-                                              LdsRegionCompactInstanceId);
+                        WritePerThreadDataToLds(pInstanceId, pCompactThreadIdInSubrgoup, LdsRegionCompactInstanceId);
                     }
 
                     // Write primitive ID to LDS
                     if (pResUsage->builtInUsage.vs.primitiveId)
                     {
                         assert(m_nggFactor.pPrimitiveId != nullptr);
-                        WriteCompactDataToLds(m_nggFactor.pPrimitiveId,
-                                              pCompactThreadIdInSubrgoup,
-                                              LdsRegionCompactPrimId);
+                        WritePerThreadDataToLds(m_nggFactor.pPrimitiveId,
+                                                pCompactThreadIdInSubrgoup,
+                                                LdsRegionCompactPrimId);
                     }
                 }
 
@@ -2838,19 +2823,19 @@ void NggPrimShader::DoPrimitiveExport(
             {
                 m_pBuilder->SetInsertPoint(pReadCompactIdBlock);
 
-                pCompactVertexId0 = ReadCompactDataFromLds(m_pBuilder->getInt8Ty(),
-                                                           pVertexId0,
-                                                           LdsRegionCompactThreadIdInSubgroup);
+                pCompactVertexId0 = ReadPerThreadDataFromLds(m_pBuilder->getInt8Ty(),
+                                                             pVertexId0,
+                                                             LdsRegionVertThreadIdMap);
                 pCompactVertexId0 = m_pBuilder->CreateZExt(pCompactVertexId0, m_pBuilder->getInt32Ty());
 
-                pCompactVertexId1 = ReadCompactDataFromLds(m_pBuilder->getInt8Ty(),
-                                                           pVertexId1,
-                                                           LdsRegionCompactThreadIdInSubgroup);
+                pCompactVertexId1 = ReadPerThreadDataFromLds(m_pBuilder->getInt8Ty(),
+                                                             pVertexId1,
+                                                             LdsRegionVertThreadIdMap);
                 pCompactVertexId1 = m_pBuilder->CreateZExt(pCompactVertexId1, m_pBuilder->getInt32Ty());
 
-                pCompactVertexId2 = ReadCompactDataFromLds(m_pBuilder->getInt8Ty(),
-                                                           pVertexId2,
-                                                           LdsRegionCompactThreadIdInSubgroup);
+                pCompactVertexId2 = ReadPerThreadDataFromLds(m_pBuilder->getInt8Ty(),
+                                                             pVertexId2,
+                                                             LdsRegionVertThreadIdMap);
                 pCompactVertexId2 = m_pBuilder->CreateZExt(pCompactVertexId2, m_pBuilder->getInt32Ty());
 
                 m_pBuilder->CreateBr(pExpPrimContBlock);
@@ -3069,49 +3054,49 @@ void NggPrimShader::RunEsOrEsVariant(
         {
             if (pResUsage->builtInUsage.tes.tessCoord)
             {
-                pTessCoordX = ReadCompactDataFromLds(m_pBuilder->getFloatTy(),
-                                                     m_nggFactor.pThreadIdInSubgroup,
-                                                     LdsRegionCompactTessCoordX);
+                pTessCoordX = ReadPerThreadDataFromLds(m_pBuilder->getFloatTy(),
+                                                       m_nggFactor.pThreadIdInSubgroup,
+                                                       LdsRegionCompactTessCoordX);
 
-                pTessCoordY = ReadCompactDataFromLds(m_pBuilder->getFloatTy(),
-                                                     m_nggFactor.pThreadIdInSubgroup,
-                                                     LdsRegionCompactTessCoordY);
+                pTessCoordY = ReadPerThreadDataFromLds(m_pBuilder->getFloatTy(),
+                                                       m_nggFactor.pThreadIdInSubgroup,
+                                                       LdsRegionCompactTessCoordY);
             }
 
-            pRelPatchId = ReadCompactDataFromLds(m_pBuilder->getInt32Ty(),
-                                                 m_nggFactor.pThreadIdInSubgroup,
-                                                 LdsRegionCompactRelPatchId);
+            pRelPatchId = ReadPerThreadDataFromLds(m_pBuilder->getInt32Ty(),
+                                                   m_nggFactor.pThreadIdInSubgroup,
+                                                   LdsRegionCompactRelPatchId);
 
             if (pResUsage->builtInUsage.tes.primitiveId)
             {
-                pPatchId = ReadCompactDataFromLds(m_pBuilder->getInt32Ty(),
-                                                  m_nggFactor.pThreadIdInSubgroup,
-                                                  LdsRegionCompactPatchId);
+                pPatchId = ReadPerThreadDataFromLds(m_pBuilder->getInt32Ty(),
+                                                    m_nggFactor.pThreadIdInSubgroup,
+                                                    LdsRegionCompactPatchId);
             }
         }
         else
         {
             if (pResUsage->builtInUsage.vs.vertexIndex)
             {
-                pVertexId = ReadCompactDataFromLds(m_pBuilder->getInt32Ty(),
-                                                   m_nggFactor.pThreadIdInSubgroup,
-                                                   LdsRegionCompactVertexId);
+                pVertexId = ReadPerThreadDataFromLds(m_pBuilder->getInt32Ty(),
+                                                     m_nggFactor.pThreadIdInSubgroup,
+                                                     LdsRegionCompactVertexId);
             }
 
             // NOTE: Relative vertex ID Will not be used when VS is merged to GS.
 
             if (pResUsage->builtInUsage.vs.primitiveId)
             {
-                pVsPrimitiveId = ReadCompactDataFromLds(m_pBuilder->getInt32Ty(),
-                                                        m_nggFactor.pThreadIdInSubgroup,
-                                                        LdsRegionCompactPrimId);
+                pVsPrimitiveId = ReadPerThreadDataFromLds(m_pBuilder->getInt32Ty(),
+                                                          m_nggFactor.pThreadIdInSubgroup,
+                                                          LdsRegionCompactPrimId);
             }
 
             if (pResUsage->builtInUsage.vs.instanceIndex)
             {
-                pInstanceId = ReadCompactDataFromLds(m_pBuilder->getInt32Ty(),
-                                                     m_nggFactor.pThreadIdInSubgroup,
-                                                     LdsRegionCompactInstanceId);
+                pInstanceId = ReadPerThreadDataFromLds(m_pBuilder->getInt32Ty(),
+                                                       m_nggFactor.pThreadIdInSubgroup,
+                                                       LdsRegionCompactInstanceId);
             }
         }
     }
@@ -4654,11 +4639,11 @@ void NggPrimShader::ReviseOutputPrimitiveData(
 }
 
 // =====================================================================================================================
-// Reads the specified data from NGG compaction data region in LDS.
-Value* NggPrimShader::ReadCompactDataFromLds(
+// Reads per-thread data from the specified NGG region in LDS.
+Value* NggPrimShader::ReadPerThreadDataFromLds(
     Type*             pReadDataTy,  // [in] Data written to LDS
     Value*            pThreadId,    // [in] Thread ID in sub-group to calculate LDS offset
-    NggLdsRegionType  region)       // NGG compaction data region
+    NggLdsRegionType  region)       // NGG LDS region
 {
     auto sizeInBytes = pReadDataTy->getPrimitiveSizeInBits() / 8;
 
@@ -4679,11 +4664,11 @@ Value* NggPrimShader::ReadCompactDataFromLds(
 }
 
 // =====================================================================================================================
-// Writes the specified data to NGG compaction data region in LDS.
-void NggPrimShader::WriteCompactDataToLds(
+// Writes the per-thread data to the specified NGG region in LDS.
+void NggPrimShader::WritePerThreadDataToLds(
     Value*           pWriteData,        // [in] Data written to LDS
     Value*           pThreadId,         // [in] Thread ID in sub-group to calculate LDS offset
-    NggLdsRegionType region)            // NGG compaction data region
+    NggLdsRegionType region)            // NGG LDS region
 {
     auto pWriteDataTy = pWriteData->getType();
     auto sizeInBytes = pWriteDataTy->getPrimitiveSizeInBits() / 8;

--- a/llpc/patch/gfx9/llpcNggPrimShader.h
+++ b/llpc/patch/gfx9/llpcNggPrimShader.h
@@ -138,13 +138,13 @@ private:
 
     void ReviseOutputPrimitiveData(llvm::Value* pOutPrimId, llvm::Value* pVertexIdAdjust);
 
-    llvm::Value* ReadCompactDataFromLds(llvm::Type*       pReadDataTy,
-                                        llvm::Value*      pThreadId,
-                                        NggLdsRegionType  region);
+    llvm::Value* ReadPerThreadDataFromLds(llvm::Type*       pReadDataTy,
+                                          llvm::Value*      pThreadId,
+                                          NggLdsRegionType  region);
 
-    void WriteCompactDataToLds(llvm::Value*      pWriteData,
-                               llvm::Value*      pThreadId,
-                               NggLdsRegionType  region);
+    void WritePerThreadDataToLds(llvm::Value*      pWriteData,
+                                 llvm::Value*      pThreadId,
+                                 NggLdsRegionType  region);
 
     llvm::Value* DoBackfaceCulling(llvm::Module*     pModule,
                                    llvm::Value*      pCullFlag,


### PR DESCRIPTION
- Rename the functions: ReadCompactDataFromLds -> ReadPerThreadDataFromLds
  WriteCompactDataToLds -> WritePerThreadDataToLds.
- Rename one LDS region: CompactThreadIdInSubgroup -> VertThreadIdMap.
- Correct some inaccurate comments.