### PR TITLE
Removed 'using namespace llvm' in header files

### DIFF
--- a/lgc/builder/llpcBuilderImpl.h
+++ b/lgc/builder/llpcBuilderImpl.h
@@ -36,8 +36,6 @@
 namespace lgc
 {
 
-using namespace llvm;
-
 // =====================================================================================================================
 // Builder implementation base class
 class BuilderImplBase : public Builder
@@ -46,9 +44,9 @@ public:
     BuilderImplBase(BuilderContext* pBuilderContext) : Builder(pBuilderContext) {}
 
     // Create scalar from dot product of vector
-    Value* CreateDotProduct(Value* const pVector1,
-                            Value* const pVector2,
-                            const Twine& instName = "") override final;
+    llvm::Value* CreateDotProduct(llvm::Value* const pVector1,
+                            llvm::Value* const pVector2,
+                            const llvm::Twine& instName = "") override final;
 
 protected:
     // Get the ShaderModes object.
@@ -67,30 +65,30 @@ protected:
     bool SupportPermLaneDpp() const;
 
     // Create an "if..endif" or "if..else..endif" structure.
-    BranchInst* CreateIf(Value* pCondition, bool wantElse, const Twine& instName);
+    llvm::BranchInst* CreateIf(llvm::Value* pCondition, bool wantElse, const llvm::Twine& instName);
 
     // Create a waterfall loop containing the specified instruction.
-    Instruction* CreateWaterfallLoop(Instruction*       pNonUniformInst,
-                                     ArrayRef<uint32_t> operandIdxs,
-                                     const Twine&       instName = "");
+    llvm::Instruction* CreateWaterfallLoop(llvm::Instruction*       pNonUniformInst,
+                                     llvm::ArrayRef<uint32_t> operandIdxs,
+                                     const llvm::Twine&       instName = "");
 
     // Helper method to scalarize a possibly vector unary operation
-    Value* Scalarize(Value* pValue, std::function<Value*(Value*)> callback);
+    llvm::Value* Scalarize(llvm::Value* pValue, std::function<llvm::Value*(llvm::Value*)> callback);
 
     // Helper method to scalarize in pairs a possibly vector unary operation.
-    Value* ScalarizeInPairs(Value*                        pValue,
-                            std::function<Value*(Value*)> callback);
+    llvm::Value* ScalarizeInPairs(llvm::Value*                        pValue,
+                            std::function<llvm::Value*(llvm::Value*)> callback);
 
     // Helper method to scalarize a possibly vector binary operation
-    Value* Scalarize(Value*                                 pValue0,
-                     Value*                                 pValue1,
-                     std::function<Value*(Value*, Value*)>  callback);
+    llvm::Value* Scalarize(llvm::Value*                                 pValue0,
+                     llvm::Value*                                 pValue1,
+                     std::function<llvm::Value*(llvm::Value*, llvm::Value*)>  callback);
 
     // Helper method to scalarize a possibly vector trinary operation
-    Value* Scalarize(Value*                                        pValue0,
-                     Value*                                        pValue1,
-                     Value*                                        pValue2,
-                     std::function<Value*(Value*, Value*, Value*)> callback);
+    llvm::Value* Scalarize(llvm::Value*                                        pValue0,
+                     llvm::Value*                                        pValue1,
+                     llvm::Value*                                        pValue2,
+                     std::function<llvm::Value*(llvm::Value*, llvm::Value*, llvm::Value*)> callback);
 
     PipelineState*  m_pPipelineState = nullptr;   // Pipeline state
 
@@ -109,97 +107,97 @@ public:
 
     // Create calculation of 2D texture coordinates that would be used for accessing the selected cube map face for
     // the given cube map texture coordinates.
-    Value* CreateCubeFaceCoord(Value* pCoord, const Twine& instName = "") override final;
+    llvm::Value* CreateCubeFaceCoord(llvm::Value* pCoord, const llvm::Twine& instName = "") override final;
 
     // Create calculation of the index of the cube map face that would be accessed by a texture lookup function for
     // the given cube map texture coordinates.
-    Value* CreateCubeFaceIndex(Value* pCoord, const Twine& instName = "") override final;
+    llvm::Value* CreateCubeFaceIndex(llvm::Value* pCoord, const llvm::Twine& instName = "") override final;
 
     // Create scalar or vector FP truncate operation with rounding mode.
-    Value* CreateFpTruncWithRounding(Value*                                pValue,
-                                     Type*                                 pDestTy,
+    llvm::Value* CreateFpTruncWithRounding(llvm::Value*                                pValue,
+                                     llvm::Type*                                 pDestTy,
                                      unsigned                              roundingMode,
-                                     const Twine&                          instName = "") override final;
+                                     const llvm::Twine&                          instName = "") override final;
 
     // Create quantize operation.
-    Value* CreateQuantizeToFp16(Value* pValue, const Twine& instName = "") override final;
+    llvm::Value* CreateQuantizeToFp16(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
 
     // Create signed integer or FP modulo operation.
-    Value* CreateSMod(Value* pDividend, Value* pDivisor, const Twine& instName = "") override final;
-    Value* CreateFMod(Value* pDividend, Value* pDivisor, const Twine& instName = "") override final;
+    llvm::Value* CreateSMod(llvm::Value* pDividend, llvm::Value* pDivisor, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMod(llvm::Value* pDividend, llvm::Value* pDivisor, const llvm::Twine& instName = "") override final;
 
     // Create scalar/vector float/half fused multiply-and-add, to compute a * b + c
-    Value* CreateFma(Value* pA, Value* pB, Value* pC, const Twine& instName = "") override final;
+    llvm::Value* CreateFma(llvm::Value* pA, llvm::Value* pB, llvm::Value* pC, const llvm::Twine& instName = "") override final;
 
     // Methods to create trig and exponential operations.
-    Value* CreateTan(Value* pX, const Twine& instName = "") override final;
-    Value* CreateASin(Value* pX, const Twine& instName = "") override final;
-    Value* CreateACos(Value* pX, const Twine& instName = "") override final;
-    Value* CreateATan(Value* pYOverX, const Twine& instName = "") override final;
-    Value* CreateATan2(Value* pY, Value* pX, const Twine& instName = "") override final;
-    Value* CreateSinh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateCosh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateTanh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateASinh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateACosh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateATanh(Value* pX, const Twine& instName = "") override final;
-    Value* CreatePower(Value* pX, Value* pY, const Twine& instName = "") override final;
-    Value* CreateExp(Value* pX, const Twine& instName = "") override final;
-    Value* CreateLog(Value* pX, const Twine& instName = "") override final;
-    Value* CreateInverseSqrt(Value* pX, const Twine& instName = "") override final;
+    llvm::Value* CreateTan(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateASin(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateACos(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateATan(llvm::Value* pYOverX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateATan2(llvm::Value* pY, llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateSinh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateCosh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateTanh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateASinh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateACosh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateATanh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreatePower(llvm::Value* pX, llvm::Value* pY, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateExp(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateLog(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateInverseSqrt(llvm::Value* pX, const llvm::Twine& instName = "") override final;
 
     // General arithmetic operations.
-    Value* CreateSAbs(Value* pX, const Twine& instName = "") override final;
-    Value* CreateFSign(Value* pX, const Twine& instName = "") override final;
-    Value* CreateSSign(Value* pX, const Twine& instName = "") override final;
-    Value* CreateFract(Value* pX, const Twine& instName = "") override final;
-    Value* CreateSmoothStep(Value* pEdge0, Value* pEdge1, Value* pX, const Twine& instName = "") override final;
-    Value* CreateLdexp(Value* pX, Value* pExp, const Twine& instName = "") override final;
-    Value* CreateExtractSignificand(Value* pValue, const Twine& instName = "") override final;
-    Value* CreateExtractExponent(Value* pValue, const Twine& instName = "") override final;
-    Value* CreateCrossProduct(Value* pX, Value* pY, const Twine& instName = "") override final;
-    Value* CreateNormalizeVector(Value* pX, const Twine& instName = "") override final;
-    Value* CreateFaceForward(Value* pN, Value* pI, Value* pNref, const Twine& instName = "") override final;
-    Value* CreateReflect(Value* pI, Value* pN, const Twine& instName = "") override final;
-    Value* CreateRefract(Value* pI, Value* pN, Value* pEta, const Twine& instName = "") override final;
+    llvm::Value* CreateSAbs(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFSign(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateSSign(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFract(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateSmoothStep(llvm::Value* pEdge0, llvm::Value* pEdge1, llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateLdexp(llvm::Value* pX, llvm::Value* pExp, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateExtractSignificand(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateExtractExponent(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateCrossProduct(llvm::Value* pX, llvm::Value* pY, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateNormalizeVector(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFaceForward(llvm::Value* pN, llvm::Value* pI, llvm::Value* pNref, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateReflect(llvm::Value* pI, llvm::Value* pN, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateRefract(llvm::Value* pI, llvm::Value* pN, llvm::Value* pEta, const llvm::Twine& instName = "") override final;
 
     // Create "fclamp" operation.
-    Value* CreateFClamp(Value* pX, Value* pMinVal, Value* pMaxVal, const Twine& instName = "") override final;
+    llvm::Value* CreateFClamp(llvm::Value* pX, llvm::Value* pMinVal, llvm::Value* pMaxVal, const llvm::Twine& instName = "") override final;
 
     // FP min/max
-    Value* CreateFMin(Value* pValue1, Value* pValue2, const Twine& instName = "") override final;
-    Value* CreateFMax(Value* pValue1, Value* pValue2, const Twine& instName = "") override final;
+    llvm::Value* CreateFMin(llvm::Value* pValue1, llvm::Value* pValue2, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMax(llvm::Value* pValue1, llvm::Value* pValue2, const llvm::Twine& instName = "") override final;
 
     // Methods for trinary min/max/mid.
-    Value* CreateFMin3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
-    Value* CreateFMax3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
-    Value* CreateFMid3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    llvm::Value* CreateFMin3(llvm::Value* pValue1, llvm::Value* pValue2, llvm::Value* pValue3, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMax3(llvm::Value* pValue1, llvm::Value* pValue2, llvm::Value* pValue3, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMid3(llvm::Value* pValue1, llvm::Value* pValue2, llvm::Value* pValue3, const llvm::Twine& instName = "") override final;
 
     // Create "isInf" operation: return true if the supplied FP (or vector) value is infinity
-    Value* CreateIsInf(Value* pX, const Twine& instName = "") override final;
+    llvm::Value* CreateIsInf(llvm::Value* pX, const llvm::Twine& instName = "") override final;
 
     // Create "isNaN" operation: return true if the supplied FP (or vector) value is NaN
-    Value* CreateIsNaN(Value* pX, const Twine& instName = "") override final;
+    llvm::Value* CreateIsNaN(llvm::Value* pX, const llvm::Twine& instName = "") override final;
 
     // Create an "insert bitfield" operation for a (vector of) integer type.
-    Value* CreateInsertBitField(Value*        pBase,
-                                Value*        pInsert,
-                                Value*        pOffset,
-                                Value*        pCount,
-                                const Twine&  instName = "") override final;
+    llvm::Value* CreateInsertBitField(llvm::Value*        pBase,
+                                llvm::Value*        pInsert,
+                                llvm::Value*        pOffset,
+                                llvm::Value*        pCount,
+                                const llvm::Twine&  instName = "") override final;
 
     // Create an "extract bitfield " operation for a (vector of) i32.
-    Value* CreateExtractBitField(Value*        pBase,
-                                 Value*        pOffset,
-                                 Value*        pCount,
+    llvm::Value* CreateExtractBitField(llvm::Value*        pBase,
+                                 llvm::Value*        pOffset,
+                                 llvm::Value*        pCount,
                                  bool          isSigned,
-                                 const Twine&  instName = "") override final;
+                                 const llvm::Twine&  instName = "") override final;
 
     // Create "find MSB" operation for a (vector of) signed int.
-    Value* CreateFindSMsb(Value* pValue, const Twine& instName = "") override final;
+    llvm::Value* CreateFindSMsb(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
 
     // Create "fmix" operation.
-    Value* CreateFMix(Value* pX, Value* pY, Value* pA, const Twine& instName = "") override final;
+    llvm::Value* CreateFMix(llvm::Value* pX, llvm::Value* pY, llvm::Value* pA, const llvm::Twine& instName = "") override final;
 
 private:
     BuilderImplArith() = delete;
@@ -207,14 +205,14 @@ private:
     BuilderImplArith& operator=(const BuilderImplArith&) = delete;
 
     // Common code for asin and acos
-    Value* ASinACosCommon(Value* pX, Constant* pCoefP0, Constant* pCoefP1);
+    llvm::Value* ASinACosCommon(llvm::Value* pX, llvm::Constant* pCoefP0, llvm::Constant* pCoefP1);
 
     // Generate FP division, using fast fdiv for float to bypass optimization.
-    Value* FDivFast(Value* pNumerator, Value* pDenominator);
+    llvm::Value* FDivFast(llvm::Value* pNumerator, llvm::Value* pDenominator);
 
     // Helper method to create call to llvm.amdgcn.class, scalarizing if necessary. This is not exposed outside of
     // BuilderImplArith.
-    Value* CreateCallAmdgcnClass(Value* pValue, uint32_t flags, const Twine& instName = "");
+    llvm::Value* CreateCallAmdgcnClass(llvm::Value* pValue, uint32_t flags, const llvm::Twine& instName = "");
 
     // Methods to get various FP constants as scalar or vector. Any needed directly by a client should be moved
     // to llpcBuilder.h. Using these (rather than just using for example
@@ -223,49 +221,49 @@ private:
     // TODO: Use values that are suitable for doubles.
 
     // Get PI = 3.14159274 scalar or vector
-    Constant* GetPi(Type* pTy)
+    llvm::Constant* GetPi(llvm::Type* pTy)
     {
-        return GetFpConstant(pTy, APFloat(APFloat::IEEEdouble(), APInt(64, 0x400921FB60000000)));
+        return GetFpConstant(pTy, llvm::APFloat(llvm::APFloat::IEEEdouble(), llvm::APInt(64, 0x400921FB60000000)));
     }
 
     // Get PI/2 = 1.57079637 scalar or vector
-    Constant* GetPiByTwo(Type* pTy)
+    llvm::Constant* GetPiByTwo(llvm::Type* pTy)
     {
-        return GetFpConstant(pTy, APFloat(APFloat::IEEEdouble(), APInt(64, 0x3FF921FB60000000)));
+        return GetFpConstant(pTy, llvm::APFloat(llvm::APFloat::IEEEdouble(), llvm::APInt(64, 0x3FF921FB60000000)));
     }
 
     // Get PI/4 - 1 = -0.21460181 scalar or vector
-    Constant* GetPiByFourMinusOne(Type* pTy)
+    llvm::Constant* GetPiByFourMinusOne(llvm::Type* pTy)
     {
-        return GetFpConstant(pTy, APFloat(APFloat::IEEEdouble(), APInt(64, 0xBFCB781280000000)));
+        return GetFpConstant(pTy, llvm::APFloat(llvm::APFloat::IEEEdouble(), llvm::APInt(64, 0xBFCB781280000000)));
     }
 
     // Get 1/log(2) = 1.442695 scalar or vector
-    Constant* GetRecipLog2(Type* pTy)
+    llvm::Constant* GetRecipLog2(llvm::Type* pTy)
     {
-        return GetFpConstant(pTy, APFloat(APFloat::IEEEdouble(), APInt(64, 0x3FF7154760000000)));
+        return GetFpConstant(pTy, llvm::APFloat(llvm::APFloat::IEEEdouble(), llvm::APInt(64, 0x3FF7154760000000)));
     }
 
     // Get 0.5 * log(2) = 0.34657359 scalar or vector
-    Constant* GetHalfLog2(Type* pTy)
+    llvm::Constant* GetHalfLog2(llvm::Type* pTy)
     {
-        return GetFpConstant(pTy, APFloat(APFloat::IEEEdouble(), APInt(64, 0x3FD62E4300000000)));
+        return GetFpConstant(pTy, llvm::APFloat(llvm::APFloat::IEEEdouble(), llvm::APInt(64, 0x3FD62E4300000000)));
     }
 
     // Get log(2) = 0.6931471824646 scalar or vector
-    Constant* GetLog2(Type* pTy)
+    llvm::Constant* GetLog2(llvm::Type* pTy)
     {
-        return GetFpConstant(pTy, APFloat(APFloat::IEEEdouble(), APInt(64, 0x3FE62E4300000000)));
+        return GetFpConstant(pTy, llvm::APFloat(llvm::APFloat::IEEEdouble(), llvm::APInt(64, 0x3FE62E4300000000)));
     }
 
     // Get 2^-15 (normalized float16 minimum) scalar or vector
-    Constant* GetMinNormalizedF16(Type* pTy)
+    llvm::Constant* GetMinNormalizedF16(llvm::Type* pTy)
     {
-        return ConstantFP::get(pTy, 0.000030517578125);
+        return llvm::ConstantFP::get(pTy, 0.000030517578125);
     }
 
     // Ensure result is canonicalized if the shader's FP mode is flush denorms.
-    Value* Canonicalize(Value* pValue);
+    llvm::Value* Canonicalize(llvm::Value* pValue);
 };
 
 // =====================================================================================================================
@@ -276,58 +274,58 @@ public:
     BuilderImplDesc(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a load of a buffer descriptor.
-    Value* CreateLoadBufferDesc(uint32_t      descSet,
+    llvm::Value* CreateLoadBufferDesc(uint32_t      descSet,
                                 uint32_t      binding,
-                                Value*        pDescIndex,
+                                llvm::Value*        pDescIndex,
                                 bool          isNonUniform,
                                 bool          isWritten,
-                                Type*         pPointeeTy,
-                                const Twine&  instName) override final;
+                                llvm::Type*         pPointeeTy,
+                                const llvm::Twine&  instName) override final;
 
     // Add index onto pointer to image/sampler/texelbuffer/F-mask array of descriptors.
-    Value* CreateIndexDescPtr(Value*        pDescPtr,
-                              Value*        pIndex,
+    llvm::Value* CreateIndexDescPtr(llvm::Value*        pDescPtr,
+                              llvm::Value*        pIndex,
                               bool          isNonUniform,
-                              const Twine&  instName) override final;
+                              const llvm::Twine&  instName) override final;
 
     // Load image/sampler/texelbuffer/F-mask descriptor from pointer.
-    Value* CreateLoadDescFromPtr(Value*        pDescPtr,
-                                 const Twine&  instName) override final;
+    llvm::Value* CreateLoadDescFromPtr(llvm::Value*        pDescPtr,
+                                 const llvm::Twine&  instName) override final;
 
     // Create a pointer to sampler descriptor. Returns a value of the type returned by GetSamplerDescPtrTy.
-    Value* CreateGetSamplerDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetSamplerDescPtr(uint32_t      descSet,
                                    uint32_t      binding,
-                                   const Twine&  instName) override final;
+                                   const llvm::Twine&  instName) override final;
 
     // Create a pointer to image descriptor. Returns a value of the type returned by GetImageDescPtrTy.
-    Value* CreateGetImageDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetImageDescPtr(uint32_t      descSet,
                                  uint32_t      binding,
-                                 const Twine&  instName) override final;
+                                 const llvm::Twine&  instName) override final;
 
     // Create a pointer to texel buffer descriptor. Returns a value of the type returned by GetTexelBufferDescPtrTy.
-    Value* CreateGetTexelBufferDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetTexelBufferDescPtr(uint32_t      descSet,
                                        uint32_t      binding,
-                                       const Twine&  instName) override final;
+                                       const llvm::Twine&  instName) override final;
 
     // Create a pointer to F-mask descriptor. Returns a value of the type returned by GetFmaskDescPtrTy.
-    Value* CreateGetFmaskDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetFmaskDescPtr(uint32_t      descSet,
                                  uint32_t      binding,
-                                 const Twine&  instName) override final;
+                                 const llvm::Twine&  instName) override final;
 
     // Create a load of the push constants pointer.
-    Value* CreateLoadPushConstantsPtr(Type*         pPushConstantsTy,
-                                      const Twine&  instName) override final;
+    llvm::Value* CreateLoadPushConstantsPtr(llvm::Type*         pPushConstantsTy,
+                                      const llvm::Twine&  instName) override final;
 
     // Create a buffer length query based on the specified descriptor.
-    Value* CreateGetBufferDescLength(Value* const pBufferDesc,
-                                     const Twine& instName = "") override final;
+    llvm::Value* CreateGetBufferDescLength(llvm::Value* const pBufferDesc,
+                                     const llvm::Twine& instName = "") override final;
 
 private:
     BuilderImplDesc() = delete;
     BuilderImplDesc(const BuilderImplDesc&) = delete;
     BuilderImplDesc& operator=(const BuilderImplDesc&) = delete;
 
-    Value* ScalarizeIfUniform(Value* pValue, bool isNonUniform);
+    llvm::Value* ScalarizeIfUniform(llvm::Value* pValue, bool isNonUniform);
 };
 
 // =====================================================================================================================
@@ -338,109 +336,109 @@ public:
     BuilderImplImage(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create an image load.
-    Value* CreateImageLoad(Type*             pResultTy,
+    llvm::Value* CreateImageLoad(llvm::Type*             pResultTy,
                            uint32_t          dim,
                            uint32_t          flags,
-                           Value*            pImageDesc,
-                           Value*            pCoord,
-                           Value*            pMipLevel,
-                           const Twine&      instName = "") override final;
+                           llvm::Value*            pImageDesc,
+                           llvm::Value*            pCoord,
+                           llvm::Value*            pMipLevel,
+                           const llvm::Twine&      instName = "") override final;
 
     // Create an image load with F-mask.
-    Value* CreateImageLoadWithFmask(Type*             pResultTy,
+    llvm::Value* CreateImageLoadWithFmask(llvm::Type*             pResultTy,
                                     uint32_t          dim,
                                     uint32_t          flags,
-                                    Value*            pImageDesc,
-                                    Value*            pFmaskDesc,
-                                    Value*            pCoord,
-                                    Value*            pSampleNum,
-                                    const Twine&      instName = "") override final;
+                                    llvm::Value*            pImageDesc,
+                                    llvm::Value*            pFmaskDesc,
+                                    llvm::Value*            pCoord,
+                                    llvm::Value*            pSampleNum,
+                                    const llvm::Twine&      instName = "") override final;
 
     // Create an image store.
-    Value* CreateImageStore(Value*           pTexel,
+    llvm::Value* CreateImageStore(llvm::Value*           pTexel,
                             uint32_t         dim,
                             uint32_t         flags,
-                            Value*           pImageDesc,
-                            Value*           pCoord,
-                            Value*           pMipLevel,
-                            const Twine&     instName = "") override final;
+                            llvm::Value*           pImageDesc,
+                            llvm::Value*           pCoord,
+                            llvm::Value*           pMipLevel,
+                            const llvm::Twine&     instName = "") override final;
 
     // Create an image sample.
-    Value* CreateImageSample(Type*             pResultTy,
+    llvm::Value* CreateImageSample(llvm::Type*             pResultTy,
                              uint32_t          dim,
                              uint32_t          flags,
-                             Value*            pImageDesc,
-                             Value*            pSamplerDesc,
-                             ArrayRef<Value*>  address,
-                             const Twine&      instName = "") override final;
+                             llvm::Value*            pImageDesc,
+                             llvm::Value*            pSamplerDesc,
+                             llvm::ArrayRef<llvm::Value*>  address,
+                             const llvm::Twine&      instName = "") override final;
 
     // Create an image sample with conversion.
     // This is not yet a Builder API, but it could become one if there was to be a new SPIR-V YCbCr
     // converting sampler spec that allows the SPIR-V reader to tell that it has a converting sampler.
-    Value* CreateImageSampleConvert(Type*             pResultTy,
+    llvm::Value* CreateImageSampleConvert(llvm::Type*             pResultTy,
                                     uint32_t          dim,
                                     uint32_t          flags,
-                                    Value*            pImageDesc,
-                                    Value*            pConvertingSamplerDesc,
-                                    ArrayRef<Value*>  address,
-                                    const Twine&      instName = "");
+                                    llvm::Value*            pImageDesc,
+                                    llvm::Value*            pConvertingSamplerDesc,
+                                    llvm::ArrayRef<llvm::Value*>  address,
+                                    const llvm::Twine&      instName = "");
 
     // Create an image gather
-    Value* CreateImageGather(Type*             pResultTy,
+    llvm::Value* CreateImageGather(llvm::Type*             pResultTy,
                              uint32_t          dim,
                              uint32_t          flags,
-                             Value*            pImageDesc,
-                             Value*            pSamplerDesc,
-                             ArrayRef<Value*>  address,
-                             const Twine&      instName = "") override final;
+                             llvm::Value*            pImageDesc,
+                             llvm::Value*            pSamplerDesc,
+                             llvm::ArrayRef<llvm::Value*>  address,
+                             const llvm::Twine&      instName = "") override final;
 
     // Create an image atomic operation other than compare-and-swap.
-    Value* CreateImageAtomic(uint32_t         atomicOp,
+    llvm::Value* CreateImageAtomic(uint32_t         atomicOp,
                              uint32_t         dim,
                              uint32_t         flags,
-                             AtomicOrdering   ordering,
-                             Value*           pImageDesc,
-                             Value*           pCoord,
-                             Value*           pInputValue,
-                             const Twine&     instName = "") override final;
+                             llvm::AtomicOrdering   ordering,
+                             llvm::Value*           pImageDesc,
+                             llvm::Value*           pCoord,
+                             llvm::Value*           pInputValue,
+                             const llvm::Twine&     instName = "") override final;
 
     // Create an image atomic compare-and-swap.
-    Value* CreateImageAtomicCompareSwap(uint32_t        dim,
+    llvm::Value* CreateImageAtomicCompareSwap(uint32_t        dim,
                                         uint32_t        flags,
-                                        AtomicOrdering  ordering,
-                                        Value*          pImageDesc,
-                                        Value*          pCoord,
-                                        Value*          pInputValue,
-                                        Value*          pComparatorValue,
-                                        const Twine&    instName = "") override final;
+                                        llvm::AtomicOrdering  ordering,
+                                        llvm::Value*          pImageDesc,
+                                        llvm::Value*          pCoord,
+                                        llvm::Value*          pInputValue,
+                                        llvm::Value*          pComparatorValue,
+                                        const llvm::Twine&    instName = "") override final;
 
     // Create a query of the number of mipmap levels in an image. Returns an i32 value.
-    Value* CreateImageQueryLevels(uint32_t                dim,
+    llvm::Value* CreateImageQueryLevels(uint32_t                dim,
                                   uint32_t                flags,
-                                  Value*                  pImageDesc,
-                                  const Twine&            instName = "") override final;
+                                  llvm::Value*                  pImageDesc,
+                                  const llvm::Twine&            instName = "") override final;
 
     // Create a query of the number of samples in an image. Returns an i32 value.
-    Value* CreateImageQuerySamples(uint32_t                dim,
+    llvm::Value* CreateImageQuerySamples(uint32_t                dim,
                                    uint32_t                flags,
-                                   Value*                  pImageDesc,
-                                   const Twine&            instName = "") override final;
+                                   llvm::Value*                  pImageDesc,
+                                   const llvm::Twine&            instName = "") override final;
 
     // Create a query of size of an image at the specified LOD
-    Value* CreateImageQuerySize(uint32_t          dim,
+    llvm::Value* CreateImageQuerySize(uint32_t          dim,
                                 uint32_t          flags,
-                                Value*            pImageDesc,
-                                Value*            pLod,
-                                const Twine&      instName = "") override final;
+                                llvm::Value*            pImageDesc,
+                                llvm::Value*            pLod,
+                                const llvm::Twine&      instName = "") override final;
 
     // Create a get of the LOD that would be used for an image sample with the given coordinates
     // and implicit LOD.
-    Value* CreateImageGetLod(uint32_t          dim,
+    llvm::Value* CreateImageGetLod(uint32_t          dim,
                              uint32_t          flags,
-                             Value*            pImageDesc,
-                             Value*            pSamplerDesc,
-                             Value*            pCoord,
-                             const Twine&      instName = "") override final;
+                             llvm::Value*            pImageDesc,
+                             llvm::Value*            pSamplerDesc,
+                             llvm::Value*            pCoord,
+                             const llvm::Twine&      instName = "") override final;
 
 private:
     BuilderImplImage() = delete;
@@ -448,36 +446,36 @@ private:
     BuilderImplImage& operator=(const BuilderImplImage&) = delete;
 
     // Implement pre-GFX9 integer gather workaround to patch descriptor or coordinate before the gather
-    Value* PreprocessIntegerImageGather(uint32_t dim, Value*& pImageDesc, Value*& pCoord);
+    llvm::Value* PreprocessIntegerImageGather(uint32_t dim, llvm::Value*& pImageDesc, llvm::Value*& pCoord);
 
     // Implement pre-GFX9 integer gather workaround to modify result.
-    Value* PostprocessIntegerImageGather(Value*   pNeedDescPatch,
+    llvm::Value* PostprocessIntegerImageGather(llvm::Value*   pNeedDescPatch,
                                          uint32_t flags,
-                                         Value*   pImageDesc,
-                                         Type*    pTexelTy,
-                                         Value*   pResult);
+                                         llvm::Value*   pImageDesc,
+                                         llvm::Type*    pTexelTy,
+                                         llvm::Value*   pResult);
 
     // Common code to create an image sample or gather.
-    Value* CreateImageSampleGather(Type*            pResultTy,
+    llvm::Value* CreateImageSampleGather(llvm::Type*            pResultTy,
                                    uint32_t         dim,
                                    uint32_t         flags,
-                                   Value*           pCoord,
-                                   Value*           pImageDesc,
-                                   Value*           pSamplerDesc,
-                                   ArrayRef<Value*> address,
-                                   const Twine&     instName,
+                                   llvm::Value*           pCoord,
+                                   llvm::Value*           pImageDesc,
+                                   llvm::Value*           pSamplerDesc,
+                                   llvm::ArrayRef<llvm::Value*> address,
+                                   const llvm::Twine&     instName,
                                    bool             isSample);
 
     // Common code for CreateImageAtomic and CreateImageAtomicCompareSwap
-    Value* CreateImageAtomicCommon(uint32_t          atomicOp,
+    llvm::Value* CreateImageAtomicCommon(uint32_t          atomicOp,
                                    uint32_t          dim,
                                    uint32_t          flags,
-                                   AtomicOrdering    ordering,
-                                   Value*            pImageDesc,
-                                   Value*            pCoord,
-                                   Value*            pInputValue,
-                                   Value*            pComparatorValue,
-                                   const Twine&      instName);
+                                   llvm::AtomicOrdering    ordering,
+                                   llvm::Value*            pImageDesc,
+                                   llvm::Value*            pCoord,
+                                   llvm::Value*            pInputValue,
+                                   llvm::Value*            pComparatorValue,
+                                   const llvm::Twine&      instName);
 
     // Change 1D or 1DArray dimension to 2D or 2DArray if needed as a workaround on GFX9+
     uint32_t Change1DTo2DIfNeeded(uint32_t dim);
@@ -486,21 +484,21 @@ private:
     // modifying if necessary.
     // Returns possibly modified image dimension.
     uint32_t PrepareCoordinate(uint32_t                  dim,
-                               Value*                    pCoord,
-                               Value*                    pProjective,
-                               Value*                    pDerivativeX,
-                               Value*                    pDerivativeY,
-                               SmallVectorImpl<Value*>&  outCoords,
-                               SmallVectorImpl<Value*>&  outDerivatives);
+                               llvm::Value*                    pCoord,
+                               llvm::Value*                    pProjective,
+                               llvm::Value*                    pDerivativeX,
+                               llvm::Value*                    pDerivativeY,
+                               llvm::SmallVectorImpl<llvm::Value*>&  outCoords,
+                               llvm::SmallVectorImpl<llvm::Value*>&  outDerivatives);
 
     // For a cubearray with integer coordinates, combine the face and slice into a single component.
-    void CombineCubeArrayFaceAndSlice(Value* pCoord, SmallVectorImpl<Value*>& coords);
+    void CombineCubeArrayFaceAndSlice(llvm::Value* pCoord, llvm::SmallVectorImpl<llvm::Value*>& coords);
 
     // Patch descriptor with cube dimension for image call
-    Value* PatchCubeDescriptor(Value* pDesc, uint32_t dim);
+    llvm::Value* PatchCubeDescriptor(llvm::Value* pDesc, uint32_t dim);
 
     // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
-    Value* HandleFragCoordViewIndex(Value* pCoord, uint32_t flags, uint32_t& dim);
+    llvm::Value* HandleFragCoordViewIndex(llvm::Value* pCoord, uint32_t flags, uint32_t& dim);
 
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -522,66 +520,66 @@ public:
     BuilderImplInOut(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a read of (part of) a user input value.
-    Value* CreateReadGenericInput(Type*         pResultTy,
+    llvm::Value* CreateReadGenericInput(llvm::Type*         pResultTy,
                                   uint32_t      location,
-                                  Value*        pLocationOffset,
-                                  Value*        pElemIdx,
+                                  llvm::Value*        pLocationOffset,
+                                  llvm::Value*        pElemIdx,
                                   uint32_t      locationCount,
                                   InOutInfo     inputInfo,
-                                  Value*        pVertexIndex,
-                                  const Twine&  instName = "") override final;
+                                  llvm::Value*        pVertexIndex,
+                                  const llvm::Twine&  instName = "") override final;
 
     // Create a read of (part of) a user output value.
-    Value* CreateReadGenericOutput(Type*         pResultTy,
+    llvm::Value* CreateReadGenericOutput(llvm::Type*         pResultTy,
                                    uint32_t      location,
-                                   Value*        pLocationOffset,
-                                   Value*        pElemIdx,
+                                   llvm::Value*        pLocationOffset,
+                                   llvm::Value*        pElemIdx,
                                    uint32_t      locationCount,
                                    InOutInfo     outputInfo,
-                                   Value*        pVertexIndex,
-                                   const Twine&  instName = "") override final;
+                                   llvm::Value*        pVertexIndex,
+                                   const llvm::Twine&  instName = "") override final;
 
     // Create a write of (part of) a user output value.
-    Instruction* CreateWriteGenericOutput(Value*        pValueToWrite,
+    llvm::Instruction* CreateWriteGenericOutput(llvm::Value*        pValueToWrite,
                                           uint32_t      location,
-                                          Value*        pLocationOffset,
-                                          Value*        pElemIdx,
+                                          llvm::Value*        pLocationOffset,
+                                          llvm::Value*        pElemIdx,
                                           uint32_t      locationCount,
                                           InOutInfo     outputInfo,
-                                          Value*        pVertexIndex) override final;
+                                          llvm::Value*        pVertexIndex) override final;
 
     // Create a write to an XFB (transform feedback / streamout) buffer.
-    Instruction* CreateWriteXfbOutput(Value*        pValueToWrite,
+    llvm::Instruction* CreateWriteXfbOutput(llvm::Value*        pValueToWrite,
                                       bool          isBuiltIn,
                                       uint32_t      location,
                                       uint32_t      xfbBuffer,
                                       uint32_t      xfbStride,
-                                      Value*        pXfbOffset,
+                                      llvm::Value*        pXfbOffset,
                                       InOutInfo     outputInfo) override final;
 
     // Create a read of (part of) a built-in input value.
-    Value* CreateReadBuiltInInput(BuiltInKind  builtIn,
+    llvm::Value* CreateReadBuiltInInput(BuiltInKind  builtIn,
                                   InOutInfo    inputInfo,
-                                  Value*       pVertexIndex,
-                                  Value*       pIndex,
-                                  const Twine& instName = "") override final;
+                                  llvm::Value*       pVertexIndex,
+                                  llvm::Value*       pIndex,
+                                  const llvm::Twine& instName = "") override final;
 
     // Create a read of (part of) an output built-in value.
-    Value* CreateReadBuiltInOutput(BuiltInKind  builtIn,
+    llvm::Value* CreateReadBuiltInOutput(BuiltInKind  builtIn,
                                    InOutInfo    outputInfo,
-                                   Value*       pVertexIndex,
-                                   Value*       pIndex,
-                                   const Twine& instName = "") override final;
+                                   llvm::Value*       pVertexIndex,
+                                   llvm::Value*       pIndex,
+                                   const llvm::Twine& instName = "") override final;
 
     // Create a write of (part of) a built-in output value.
-    Instruction* CreateWriteBuiltInOutput(Value*        pValueToWrite,
+    llvm::Instruction* CreateWriteBuiltInOutput(llvm::Value*        pValueToWrite,
                                           BuiltInKind   builtIn,
                                           InOutInfo     outputInfo,
-                                          Value*        pVertexIndex,
-                                          Value*        pIndex) override final;
+                                          llvm::Value*        pVertexIndex,
+                                          llvm::Value*        pIndex) override final;
 
     // Get name of built-in
-    static StringRef GetBuiltInName(BuiltInKind builtIn);
+    static llvm::StringRef GetBuiltInName(BuiltInKind builtIn);
 
 private:
     BuilderImplInOut() = delete;
@@ -589,45 +587,45 @@ private:
     BuilderImplInOut& operator=(const BuilderImplInOut&) = delete;
 
     // Read (a part of) a generic (user) input/output value.
-    Value* ReadGenericInputOutput(bool          isOutput,
-                                  Type*         pResultTy,
+    llvm::Value* ReadGenericInputOutput(bool          isOutput,
+                                  llvm::Type*         pResultTy,
                                   uint32_t      location,
-                                  Value*        pLocationOffset,
-                                  Value*        pElemIdx,
+                                  llvm::Value*        pLocationOffset,
+                                  llvm::Value*        pElemIdx,
                                   uint32_t      locationCount,
                                   InOutInfo     inOutInfo,
-                                  Value*        pVertexIndex,
-                                  const Twine&  instName);
+                                  llvm::Value*        pVertexIndex,
+                                  const llvm::Twine&  instName);
 
     // Mark usage for a generic (user) input or output
     void MarkGenericInputOutputUsage(bool          isOutput,
                                      uint32_t      location,
                                      uint32_t      locationCount,
                                      InOutInfo     inOutInfo,
-                                     Value*        pVertexIndex);
+                                     llvm::Value*        pVertexIndex);
 
     // Mark interpolation info for FS input.
     void MarkInterpolationInfo(InOutInfo interpInfo);
 
     // Mark fragment output type
-    void MarkFsOutputType(Type* pOutputTy, uint32_t location, InOutInfo outputInfo);
+    void MarkFsOutputType(llvm::Type* pOutputTy, uint32_t location, InOutInfo outputInfo);
 
     // Modify aux interp value according to custom interp mode, and its helper functions.
-    Value* ModifyAuxInterpValue(Value* pAuxInterpValue, InOutInfo inputInfo);
-    Value* EvalIJOffsetNoPersp(Value* pOffset);
-    Value* EvalIJOffsetSmooth(Value* pOffset);
-    Value* AdjustIJ(Value* pValue, Value* pOffset);
+    llvm::Value* ModifyAuxInterpValue(llvm::Value* pAuxInterpValue, InOutInfo inputInfo);
+    llvm::Value* EvalIJOffsetNoPersp(llvm::Value* pOffset);
+    llvm::Value* EvalIJOffsetSmooth(llvm::Value* pOffset);
+    llvm::Value* AdjustIJ(llvm::Value* pValue, llvm::Value* pOffset);
 
     // Read (part of) a built-in value
-    Value* ReadBuiltIn(bool         isOutput,
+    llvm::Value* ReadBuiltIn(bool         isOutput,
                        BuiltInKind  builtIn,
                        InOutInfo    inOutInfo,
-                       Value*       pVertexIndex,
-                       Value*       pIndex,
-                       const Twine& instName);
+                       llvm::Value*       pVertexIndex,
+                       llvm::Value*       pIndex,
+                       const llvm::Twine& instName);
 
     // Get the type of a built-in. This overrides the one in Builder to additionally recognize the internal built-ins.
-    Type* GetBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo);
+    llvm::Type* GetBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo);
 
     // Mark usage of a built-in input
     void MarkBuiltInInputUsage(BuiltInKind builtIn, uint32_t arraySize);
@@ -655,39 +653,39 @@ public:
     BuilderImplMatrix(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a matrix transpose.
-    Value* CreateTransposeMatrix(Value* const pMatrix,
-                                 const Twine& instName = "") override final;
+    llvm::Value* CreateTransposeMatrix(llvm::Value* const pMatrix,
+                                 const llvm::Twine& instName = "") override final;
 
     // Create matrix multiplication: matrix times scalar, resulting in matrix
-    Value* CreateMatrixTimesScalar(Value* const pMatrix,
-                                   Value* const pScalar,
-                                   const Twine& instName = "") override final;
+    llvm::Value* CreateMatrixTimesScalar(llvm::Value* const pMatrix,
+                                   llvm::Value* const pScalar,
+                                   const llvm::Twine& instName = "") override final;
 
     // Create matrix multiplication: vector times matrix, resulting in vector
-    Value* CreateVectorTimesMatrix(Value* const pVector,
-                                   Value* const pMatrix,
-                                   const Twine& instName = "") override final;
+    llvm::Value* CreateVectorTimesMatrix(llvm::Value* const pVector,
+                                   llvm::Value* const pMatrix,
+                                   const llvm::Twine& instName = "") override final;
 
     // Create matrix multiplication: matrix times vector, resulting in vector
-    Value* CreateMatrixTimesVector(Value* const pMatrix,
-                                   Value* const pVector,
-                                   const Twine& instName = "") override final;
+    llvm::Value* CreateMatrixTimesVector(llvm::Value* const pMatrix,
+                                   llvm::Value* const pVector,
+                                   const llvm::Twine& instName = "") override final;
 
     // Create matrix multiplication:  matrix times matrix, resulting in matrix
-    Value* CreateMatrixTimesMatrix(Value* const pMatrix1,
-                                   Value* const pMatrix2,
-                                   const Twine& instName = "") override final;
+    llvm::Value* CreateMatrixTimesMatrix(llvm::Value* const pMatrix1,
+                                   llvm::Value* const pMatrix2,
+                                   const llvm::Twine& instName = "") override final;
 
     // Create vector outer product operation, resulting in matrix
-    Value* CreateOuterProduct(Value* const pVector1,
-                              Value* const pVector2,
-                              const Twine& instName = "") override final;
+    llvm::Value* CreateOuterProduct(llvm::Value* const pVector1,
+                              llvm::Value* const pVector2,
+                              const llvm::Twine& instName = "") override final;
 
     // Create matrix determinant operation.
-    Value* CreateDeterminant(Value* const pMatrix, const Twine& instName = "") override final;
+    llvm::Value* CreateDeterminant(llvm::Value* const pMatrix, const llvm::Twine& instName = "") override final;
 
     // Create matrix inverse operation.
-    Value* CreateMatrixInverse(Value* const pMatrix, const Twine& instName = "") override final;
+    llvm::Value* CreateMatrixInverse(llvm::Value* const pMatrix, const llvm::Twine& instName = "") override final;
 
 private:
     BuilderImplMatrix() = delete;
@@ -695,11 +693,11 @@ private:
     BuilderImplMatrix& operator=(const BuilderImplMatrix&) = delete;
 
     // Helper function for determinant calculation
-    Value* Determinant(ArrayRef<Value*> elements, uint32_t order);
+    llvm::Value* Determinant(llvm::ArrayRef<llvm::Value*> elements, uint32_t order);
 
     // Get submatrix by deleting specified row and column
-    void GetSubmatrix(ArrayRef<Value*>        matrix,
-                      MutableArrayRef<Value*> submatrix,
+    void GetSubmatrix(llvm::ArrayRef<llvm::Value*>        matrix,
+                      llvm::MutableArrayRef<llvm::Value*> submatrix,
                       uint32_t                order,
                       uint32_t                rowToDelete,
                       uint32_t                columnToDelete);
@@ -714,28 +712,28 @@ public:
 
     // In the GS, emit the current values of outputs (as written by CreateWriteBuiltIn and CreateWriteOutput) to
     // the current output primitive in the specified output-primitive stream.
-    Instruction* CreateEmitVertex(uint32_t streamId) override final;
+    llvm::Instruction* CreateEmitVertex(uint32_t streamId) override final;
 
     // In the GS, finish the current primitive and start a new one in the specified output-primitive stream.
-    Instruction* CreateEndPrimitive(uint32_t streamId) override final;
+    llvm::Instruction* CreateEndPrimitive(uint32_t streamId) override final;
 
     // Create a workgroup control barrier.
-    Instruction* CreateBarrier() override final;
+    llvm::Instruction* CreateBarrier() override final;
 
     // Create a "kill". Only allowed in a fragment shader.
-    Instruction* CreateKill(const Twine& instName) override final;
+    llvm::Instruction* CreateKill(const llvm::Twine& instName) override final;
 
     // Create a "readclock".
-    Instruction* CreateReadClock(bool realtime, const Twine& instName) override final;
+    llvm::Instruction* CreateReadClock(bool realtime, const llvm::Twine& instName) override final;
 
     // Create derivative calculation on float or vector of float or half
-    Value* CreateDerivative(Value* pValue, bool isDirectionY, bool isFine, const Twine& instName = "") override final;
+    llvm::Value* CreateDerivative(llvm::Value* pValue, bool isDirectionY, bool isFine, const llvm::Twine& instName = "") override final;
 
     // Create a demote to helper invocation operation. Only allowed in a fragment shader.
-    Instruction* CreateDemoteToHelperInvocation(const Twine& instName) override final;
+    llvm::Instruction* CreateDemoteToHelperInvocation(const llvm::Twine& instName) override final;
 
     // Create a helper invocation query. Only allowed in a fragment shader.
-    Value* CreateIsHelperInvocation(const Twine& instName) override final;
+    llvm::Value* CreateIsHelperInvocation(const llvm::Twine& instName) override final;
 
 private:
     BuilderImplMisc() = delete;
@@ -751,142 +749,142 @@ public:
     BuilderImplSubgroup(BuilderContext* pBuilderContext) : BuilderImplBase(pBuilderContext) {}
 
     // Create a get subgroup size query.
-    Value* CreateGetSubgroupSize(const Twine& instName) override final;
+    llvm::Value* CreateGetSubgroupSize(const llvm::Twine& instName) override final;
 
     // Create a subgroup elect.
-    Value* CreateSubgroupElect(const Twine& instName) override final;
+    llvm::Value* CreateSubgroupElect(const llvm::Twine& instName) override final;
 
     // Create a subgroup all.
-    Value* CreateSubgroupAll(Value* const pValue,
+    llvm::Value* CreateSubgroupAll(llvm::Value* const pValue,
                              bool         wqm,
-                             const Twine& instName) override final;
+                             const llvm::Twine& instName) override final;
 
     // Create a subgroup any
-    Value* CreateSubgroupAny(Value* const pValue,
+    llvm::Value* CreateSubgroupAny(llvm::Value* const pValue,
                              bool         wqm,
-                             const Twine& instName) override final;
+                             const llvm::Twine& instName) override final;
 
     // Create a subgroup all equal.
-    Value* CreateSubgroupAllEqual(Value* const pValue,
+    llvm::Value* CreateSubgroupAllEqual(llvm::Value* const pValue,
                                   bool         wqm,
-                                  const Twine& instName) override final;
+                                  const llvm::Twine& instName) override final;
 
     // Create a subgroup broadcast.
-    Value* CreateSubgroupBroadcast(Value* const pValue,
-                                   Value* const pIndex,
-                                   const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBroadcast(llvm::Value* const pValue,
+                                   llvm::Value* const pIndex,
+                                   const llvm::Twine& instName) override final;
 
     // Create a subgroup broadcast first.
-    Value* CreateSubgroupBroadcastFirst(Value* const pValue,
-                                        const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBroadcastFirst(llvm::Value* const pValue,
+                                        const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot.
-    Value* CreateSubgroupBallot(Value* const pValue,
-                                const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallot(llvm::Value* const pValue,
+                                const llvm::Twine& instName) override final;
 
     // Create a subgroup inverse ballot.
-    Value* CreateSubgroupInverseBallot(Value* const pValue,
-                                       const Twine& instName) override final;
+    llvm::Value* CreateSubgroupInverseBallot(llvm::Value* const pValue,
+                                       const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot bit extract.
-    Value* CreateSubgroupBallotBitExtract(Value* const pValue,
-                                          Value* const pIndex,
-                                          const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotBitExtract(llvm::Value* const pValue,
+                                          llvm::Value* const pIndex,
+                                          const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot bit count.
-    Value* CreateSubgroupBallotBitCount(Value* const pValue,
-                                        const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotBitCount(llvm::Value* const pValue,
+                                        const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot inclusive bit count.
-    Value* CreateSubgroupBallotInclusiveBitCount(Value* const pValue,
-                                                 const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotInclusiveBitCount(llvm::Value* const pValue,
+                                                 const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot exclusive bit count.
-    Value* CreateSubgroupBallotExclusiveBitCount(Value* const pValue,
-                                                 const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotExclusiveBitCount(llvm::Value* const pValue,
+                                                 const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot find least significant bit.
-    Value* CreateSubgroupBallotFindLsb(Value* const pValue,
-                                       const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotFindLsb(llvm::Value* const pValue,
+                                       const llvm::Twine& instName) override final;
 
     // Create a subgroup ballot find most significant bit.
-    Value* CreateSubgroupBallotFindMsb(Value* const pValue,
-                                       const Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotFindMsb(llvm::Value* const pValue,
+                                       const llvm::Twine& instName) override final;
 
     // Create a subgroup shuffle.
-    Value* CreateSubgroupShuffle(Value* const pValue,
-                                 Value* const pIndex,
-                                 const Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffle(llvm::Value* const pValue,
+                                 llvm::Value* const pIndex,
+                                 const llvm::Twine& instName) override final;
 
     // Create a subgroup shuffle xor.
-    Value* CreateSubgroupShuffleXor(Value* const pValue,
-                                    Value* const pMask,
-                                    const Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffleXor(llvm::Value* const pValue,
+                                    llvm::Value* const pMask,
+                                    const llvm::Twine& instName) override final;
 
     // Create a subgroup shuffle up.
-    Value* CreateSubgroupShuffleUp(Value* const pValue,
-                                   Value* const pDelta,
-                                   const Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffleUp(llvm::Value* const pValue,
+                                   llvm::Value* const pDelta,
+                                   const llvm::Twine& instName) override final;
 
     // Create a subgroup shuffle down.
-    Value* CreateSubgroupShuffleDown(Value* const pValue,
-                                     Value* const pDelta,
-                                     const Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffleDown(llvm::Value* const pValue,
+                                     llvm::Value* const pDelta,
+                                     const llvm::Twine& instName) override final;
 
     // Create a subgroup clustered reduction.
-    Value* CreateSubgroupClusteredReduction(GroupArithOp groupArithOp,
-                                            Value* const pValue,
-                                            Value* const pClusterSize,
-                                            const Twine& instName) override final;
+    llvm::Value* CreateSubgroupClusteredReduction(GroupArithOp groupArithOp,
+                                            llvm::Value* const pValue,
+                                            llvm::Value* const pClusterSize,
+                                            const llvm::Twine& instName) override final;
 
     // Create a subgroup clustered inclusive scan.
-    Value* CreateSubgroupClusteredInclusive(GroupArithOp groupArithOp,
-                                            Value* const pValue,
-                                            Value* const pClusterSize,
-                                            const Twine& instName) override final;
+    llvm::Value* CreateSubgroupClusteredInclusive(GroupArithOp groupArithOp,
+                                            llvm::Value* const pValue,
+                                            llvm::Value* const pClusterSize,
+                                            const llvm::Twine& instName) override final;
 
     // Create a subgroup clustered exclusive scan.
-    Value* CreateSubgroupClusteredExclusive(GroupArithOp groupArithOp,
-                                            Value* const pValue,
-                                            Value* const pClusterSize,
-                                            const Twine& instName) override final;
+    llvm::Value* CreateSubgroupClusteredExclusive(GroupArithOp groupArithOp,
+                                            llvm::Value* const pValue,
+                                            llvm::Value* const pClusterSize,
+                                            const llvm::Twine& instName) override final;
 
     // Create a subgroup quad broadcast.
-    Value* CreateSubgroupQuadBroadcast(Value* const pValue,
-                                       Value* const pIndex,
-                                       const Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadBroadcast(llvm::Value* const pValue,
+                                       llvm::Value* const pIndex,
+                                       const llvm::Twine& instName) override final;
 
     // Create a subgroup quad swap horizontal.
-    Value* CreateSubgroupQuadSwapHorizontal(Value* const pValue,
-                                            const Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadSwapHorizontal(llvm::Value* const pValue,
+                                            const llvm::Twine& instName) override final;
 
     // Create a subgroup quad swap vertical.
-    Value* CreateSubgroupQuadSwapVertical(Value* const pValue,
-                                          const Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadSwapVertical(llvm::Value* const pValue,
+                                          const llvm::Twine& instName) override final;
 
     // Create a subgroup quad swap diagonal.
-    Value* CreateSubgroupQuadSwapDiagonal(Value* const pValue,
-                                          const Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadSwapDiagonal(llvm::Value* const pValue,
+                                          const llvm::Twine& instName) override final;
 
     // Create a subgroup swizzle quad.
-    Value* CreateSubgroupSwizzleQuad(Value* const pValue,
-                                     Value* const pOffset,
-                                     const Twine& instName) override final;
+    llvm::Value* CreateSubgroupSwizzleQuad(llvm::Value* const pValue,
+                                     llvm::Value* const pOffset,
+                                     const llvm::Twine& instName) override final;
 
     // Create a subgroup swizzle masked.
-    Value* CreateSubgroupSwizzleMask(Value* const pValue,
-                                     Value* const pMask,
-                                     const Twine& instName) override final;
+    llvm::Value* CreateSubgroupSwizzleMask(llvm::Value* const pValue,
+                                     llvm::Value* const pMask,
+                                     const llvm::Twine& instName) override final;
 
     // Create a subgroup write invocation.
-    Value* CreateSubgroupWriteInvocation(Value* const pInputValue,
-                                         Value* const pWriteValue,
-                                         Value* const pIndex,
-                                         const Twine& instName) override final;
+    llvm::Value* CreateSubgroupWriteInvocation(llvm::Value* const pInputValue,
+                                         llvm::Value* const pWriteValue,
+                                         llvm::Value* const pIndex,
+                                         const llvm::Twine& instName) override final;
 
     // Create a subgroup mbcnt.
-    Value* CreateSubgroupMbcnt(Value* const pMask,
-                               const Twine& instName) override final;
+    llvm::Value* CreateSubgroupMbcnt(llvm::Value* const pMask,
+                               const llvm::Twine& instName) override final;
 
 private:
     BuilderImplSubgroup() = delete;
@@ -916,48 +914,48 @@ private:
     };
 
     uint32_t GetShaderSubgroupSize();
-    Value* CreateGroupArithmeticIdentity(GroupArithOp   groupArithOp,
-                                         Type* const    pType);
-    Value* CreateGroupArithmeticOperation(GroupArithOp groupArithOp,
-                                          Value* const pX,
-                                          Value* const pY);
-    Value* CreateInlineAsmSideEffect(Value* const pValue);
-    Value* CreateDppMov(Value* const pValue,
+    llvm::Value* CreateGroupArithmeticIdentity(GroupArithOp   groupArithOp,
+                                         llvm::Type* const    pType);
+    llvm::Value* CreateGroupArithmeticOperation(GroupArithOp groupArithOp,
+                                          llvm::Value* const pX,
+                                          llvm::Value* const pY);
+    llvm::Value* CreateInlineAsmSideEffect(llvm::Value* const pValue);
+    llvm::Value* CreateDppMov(llvm::Value* const pValue,
                         DppCtrl      dppCtrl,
                         uint32_t     rowMask,
                         uint32_t     bankMask,
                         bool         boundCtrl);
-    Value* CreateDppUpdate(Value* const pOrigValue,
-                           Value* const pUpdateValue,
+    llvm::Value* CreateDppUpdate(llvm::Value* const pOrigValue,
+                           llvm::Value* const pUpdateValue,
                            DppCtrl      dppCtrl,
                            uint32_t     rowMask,
                            uint32_t     bankMask,
                            bool         boundCtrl);
 
-    Value* CreatePermLane16(Value* const pOrigValue,
-                            Value* const pUpdateValue,
+    llvm::Value* CreatePermLane16(llvm::Value* const pOrigValue,
+                            llvm::Value* const pUpdateValue,
                             uint32_t     selectBitsLow,
                             uint32_t     selectBitsHigh,
                             bool         fetchInactive,
                             bool         boundCtrl);
-    Value* CreatePermLaneX16(Value* const pOrigValue,
-                             Value* const pUpdateValue,
+    llvm::Value* CreatePermLaneX16(llvm::Value* const pOrigValue,
+                             llvm::Value* const pUpdateValue,
                              uint32_t     selectBitsLow,
                              uint32_t     selectBitsHigh,
                              bool         fetchInactive,
                              bool         boundCtrl);
 
-    Value* CreateDsSwizzle(Value* const pValue,
+    llvm::Value* CreateDsSwizzle(llvm::Value* const pValue,
                            uint16_t     dsPattern);
-    Value* CreateWwm(Value* const pValue);
-    Value* CreateSetInactive(Value* const pActive,
-                             Value* const pInactive);
-    Value* CreateThreadMask();
-    Value* CreateThreadMaskedSelect(
-        Value* const pThreadMask,
+    llvm::Value* CreateWwm(llvm::Value* const pValue);
+    llvm::Value* CreateSetInactive(llvm::Value* const pActive,
+                             llvm::Value* const pInactive);
+    llvm::Value* CreateThreadMask();
+    llvm::Value* CreateThreadMaskedSelect(
+        llvm::Value* const pThreadMask,
         uint64_t     andMask,
-        Value* const pValue1,
-        Value* const pValue2);
+        llvm::Value* const pValue1,
+        llvm::Value* const pValue2);
     uint16_t GetDsSwizzleBitMode(uint8_t xorMask,
                                  uint8_t orMask,
                                  uint8_t andMask);
@@ -965,7 +963,7 @@ private:
                                   uint8_t lane1,
                                   uint8_t lane2,
                                   uint8_t lane3);
-    Value* CreateGroupBallot(Value* const pValue);
+    llvm::Value* CreateGroupBallot(llvm::Value* const pValue);
 };
 
 // =====================================================================================================================

--- a/lgc/builder/llpcBuilderRecorder.h
+++ b/lgc/builder/llpcBuilderRecorder.h
@@ -48,8 +48,6 @@ void initializeBuilderReplayerPass(PassRegistry&);
 namespace lgc
 {
 
-using namespace llvm;
-
 class PipelineState;
 
 // Prefix of all recorded calls.
@@ -64,7 +62,7 @@ class BuilderRecorderMetadataKinds
 {
 public:
     BuilderRecorderMetadataKinds() {}
-    BuilderRecorderMetadataKinds(LLVMContext& context);
+    BuilderRecorderMetadataKinds(llvm::LLVMContext& context);
 
     uint32_t        m_opcodeMetaKindId;                         // Cached metadata kinds for opcode
 };
@@ -224,438 +222,438 @@ public:
     };
 
     // Given an opcode, get the call name (without the "llpc.call." prefix)
-    static StringRef GetCallName(Opcode opcode);
+    static llvm::StringRef GetCallName(Opcode opcode);
 
     // Record shader modes into IR metadata if this is a shader compile (no PipelineState).
-    void RecordShaderModes(Module* pModule) override final;
+    void RecordShaderModes(llvm::Module* pModule) override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Base class operations
 
-    Value* CreateDotProduct(Value* const pVector1,
-                            Value* const pVector2,
-                            const Twine& instName = "") override final;
+    llvm::Value* CreateDotProduct(llvm::Value* const pVector1,
+                            llvm::Value* const pVector2,
+                            const llvm::Twine& instName = "") override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Arithmetic operations
 
     // Create calculation of 2D texture coordinates that would be used for accessing the selected cube map face for
     // the given cube map texture coordinates.
-    Value* CreateCubeFaceCoord(Value* pCoord, const Twine& instName = "") override final;
+    llvm::Value* CreateCubeFaceCoord(llvm::Value* pCoord, const llvm::Twine& instName = "") override final;
 
     // Create calculation of the index of the cube map face that would be accessed by a texture lookup function for
     // the given cube map texture coordinates.
-    Value* CreateCubeFaceIndex(Value* pCoord, const Twine& instName = "") override final;
+    llvm::Value* CreateCubeFaceIndex(llvm::Value* pCoord, const llvm::Twine& instName = "") override final;
 
     // Create scalar or vector FP truncate operation with rounding mode.
-    Value* CreateFpTruncWithRounding(Value*            pValue,
-                                     Type*             pDestTy,
+    llvm::Value* CreateFpTruncWithRounding(llvm::Value*            pValue,
+                                     llvm::Type*             pDestTy,
                                      unsigned          roundingMode,
-                                     const Twine&      instName = "") override final;
+                                     const llvm::Twine&      instName = "") override final;
 
     // Create quantize operation.
-    Value* CreateQuantizeToFp16(Value* pValue, const Twine& instName = "") override final;
+    llvm::Value* CreateQuantizeToFp16(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
 
     // Create signed integer or FP modulo operation.
-    Value* CreateSMod(Value* pDividend, Value* pDivisor, const Twine& instName = "") override final;
-    Value* CreateFMod(Value* pDividend, Value* pDivisor, const Twine& instName = "") override final;
+    llvm::Value* CreateSMod(llvm::Value* pDividend, llvm::Value* pDivisor, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMod(llvm::Value* pDividend, llvm::Value* pDivisor, const llvm::Twine& instName = "") override final;
 
     // Create scalar/vector float/half fused multiply-and-add, to compute a * b + c
-    Value* CreateFma(Value* pA, Value* pB, Value* pC, const Twine& instName = "") override final;
+    llvm::Value* CreateFma(llvm::Value* pA, llvm::Value* pB, llvm::Value* pC, const llvm::Twine& instName = "") override final;
 
     // Trig and exponent operations.
-    Value* CreateTan(Value* pX, const Twine& instName = "") override final;
-    Value* CreateASin(Value* pX, const Twine& instName = "") override final;
-    Value* CreateACos(Value* pX, const Twine& instName = "") override final;
-    Value* CreateATan(Value* pYOverX, const Twine& instName = "") override final;
-    Value* CreateATan2(Value* pY, Value* pX, const Twine& instName = "") override final;
-    Value* CreateSinh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateCosh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateTanh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateASinh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateACosh(Value* pX, const Twine& instName = "") override final;
-    Value* CreateATanh(Value* pX, const Twine& instName = "") override final;
-    Value* CreatePower(Value* pX, Value* pY, const Twine& instName = "") override final;
-    Value* CreateExp(Value* pX, const Twine& instName = "") override final;
-    Value* CreateLog(Value* pX, const Twine& instName = "") override final;
-    Value* CreateInverseSqrt(Value* pX, const Twine& instName = "") override final;
+    llvm::Value* CreateTan(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateASin(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateACos(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateATan(llvm::Value* pYOverX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateATan2(llvm::Value* pY, llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateSinh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateCosh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateTanh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateASinh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateACosh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateATanh(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreatePower(llvm::Value* pX, llvm::Value* pY, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateExp(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateLog(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateInverseSqrt(llvm::Value* pX, const llvm::Twine& instName = "") override final;
 
     // General arithmetic operations.
-    Value* CreateSAbs(Value* pX, const Twine& instName = "") override final;
-    Value* CreateFSign(Value* pX, const Twine& instName = "") override final;
-    Value* CreateSSign(Value* pX, const Twine& instName = "") override final;
-    Value* CreateFract(Value* pX, const Twine& instName = "") override final;
-    Value* CreateSmoothStep(Value* pEdge0, Value* pEdge1, Value* pXValue, const Twine& instName = "") override final;
-    Value* CreateLdexp(Value* pX, Value* pExp, const Twine& instName = "") override final;
-    Value* CreateExtractSignificand(Value* pValue, const Twine& instName = "") override final;
-    Value* CreateExtractExponent(Value* pValue, const Twine& instName = "") override final;
-    Value* CreateCrossProduct(Value* pX, Value* pY, const Twine& instName = "") override final;
-    Value* CreateNormalizeVector(Value* pX, const Twine& instName = "") override final;
-    Value* CreateFaceForward(Value* pN, Value* pI, Value* pNref, const Twine& instName = "") override final;
-    Value* CreateReflect(Value* pI, Value* pN, const Twine& instName = "") override final;
-    Value* CreateRefract(Value* pI, Value* pN, Value* pEta, const Twine& instName = "") override final;
+    llvm::Value* CreateSAbs(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFSign(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateSSign(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFract(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateSmoothStep(llvm::Value* pEdge0, llvm::Value* pEdge1, llvm::Value* pXValue, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateLdexp(llvm::Value* pX, llvm::Value* pExp, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateExtractSignificand(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateExtractExponent(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateCrossProduct(llvm::Value* pX, llvm::Value* pY, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateNormalizeVector(llvm::Value* pX, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFaceForward(llvm::Value* pN, llvm::Value* pI, llvm::Value* pNref, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateReflect(llvm::Value* pI, llvm::Value* pN, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateRefract(llvm::Value* pI, llvm::Value* pN, llvm::Value* pEta, const llvm::Twine& instName = "") override final;
 
     // Create "fclamp" operation.
-    Value* CreateFClamp(Value* pX, Value* pMinVal, Value* pMaxVal, const Twine& instName = "") override final;
+    llvm::Value* CreateFClamp(llvm::Value* pX, llvm::Value* pMinVal, llvm::Value* pMaxVal, const llvm::Twine& instName = "") override final;
 
     // FP min/max
-    Value* CreateFMin(Value* pValue1, Value* pValue2, const Twine& instName = "") override final;
-    Value* CreateFMax(Value* pValue1, Value* pValue2, const Twine& instName = "") override final;
+    llvm::Value* CreateFMin(llvm::Value* pValue1, llvm::Value* pValue2, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMax(llvm::Value* pValue1, llvm::Value* pValue2, const llvm::Twine& instName = "") override final;
 
     // Methods for trinary min/max/mid.
-    Value* CreateFMin3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
-    Value* CreateFMax3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
-    Value* CreateFMid3(Value* pValue1, Value* pValue2, Value* pValue3, const Twine& instName = "") override final;
+    llvm::Value* CreateFMin3(llvm::Value* pValue1, llvm::Value* pValue2, llvm::Value* pValue3, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMax3(llvm::Value* pValue1, llvm::Value* pValue2, llvm::Value* pValue3, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateFMid3(llvm::Value* pValue1, llvm::Value* pValue2, llvm::Value* pValue3, const llvm::Twine& instName = "") override final;
 
     // Create derivative calculation on float or vector of float or half
-    Value* CreateDerivative(Value* pValue, bool isDirectionY, bool isFine, const Twine& instName = "") override final;
+    llvm::Value* CreateDerivative(llvm::Value* pValue, bool isDirectionY, bool isFine, const llvm::Twine& instName = "") override final;
 
     // Create "isInf" operation: return true if the supplied FP (or vector) value is infinity
-    Value* CreateIsInf(Value* pX, const Twine& instName = "") override final;
+    llvm::Value* CreateIsInf(llvm::Value* pX, const llvm::Twine& instName = "") override final;
 
     // Create "isNaN" operation: return true if the supplied FP (or vector) value is NaN
-    Value* CreateIsNaN(Value* pX, const Twine& instName = "") override final;
+    llvm::Value* CreateIsNaN(llvm::Value* pX, const llvm::Twine& instName = "") override final;
 
     // Create an "insert bitfield" operation for a (vector of) integer type.
-    Value* CreateInsertBitField(Value*        pBase,
-                                Value*        pInsert,
-                                Value*        pOffset,
-                                Value*        pCount,
-                                const Twine&  instName = "") override final;
+    llvm::Value* CreateInsertBitField(llvm::Value*        pBase,
+                                llvm::Value*        pInsert,
+                                llvm::Value*        pOffset,
+                                llvm::Value*        pCount,
+                                const llvm::Twine&  instName = "") override final;
 
     // Create an "extract bitfield " operation for a (vector of) i32.
-    Value* CreateExtractBitField(Value*        pBase,
-                                 Value*        pOffset,
-                                 Value*        pCount,
+    llvm::Value* CreateExtractBitField(llvm::Value*        pBase,
+                                 llvm::Value*        pOffset,
+                                 llvm::Value*        pCount,
                                  bool          isSigned,
-                                 const Twine&  instName = "") override final;
+                                 const llvm::Twine&  instName = "") override final;
 
     // Create "find MSB" operation for a (vector of) signed int.
-    Value* CreateFindSMsb(Value* pValue, const Twine& instName = "") override final;
+    llvm::Value* CreateFindSMsb(llvm::Value* pValue, const llvm::Twine& instName = "") override final;
 
     // Create "fmix" operation.
-    Value* CreateFMix(Value* pX, Value* pY, Value* pA, const Twine& instName = "") override final;
+    llvm::Value* CreateFMix(llvm::Value* pX, llvm::Value* pY, llvm::Value* pA, const llvm::Twine& instName = "") override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Descriptor operations
 
-    Value* CreateLoadBufferDesc(uint32_t      descSet,
+    llvm::Value* CreateLoadBufferDesc(uint32_t      descSet,
                                 uint32_t      binding,
-                                Value*        pDescIndex,
+                                llvm::Value*        pDescIndex,
                                 bool          isNonUniform,
                                 bool          isWritten,
-                                Type*         pPointeeTy,
-                                const Twine&  instName) override final;
+                                llvm::Type*         pPointeeTy,
+                                const llvm::Twine&  instName) override final;
 
-    Value* CreateIndexDescPtr(Value*        pDescPtr,
-                              Value*        pIndex,
+    llvm::Value* CreateIndexDescPtr(llvm::Value*        pDescPtr,
+                              llvm::Value*        pIndex,
                               bool          isNonUniform,
-                              const Twine&  instName) override final;
+                              const llvm::Twine&  instName) override final;
 
-    Value* CreateLoadDescFromPtr(Value*        pDescPtr,
-                                 const Twine&  instName) override final;
+    llvm::Value* CreateLoadDescFromPtr(llvm::Value*        pDescPtr,
+                                 const llvm::Twine&  instName) override final;
 
-    Value* CreateGetSamplerDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetSamplerDescPtr(uint32_t      descSet,
                                    uint32_t      binding,
-                                   const Twine&  instName) override final;
+                                   const llvm::Twine&  instName) override final;
 
-    Value* CreateGetImageDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetImageDescPtr(uint32_t      descSet,
                                  uint32_t      binding,
-                                 const Twine&  instName) override final;
+                                 const llvm::Twine&  instName) override final;
 
-    Value* CreateGetTexelBufferDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetTexelBufferDescPtr(uint32_t      descSet,
                                        uint32_t      binding,
-                                       const Twine&  instName) override final;
+                                       const llvm::Twine&  instName) override final;
 
-    Value* CreateGetFmaskDescPtr(uint32_t      descSet,
+    llvm::Value* CreateGetFmaskDescPtr(uint32_t      descSet,
                                  uint32_t      binding,
-                                 const Twine&  instName) override final;
+                                 const llvm::Twine&  instName) override final;
 
-    Value* CreateLoadPushConstantsPtr(Type*         pPushConstantsTy,
-                                      const Twine&  instName) override final;
+    llvm::Value* CreateLoadPushConstantsPtr(llvm::Type*         pPushConstantsTy,
+                                      const llvm::Twine&  instName) override final;
 
-    Value* CreateGetBufferDescLength(Value* const pBufferDesc,
-                                     const Twine& instName = "") override final;
+    llvm::Value* CreateGetBufferDescLength(llvm::Value* const pBufferDesc,
+                                     const llvm::Twine& instName = "") override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Image operations
 
     // Create an image load.
-    Value* CreateImageLoad(Type*               pResultTy,
+    llvm::Value* CreateImageLoad(llvm::Type*               pResultTy,
                            uint32_t            dim,
                            uint32_t            flags,
-                           Value*              pImageDesc,
-                           Value*              pCoord,
-                           Value*              pMipLevel,
-                           const Twine&        instName = "") override final;
+                           llvm::Value*              pImageDesc,
+                           llvm::Value*              pCoord,
+                           llvm::Value*              pMipLevel,
+                           const llvm::Twine&        instName = "") override final;
 
     // Create an image load with F-mask.
-    Value* CreateImageLoadWithFmask(Type*                   pResultTy,
+    llvm::Value* CreateImageLoadWithFmask(llvm::Type*                   pResultTy,
                                     uint32_t                dim,
                                     uint32_t                flags,
-                                    Value*                  pImageDesc,
-                                    Value*                  pFmaskDesc,
-                                    Value*                  pCoord,
-                                    Value*                  pSampleNum,
-                                    const Twine&            instName) override final;
+                                    llvm::Value*                  pImageDesc,
+                                    llvm::Value*                  pFmaskDesc,
+                                    llvm::Value*                  pCoord,
+                                    llvm::Value*                  pSampleNum,
+                                    const llvm::Twine&            instName) override final;
 
     // Create an image store.
-    Value* CreateImageStore(Value*           pTexel,
+    llvm::Value* CreateImageStore(llvm::Value*           pTexel,
                             uint32_t         dim,
                             uint32_t         flags,
-                            Value*           pImageDesc,
-                            Value*           pCoord,
-                            Value*           pMipLevel,
-                            const Twine&     instName = "") override final;
+                            llvm::Value*           pImageDesc,
+                            llvm::Value*           pCoord,
+                            llvm::Value*           pMipLevel,
+                            const llvm::Twine&     instName = "") override final;
 
     // Create an image sample.
-    Value* CreateImageSample(Type*             pResultTy,
+    llvm::Value* CreateImageSample(llvm::Type*             pResultTy,
                              uint32_t          dim,
                              uint32_t          flags,
-                             Value*            pImageDesc,
-                             Value*            pSamplerDesc,
-                             ArrayRef<Value*>  address,
-                             const Twine&      instName = "") override final;
+                             llvm::Value*            pImageDesc,
+                             llvm::Value*            pSamplerDesc,
+                             llvm::ArrayRef<llvm::Value*>  address,
+                             const llvm::Twine&      instName = "") override final;
 
     // Create an image gather.
-    Value* CreateImageGather(Type*             pResultTy,
+    llvm::Value* CreateImageGather(llvm::Type*             pResultTy,
                              uint32_t          dim,
                              uint32_t          flags,
-                             Value*            pImageDesc,
-                             Value*            pSamplerDesc,
-                             ArrayRef<Value*>  address,
-                             const Twine&      instName = "") override final;
+                             llvm::Value*            pImageDesc,
+                             llvm::Value*            pSamplerDesc,
+                             llvm::ArrayRef<llvm::Value*>  address,
+                             const llvm::Twine&      instName = "") override final;
 
     // Create an image atomic operation other than compare-and-swap.
-    Value* CreateImageAtomic(uint32_t         atomicOp,
+    llvm::Value* CreateImageAtomic(uint32_t         atomicOp,
                              uint32_t         dim,
                              uint32_t         flags,
-                             AtomicOrdering   ordering,
-                             Value*           pImageDesc,
-                             Value*           pCoord,
-                             Value*           pInputValue,
-                             const Twine&     instName = "") override final;
+                             llvm::AtomicOrdering   ordering,
+                             llvm::Value*           pImageDesc,
+                             llvm::Value*           pCoord,
+                             llvm::Value*           pInputValue,
+                             const llvm::Twine&     instName = "") override final;
 
     // Create an image atomic compare-and-swap.
-    Value* CreateImageAtomicCompareSwap(uint32_t        dim,
+    llvm::Value* CreateImageAtomicCompareSwap(uint32_t        dim,
                                         uint32_t        flags,
-                                        AtomicOrdering  ordering,
-                                        Value*          pImageDesc,
-                                        Value*          pCoord,
-                                        Value*          pInputValue,
-                                        Value*          pComparatorValue,
-                                        const Twine&    instName = "") override final;
+                                        llvm::AtomicOrdering  ordering,
+                                        llvm::Value*          pImageDesc,
+                                        llvm::Value*          pCoord,
+                                        llvm::Value*          pInputValue,
+                                        llvm::Value*          pComparatorValue,
+                                        const llvm::Twine&    instName = "") override final;
 
     // Create a query of the number of mipmap levels in an image. Returns an i32 value.
-    Value* CreateImageQueryLevels(uint32_t                dim,
+    llvm::Value* CreateImageQueryLevels(uint32_t                dim,
                                   uint32_t                flags,
-                                  Value*                  pImageDesc,
-                                  const Twine&            instName = "") override final;
+                                  llvm::Value*                  pImageDesc,
+                                  const llvm::Twine&            instName = "") override final;
 
     // Create a query of the number of samples in an image. Returns an i32 value.
-    Value* CreateImageQuerySamples(uint32_t                dim,
+    llvm::Value* CreateImageQuerySamples(uint32_t                dim,
                                    uint32_t                flags,
-                                   Value*                  pImageDesc,
-                                   const Twine&            instName = "") override final;
+                                   llvm::Value*                  pImageDesc,
+                                   const llvm::Twine&            instName = "") override final;
 
     // Create a query of size of an image at the specified LOD
-    Value* CreateImageQuerySize(uint32_t          dim,
+    llvm::Value* CreateImageQuerySize(uint32_t          dim,
                                 uint32_t          flags,
-                                Value*            pImageDesc,
-                                Value*            pLod,
-                                const Twine&      instName = "") override final;
+                                llvm::Value*            pImageDesc,
+                                llvm::Value*            pLod,
+                                const llvm::Twine&      instName = "") override final;
 
     // Create a get of the LOD that would be used for an image sample with the given coordinates
     // and implicit LOD.
-    Value* CreateImageGetLod(uint32_t          dim,
+    llvm::Value* CreateImageGetLod(uint32_t          dim,
                              uint32_t          flags,
-                             Value*            pImageDesc,
-                             Value*            pSamplerDesc,
-                             Value*            pCoord,
-                             const Twine&      instName = "") override final;
+                             llvm::Value*            pImageDesc,
+                             llvm::Value*            pSamplerDesc,
+                             llvm::Value*            pCoord,
+                             const llvm::Twine&      instName = "") override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Shader input/output methods
 
     // Create a read of (part of) a user input value.
-    Value* CreateReadGenericInput(Type*         pResultTy,
+    llvm::Value* CreateReadGenericInput(llvm::Type*         pResultTy,
                                   uint32_t      location,
-                                  Value*        pLocationOffset,
-                                  Value*        pElemIdx,
+                                  llvm::Value*        pLocationOffset,
+                                  llvm::Value*        pElemIdx,
                                   uint32_t      locationCount,
                                   InOutInfo     inputInfo,
-                                  Value*        pVertexIndex,
-                                  const Twine&  instName = "") override final;
+                                  llvm::Value*        pVertexIndex,
+                                  const llvm::Twine&  instName = "") override final;
 
     // Create a read of (part of) a user output value.
-    Value* CreateReadGenericOutput(Type*         pResultTy,
+    llvm::Value* CreateReadGenericOutput(llvm::Type*         pResultTy,
                                    uint32_t      location,
-                                   Value*        pLocationOffset,
-                                   Value*        pElemIdx,
+                                   llvm::Value*        pLocationOffset,
+                                   llvm::Value*        pElemIdx,
                                    uint32_t      locationCount,
                                    InOutInfo     outputInfo,
-                                   Value*        pVertexIndex,
-                                   const Twine&  instName = "") override final;
+                                   llvm::Value*        pVertexIndex,
+                                   const llvm::Twine&  instName = "") override final;
 
     // Create a write of (part of) a user output value.
-    Instruction* CreateWriteGenericOutput(Value*        pValueToWrite,
+    llvm::Instruction* CreateWriteGenericOutput(llvm::Value*        pValueToWrite,
                                           uint32_t      location,
-                                          Value*        pLocationOffset,
-                                          Value*        pElemIdx,
+                                          llvm::Value*        pLocationOffset,
+                                          llvm::Value*        pElemIdx,
                                           uint32_t      locationCount,
                                           InOutInfo     outputInfo,
-                                          Value*        pVertexIndex) override final;
+                                          llvm::Value*        pVertexIndex) override final;
 
     // Create a write to an XFB (transform feedback / streamout) buffer.
-    Instruction* CreateWriteXfbOutput(Value*        pValueToWrite,
+    llvm::Instruction* CreateWriteXfbOutput(llvm::Value*        pValueToWrite,
                                       bool          isBuiltIn,
                                       uint32_t      location,
                                       uint32_t      xfbBuffer,
                                       uint32_t      xfbStride,
-                                      Value*        pXfbOffset,
+                                      llvm::Value*        pXfbOffset,
                                       InOutInfo     outputInfo) override final;
 
     // Create a read of (part of) a built-in input value.
-    Value* CreateReadBuiltInInput(BuiltInKind  builtIn,
+    llvm::Value* CreateReadBuiltInInput(BuiltInKind  builtIn,
                                   InOutInfo    inputInfo,
-                                  Value*       pVertexIndex,
-                                  Value*       pIndex,
-                                  const Twine& instName = "") override final;
+                                  llvm::Value*       pVertexIndex,
+                                  llvm::Value*       pIndex,
+                                  const llvm::Twine& instName = "") override final;
 
     // Create a read of (part of) a built-in output value.
-    Value* CreateReadBuiltInOutput(BuiltInKind  builtIn,
+    llvm::Value* CreateReadBuiltInOutput(BuiltInKind  builtIn,
                                    InOutInfo    outputInfo,
-                                   Value*       pVertexIndex,
-                                   Value*       pIndex,
-                                   const Twine& instName = "") override final;
+                                   llvm::Value*       pVertexIndex,
+                                   llvm::Value*       pIndex,
+                                   const llvm::Twine& instName = "") override final;
 
     // Create a write of (part of) a built-in output value.
-    Instruction* CreateWriteBuiltInOutput(Value*        pValueToWrite,
+    llvm::Instruction* CreateWriteBuiltInOutput(llvm::Value*        pValueToWrite,
                                           BuiltInKind   builtIn,
                                           InOutInfo     outputInfo,
-                                          Value*        pVertexIndex,
-                                          Value*        pIndex) override final;
+                                          llvm::Value*        pVertexIndex,
+                                          llvm::Value*        pIndex) override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Miscellaneous operations
 
     // In the GS, emit the current values of outputs (as written by CreateWriteBuiltIn and CreateWriteOutput) to
     // the current output primitive in the specified output-primitive stream.
-    Instruction* CreateEmitVertex(uint32_t streamId) override final;
+    llvm::Instruction* CreateEmitVertex(uint32_t streamId) override final;
 
     // In the GS, finish the current primitive and start a new one in the specified output-primitive stream.
-    Instruction* CreateEndPrimitive(uint32_t streamId) override final;
+    llvm::Instruction* CreateEndPrimitive(uint32_t streamId) override final;
 
     // Create a workgroup control barrier.
-    Instruction* CreateBarrier() override final;
+    llvm::Instruction* CreateBarrier() override final;
 
-    Instruction* CreateKill(const Twine& instName = "") override final;
-    Instruction* CreateReadClock(bool realtime, const Twine& instName = "") override final;
-    Instruction* CreateDemoteToHelperInvocation(const Twine& instName) override final;
-    Value* CreateIsHelperInvocation(const Twine& instName) override final;
+    llvm::Instruction* CreateKill(const llvm::Twine& instName = "") override final;
+    llvm::Instruction* CreateReadClock(bool realtime, const llvm::Twine& instName = "") override final;
+    llvm::Instruction* CreateDemoteToHelperInvocation(const llvm::Twine& instName) override final;
+    llvm::Value* CreateIsHelperInvocation(const llvm::Twine& instName) override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Builder methods implemented in BuilderImplMatrix
-    Value* CreateTransposeMatrix(Value* const pMatrix, const Twine& instName = "") override final;
-    Value* CreateMatrixTimesScalar(Value* const pMatrix,
-                                   Value* const pScalar,
-                                   const Twine& instName = "") override final;
-    Value* CreateVectorTimesMatrix(Value* const pVector,
-                                   Value* const pMatrix,
-                                   const Twine& instName = "") override final;
-    Value* CreateMatrixTimesVector(Value* const pMatrix,
-                                   Value* const pVector,
-                                   const Twine& instName = "") override final;
-    Value* CreateMatrixTimesMatrix(Value* const pMatrix1,
-                                   Value* const pMatrix2,
-                                   const Twine& instName = "") override final;
-    Value* CreateOuterProduct(Value* const pVector1,
-                              Value* const pVector2,
-                              const Twine& instName = "") override final;
-    Value* CreateDeterminant(Value* const pMatrix, const Twine& instName = "") override final;
-    Value* CreateMatrixInverse(Value* const pMatrix, const Twine& instName = "") override final;
+    llvm::Value* CreateTransposeMatrix(llvm::Value* const pMatrix, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateMatrixTimesScalar(llvm::Value* const pMatrix,
+                                   llvm::Value* const pScalar,
+                                   const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateVectorTimesMatrix(llvm::Value* const pVector,
+                                   llvm::Value* const pMatrix,
+                                   const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateMatrixTimesVector(llvm::Value* const pMatrix,
+                                   llvm::Value* const pVector,
+                                   const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateMatrixTimesMatrix(llvm::Value* const pMatrix1,
+                                   llvm::Value* const pMatrix2,
+                                   const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateOuterProduct(llvm::Value* const pVector1,
+                              llvm::Value* const pVector2,
+                              const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateDeterminant(llvm::Value* const pMatrix, const llvm::Twine& instName = "") override final;
+    llvm::Value* CreateMatrixInverse(llvm::Value* const pMatrix, const llvm::Twine& instName = "") override final;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Subgroup operations
 
-    Value* CreateGetSubgroupSize(const Twine& instName) override final;
-    Value* CreateSubgroupElect(const Twine& instName) override final;
-    Value* CreateSubgroupAll(Value* const pValue,
+    llvm::Value* CreateGetSubgroupSize(const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupElect(const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupAll(llvm::Value* const pValue,
                              bool         wqm,
-                             const Twine& instName) override final;
-    Value* CreateSubgroupAny(Value* const pValue,
+                             const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupAny(llvm::Value* const pValue,
                              bool         wqm,
-                             const Twine& instName) override final;
-    Value* CreateSubgroupAllEqual(Value* const pValue,
+                             const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupAllEqual(llvm::Value* const pValue,
                                   bool         wqm,
-                                  const Twine& instName) override final;
-    Value* CreateSubgroupBroadcast(Value* const pValue,
-                                   Value* const pIndex,
-                                   const Twine& instName) override final;
-    Value* CreateSubgroupBroadcastFirst(Value* const pValue,
-                                        const Twine& instName) override final;
-    Value* CreateSubgroupBallot(Value* const pValue,
-                                const Twine& instName) override final;
-    Value* CreateSubgroupInverseBallot(Value* const pValue,
-                                       const Twine& instName) override final;
-    Value* CreateSubgroupBallotBitExtract(Value* const pValue,
-                                          Value* const pIndex,
-                                          const Twine& instName) override final;
-    Value* CreateSubgroupBallotBitCount(Value* const pValue,
-                                        const Twine& instName) override final;
-    Value* CreateSubgroupBallotInclusiveBitCount(Value* const pValue,
-                                                 const Twine& instName) override final;
-    Value* CreateSubgroupBallotExclusiveBitCount(Value* const pValue,
-                                                 const Twine& instName) override final;
-    Value* CreateSubgroupBallotFindLsb(Value* const pValue,
-                                       const Twine& instName) override final;
-    Value* CreateSubgroupBallotFindMsb(Value* const pValue,
-                                       const Twine& instName) override final;
-    Value* CreateSubgroupShuffle(Value* const pValue,
-                                 Value* const pIndex,
-                                 const Twine& instName) override final;
-    Value* CreateSubgroupShuffleXor(Value* const pValue,
-                                    Value* const pMask,
-                                    const Twine& instName) override final;
-    Value* CreateSubgroupShuffleUp(Value* const pValue,
-                                   Value* const pDelta,
-                                   const Twine& instName) override final;
-    Value* CreateSubgroupShuffleDown(Value* const pValue,
-                                     Value* const pDelta,
-                                     const Twine& instName) override final;
-    Value* CreateSubgroupClusteredReduction(GroupArithOp groupArithOp,
-                                            Value* const pValue,
-                                            Value* const pClusterSize,
-                                            const Twine& instName) override final;
-    Value* CreateSubgroupClusteredInclusive(GroupArithOp groupArithOp,
-                                            Value* const pValue,
-                                            Value* const pClusterSize,
-                                            const Twine& instName) override final;
-    Value* CreateSubgroupClusteredExclusive(GroupArithOp groupArithOp,
-                                            Value* const pValue,
-                                            Value* const pClusterSize,
-                                            const Twine& instName) override final;
-    Value* CreateSubgroupQuadBroadcast(Value* const pValue,
-                                       Value* const pIndex,
-                                       const Twine& instName) override final;
-    Value* CreateSubgroupQuadSwapHorizontal(Value* const pValue,
-                                            const Twine& instName) override final;
-    Value* CreateSubgroupQuadSwapVertical(Value* const pValue,
-                                          const Twine& instName) override final;
-    Value* CreateSubgroupQuadSwapDiagonal(Value* const pValue,
-                                          const Twine& instName) override final;
-    Value* CreateSubgroupSwizzleQuad(Value* const pValue,
-                                     Value* const pOffset,
-                                     const Twine& instName) override final;
-    Value* CreateSubgroupSwizzleMask(Value* const pValue,
-                                     Value* const pMask,
-                                     const Twine& instName) override final;
-    Value* CreateSubgroupWriteInvocation(Value* const pInputValue,
-                                         Value* const pWriteValue,
-                                         Value* const pIndex,
-                                         const Twine& instName) override final;
-    Value* CreateSubgroupMbcnt(Value* const pMask,
-                               const Twine& instName ) override final;
+                                  const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBroadcast(llvm::Value* const pValue,
+                                   llvm::Value* const pIndex,
+                                   const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBroadcastFirst(llvm::Value* const pValue,
+                                        const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallot(llvm::Value* const pValue,
+                                const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupInverseBallot(llvm::Value* const pValue,
+                                       const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotBitExtract(llvm::Value* const pValue,
+                                          llvm::Value* const pIndex,
+                                          const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotBitCount(llvm::Value* const pValue,
+                                        const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotInclusiveBitCount(llvm::Value* const pValue,
+                                                 const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotExclusiveBitCount(llvm::Value* const pValue,
+                                                 const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotFindLsb(llvm::Value* const pValue,
+                                       const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupBallotFindMsb(llvm::Value* const pValue,
+                                       const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffle(llvm::Value* const pValue,
+                                 llvm::Value* const pIndex,
+                                 const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffleXor(llvm::Value* const pValue,
+                                    llvm::Value* const pMask,
+                                    const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffleUp(llvm::Value* const pValue,
+                                   llvm::Value* const pDelta,
+                                   const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupShuffleDown(llvm::Value* const pValue,
+                                     llvm::Value* const pDelta,
+                                     const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupClusteredReduction(GroupArithOp groupArithOp,
+                                            llvm::Value* const pValue,
+                                            llvm::Value* const pClusterSize,
+                                            const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupClusteredInclusive(GroupArithOp groupArithOp,
+                                            llvm::Value* const pValue,
+                                            llvm::Value* const pClusterSize,
+                                            const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupClusteredExclusive(GroupArithOp groupArithOp,
+                                            llvm::Value* const pValue,
+                                            llvm::Value* const pClusterSize,
+                                            const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadBroadcast(llvm::Value* const pValue,
+                                       llvm::Value* const pIndex,
+                                       const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadSwapHorizontal(llvm::Value* const pValue,
+                                            const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadSwapVertical(llvm::Value* const pValue,
+                                          const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupQuadSwapDiagonal(llvm::Value* const pValue,
+                                          const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupSwizzleQuad(llvm::Value* const pValue,
+                                     llvm::Value* const pOffset,
+                                     const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupSwizzleMask(llvm::Value* const pValue,
+                                     llvm::Value* const pMask,
+                                     const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupWriteInvocation(llvm::Value* const pInputValue,
+                                         llvm::Value* const pWriteValue,
+                                         llvm::Value* const pIndex,
+                                         const llvm::Twine& instName) override final;
+    llvm::Value* CreateSubgroupMbcnt(llvm::Value* const pMask,
+                               const llvm::Twine& instName ) override final;
 
 protected:
     // Get the ShaderModes object.
@@ -669,11 +667,11 @@ private:
     BuilderRecorder(BuilderContext* pBuilderContext, Pipeline* pPipeline);
 
     // Record one Builder call
-    Instruction* Record(Opcode                        opcode,
-                        Type*                         pReturnTy,
-                        ArrayRef<Value*>              args,
-                        const Twine&                  instName,
-                        ArrayRef<Attribute::AttrKind> attribs = {});
+    llvm::Instruction* Record(Opcode                        opcode,
+                        llvm::Type*                         pReturnTy,
+                        llvm::ArrayRef<llvm::Value*>              args,
+                        const llvm::Twine&                  instName,
+                        llvm::ArrayRef<llvm::Attribute::AttrKind> attribs = {});
 
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -682,6 +680,6 @@ private:
 };
 
 // Create BuilderReplayer pass
-ModulePass* CreateBuilderReplayer(Pipeline* pPipeline);
+llvm::ModulePass* CreateBuilderReplayer(Pipeline* pPipeline);
 
 } // lgc

--- a/lgc/builder/llpcShaderModes.h
+++ b/lgc/builder/llpcShaderModes.h
@@ -80,15 +80,15 @@ public:
     void Clear();
 
     // Record modes to IR metadata
-    void Record(Module* pModule);
+    void Record(llvm::Module* pModule);
 
     // Read shader modes (common and specific) from a shader IR module, but only if no modes have been set
     // in this ShaderModes. This is used to handle the case that the shader module comes from an earlier
     // shader compile, and it had its ShaderModes recorded into IR then.
-    void ReadModesFromShader(Module* pModule, ShaderStage stage);
+    void ReadModesFromShader(llvm::Module* pModule, ShaderStage stage);
 
     // Read shader modes from IR metadata in a pipeline
-    void ReadModesFromPipeline(Module* pModule);
+    void ReadModesFromPipeline(llvm::Module* pModule);
 
 private:
     bool                m_anySet = false;                                 // Whether any Set*Mode method called

--- a/lgc/builder/llpcTargetInfo.h
+++ b/lgc/builder/llpcTargetInfo.h
@@ -35,8 +35,6 @@
 namespace lgc
 {
 
-using namespace llvm;
-
 // Represents graphics IP version info. See https://llvm.org/docs/AMDGPUUsage.html#processors for more
 // details.
 struct GfxIpVersion
@@ -144,7 +142,7 @@ class TargetInfo
 {
 public:
     // Set TargetInfo. Returns false if the GPU name is not found or not supported.
-    bool SetTargetInfo(StringRef gpuName);
+    bool SetTargetInfo(llvm::StringRef gpuName);
 
     // Accessors.
     GfxIpVersion GetGfxIpVersion() const { return m_gfxIp; }

--- a/lgc/include/lgc/llpcBuilder.h
+++ b/lgc/include/lgc/llpcBuilder.h
@@ -39,8 +39,6 @@
 namespace lgc
 {
 
-using namespace llvm;
-
 class BuilderContext;
 struct CommonShaderMode;
 struct ComputeShaderMode;
@@ -125,7 +123,7 @@ private:
 
 // =====================================================================================================================
 // Builder is the part of the LLPC middle-end interface used by the front-end to build IR. It is a subclass
-// of llvm::IRBuilder<>, so the front-end can use its methods to create IR instructions at the set insertion
+// of IRBuilder<>, so the front-end can use its methods to create IR instructions at the set insertion
 // point. In addition it has its own Create* methods to create graphics-specific IR constructs.
 //
 class Builder : public BuilderBase
@@ -154,7 +152,7 @@ public:
 
     // Get the type pElementTy, turned into a vector of the same vector width as pMaybeVecTy if the latter
     // is a vector type.
-    static Type* GetConditionallyVectorizedTy(Type* pElementTy, Type* pMaybeVecTy);
+    static llvm::Type* GetConditionallyVectorizedTy(llvm::Type* pElementTy, llvm::Type* pMaybeVecTy);
 
     // Get the BuilderContext
     BuilderContext* GetBuilderContext() const { return m_pBuilderContext; }
@@ -199,7 +197,7 @@ public:
     void SetComputeShaderMode(const ComputeShaderMode& computeShaderMode);
 
     // Record shader modes into IR metadata if this is a shader compile (no PipelineState).
-    virtual void RecordShaderModes(Module* pModule) {}
+    virtual void RecordShaderModes(llvm::Module* pModule) {}
 
     // -----------------------------------------------------------------------------------------------------------------
     // Base class operations
@@ -207,39 +205,39 @@ public:
     // Create scalar from dot product of scalar or vector FP type. (The dot product of two scalars is their product.)
     // The two vectors must be the same floating point scalar/vector type.
     // Returns a value whose type is the element type of the vectors.
-    virtual Value* CreateDotProduct(
-        Value* const pVector1,            // [in] The float vector 1
-        Value* const pVector2,            // [in] The float vector 2
-        const Twine& instName = "") = 0;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateDotProduct(
+        llvm::Value* const pVector1,            // [in] The float vector 1
+        llvm::Value* const pVector2,            // [in] The float vector 2
+        const llvm::Twine& instName = "") = 0;  // [in] Name to give instruction(s)
 
     // Create a call to the specified intrinsic with one operand, mangled on its type.
     // This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math
     // flags from the Builder if none are specified by pFmfSource.
-    CallInst* CreateUnaryIntrinsic(
-        Intrinsic::ID id,                   // Intrinsic ID
-        Value*        pValue,               // [in] Input value
-        Instruction*  pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
+    llvm::CallInst* CreateUnaryIntrinsic(
+        llvm::Intrinsic::ID id,                   // Intrinsic ID
+        llvm::Value*        pValue,               // [in] Input value
+        llvm::Instruction*  pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
                                             //    from Builder
-        const Twine&  instName = "");       // [in] Name to give instruction
+        const llvm::Twine&  instName = "");       // [in] Name to give instruction
 
     // Create a call to the specified intrinsic with two operands of the same type, mangled on that type.
     // This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math
     // flags from the Builder if none are specified by pFmfSource.
-    CallInst* CreateBinaryIntrinsic(
-        Intrinsic::ID id,                   // Intrinsic ID
-        Value*        pValue1,              // [in] Input value 1
-        Value*        pValue2,              // [in] Input value 2
-        Instruction*  pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
+    llvm::CallInst* CreateBinaryIntrinsic(
+        llvm::Intrinsic::ID id,                   // Intrinsic ID
+        llvm::Value*        pValue1,              // [in] Input value 1
+        llvm::Value*        pValue2,              // [in] Input value 2
+        llvm::Instruction*  pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
                                             //    from Builder
-        const Twine&  name = "");           // [in] Name to give instruction
+        const llvm::Twine&  name = "");           // [in] Name to give instruction
 
-    CallInst* CreateIntrinsic(
-        Intrinsic::ID    id,                   // Intrinsic ID
-        ArrayRef<Type*>  types,                // [in] Types
-        ArrayRef<Value*> args,                 // [in] Input values
-        Instruction*     pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
+    llvm::CallInst* CreateIntrinsic(
+        llvm::Intrinsic::ID    id,                   // Intrinsic ID
+        llvm::ArrayRef<llvm::Type*>  types,                // [in] Types
+        llvm::ArrayRef<llvm::Value*> args,                 // [in] Input values
+        llvm::Instruction*     pFmfSource = nullptr, // [in] Instruction to copy fast math flags from; nullptr to get
                                                //    from Builder
-        const Twine&     name = "");           // [in] Name to give instruction
+        const llvm::Twine&     name = "");           // [in] Name to give instruction
 
     // -----------------------------------------------------------------------------------------------------------------
     // Arithmetic operations
@@ -249,19 +247,19 @@ public:
     // host platform and its compiler.
 
     // Get a constant of FP or vector of FP type for the value PI/180, for converting radians to degrees.
-    Constant* GetPiOver180(Type* pTy);
+    llvm::Constant* GetPiOver180(llvm::Type* pTy);
 
     // Get a constant of FP or vector of FP type for the value 180/PI, for converting degrees to radians.
-    Constant* Get180OverPi(Type* pTy);
+    llvm::Constant* Get180OverPi(llvm::Type* pTy);
 
     // Get a constant of FP or vector of FP type for the value 1/(2^n - 1)
-    Constant* GetOneOverPower2MinusOne(Type* pTy, uint32_t n);
+    llvm::Constant* GetOneOverPower2MinusOne(llvm::Type* pTy, uint32_t n);
 
     // Create calculation of 2D texture coordinates that would be used for accessing the selected cube map face for
     // the given cube map texture coordinates. Returns <2 x float>.
-    virtual Value* CreateCubeFaceCoord(
-        Value*        pCoord,             // [in] Input coordinate <3 x float>
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateCubeFaceCoord(
+        llvm::Value*        pCoord,             // [in] Input coordinate <3 x float>
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create calculation of the index of the cube map face that would be accessed by a texture lookup function for
     // the given cube map texture coordinates. Returns a single float with value:
@@ -271,274 +269,274 @@ public:
     //  3.0 = the cube map face facing the negative Y direction
     //  4.0 = the cube map face facing the positive Z direction
     //  5.0 = the cube map face facing the negative Z direction
-    virtual Value* CreateCubeFaceIndex(
-        Value*        pCoord,             // [in] Input coordinate <3 x float>
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateCubeFaceIndex(
+        llvm::Value*        pCoord,             // [in] Input coordinate <3 x float>
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create scalar or vector FP truncate operation with the given rounding mode.
     // Currently the rounding mode is only implemented for float/double -> half conversion.
-    virtual Value* CreateFpTruncWithRounding(
-        Value*                                pValue,             // [in] Input value
-        Type*                                 pDestTy,            // [in] Type to convert to
+    virtual llvm::Value* CreateFpTruncWithRounding(
+        llvm::Value*                                pValue,             // [in] Input value
+        llvm::Type*                                 pDestTy,            // [in] Type to convert to
         unsigned                              roundingMode,       // Rounding mode
-        const Twine&                          instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine&                          instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create quantize operation: truncates float (or vector) value to a value that is representable by a half.
-    virtual Value* CreateQuantizeToFp16(
-        Value*        pValue,               // [in] Input value (float or float vector)
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateQuantizeToFp16(
+        llvm::Value*        pValue,               // [in] Input value (float or float vector)
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create signed integer modulo operation, where the sign of the result (if not zero) is the same as
     // the sign of the divisor. The result is undefined if pDivisor is zero.
-    virtual Value* CreateSMod(
-        Value*        pDividend,            // [in] Dividend value
-        Value*        pDivisor,             // [in] Divisor value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSMod(
+        llvm::Value*        pDividend,            // [in] Dividend value
+        llvm::Value*        pDivisor,             // [in] Divisor value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create FP modulo operation, where the sign of the result (if not zero) is the same as
     // the sign of the divisor. The result is undefined if pDivisor is zero.
-    virtual Value* CreateFMod(
-        Value*        pDividend,            // [in] Dividend value
-        Value*        pDivisor,             // [in] Divisor value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFMod(
+        llvm::Value*        pDividend,            // [in] Dividend value
+        llvm::Value*        pDivisor,             // [in] Divisor value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create scalar/vector float/half fused multiply-and-add, to compute a * b + c
-    virtual Value* CreateFma(
-        Value*        pA,                   // [in] One value to multiply
-        Value*        pB,                   // [in] The other value to multiply
-        Value*        pC,                   // [in] The value to add to the product of A and B
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFma(
+        llvm::Value*        pA,                   // [in] One value to multiply
+        llvm::Value*        pB,                   // [in] The other value to multiply
+        llvm::Value*        pC,                   // [in] The value to add to the product of A and B
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a "tan" operation for a scalar or vector float or half.
-    virtual Value* CreateTan(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateTan(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "asin" operation for a scalar or vector float or half.
-    virtual Value* CreateASin(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateASin(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "acos" operation for a scalar or vector float or half.
-    virtual Value* CreateACos(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateACos(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "atan" operation for a scalar or vector float or half.
-    virtual Value* CreateATan(
-        Value*        pYOverX,              // [in] Input value Y/X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateATan(
+        llvm::Value*        pYOverX,              // [in] Input value Y/X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "atan2" operation for a scalar or vector float or half.
     // Returns atan(Y/X) but in the correct quadrant for the input value signs.
-    virtual Value* CreateATan2(
-        Value*        pY,                   // [in] Input value Y
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateATan2(
+        llvm::Value*        pY,                   // [in] Input value Y
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a "sinh" operation for a scalar or vector float or half.
-    virtual Value* CreateSinh(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSinh(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a "cosh" operation for a scalar or vector float or half.
-    virtual Value* CreateCosh(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateCosh(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a "tanh" operation for a scalar or vector float or half.
-    virtual Value* CreateTanh(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateTanh(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "asinh" operation for a scalar or vector float or half.
-    virtual Value* CreateASinh(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateASinh(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "acosh" operation for a scalar or vector float or half.
-    virtual Value* CreateACosh(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateACosh(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "atanh" operation for a scalar or vector float or half.
-    virtual Value* CreateATanh(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateATanh(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a "power" operation for a scalar or vector float or half, calculating X ^ Y
-    virtual Value* CreatePower(
-        Value*        pX,                   // [in] Input value X
-        Value*        pY,                   // [in] Input value Y
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreatePower(
+        llvm::Value*        pX,                   // [in] Input value X
+        llvm::Value*        pY,                   // [in] Input value Y
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "exp" operation for a scalar or vector float or half.
-    virtual Value* CreateExp(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateExp(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a "log" operation for a scalar or vector float or half.
-    virtual Value* CreateLog(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateLog(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an inverse square root operation for a scalar or vector FP type
-    virtual Value* CreateInverseSqrt(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateInverseSqrt(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "signed integer abs" operation for a scalar or vector integer value.
-    virtual Value* CreateSAbs(
-        Value*        pX,                   // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSAbs(
+        llvm::Value*        pX,                   // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fsign" operation for a scalar or vector floating-point type, returning -1.0, 0.0 or +1.0 if the input
     // value is negative, zero or positive.
-    virtual Value* CreateFSign(
-        Value*        pInValue,             // [in] Input value X
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFSign(
+        llvm::Value*        pInValue,             // [in] Input value X
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "ssign" operation for a scalar or vector integer type, returning -1, 0 or +1 if the input
     // value is negative, zero or positive.
-    virtual Value* CreateSSign(
-        Value*        pX,                   // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSSign(
+        llvm::Value*        pX,                   // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fract" operation for a scalar or vector floating-point type, returning x - floor(x).
-    virtual Value* CreateFract(
-        Value*        pX,                   // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFract(
+        llvm::Value*        pX,                   // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "smoothStep" operation. Result is 0.0 if x <= edge0 and 1.0 if x >= edge1 and performs smooth Hermite
     // interpolation between 0 and 1 when edge0 < x < edge1. This is equivalent to:
     // t * t * (3 - 2 * t), where t = clamp ((x - edge0) / (edge1 - edge0), 0, 1)
     // Result is undefined if edge0 >= edge1.
-    virtual Value* CreateSmoothStep(
-        Value*        pEdge0,               // [in] Edge0 value
-        Value*        pEdge1,               // [in] Edge1 value
-        Value*        pX,                   // [in] X (input) value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSmoothStep(
+        llvm::Value*        pEdge0,               // [in] Edge0 value
+        llvm::Value*        pEdge1,               // [in] Edge1 value
+        llvm::Value*        pX,                   // [in] X (input) value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "ldexp" operation: given an FP mantissa and int exponent, build an FP value
-    virtual Value* CreateLdexp(
-        Value*        pX,                   // [in] Mantissa
-        Value*        pExp,                 // [in] Exponent
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateLdexp(
+        llvm::Value*        pX,                   // [in] Mantissa
+        llvm::Value*        pExp,                 // [in] Exponent
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "extract significand" operation: given an FP scalar or vector value, return the significand in the range
     // [0.5,1.0), of the same type as the input. If the input is 0, the result is 0. If the input is infinite or NaN,
     // the result is undefined.
-    virtual Value* CreateExtractSignificand(
-        Value*        pValue,               // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateExtractSignificand(
+        llvm::Value*        pValue,               // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "extract exponent" operation: given an FP scalar or vector value, return the exponent as a signed integer.
     // If the input is (vector of) half, the result type is (vector of) i16, otherwise it is (vector of) i32.
     // If the input is 0, the result is 0. If the input is infinite or NaN, the result is undefined.
-    virtual Value* CreateExtractExponent(
-        Value*        pValue,               // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateExtractExponent(
+        llvm::Value*        pValue,               // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create vector cross product operation. Inputs must be <3 x FP>
-    virtual Value* CreateCrossProduct(
-        Value*        pX,                   // [in] Input value X
-        Value*        pY,                   // [in] Input value Y
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateCrossProduct(
+        llvm::Value*        pX,                   // [in] Input value X
+        llvm::Value*        pY,                   // [in] Input value Y
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create FP scalar/vector normalize operation: returns a scalar/vector with the same direction and magnitude 1.
-    virtual Value* CreateNormalizeVector(
-        Value*        pX,                   // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateNormalizeVector(
+        llvm::Value*        pX,                   // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "face forward" operation: given three FP scalars/vectors {N, I, Nref}, if the dot product of
     // Nref and I is negative, the result is N, otherwise it is -N
-    virtual Value* CreateFaceForward(
-        Value*        pN,                   // [in] Input value "N"
-        Value*        pI,                   // [in] Input value "I"
-        Value*        pNref,                // [in] Input value "Nref"
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFaceForward(
+        llvm::Value*        pN,                   // [in] Input value "N"
+        llvm::Value*        pI,                   // [in] Input value "I"
+        llvm::Value*        pNref,                // [in] Input value "Nref"
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "reflect" operation. For the incident vector I and normalized surface orientation N, the result is
     // the reflection direction:
     // I - 2 * dot(N, I) * N
-    virtual Value* CreateReflect(
-        Value*        pI,                   // [in] Input value "I"
-        Value*        pN,                   // [in] Input value "N"
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateReflect(
+        llvm::Value*        pI,                   // [in] Input value "I"
+        llvm::Value*        pN,                   // [in] Input value "N"
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "refract" operation. For the normalized incident vector I, normalized surface orientation N and ratio
     // of indices of refraction eta, the result is the refraction vector:
     // k = 1.0 - eta * eta * (1.0 - dot(N,I) * dot(N,I))
     // If k < 0.0 the result is 0.0.
     // Otherwise, the result is eta * I - (eta * dot(N,I) + sqrt(k)) * N
-    virtual Value* CreateRefract(
-        Value*        pI,                   // [in] Input value "I"
-        Value*        pN,                   // [in] Input value "N"
-        Value*        pEta,                 // [in] Input value "eta"
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateRefract(
+        llvm::Value*        pI,                   // [in] Input value "I"
+        llvm::Value*        pN,                   // [in] Input value "N"
+        llvm::Value*        pEta,                 // [in] Input value "eta"
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fclamp" operation, returning min(max(x, minVal), maxVal). Result is undefined if minVal > maxVal.
     // This honors the fast math flags; clear "nnan" in fast math flags in order to obtain the "NaN avoiding
     // semantics" for the min and max where, if one input is NaN, it returns the other one.
     // It also honors the shader's FP mode being "flush denorm".
-    virtual Value* CreateFClamp(
-        Value*        pX,                   // [in] Value to clamp
-        Value*        pMinVal,              // [in] Minimum of clamp range
-        Value*        pMaxVal,              // [in] Maximum of clamp range
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFClamp(
+        llvm::Value*        pX,                   // [in] Value to clamp
+        llvm::Value*        pMinVal,              // [in] Minimum of clamp range
+        llvm::Value*        pMaxVal,              // [in] Maximum of clamp range
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fmin" operation, returning the minimum of two scalar or vector FP values.
     // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
     // It also honors the shader's FP mode being "flush denorm".
-    virtual Value* CreateFMin(
-        Value*        pValue1,              // [in] First value
-        Value*        pValue2,              // [in] Second value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFMin(
+        llvm::Value*        pValue1,              // [in] First value
+        llvm::Value*        pValue2,              // [in] Second value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fmax" operation, returning the maximum of two scalar or vector float or half values.
     // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
     // It also honors the shader's FP mode being "flush denorm".
-    virtual Value* CreateFMax(
-        Value*        pValue1,              // [in] First value
-        Value*        pValue2,              // [in] Second value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFMax(
+        llvm::Value*        pValue1,              // [in] First value
+        llvm::Value*        pValue2,              // [in] Second value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fmin3" operation, returning the minimum of three scalar or vector float or half values.
     // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
     // It also honors the shader's FP mode being "flush denorm".
-    virtual Value* CreateFMin3(
-        Value*        pValue1,              // [in] First value
-        Value*        pValue2,              // [in] Second value
-        Value*        pValue3,              // [in] Third value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFMin3(
+        llvm::Value*        pValue1,              // [in] First value
+        llvm::Value*        pValue2,              // [in] Second value
+        llvm::Value*        pValue3,              // [in] Third value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fmax3" operation, returning the maximum of three scalar or vector float or half values.
     // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
     // It also honors the shader's FP mode being "flush denorm".
-    virtual Value* CreateFMax3(
-        Value*        pValue1,              // [in] First value
-        Value*        pValue2,              // [in] Second value
-        Value*        pValue3,              // [in] Third value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFMax3(
+        llvm::Value*        pValue1,              // [in] First value
+        llvm::Value*        pValue2,              // [in] Second value
+        llvm::Value*        pValue3,              // [in] Third value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fmid3" operation, returning the middle one of three scalar or vector float or half values.
     // This honors the fast math flags; do not set "nnan" if you want the "return the non-NaN input" behavior.
     // It also honors the shader's FP mode being "flush denorm".
-    virtual Value* CreateFMid3(
-        Value*        pValue1,              // [in] First value
-        Value*        pValue2,              // [in] Second value
-        Value*        pValue3,              // [in] Third value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFMid3(
+        llvm::Value*        pValue1,              // [in] First value
+        llvm::Value*        pValue2,              // [in] Second value
+        llvm::Value*        pValue3,              // [in] Third value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "isInf" operation: return true if the supplied FP (or vector) value is infinity
-    virtual Value* CreateIsInf(
-        Value*        pX,                   // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateIsInf(
+        llvm::Value*        pX,                   // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "isNaN" operation: return true if the supplied FP (or vector) value is NaN
-    virtual Value* CreateIsNaN(
-        Value*        pX,                   // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateIsNaN(
+        llvm::Value*        pX,                   // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "insert bitfield" operation for a (vector of) integer type.
     // Returns a value where the "pCount" bits starting at bit "pOffset" come from the least significant "pCount"
@@ -547,12 +545,12 @@ public:
     // If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
     // width. The scalar type of "pOffset" and "pCount" must be integer, but can be different to that of "pBase"
     // and "pInsert" (and different to each other too).
-    virtual Value* CreateInsertBitField(
-        Value*        pBase,                // [in] Base value
-        Value*        pInsert,              // [in] Value to insert (same type as base)
-        Value*        pOffset,              // Bit number of least-significant end of bitfield
-        Value*        pCount,               // Count of bits in bitfield
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateInsertBitField(
+        llvm::Value*        pBase,                // [in] Base value
+        llvm::Value*        pInsert,              // [in] Value to insert (same type as base)
+        llvm::Value*        pOffset,              // Bit number of least-significant end of bitfield
+        llvm::Value*        pCount,               // Count of bits in bitfield
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create an "extract bitfield " operation for a (vector of) i32.
     // Returns a value where the least significant "pCount" bits come from the "pCount" bits starting at bit
@@ -560,12 +558,12 @@ public:
     // If "pBase" and "pInsert" are vectors, "pOffset" and "pCount" can be either scalar or vector of the same
     // width. The scalar type of "pOffset" and "pCount" must be integer, but can be different to that of "pBase"
     // (and different to each other too).
-    virtual Value* CreateExtractBitField(
-        Value*        pBase,                // [in] Base value
-        Value*        pOffset,              // Bit number of least-significant end of bitfield
-        Value*        pCount,               // Count of bits in bitfield
+    virtual llvm::Value* CreateExtractBitField(
+        llvm::Value*        pBase,                // [in] Base value
+        llvm::Value*        pOffset,              // Bit number of least-significant end of bitfield
+        llvm::Value*        pCount,               // Count of bits in bitfield
         bool          isSigned,             // True for a signed int bitfield extract, false for unsigned
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "find MSB" operation for a (vector of) signed i32. For a postive number, the result is the bit number of
     // the most significant 1-bit. For a negative number, the result is the bit number of the most significant 0-bit.
@@ -574,9 +572,9 @@ public:
     // Note that unsigned "find MSB" is not provided as a Builder method, because it is easily synthesized from
     // the standard LLVM intrinsic llvm.ctlz. Similarly "find LSB" is not provided because it is easily synthesized
     // from the standard LLVM intrinsic llvm.cttz.
-    virtual Value* CreateFindSMsb(
-        Value*        pValue,               // [in] Input value
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateFindSMsb(
+        llvm::Value*        pValue,               // [in] Input value
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create "fmix" operation, returning ( 1 - A ) * X + A * Y. Result would be FP scalar or vector value.
     // Returns scalar, if and only if "pX", "pY" and "pA" are all scalars.
@@ -585,11 +583,11 @@ public:
     //
     // Note that when doing vector calculation, it means add/sub are element-wise between vectors, and the product will
     // be Hadamard product.
-    virtual Value* CreateFMix(
-        Value*        pX,                   // [in] left Value
-        Value*        pY,                   // [in] right Value
-        Value*        pA,                   // [in] wight Value
-        const Twine& instName = "") = 0;
+    virtual llvm::Value* CreateFMix(
+        llvm::Value*        pX,                   // [in] left Value
+        llvm::Value*        pY,                   // [in] right Value
+        llvm::Value*        pA,                   // [in] wight Value
+        const llvm::Twine& instName = "") = 0;
 
     // -----------------------------------------------------------------------------------------------------------------
     // Descriptor operations
@@ -610,103 +608,103 @@ public:
     //    performed without needing to see the resource node used in (a).
 
     // Get the type of pointer returned by CreateLoadBufferDesc.
-    PointerType* GetBufferDescTy(Type* pPointeeTy);
+    llvm::PointerType* GetBufferDescTy(llvm::Type* pPointeeTy);
 
     // Create a load of a buffer descriptor.
-    virtual Value* CreateLoadBufferDesc(
+    virtual llvm::Value* CreateLoadBufferDesc(
         uint32_t      descSet,            // Descriptor set
         uint32_t      binding,            // Descriptor binding
-        Value*        pDescIndex,         // [in] Descriptor index
+        llvm::Value*        pDescIndex,         // [in] Descriptor index
         bool          isNonUniform,       // Whether the descriptor index is non-uniform
         bool          isWritten,          // Whether the buffer is (or might be) written to
-        Type*         pPointeeTy,         // [in] Type that the returned pointer should point to.
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Type*         pPointeeTy,         // [in] Type that the returned pointer should point to.
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Add index onto pointer to image/sampler/texelbuffer/F-mask array of descriptors.
-    virtual Value* CreateIndexDescPtr(
-        Value*        pDescPtr,           // [in] Descriptor pointer, as returned by this function or one of
+    virtual llvm::Value* CreateIndexDescPtr(
+        llvm::Value*        pDescPtr,           // [in] Descriptor pointer, as returned by this function or one of
                                           //    the CreateGet*DescPtr methods
-        Value*        pIndex,             // [in] Index value
+        llvm::Value*        pIndex,             // [in] Index value
         bool          isNonUniform,       // Whether the descriptor index is non-uniform
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Load image/sampler/texelbuffer/F-mask descriptor from pointer.
     // Returns <8 x i32> descriptor for image or F-mask, or <4 x i32> descriptor for sampler or texel buffer.
-    virtual Value* CreateLoadDescFromPtr(
-        Value*        pDescPtr,           // [in] Descriptor pointer, as returned by CreateIndexDesc or one of
+    virtual llvm::Value* CreateLoadDescFromPtr(
+        llvm::Value*        pDescPtr,           // [in] Descriptor pointer, as returned by CreateIndexDesc or one of
                                           //    the CreateGet*DescPtr methods
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Get the type of an image descriptor.
-    VectorType* GetImageDescTy();
+    llvm::VectorType* GetImageDescTy();
 
     // Get the type of an F-mask descriptor.
-    VectorType* GetFmaskDescTy();
+    llvm::VectorType* GetFmaskDescTy();
 
     // Get the type of a sampler descriptor.
-    VectorType* GetSamplerDescTy();
+    llvm::VectorType* GetSamplerDescTy();
 
     // Get the type of a texel buffer descriptor.
-    VectorType* GetTexelBufferDescTy();
+    llvm::VectorType* GetTexelBufferDescTy();
 
     // Get the type of pointer to image or F-mask descriptor, as returned by CreateGetImageDescPtr.
     // The type is in fact a struct containing the actual pointer plus a stride in dwords.
-    Type* GetImageDescPtrTy();
+    llvm::Type* GetImageDescPtrTy();
 
     // Get the type of pointer to F-mask descriptor, as returned by CreateGetFmaskDescPtr.
     // The type is in fact a struct containing the actual pointer plus a stride in dwords.
-    Type* GetFmaskDescPtrTy();
+    llvm::Type* GetFmaskDescPtrTy();
 
     // Get the type of pointer to texel buffer descriptor, as returned by CreateGetTexelBufferDescPtr.
     // The type is in fact a struct containing the actual pointer plus a stride in dwords.
     // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
     // set up the stride, and CreateIndexDescPtr will use it.
-    Type* GetTexelBufferDescPtrTy();
+    llvm::Type* GetTexelBufferDescPtrTy();
 
     // Get the type of pointer to sampler descriptor, as returned by CreateGetSamplerDescPtr.
     // The type is in fact a struct containing the actual pointer plus a stride in dwords.
     // Currently the stride is not set up or used by anything; in the future, CreateGet*DescPtr calls will
     // set up the stride, and CreateIndexDescPtr will use it.
-    Type* GetSamplerDescPtrTy();
+    llvm::Type* GetSamplerDescPtrTy();
 
     // Create a pointer to sampler descriptor. Returns a value of the type returned by GetSamplerDescPtrTy.
-    virtual Value* CreateGetSamplerDescPtr(
+    virtual llvm::Value* CreateGetSamplerDescPtr(
         uint32_t      descSet,          // Descriptor set
         uint32_t      binding,          // Descriptor binding
-        const Twine&  instName = ""     // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 
     // Create a pointer to image descriptor. Returns a value of the type returned by GetImageDescPtrTy.
-    virtual Value* CreateGetImageDescPtr(
+    virtual llvm::Value* CreateGetImageDescPtr(
         uint32_t      descSet,          // Descriptor set
         uint32_t      binding,          // Descriptor binding
-        const Twine&  instName = ""     // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 
     // Create a pointer to texel buffer descriptor. Returns a value of the type returned by GetTexelBufferDescPtrTy.
-    virtual Value* CreateGetTexelBufferDescPtr(
+    virtual llvm::Value* CreateGetTexelBufferDescPtr(
         uint32_t      descSet,          // Descriptor set
         uint32_t      binding,          // Descriptor binding
-        const Twine&  instName = ""     // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 
     // Create a load of a F-mask descriptor. Returns a value of the type returned by GetFmaskDescPtrTy.
-    virtual Value* CreateGetFmaskDescPtr(
+    virtual llvm::Value* CreateGetFmaskDescPtr(
         uint32_t      descSet,          // Descriptor set
         uint32_t      binding,          // Descriptor binding
-        const Twine&  instName = ""     // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = ""     // [in] Name to give instruction(s)
     ) = 0;
 
     // Create a load of the push constants pointer.
     // This returns a pointer to the ResourceNodeType::PushConst resource in the top-level user data table.
-    virtual Value* CreateLoadPushConstantsPtr(
-        Type*         pPushConstantsTy,   // [in] Type that the returned pointer will point to
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateLoadPushConstantsPtr(
+        llvm::Type*         pPushConstantsTy,   // [in] Type that the returned pointer will point to
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a buffer length query based on the specified descriptor.
-    virtual Value* CreateGetBufferDescLength(
-        Value* const  pBufferDesc,        // [in] The buffer descriptor to query.
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateGetBufferDescLength(
+        llvm::Value* const  pBufferDesc,        // [in] The buffer descriptor to query.
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // -----------------------------------------------------------------------------------------------------------------
     // Image operations
@@ -825,14 +823,14 @@ public:
     };
 
     // Create an image load.
-    virtual Value* CreateImageLoad(
-        Type*                   pResultTy,          // [in] Result type
+    virtual llvm::Value* CreateImageLoad(
+        llvm::Type*                   pResultTy,          // [in] Result type
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor.
-        Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
-        Value*                  pMipLevel,          // [in] Mipmap level if doing load_mip, otherwise nullptr
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor.
+        llvm::Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
+        llvm::Value*                  pMipLevel,          // [in] Mipmap level if doing load_mip, otherwise nullptr
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create an image load with fmask. Dim must be 2DMsaa or 2DArrayMsaa. If the F-mask descriptor has a valid
     // format field, then it reads "fmask_texel_R", the R component of the texel read from the given coordinates
@@ -840,26 +838,26 @@ public:
     // the least significant nibble) of fmask_texel_R. If the F-mask descriptor has an invalid format, then it
     // just uses the supplied sample number. The calculated sample is then appended to the supplied coordinates
     // for a normal image load.
-    virtual Value* CreateImageLoadWithFmask(
-        Type*                   pResultTy,          // [in] Result type
+    virtual llvm::Value* CreateImageLoadWithFmask(
+        llvm::Type*                   pResultTy,          // [in] Result type
         uint32_t                dim,                // Image dimension, 2DMsaa or 2DArrayMsaa
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor
-        Value*                  pFmaskDesc,         // [in] Fmask descriptor
-        Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor
+        llvm::Value*                  pFmaskDesc,         // [in] Fmask descriptor
+        llvm::Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right
                                                     //    width for given dimension excluding sample
-        Value*                  pSampleNum,         // [in] Sample number, i32
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pSampleNum,         // [in] Sample number, i32
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create an image store.
-    virtual Value* CreateImageStore(
-        Value*                  pTexel,             // [in] Texel value to store; v4i16, v4i32, v4f16 or v4f32
+    virtual llvm::Value* CreateImageStore(
+        llvm::Value*                  pTexel,             // [in] Texel value to store; v4i16, v4i32, v4f16 or v4f32
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
-        Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
-        Value*                  pMipLevel,          // [in] Mipmap level if doing store_mip, otherwise nullptr
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
+        llvm::Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
+        llvm::Value*                  pMipLevel,          // [in] Mipmap level if doing store_mip, otherwise nullptr
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create an image sample.
     // The return type is specified by pResultTy as follows:
@@ -869,14 +867,14 @@ public:
     // * If the ZCompare address component is supplied, then the texel type is the scalar texel component
     //   type. Otherwise the texel type is a 4-vector of the texel component type.
     // * The texel component type is i32, f16 or f32.
-    virtual Value* CreateImageSample(
-        Type*                   pResultTy,          // [in] Result type
+    virtual llvm::Value* CreateImageSample(
+        llvm::Type*                   pResultTy,          // [in] Result type
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor
-        Value*                  pSamplerDesc,       // [in] Sampler descriptor
-        ArrayRef<Value*>        address,            // Address and other arguments
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor
+        llvm::Value*                  pSamplerDesc,       // [in] Sampler descriptor
+        llvm::ArrayRef<llvm::Value*>        address,            // Address and other arguments
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create an image gather.
     // The return type is specified by pResultTy as follows:
@@ -884,78 +882,78 @@ public:
     //   texel type, and the second field is i32, where bit 0 is the TFE bit. Otherwise, the return type is the texel
     //   type.
     // * The texel type is a 4-vector of the texel component type, which is i32, f16 or f32.
-    virtual Value* CreateImageGather(
-        Type*                   pResultTy,          // [in] Result type
+    virtual llvm::Value* CreateImageGather(
+        llvm::Type*                   pResultTy,          // [in] Result type
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor
-        Value*                  pSamplerDesc,       // [in] Sampler descriptor
-        ArrayRef<Value*>        address,            // Address and other arguments
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor
+        llvm::Value*                  pSamplerDesc,       // [in] Sampler descriptor
+        llvm::ArrayRef<llvm::Value*>        address,            // Address and other arguments
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create an image atomic operation other than compare-and-swap. An add of +1 or -1, or a sub
     // of -1 or +1, is generated as inc or dec. Result type is the same as the input value type.
     // Normally pImageDesc is an image descriptor, as returned by CreateLoadImageDesc, and this method
     // creates an image atomic instruction. But pImageDesc can instead be a texel buffer descriptor, as
     // returned by CreateLoadTexelBufferDesc, in which case the method creates a buffer atomic instruction.
-    virtual Value* CreateImageAtomic(
+    virtual llvm::Value* CreateImageAtomic(
         uint32_t                atomicOp,           // Atomic op to create
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        AtomicOrdering          ordering,           // Atomic ordering
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
-        Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
-        Value*                  pInputValue,        // [in] Input value: i32
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::AtomicOrdering          ordering,           // Atomic ordering
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
+        llvm::Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
+        llvm::Value*                  pInputValue,        // [in] Input value: i32
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create an image atomic compare-and-swap.
     // Normally pImageDesc is an image descriptor, as returned by CreateLoadImageDesc, and this method
     // creates an image atomic instruction. But pImageDesc can instead be a texel buffer descriptor, as
     // returned by CreateLoadTexelBufferDesc, in which case the method creates a buffer atomic instruction.
-    virtual Value* CreateImageAtomicCompareSwap(
+    virtual llvm::Value* CreateImageAtomicCompareSwap(
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        AtomicOrdering          ordering,           // Atomic ordering
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
-        Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
-        Value*                  pInputValue,        // [in] Input value: i32
-        Value*                  pComparatorValue,   // [in] Value to compare against: i32
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::AtomicOrdering          ordering,           // Atomic ordering
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
+        llvm::Value*                  pCoord,             // [in] Coordinates: scalar or vector i32, exactly right width
+        llvm::Value*                  pInputValue,        // [in] Input value: i32
+        llvm::Value*                  pComparatorValue,   // [in] Value to compare against: i32
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a query of the number of mipmap levels in an image. Returns an i32 value.
-    virtual Value* CreateImageQueryLevels(
+    virtual llvm::Value* CreateImageQueryLevels(
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a query of the number of samples in an image. Returns an i32 value.
-    virtual Value* CreateImageQuerySamples(
+    virtual llvm::Value* CreateImageQuerySamples(
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a query of size of an image at the specified LOD.
     // Returns an i32 scalar or vector of the width given by GetImageQuerySizeComponentCount.
-    virtual Value* CreateImageQuerySize(
+    virtual llvm::Value* CreateImageQuerySize(
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
-        Value*                  pLod,               // [in] LOD
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor or texel buffer descriptor
+        llvm::Value*                  pLod,               // [in] LOD
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a get of the LOD that would be used for an image sample with the given coordinates
     // and implicit LOD. Returns a v2f32 containing the layer number and the implicit level of
     // detail relative to the base level.
-    virtual Value* CreateImageGetLod(
+    virtual llvm::Value* CreateImageGetLod(
         uint32_t                dim,                // Image dimension
         uint32_t                flags,              // ImageFlag* flags
-        Value*                  pImageDesc,         // [in] Image descriptor
-        Value*                  pSamplerDesc,       // [in] Sampler descriptor
-        Value*                  pCoord,             // [in] Coordinates: scalar or vector f32, exactly right
+        llvm::Value*                  pImageDesc,         // [in] Image descriptor
+        llvm::Value*                  pSamplerDesc,       // [in] Sampler descriptor
+        llvm::Value*                  pCoord,             // [in] Coordinates: scalar or vector f32, exactly right
                                                     //    width without array layer
-        const Twine&            instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine&            instName = "") = 0; // [in] Name to give instruction(s)
 
     // -----------------------------------------------------------------------------------------------------------------
     // Shader input/output methods
@@ -966,18 +964,18 @@ public:
     // 64-bit components. Two consecutive locations together can contain up to a 4-vector of 64-bit components.
     // A non-constant pLocationOffset is currently only supported for TCS and TES, and for an FS custom-interpolated
     // input.
-    virtual Value* CreateReadGenericInput(
-        Type*         pResultTy,          // [in] Type of value to read
+    virtual llvm::Value* CreateReadGenericInput(
+        llvm::Type*         pResultTy,          // [in] Type of value to read
         uint32_t      location,           // Base location (row) of input
-        Value*        pLocationOffset,    // [in] Location offset; must be within locationCount if variable
-        Value*        pElemIdx,           // [in] Element index in vector. (This is the SPIR-V "component", except
+        llvm::Value*        pLocationOffset,    // [in] Location offset; must be within locationCount if variable
+        llvm::Value*        pElemIdx,           // [in] Element index in vector. (This is the SPIR-V "component", except
                                           //      that it is half the component for 64-bit elements.)
         uint32_t      locationCount,      // Count of locations taken by the input. Ignored if pLocationOffset is const
         InOutInfo     inputInfo,          // Extra input info (FS interp info)
-        Value*        pVertexIndex,       // [in] For TCS/TES/GS per-vertex input: vertex index;
+        llvm::Value*        pVertexIndex,       // [in] For TCS/TES/GS per-vertex input: vertex index;
                                           //      for FS custom interpolated input: auxiliary interpolation value;
                                           //      else nullptr
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a read of (part of) a generic (user) output value, returning the value last written in this shader stage.
     // The result type is as specified by pResultTy, a scalar or vector type with no more than four elements.
@@ -985,31 +983,31 @@ public:
     // 64-bit components. Two consecutive locations together can contain up to a 4-vector of 64-bit components.
     // This operation is only supported for TCS; other shader stages do not have per-vertex outputs, and
     // the frontend is expected to do its own cacheing of a written output if the shader wants to read it back again.
-    virtual Value* CreateReadGenericOutput(
-        Type*         pResultTy,          // [in] Type of value to read
+    virtual llvm::Value* CreateReadGenericOutput(
+        llvm::Type*         pResultTy,          // [in] Type of value to read
         uint32_t      location,           // Base location (row) of output
-        Value*        pLocationOffset,    // [in] Location offset; must be within locationCount if variable
-        Value*        pElemIdx,           // [in] Element index in vector. (This is the SPIR-V "component", except
+        llvm::Value*        pLocationOffset,    // [in] Location offset; must be within locationCount if variable
+        llvm::Value*        pElemIdx,           // [in] Element index in vector. (This is the SPIR-V "component", except
                                           //      that it is half the component for 64-bit elements.)
         uint32_t      locationCount,      // Count of locations taken by the output. Ignored if pLocationOffset is const
         InOutInfo     outputInfo,         // Extra output info (GS stream ID)
-        Value*        pVertexIndex,       // [in] For TCS per-vertex output: vertex index; else nullptr
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*        pVertexIndex,       // [in] For TCS per-vertex output: vertex index; else nullptr
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a write of (part of) a generic (user) output value, setting the value to pass to the next shader stage.
     // The value to write must be a scalar or vector type with no more than four elements.
     // A "location" can contain up to a 4-vector of 16- or 32-bit components, or up to a 2-vector of
     // 64-bit components. Two consecutive locations together can contain up to a 4-vector of 64-bit components.
     // A non-constant pLocationOffset is currently only supported for TCS.
-    virtual Instruction* CreateWriteGenericOutput(
-        Value*        pValueToWrite,      // [in] Value to write
+    virtual llvm::Instruction* CreateWriteGenericOutput(
+        llvm::Value*        pValueToWrite,      // [in] Value to write
         uint32_t      location,           // Base location (row) of output
-        Value*        pLocationOffset,    // [in] Location offset; must be within locationCount if variable
-        Value*        pElemIdx,           // [in] Element index in vector. (This is the SPIR-V "component", except
+        llvm::Value*        pLocationOffset,    // [in] Location offset; must be within locationCount if variable
+        llvm::Value*        pElemIdx,           // [in] Element index in vector. (This is the SPIR-V "component", except
                                           //      that it is half the component for 64-bit elements.)
         uint32_t      locationCount,      // Count of locations taken by the output. Ignored if pLocationOffset is const
         InOutInfo     outputInfo,         // Extra output info (GS stream ID, FS integer signedness)
-        Value*        pVertexIndex) = 0;  // [in] For TCS per-vertex output: vertex index; else nullptr
+        llvm::Value*        pVertexIndex) = 0;  // [in] For TCS per-vertex output: vertex index; else nullptr
 
     // Create a write to an XFB (transform feedback / streamout) buffer.
     // The value to write must be a scalar or vector type with no more than four elements.
@@ -1025,18 +1023,18 @@ public:
     // If calls to CreateWriteXfbOutput for multiple vertices in a primitive, or in
     // different primitives in the same stream, have different output correspondence, then it is undefined which
     // of those correspondences is actually used when writing to XFB for each affected vertex.
-    virtual Instruction* CreateWriteXfbOutput(
-        Value*        pValueToWrite,      // [in] Value to write
+    virtual llvm::Instruction* CreateWriteXfbOutput(
+        llvm::Value*        pValueToWrite,      // [in] Value to write
         bool          isBuiltIn,          // True for built-in, false for user output (ignored if not GS)
         uint32_t      location,           // Location (row) or built-in kind of output (ignored if not GS)
         uint32_t      xfbBuffer,          // XFB buffer ID
         uint32_t      xfbStride,          // XFB stride
-        Value*        pXfbOffset,         // [in] XFB byte offset
+        llvm::Value*        pXfbOffset,         // [in] XFB byte offset
         InOutInfo     outputInfo) = 0;    // Extra output info (GS stream ID)
 
     // Get the type of a built-in. Where the built-in has a shader-defined array length (ClipDistance,
     // CullDistance, SampleMask), inOutInfo.GetArraySize() is used as the array size.
-    Type* GetBuiltInTy(
+    llvm::Type* GetBuiltInTy(
         BuiltInKind   builtIn,            // Built-in kind, one of the BuiltIn* constants
         InOutInfo     inOutInfo);         // Extra input/output info (shader-defined array length)
 
@@ -1044,295 +1042,295 @@ public:
     // The type of the returned value is the fixed type of the specified built-in (see llpcBuilderBuiltInDefs.h),
     // or the element type if pIndex is not nullptr. For ClipDistance or CullDistance when pIndex is nullptr,
     // the array size is determined by inputInfo.GetArraySize().
-    virtual Value* CreateReadBuiltInInput(
+    virtual llvm::Value* CreateReadBuiltInInput(
         BuiltInKind   builtIn,            // Built-in kind, one of the BuiltIn* constants
         InOutInfo     inputInfo,          // Extra input info (shader-defined array length)
-        Value*        pVertexIndex,       // [in] For TCS/TES/GS per-vertex input: vertex index, else nullptr
-        Value*        pIndex,             // [in] Array or vector index to access part of an input, else nullptr
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*        pVertexIndex,       // [in] For TCS/TES/GS per-vertex input: vertex index, else nullptr
+        llvm::Value*        pIndex,             // [in] Array or vector index to access part of an input, else nullptr
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a read of (part of) a built-in output value.
     // The type of the returned value is the fixed type of the specified built-in (see llpcBuilderBuiltInDefs.h),
     // or the element type if pIndex is not nullptr.
     // This operation is only supported for TCS; other shader stages do not have per-vertex outputs, and
     // the frontend is expected to do its own cacheing of a written output if the shader wants to read it back again.
-    virtual Value* CreateReadBuiltInOutput(
+    virtual llvm::Value* CreateReadBuiltInOutput(
         BuiltInKind   builtIn,            // Built-in kind, one of the BuiltIn* constants
         InOutInfo     outputInfo,         // Extra output info (shader-defined array length)
-        Value*        pVertexIndex,       // [in] For TCS per-vertex output: vertex index, else nullptr
-        Value*        pIndex,             // [in] Array or vector index to access part of an input, else nullptr
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value*        pVertexIndex,       // [in] For TCS per-vertex output: vertex index, else nullptr
+        llvm::Value*        pIndex,             // [in] Array or vector index to access part of an input, else nullptr
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a write of (part of) a built-in output value.
     // The type of the value to write must be the fixed type of the specified built-in (see llpcBuilderBuiltInDefs.h),
     // or the element type if pIndex is not nullptr.
-    virtual Instruction* CreateWriteBuiltInOutput(
-        Value*        pValueToWrite,      // [in] Value to write
+    virtual llvm::Instruction* CreateWriteBuiltInOutput(
+        llvm::Value*        pValueToWrite,      // [in] Value to write
         BuiltInKind   builtIn,            // Built-in kind, one of the BuiltIn* constants
         InOutInfo     outputInfo,         // Extra output info (shader-defined array length; GS stream id)
-        Value*        pVertexIndex,       // [in] For TCS per-vertex output: vertex index, else nullptr
-        Value*        pIndex) = 0;        // [in] Array or vector index to access part of an input, else nullptr
+        llvm::Value*        pVertexIndex,       // [in] For TCS per-vertex output: vertex index, else nullptr
+        llvm::Value*        pIndex) = 0;        // [in] Array or vector index to access part of an input, else nullptr
 
     // -----------------------------------------------------------------------------------------------------------------
     // Matrix operations
 
     // Create a matrix transpose.
-    virtual Value* CreateTransposeMatrix(
-        Value* const pMatrix,            // [in] The matrix to transpose
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateTransposeMatrix(
+        llvm::Value* const pMatrix,            // [in] The matrix to transpose
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create matrix multiplication: matrix times scalar, resulting in matrix
-    virtual Value* CreateMatrixTimesScalar(
-        Value* const pMatrix,             // [in] The column major matrix, [n x <n x float>]
-        Value* const pScalar,             // [in] The float scalar
-        const Twine& instName = "") = 0;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateMatrixTimesScalar(
+        llvm::Value* const pMatrix,             // [in] The column major matrix, [n x <n x float>]
+        llvm::Value* const pScalar,             // [in] The float scalar
+        const llvm::Twine& instName = "") = 0;  // [in] Name to give instruction(s)
 
     // Create matrix multiplication: vector times matrix, resulting in vector
-    virtual Value* CreateVectorTimesMatrix(
-        Value* const pVector,              // [in] The float vector
-        Value* const pMatrix,              // [in] The column major matrix, n x <n x float>
-        const Twine& instName = "") = 0;   // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateVectorTimesMatrix(
+        llvm::Value* const pVector,              // [in] The float vector
+        llvm::Value* const pMatrix,              // [in] The column major matrix, n x <n x float>
+        const llvm::Twine& instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create matrix multiplication: matrix times vector, resulting in vector
-    virtual Value* CreateMatrixTimesVector(
-        Value* const pMatrix,             // [in] The column major matrix, n x <n x float>
-        Value* const pVector,             // [in] The float vector
-        const Twine& instName = "") = 0;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateMatrixTimesVector(
+        llvm::Value* const pMatrix,             // [in] The column major matrix, n x <n x float>
+        llvm::Value* const pVector,             // [in] The float vector
+        const llvm::Twine& instName = "") = 0;  // [in] Name to give instruction(s)
 
     // Create matrix multiplication:  matrix times matrix, resulting in matrix
-    virtual Value* CreateMatrixTimesMatrix(
-        Value* const pMatrix1,             // [in] The float matrix 1
-        Value* const pMatrix2,             // [in] The float matrix 2
-        const Twine& instName = "") = 0 ;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateMatrixTimesMatrix(
+        llvm::Value* const pMatrix1,             // [in] The float matrix 1
+        llvm::Value* const pMatrix2,             // [in] The float matrix 2
+        const llvm::Twine& instName = "") = 0 ;  // [in] Name to give instruction(s)
 
     // Create vector outer product operation, resulting in matrix
-    virtual Value* CreateOuterProduct(
-        Value* const pVector1,            // [in] The float vector 1
-        Value* const pVector2,            // [in] The float vector 2
-        const Twine& instName = "") = 0;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateOuterProduct(
+        llvm::Value* const pVector1,            // [in] The float vector 1
+        llvm::Value* const pVector2,            // [in] The float vector 2
+        const llvm::Twine& instName = "") = 0;  // [in] Name to give instruction(s)
 
     // Create matrix determinant operation. Matrix must be square
-    virtual Value* CreateDeterminant(
-        Value* const pMatrix,             // [in] Matrix
-        const Twine& instName = "") = 0;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateDeterminant(
+        llvm::Value* const pMatrix,             // [in] Matrix
+        const llvm::Twine& instName = "") = 0;  // [in] Name to give instruction(s)
 
     // Create matrix inverse operation. Matrix must be square. Result is undefined if the matrix
     // is singular or poorly conditioned (nearly singular).
-    virtual Value* CreateMatrixInverse(
-        Value* const pMatrix,             // [in] Matrix
-        const Twine& instName = "") = 0;  // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateMatrixInverse(
+        llvm::Value* const pMatrix,             // [in] Matrix
+        const llvm::Twine& instName = "") = 0;  // [in] Name to give instruction(s)
 
     // -----------------------------------------------------------------------------------------------------------------
     // Miscellaneous operations
 
     // In the GS, emit the current values of outputs (as written by CreateWriteBuiltIn and CreateWriteOutput) to
     // the current output primitive in the specified output-primitive stream.
-    virtual Instruction* CreateEmitVertex(
+    virtual llvm::Instruction* CreateEmitVertex(
         uint32_t                      streamId) = 0;      // Stream number, 0 if only one stream is present
 
     // In the GS, finish the current primitive and start a new one in the specified output-primitive stream.
-    virtual Instruction* CreateEndPrimitive(
+    virtual llvm::Instruction* CreateEndPrimitive(
         uint32_t                      streamId) = 0;      // Stream number, 0 if only one stream is present
 
     // Create a workgroup control barrier.
-    virtual Instruction* CreateBarrier() = 0;
+    virtual llvm::Instruction* CreateBarrier() = 0;
 
     // Create a "kill". Only allowed in a fragment shader.
-    virtual Instruction* CreateKill(
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Instruction* CreateKill(
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a "readclock".
-    virtual Instruction* CreateReadClock(
+    virtual llvm::Instruction* CreateReadClock(
         bool          realtime,           // Whether to read real-time clock counter
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create derivative calculation on float or vector of float or half
-    virtual Value* CreateDerivative(
-        Value*        pValue,               // [in] Input value
+    virtual llvm::Value* CreateDerivative(
+        llvm::Value*        pValue,               // [in] Input value
         bool          isDirectionY,         // False for derivative in X direction, true for Y direction
         bool          isFine,               // True for "fine" calculation, where the value in the current fragment
                                             //   is used. False for "coarse" calculation, where it might use fewer
                                             //   locations to calculate.
-        const Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
+        const llvm::Twine&  instName = "") = 0;   // [in] Name to give instruction(s)
 
     // Create a demote to helper invocation operation. Only allowed in a fragment shader.
-    virtual Instruction* CreateDemoteToHelperInvocation(
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Instruction* CreateDemoteToHelperInvocation(
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a helper invocation query. Only allowed in a fragment shader.
-    virtual Value* CreateIsHelperInvocation(
-        const Twine&  instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateIsHelperInvocation(
+        const llvm::Twine&  instName = "") = 0; // [in] Name to give instruction(s)
 
     // -----------------------------------------------------------------------------------------------------------------
     // Subgroup operations
 
     // Create a get subgroup size query.
-    virtual Value* CreateGetSubgroupSize(
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateGetSubgroupSize(
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup elect.
-    virtual Value* CreateSubgroupElect(
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupElect(
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup all.
-    virtual Value* CreateSubgroupAll(
-        Value* const pValue,             // [in] The value to compare
+    virtual llvm::Value* CreateSubgroupAll(
+        llvm::Value* const pValue,             // [in] The value to compare
         bool         wqm = false,        // Executed in WQM (whole quad mode)
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup any
-    virtual Value* CreateSubgroupAny(
-        Value* const pValue,             // [in] The value to compare
+    virtual llvm::Value* CreateSubgroupAny(
+        llvm::Value* const pValue,             // [in] The value to compare
         bool         wqm = false,        // Executed in WQM (whole quad mode)
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup all equal.
-    virtual Value* CreateSubgroupAllEqual(
-        Value* const pValue,             // [in] The value to compare
+    virtual llvm::Value* CreateSubgroupAllEqual(
+        llvm::Value* const pValue,             // [in] The value to compare
         bool         wqm = false,        // Executed in WQM (whole quad mode)
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup broadcast.
-    virtual Value* CreateSubgroupBroadcast(
-        Value* const pValue,             // [in] The value to broadcast
-        Value* const pIndex,             // [in] The index to broadcast from
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBroadcast(
+        llvm::Value* const pValue,             // [in] The value to broadcast
+        llvm::Value* const pIndex,             // [in] The index to broadcast from
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup broadcast first.
-    virtual Value* CreateSubgroupBroadcastFirst(
-        Value* const pValue,             // [in] The value to broadcast
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBroadcastFirst(
+        llvm::Value* const pValue,             // [in] The value to broadcast
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot.
-    virtual Value* CreateSubgroupBallot(
-        Value* const pValue,             // [in] The value to contribute
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallot(
+        llvm::Value* const pValue,             // [in] The value to contribute
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup inverse ballot.
-    virtual Value* CreateSubgroupInverseBallot(
-        Value* const pValue,             // [in] The ballot value
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupInverseBallot(
+        llvm::Value* const pValue,             // [in] The ballot value
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot bit extract.
-    virtual Value* CreateSubgroupBallotBitExtract(
-        Value* const pValue,             // [in] The ballot value
-        Value* const pIndex,             // [in] The index to extract from the ballot
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallotBitExtract(
+        llvm::Value* const pValue,             // [in] The ballot value
+        llvm::Value* const pIndex,             // [in] The index to extract from the ballot
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot bit count.
-    virtual Value* CreateSubgroupBallotBitCount(
-        Value* const pValue,             // [in] The ballot value
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallotBitCount(
+        llvm::Value* const pValue,             // [in] The ballot value
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot inclusive bit count.
-    virtual Value* CreateSubgroupBallotInclusiveBitCount(
-        Value* const pValue,             // [in] The ballot value
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallotInclusiveBitCount(
+        llvm::Value* const pValue,             // [in] The ballot value
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot exclusive bit count.
-    virtual Value* CreateSubgroupBallotExclusiveBitCount(
-        Value* const pValue,             // [in] The ballot value
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallotExclusiveBitCount(
+        llvm::Value* const pValue,             // [in] The ballot value
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot find least significant bit.
-    virtual Value* CreateSubgroupBallotFindLsb(
-        Value* const pValue,             // [in] The ballot value
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallotFindLsb(
+        llvm::Value* const pValue,             // [in] The ballot value
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup ballot find most significant bit.
-    virtual Value* CreateSubgroupBallotFindMsb(
-        Value* const pValue,             // [in] The ballot value
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupBallotFindMsb(
+        llvm::Value* const pValue,             // [in] The ballot value
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup shuffle.
-    virtual Value* CreateSubgroupShuffle(
-        Value* const pValue,             // [in] The value to shuffle
-        Value* const pIndex,             // [in] The index to shuffle from
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupShuffle(
+        llvm::Value* const pValue,             // [in] The value to shuffle
+        llvm::Value* const pIndex,             // [in] The index to shuffle from
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup shuffle xor.
-    virtual Value* CreateSubgroupShuffleXor(
-        Value* const pValue,             // [in] The value to shuffle
-        Value* const pMask,              // [in] The mask to shuffle with
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupShuffleXor(
+        llvm::Value* const pValue,             // [in] The value to shuffle
+        llvm::Value* const pMask,              // [in] The mask to shuffle with
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup shuffle up.
-    virtual Value* CreateSubgroupShuffleUp(
-        Value* const pValue,             // [in] The value to shuffle
-        Value* const pDelta,             // [in] The delta to shuffle up to
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupShuffleUp(
+        llvm::Value* const pValue,             // [in] The value to shuffle
+        llvm::Value* const pDelta,             // [in] The delta to shuffle up to
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup shuffle down.
-    virtual Value* CreateSubgroupShuffleDown(
-        Value* const pValue,             // [in] The value to shuffle
-        Value* const pDelta,             // [in] The delta to shuffle down to
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupShuffleDown(
+        llvm::Value* const pValue,             // [in] The value to shuffle
+        llvm::Value* const pDelta,             // [in] The delta to shuffle down to
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup clustered reduction.
-    virtual Value* CreateSubgroupClusteredReduction(
+    virtual llvm::Value* CreateSubgroupClusteredReduction(
         GroupArithOp groupArithOp,       // The group arithmetic operation to perform
-        Value* const pValue,             // [in] The value to perform on
-        Value* const pClusterSize,       // [in] The cluster size
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value* const pValue,             // [in] The value to perform on
+        llvm::Value* const pClusterSize,       // [in] The cluster size
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup clustered inclusive scan.
-    virtual Value* CreateSubgroupClusteredInclusive(
+    virtual llvm::Value* CreateSubgroupClusteredInclusive(
         GroupArithOp groupArithOp,       // The group arithmetic operation to perform
-        Value* const pValue,             // [in] The value to perform on
-        Value* const pClusterSize,       // [in] The cluster size
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value* const pValue,             // [in] The value to perform on
+        llvm::Value* const pClusterSize,       // [in] The cluster size
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup clustered exclusive scan.
-    virtual Value* CreateSubgroupClusteredExclusive(
+    virtual llvm::Value* CreateSubgroupClusteredExclusive(
         GroupArithOp groupArithOp,       // The group arithmetic operation to perform
-        Value* const pValue,             // [in] The value to perform on
-        Value* const pClusterSize,       // [in] The cluster size
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+        llvm::Value* const pValue,             // [in] The value to perform on
+        llvm::Value* const pClusterSize,       // [in] The cluster size
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup quad broadcast.
-    virtual Value* CreateSubgroupQuadBroadcast(
-        Value* const pValue,             // [in] The value to broadcast
-        Value* const pIndex,             // [in] the index within the quad to broadcast from
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupQuadBroadcast(
+        llvm::Value* const pValue,             // [in] The value to broadcast
+        llvm::Value* const pIndex,             // [in] the index within the quad to broadcast from
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup quad swap horizontal.
-    virtual Value* CreateSubgroupQuadSwapHorizontal(
-        Value* const pValue,             // [in] The value to swap
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupQuadSwapHorizontal(
+        llvm::Value* const pValue,             // [in] The value to swap
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup quad swap vertical.
-    virtual Value* CreateSubgroupQuadSwapVertical(
-        Value* const pValue,             // [in] The value to swap
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupQuadSwapVertical(
+        llvm::Value* const pValue,             // [in] The value to swap
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup quad swap diagonal.
-    virtual Value* CreateSubgroupQuadSwapDiagonal(
-        Value* const pValue,             // [in] The value to swap
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupQuadSwapDiagonal(
+        llvm::Value* const pValue,             // [in] The value to swap
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup swizzle quad.
-    virtual Value* CreateSubgroupSwizzleQuad(
-        Value* const pValue,             // [in] The value to swizzle.
-        Value* const pOffset,            // [in] The value to specify the swizzle offsets.
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupSwizzleQuad(
+        llvm::Value* const pValue,             // [in] The value to swizzle.
+        llvm::Value* const pOffset,            // [in] The value to specify the swizzle offsets.
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup swizzle masked.
-    virtual Value* CreateSubgroupSwizzleMask(
-        Value* const pValue,             // [in] The value to swizzle.
-        Value* const pMask,              // [in] The value to specify the swizzle masks.
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupSwizzleMask(
+        llvm::Value* const pValue,             // [in] The value to swizzle.
+        llvm::Value* const pMask,              // [in] The value to specify the swizzle masks.
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup write invocation.
-    virtual Value* CreateSubgroupWriteInvocation(
-        Value* const pInputValue,        // [in] The value to return for all but one invocations.
-        Value* const pWriteValue,        // [in] The value to return for one invocation.
-        Value* const pIndex,             // [in] The index of the invocation that gets the write value.
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupWriteInvocation(
+        llvm::Value* const pInputValue,        // [in] The value to return for all but one invocations.
+        llvm::Value* const pWriteValue,        // [in] The value to return for one invocation.
+        llvm::Value* const pIndex,             // [in] The index of the invocation that gets the write value.
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // Create a subgroup mbcnt.
-    virtual Value* CreateSubgroupMbcnt(
-        Value* const pMask,              // [in] The mask to mbcnt with.
-        const Twine& instName = "") = 0; // [in] Name to give instruction(s)
+    virtual llvm::Value* CreateSubgroupMbcnt(
+        llvm::Value* const pMask,              // [in] The mask to mbcnt with.
+        const llvm::Twine& instName = "") = 0; // [in] Name to give instruction(s)
 
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -1344,25 +1342,25 @@ protected:
     virtual ShaderModes* GetShaderModes() = 0;
 
     // Get a constant of FP or vector of FP type from the given APFloat, converting APFloat semantics where necessary
-    Constant* GetFpConstant(Type* pTy, APFloat value);
+    llvm::Constant* GetFpConstant(llvm::Type* pTy, llvm::APFloat value);
 
     // -----------------------------------------------------------------------------------------------------------------
 
     bool                            m_isBuilderRecorder = false;        // Whether this is a BuilderRecorder
     ShaderStage                     m_shaderStage = ShaderStageInvalid; // Current shader stage being built.
 
-    Type* GetTransposedMatrixTy(
-        Type* const pMatrixType) const; // [in] The matrix type to tranpose
+    llvm::Type* GetTransposedMatrixTy(
+        llvm::Type* const pMatrixType) const; // [in] The matrix type to tranpose
 
-    typedef std::function<Value* (Builder& builder,
-                                  ArrayRef<Value*> mappedArgs,
-                                  ArrayRef<Value*> passthroughArgs)> PFN_MapToInt32Func;
+    typedef std::function<llvm::Value* (Builder& builder,
+                                  llvm::ArrayRef<llvm::Value*> mappedArgs,
+                                  llvm::ArrayRef<llvm::Value*> passthroughArgs)> PFN_MapToInt32Func;
 
     // Create a call that'll map the massage arguments to an i32 type (for functions that only take i32).
-    Value* CreateMapToInt32(
+    llvm::Value* CreateMapToInt32(
         PFN_MapToInt32Func  pfnMapFunc,       // [in] Pointer to the function to call on each i32.
-        ArrayRef<Value*>    mappedArgs,       // The arguments to massage into an i32 type.
-        ArrayRef<Value*>    passthroughArgs); // The arguments to pass-through without massaging.
+        llvm::ArrayRef<llvm::Value*>    mappedArgs,       // The arguments to massage into an i32 type.
+        llvm::ArrayRef<llvm::Value*>    passthroughArgs); // The arguments to pass-through without massaging.
 private:
     Builder() = delete;
     Builder(const Builder&) = delete;

--- a/lgc/include/lgc/llpcBuilderContext.h
+++ b/lgc/include/lgc/llpcBuilderContext.h
@@ -53,8 +53,6 @@ class PassManager;
 namespace lgc
 {
 
-using namespace llvm;
-
 class Builder;
 class PassManager;
 class Pipeline;
@@ -74,17 +72,17 @@ public:
 
     // Create the BuilderContext. Returns nullptr on failure to recognize the AMDGPU target whose name is specified
     static BuilderContext* Create(
-        LLVMContext&  context,               // [in] LLVM context to use on all compiles
-        StringRef     gpuName,               // LLVM GPU name (e.g. "gfx900"); empty to use -mcpu option setting
+        llvm::LLVMContext&  context,               // [in] LLVM context to use on all compiles
+        llvm::StringRef     gpuName,               // LLVM GPU name (e.g. "gfx900"); empty to use -mcpu option setting
         uint32_t      palAbiVersion);        // PAL pipeline ABI version to compile for
 
     ~BuilderContext();
 
     // Get LLVM context
-    LLVMContext& GetContext() const { return m_context; }
+    llvm::LLVMContext& GetContext() const { return m_context; }
 
     // Get the target machine.
-    TargetMachine* GetTargetMachine() const { return m_pTargetMachine; }
+    llvm::TargetMachine* GetTargetMachine() const { return m_pTargetMachine; }
 
     // Get targetinfo
     const TargetInfo& GetTargetInfo() const { return *m_pTargetInfo; }
@@ -104,36 +102,36 @@ public:
     // Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
     // think that we have library functions.
     void PreparePassManager(
-        legacy::PassManager*  pPassMgr);  // [in/out] Pass manager
+        llvm::legacy::PassManager*  pPassMgr);  // [in/out] Pass manager
 
     // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
-    void AddTargetPasses(lgc::PassManager& passMgr, Timer* pCodeGenTimer, raw_pwrite_stream& outStream);
+    void AddTargetPasses(lgc::PassManager& passMgr, llvm::Timer* pCodeGenTimer, llvm::raw_pwrite_stream& outStream);
 
     void SetBuildRelocatableElf(bool buildRelocatableElf) { m_buildRelocatableElf = buildRelocatableElf; }
     bool BuildingRelocatableElf() { return m_buildRelocatableElf; }
 
     // Utility method to create a start/stop timer pass
-    static ModulePass* CreateStartStopTimer(Timer* pTimer, bool starting);
+    static llvm::ModulePass* CreateStartStopTimer(llvm::Timer* pTimer, bool starting);
 
     // Set and get a pointer to the stream used for LLPC_OUTS. This is initially nullptr,
     // signifying no output from LLPC_OUTS. Setting this to a stream means that LLPC_OUTS
     // statements in the middle-end output to that stream, giving a dump of LLVM IR at a
     // few strategic places in the pass flow, as well as information such as input/output
     // mapping.
-    static void SetLlpcOuts(raw_ostream* pStream) { m_pLlpcOuts = pStream; }
-    static raw_ostream* GetLgcOuts() { return m_pLlpcOuts; }
+    static void SetLlpcOuts(llvm::raw_ostream* pStream) { m_pLlpcOuts = pStream; }
+    static llvm::raw_ostream* GetLgcOuts() { return m_pLlpcOuts; }
 
 private:
     BuilderContext() = delete;
     BuilderContext(const BuilderContext&) = delete;
     BuilderContext& operator =(const BuilderContext&) = delete;
 
-    BuilderContext(LLVMContext& context, uint32_t palAbiVersion);
+    BuilderContext(llvm::LLVMContext& context, uint32_t palAbiVersion);
 
     // -----------------------------------------------------------------------------------------------------------------
-    static raw_ostream*        m_pLlpcOuts;                   // nullptr or stream for LLPC_OUTS
-    LLVMContext&               m_context;                     // LLVM context
-    TargetMachine*             m_pTargetMachine = nullptr;    // Target machine
+    static llvm::raw_ostream*        m_pLlpcOuts;                   // nullptr or stream for LLPC_OUTS
+    llvm::LLVMContext&               m_context;                     // LLVM context
+    llvm::TargetMachine*             m_pTargetMachine = nullptr;    // Target machine
     TargetInfo*                m_pTargetInfo = nullptr;       // Target info
     bool                       m_buildRelocatableElf = false; // Flag indicating whether we are building relocatable ELF
     uint32_t                   m_palAbiVersion = 0xFFFFFFFF;  // PAL pipeline ABI version to compile for

--- a/lgc/include/lgc/llpcPipeline.h
+++ b/lgc/include/lgc/llpcPipeline.h
@@ -45,8 +45,6 @@ class Timer;
 namespace lgc
 {
 
-using namespace llvm;
-
 class BuilderContext;
 
 // =====================================================================================================================
@@ -218,11 +216,11 @@ struct ResourceNode
         {
             uint32_t            set;                  // Descriptor set
             uint32_t            binding;              // Binding
-            Constant*           pImmutableValue;      // Array of vectors of i32 constants for immutable value
+            llvm::Constant*           pImmutableValue;      // Array of vectors of i32 constants for immutable value
         };
 
         // Info for DescriptorTableVaPtr
-        ArrayRef<ResourceNode>  innerTable;
+        llvm::ArrayRef<ResourceNode>  innerTable;
 
         // Info for indirect data nodes (IndirectUserDataVaPtr, StreamOutVaTablePtr)
         uint32_t                indirectSizeInDwords;
@@ -556,7 +554,7 @@ public:
     BuilderContext* GetBuilderContext() const { return m_pBuilderContext; }
 
     // Get LLVMContext
-    LLVMContext& GetContext() const;
+    llvm::LLVMContext& GetContext() const;
 
     // -----------------------------------------------------------------------------------------------------------------
     // State setting methods
@@ -580,7 +578,7 @@ public:
     // If using a BuilderImpl, this method must be called before any Create* methods.
     // If using a BuilderRecorder, it can be delayed until after linking.
     virtual void SetUserDataNodes(
-        ArrayRef<ResourceNode>          nodes) = 0;       // The resource mapping nodes. Only used for the duration
+        llvm::ArrayRef<ResourceNode>          nodes) = 0;       // The resource mapping nodes. Only used for the duration
                                                           //  of the call; the call copies the nodes.
 
     // Set device index.
@@ -588,13 +586,13 @@ public:
 
     // Set vertex input descriptions. Each location referenced in a call to CreateReadGenericInput in the
     // vertex shader must have a corresponding description provided here.
-    virtual void SetVertexInputDescriptions(ArrayRef<VertexInputDescription> inputs) = 0;
+    virtual void SetVertexInputDescriptions(llvm::ArrayRef<VertexInputDescription> inputs) = 0;
 
     // Set color export state.
     // The client should always zero-initialize the ColorExportState struct before setting it up, in case future
     // versions add more fields. A local struct variable can be zero-initialized with " = {}".
     virtual void SetColorExportState(
-        ArrayRef<ColorExportFormat> formats,          // Array of ColorExportFormat structs
+        llvm::ArrayRef<ColorExportFormat> formats,          // Array of ColorExportFormat structs
         const ColorExportState&     exportState) = 0; // [in] Color export flags
 
     // Set graphics state (input-assembly, viewport, rasterizer).
@@ -613,17 +611,17 @@ public:
     // Before calling this, each shader module needs to have one global function for the shader
     // entrypoint, then all other functions with internal linkage.
     // Returns the pipeline module, or nullptr on link failure.
-    virtual Module* Link(
-        ArrayRef<Module*> modules) = 0; // Array of modules indexed by shader stage, with nullptr entry
+    virtual llvm::Module* Link(
+        llvm::ArrayRef<llvm::Module*> modules) = 0; // Array of modules indexed by shader stage, with nullptr entry
                                         //  for any stage not present in the pipeline
 
     // Typedef of function passed in to Generate to check the shader cache.
     // Returns the updated shader stage mask, allowing the client to decide not to compile shader stages
     // that got a hit in the cache.
     typedef std::function<uint32_t(
-        const Module*               pModule,      // [in] Module
+        const llvm::Module*               pModule,      // [in] Module
         uint32_t                    stageMask,    // Shader stage mask
-        ArrayRef<ArrayRef<uint8_t>> stageHashes   // Per-stage hash of in/out usage
+        llvm::ArrayRef<llvm::ArrayRef<uint8_t>> stageHashes   // Per-stage hash of in/out usage
     )> CheckShaderCacheFunc;
 
     // Generate pipeline module by running patch, middle-end optimization and backend codegen passes.
@@ -632,10 +630,10 @@ public:
     // Like other Builder methods, on error, this calls report_fatal_error, which you can catch by setting
     // a diagnostic handler with LLVMContext::setDiagnosticHandler.
     virtual void Generate(
-        std::unique_ptr<Module>   pipelineModule,       // IR pipeline module
-        raw_pwrite_stream&        outStream,            // [in/out] Stream to write ELF or IR disassembly output
+        std::unique_ptr<llvm::Module>   pipelineModule,       // IR pipeline module
+        llvm::raw_pwrite_stream&        outStream,            // [in/out] Stream to write ELF or IR disassembly output
         CheckShaderCacheFunc      checkShaderCacheFunc, // Function to check shader cache in graphics pipeline
-        ArrayRef<Timer*>          timers) = 0;          // Timers for: patch passes, llvm optimizations, codegen
+        llvm::ArrayRef<llvm::Timer*>          timers) = 0;          // Timers for: patch passes, llvm optimizations, codegen
 
     // -----------------------------------------------------------------------------------------------------------------
     // Non-compiling methods
@@ -643,7 +641,7 @@ public:
     // Compute the ExportFormat (as an opaque int) of the specified color export location with the specified output
     // type. Only the number of elements of the type is significant.
     // This is not used in a normal compile; it is only used by amdllpc's -check-auto-layout-compatible option.
-    virtual uint32_t ComputeExportFormat(Type* pOutputTy, uint32_t location) = 0;
+    virtual uint32_t ComputeExportFormat(llvm::Type* pOutputTy, uint32_t location) = 0;
 
 private:
     BuilderContext*                 m_pBuilderContext;                  // Builder context

--- a/lgc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/lgc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -49,6 +49,8 @@ extern opt<bool> InRegEsGsLdsSize;
 
 } // llvm
 
+using namespace llvm;
+
 namespace lgc
 {
 

--- a/lgc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/lgc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -49,6 +49,8 @@ extern opt<bool> InRegEsGsLdsSize;
 
 } // llvm
 
+using namespace llvm;
+
 namespace lgc
 {
 

--- a/lgc/patch/llpcPatch.h
+++ b/lgc/patch/llpcPatch.h
@@ -68,8 +68,6 @@ void initializePatchSetupTargetFeaturesPass(PassRegistry&);
 namespace lgc
 {
 
-using namespace llvm;
-
 class PatchCheckShaderCache;
 
 // Initialize passes for patching

--- a/lgc/patch/llpcPatchBufferOp.h
+++ b/lgc/patch/llpcPatchBufferOp.h
@@ -53,7 +53,7 @@ public:
     bool runOnFunction(llvm::Function& function) override;
 
     // Visitors
-    void visitAtomicCmpXchgInst(AtomicCmpXchgInst& atomicCmpXchgInst);
+    void visitAtomicCmpXchgInst(llvm::AtomicCmpXchgInst& atomicCmpXchgInst);
     void visitAtomicRMWInst(llvm::AtomicRMWInst& atomicRmwInst);
     void visitBitCastInst(llvm::BitCastInst& bitCastInst);
     void visitCallInst(llvm::CallInst& callInst);

--- a/lgc/patch/llpcPatchDescriptorLoad.h
+++ b/lgc/patch/llpcPatchDescriptorLoad.h
@@ -91,7 +91,7 @@ private:
                                       llvm::Value*        pArrayOffset,
                                       llvm::Instruction*  pInsertPoint);
 
-    llvm::Value* BuildInlineBufferDesc(Value* pDescPtr, llvm::IRBuilder<>& builder);
+    llvm::Value* BuildInlineBufferDesc(llvm::Value* pDescPtr, llvm::IRBuilder<>& builder);
     llvm::Value* BuildBufferCompactDesc(llvm::Value* pDesc, llvm::Instruction* pInsertPoint);
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/lgc/patch/llpcPatchInOutImportExport.h
+++ b/lgc/patch/llpcPatchInOutImportExport.h
@@ -103,9 +103,9 @@ private:
                                            llvm::Instruction* pInsertPos);
     llvm::Value* PatchFsGenericInputImport(llvm::Type*        pInputTy,
                                            uint32_t           location,
-                                           Value*             pLocOffset,
-                                           Value*             pCompIdx,
-                                           Value*             pAuxInterpValue,
+                                           llvm::Value*             pLocOffset,
+                                           llvm::Value*             pCompIdx,
+                                           llvm::Value*             pAuxInterpValue,
                                            uint32_t           interpMode,
                                            uint32_t           interpLoc,
                                            llvm::Instruction* pInsertPos);
@@ -158,7 +158,7 @@ private:
                                            llvm::Instruction* pInsertPos);
     llvm::Value* PatchFsBuiltInInputImport(llvm::Type*        pInputTy,
                                            uint32_t           builtInId,
-                                           Value*             pSampleId,
+                                           llvm::Value*             pSampleId,
                                            llvm::Instruction* pInsertPos);
     llvm::Value* GetSamplePosOffset(llvm::Type* pInputTy, llvm::Value* pSampleId, llvm::Instruction* pInsertPos);
     llvm::Value* GetSamplePosition(llvm::Type* pInputTy, llvm::Instruction* pInsertPos);
@@ -273,26 +273,26 @@ private:
                                           uint32_t patchConstCount,
                                           uint32_t tessFactorStride) const;
 
-    llvm::Value* CalcLdsOffsetForVsOutput(Type*              pOutputTy,
+    llvm::Value* CalcLdsOffsetForVsOutput(llvm::Type*        pOutputTy,
                                           uint32_t           location,
                                           uint32_t           compIdx,
                                           llvm::Instruction* pInsertPos);
 
-    llvm::Value* CalcLdsOffsetForTcsInput(Type*              pInputTy,
+    llvm::Value* CalcLdsOffsetForTcsInput(llvm::Type*        pInputTy,
                                           uint32_t           location,
                                           llvm::Value*       pLocOffset,
                                           llvm::Value*       pCompIdx,
                                           llvm::Value*       pVertexIdx,
                                           llvm::Instruction* pInsertPos);
 
-    llvm::Value* CalcLdsOffsetForTcsOutput(Type*              pOutputTy,
+    llvm::Value* CalcLdsOffsetForTcsOutput(llvm::Type*        pOutputTy,
                                            uint32_t           location,
                                            llvm::Value*       pLocOffset,
                                            llvm::Value*       pCompIdx,
                                            llvm::Value*       pVertexIdx,
                                            llvm::Instruction* pInsertPos);
 
-    llvm::Value* CalcLdsOffsetForTesInput(Type*              pInputTy,
+    llvm::Value* CalcLdsOffsetForTesInput(llvm::Type*        pInputTy,
                                           uint32_t           location,
                                           llvm::Value*       pLocOffset,
                                           llvm::Value*       pCompIdx,
@@ -344,7 +344,7 @@ private:
     llvm::GlobalVariable*   m_pLds;                     // Global variable to model LDS
     llvm::Value*            m_pThreadId;                // Thread ID
 
-    std::vector<Value*>     m_expFragColors[MaxColorTargets]; // Exported fragment colors
+    std::vector<llvm::Value*>     m_expFragColors[MaxColorTargets]; // Exported fragment colors
     std::vector<llvm::CallInst*> m_importCalls; // List of "call" instructions to import inputs
     std::vector<llvm::CallInst*> m_exportCalls; // List of "call" instructions to export outputs
     PipelineState*          m_pPipelineState = nullptr; // Pipeline state from PipelineStateWrapper pass

--- a/lgc/patch/llpcPatchIntrinsicSimplify.h
+++ b/lgc/patch/llpcPatchIntrinsicSimplify.h
@@ -75,7 +75,7 @@ public:
 
 private:
     bool CanSafelyConvertTo16Bit(llvm::Value& value) const;
-    llvm::Value* ConvertTo16Bit(llvm::Value& value, IRBuilder<>& builder) const;
+    llvm::Value* ConvertTo16Bit(llvm::Value& value, llvm::IRBuilder<>& builder) const;
     llvm::Value* SimplifyImage(llvm::IntrinsicInst& intrinsicCall,
                                llvm::ArrayRef<uint32_t> coordOperandIndices) const;
     llvm::Value* SimplifyTrigonometric(llvm::IntrinsicInst& intrinsicCall) const;

--- a/lgc/patch/llpcPatchResourceCollect.h
+++ b/lgc/patch/llpcPatchResourceCollect.h
@@ -98,9 +98,9 @@ private:
     void ReassembleOutputExportCalls();
 
     // Input/output scalarizing
-    void ScalarizeForInOutPacking(Module* pModule);
-    void ScalarizeGenericInput(CallInst* pCall);
-    void ScalarizeGenericOutput(CallInst* pCall);
+    void ScalarizeForInOutPacking(llvm::Module* pModule);
+    void ScalarizeGenericInput(llvm::CallInst* pCall);
+    void ScalarizeGenericOutput(llvm::CallInst* pCall);
 
     // -----------------------------------------------------------------------------------------------------------------
 
@@ -170,7 +170,7 @@ class InOutLocationMapManager
 public:
     InOutLocationMapManager() {}
 
-    bool AddSpan(CallInst* pCall);
+    bool AddSpan(llvm::CallInst* pCall);
     void BuildLocationMap();
 
     bool FindMap(const InOutLocation& originalLocation, const InOutLocation*& pNewLocation);

--- a/lgc/util/llpcBuilderDebug.h
+++ b/lgc/util/llpcBuilderDebug.h
@@ -35,12 +35,10 @@
 namespace lgc
 {
 
-using namespace llvm;
-
 // Get pointer to stream for LLPC_OUTS, or nullptr if disabled.
-raw_ostream* GetLgcOuts();
+llvm::raw_ostream* GetLgcOuts();
 
 } // lgc
 
 // Output general message
-#define LLPC_OUTS(msg) do if (raw_ostream* pStream = GetLgcOuts()) { *pStream << msg; } while (false)
+#define LLPC_OUTS(msg) do if (llvm::raw_ostream* pStream = GetLgcOuts()) { *pStream << msg; } while (false)

--- a/lgc/util/llpcGfxRegHandler.h
+++ b/lgc/util/llpcGfxRegHandler.h
@@ -36,8 +36,6 @@
 namespace lgc
 {
 
-using namespace llvm;
-
 // General bits info for indexed DWORD
 struct BitsInfo
 {
@@ -52,34 +50,34 @@ class GfxRegHandlerBase
 {
 public:
     // Set register
-    void SetRegister(Value* pNewRegister);
+    void SetRegister(llvm::Value* pNewRegister);
 
     // Get register
-    Value* GetRegister();
+    llvm::Value* GetRegister();
 
 protected:
     // Constructor
-    inline GfxRegHandlerBase(Builder* pBuilder, Value* pRegister)
+    inline GfxRegHandlerBase(Builder* pBuilder, llvm::Value* pRegister)
     {
         m_pBuilder = pBuilder;
         SetRegister(pRegister);
     }
 
     // Return new DWORD with replacing the specific range of bits in old DWORD
-    Value* ReplaceBits(Value* pDword, uint32_t offset, uint32_t count, Value* pNewBits);
+    llvm::Value* ReplaceBits(llvm::Value* pDword, uint32_t offset, uint32_t count, llvm::Value* pNewBits);
 
     // Return the size of registered DWORDs
     inline uint32_t GetDwordsCount() { return m_dwords.size(); }
 
     // Get indexed DWORD
-    inline Value* GetDword(uint32_t index)
+    inline llvm::Value* GetDword(uint32_t index)
     {
         ExtractDwordIfNecessary(index);
         return m_dwords[index];
     }
 
     // Set indexed DWORD
-    inline void SetDword(uint32_t index, Value* pDword)
+    inline void SetDword(uint32_t index, llvm::Value* pDword)
     {
         // Set the whole 32bits data
         m_dwords[index] = pDword;
@@ -94,10 +92,10 @@ protected:
     }
 
     // Get data from a range of bits in indexed DWORD according to BitsInfo
-    Value* GetBits(const BitsInfo& bitsInfo);
+    llvm::Value* GetBits(const BitsInfo& bitsInfo);
 
     // Set data to a range of bits in indexed DWORD according to BitsInfo
-    void SetBits(const BitsInfo& bitsInfo, Value* pNewBits);
+    void SetBits(const BitsInfo& bitsInfo, llvm::Value* pNewBits);
 
 private:
     // Load indexed DWORD from <n x i32> vector, if the specific DWORD is nullptr
@@ -115,11 +113,11 @@ protected:
 private:
     // Contains (possibly updated) dwords for the register value. Each element will be a nullptr until it
     // is requested or updated for the first time.
-    SmallVector<Value*, 8> m_dwords;
+    llvm::SmallVector<llvm::Value*, 8> m_dwords;
 
     // Combined <n x i32> vector containing the register value, which does not yet reflect the dwords
     // that are marked as dirty.
-    Value* m_pRegister;
+    llvm::Value* m_pRegister;
 
     // Bit-mask of dwords whose value was changed but is not yet reflected in m_pRegister.
     uint32_t m_dirtyDwords;

--- a/lgc/util/llpcPipelineShaders.h
+++ b/lgc/util/llpcPipelineShaders.h
@@ -44,7 +44,7 @@ class PipelineShaders : public llvm::ModulePass
 {
 public:
     static char ID;
-    PipelineShaders() : ModulePass(ID)
+    PipelineShaders() : llvm::ModulePass(ID)
     {
     }
 

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.h
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.h
@@ -68,7 +68,7 @@ private:
     SpirvLowerAlgebraTransform& operator=(const SpirvLowerAlgebraTransform&) = delete;
 
     bool IsOperandNoContract(llvm::Value* pOperand);
-    void DisableFastMath(Value* pValue);
+    void DisableFastMath(llvm::Value* pValue);
 
     bool m_enableConstFolding; // Whether enable constant folding in this pass
     bool m_enableFloatOpt;     // Whether enable floating point optimization in this pass

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -85,7 +85,7 @@ private:
                                            llvm::Value*       pCompIdx,
                                            llvm::Value*       pVertexIdx,
                                            uint32_t           interpLoc,
-                                           Value*             pInterpInfo,
+                                           llvm::Value*             pInterpInfo,
                                            llvm::Instruction* pInsertPos);
 
     void AddCallInstForOutputExport(llvm::Value*       pOutputValue,

--- a/llpc/lower/llpcSpirvLowerMemoryOp.h
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.h
@@ -43,8 +43,8 @@ namespace Llpc
 struct StoreExpandInfo
 {
     StoreInst*                          pStoreInst;  ///< "Store" instruction
-    SmallVector<GetElementPtrInst*, 1>  getElemPtrs; ///< A group of "getelementptr" with constant indices
-    Value*                              pDynIndex;   ///< Dynamic index of destination.
+    llvm::SmallVector<GetElementPtrInst*, 1>  getElemPtrs; ///< A group of "getelementptr" with constant indices
+    llvm::Value*                              pDynIndex;   ///< Dynamic index of destination.
 };
 
 // =====================================================================================================================
@@ -82,7 +82,7 @@ private:
 
     std::unordered_set<llvm::Instruction*> m_removeInsts;
     std::unordered_set<llvm::Instruction*> m_preRemoveInsts;
-    SmallVector<StoreExpandInfo, 1>        m_storeExpandInfo;
+    llvm::SmallVector<StoreExpandInfo, 1>        m_storeExpandInfo;
 };
 
 } // Llpc

--- a/llpc/lower/llpcSpirvLowerResourceCollect.h
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.h
@@ -80,8 +80,8 @@ public:
     bool DetailUsageValid() { return m_detailUsageValid; }
 
     virtual bool runOnModule(llvm::Module& module);
-    void VisitCalls(Module& module);
-    Value* FindCallAndGetIndexValue(Module& module, CallInst* const pTargetCall);
+    void VisitCalls(llvm::Module& module);
+    llvm::Value* FindCallAndGetIndexValue(llvm::Module& module, llvm::CallInst* const pTargetCall);
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/llpc/translator/include/LLVMSPIRVLib.h
+++ b/llpc/translator/include/LLVMSPIRVLib.h
@@ -50,7 +50,7 @@
 #endif
 
 namespace llvm {
-// Pass initialization functions need to be declared before inclusion of
+// llvm::Pass initialization functions need to be declared before inclusion of
 // PassSupport.h.
 class PassRegistry;
 void initializeSPIRVLowerBoolPass(PassRegistry&);
@@ -122,47 +122,47 @@ bool readSpirv(lgc::Builder *Builder,
 bool regularizeLlvmForSpirv(llvm::Module *M, std::string &ErrMsg);
 
 /// Create a pass for lowering cast instructions of i1 type.
-ModulePass *createSPIRVLowerBool();
+llvm::ModulePass *createSPIRVLowerBool();
 
 /// Create a pass for lowering constant expressions to instructions.
-ModulePass *createSPIRVLowerConstExpr();
+llvm::ModulePass *createSPIRVLowerConstExpr();
 
 /// Create a pass for regularize LLVM module to be translated to SPIR-V.
-ModulePass *createSPIRVRegularizeLLVM();
+llvm::ModulePass *createSPIRVRegularizeLLVM();
 
 /// Create a pass for lowering llvm.memmove to llvm.memcpys with a temporary variable.
-ModulePass *createSPIRVLowerMemmove();
+llvm::ModulePass *createSPIRVLowerMemmove();
 
 /// Create a pass for lowering GLSL inputs to function calls
-ModulePass *createSPIRVLowerInput();
+llvm::ModulePass *createSPIRVLowerInput();
 
 /// Create a pass for lowering GLSL outputs to function calls
-ModulePass *createSPIRVLowerOutput();
+llvm::ModulePass *createSPIRVLowerOutput();
 
 /// Create a pass for translating GLSL generic global variables to function local variables
-ModulePass *createSPIRVLowerGlobal();
+llvm::ModulePass *createSPIRVLowerGlobal();
 
 /// Create a pass for lowering GLSL buffers (UBO and SSBO) to function calls
-ModulePass *createSPIRVLowerBuffer();
+llvm::ModulePass *createSPIRVLowerBuffer();
 
 /// Create a pass for lowering resource fetches to function calls
-ModulePass *createSPIRVLowerFetch();
+llvm::ModulePass *createSPIRVLowerFetch();
 
-ModulePass *createSPIRVResourceCollect();
+llvm::ModulePass *createSPIRVResourceCollect();
 
 /// Create a pass for translating input function call to real access input instruction
-ModulePass *createLLVMInput();
+llvm::ModulePass *createLLVMInput();
 
 /// Create a pass for translating input function call to real access output instruction
-ModulePass *createLLVMOutput();
+llvm::ModulePass *createLLVMOutput();
 
 /// Create a pass for translating descriptor function call to real descritpor setup instruction
-ModulePass *createLLVMDescriptor();
+llvm::ModulePass *createLLVMDescriptor();
 
 /// Create a pass for removing unused built-in functions
-ModulePass *createLLVMBuiltInFunc();
+llvm::ModulePass *createLLVMBuiltInFunc();
 
-ModulePass *createLLVMMutateEntry();
+llvm::ModulePass *createLLVMMutateEntry();
 
 } // namespace llvm
 


### PR DESCRIPTION
It has been agreed that "using namespace" in a header file is a bad
idea, even inside a namespace. This commit removes them.

Change-Id: Ia1ecd62d97a822e382cc1f07192d19f135d73230