### PR TITLE
Replace use of amdgcn.s_memtime intrinsic with llvm readcyclecounter

### DIFF
--- a/lgc/builder/llpcBuilderImplMisc.cpp
+++ b/lgc/builder/llpcBuilderImplMisc.cpp
@@ -138,7 +138,7 @@ Instruction* BuilderImplMisc::CreateReadClock(
     }
     else
     {
-        pReadClock = CreateIntrinsic(Intrinsic::amdgcn_s_memtime, {}, {}, nullptr, instName);
+        pReadClock = CreateIntrinsic(Intrinsic::readcyclecounter, {}, {}, nullptr, instName);
     }
     pReadClock->addAttribute(AttributeList::FunctionIndex, Attribute::ReadOnly);
 

--- a/llpc/test/shaderdb/ExtGcnShader_TestBuiltInFunc_lit.frag
+++ b/llpc/test/shaderdb/ExtGcnShader_TestBuiltInFunc_lit.frag
@@ -31,7 +31,7 @@ void main()
 ; SHADERTEST: call {{.*}} float @llvm.amdgcn.cubema
 ; SHADERTEST: call {{.*}} float @llvm.amdgcn.cubesc
 ; SHADERTEST: call {{.*}} float @llvm.amdgcn.cubetc
-; SHADERTEST: [[TIME:%[^ ]*]] = call i64 @llvm.amdgcn.s.memtime()
+; SHADERTEST: [[TIME:%[^ ]*]] = call i64 @llvm.readcyclecounter()
 ; SHADERTEST: = call i64 asm sideeffect "; %1", "=r,0"(i64 [[TIME]])
 ; SHADERTEST: AMDLLPC SUCCESS
 */


### PR DESCRIPTION
The result is the same and we're now using a more generic approach.