### PR TITLE
Be explicit about signedness in CreateShuffleVector

### DIFF
--- a/lgc/builder/llpcBuilderImpl.cpp
+++ b/lgc/builder/llpcBuilderImpl.cpp
@@ -346,7 +346,7 @@ Value* BuilderImplBase::ScalarizeInPairs(
 {
     if (auto pVecTy = dyn_cast<VectorType>(pValue->getType()))
     {
-        Value* pInComps = CreateShuffleVector(pValue, pValue, { 0, 1 });
+        Value* pInComps = CreateShuffleVector(pValue, pValue, ArrayRef<uint32_t>{ 0, 1 });
         Value* pResultComps = callback(pInComps);
         Value* pResult = UndefValue::get(VectorType::get(pResultComps->getType()->getScalarType(),
                                                          pVecTy->getNumElements()));

--- a/lgc/builder/llpcBuilderImplImage.cpp
+++ b/lgc/builder/llpcBuilderImplImage.cpp
@@ -1188,7 +1188,9 @@ Value* BuilderImplImage::CreateImageStore(
         {
             if (pVectorTexelTy->getNumElements() != 4)
             {
-                pTexel = CreateShuffleVector(pTexel, Constant::getNullValue(pTexelTy), { 0, 1, 2, 3 });
+                pTexel = CreateShuffleVector(pTexel,
+                                             Constant::getNullValue(pTexelTy),
+                                             ArrayRef<uint32_t>{ 0, 1, 2, 3 });
             }
         }
         else
@@ -1354,7 +1356,7 @@ Value* BuilderImplImage::CreateImageGather(
     }
 
     // Only the first 4 DWORDs are sampler descriptor, we need to extract these values under any condition
-    pSamplerDesc = CreateShuffleVector(pSamplerDesc, pSamplerDesc, { 0, 1, 2, 3 });
+    pSamplerDesc = CreateShuffleVector(pSamplerDesc, pSamplerDesc, ArrayRef<uint32_t>{ 0, 1, 2, 3 });
 
     Value* pResult = nullptr;
     Value* pAddrOffset = address[ImageAddressIdxOffset];
@@ -1477,7 +1479,7 @@ Value* BuilderImplImage::PreprocessIntegerImageGather(
                                       { getInt32(15), pZero, pImageDesc, pZero, pZero });
     pResInfo = CreateBitCast(pResInfo, VectorType::get(getInt32Ty(), 4));
 
-    Value* pWidthHeight = CreateShuffleVector(pResInfo, pResInfo, { 0, 1 });
+    Value* pWidthHeight = CreateShuffleVector(pResInfo, pResInfo, ArrayRef<uint32_t>{ 0, 1 });
     pWidthHeight = CreateSIToFP(pWidthHeight, VectorType::get(getFloatTy(), 2));
     Value* pValueToAdd = CreateFDiv(ConstantFP::get(pWidthHeight->getType(), -0.5), pWidthHeight);
     uint32_t coordCount = pCoord->getType()->getVectorNumElements();
@@ -1995,7 +1997,7 @@ Value* BuilderImplImage::CreateImageQuerySize(
     if ((dim == Dim1DArray) && (modifiedDim == Dim2DArray))
     {
         // For a 1D array on gfx9+ that we treated as a 2D array, we want components 0 and 2.
-        return CreateShuffleVector(pIntResInfo, pIntResInfo, { 0, 2 }, instName);
+        return CreateShuffleVector(pIntResInfo, pIntResInfo, ArrayRef<uint32_t>{ 0, 2 }, instName);
     }
     return CreateShuffleVector(pIntResInfo,
                                pIntResInfo,
@@ -2039,7 +2041,7 @@ Value* BuilderImplImage::CreateImageGetLod(
                             derivatives);
 
     // Only the first 4 DWORDs are sampler descriptor, we need to extract these values under any condition
-    pSamplerDesc = CreateShuffleVector(pSamplerDesc, pSamplerDesc, { 0, 1, 2, 3 });
+    pSamplerDesc = CreateShuffleVector(pSamplerDesc, pSamplerDesc, ArrayRef<uint32_t>{ 0, 1, 2, 3 });
 
     SmallVector<Value*, 9> args;
     args.push_back(getInt32(3));                    // dmask
@@ -2506,7 +2508,7 @@ Value* BuilderImplImage::HandleFragCoordViewIndex(
                                      {},
                                      &*GetInsertPoint());
         pFragCoord->setName("FragCoord");
-        pFragCoord = CreateShuffleVector(pFragCoord, pFragCoord, { 0, 1 });
+        pFragCoord = CreateShuffleVector(pFragCoord, pFragCoord, ArrayRef<uint32_t>{ 0, 1 });
         pFragCoord = CreateFPToSI(pFragCoord, VectorType::get(getInt32Ty(), 2));
         uint32_t coordCount = pCoord->getType()->getVectorNumElements();
         if (coordCount > 2)

--- a/lgc/builder/llpcBuilderImplInOut.cpp
+++ b/lgc/builder/llpcBuilderImplInOut.cpp
@@ -567,7 +567,7 @@ Value* BuilderImplInOut::EvalIJOffsetSmooth(
     // Adjust each coefficient by offset.
     Value* pAdjusted = AdjustIJ(pPullModel, pOffset);
     // Extract <I/W, J/W, 1/W> part of that
-    Value* pIJDivW = CreateShuffleVector(pAdjusted, pAdjusted, { 0, 1 });
+    Value* pIJDivW = CreateShuffleVector(pAdjusted, pAdjusted, ArrayRef<uint32_t>{ 0, 1 });
     Value* pRcpW = CreateExtractElement(pAdjusted, 2);
     // Get W by making a reciprocal of 1/W
     Value* pW = CreateFDiv(ConstantFP::get(getFloatTy(), 1.0), pRcpW);

--- a/lgc/builder/llpcBuilderImplSubgroup.cpp
+++ b/lgc/builder/llpcBuilderImplSubgroup.cpp
@@ -191,7 +191,9 @@ Value* BuilderImplSubgroup::CreateSubgroupBallot(
     pBallot = CreateBitCast(pBallot, VectorType::get(getInt32Ty(), 2));
 
     ElementCount elementCount = pBallot->getType()->getVectorElementCount();
-    return CreateShuffleVector(pBallot, ConstantVector::getSplat(elementCount, getInt32(0)), { 0, 1, 2, 3 });
+    return CreateShuffleVector(pBallot,
+                               ConstantVector::getSplat(elementCount, getInt32(0)),
+                               ArrayRef<uint32_t>{ 0, 1, 2, 3 });
 }
 
 // =====================================================================================================================
@@ -221,7 +223,9 @@ Value* BuilderImplSubgroup::CreateSubgroupBallotBitExtract(
     {
         Value* pIndexMask = CreateZExtOrTrunc(pIndex, getInt64Ty());
         pIndexMask = CreateShl(getInt64(1), pIndexMask);
-        Value* pValueAsInt64 = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), { 0, 1 });
+        Value* pValueAsInt64 = CreateShuffleVector(pValue,
+                                                   UndefValue::get(pValue->getType()),
+                                                   ArrayRef<uint32_t>{ 0, 1 });
         pValueAsInt64 = CreateBitCast(pValueAsInt64, getInt64Ty());
         Value* const pResult = CreateAnd(pIndexMask, pValueAsInt64);
         return CreateICmpNE(pResult, getInt64(0));
@@ -240,7 +244,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBallotBitCount(
     }
     else
     {
-        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), { 0, 1 });
+        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), ArrayRef<uint32_t>{ 0, 1 });
         pResult = CreateBitCast(pResult, getInt64Ty());
         pResult = CreateUnaryIntrinsic(Intrinsic::ctpop, pResult);
         return CreateZExtOrTrunc(pResult, getInt32Ty());
@@ -271,7 +275,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBallotExclusiveBitCount(
     }
     else
     {
-        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), { 0, 1 });
+        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), ArrayRef<uint32_t>{ 0, 1 });
         pResult = CreateBitCast(pResult, getInt64Ty());
         return CreateSubgroupMbcnt(pResult, "");
     }
@@ -290,7 +294,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBallotFindLsb(
     }
     else
     {
-        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), { 0, 1 });
+        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), ArrayRef<uint32_t>{ 0, 1 });
         pResult = CreateBitCast(pResult, getInt64Ty());
         pResult = CreateIntrinsic(Intrinsic::cttz, getInt64Ty(), { pResult, getTrue() });
         return CreateZExtOrTrunc(pResult, getInt32Ty());
@@ -311,7 +315,7 @@ Value* BuilderImplSubgroup::CreateSubgroupBallotFindMsb(
     }
     else
     {
-        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), { 0, 1 });
+        Value* pResult = CreateShuffleVector(pValue, UndefValue::get(pValue->getType()), ArrayRef<uint32_t>{ 0, 1 });
         pResult = CreateBitCast(pResult, getInt64Ty());
         pResult = CreateIntrinsic(Intrinsic::ctlz, getInt64Ty(), { pResult, getTrue() });
         pResult = CreateZExtOrTrunc(pResult, getInt32Ty());

--- a/lgc/patch/llpcPatchBufferOp.cpp
+++ b/lgc/patch/llpcPatchBufferOp.cpp
@@ -1422,7 +1422,9 @@ Value* PatchBufferOp::GetBaseAddressFromBufferDesc(
     assert(pDescType->getVectorElementType()->isIntegerTy(32));
 
     // Get the base address of our buffer by extracting the two components with the 48-bit address, and masking.
-    Value* pBaseAddr = m_pBuilder->CreateShuffleVector(pBufferDesc, UndefValue::get(pDescType), { 0, 1 });
+    Value* pBaseAddr = m_pBuilder->CreateShuffleVector(pBufferDesc,
+                                                       UndefValue::get(pDescType),
+                                                       ArrayRef<uint32_t>{ 0, 1 });
     Value* const pBaseAddrMask = ConstantVector::get({
                                                         m_pBuilder->getInt32(0xFFFFFFFF),
                                                         m_pBuilder->getInt32(0xFFFF)

--- a/lgc/patch/llpcPatchPeepholeOpt.cpp
+++ b/lgc/patch/llpcPatchPeepholeOpt.cpp
@@ -230,7 +230,7 @@ void PatchPeepholeOpt::visitBitCast(
 
         // Create our new shuffle instruction.
         ShuffleVectorInst* const pNewShuffleVector = new ShuffleVectorInst(
-            pBitCastLhs, pBitCastRhs, pShuffleVector->getMask(), pShuffleVector->getName());
+            pBitCastLhs, pBitCastRhs, pShuffleVector->getOperand(2), pShuffleVector->getName());
         pNewShuffleVector->insertAfter(&bitCast);
 
         // Replace the bit cast with the new shuffle vector.


### PR DESCRIPTION
This is in preparation for https://reviews.llvm.org/D72467
which introduces also the signed version of mask indices in
CreateShuffleVector.