### PR TITLE
Fixed clang error in "Reserve enum and bitfield spaces for future use"

### DIFF
--- a/lgc/builder/llpcBuilderRecorder.cpp
+++ b/lgc/builder/llpcBuilderRecorder.cpp
@@ -231,6 +231,8 @@ StringRef BuilderRecorder::GetCallName(
         return "image.query.size";
     case Opcode::ImageGetLod:
         return "image.get.lod";
+    case Opcode::Reserved1:
+        return "reserved1";
     case GetSubgroupSize:
         return "get.subgroup.size";
     case SubgroupElect:


### PR DESCRIPTION
My earlier commit caused an error with some versions of clang.

Change-Id: I5eb77c68751cf47fc9813c3c32c0b7ee4182ea5c