### PR TITLE
Re-instate direct sgpr use for top-level compact descriptor

### DIFF
--- a/lgc/patch/llpcPatchEntryPointMutate.cpp
+++ b/lgc/patch/llpcPatchEntryPointMutate.cpp
@@ -433,7 +433,6 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
             switch (pNode->type)
             {
             case ResourceNodeType::DescriptorBuffer:
-            case ResourceNodeType::DescriptorBufferCompact:
             case ResourceNodeType::DescriptorResource:
             case ResourceNodeType::DescriptorSampler:
             case ResourceNodeType::DescriptorTexelBuffer:
@@ -705,7 +704,6 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
                 }
 
             case ResourceNodeType::DescriptorBuffer:
-            case ResourceNodeType::DescriptorBufferCompact:
             case ResourceNodeType::DescriptorResource:
             case ResourceNodeType::DescriptorSampler:
             case ResourceNodeType::DescriptorTexelBuffer:
@@ -720,6 +718,7 @@ FunctionType* PatchEntryPointMutate::GenerateEntryPointType(
                 break;
 
             case ResourceNodeType::PushConst:
+            case ResourceNodeType::DescriptorBufferCompact:
                 {
                     argTys.push_back(VectorType::get(Type::getInt32Ty(*m_pContext), pNode->sizeInDwords));
                     for (uint32_t j = 0; j < pNode->sizeInDwords; ++j)


### PR DESCRIPTION
    Part of my change "Revamped PatchDescriptorLoad" was to handle a
    descriptor in the top-level table (used for a Vulkan "dynamic
    descriptor") by s_loading it from the spill table, to make handling it
    more uniform with other descriptors.
    
    In the case of a compact buffer descriptor, that caused a performance
    regression, because the previous code would pass the two-dword
    descriptor as part of user data sgprs.
    
    This commit reinstates that behavior for a compact buffer descriptor in
    the top-level table.
    
    Change-Id: I46e4fca9a440aeb9c51a52ac618081b616988b40
