### PR TITLE
Fix the use of Llpc::ShadowDescriptorTableUsage with Vkgc::

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -246,11 +246,11 @@ void PipelineContext::SetOptionsInPipeline(
     options.reconfigWorkgroupLayout = GetPipelineOptions()->reconfigWorkgroupLayout;
     options.includeIr = (IncludeLlvmIr || GetPipelineOptions()->includeIr);
 
-    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Llpc::ShadowDescriptorTableUsage::Auto) ==
+    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Vkgc::ShadowDescriptorTableUsage::Auto) ==
                                                           lgc::ShadowDescriptorTableUsage::Auto, "mismatch");
-    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Llpc::ShadowDescriptorTableUsage::Enable) ==
+    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Vkgc::ShadowDescriptorTableUsage::Enable) ==
                                                           lgc::ShadowDescriptorTableUsage::Enable, "mismatch");
-    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Llpc::ShadowDescriptorTableUsage::Disable) ==
+    static_assert(static_cast<lgc::ShadowDescriptorTableUsage>(Vkgc::ShadowDescriptorTableUsage::Disable) ==
                                                           lgc::ShadowDescriptorTableUsage::Disable, "mismatch");
     options.shadowDescriptorTableUsage =
           static_cast<lgc::ShadowDescriptorTableUsage>(GetPipelineOptions()->shadowDescriptorTableUsage);


### PR DESCRIPTION
Vkgc:: should be used for items defined in vkgcDefs.h to avoid build failure when LLPC_CLIENT_INTEFACE_MAJOR_VERSION >= 39.