### PR TITLE
Add pipeline options for shadow descriptor table.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -71,6 +71,7 @@
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
 //* |     40.0 | Added DescriptorReserved12, which moves DescriptorYCbCrSampler down to 13                             |
 //* |     39.0 | Non-LLPC-specific XGL code should #include vkcgDefs.h instead of llpc.h                               |
+//* |     38.3 | Added shadowDescriptorTableUsage and shadowDescriptorTablePtrHigh to PipelineOptions                  |
 //* |     38.2 | Added scalarThreshold to PipelineShaderOptions                                                        |
 //* |     38.1 | Added unrollThreshold to PipelineShaderOptions                                                        |
 //* |     38.0 | Removed CreateShaderCache in ICompiler and pShaderCache in pipeline build info                        |
@@ -253,6 +254,14 @@ struct BinaryData
     const void*     pCode;              ///< Shader binary data
 };
 
+/// Values for shadowDescriptorTableUsage pipeline option.
+enum class ShadowDescriptorTableUsage : uint32_t
+{
+    Auto     = 0,  ///< Use 0 for auto setting so null initialized structures default to auto.
+    Enable   = 1,
+    Disable  = 2,
+};
+
 /// Represents per pipeline options.
 struct PipelineOptions
 {
@@ -264,6 +273,9 @@ struct PipelineOptions
     bool robustBufferAccess;       ///< If set, out of bounds accesses to buffer or private array will be handled.
                                    ///  for now this option is used by LLPC shader and affects only the private array,
                                    ///  the out of bounds accesses will be skipped with this setting.
+
+    ShadowDescriptorTableUsage shadowDescriptorTableUsage;    ///< Controls shadow descriptor table.
+    uint32_t                   shadowDescriptorTablePtrHigh;  ///< Sets high part of VA ptr for shadow descriptor table.
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/include/lgc/llpcPipeline.h
+++ b/lgc/include/lgc/llpcPipeline.h
@@ -97,10 +97,16 @@ enum class WaveBreak : uint32_t
     DrawTime = 0xF,        ///< Choose wave break size per draw
 };
 
+/// Values for shadowDescriptorTableUsage pipeline option.
+enum class ShadowDescriptorTableUsage : uint32_t
+{
+    Auto     = 0,  ///< Use 0 for auto setting so null initialized structures default to auto.
+    Enable   = 1,
+    Disable  = 2,
+};
+
 // Middle-end per-pipeline options to pass to SetOptions.
 // The front-end should zero-initialize it with "= {}" in case future changes add new fields.
-// All fields are uint32_t, even those that could be bool, because the way the state is written to and read
-// from IR metadata relies on that.
 struct Options
 {
     uint64_t              hash[2];                 // Pipeline hash to set in ELF PAL metadata
@@ -119,12 +125,12 @@ struct Options
     NggSubgroupSizing     nggSubgroupSizing;       // NGG subgroup sizing type
     uint32_t              nggVertsPerSubgroup;     // How to determine NGG verts per subgroup
     uint32_t              nggPrimsPerSubgroup;     // How to determine NGG prims per subgroup
+    ShadowDescriptorTableUsage  shadowDescriptorTableUsage;   // Shadow descriptor table setting
+    uint32_t                    shadowDescriptorTablePtrHigh; // High part of VA ptr.
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.
 // The front-end should zero-initialize it with "= {}" in case future changes add new fields.
-// All fields are uint32_t, even those that could be bool, because the way the state is written to and read
-// from IR metadata relies on that.
 struct ShaderOptions
 {
     uint64_t      hash[2];        // Shader hash to set in ELF PAL metadata

--- a/lgc/patch/llpcPatchDescriptorLoad.cpp
+++ b/lgc/patch/llpcPatchDescriptorLoad.cpp
@@ -41,11 +41,6 @@
 using namespace lgc;
 using namespace llvm;
 
-// -enable-shadow-desc: enable shadow desriptor table
-static cl::opt<bool> EnableShadowDescriptorTable("enable-shadow-desc",
-                                                 cl::desc("Enable shadow descriptor table"),
-                                                 cl::init(true));
-
 namespace lgc
 {
 
@@ -161,7 +156,7 @@ void PatchDescriptorLoad::ProcessDescriptorGetPtr(
     }
     else if (descPtrCallName.startswith(lgcName::DescriptorGetFmaskPtr))
     {
-        shadow = EnableShadowDescriptorTable;
+        shadow = m_pipelineSysValues.Get(m_pEntryPoint)->IsShadowDescTableEnabled();
         resType = ResourceNodeType::DescriptorFmask;
     }
 

--- a/lgc/patch/llpcSystemValues.h
+++ b/lgc/patch/llpcSystemValues.h
@@ -113,6 +113,9 @@ public:
     // Get spill table pointer
     llvm::Instruction* GetSpillTablePtr();
 
+    // Test if shadow descriptor table is enabled
+    bool IsShadowDescTableEnabled() const;
+
 private:
     // Get stream-out buffer table pointer
     llvm::Instruction* GetStreamOutTablePtr();
@@ -178,6 +181,10 @@ private:
     llvm::Instruction*  m_pStreamOutTablePtr;           // Stream-out buffer table pointer
     llvm::Instruction*  m_pSpillTablePtr = nullptr;     // Spill table pointer
     llvm::Instruction*  m_pPc = nullptr;                // Program counter as <2 x i32>
+
+    bool                m_enableShadowDescTable = true; // Enable shadow descriptor table
+    uint32_t            m_shadowDescTablePtrHigh = 2;   // High part of VA for shadow table pointer
+                                                        // 2 is a dummy value for use in offline compiling
 };
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -246,6 +246,16 @@ void PipelineContext::SetOptionsInPipeline(
     options.reconfigWorkgroupLayout = GetPipelineOptions()->reconfigWorkgroupLayout;
     options.includeIr = (IncludeLlvmIr || GetPipelineOptions()->includeIr);
 
+    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Llpc::ShadowDescriptorTableUsage::Auto) ==
+                                                          lgc::ShadowDescriptorTableUsage::Auto, "mismatch");
+    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Llpc::ShadowDescriptorTableUsage::Enable) ==
+                                                          lgc::ShadowDescriptorTableUsage::Enable, "mismatch");
+    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Llpc::ShadowDescriptorTableUsage::Disable) ==
+                                                          lgc::ShadowDescriptorTableUsage::Disable, "mismatch");
+    options.shadowDescriptorTableUsage =
+          static_cast<lgc::ShadowDescriptorTableUsage>(GetPipelineOptions()->shadowDescriptorTableUsage);
+    options.shadowDescriptorTablePtrHigh = GetPipelineOptions()->shadowDescriptorTablePtrHigh;
+
     if (IsGraphics() && (GetGfxIpVersion().major >= 10))
     {
         // Only set NGG options for a GFX10+ graphics pipeline.

--- a/tool/pipelineDump/vkgcPipelineDumper.cpp
+++ b/tool/pipelineDump/vkgcPipelineDumper.cpp
@@ -53,16 +53,17 @@ namespace Vkgc
 {
 
 // Forward declaration
-std::ostream& operator<<(std::ostream& out, VkVertexInputRate       inputRate);
-std::ostream& operator<<(std::ostream& out, VkFormat                format);
-std::ostream& operator<<(std::ostream& out, VkPrimitiveTopology     topology);
-std::ostream& operator<<(std::ostream& out, VkPolygonMode           polygonMode);
-std::ostream& operator<<(std::ostream& out, VkCullModeFlagBits      cullMode);
-std::ostream& operator<<(std::ostream& out, VkFrontFace             frontFace);
-std::ostream& operator<<(std::ostream& out, ResourceMappingNodeType type);
-std::ostream& operator<<(std::ostream& out, NggSubgroupSizingType   subgroupSizing);
-std::ostream& operator<<(std::ostream& out, NggCompactMode          compactMode);
-std::ostream& operator<<(std::ostream& out, WaveBreakSize           waveBreakSize);
+std::ostream& operator<<(std::ostream& out, VkVertexInputRate           inputRate);
+std::ostream& operator<<(std::ostream& out, VkFormat                    format);
+std::ostream& operator<<(std::ostream& out, VkPrimitiveTopology         topology);
+std::ostream& operator<<(std::ostream& out, VkPolygonMode               polygonMode);
+std::ostream& operator<<(std::ostream& out, VkCullModeFlagBits          cullMode);
+std::ostream& operator<<(std::ostream& out, VkFrontFace                 frontFace);
+std::ostream& operator<<(std::ostream& out, ResourceMappingNodeType     type);
+std::ostream& operator<<(std::ostream& out, NggSubgroupSizingType       subgroupSizing);
+std::ostream& operator<<(std::ostream& out, NggCompactMode              compactMode);
+std::ostream& operator<<(std::ostream& out, WaveBreakSize               waveBreakSize);
+std::ostream& operator<<(std::ostream& out, ShadowDescriptorTableUsage  shadowDescriptorTableUsage);
 
 template std::ostream& operator<<(std::ostream& out, ElfReader<Elf64>& reader);
 template raw_ostream& operator<<(raw_ostream& out, ElfReader<Elf64>& reader);
@@ -714,6 +715,8 @@ void PipelineDumper::DumpPipelineOptions(
     dumpFile << "options.includeIr = " << pOptions->includeIr << "\n";
     dumpFile << "options.robustBufferAccess = " << pOptions->robustBufferAccess << "\n";
     dumpFile << "options.reconfigWorkgroupLayout = " << pOptions->reconfigWorkgroupLayout << "\n";
+    dumpFile << "options.shadowDescriptorTableUsgae = " << pOptions->shadowDescriptorTableUsage << "\n";
+    dumpFile << "options.shadowDescriptorTablePtrHigh = " << pOptions->shadowDescriptorTablePtrHigh << "\n";
 }
 
 // =====================================================================================================================
@@ -939,6 +942,8 @@ MetroHash::Hash PipelineDumper::GenerateHashForComputePipeline(
     hasher.Update(pPipeline->options.scalarBlockLayout);
     hasher.Update(pPipeline->options.includeIr);
     hasher.Update(pPipeline->options.robustBufferAccess);
+    hasher.Update(pPipeline->options.shadowDescriptorTableUsage);
+    hasher.Update(pPipeline->options.shadowDescriptorTablePtrHigh);
 
     MetroHash::Hash hash = {};
     hasher.Finalize(hash.bytes);
@@ -1045,6 +1050,8 @@ void PipelineDumper::UpdateHashForNonFragmentState(
         pHasher->Update(pPipeline->options.includeIr);
         pHasher->Update(pPipeline->options.robustBufferAccess);
         pHasher->Update(pPipeline->options.reconfigWorkgroupLayout);
+        pHasher->Update(pPipeline->options.shadowDescriptorTableUsage);
+        pHasher->Update(pPipeline->options.shadowDescriptorTablePtrHigh);
     }
 }
 
@@ -1803,6 +1810,27 @@ std::ostream& operator<<(
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, _16x16)
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, _32x32)
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, DrawTime)
+        break;
+    default:
+        llvm_unreachable("Should never be called!");
+        break;
+    }
+
+    return out << pString;
+}
+
+// =====================================================================================================================
+// Translates enum "ShadowDescriptorTableUsage" to string and output to ostream.
+std::ostream& operator<<(
+    std::ostream&              out,                         // [out] Output stream
+    ShadowDescriptorTableUsage shadowDescriptorTableUsage)  // Shadow descriptor table setting
+{
+    const char* pString = nullptr;
+    switch (shadowDescriptorTableUsage)
+    {
+    CASE_CLASSENUM_TO_STRING(ShadowDescriptorTableUsage, Auto)
+    CASE_CLASSENUM_TO_STRING(ShadowDescriptorTableUsage, Enable)
+    CASE_CLASSENUM_TO_STRING(ShadowDescriptorTableUsage, Disable)
         break;
     default:
         llvm_unreachable("Should never be called!");

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1118,6 +1118,8 @@ public:
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
         INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
+        INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
         VFX_ASSERT(pTableItem - &m_addrTable[0] <= MemberCount);
     }
 


### PR DESCRIPTION
This allows the VA high ptr value to vary on a per-pipeline basis.
Old command line options are still present and override pipeline
options.

Specifically this is required to address a problem exposed by
PR503 which stopped ignoring variations in VA high ptr value
supplied on the command line.