### PR TITLE
Commits to prepare for coding standards change

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+BasedOnStyle: LLVM
+ColumnLimit: 120
+IncludeBlocks: Merge
+IncludeCategories:
+  - Regex:           '^"lgc/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        4
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 * [amdllpc standalone compiler](llpc/docs/amdllpc.md)
 
+* [Coding standard](docs/CodingStandards.md)
+
 ## Third Party Software
 LLPC contains code written by third parties:
 * SPIRV-LLVM translator is distributed under the terms of University of Illinois/NCSA Open Source License. See llpc/translator/LICENSE.TXT.

--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -1,0 +1,170 @@
+# LLPC coding standard
+
+## Introduction
+
+This file documents the coding standard used by the LLPC project, that is:
+* LLPC itself
+* LGC
+* The VKGC utilities and definitions that have been separated out of LLPC.
+
+LLPC coding standard is generally based on
+[LLVM coding standard](https://llvm.org/docs/CodingStandards.html),
+with some specific changes. One notable change is that LLPC follows
+[MLIR](https://github.com/tensorflow/mlir/blob/master/g3doc/DeveloperGuide.md)
+and LLD in using camelBack for variable and field names; this change is
+expected to be made in LLVM per
+[this proposal](https://llvm.org/docs/Proposals/VariableNames.html).
+
+## `using namespace`
+
+Do not use `using namespace` in a header file, even inside a namespace.
+
+Do not use `using namespace std` anywhere.
+
+See the
+[LLVM coding standard](https://llvm.org/docs/CodingStandards.html#do-not-use-using-namespace-std)
+for more details.
+
+## Integer types
+
+Usually you want an integer to be at least 32 bits. In that case use `int` or `unsigned`.
+Only use `int32_t` or `uint32_t` if you need an integer of _exactly_ 32 bits, for example
+in an externally-defined memory layout.
+
+## Identifier naming
+
+Names should be in CamelCase (initial capital) or camelBack (initial lower-case), depending on
+the category of identifier:
+
+* A *type name* (including classes, structs, enums, typedefs, etc) should be a noun phrase
+  in CamelCase (e.g. `Boat` or `TextFileReader`).
+
+* A *variable name* should be a noun phrase in camelBack (unlike current LLVM style).
+
+  Much LLVM code uses extreme abbreviation in variable names (e.g. `M` for a module); the LLVM coding
+  standard advises against this, and in LLPC we can avoid it by using the same name as the type but
+  in camelBack (e.g. `module`) or a somewhat abbreviated form (e.g. `inputMod`).
+
+  Do not use a type prefix on a variable name (e.g. p for pointer) (unlike PAL style).
+
+  A global or static variable name should start with an upper-case letter.
+
+* A *public member variable* (usually a struct member) should be named like a variable.
+
+* A *non-public member variable* should be named like a variable, but
+  with an extra `m_` prefix (unlike LLVM style, but like PAL style, and like LLDB and WebKit).
+
+* A *function name* or *method name* should be an imperative verb phrase in camelBack
+  (like LLVM style, but unlike PAL style).
+
+  There are some exceptions to the camelBack rule for historical reasons:
+
+  - Following subclasses of llvm::Instruction, a static method that creates an instance of the class is
+    called `Create` with an upper-case C.
+
+  - Builder and its subclasses follow llvm::IRBuilder in that any method whose name starts with Create
+    has an upper-case C. IRBuilder also uses an initial upper-case letter for a method that sets
+    or gets its internal state, but not a method that gets a type or constant.
+
+  Further exceptions outlined in the LLVM coding standard are where a class has a method that
+  mimics an STL class action, such as `push_back`. Such a method can keep the STL-like name.
+
+* A *constant* (technically a static variable or class/struct member variable, but `final` so it is used
+  like a constant) should be in CamelCase.
+
+* An *enumerator* (e.g. `enum { Foo, Bar }`) acts like a constant, so should start with an
+  upper-case letter. In addition, if the enum is not an enum class, and is not hidden inside a
+  class that suitably qualifies it, then each enumerator should have
+  a prefix corresponding to (not necessarily exactly the same as) the enum declaration name.
+
+Unlike in LLVM, an initialism (e.g. "NGG") should be treated as a word in identifier-naming
+rules. Thus, if it appears at the start of a variable or function name, it should be entirely
+lower-case (`nggControl`); if it appears at the start of a type or constant name, or anywhere
+other than the start in any name, it should have an initial upper-case letter (`NggControl`).
+
+For API compatibility, vkgcDefs.h, llpc.h and vfx.h have not been modified from PAL-style naming,
+which means they still
+contain struct members with a p prefix for pointer, and CamelCase for methods. Any method
+in .cpp files that implements or overrides a method in a class declared there, such as an
+ICompiler method, also keeps CamelCase rather than camelBack. Similarly the ElfReader/ElfWriter
+methods `ReadFromBuffer`, `GetSectionIndex`, `GetSymbolsBySectionIndex` and `GetSectionData`
+remain in PAL-style CamelCase. In addition, ElfReader's `ElfSymbol::pSymName` retains its
+PAL-style p prefix as it is directly referenced outside of LLPC/VKGC.
+
+## Local variable initialization
+
+A POD type local variable declaration should always be initialized, even if the initialized
+value is always overwritten in later code (for example in both legs of conditional code).
+A local variable of aggregate type can be initialized with `= {}` to zero all fields.
+
+A non-POD type with a sensible default constructor could also be initialized to make it
+obvious that you are running the default constructor, perhaps by appending `{}` to the
+variable name. This is considered unnecessary for well-known types with a sensible default
+constructor, such as the standard library and LLVM container types.
+
+## Braces
+
+Brace placement is covered by clang-format below.
+
+C++ allows the body of an if, else, while, do, for to be a single simple statement,
+without any braces. We follow the LLVM convention of only using an unbraced body if
+it is a single line, including comments. Otherwise the body should be braced. For
+an "if..else", if one of the two bodies is braced, the other one should be too. For
+an "if..else if..else if..else", if any body is braced, the others should be too.
+
+## Redundant comparisons
+
+Comparison of a bool with `false` or a pointer with `nullptr` is redundant and should
+be avoided. Use `!` instead where appropriate.
+
+## Redundant parentheses
+
+Certain cases of theoretically redundant parentheses around a subexpression are needed
+because compilers warn about them otherwise, for the good reason that C/C++ operator
+precedence makes it difficult to understand and easy to get wrong (in particular
+`&` `|` `^` vs comparison operators, and `&&` vs `||`). However redundant parentheses
+are not needed in cases that compilers do not warn about, in particular a comparison
+inside `&&` or `||`, or a comparison used as the condition of `?:` or in an assignment
+or `return`.
+
+## Comments
+
+Despite the look of much LLVM code, the LLVM coding standard does actually recommend
+placing a comment at the top of a function/method. :-)
+
+In LLPC, that is mandatory. Parameters should be commented in the main comment at
+the top of the function like this:
+
+```
+// \param hatstand : [in/out] The Hatstand object to modify
+```
+
+A tag of `[in]` is unnecessary, and is assumed for a reference or pointer parameter
+where no tag is given.
+
+Parameter comments should not be placed on the parameter line itself and aligned
+(as happens in PAL style), to avoid spuriously large diffs when a change or addition
+of one parameter means all the others need realigning.
+
+Similarly, a bunch of fields or variables should not have aligned inline comments.
+Instead, put each field's comment on the line above the field.
+
+## clang-format
+
+The LLPC coding standard uses a clang-format configuration based on the LLVM one,
+with the following changes:
+
+- 120 column limit (rather than 80)
+- `#include` blocks are merged together (removing blank lines) before sorting
+- `#include` directives are sorted in this order:
+  - the `.h` file for the current `.cpp` file;
+  - all other ones;
+  - `lgc/*` files;
+  - `llvm/*` files;
+  - standard library.
+
+You should use clang-format to format code modified or added in your change, but do not
+reformat any other code. Reviewers should reject a change that has spurious reformatting
+outside the lines affected by the substantive change, unless the whole point of the change
+is purely reformatting.
+

--- a/lgc/builder/llpcBuilderImplImage.cpp
+++ b/lgc/builder/llpcBuilderImplImage.cpp
@@ -1824,7 +1824,7 @@ Value* BuilderImplImage::CreateImageAtomicCommon(
                             derivatives);
 
     SmallVector<Value*, 8> args;
-    Instruction* pAtomicOp = nullptr;
+    Instruction* pAtomicInst = nullptr;
     uint32_t imageDescArgIndex = 0;
     if (pImageDesc->getType() == GetImageDescTy())
     {
@@ -1843,11 +1843,11 @@ Value* BuilderImplImage::CreateImageAtomicCommon(
 
         // Get the intrinsic ID from the load intrinsic ID table, and create the intrinsic.
         Intrinsic::ID intrinsicId = ImageAtomicIntrinsicTable[atomicOp][dim];
-        pAtomicOp = CreateIntrinsic(intrinsicId,
-                                    { pInputValue->getType(), pCoord->getType()->getScalarType() },
-                                    args,
-                                    nullptr,
-                                    instName);
+        pAtomicInst = CreateIntrinsic(intrinsicId,
+                                      { pInputValue->getType(), pCoord->getType()->getScalarType() },
+                                      args,
+                                      nullptr,
+                                      instName);
     }
     else
     {
@@ -1863,15 +1863,15 @@ Value* BuilderImplImage::CreateImageAtomicCommon(
         args.push_back(getInt32(0));
         args.push_back(getInt32(0));
         args.push_back(getInt32(0));
-        pAtomicOp = CreateIntrinsic(StructBufferAtomicIntrinsicTable[atomicOp],
-                                    pInputValue->getType(),
-                                    args,
-                                    nullptr,
-                                    instName);
+        pAtomicInst = CreateIntrinsic(StructBufferAtomicIntrinsicTable[atomicOp],
+                                      pInputValue->getType(),
+                                      args,
+                                      nullptr,
+                                      instName);
     }
     if (flags & ImageFlagNonUniformImage)
     {
-        pAtomicOp = CreateWaterfallLoop(pAtomicOp, imageDescArgIndex);
+        pAtomicInst = CreateWaterfallLoop(pAtomicInst, imageDescArgIndex);
     }
 
     switch (ordering)
@@ -1885,7 +1885,7 @@ Value* BuilderImplImage::CreateImageAtomicCommon(
         break;
     }
 
-    return pAtomicOp;
+    return pAtomicInst;
 }
 
 // =====================================================================================================================

--- a/lgc/builder/llpcBuilderImplImage.cpp
+++ b/lgc/builder/llpcBuilderImplImage.cpp
@@ -1575,7 +1575,8 @@ Value* BuilderImplImage::CreateImageSampleGather(
     uint32_t addressMask = 0;
     for (uint32_t i = 0; i != ImageAddressCount; ++i)
     {
-        addressMask |= (address[i] != nullptr) << i;
+        uint32_t addressMaskBit = (address[i] != nullptr) ? 1 : 0;
+        addressMask |= addressMaskBit << i;
     }
     addressMask &= ~(1U << ImageAddressIdxProjective);
     addressMask &= ~(1U << ImageAddressIdxComponent);

--- a/lgc/builder/llpcBuilderImplSubgroup.cpp
+++ b/lgc/builder/llpcBuilderImplSubgroup.cpp
@@ -1435,9 +1435,9 @@ Value* BuilderImplSubgroup::CreateThreadMaskedSelect(
     Value* const pValue1,     // [in] The first value to select.
     Value* const pValue2)     // [in] The second value to select.
 {
-    Value* const pAndMask = getIntN(GetShaderSubgroupSize(), andMask);
+    Value* const pAndMaskVal = getIntN(GetShaderSubgroupSize(), andMask);
     Value* const pZero = getIntN(GetShaderSubgroupSize(), 0);
-    return CreateSelect(CreateICmpNE(CreateAnd(pThreadMask, pAndMask), pZero), pValue1, pValue2);
+    return CreateSelect(CreateICmpNE(CreateAnd(pThreadMask, pAndMaskVal), pZero), pValue1, pValue2);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/llpcPipelineState.cpp
+++ b/lgc/builder/llpcPipelineState.cpp
@@ -1285,14 +1285,14 @@ const char* PipelineState::GetShaderStageAbbreviation(
 // =====================================================================================================================
 // Helper macro
 #define CASE_CLASSENUM_TO_STRING(TYPE, ENUM) \
-    case TYPE::ENUM: pString = #ENUM; break;
+    case TYPE::ENUM: string = #ENUM; break;
 
 // =====================================================================================================================
 // Translate enum "ResourceNodeType" to string
 const char* PipelineState::GetResourceNodeTypeName(
     ResourceNodeType type)  // Resource map node type
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (type)
     {
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, Unknown)
@@ -1314,7 +1314,7 @@ const char* PipelineState::GetResourceNodeTypeName(
         llvm_unreachable("Should never be called!");
         break;
     }
-    return pString;
+    return string;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/gfx6/chip/llpcGfx6Chip.h
+++ b/lgc/patch/gfx6/chip/llpcGfx6Chip.h
@@ -200,10 +200,10 @@ struct PsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-FS).
 struct PipelineVsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    VsRegConfig m_vsRegs;   // VS -> hardware VS
-    PsRegConfig m_psRegs;   // FS -> hardware PS
+    VsRegConfig vsRegs;   // VS -> hardware VS
+    PsRegConfig psRegs;   // FS -> hardware PS
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
 
@@ -214,12 +214,12 @@ struct PipelineVsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-TS-FS).
 struct PipelineVsTsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    LsRegConfig m_lsRegs;   // VS  -> hardware LS
-    HsRegConfig m_hsRegs;   // TCS -> hardware HS
-    VsRegConfig m_vsRegs;   // TES -> hardware VS
-    PsRegConfig m_psRegs;   // FS  -> hardware PS
+    LsRegConfig lsRegs;   // VS  -> hardware LS
+    HsRegConfig hsRegs;   // TCS -> hardware HS
+    VsRegConfig vsRegs;   // TES -> hardware VS
+    PsRegConfig psRegs;   // FS  -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -232,12 +232,12 @@ struct PipelineVsTsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-GS-FS).
 struct PipelineVsGsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    EsRegConfig m_esRegs;   // VS -> hardware ES
-    GsRegConfig m_gsRegs;   // GS -> hardware GS
-    PsRegConfig m_psRegs;   // FS -> hardware PS
-    VsRegConfig m_vsRegs;   // Copy shader -> hardware VS
+    EsRegConfig esRegs;   // VS -> hardware ES
+    GsRegConfig gsRegs;   // GS -> hardware GS
+    PsRegConfig psRegs;   // FS -> hardware PS
+    VsRegConfig vsRegs;   // Copy shader -> hardware VS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -249,14 +249,14 @@ struct PipelineVsGsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-TS-GS-FS).
 struct PipelineVsTsGsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    LsRegConfig m_lsRegs;   // VS  -> hardware LS
-    HsRegConfig m_hsRegs;   // TCS -> hardware HS
-    EsRegConfig m_esRegs;   // TES -> hardware ES
-    GsRegConfig m_gsRegs;   // GS  -> hardware GS
-    PsRegConfig m_psRegs;   // FS  -> hardware PS
-    VsRegConfig m_vsRegs;   // Copy shader -> hardware VS
+    LsRegConfig lsRegs;   // VS  -> hardware LS
+    HsRegConfig hsRegs;   // TCS -> hardware HS
+    EsRegConfig esRegs;   // TES -> hardware ES
+    GsRegConfig gsRegs;   // GS  -> hardware GS
+    PsRegConfig psRegs;   // FS  -> hardware PS
+    VsRegConfig vsRegs;   // Copy shader -> hardware VS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -269,7 +269,7 @@ struct PipelineVsTsGsFsRegConfig
 // Represents configuration of registers relevant to compute shader.
 struct CsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
     DEF_REG(COMPUTE_PGM_RSRC1);
     DEF_REG(COMPUTE_PGM_RSRC2);

--- a/lgc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/lgc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -397,92 +397,92 @@ void ConfigBuilder::BuildVsRegConfig(
     const auto& builtInUsage = pResUsage->builtInUsage;
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, DX10_CLAMP, true);  // Follow PAL setting
 
     const auto& xfbStrides = pResUsage->inOutUsage.xfbStrides;
     bool enableXfb = pResUsage->inOutUsage.enableXfb;
 
     if (shaderStage == ShaderStageCopyShader)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, lgc::CopyShaderUserSgprCount);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, lgc::CopyShaderUserSgprCount);
         SetNumAvailSgprs(Util::Abi::HardwareStage::Vs, m_pPipelineState->GetTargetInfo().GetGpuProperty().maxSgprsAvailable);
         SetNumAvailVgprs(Util::Abi::HardwareStage::Vs, m_pPipelineState->GetTargetInfo().GetGpuProperty().maxVgprsAvailable);
 
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN,
             (pResUsage->inOutUsage.gs.outLocCount[0] > 0) && enableXfb);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN,
             pResUsage->inOutUsage.gs.outLocCount[1] > 0);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG,
             STREAMOUT_2_EN, pResUsage->inOutUsage.gs.outLocCount[2] > 0);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN,
             pResUsage->inOutUsage.gs.outLocCount[3] > 0);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM,
             pResUsage->inOutUsage.gs.rasterStream);
     }
     else
     {
         const auto& shaderOptions = m_pPipelineState->GetShaderOptions(shaderStage);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, DEBUG_MODE, shaderOptions.debugMode);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, TRAP_PRESENT, shaderOptions.trapPresent);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, DEBUG_MODE, shaderOptions.debugMode);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, TRAP_PRESENT, shaderOptions.trapPresent);
 
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, pIntfData->userDataCount);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, pIntfData->userDataCount);
 
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN, enableXfb);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN, false);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN, false);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN, false);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN, enableXfb);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN, false);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN, false);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN, false);
 
         SetNumAvailSgprs(Util::Abi::HardwareStage::Vs, pResUsage->numSgprsAvailable);
         SetNumAvailVgprs(Util::Abi::HardwareStage::Vs, pResUsage->numVgprsAvailable);
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_EN, enableXfb);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE0_EN, (xfbStrides[0] > 0));
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE1_EN, (xfbStrides[1] > 0));
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE2_EN, (xfbStrides[2] > 0));
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE3_EN, (xfbStrides[3] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_EN, enableXfb);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE0_EN, (xfbStrides[0] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE1_EN, (xfbStrides[1] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE2_EN, (xfbStrides[2] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE3_EN, (xfbStrides[3] > 0));
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_0, STRIDE, xfbStrides[0] / sizeof(int));
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_1, STRIDE, xfbStrides[1] / sizeof(int));
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_2, STRIDE, xfbStrides[2] / sizeof(int));
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_3, STRIDE, xfbStrides[3] / sizeof(int));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_0, STRIDE, xfbStrides[0] / sizeof(int));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_1, STRIDE, xfbStrides[1] / sizeof(int));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_2, STRIDE, xfbStrides[2] / sizeof(int));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_3, STRIDE, xfbStrides[3] / sizeof(int));
 
     uint32_t streamBufferConfig = 0;
     for (auto i = 0; i < MaxGsStreams; ++i)
     {
         streamBufferConfig |= (pResUsage->inOutUsage.streamXfbBuffers[i] << (i * 4));
     }
-    SET_REG(&pConfig->m_vsRegs, VGT_STRMOUT_BUFFER_CONFIG, streamBufferConfig);
+    SET_REG(&pConfig->vsRegs, VGT_STRMOUT_BUFFER_CONFIG, streamBufferConfig);
 
     uint8_t usrClipPlaneMask = m_pPipelineState->GetRasterizerState().usrClipPlaneMask;
     bool depthClipDisable = (m_pPipelineState->GetViewportState().depthClipEnable == false);
     bool rasterizerDiscardEnable = m_pPipelineState->GetRasterizerState().rasterizerDiscardEnable;
     bool disableVertexReuse = m_pPipelineState->GetInputAssemblyState().disableVertexReuse;
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_3, (usrClipPlaneMask >> 3) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_4, (usrClipPlaneMask >> 4) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_5, (usrClipPlaneMask >> 5) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, DX_LINEAR_ATTR_CLIP_ENA,true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, DX_CLIP_SPACE_DEF, true); // DepthRange::ZeroToOne
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, ZCLIP_NEAR_DISABLE,depthClipDisable);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, ZCLIP_FAR_DISABLE, depthClipDisable);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, DX_RASTERIZATION_KILL,rasterizerDiscardEnable);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_3, (usrClipPlaneMask >> 3) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_4, (usrClipPlaneMask >> 4) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_5, (usrClipPlaneMask >> 5) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, DX_LINEAR_ATTR_CLIP_ENA,true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, DX_CLIP_SPACE_DEF, true); // DepthRange::ZeroToOne
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, ZCLIP_NEAR_DISABLE,depthClipDisable);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, ZCLIP_FAR_DISABLE, depthClipDisable);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, DX_RASTERIZATION_KILL,rasterizerDiscardEnable);
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_X_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_X_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Y_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Y_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Z_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Z_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VTX_W0_FMT, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_X_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_X_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Y_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Y_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Z_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Z_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VTX_W0_FMT, true);
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_SU_VTX_CNTL, PIX_CENTER, 1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_SU_VTX_CNTL, ROUND_MODE, 2); // Round to even
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_SU_VTX_CNTL, QUANT_MODE, 5); // Use 8-bit fractions
+    SET_REG_FIELD(&pConfig->vsRegs, PA_SU_VTX_CNTL, PIX_CENTER, 1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_SU_VTX_CNTL, ROUND_MODE, 2); // Round to even
+    SET_REG_FIELD(&pConfig->vsRegs, PA_SU_VTX_CNTL, QUANT_MODE, 5); // Use 8-bit fractions
 
     // Stage-specific processing
     bool usePointSize = false;
@@ -503,11 +503,11 @@ void ConfigBuilder::BuildVsRegConfig(
 
         if (builtInUsage.vs.instanceIndex)
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable instance ID
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable instance ID
         }
         else if (builtInUsage.vs.primitiveId)
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
         }
     }
     else if (shaderStage == ShaderStageTessEval)
@@ -522,16 +522,16 @@ void ConfigBuilder::BuildVsRegConfig(
         if (builtInUsage.tes.primitiveId)
         {
             // NOTE: when primitive ID is used, set vgtCompCnt to 3 directly because primitive ID is the last VGPR.
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable primitive ID
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable primitive ID
         }
         else
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
         }
 
         if (m_pPipelineState->IsTessOffChip())
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, OC_LDS_EN, true);
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, OC_LDS_EN, true);
         }
     }
     else
@@ -559,8 +559,8 @@ void ConfigBuilder::BuildVsRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, usePrimitiveId);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, pResUsage->inOutUsage.expCount - 1);
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, usePrimitiveId);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, pResUsage->inOutUsage.expCount - 1);
     SetUsesViewportArrayIndex(useViewportIndex);
 
     // According to the IA_VGT_Spec, it is only legal to enable vertex reuse when we're using viewport array
@@ -571,44 +571,44 @@ void ConfigBuilder::BuildVsRegConfig(
         // TODO: In the future, we can only disable vertex reuse only if viewport array index is emitted divergently
         // for each vertex.
         disableVertexReuse = true;
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, true);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_VERTEX_REUSE_BLOCK_CNTL, VTX_REUSE_DEPTH, 14);
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_VERTEX_REUSE_BLOCK_CNTL, VTX_REUSE_DEPTH, 14);
 
     useLayer = useLayer || m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     if (usePointSize || useLayer || useViewportIndex)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_VEC_ENA, true);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_VEC_ENA, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
     }
 
     if ((clipDistanceCount > 0) || (cullDistanceCount > 0))
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST0_VEC_ENA, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST0_VEC_ENA, true);
         if (clipDistanceCount + cullDistanceCount > 4)
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST1_VEC_ENA, true);
+            SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST1_VEC_ENA, true);
         }
 
         uint32_t clipDistanceMask = (1 << clipDistanceCount) - 1;
         uint32_t cullDistanceMask = (1 << cullDistanceCount) - 1;
 
         // Set fields CLIP_DIST_ENA_0 ~ CLIP_DIST_ENA_7 and CULL_DIST_ENA_0 ~ CULL_DIST_ENA_7
-        uint32_t paClVsOutCntl = GET_REG(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL);
+        uint32_t paClVsOutCntl = GET_REG(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL);
         paClVsOutCntl |= clipDistanceMask;
         paClVsOutCntl |= (cullDistanceMask << 8);
-        SET_REG(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
+        SET_REG(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
     }
 
     uint32_t posCount = 1; // gl_Position is always exported
@@ -626,18 +626,18 @@ void ConfigBuilder::BuildVsRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS0_EXPORT_FORMAT, SPI_SHADER_4COMP);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS0_EXPORT_FORMAT, SPI_SHADER_4COMP);
     if (posCount > 1)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS1_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS1_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
     if (posCount > 2)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS2_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS2_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
     if (posCount > 3)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
 
     // Set shader user data maping
@@ -659,34 +659,34 @@ void ConfigBuilder::BuildHsRegConfig(
     const auto& tessMode = m_pPipelineState->GetShaderModes()->GetTessellationMode();
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_hsRegs, SPI_SHADER_PGM_RSRC1_HS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_hsRegs, SPI_SHADER_PGM_RSRC1_HS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->hsRegs, SPI_SHADER_PGM_RSRC1_HS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->hsRegs, SPI_SHADER_PGM_RSRC1_HS, DX10_CLAMP, true);  // Follow PAL setting
 
     const auto& shaderOptions = m_pPipelineState->GetShaderOptions(shaderStage);
-    SET_REG_FIELD(&pConfig->m_hsRegs, SPI_SHADER_PGM_RSRC1_HS, DEBUG_MODE, shaderOptions.debugMode);
-    SET_REG_FIELD(&pConfig->m_hsRegs, SPI_SHADER_PGM_RSRC2_HS, TRAP_PRESENT, shaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_hsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR, pIntfData->userDataCount);
+    SET_REG_FIELD(&pConfig->hsRegs, SPI_SHADER_PGM_RSRC1_HS, DEBUG_MODE, shaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->hsRegs, SPI_SHADER_PGM_RSRC2_HS, TRAP_PRESENT, shaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->hsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR, pIntfData->userDataCount);
 
     if (m_pPipelineState->IsTessOffChip())
     {
-        SET_REG_FIELD(&pConfig->m_hsRegs, SPI_SHADER_PGM_RSRC2_HS, OC_LDS_EN, true);
+        SET_REG_FIELD(&pConfig->hsRegs, SPI_SHADER_PGM_RSRC2_HS, OC_LDS_EN, true);
     }
 
     // Minimum and maximum tessellation factors supported by the hardware.
     constexpr float MinTessFactor = 1.0f;
     constexpr float MaxTessFactor = 64.0f;
-    SET_REG(&pConfig->m_hsRegs, VGT_HOS_MIN_TESS_LEVEL, FloatToBits(MinTessFactor));
-    SET_REG(&pConfig->m_hsRegs, VGT_HOS_MAX_TESS_LEVEL, FloatToBits(MaxTessFactor));
+    SET_REG(&pConfig->hsRegs, VGT_HOS_MIN_TESS_LEVEL, FloatToBits(MinTessFactor));
+    SET_REG(&pConfig->hsRegs, VGT_HOS_MAX_TESS_LEVEL, FloatToBits(MaxTessFactor));
 
     // Set VGT_LS_HS_CONFIG
-    SET_REG_FIELD(&pConfig->m_hsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);
-    SET_REG_FIELD(&pConfig->m_hsRegs,
+    SET_REG_FIELD(&pConfig->hsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);
+    SET_REG_FIELD(&pConfig->hsRegs,
                   VGT_LS_HS_CONFIG,
                   HS_NUM_INPUT_CP,
                   m_pPipelineState->GetInputAssemblyState().patchControlPoints);
 
     auto hsNumOutputCp = tessMode.outputVertices;
-    SET_REG_FIELD(&pConfig->m_hsRegs, VGT_LS_HS_CONFIG, HS_NUM_OUTPUT_CP, hsNumOutputCp);
+    SET_REG_FIELD(&pConfig->hsRegs, VGT_LS_HS_CONFIG, HS_NUM_OUTPUT_CP, hsNumOutputCp);
 
     SetNumAvailSgprs(Util::Abi::HardwareStage::Hs, pResUsage->numSgprsAvailable);
     SetNumAvailVgprs(Util::Abi::HardwareStage::Hs, pResUsage->numVgprsAvailable);
@@ -711,18 +711,18 @@ void ConfigBuilder::BuildEsRegConfig(
     const auto& calcFactor = m_pPipelineState->GetShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor;
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC1_ES, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC1_ES, DX10_CLAMP, true); // Follow PAL setting
+    SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC1_ES, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC1_ES, DX10_CLAMP, true); // Follow PAL setting
 
     const auto& shaderOptions = m_pPipelineState->GetShaderOptions(shaderStage);
-    SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC1_ES, DEBUG_MODE, shaderOptions.debugMode);
-    SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC2_ES, TRAP_PRESENT, shaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC1_ES, DEBUG_MODE, shaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC2_ES, TRAP_PRESENT, shaderOptions.trapPresent);
     if (m_pPipelineState->IsGsOnChip())
     {
         assert(calcFactor.gsOnChipLdsSize <= m_pPipelineState->GetTargetInfo().GetGpuProperty().gsOnChipMaxLdsSize);
         assert((calcFactor.gsOnChipLdsSize %
                      (1 << m_pPipelineState->GetTargetInfo().GetGpuProperty().ldsSizeDwordGranularityShift)) == 0);
-        SET_REG_FIELD(&pConfig->m_esRegs,
+        SET_REG_FIELD(&pConfig->esRegs,
                       SPI_SHADER_PGM_RSRC2_ES,
                       LDS_SIZE__CI__VI,
                       (calcFactor.gsOnChipLdsSize >>
@@ -754,15 +754,15 @@ void ConfigBuilder::BuildEsRegConfig(
 
         if (m_pPipelineState->IsTessOffChip())
         {
-            SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC2_ES, OC_LDS_EN, true);
+            SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC2_ES, OC_LDS_EN, true);
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC1_ES, VGPR_COMP_CNT, vgprCompCnt);
+    SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC1_ES, VGPR_COMP_CNT, vgprCompCnt);
 
-    SET_REG_FIELD(&pConfig->m_esRegs, SPI_SHADER_PGM_RSRC2_ES, USER_SGPR, pIntfData->userDataCount);
+    SET_REG_FIELD(&pConfig->esRegs, SPI_SHADER_PGM_RSRC2_ES, USER_SGPR, pIntfData->userDataCount);
 
-    SET_REG_FIELD(&pConfig->m_esRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
+    SET_REG_FIELD(&pConfig->esRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
 
     SetNumAvailSgprs(Util::Abi::HardwareStage::Es, pResUsage->numSgprsAvailable);
     SetNumAvailVgprs(Util::Abi::HardwareStage::Es, pResUsage->numVgprsAvailable);
@@ -786,19 +786,19 @@ void ConfigBuilder::BuildLsRegConfig(
     const auto& builtInUsage = pResUsage->builtInUsage.vs;
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC1_LS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC1_LS, DX10_CLAMP, true);  // Follow PAL setting
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC1_LS, DEBUG_MODE, shaderOptions.debugMode);
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC2_LS, TRAP_PRESENT, shaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC1_LS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC1_LS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC1_LS, DEBUG_MODE, shaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC2_LS, TRAP_PRESENT, shaderOptions.trapPresent);
 
     uint32_t vgtCompCnt = 1;
     if (builtInUsage.instanceIndex)
     {
         vgtCompCnt += 2; // Enable instance ID
     }
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC1_LS, VGPR_COMP_CNT, vgtCompCnt);
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC1_LS, VGPR_COMP_CNT, vgtCompCnt);
 
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC2_LS, USER_SGPR, pIntfData->userDataCount);
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC2_LS, USER_SGPR, pIntfData->userDataCount);
 
     const auto& calcFactor = m_pPipelineState->GetShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor;
 
@@ -846,7 +846,7 @@ void ConfigBuilder::BuildLsRegConfig(
     const uint32_t ldsSizeDwordGranularity = 1u << ldsSizeDwordGranularityShift;
     ldsSize = alignTo(ldsSizeInDwords, ldsSizeDwordGranularity) >> ldsSizeDwordGranularityShift;
 
-    SET_REG_FIELD(&pConfig->m_lsRegs, SPI_SHADER_PGM_RSRC2_LS, LDS_SIZE, ldsSize);
+    SET_REG_FIELD(&pConfig->lsRegs, SPI_SHADER_PGM_RSRC2_LS, LDS_SIZE, ldsSize);
     SetLdsSizeByteSize(Util::Abi::HardwareStage::Ls, ldsSizeInDwords * 4);
 
     SetNumAvailSgprs(Util::Abi::HardwareStage::Ls, pResUsage->numSgprsAvailable);
@@ -873,13 +873,13 @@ void ConfigBuilder::BuildGsRegConfig(
     const auto& inOutUsage   = pResUsage->inOutUsage;
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_gsRegs, SPI_SHADER_PGM_RSRC1_GS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_gsRegs, SPI_SHADER_PGM_RSRC1_GS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->gsRegs, SPI_SHADER_PGM_RSRC1_GS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->gsRegs, SPI_SHADER_PGM_RSRC1_GS, DX10_CLAMP, true);  // Follow PAL setting
 
     const auto& shaderOptions = m_pPipelineState->GetShaderOptions(shaderStage);
-    SET_REG_FIELD(&pConfig->m_gsRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, shaderOptions.debugMode);
-    SET_REG_FIELD(&pConfig->m_gsRegs, SPI_SHADER_PGM_RSRC2_GS, TRAP_PRESENT, shaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_gsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR, pIntfData->userDataCount);
+    SET_REG_FIELD(&pConfig->gsRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, shaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->gsRegs, SPI_SHADER_PGM_RSRC2_GS, TRAP_PRESENT, shaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->gsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR, pIntfData->userDataCount);
 
     const bool primAdjacency = (geometryMode.inputPrimitive == InputPrimitives::LinesAdjacency) ||
                                (geometryMode.inputPrimitive == InputPrimitives::TrianglesAdjacency);
@@ -895,27 +895,27 @@ void ConfigBuilder::BuildGsRegConfig(
     }
 
     uint32_t maxVertOut = std::max(1u, static_cast<uint32_t>(geometryMode.outputVertices));
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
 
     // TODO: Currently only support offchip GS
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, MODE, GS_SCENARIO_G);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, MODE, GS_SCENARIO_G);
     if (m_pPipelineState->IsGsOnChip())
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, ONCHIP__CI__VI, VGT_GS_MODE_ONCHIP_ON);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, false);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, ONCHIP__CI__VI, VGT_GS_MODE_ONCHIP_ON);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, false);
 
         uint32_t gsPrimsPerSubgrp = std::min(maxGsPerEs, inOutUsage.gs.calcFactor.gsPrimsPerSubgroup);
 
-        SET_REG_FIELD(&pConfig->m_gsRegs,
+        SET_REG_FIELD(&pConfig->gsRegs,
                       VGT_GS_ONCHIP_CNTL__CI__VI,
                       ES_VERTS_PER_SUBGRP,
                       inOutUsage.gs.calcFactor.esVertsPerSubgroup);
 
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_ONCHIP_CNTL__CI__VI, GS_PRIMS_PER_SUBGRP, gsPrimsPerSubgrp);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_ONCHIP_CNTL__CI__VI, GS_PRIMS_PER_SUBGRP, gsPrimsPerSubgrp);
 
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_ES_PER_GS, ES_PER_GS, inOutUsage.gs.calcFactor.esVertsPerSubgroup);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_PER_ES, GS_PER_ES, gsPrimsPerSubgrp);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_ES_PER_GS, ES_PER_GS, inOutUsage.gs.calcFactor.esVertsPerSubgroup);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_PER_ES, GS_PER_ES, gsPrimsPerSubgrp);
 
         if (cl::InRegEsGsLdsSize)
         {
@@ -925,58 +925,58 @@ void ConfigBuilder::BuildGsRegConfig(
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, ONCHIP__CI__VI, VGT_GS_MODE_ONCHIP_OFF);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, true);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, true);
-        SET_REG(&pConfig->m_gsRegs, VGT_GS_ONCHIP_CNTL__CI__VI, 0);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, ONCHIP__CI__VI, VGT_GS_MODE_ONCHIP_OFF);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, true);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, true);
+        SET_REG(&pConfig->gsRegs, VGT_GS_ONCHIP_CNTL__CI__VI, 0);
 
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_ES_PER_GS, ES_PER_GS, EsThreadsPerGsThread);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_PER_ES, GS_PER_ES, std::min(maxGsPerEs, GsPrimsPerEsThread));
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_ES_PER_GS, ES_PER_GS, EsThreadsPerGsThread);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_PER_ES, GS_PER_ES, std::min(maxGsPerEs, GsPrimsPerEsThread));
     }
     if (geometryMode.outputVertices <= 128)
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_128);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_128);
     }
     else if (geometryMode.outputVertices <= 256)
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_256);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_256);
     }
     else if (geometryMode.outputVertices <= 512)
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_512);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_512);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_1024);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_1024);
     }
 
     uint32_t gsVertItemSize0 = sizeof(uint32_t) * inOutUsage.gs.outLocCount[0];
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_VERT_ITEMSIZE, ITEMSIZE, gsVertItemSize0);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_VERT_ITEMSIZE, ITEMSIZE, gsVertItemSize0);
 
     uint32_t gsVertItemSize1 = sizeof(uint32_t) * inOutUsage.gs.outLocCount[1];
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_VERT_ITEMSIZE_1, ITEMSIZE, gsVertItemSize1);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_VERT_ITEMSIZE_1, ITEMSIZE, gsVertItemSize1);
 
     uint32_t gsVertItemSize2 = sizeof(uint32_t) * inOutUsage.gs.outLocCount[2];
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_VERT_ITEMSIZE_2, ITEMSIZE, gsVertItemSize2);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_VERT_ITEMSIZE_2, ITEMSIZE, gsVertItemSize2);
 
     uint32_t gsVertItemSize3 = sizeof(uint32_t) * inOutUsage.gs.outLocCount[3];
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_VERT_ITEMSIZE_3, ITEMSIZE, gsVertItemSize3);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_VERT_ITEMSIZE_3, ITEMSIZE, gsVertItemSize3);
 
     uint32_t gsVsRingOffset = gsVertItemSize0 * maxVertOut;
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GSVS_RING_OFFSET_1, OFFSET, gsVsRingOffset);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GSVS_RING_OFFSET_1, OFFSET, gsVsRingOffset);
 
     gsVsRingOffset += gsVertItemSize1 * maxVertOut;
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GSVS_RING_OFFSET_2, OFFSET, gsVsRingOffset);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GSVS_RING_OFFSET_2, OFFSET, gsVsRingOffset);
 
     gsVsRingOffset += gsVertItemSize2 * maxVertOut;
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GSVS_RING_OFFSET_3, OFFSET, gsVsRingOffset);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GSVS_RING_OFFSET_3, OFFSET, gsVsRingOffset);
 
     if ((geometryMode.invocations > 1) || builtInUsage.invocationId)
     {
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_INSTANCE_CNT, ENABLE, true);
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_INSTANCE_CNT, CNT, geometryMode.invocations);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_INSTANCE_CNT, ENABLE, true);
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_INSTANCE_CNT, CNT, geometryMode.invocations);
     }
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
 
     VGT_GS_OUTPRIM_TYPE gsOutputPrimitiveType = TRISTRIP;
     if (inOutUsage.outputMapLocCount == 0)
@@ -992,23 +992,23 @@ void ConfigBuilder::BuildGsRegConfig(
         gsOutputPrimitiveType = LINESTRIP;
     }
 
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
 
     // Set multi-stream output primitive type
     if ((gsVertItemSize1 > 0) || (gsVertItemSize2 > 0) || (gsVertItemSize3 > 0))
     {
         const static auto GS_OUT_PRIM_INVALID = 3u;
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_1,
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_1,
             (gsVertItemSize1 > 0) ? gsOutputPrimitiveType : GS_OUT_PRIM_INVALID);
 
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_2,
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_2,
             (gsVertItemSize2 > 0) ? gsOutputPrimitiveType : GS_OUT_PRIM_INVALID);
 
-        SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_3,
+        SET_REG_FIELD(&pConfig->gsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_3,
             (gsVertItemSize3 > 0) ? gsOutputPrimitiveType : GS_OUT_PRIM_INVALID);
     }
 
-    SET_REG_FIELD(&pConfig->m_gsRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, inOutUsage.gs.calcFactor.gsVsRingItemSize);
+    SET_REG_FIELD(&pConfig->gsRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, inOutUsage.gs.calcFactor.gsVsRingItemSize);
 
     SetNumAvailSgprs(Util::Abi::HardwareStage::Gs, pResUsage->numSgprsAvailable);
     SetNumAvailVgprs(Util::Abi::HardwareStage::Gs, pResUsage->numVgprsAvailable);
@@ -1032,39 +1032,39 @@ void ConfigBuilder::BuildPsRegConfig(
     const auto& fragmentMode = m_pPipelineState->GetShaderModes()->GetFragmentShaderMode();
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, DX10_CLAMP, true);  // Follow PAL setting
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, DEBUG_MODE, shaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, DEBUG_MODE, shaderOptions.debugMode);
 
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, TRAP_PRESENT, shaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR, pIntfData->userDataCount);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, TRAP_PRESENT, shaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR, pIntfData->userDataCount);
 
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, FRONT_FACE_ALL_BITS, true);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, FRONT_FACE_ALL_BITS, true);
     if (fragmentMode.pixelCenterInteger)
     {
         // TRUE - Force floating point position to upper left corner of pixel (X.0, Y.0)
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, POS_FLOAT_ULC, true);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, POS_FLOAT_ULC, true);
     }
     else if (builtInUsage.runAtSampleRate)
     {
         // 2 - Calculate per-pixel floating point position at iterated sample number
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 2);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 2);
     }
     else
     {
         // 0 - Calculate per-pixel floating point position at pixel center
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 0);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 0);
     }
 
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, WALK_ALIGN8_PRIM_FITS_ST, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, WALK_FENCE_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, TILE_WALK_ORDER_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, PS_ITER_SAMPLE, builtInUsage.runAtSampleRate);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, WALK_ALIGN8_PRIM_FITS_ST, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, WALK_FENCE_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, TILE_WALK_ORDER_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, PS_ITER_SAMPLE, builtInUsage.runAtSampleRate);
 
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, SUPERTILE_WALK_ORDER_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, MULTI_SHADER_ENGINE_PRIM_DISCARD_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, SUPERTILE_WALK_ORDER_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, MULTI_SHADER_ENGINE_PRIM_DISCARD_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
 
     ZOrder zOrder = LATE_Z;
     bool execOnHeirFail = false;
@@ -1086,16 +1086,16 @@ void ConfigBuilder::BuildPsRegConfig(
         zOrder = EARLY_Z_THEN_LATE_Z;
     }
 
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, Z_ORDER, zOrder);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, KILL_ENABLE, builtInUsage.discard);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, Z_EXPORT_ENABLE, builtInUsage.fragDepth);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE, builtInUsage.sampleMask);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, Z_ORDER, zOrder);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, KILL_ENABLE, builtInUsage.discard);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, Z_EXPORT_ENABLE, builtInUsage.fragDepth);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE, builtInUsage.sampleMask);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                   (fragmentMode.earlyFragmentTests && pResUsage->resourceWrite));
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);
 
     uint32_t depthExpFmt = EXP_FORMAT_ZERO;
     if (builtInUsage.sampleMask)
@@ -1110,7 +1110,7 @@ void ConfigBuilder::BuildPsRegConfig(
     {
         depthExpFmt = EXP_FORMAT_32_R;
     }
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
 
     uint32_t spiShaderColFormat = 0;
     uint32_t cbShaderMask = pResUsage->inOutUsage.fs.cbShaderMask;
@@ -1131,10 +1131,10 @@ void ConfigBuilder::BuildPsRegConfig(
         spiShaderColFormat = SPI_SHADER_32_R;
     }
 
-    SET_REG(&pConfig->m_psRegs, SPI_SHADER_COL_FORMAT, spiShaderColFormat);
+    SET_REG(&pConfig->psRegs, SPI_SHADER_COL_FORMAT, spiShaderColFormat);
 
-    SET_REG(&pConfig->m_psRegs, CB_SHADER_MASK, cbShaderMask);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, pResUsage->inOutUsage.fs.interpInfo.size());
+    SET_REG(&pConfig->psRegs, CB_SHADER_MASK, cbShaderMask);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, pResUsage->inOutUsage.fs.interpInfo.size());
 
     uint32_t pointCoordLoc = InvalidValue;
     if (pResUsage->inOutUsage.builtInInputLocMap.find(BuiltInPointCoord) !=
@@ -1193,11 +1193,11 @@ void ConfigBuilder::BuildPsRegConfig(
 
     if (pointCoordLoc != InvalidValue)
     {
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_ENA, true);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_X, SPI_PNT_SPRITE_SEL_S);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Y, SPI_PNT_SPRITE_SEL_T);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Z, SPI_PNT_SPRITE_SEL_0);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_W, SPI_PNT_SPRITE_SEL_1);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_ENA, true);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_X, SPI_PNT_SPRITE_SEL_S);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Y, SPI_PNT_SPRITE_SEL_T);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Z, SPI_PNT_SPRITE_SEL_0);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_W, SPI_PNT_SPRITE_SEL_1);
     }
 
     SetPsUsesUavs(pResUsage->resourceWrite || pResUsage->resourceRead);

--- a/lgc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
+++ b/lgc/patch/gfx6/chip/llpcGfx6ConfigBuilder.cpp
@@ -104,7 +104,6 @@ void ConfigBuilder::BuildPipelineVsFsRegConfig()
     const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     PipelineVsFsRegConfig config;
-    auto* pConfig = &config; // TODO: remove; this was added in refactoring to reduce the size of a diff
 
     AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderVs);
     AddApiHwShaderMapping(ShaderStageFragment, Util::Abi::HwShaderPs);
@@ -115,7 +114,7 @@ void ConfigBuilder::BuildPipelineVsFsRegConfig()
     {
         BuildVsRegConfig<PipelineVsFsRegConfig>(ShaderStageVertex, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_REAL);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_REAL);
 
         SetShaderHash(ShaderStageVertex);
     }
@@ -133,7 +132,7 @@ void ConfigBuilder::BuildPipelineVsFsRegConfig()
     const uint32_t primGroupSize = 128;
     iaMultiVgtParam.bits.PRIMGROUP_SIZE = primGroupSize - 1;
 
-    SET_REG(pConfig, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
+    SET_REG(&config, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
 
     AppendConfig(config);
 }
@@ -145,7 +144,6 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
     const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     PipelineVsTsFsRegConfig config;
-    auto* pConfig = &config; // TODO: remove; this was added in refactoring to reduce the size of a diff
 
     AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderLs);
     AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
@@ -158,7 +156,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
     {
         BuildLsRegConfig<PipelineVsTsFsRegConfig>(ShaderStageVertex, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, LS_EN, LS_STAGE_ON);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, LS_EN, LS_STAGE_ON);
 
         SetShaderHash(ShaderStageVertex);
     }
@@ -167,7 +165,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
     {
         BuildHsRegConfig<PipelineVsTsFsRegConfig>(ShaderStageTessControl, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
 
         SetShaderHash(ShaderStageTessControl);
     }
@@ -176,7 +174,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
     {
         BuildVsRegConfig<PipelineVsTsFsRegConfig>(ShaderStageTessEval, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_DS);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_DS);
 
         SetShaderHash(ShaderStageTessEval);
     }
@@ -190,7 +188,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
 
     if (m_pPipelineState->IsTessOffChip())
     {
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, DYNAMIC_HS, true);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, DYNAMIC_HS, true);
     }
 
     // Set up IA_MULTI_VGT_PARAM
@@ -205,7 +203,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
         iaMultiVgtParam.bits.SWITCH_ON_EOI = true;
     }
 
-    SET_REG(pConfig, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
+    SET_REG(&config, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
 
     // Set up VGT_TF_PARAM
     SetupVgtTfParam<PipelineVsTsFsRegConfig>(&config);
@@ -220,7 +218,6 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()
     const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     PipelineVsGsFsRegConfig config;
-    auto* pConfig = &config; // TODO: remove; this was added in refactoring to reduce the size of a diff
 
     AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderEs);
     AddApiHwShaderMapping(ShaderStageGeometry, Util::Abi::HwShaderGs | Util::Abi::HwShaderVs);
@@ -232,7 +229,7 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()
     {
         BuildEsRegConfig<PipelineVsGsFsRegConfig>(ShaderStageVertex, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_REAL);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_REAL);
 
         SetShaderHash(ShaderStageVertex);
     }
@@ -241,7 +238,7 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()
     {
         BuildGsRegConfig<PipelineVsGsFsRegConfig>(ShaderStageGeometry, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
 
         SetShaderHash(ShaderStageGeometry);
     }
@@ -257,7 +254,7 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()
     {
         BuildVsRegConfig<PipelineVsGsFsRegConfig>(ShaderStageCopyShader, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_COPY_SHADER);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_COPY_SHADER);
     }
 
     // Set up IA_MULTI_VGT_PARAM
@@ -266,7 +263,7 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()
     const uint32_t primGroupSize = 128;
     iaMultiVgtParam.bits.PRIMGROUP_SIZE = primGroupSize - 1;
 
-    SET_REG(pConfig, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
+    SET_REG(&config, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
 
     AppendConfig(config);
 }
@@ -278,7 +275,6 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     const uint32_t stageMask = m_pPipelineState->GetShaderStageMask();
 
     PipelineVsTsGsFsRegConfig config;
-    auto* pConfig = &config; // TODO: remove; this was added in refactoring to reduce the size of a diff
 
     AddApiHwShaderMapping(ShaderStageVertex, Util::Abi::HwShaderLs);
     AddApiHwShaderMapping(ShaderStageTessControl, Util::Abi::HwShaderHs);
@@ -292,7 +288,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     {
         BuildLsRegConfig<PipelineVsTsGsFsRegConfig>(ShaderStageVertex, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, LS_EN, LS_STAGE_ON);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, LS_EN, LS_STAGE_ON);
 
         SetShaderHash(ShaderStageVertex);
     }
@@ -301,7 +297,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     {
         BuildHsRegConfig<PipelineVsTsGsFsRegConfig>(ShaderStageTessControl, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
 
         SetShaderHash(ShaderStageTessControl);
     }
@@ -310,7 +306,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     {
         BuildEsRegConfig<PipelineVsTsGsFsRegConfig>(ShaderStageTessEval, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_DS);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_DS);
 
         SetShaderHash(ShaderStageTessEval);
     }
@@ -319,7 +315,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     {
         BuildGsRegConfig<PipelineVsTsGsFsRegConfig>(ShaderStageGeometry, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
 
         SetShaderHash(ShaderStageGeometry);
     }
@@ -335,12 +331,12 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     {
         BuildVsRegConfig<PipelineVsTsGsFsRegConfig>(ShaderStageCopyShader, &config);
 
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_COPY_SHADER);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, VS_EN, VS_STAGE_COPY_SHADER);
     }
 
     if (m_pPipelineState->IsTessOffChip())
     {
-        SET_REG_FIELD(pConfig, VGT_SHADER_STAGES_EN, DYNAMIC_HS, true);
+        SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, DYNAMIC_HS, true);
     }
 
     // Set up IA_MULTI_VGT_PARAM
@@ -357,7 +353,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
         iaMultiVgtParam.bits.SWITCH_ON_EOI = true;
     }
 
-    SET_REG(pConfig, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
+    SET_REG(&config, IA_MULTI_VGT_PARAM, iaMultiVgtParam.u32All);
 
     // Set up VGT_TF_PARAM
     SetupVgtTfParam<PipelineVsTsGsFsRegConfig>(&config);

--- a/lgc/patch/gfx9/chip/llpcGfx9Chip.cpp
+++ b/lgc/patch/gfx9/chip/llpcGfx9Chip.cpp
@@ -208,8 +208,8 @@ PsRegConfig::PsRegConfig(
 PipelineVsFsRegConfig::PipelineVsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_vsRegs(gfxIp),
-    m_psRegs(gfxIp)
+    vsRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG(VGT_GS_ONCHIP_CNTL);
@@ -222,9 +222,9 @@ PipelineVsFsRegConfig::PipelineVsFsRegConfig(
 PipelineVsTsFsRegConfig::PipelineVsTsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_lsHsRegs(gfxIp),
-    m_vsRegs(gfxIp),
-    m_psRegs(gfxIp)
+    lsHsRegs(gfxIp),
+    vsRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX9(gfxIp.major, IA_MULTI_VGT_PARAM);
@@ -237,9 +237,9 @@ PipelineVsTsFsRegConfig::PipelineVsTsFsRegConfig(
 PipelineVsGsFsRegConfig::PipelineVsGsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_esGsRegs(gfxIp),
-    m_vsRegs(gfxIp),
-    m_psRegs(gfxIp)
+    esGsRegs(gfxIp),
+    vsRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX9(gfxIp.major, IA_MULTI_VGT_PARAM);
@@ -250,10 +250,10 @@ PipelineVsGsFsRegConfig::PipelineVsGsFsRegConfig(
 // Initializer
 PipelineVsTsGsFsRegConfig::PipelineVsTsGsFsRegConfig(GfxIpVersion gfxIp)
     :
-    m_lsHsRegs(gfxIp),
-    m_esGsRegs(gfxIp),
-    m_vsRegs(gfxIp),
-    m_psRegs(gfxIp)
+    lsHsRegs(gfxIp),
+    esGsRegs(gfxIp),
+    vsRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX9(gfxIp.major, IA_MULTI_VGT_PARAM);
@@ -265,8 +265,8 @@ PipelineVsTsGsFsRegConfig::PipelineVsTsGsFsRegConfig(GfxIpVersion gfxIp)
 PipelineNggVsFsRegConfig::PipelineNggVsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_primShaderRegs(gfxIp),
-    m_psRegs(gfxIp)
+    primShaderRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX10_PLUS(gfxIp.major, IA_MULTI_VGT_PARAM_PIPED);
@@ -277,9 +277,9 @@ PipelineNggVsFsRegConfig::PipelineNggVsFsRegConfig(
 PipelineNggVsTsFsRegConfig::PipelineNggVsTsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_lsHsRegs(gfxIp),
-    m_primShaderRegs(gfxIp),
-    m_psRegs(gfxIp)
+    lsHsRegs(gfxIp),
+    primShaderRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX10_PLUS(gfxIp.major, IA_MULTI_VGT_PARAM_PIPED);
@@ -290,8 +290,8 @@ PipelineNggVsTsFsRegConfig::PipelineNggVsTsFsRegConfig(
 PipelineNggVsGsFsRegConfig::PipelineNggVsGsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_primShaderRegs(gfxIp),
-    m_psRegs(gfxIp)
+    primShaderRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX10_PLUS(gfxIp.major, IA_MULTI_VGT_PARAM_PIPED);
@@ -302,9 +302,9 @@ PipelineNggVsGsFsRegConfig::PipelineNggVsGsFsRegConfig(
 PipelineNggVsTsGsFsRegConfig::PipelineNggVsTsGsFsRegConfig(
     GfxIpVersion gfxIp) // Graphics IP version info
     :
-    m_lsHsRegs(gfxIp),
-    m_primShaderRegs(gfxIp),
-    m_psRegs(gfxIp)
+    lsHsRegs(gfxIp),
+    primShaderRegs(gfxIp),
+    psRegs(gfxIp)
 {
     INIT_REG(VGT_SHADER_STAGES_EN);
     INIT_REG_GFX10_PLUS(gfxIp.major, IA_MULTI_VGT_PARAM_PIPED);

--- a/lgc/patch/gfx9/chip/llpcGfx9Chip.cpp
+++ b/lgc/patch/gfx9/chip/llpcGfx9Chip.cpp
@@ -695,7 +695,7 @@ void InitRegisterNameMap(
 
         ADD_REG_MAP_GFX10(COMPUTE_PGM_RSRC3);
 
-        if (((gfxIp.major == 10) && (gfxIp.minor == 0)) == false)
+        if ((gfxIp.major != 10) || (gfxIp.minor != 0))
         {
             // For GFX10.1+
             ADD_REG_MAP_GFX10(SPI_SHADER_USER_ACCUM_VS_0);

--- a/lgc/patch/gfx9/chip/llpcGfx9Chip.h
+++ b/lgc/patch/gfx9/chip/llpcGfx9Chip.h
@@ -396,10 +396,10 @@ struct PsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-FS).
 struct PipelineVsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    VsRegConfig m_vsRegs;   // VS -> hardware VS
-    PsRegConfig m_psRegs;   // FS -> hardware PS
+    VsRegConfig vsRegs;   // VS -> hardware VS
+    PsRegConfig psRegs;   // FS -> hardware PS
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(VGT_GS_ONCHIP_CNTL);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -412,11 +412,11 @@ struct PipelineVsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-TS-FS).
 struct PipelineVsTsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    LsHsRegConfig m_lsHsRegs; // VS-TCS -> hardware LS-HS
-    VsRegConfig   m_vsRegs;   // TES    -> hardware VS
-    PsRegConfig   m_psRegs;   // FS     -> hardware PS
+    LsHsRegConfig lsHsRegs; // VS-TCS -> hardware LS-HS
+    VsRegConfig   vsRegs;   // TES    -> hardware VS
+    PsRegConfig   psRegs;   // FS     -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -430,11 +430,11 @@ struct PipelineVsTsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-GS-FS).
 struct PipelineVsGsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    EsGsRegConfig m_esGsRegs;   // VS-GS -> hardware ES-GS
-    VsRegConfig   m_vsRegs;     // Copy shader -> hardware VS
-    PsRegConfig   m_psRegs;     // FS -> hardware PS
+    EsGsRegConfig esGsRegs;   // VS-GS -> hardware ES-GS
+    VsRegConfig   vsRegs;     // Copy shader -> hardware VS
+    PsRegConfig   psRegs;     // FS -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -447,12 +447,12 @@ struct PipelineVsGsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (VS-TS-GS-FS).
 struct PipelineVsTsGsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    LsHsRegConfig m_lsHsRegs;   // VS-TCS -> hardware LS-HS
-    EsGsRegConfig m_esGsRegs;   // TES-GS -> hardware ES-GS
-    VsRegConfig   m_vsRegs;     // Copy shader -> hardware VS
-    PsRegConfig   m_psRegs;     // FS -> hardware PS
+    LsHsRegConfig lsHsRegs;   // VS-TCS -> hardware LS-HS
+    EsGsRegConfig esGsRegs;   // TES-GS -> hardware ES-GS
+    VsRegConfig   vsRegs;     // Copy shader -> hardware VS
+    PsRegConfig   psRegs;     // FS -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM);
@@ -465,10 +465,10 @@ struct PipelineVsTsGsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (NGG, VS-FS).
 struct PipelineNggVsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    PrimShaderRegConfig m_primShaderRegs; // VS -> hardware primitive shader (NGG, ES-GS)
-    PsRegConfig         m_psRegs;         // FS -> hardware PS
+    PrimShaderRegConfig primShaderRegs; // VS -> hardware primitive shader (NGG, ES-GS)
+    PsRegConfig         psRegs;         // FS -> hardware PS
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM_PIPED);
 
@@ -479,11 +479,11 @@ struct PipelineNggVsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (NGG, VS-TS-FS).
 struct PipelineNggVsTsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    LsHsRegConfig       m_lsHsRegs;       // VS-TCS -> hardware LS-HS
-    PrimShaderRegConfig m_primShaderRegs; // TES    -> hardware primitive shader (NGG, ES-GS)
-    PsRegConfig         m_psRegs;         // FS     -> hardware PS
+    LsHsRegConfig       lsHsRegs;       // VS-TCS -> hardware LS-HS
+    PrimShaderRegConfig primShaderRegs; // TES    -> hardware primitive shader (NGG, ES-GS)
+    PsRegConfig         psRegs;         // FS     -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM_PIPED);
@@ -495,10 +495,10 @@ struct PipelineNggVsTsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (NGG, VS-GS-FS).
 struct PipelineNggVsGsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    PrimShaderRegConfig m_primShaderRegs; // VS-GS -> hardware primitive shader (NGG, ES-GS)
-    PsRegConfig         m_psRegs;         // FS    -> hardware PS
+    PrimShaderRegConfig primShaderRegs; // VS-GS -> hardware primitive shader (NGG, ES-GS)
+    PsRegConfig         psRegs;         // FS    -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM_PIPED);
@@ -510,11 +510,11 @@ struct PipelineNggVsGsFsRegConfig
 // Represents configuration of registers relevant to graphics pipeline (NGG, VS-TS-GS-FS).
 struct PipelineNggVsTsGsFsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
-    LsHsRegConfig       m_lsHsRegs;       // VS-TCS -> hardware LS-HS
-    PrimShaderRegConfig m_primShaderRegs; // TES-GS -> hardware primitive shader (NGG, ES-GS)
-    PsRegConfig         m_psRegs;         // FS     -> hardware PS
+    LsHsRegConfig       lsHsRegs;       // VS-TCS -> hardware LS-HS
+    PrimShaderRegConfig primShaderRegs; // TES-GS -> hardware primitive shader (NGG, ES-GS)
+    PsRegConfig         psRegs;         // FS     -> hardware PS
 
     DEF_REG(VGT_SHADER_STAGES_EN);
     DEF_REG(IA_MULTI_VGT_PARAM_PIPED);
@@ -526,7 +526,7 @@ struct PipelineNggVsTsGsFsRegConfig
 // Represents configuration of registers relevant to compute shader.
 struct CsRegConfig
 {
-    static constexpr bool containsPalAbiMetadataOnly = true;
+    static constexpr bool ContainsPalAbiMetadataOnly = true;
 
     DEF_REG(COMPUTE_PGM_RSRC1);
     DEF_REG(COMPUTE_PGM_RSRC2);

--- a/lgc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
+++ b/lgc/patch/gfx9/chip/llpcGfx9ConfigBuilder.cpp
@@ -164,7 +164,7 @@ void ConfigBuilder::BuildPipelineVsFsRegConfig()      // [out] Size of register 
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_vsRegs, SPI_SHADER_PGM_CHKSUM_VS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.vsRegs, SPI_SHADER_PGM_CHKSUM_VS, CHECKSUM, checksum);
         }
     }
 
@@ -176,7 +176,7 @@ void ConfigBuilder::BuildPipelineVsFsRegConfig()      // [out] Size of register 
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -241,7 +241,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
@@ -279,7 +279,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_vsRegs, SPI_SHADER_PGM_CHKSUM_VS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.vsRegs, SPI_SHADER_PGM_CHKSUM_VS, CHECKSUM, checksum);
         }
     }
 
@@ -291,7 +291,7 @@ void ConfigBuilder::BuildPipelineVsTsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -355,7 +355,7 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()      // [out] Size of registe
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_esGsRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.esGsRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_REAL);
@@ -380,7 +380,7 @@ void ConfigBuilder::BuildPipelineVsGsFsRegConfig()      // [out] Size of registe
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -453,7 +453,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
@@ -488,7 +488,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_esGsRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.esGsRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_DS);
@@ -514,7 +514,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -558,7 +558,7 @@ void ConfigBuilder::BuildPipelineVsTsGsFsRegConfig()
     }
 
     // Set up VGT_TF_PARAM
-    SetupVgtTfParam(&config.m_lsHsRegs);
+    SetupVgtTfParam(&config.lsHsRegs);
 
     AppendConfig(config);
 }
@@ -610,7 +610,7 @@ void ConfigBuilder::BuildPipelineNggVsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
     }
 
@@ -622,7 +622,7 @@ void ConfigBuilder::BuildPipelineNggVsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -684,7 +684,7 @@ void ConfigBuilder::BuildPipelineNggVsTsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
@@ -723,7 +723,7 @@ void ConfigBuilder::BuildPipelineNggVsTsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
     }
 
@@ -735,7 +735,7 @@ void ConfigBuilder::BuildPipelineNggVsTsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -795,7 +795,7 @@ void ConfigBuilder::BuildPipelineNggVsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_REAL);
@@ -821,7 +821,7 @@ void ConfigBuilder::BuildPipelineNggVsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -879,7 +879,7 @@ void ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.lsHsRegs, SPI_SHADER_PGM_CHKSUM_HS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, HS_EN, HS_STAGE_ON);
@@ -910,7 +910,7 @@ void ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.primShaderRegs, SPI_SHADER_PGM_CHKSUM_GS, CHECKSUM, checksum);
         }
 
         SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_DS);
@@ -936,7 +936,7 @@ void ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig()
 
         if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportShaderPowerProfiling)
         {
-            SET_REG_FIELD(&config.m_psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
+            SET_REG_FIELD(&config.psRegs, SPI_SHADER_PGM_CHKSUM_PS, CHECKSUM, checksum);
         }
     }
 
@@ -954,7 +954,7 @@ void ConfigBuilder::BuildPipelineNggVsTsGsFsRegConfig()
     SET_REG(&config, IA_MULTI_VGT_PARAM_PIPED, iaMultiVgtParam.u32All);
 
     // Set up VGT_TF_PARAM
-    SetupVgtTfParam(&config.m_lsHsRegs);
+    SetupVgtTfParam(&config.lsHsRegs);
 
     AppendConfig(config);
 }
@@ -1004,77 +1004,77 @@ void ConfigBuilder::BuildVsRegConfig(
     const auto& builtInUsage = pResUsage->builtInUsage;
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, DX10_CLAMP, true);  // Follow PAL setting
 
     const auto& xfbStrides = pResUsage->inOutUsage.xfbStrides;
     bool enableXfb = pResUsage->inOutUsage.enableXfb;
     if (shaderStage == ShaderStageCopyShader)
     {
         // NOTE: For copy shader, we use fixed number of user data registers.
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, lgc::CopyShaderUserSgprCount);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, lgc::CopyShaderUserSgprCount);
         SetNumAvailSgprs(Util::Abi::HardwareStage::Vs, m_pPipelineState->GetTargetInfo().GetGpuProperty().maxSgprsAvailable);
         SetNumAvailVgprs(Util::Abi::HardwareStage::Vs, m_pPipelineState->GetTargetInfo().GetGpuProperty().maxVgprsAvailable);
 
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN,
             (pResUsage->inOutUsage.gs.outLocCount[0] > 0) && enableXfb);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN,
             pResUsage->inOutUsage.gs.outLocCount[1] > 0);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN,
             pResUsage->inOutUsage.gs.outLocCount[2] > 0);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN,
             pResUsage->inOutUsage.gs.outLocCount[3] > 0);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM,
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM,
             pResUsage->inOutUsage.gs.rasterStream);
     }
     else
     {
         const auto& shaderOptions = m_pPipelineState->GetShaderOptions(shaderStage);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, DEBUG_MODE, shaderOptions.debugMode);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, DEBUG_MODE, shaderOptions.debugMode);
 
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, TRAP_PRESENT, shaderOptions.trapPresent);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, pIntfData->userDataCount);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, TRAP_PRESENT, shaderOptions.trapPresent);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR, pIntfData->userDataCount);
         const bool userSgprMsb = (pIntfData->userDataCount > 31);
 
         if (gfxIp.major == 10)
         {
-            SET_REG_GFX10_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR_MSB, userSgprMsb);
+            SET_REG_GFX10_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR_MSB, userSgprMsb);
         }
         else
         {
-            SET_REG_GFX9_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR_MSB, userSgprMsb);
+            SET_REG_GFX9_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, USER_SGPR_MSB, userSgprMsb);
         }
 
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN, enableXfb);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN, false);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN, false);
-        SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN, false);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_0_EN, enableXfb);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN, false);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN, false);
+        SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN, false);
 
         SetNumAvailSgprs(Util::Abi::HardwareStage::Vs, pResUsage->numSgprsAvailable);
         SetNumAvailVgprs(Util::Abi::HardwareStage::Vs, pResUsage->numVgprsAvailable);
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_EN, enableXfb);
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE0_EN, (xfbStrides[0] > 0));
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE1_EN, (xfbStrides[1] > 0));
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE2_EN, (xfbStrides[2] > 0));
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE3_EN, (xfbStrides[3] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_EN, enableXfb);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE0_EN, (xfbStrides[0] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE1_EN, (xfbStrides[1] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE2_EN, (xfbStrides[2] > 0));
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, SO_BASE3_EN, (xfbStrides[3] > 0));
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_0, STRIDE, xfbStrides[0] / sizeof(uint32_t));
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_1, STRIDE, xfbStrides[1] / sizeof(uint32_t));
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_2, STRIDE, xfbStrides[2] / sizeof(uint32_t));
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_STRMOUT_VTX_STRIDE_3, STRIDE, xfbStrides[3] / sizeof(uint32_t));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_0, STRIDE, xfbStrides[0] / sizeof(uint32_t));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_1, STRIDE, xfbStrides[1] / sizeof(uint32_t));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_2, STRIDE, xfbStrides[2] / sizeof(uint32_t));
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_STRMOUT_VTX_STRIDE_3, STRIDE, xfbStrides[3] / sizeof(uint32_t));
 
     uint32_t streamBufferConfig = 0;
     for (auto i = 0; i < MaxGsStreams; ++i)
     {
         streamBufferConfig |= (pResUsage->inOutUsage.streamXfbBuffers[i] << (i * 4));
     }
-    SET_REG(&pConfig->m_vsRegs, VGT_STRMOUT_BUFFER_CONFIG, streamBufferConfig);
+    SET_REG(&pConfig->vsRegs, VGT_STRMOUT_BUFFER_CONFIG, streamBufferConfig);
 
     if (gfxIp.major == 10)
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, MEM_ORDERED, true);
+        SET_REG_GFX10_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, MEM_ORDERED, true);
     }
 
     uint8_t usrClipPlaneMask = m_pPipelineState->GetRasterizerState().usrClipPlaneMask;
@@ -1082,29 +1082,29 @@ void ConfigBuilder::BuildVsRegConfig(
     bool rasterizerDiscardEnable = m_pPipelineState->GetRasterizerState().rasterizerDiscardEnable;
     bool disableVertexReuse = m_pPipelineState->GetInputAssemblyState().disableVertexReuse;
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_3, (usrClipPlaneMask >> 3) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_4, (usrClipPlaneMask >> 4) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_5, (usrClipPlaneMask >> 5) & 0x1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, DX_LINEAR_ATTR_CLIP_ENA,true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, DX_CLIP_SPACE_DEF, true); // DepthRange::ZeroToOne
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, ZCLIP_NEAR_DISABLE,depthClipDisable);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, ZCLIP_FAR_DISABLE, depthClipDisable);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, DX_RASTERIZATION_KILL,rasterizerDiscardEnable);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_3, (usrClipPlaneMask >> 3) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_4, (usrClipPlaneMask >> 4) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, UCP_ENA_5, (usrClipPlaneMask >> 5) & 0x1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, DX_LINEAR_ATTR_CLIP_ENA,true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, DX_CLIP_SPACE_DEF, true); // DepthRange::ZeroToOne
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, ZCLIP_NEAR_DISABLE,depthClipDisable);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, ZCLIP_FAR_DISABLE, depthClipDisable);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, DX_RASTERIZATION_KILL,rasterizerDiscardEnable);
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_X_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_X_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Y_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Y_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Z_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VPORT_Z_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VTE_CNTL, VTX_W0_FMT, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_X_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_X_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Y_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Y_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Z_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VPORT_Z_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VTE_CNTL, VTX_W0_FMT, true);
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_SU_VTX_CNTL, PIX_CENTER, 1);
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_SU_VTX_CNTL, ROUND_MODE, 2); // Round to even
-    SET_REG_FIELD(&pConfig->m_vsRegs, PA_SU_VTX_CNTL, QUANT_MODE, 5); // Use 8-bit fractions
+    SET_REG_FIELD(&pConfig->vsRegs, PA_SU_VTX_CNTL, PIX_CENTER, 1);
+    SET_REG_FIELD(&pConfig->vsRegs, PA_SU_VTX_CNTL, ROUND_MODE, 2); // Round to even
+    SET_REG_FIELD(&pConfig->vsRegs, PA_SU_VTX_CNTL, QUANT_MODE, 5); // Use 8-bit fractions
 
     // Stage-specific processing
     bool usePointSize = false;
@@ -1125,11 +1125,11 @@ void ConfigBuilder::BuildVsRegConfig(
 
         if (builtInUsage.vs.instanceIndex)
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable instance ID
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable instance ID
         }
         else if (builtInUsage.vs.primitiveId)
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
         }
     }
     else if (shaderStage == ShaderStageTessEval)
@@ -1144,16 +1144,16 @@ void ConfigBuilder::BuildVsRegConfig(
         if (builtInUsage.tes.primitiveId)
         {
             // NOTE: when primitive ID is used, set vgtCompCnt to 3 directly because primitive ID is the last VGPR.
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable primitive ID
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 3); // 3: Enable primitive ID
         }
         else
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
         }
 
         if (m_pPipelineState->IsTessOffChip())
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_PGM_RSRC2_VS, OC_LDS_EN, true);
+            SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_PGM_RSRC2_VS, OC_LDS_EN, true);
         }
     }
     else
@@ -1198,15 +1198,15 @@ void ConfigBuilder::BuildVsRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, usePrimitiveId);
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, usePrimitiveId);
 
     if ((gfxIp.major >= 10) && (pResUsage->inOutUsage.expCount == 0))
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_vsRegs, SPI_VS_OUT_CONFIG, NO_PC_EXPORT, true);
+        SET_REG_GFX10_FIELD(&pConfig->vsRegs, SPI_VS_OUT_CONFIG, NO_PC_EXPORT, true);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, pResUsage->inOutUsage.expCount - 1);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, pResUsage->inOutUsage.expCount - 1);
     }
 
     SetUsesViewportArrayIndex(useViewportIndex);
@@ -1219,11 +1219,11 @@ void ConfigBuilder::BuildVsRegConfig(
         // TODO: In the future, we can only disable vertex reuse only if viewport array index is emitted divergently
         // for each vertex.
         disableVertexReuse = true;
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, true);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
     }
 
     if (m_pPipelineState->GetTargetInfo().GetGpuWorkarounds().gfx10.waTessIncorrectRelativeIndex)
@@ -1231,17 +1231,17 @@ void ConfigBuilder::BuildVsRegConfig(
         disableVertexReuse = true;
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
+    SET_REG_FIELD(&pConfig->vsRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
 
     useLayer = useLayer || m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     if (usePointSize || useLayer || useViewportIndex)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_VEC_ENA, true);
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_VEC_ENA, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
 
         if (gfxIp.major == 9)
         {
@@ -1257,20 +1257,20 @@ void ConfigBuilder::BuildVsRegConfig(
 
     if ((clipDistanceCount > 0) || (cullDistanceCount > 0))
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST0_VEC_ENA, true);
+        SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST0_VEC_ENA, true);
         if (clipDistanceCount + cullDistanceCount > 4)
         {
-            SET_REG_FIELD(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST1_VEC_ENA, true);
+            SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST1_VEC_ENA, true);
         }
 
         uint32_t clipDistanceMask = (1 << clipDistanceCount) - 1;
         uint32_t cullDistanceMask = (1 << cullDistanceCount) - 1;
 
         // Set fields CLIP_DIST_ENA_0 ~ CLIP_DIST_ENA_7 and CULL_DIST_ENA_0 ~ CULL_DIST_ENA_7
-        uint32_t paClVsOutCntl = GET_REG(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL);
+        uint32_t paClVsOutCntl = GET_REG(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL);
         paClVsOutCntl |= clipDistanceMask;
         paClVsOutCntl |= (cullDistanceMask << 8);
-        SET_REG(&pConfig->m_vsRegs, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
+        SET_REG(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
     }
 
     uint32_t posCount = 1; // gl_Position is always exported
@@ -1288,26 +1288,26 @@ void ConfigBuilder::BuildVsRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS0_EXPORT_FORMAT, SPI_SHADER_4COMP);
+    SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS0_EXPORT_FORMAT, SPI_SHADER_4COMP);
     if (posCount > 1)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS1_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS1_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
     if (posCount > 2)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS2_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS2_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
     if (posCount > 3)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
 
     if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportSpiPrefPriority)
     {
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_USER_ACCUM_VS_0, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_USER_ACCUM_VS_1, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_USER_ACCUM_VS_2, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_vsRegs, SPI_SHADER_USER_ACCUM_VS_3, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_USER_ACCUM_VS_0, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_USER_ACCUM_VS_1, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_USER_ACCUM_VS_2, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->vsRegs, SPI_SHADER_USER_ACCUM_VS_3, CONTRIBUTION, 1);
     }
 
     // Set shader user data maping
@@ -1332,22 +1332,22 @@ void ConfigBuilder::BuildLsHsRegConfig(
 
     uint32_t floatMode =
         SetupFloatingPointMode((shaderStage2 != ShaderStageInvalid) ? shaderStage2 : shaderStage1);
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, DX10_CLAMP, true); // Follow PAL setting
+    SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, DX10_CLAMP, true); // Follow PAL setting
 
     uint32_t lsVgtCompCnt = 1;
     if (vsBuiltInUsage.instanceIndex)
     {
         lsVgtCompCnt += 2; // Enable instance ID
     }
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, LS_VGPR_COMP_CNT, lsVgtCompCnt);
+    SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, LS_VGPR_COMP_CNT, lsVgtCompCnt);
 
     const auto& pVsIntfData = m_pPipelineState->GetShaderInterfaceData(ShaderStageVertex);
     const auto& pTcsIntfData = m_pPipelineState->GetShaderInterfaceData(ShaderStageTessControl);
     uint32_t userDataCount = std::max(pVsIntfData->userDataCount, pTcsIntfData->userDataCount);
 
     const auto& tcsShaderOptions = m_pPipelineState->GetShaderOptions(ShaderStageTessControl);
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, DEBUG_MODE, tcsShaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, DEBUG_MODE, tcsShaderOptions.debugMode);
 
     const bool userSgprMsb = (userDataCount > 31);
     if (gfxIp.major == 10)
@@ -1355,16 +1355,16 @@ void ConfigBuilder::BuildLsHsRegConfig(
         bool wgpMode = (GetShaderWgpMode(ShaderStageVertex) ||
                         GetShaderWgpMode(ShaderStageTessControl));
 
-        SET_REG_GFX10_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, MEM_ORDERED, true);
-        SET_REG_GFX10_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, WGP_MODE, wgpMode);
-        SET_REG_GFX10_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX10_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, MEM_ORDERED, true);
+        SET_REG_GFX10_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, WGP_MODE, wgpMode);
+        SET_REG_GFX10_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR_MSB, userSgprMsb);
     }
     else
     {
-        SET_REG_GFX9_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX9_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR_MSB, userSgprMsb);
     }
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, TRAP_PRESENT, tcsShaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR, userDataCount);
+    SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, TRAP_PRESENT, tcsShaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR, userDataCount);
 
     // NOTE: On GFX7+, granularity for the LDS_SIZE field is 128. The range is 0~128 which allocates 0 to 16K
     // DWORDs.
@@ -1382,11 +1382,11 @@ void ConfigBuilder::BuildLsHsRegConfig(
 
     if (gfxIp.major == 9)
     {
-        SET_REG_GFX9_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, LDS_SIZE, ldsSize);
+        SET_REG_GFX9_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, LDS_SIZE, ldsSize);
     }
     else if (gfxIp.major == 10)
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, LDS_SIZE, ldsSize);
+        SET_REG_GFX10_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, LDS_SIZE, ldsSize);
     }
     else
     {
@@ -1398,31 +1398,31 @@ void ConfigBuilder::BuildLsHsRegConfig(
     // Minimum and maximum tessellation factors supported by the hardware.
     constexpr float MinTessFactor = 1.0f;
     constexpr float MaxTessFactor = 64.0f;
-    SET_REG(&pConfig->m_lsHsRegs, VGT_HOS_MIN_TESS_LEVEL, FloatToBits(MinTessFactor));
-    SET_REG(&pConfig->m_lsHsRegs, VGT_HOS_MAX_TESS_LEVEL, FloatToBits(MaxTessFactor));
+    SET_REG(&pConfig->lsHsRegs, VGT_HOS_MIN_TESS_LEVEL, FloatToBits(MinTessFactor));
+    SET_REG(&pConfig->lsHsRegs, VGT_HOS_MAX_TESS_LEVEL, FloatToBits(MaxTessFactor));
 
     // Set VGT_LS_HS_CONFIG
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);
-    SET_REG_FIELD(&pConfig->m_lsHsRegs,
+    SET_REG_FIELD(&pConfig->lsHsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);
+    SET_REG_FIELD(&pConfig->lsHsRegs,
                   VGT_LS_HS_CONFIG,
                   HS_NUM_INPUT_CP,
                   m_pPipelineState->GetInputAssemblyState().patchControlPoints);
 
     auto hsNumOutputCp = m_pPipelineState->GetShaderModes()->GetTessellationMode().outputVertices;
-    SET_REG_FIELD(&pConfig->m_lsHsRegs, VGT_LS_HS_CONFIG, HS_NUM_OUTPUT_CP, hsNumOutputCp);
+    SET_REG_FIELD(&pConfig->lsHsRegs, VGT_LS_HS_CONFIG, HS_NUM_OUTPUT_CP, hsNumOutputCp);
 
     SetNumAvailSgprs(Util::Abi::HardwareStage::Hs, pTcsResUsage->numSgprsAvailable);
     SetNumAvailVgprs(Util::Abi::HardwareStage::Hs, pTcsResUsage->numVgprsAvailable);
 
     // Set up VGT_TF_PARAM
-    SetupVgtTfParam(&pConfig->m_lsHsRegs);
+    SetupVgtTfParam(&pConfig->lsHsRegs);
 
     if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportSpiPrefPriority)
     {
-        SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_0, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_1, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_2, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_3, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_0, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_1, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_2, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_USER_ACCUM_LSHS_3, CONTRIBUTION, 1);
     }
 
     if (gfxIp.major == 9)
@@ -1489,12 +1489,12 @@ void ConfigBuilder::BuildEsGsRegConfig(
         gsVgprCompCnt = 1;
     }
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC1_GS, GS_VGPR_COMP_CNT, gsVgprCompCnt);
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, GS_VGPR_COMP_CNT, gsVgprCompCnt);
 
     uint32_t floatMode =
         SetupFloatingPointMode((shaderStage2 != ShaderStageInvalid) ? shaderStage2 : shaderStage1);
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC1_GS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC1_GS, DX10_CLAMP, true); // Follow PAL setting
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, DX10_CLAMP, true); // Follow PAL setting
 
     const auto pVsIntfData = m_pPipelineState->GetShaderInterfaceData(ShaderStageVertex);
     const auto pTesIntfData = m_pPipelineState->GetShaderInterfaceData(ShaderStageTessEval);
@@ -1503,7 +1503,7 @@ void ConfigBuilder::BuildEsGsRegConfig(
                                       pGsIntfData->userDataCount);
 
     const auto& gsShaderOptions = m_pPipelineState->GetShaderOptions(ShaderStageGeometry);
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, gsShaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, gsShaderOptions.debugMode);
 
     const bool userSgprMsb = (userDataCount > 31);
     if (gfxIp.major == 10)
@@ -1511,17 +1511,17 @@ void ConfigBuilder::BuildEsGsRegConfig(
         bool wgpMode = (GetShaderWgpMode(hasTs ? ShaderStageTessEval : ShaderStageVertex) ||
                         GetShaderWgpMode(ShaderStageGeometry));
 
-        SET_REG_GFX10_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
-        SET_REG_GFX10_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC1_GS, WGP_MODE, wgpMode);
-        SET_REG_GFX10_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX10_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
+        SET_REG_GFX10_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, WGP_MODE, wgpMode);
+        SET_REG_GFX10_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
     }
     else
     {
-        SET_REG_GFX9_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX9_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
     }
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC2_GS, TRAP_PRESENT, gsShaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR, userDataCount);
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, TRAP_PRESENT, gsShaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR, userDataCount);
 
     uint32_t esVgprCompCnt = 0;
     if (hasTs)
@@ -1538,7 +1538,7 @@ void ConfigBuilder::BuildEsGsRegConfig(
 
         if (m_pPipelineState->IsTessOffChip())
         {
-            SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC2_GS, OC_LDS_EN, true);
+            SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, OC_LDS_EN, true);
         }
     }
     else
@@ -1549,11 +1549,11 @@ void ConfigBuilder::BuildEsGsRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_PGM_RSRC2_GS, ES_VGPR_COMP_CNT, esVgprCompCnt);
+    SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, ES_VGPR_COMP_CNT, esVgprCompCnt);
 
     const auto ldsSizeDwordGranularityShift = m_pPipelineState->GetTargetInfo().GetGpuProperty().ldsSizeDwordGranularityShift;
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs,
+    SET_REG_FIELD(&pConfig->esGsRegs,
                   SPI_SHADER_PGM_RSRC2_GS,
                   LDS_SIZE,
                   calcFactor.gsOnChipLdsSize >> ldsSizeDwordGranularityShift);
@@ -1561,79 +1561,79 @@ void ConfigBuilder::BuildEsGsRegConfig(
     SetEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 
     uint32_t maxVertOut = std::max(1u, static_cast<uint32_t>(geometryMode.outputVertices));
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
 
     // TODO: Currently only support offchip GS
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, MODE, GS_SCENARIO_G);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, MODE, GS_SCENARIO_G);
 
     if (m_pPipelineState->IsGsOnChip())
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_ON);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, false);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_ON);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, false);
 
         SetEsGsLdsByteSize(calcFactor.esGsLdsSize * 4);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_OFF);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, true);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_OFF);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, true);
     }
 
     if (geometryMode.outputVertices <= 128)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_128);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_128);
     }
     else if (geometryMode.outputVertices <= 256)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_256);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_256);
     }
     else if (geometryMode.outputVertices <= 512)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_512);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_512);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_1024);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_MODE, CUT_MODE, GS_CUT_1024);
     }
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_ONCHIP_CNTL, ES_VERTS_PER_SUBGRP, calcFactor.esVertsPerSubgroup);
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_ONCHIP_CNTL, GS_PRIMS_PER_SUBGRP, calcFactor.gsPrimsPerSubgroup);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_ONCHIP_CNTL, ES_VERTS_PER_SUBGRP, calcFactor.esVertsPerSubgroup);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_ONCHIP_CNTL, GS_PRIMS_PER_SUBGRP, calcFactor.gsPrimsPerSubgroup);
 
     // NOTE: The value of field "GS_INST_PRIMS_IN_SUBGRP" should be strictly equal to the product of
     // VGT_GS_ONCHIP_CNTL.GS_PRIMS_PER_SUBGRP * VGT_GS_INSTANCE_CNT.CNT.
     const uint32_t gsInstPrimsInSubgrp =
         (geometryMode.invocations > 1) ? (calcFactor.gsPrimsPerSubgroup * geometryMode.invocations) : 0;
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_ONCHIP_CNTL, GS_INST_PRIMS_IN_SUBGRP, gsInstPrimsInSubgrp);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_ONCHIP_CNTL, GS_INST_PRIMS_IN_SUBGRP, gsInstPrimsInSubgrp);
 
     uint32_t gsVertItemSize0 = sizeof(uint32_t) * gsInOutUsage.gs.outLocCount[0];
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_VERT_ITEMSIZE, ITEMSIZE, gsVertItemSize0);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_VERT_ITEMSIZE, ITEMSIZE, gsVertItemSize0);
 
     uint32_t gsVertItemSize1 = sizeof(uint32_t) * gsInOutUsage.gs.outLocCount[1];
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_VERT_ITEMSIZE_1, ITEMSIZE, gsVertItemSize1);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_VERT_ITEMSIZE_1, ITEMSIZE, gsVertItemSize1);
 
     uint32_t gsVertItemSize2 = sizeof(uint32_t) * gsInOutUsage.gs.outLocCount[2];
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_VERT_ITEMSIZE_2, ITEMSIZE, gsVertItemSize2);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_VERT_ITEMSIZE_2, ITEMSIZE, gsVertItemSize2);
 
     uint32_t gsVertItemSize3 = sizeof(uint32_t) * gsInOutUsage.gs.outLocCount[3];
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_VERT_ITEMSIZE_3, ITEMSIZE, gsVertItemSize3);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_VERT_ITEMSIZE_3, ITEMSIZE, gsVertItemSize3);
 
     uint32_t gsVsRingOffset = gsVertItemSize0 * maxVertOut;
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GSVS_RING_OFFSET_1, OFFSET, gsVsRingOffset);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GSVS_RING_OFFSET_1, OFFSET, gsVsRingOffset);
 
     gsVsRingOffset += gsVertItemSize1 * maxVertOut;
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GSVS_RING_OFFSET_2, OFFSET, gsVsRingOffset);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GSVS_RING_OFFSET_2, OFFSET, gsVsRingOffset);
 
     gsVsRingOffset += gsVertItemSize2 * maxVertOut;
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GSVS_RING_OFFSET_3, OFFSET, gsVsRingOffset);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GSVS_RING_OFFSET_3, OFFSET, gsVsRingOffset);
 
     if ((geometryMode.invocations > 1) || gsBuiltInUsage.invocationId)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_INSTANCE_CNT, ENABLE, true);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_INSTANCE_CNT, CNT, geometryMode.invocations);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_INSTANCE_CNT, ENABLE, true);
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_INSTANCE_CNT, CNT, geometryMode.invocations);
     }
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
 
     VGT_GS_OUTPRIM_TYPE gsOutputPrimitiveType = TRISTRIP;
     if (gsInOutUsage.outputMapLocCount == 0)
@@ -1649,37 +1649,37 @@ void ConfigBuilder::BuildEsGsRegConfig(
         gsOutputPrimitiveType = LINESTRIP;
     }
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
 
     // Set multi-stream output primitive type
     if ((gsVertItemSize1 > 0) || (gsVertItemSize2 > 0) || (gsVertItemSize3 > 0))
     {
         const static auto GS_OUT_PRIM_INVALID = 3u;
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_1,
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_1,
             (gsVertItemSize1 > 0)? gsOutputPrimitiveType: GS_OUT_PRIM_INVALID);
 
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_2,
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_2,
             (gsVertItemSize2 > 0) ? gsOutputPrimitiveType : GS_OUT_PRIM_INVALID);
 
-        SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_3,
+        SET_REG_FIELD(&pConfig->esGsRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE_3,
             (gsVertItemSize3 > 0) ? gsOutputPrimitiveType : GS_OUT_PRIM_INVALID);
     }
 
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, calcFactor.gsVsRingItemSize);
-    SET_REG_FIELD(&pConfig->m_esGsRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, calcFactor.gsVsRingItemSize);
+    SET_REG_FIELD(&pConfig->esGsRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
 
     const uint32_t maxPrimsPerSubgroup = std::min(gsInstPrimsInSubgrp * maxVertOut, MaxGsThreadsPerSubgroup);
 
     if (gfxIp.major == 9)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs,
+        SET_REG_FIELD(&pConfig->esGsRegs,
                       VGT_GS_MAX_PRIMS_PER_SUBGROUP,
                       MAX_PRIMS_PER_SUBGROUP,
                       maxPrimsPerSubgroup);
     }
     else if (gfxIp.major == 10)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs,
+        SET_REG_FIELD(&pConfig->esGsRegs,
                       GE_MAX_OUTPUT_PER_SUBGROUP,
                       MAX_VERTS_PER_SUBGROUP,
                       maxPrimsPerSubgroup);
@@ -1694,10 +1694,10 @@ void ConfigBuilder::BuildEsGsRegConfig(
 
     if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportSpiPrefPriority)
     {
-        SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_0, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_1, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_2, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_3, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_0, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_1, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_2, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->esGsRegs, SPI_SHADER_USER_ACCUM_ESGS_3, CONTRIBUTION, 1);
     }
 
     if (gfxIp.major == 9)
@@ -1781,12 +1781,12 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
         gsVgprCompCnt = hasTs ? 1 : (vsBuiltInUsage.primitiveId ? 2 : 1);
     }
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, GS_VGPR_COMP_CNT, gsVgprCompCnt);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, GS_VGPR_COMP_CNT, gsVgprCompCnt);
 
     uint32_t floatMode =
         SetupFloatingPointMode((shaderStage2 != ShaderStageInvalid) ? shaderStage2 : shaderStage1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, DX10_CLAMP, true); // Follow PAL setting
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, DX10_CLAMP, true); // Follow PAL setting
 
     const auto pVsIntfData = m_pPipelineState->GetShaderInterfaceData(ShaderStageVertex);
     const auto pTesIntfData = m_pPipelineState->GetShaderInterfaceData(ShaderStageTessEval);
@@ -1801,22 +1801,22 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
         wgpMode = (wgpMode || GetShaderWgpMode(ShaderStageGeometry));
     }
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, gsShaderOptions.debugMode);
-    SET_REG_GFX10_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
-    SET_REG_GFX10_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, WGP_MODE, wgpMode);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, gsShaderOptions.debugMode);
+    SET_REG_GFX10_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
+    SET_REG_GFX10_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, WGP_MODE, wgpMode);
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, TRAP_PRESENT, gsShaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR, userDataCount);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, TRAP_PRESENT, gsShaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR, userDataCount);
 
     const bool userSgprMsb = (userDataCount > 31);
 
     if (gfxIp.major == 10)
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX10_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
     }
     else
     {
-        SET_REG_GFX9_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX9_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, USER_SGPR_MSB, userSgprMsb);
     }
 
     uint32_t esVgprCompCnt = 0;
@@ -1834,7 +1834,7 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
 
         if (m_pPipelineState->IsTessOffChip())
         {
-            SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, OC_LDS_EN, true);
+            SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, OC_LDS_EN, true);
         }
     }
     else
@@ -1845,12 +1845,12 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, ES_VGPR_COMP_CNT, esVgprCompCnt);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, ES_VGPR_COMP_CNT, esVgprCompCnt);
 
     const auto ldsSizeDwordGranularityShift =
         m_pPipelineState->GetTargetInfo().GetGpuProperty().ldsSizeDwordGranularityShift;
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs,
+    SET_REG_FIELD(&pConfig->primShaderRegs,
                   SPI_SHADER_PGM_RSRC2_GS,
                   LDS_SIZE,
                   calcFactor.gsOnChipLdsSize >> ldsSizeDwordGranularityShift);
@@ -1858,37 +1858,37 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
     SetEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 
     uint32_t maxVertOut = std::max(1u, static_cast<uint32_t>(geometryMode.outputVertices));
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_MODE, MODE, GS_SCENARIO_G);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_OFF);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_MODE, MODE, GS_SCENARIO_G);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_OFF);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, true);
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_ONCHIP_CNTL, ES_VERTS_PER_SUBGRP, calcFactor.esVertsPerSubgroup);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_ONCHIP_CNTL, GS_PRIMS_PER_SUBGRP, calcFactor.gsPrimsPerSubgroup);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_ONCHIP_CNTL, ES_VERTS_PER_SUBGRP, calcFactor.esVertsPerSubgroup);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_ONCHIP_CNTL, GS_PRIMS_PER_SUBGRP, calcFactor.gsPrimsPerSubgroup);
 
     const uint32_t gsInstPrimsInSubgrp =
         (geometryMode.invocations > 1) ?
             (calcFactor.gsPrimsPerSubgroup * geometryMode.invocations) : calcFactor.gsPrimsPerSubgroup;
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_ONCHIP_CNTL, GS_INST_PRIMS_IN_SUBGRP, gsInstPrimsInSubgrp);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_ONCHIP_CNTL, GS_INST_PRIMS_IN_SUBGRP, gsInstPrimsInSubgrp);
 
     uint32_t gsVertItemSize = 4 * gsInOutUsage.outputMapLocCount;
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_VERT_ITEMSIZE, ITEMSIZE, gsVertItemSize);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_VERT_ITEMSIZE, ITEMSIZE, gsVertItemSize);
 
     if ((geometryMode.invocations > 1) || gsBuiltInUsage.invocationId)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_INSTANCE_CNT, ENABLE, true);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_INSTANCE_CNT, CNT, geometryMode.invocations);
+        SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_INSTANCE_CNT, ENABLE, true);
+        SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_INSTANCE_CNT, CNT, geometryMode.invocations);
         if ((gfxIp.major > 10) || ((gfxIp.major == 10) && (gfxIp.minor >= 1)))
         {
-            SET_REG_GFX10_1_PLUS_FIELD(&pConfig->m_primShaderRegs,
+            SET_REG_GFX10_1_PLUS_FIELD(&pConfig->primShaderRegs,
                                        VGT_GS_INSTANCE_CNT,
                                        EN_MAX_VERT_OUT_PER_GS_INSTANCE,
                                        calcFactor.enableMaxVertOut);
         }
     }
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
 
     VGT_GS_OUTPRIM_TYPE gsOutputPrimitiveType = POINTLIST;
     if (hasGs)
@@ -1967,12 +1967,12 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
     }
 
     // TODO: Multiple output streams are not supported.
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, calcFactor.gsVsRingItemSize);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, calcFactor.gsVsRingItemSize);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
 
     const uint32_t maxVertsPerSubgroup = std::min(gsInstPrimsInSubgrp * maxVertOut, NggMaxThreadsPerSubgroup);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, GE_MAX_OUTPUT_PER_SUBGROUP, MAX_VERTS_PER_SUBGROUP, maxVertsPerSubgroup);
+    SET_REG_FIELD(&pConfig->primShaderRegs, GE_MAX_OUTPUT_PER_SUBGROUP, MAX_VERTS_PER_SUBGROUP, maxVertsPerSubgroup);
 
     if (hasGs)
     {
@@ -1995,10 +1995,10 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
 
     if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportSpiPrefPriority)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_0, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_1, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_2, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_3, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_0, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_1, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_2, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_USER_ACCUM_ESGS_3, CONTRIBUTION, 1);
     }
 
     //
@@ -2009,29 +2009,29 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
     bool rasterizerDiscardEnable = m_pPipelineState->GetRasterizerState().rasterizerDiscardEnable;
     bool disableVertexReuse = m_pPipelineState->GetInputAssemblyState().disableVertexReuse;
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_3, (usrClipPlaneMask >> 3) & 0x1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_4, (usrClipPlaneMask >> 4) & 0x1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_5, (usrClipPlaneMask >> 5) & 0x1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, DX_LINEAR_ATTR_CLIP_ENA,true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, DX_CLIP_SPACE_DEF, true); // DepthRange::ZeroToOne
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, ZCLIP_NEAR_DISABLE,depthClipDisable);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, ZCLIP_FAR_DISABLE, depthClipDisable);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, DX_RASTERIZATION_KILL,rasterizerDiscardEnable);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_0, (usrClipPlaneMask >> 0) & 0x1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_1, (usrClipPlaneMask >> 1) & 0x1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_2, (usrClipPlaneMask >> 2) & 0x1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_3, (usrClipPlaneMask >> 3) & 0x1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_4, (usrClipPlaneMask >> 4) & 0x1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, UCP_ENA_5, (usrClipPlaneMask >> 5) & 0x1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, DX_LINEAR_ATTR_CLIP_ENA,true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, DX_CLIP_SPACE_DEF, true); // DepthRange::ZeroToOne
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, ZCLIP_NEAR_DISABLE,depthClipDisable);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, ZCLIP_FAR_DISABLE, depthClipDisable);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, DX_RASTERIZATION_KILL,rasterizerDiscardEnable);
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VPORT_X_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VPORT_X_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VPORT_Y_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VPORT_Y_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VPORT_Z_SCALE_ENA, true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VPORT_Z_OFFSET_ENA, true);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VTE_CNTL, VTX_W0_FMT, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VPORT_X_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VPORT_X_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VPORT_Y_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VPORT_Y_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VPORT_Z_SCALE_ENA, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VPORT_Z_OFFSET_ENA, true);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VTE_CNTL, VTX_W0_FMT, true);
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_SU_VTX_CNTL, PIX_CENTER, 1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_SU_VTX_CNTL, ROUND_MODE, 2); // Round to even
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_SU_VTX_CNTL, QUANT_MODE, 5); // Use 8-bit fractions
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_SU_VTX_CNTL, PIX_CENTER, 1);
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_SU_VTX_CNTL, ROUND_MODE, 2); // Round to even
+    SET_REG_FIELD(&pConfig->primShaderRegs, PA_SU_VTX_CNTL, QUANT_MODE, 5); // Use 8-bit fractions
 
     // Stage-specific processing
     bool usePointSize = false;
@@ -2092,24 +2092,24 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
 
     if (usePrimitiveId)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, true);
+        SET_REG_FIELD(&pConfig->primShaderRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, true);
 
         // NOTE: If primitive ID is used and there is no GS present, the field NGG_DISABLE_PROVOK_REUSE must be
         // set to ensure provoking vertex reuse is disabled in the GE.
         if (m_hasGs == false)
         {
-            SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_PRIMITIVEID_EN, NGG_DISABLE_PROVOK_REUSE, true);
+            SET_REG_FIELD(&pConfig->primShaderRegs, VGT_PRIMITIVEID_EN, NGG_DISABLE_PROVOK_REUSE, true);
         }
     }
 
     if (expCount == 0)
     {
         // No generic output is present
-        SET_REG_GFX10_FIELD(&pConfig->m_primShaderRegs, SPI_VS_OUT_CONFIG, NO_PC_EXPORT, true);
+        SET_REG_GFX10_FIELD(&pConfig->primShaderRegs, SPI_VS_OUT_CONFIG, NO_PC_EXPORT, true);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, expCount - 1);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, expCount - 1);
     }
 
     SetUsesViewportArrayIndex(useViewportIndex);
@@ -2122,42 +2122,42 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
         // TODO: In the future, we can only disable vertex reuse only if viewport array index is emitted divergently
         // for each vertex.
         disableVertexReuse = true;
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, true);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, true);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
     }
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
+    SET_REG_FIELD(&pConfig->primShaderRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
 
     useLayer = useLayer || m_pPipelineState->GetInputAssemblyState().enableMultiView;
 
     if (usePointSize || useLayer || useViewportIndex)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_VEC_ENA, true);
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_VEC_ENA, true);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
     }
 
     if ((clipDistanceCount > 0) || (cullDistanceCount > 0))
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST0_VEC_ENA, true);
+        SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST0_VEC_ENA, true);
         if (clipDistanceCount + cullDistanceCount > 4)
         {
-            SET_REG_FIELD(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST1_VEC_ENA, true);
+            SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, VS_OUT_CCDIST1_VEC_ENA, true);
         }
 
         uint32_t clipDistanceMask = (1 << clipDistanceCount) - 1;
         uint32_t cullDistanceMask = (1 << cullDistanceCount) - 1;
 
         // Set fields CLIP_DIST_ENA_0 ~ CLIP_DIST_ENA_7 and CULL_DIST_ENA_0 ~ CULL_DIST_ENA_7
-        uint32_t paClVsOutCntl = GET_REG(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL);
+        uint32_t paClVsOutCntl = GET_REG(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL);
         paClVsOutCntl |= clipDistanceMask;
         paClVsOutCntl |= (cullDistanceMask << 8);
-        SET_REG(&pConfig->m_primShaderRegs, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
+        SET_REG(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
     }
 
     uint32_t posCount = 1; // gl_Position is always exported
@@ -2175,33 +2175,33 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
         }
     }
 
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_POS_FORMAT, POS0_EXPORT_FORMAT, SPI_SHADER_4COMP);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_POS_FORMAT, POS0_EXPORT_FORMAT, SPI_SHADER_4COMP);
     if (posCount > 1)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_POS_FORMAT, POS1_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_POS_FORMAT, POS1_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
     if (posCount > 2)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_POS_FORMAT, POS2_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_POS_FORMAT, POS2_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
     if (posCount > 3)
     {
-        SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
+        SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
     }
 
     //
     // Build NGG configuration
     //
     assert(calcFactor.primAmpFactor >= 1);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, GE_NGG_SUBGRP_CNTL, PRIM_AMP_FACTOR, calcFactor.primAmpFactor);
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, GE_NGG_SUBGRP_CNTL, THDS_PER_SUBGRP, NggMaxThreadsPerSubgroup);
+    SET_REG_FIELD(&pConfig->primShaderRegs, GE_NGG_SUBGRP_CNTL, PRIM_AMP_FACTOR, calcFactor.primAmpFactor);
+    SET_REG_FIELD(&pConfig->primShaderRegs, GE_NGG_SUBGRP_CNTL, THDS_PER_SUBGRP, NggMaxThreadsPerSubgroup);
 
     // TODO: Support PIPELINE_PRIM_ID.
-    SET_REG_FIELD(&pConfig->m_primShaderRegs, SPI_SHADER_IDX_FORMAT, IDX0_EXPORT_FORMAT, SPI_SHADER_1COMP);
+    SET_REG_FIELD(&pConfig->primShaderRegs, SPI_SHADER_IDX_FORMAT, IDX0_EXPORT_FORMAT, SPI_SHADER_1COMP);
 
     if (pNggControl->passthroughMode)
     {
-        INVALIDATE_REG(&pConfig->m_primShaderRegs, SPI_SHADER_PGM_LO_GS);
+        INVALIDATE_REG(&pConfig->primShaderRegs, SPI_SHADER_PGM_LO_GS);
     }
     else
     {
@@ -2210,7 +2210,7 @@ void ConfigBuilder::BuildPrimShaderRegConfig(
         // SPI_SHADER_PGM_HI_GS if we do not provide one. By setting SPI_SHADER_PGM_LO_GS to NggCullingData, we tell
         // PAL that we will not provide it and it is fine to use SPI_SHADER_PGM_LO_GS and SPI_SHADER_PGM_HI_GS as
         // the address of that table.
-        SET_REG(&pConfig->m_primShaderRegs,
+        SET_REG(&pConfig->primShaderRegs,
                 SPI_SHADER_PGM_LO_GS,
                 static_cast<uint32_t>(Util::Abi::UserDataMapping::NggCullingData));
     }
@@ -2240,19 +2240,19 @@ void ConfigBuilder::BuildPsRegConfig(
     const auto& fragmentMode = m_pPipelineState->GetShaderModes()->GetFragmentShaderMode();
 
     uint32_t floatMode = SetupFloatingPointMode(shaderStage);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, FLOAT_MODE, floatMode);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, DX10_CLAMP, true);  // Follow PAL setting
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, DEBUG_MODE, shaderOptions.debugMode);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, FLOAT_MODE, floatMode);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, DX10_CLAMP, true);  // Follow PAL setting
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, DEBUG_MODE, shaderOptions.debugMode);
 
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, TRAP_PRESENT, shaderOptions.trapPresent);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR, pIntfData->userDataCount);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, TRAP_PRESENT, shaderOptions.trapPresent);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR, pIntfData->userDataCount);
 
     const bool userSgprMsb = (pIntfData->userDataCount > 31);
     GfxIpVersion gfxIp = m_pPipelineState->GetTargetInfo().GetGfxIpVersion();
 
     if (gfxIp.major == 10)
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC1_PS, MEM_ORDERED, true);
+        SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, MEM_ORDERED, true);
 
         if (shaderOptions.waveBreakSize == lgc::WaveBreak::DrawTime)
         {
@@ -2260,44 +2260,44 @@ void ConfigBuilder::BuildPsRegConfig(
         }
         else
         {
-            SET_REG_GFX10_FIELD(&pConfig->m_psRegs, PA_SC_SHADER_CONTROL, WAVE_BREAK_REGION_SIZE,
+            SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_SC_SHADER_CONTROL, WAVE_BREAK_REGION_SIZE,
                                 static_cast<uint32_t>(shaderOptions.waveBreakSize));
         }
 
-        SET_REG_GFX10_FIELD(&pConfig->m_psRegs, PA_STEREO_CNTL, STEREO_MODE, STATE_STEREO_X);
-        SET_REG_GFX10_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_STEREO_CNTL, STEREO_MODE, STATE_STEREO_X);
+        SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
     }
     else
     {
-        SET_REG_GFX9_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
+        SET_REG_GFX9_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
     }
 
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, FRONT_FACE_ALL_BITS, true);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, FRONT_FACE_ALL_BITS, true);
     if (fragmentMode.pixelCenterInteger)
     {
         // TRUE - Force floating point position to upper left corner of pixel (X.0, Y.0)
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, POS_FLOAT_ULC, true);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, POS_FLOAT_ULC, true);
     }
     else if (builtInUsage.runAtSampleRate)
     {
         // 2 - Calculate per-pixel floating point position at iterated sample number
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 2);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 2);
     }
     else
     {
         // 0 - Calculate per-pixel floating point position at pixel center
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 0);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_BARYC_CNTL, POS_FLOAT_LOCATION, 0);
     }
 
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, WALK_ALIGN8_PRIM_FITS_ST, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, WALK_FENCE_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, TILE_WALK_ORDER_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, PS_ITER_SAMPLE, builtInUsage.runAtSampleRate);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, WALK_ALIGN8_PRIM_FITS_ST, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, WALK_FENCE_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, TILE_WALK_ORDER_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, PS_ITER_SAMPLE, builtInUsage.runAtSampleRate);
 
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, SUPERTILE_WALK_ORDER_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, MULTI_SHADER_ENGINE_PRIM_DISCARD_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
-    SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, SUPERTILE_WALK_ORDER_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, MULTI_SHADER_ENGINE_PRIM_DISCARD_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
+    SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
 
     ZOrder zOrder = LATE_Z;
     bool execOnHeirFail = false;
@@ -2319,22 +2319,22 @@ void ConfigBuilder::BuildPsRegConfig(
         zOrder = EARLY_Z_THEN_LATE_Z;
     }
 
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, Z_ORDER, zOrder);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, KILL_ENABLE, builtInUsage.discard);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, Z_EXPORT_ENABLE, builtInUsage.fragDepth);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE,
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, Z_ORDER, zOrder);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, KILL_ENABLE, builtInUsage.discard);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, Z_EXPORT_ENABLE, builtInUsage.fragDepth);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE,
                   (builtInUsage.sampleMask ||
                    (m_pPipelineState->GetColorExportState().alphaToCoverageEnable == false)));
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                   (fragmentMode.earlyFragmentTests && pResUsage->resourceWrite));
-    SET_REG_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);
+    SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);
 
     if (gfxIp.major == 10)
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_psRegs, DB_SHADER_CONTROL, PRE_SHADER_DEPTH_COVERAGE_ENABLE,
+        SET_REG_GFX10_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, PRE_SHADER_DEPTH_COVERAGE_ENABLE,
                             fragmentMode.postDepthCoverage);
     }
 
@@ -2351,7 +2351,7 @@ void ConfigBuilder::BuildPsRegConfig(
     {
         depthExpFmt = EXP_FORMAT_32_R;
     }
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
 
     uint32_t spiShaderColFormat = 0;
     uint32_t cbShaderMask = pResUsage->inOutUsage.fs.cbShaderMask;
@@ -2372,15 +2372,15 @@ void ConfigBuilder::BuildPsRegConfig(
         spiShaderColFormat = SPI_SHADER_32_R;
     }
 
-    SET_REG(&pConfig->m_psRegs, SPI_SHADER_COL_FORMAT, spiShaderColFormat);
+    SET_REG(&pConfig->psRegs, SPI_SHADER_COL_FORMAT, spiShaderColFormat);
 
-    SET_REG(&pConfig->m_psRegs, CB_SHADER_MASK, cbShaderMask);
-    SET_REG_FIELD(&pConfig->m_psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, pResUsage->inOutUsage.fs.interpInfo.size());
+    SET_REG(&pConfig->psRegs, CB_SHADER_MASK, cbShaderMask);
+    SET_REG_FIELD(&pConfig->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, pResUsage->inOutUsage.fs.interpInfo.size());
 
     auto waveFrontSize = m_pPipelineState->GetShaderWaveSize(ShaderStageFragment);
     if (waveFrontSize == 32)
     {
-        SET_REG_GFX10_FIELD(&pConfig->m_psRegs, SPI_PS_IN_CONTROL, PS_W32_EN, true);
+        SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_PS_IN_CONTROL, PS_W32_EN, true);
     }
 
     if (gfxIp.major >= 10)
@@ -2447,11 +2447,11 @@ void ConfigBuilder::BuildPsRegConfig(
 
     if (pointCoordLoc != InvalidValue)
     {
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_ENA, true);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_X, SPI_PNT_SPRITE_SEL_S);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Y, SPI_PNT_SPRITE_SEL_T);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Z, SPI_PNT_SPRITE_SEL_0);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_W, SPI_PNT_SPRITE_SEL_1);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_ENA, true);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_X, SPI_PNT_SPRITE_SEL_S);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Y, SPI_PNT_SPRITE_SEL_T);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_Z, SPI_PNT_SPRITE_SEL_0);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_INTERP_CONTROL_0, PNT_SPRITE_OVRD_W, SPI_PNT_SPRITE_SEL_1);
     }
 
     if (m_pPipelineState->GetPalAbiVersion() >= 456)
@@ -2467,30 +2467,30 @@ void ConfigBuilder::BuildPsRegConfig(
 
     if (m_pPipelineState->GetRasterizerState().innerCoverage)
     {
-        SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_INNER_COVERAGE);
+        SET_REG_FIELD(&pConfig->psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_INNER_COVERAGE);
     }
     else
     {
-        SET_REG_FIELD(&pConfig->m_psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_COVERAGE);
+        SET_REG_FIELD(&pConfig->psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_COVERAGE);
     }
 
     const uint32_t loadCollisionWaveId =
-        GET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, LOAD_COLLISION_WAVEID);
+        GET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, LOAD_COLLISION_WAVEID);
     const uint32_t  loadIntrawaveCollision =
-        GET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_PGM_RSRC2_PS, LOAD_INTRAWAVE_COLLISION);
+        GET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, LOAD_INTRAWAVE_COLLISION);
 
-    SET_REG_CORE_FIELD(&pConfig->m_psRegs, PA_SC_SHADER_CONTROL, LOAD_COLLISION_WAVEID, loadCollisionWaveId);
-    SET_REG_CORE_FIELD(&pConfig->m_psRegs, PA_SC_SHADER_CONTROL, LOAD_INTRAWAVE_COLLISION, loadIntrawaveCollision);
+    SET_REG_CORE_FIELD(&pConfig->psRegs, PA_SC_SHADER_CONTROL, LOAD_COLLISION_WAVEID, loadCollisionWaveId);
+    SET_REG_CORE_FIELD(&pConfig->psRegs, PA_SC_SHADER_CONTROL, LOAD_INTRAWAVE_COLLISION, loadIntrawaveCollision);
 
     SetNumAvailSgprs(Util::Abi::HardwareStage::Ps, pResUsage->numSgprsAvailable);
     SetNumAvailVgprs(Util::Abi::HardwareStage::Ps, pResUsage->numVgprsAvailable);
 
     if (m_pPipelineState->GetTargetInfo().GetGpuProperty().supportSpiPrefPriority)
     {
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_USER_ACCUM_PS_0, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_USER_ACCUM_PS_1, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_USER_ACCUM_PS_2, CONTRIBUTION, 1);
-        SET_REG_FIELD(&pConfig->m_psRegs, SPI_SHADER_USER_ACCUM_PS_3, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_USER_ACCUM_PS_0, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_USER_ACCUM_PS_1, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_USER_ACCUM_PS_2, CONTRIBUTION, 1);
+        SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_USER_ACCUM_PS_3, CONTRIBUTION, 1);
     }
 
     // Set shader user data mapping

--- a/lgc/patch/llpcConfigBuilderBase.cpp
+++ b/lgc/patch/llpcConfigBuilderBase.cpp
@@ -259,34 +259,34 @@ void ConfigBuilderBase::SetApiName(
 void ConfigBuilderBase::SetPipelineType(
     Util::Abi::PipelineType value) // Value to set
 {
-    const char* pValue = "";
+    const char* pTypeStr = "";
     switch (value)
     {
     case Util::Abi::VsPs:
-        pValue = "VsPs";
+        pTypeStr = "VsPs";
         break;
     case Util::Abi::Gs:
-        pValue = "Gs";
+        pTypeStr = "Gs";
         break;
     case Util::Abi::Cs:
-        pValue = "Cs";
+        pTypeStr = "Cs";
         break;
     case Util::Abi::Ngg:
-        pValue = "Ngg";
+        pTypeStr = "Ngg";
         break;
     case Util::Abi::Tess:
-        pValue = "Tess";
+        pTypeStr = "Tess";
         break;
     case Util::Abi::GsTess:
-        pValue = "GsTess";
+        pTypeStr = "GsTess";
         break;
     case Util::Abi::NggTess:
-        pValue = "NggTess";
+        pTypeStr = "NggTess";
         break;
     default:
         break;
     }
-    m_pipelineNode[Util::Abi::PipelineMetadataKey::Type] = m_document->getNode(pValue);
+    m_pipelineNode[Util::Abi::PipelineMetadataKey::Type] = m_document->getNode(pTypeStr);
 }
 
 // =====================================================================================================================

--- a/lgc/patch/llpcConfigBuilderBase.h
+++ b/lgc/patch/llpcConfigBuilderBase.h
@@ -93,7 +93,7 @@ protected:
     template<typename T>
     void AppendConfig(const T& config)
     {
-        static_assert(T::containsPalAbiMetadataOnly,
+        static_assert(T::ContainsPalAbiMetadataOnly,
                       "may only be used with structs that are fully metadata notes");
         static_assert(sizeof(T) % sizeof(PalMetadataNoteEntry) == 0,
                       "T claims to be isPalAbiMetadataOnly, but sizeof contradicts that");

--- a/lgc/patch/llpcFragColorExport.cpp
+++ b/lgc/patch/llpcFragColorExport.cpp
@@ -395,7 +395,7 @@ Value* FragColorExport::Run(
         }
     }
 
-    Value* pExport = nullptr;
+    Value* pExportCall = nullptr;
 
     if (expFmt == EXP_FORMAT_ZERO)
     {
@@ -453,7 +453,7 @@ Value* FragColorExport::Run(
             ConstantInt::get(Type::getInt1Ty(*m_pContext), true)                          // vm
         };
 
-        pExport = EmitCall("llvm.amdgcn.exp.compr.v2f16", Type::getVoidTy(*m_pContext), args, {}, pInsertPos);
+        pExportCall = EmitCall("llvm.amdgcn.exp.compr.v2f16", Type::getVoidTy(*m_pContext), args, {}, pInsertPos);
     }
     else
     {
@@ -469,10 +469,10 @@ Value* FragColorExport::Run(
             ConstantInt::get(Type::getInt1Ty(*m_pContext), true)                          // vm
         };
 
-        pExport = EmitCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_pContext), args, {}, pInsertPos);
+        pExportCall = EmitCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_pContext), args, {}, pInsertPos);
     }
 
-    return pExport;
+    return pExportCall;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/llpcPatch.cpp
+++ b/lgc/patch/llpcPatch.cpp
@@ -109,7 +109,7 @@ void Patch::AddPasses(
         passMgr.add(pReplayerPass);
     }
 
-    if (raw_ostream* pOuts = GetLgcOuts())
+    if (raw_ostream* pOuts = getLgcOuts())
     {
         passMgr.add(createPrintModulePass(*pOuts,
                     "===============================================================================\n"
@@ -229,7 +229,7 @@ void Patch::AddPasses(
     }
 
     // Dump the result
-    if (raw_ostream* pOuts = GetLgcOuts())
+    if (raw_ostream* pOuts = getLgcOuts())
     {
         passMgr.add(createPrintModulePass(*pOuts,
                     "===============================================================================\n"

--- a/lgc/patch/llpcPatchBufferOp.cpp
+++ b/lgc/patch/llpcPatchBufferOp.cpp
@@ -1275,9 +1275,9 @@ void PatchBufferOp::PostVisitMemSetInst(
 
         Value* pNewValue = nullptr;
 
-        if (Constant* const pConst = dyn_cast<Constant>(pValue))
+        if (Constant* const pConstVal = dyn_cast<Constant>(pValue))
         {
-            pNewValue = ConstantVector::getSplat({stride, false}, pConst);
+            pNewValue = ConstantVector::getSplat({stride, false}, pConstVal);
             pNewValue = m_pBuilder->CreateBitCast(pNewValue, pCastDestType->getPointerElementType());
             CopyMetadata(pNewValue, &memSetInst);
         }
@@ -1339,9 +1339,9 @@ void PatchBufferOp::PostVisitMemSetInst(
 
         Value* pNewValue = nullptr;
 
-        if (Constant* const pConst = dyn_cast<Constant>(pValue))
+        if (Constant* const pConstVal = dyn_cast<Constant>(pValue))
         {
-            pNewValue = ConstantVector::getSplat(pMemoryType->getVectorElementCount(), pConst);
+            pNewValue = ConstantVector::getSplat(pMemoryType->getVectorElementCount(), pConstVal);
         }
         else
         {

--- a/lgc/patch/llpcPatchBufferOp.h
+++ b/lgc/patch/llpcPatchBufferOp.h
@@ -32,8 +32,14 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/IRBuilder.h"
 
 #include "llpcPatch.h"
+
+namespace llvm
+{
+class LegacyDivergenceAnalysis;
+} // llvm
 
 namespace lgc
 {

--- a/lgc/patch/llpcPatchCopyShader.cpp
+++ b/lgc/patch/llpcPatchCopyShader.cpp
@@ -635,8 +635,7 @@ void PatchCopyShader::ExportGenericOutput(
         assert(locIter != outLocMap.end());
         if (xfbOutsInfo.find(locIter->first) != xfbOutsInfo.end())
         {
-            uint32_t xfbOutInfo = xfbOutsInfo[locIter->first];
-            XfbOutInfo* pXfbOutInfo = reinterpret_cast<XfbOutInfo*>(&xfbOutInfo);
+            XfbOutInfo* pXfbOutInfo = reinterpret_cast<XfbOutInfo*>(&xfbOutsInfo[locIter->first]);
 
             if (pXfbOutInfo->is16bit)
             {
@@ -712,8 +711,7 @@ void PatchCopyShader::ExportBuiltInOutput(
         auto locIter = xfbOutsInfo.find(outLocInfo.u32All);
         if (locIter != xfbOutsInfo.end())
         {
-            uint32_t xfbOutInfo = xfbOutsInfo[locIter->first];
-            XfbOutInfo* pXfbOutInfo = reinterpret_cast<XfbOutInfo*>(&xfbOutInfo);
+            XfbOutInfo* pXfbOutInfo = reinterpret_cast<XfbOutInfo*>(&xfbOutsInfo[locIter->first]);
 
             std::string instName(lgcName::OutputExportXfb);
             Value* args[] =

--- a/lgc/patch/llpcPatchCopyShader.cpp
+++ b/lgc/patch/llpcPatchCopyShader.cpp
@@ -257,7 +257,7 @@ bool PatchCopyShader::runOnModule(
         //
 
         // Add switchInst to entry block
-        auto pSwitch = builder.CreateSwitch(pStreamId, pEndBlock, outputStreamCount);
+        auto pSwitchInst = builder.CreateSwitch(pStreamId, pEndBlock, outputStreamCount);
 
         for (uint32_t streamId = 0; streamId < MaxGsStreams; ++streamId)
         {
@@ -267,7 +267,7 @@ bool PatchCopyShader::runOnModule(
                 BasicBlock* pStreamBlock = BasicBlock::Create(*m_pContext, blockName, pEntryPoint, pEndBlock);
                 builder.SetInsertPoint(pStreamBlock);
 
-                pSwitch->addCase(builder.getInt32(streamId), pStreamBlock);
+                pSwitchInst->addCase(builder.getInt32(streamId), pStreamBlock);
 
                 ExportOutput(streamId, builder);
                 builder.CreateBr(pEndBlock);

--- a/lgc/patch/llpcPatchDescriptorLoad.cpp
+++ b/lgc/patch/llpcPatchDescriptorLoad.cpp
@@ -741,7 +741,7 @@ Value* PatchDescriptorLoad::BuildBufferCompactDesc(
     return pBufDesc;
 }
 
-} // Llpc
+} // lgc
 
 // =====================================================================================================================
 // Initializes the pass of LLVM patching opertions for descriptor load.

--- a/lgc/patch/llpcPatchIntrinsicSimplify.cpp
+++ b/lgc/patch/llpcPatchIntrinsicSimplify.cpp
@@ -339,15 +339,15 @@ Value* PatchIntrinsicSimplify::SimplifyTrigonometric(
         return nullptr;
     }
 
-    Intrinsic::ID intrinsic = Intrinsic::not_intrinsic;
+    Intrinsic::ID intrinsicId = Intrinsic::not_intrinsic;
 
     switch (intrinsicCall.getIntrinsicID())
     {
     case Intrinsic::cos:
-        intrinsic = Intrinsic::amdgcn_cos;
+        intrinsicId = Intrinsic::amdgcn_cos;
         break;
     case Intrinsic::sin:
-        intrinsic = Intrinsic::amdgcn_sin;
+        intrinsicId = Intrinsic::amdgcn_sin;
         break;
     default:
         return nullptr;
@@ -356,7 +356,7 @@ Value* PatchIntrinsicSimplify::SimplifyTrigonometric(
     Type* pIntrinsicType = intrinsicCall.getType();
 
     Function* const pIntrinsic = Intrinsic::getDeclaration(m_pModule,
-                                                           intrinsic,
+                                                           intrinsicId,
                                                            {pIntrinsicType, pIntrinsicType});
 
     assert(pIntrinsic != nullptr);

--- a/lgc/patch/llpcPatchNullFragShader.cpp
+++ b/lgc/patch/llpcPatchNullFragShader.cpp
@@ -104,16 +104,15 @@ bool PatchNullFragShader::runOnModule(
 
     Patch::Init(&module);
 
-    auto pipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
+    PipelineState* pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
 
-    if (cl::DisableNullFragShader || pipelineState->GetBuilderContext()->BuildingRelocatableElf())
+    if (cl::DisableNullFragShader || pPipelineState->GetBuilderContext()->BuildingRelocatableElf())
     {
         // NOTE: If the option -disable-null-frag-shader is set to TRUE, we skip this pass. This is done by
         // standalone compiler.
         return false;
     }
 
-    PipelineState* pPipelineState = getAnalysis<PipelineStateWrapper>().GetPipelineState(&module);
     const bool hasCs = pPipelineState->HasShaderStage(ShaderStageCompute);
     const bool hasVs = pPipelineState->HasShaderStage(ShaderStageVertex);
     const bool hasTes = pPipelineState->HasShaderStage(ShaderStageTessEval);

--- a/lgc/patch/llpcPatchResourceCollect.cpp
+++ b/lgc/patch/llpcPatchResourceCollect.cpp
@@ -1287,18 +1287,16 @@ void PatchResourceCollect::visitCallInst(
                 if (isa<ConstantInt>(pLocOffset))
                 {
                     // Location offset is constant
-                    auto locOffset = cast<ConstantInt>(pLocOffset)->getZExtValue();
-                    loc += locOffset;
+                    loc +=  cast<ConstantInt>(pLocOffset)->getZExtValue();
 
                     auto bitWidth = pInputTy->getScalarSizeInBits();
                     if (bitWidth == 64)
                     {
                         if (isa<ConstantInt>(pCompIdx))
                         {
-                            auto compIdx = cast<ConstantInt>(pCompIdx)->getZExtValue();
 
                             m_activeInputLocs.insert(loc);
-                            if (compIdx >= 2)
+                            if (cast<ConstantInt>(pCompIdx)->getZExtValue() >= 2)
                             {
                                 // NOTE: For the addressing of .z/.w component of 64-bit vector/scalar, the count of
                                 // occupied locations are two.
@@ -1354,8 +1352,7 @@ void PatchResourceCollect::visitCallInst(
             {
                 // Location offset is constant
                 auto loc = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
-                auto locOffset = cast<ConstantInt>(pLocOffset)->getZExtValue();
-                loc += locOffset;
+                loc += cast<ConstantInt>(pLocOffset)->getZExtValue();
 
                 assert(callInst.getType()->getPrimitiveSizeInBits() <= (8 * SizeOfVec4));
                 m_activeInputLocs.insert(loc);
@@ -1395,18 +1392,15 @@ void PatchResourceCollect::visitCallInst(
         if (isa<ConstantInt>(pLocOffset))
         {
             // Location offset is constant
-            auto locOffset = cast<ConstantInt>(pLocOffset)->getZExtValue();
-            loc += locOffset;
+            loc += cast<ConstantInt>(pLocOffset)->getZExtValue();
 
             auto bitWidth = pOutputTy->getScalarSizeInBits();
             if (bitWidth == 64)
             {
                 if (isa<ConstantInt>(pCompIdx))
                 {
-                    auto compIdx = cast<ConstantInt>(pCompIdx)->getZExtValue();
-
                     m_importedOutputLocs.insert(loc);
-                    if (compIdx >= 2)
+                    if (cast<ConstantInt>(pCompIdx)->getZExtValue() >= 2)
                     {
                         // NOTE: For the addressing of .z/.w component of 64-bit vector/scalar, the count of
                         // occupied locations are two.

--- a/lgc/patch/llpcSystemValues.cpp
+++ b/lgc/patch/llpcSystemValues.cpp
@@ -500,9 +500,9 @@ Value* ShaderSystemValues::GetSpilledPushConstTablePtr()
         uint32_t pushConstOffset = pPushConstNode->offsetInDwords * sizeof(uint32_t);
 
         auto pSpillTablePtrLow = GetFunctionArgument(m_pEntryPoint, pIntfData->entryArgIdxs.spillTable, "spillTable");
-        auto pPushConstOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), pushConstOffset);
         auto pSpilledPushConstTablePtrLow = BinaryOperator::CreateAdd(pSpillTablePtrLow,
-                                                                      pPushConstOffset,
+                                                                      ConstantInt::get(Type::getInt32Ty(*m_pContext),
+                                                                                       pushConstOffset),
                                                                       "",
                                                                       pInsertPos);
         auto pTy = PointerType::get(ArrayType::get(Type::getInt8Ty(*m_pContext), InterfaceData::MaxSpillTableSize),

--- a/lgc/patch/llpcSystemValues.h
+++ b/lgc/patch/llpcSystemValues.h
@@ -34,6 +34,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include "lgc/llpcBuilderBase.h"
+#include "lgc/llpcPipeline.h"
 #include "llpcInternal.h"
 
 #include <map>
@@ -167,9 +168,9 @@ private:
                         m_emitCounterPtrs;              // Pointers to emit counters (GS)
     llvm::Value*        m_pNumWorkgroups = nullptr;     // NumWorkgroups
 
-    llvm::SmallVector<llvm::Value*, InterfaceData::MaxDescTableCount>
+    llvm::SmallVector<llvm::Value *, 8>
                         m_descTablePtrs;                // Descriptor table pointers
-    llvm::SmallVector<llvm::Value*, InterfaceData::MaxDescTableCount>
+    llvm::SmallVector<llvm::Value *, 8>
                         m_shadowDescTablePtrs;          // Shadow descriptor table pointers
     llvm::Value*        m_pInternalGlobalTablePtr = nullptr;
                                                         // Internal global table pointer

--- a/lgc/patch/llpcVertexFetch.cpp
+++ b/lgc/patch/llpcVertexFetch.cpp
@@ -289,7 +289,7 @@ VertexFetch::VertexFetch(
     m_fetchDefaults.pInt16 = ConstantVector::get({ pZero, pZero, pZero, pOne });
 
     // Int (0, 0, 0, 1)
-    m_fetchDefaults.pInt = ConstantVector::get({ pZero, pZero, pZero, pOne });
+    m_fetchDefaults.pInt32 = ConstantVector::get({ pZero, pZero, pZero, pOne });
 
     // Int64 (0, 0, 0, 1)
     m_fetchDefaults.pInt64 = ConstantVector::get({ pZero, pZero, pZero, pZero, pZero, pZero, pZero, pOne });
@@ -306,7 +306,7 @@ VertexFetch::VertexFetch(
         uint32_t u32;
     } floatOne = { 1.0f };
     auto pFloatOneVal = ConstantInt::get(Type::getInt32Ty(*m_pContext), floatOne.u32);
-    m_fetchDefaults.pFloat = ConstantVector::get({ pZero, pZero, pZero, pFloatOneVal });
+    m_fetchDefaults.pFloat32 = ConstantVector::get({ pZero, pZero, pZero, pFloatOneVal });
 
     // Double (0.0, 0.0, 0.0, 1.0)
     union
@@ -316,10 +316,10 @@ VertexFetch::VertexFetch(
     } doubleOne = { 1.0 };
     auto pDoubleOne0 = ConstantInt::get(Type::getInt32Ty(*m_pContext), doubleOne.u32[0]);
     auto pDoubleOne1 = ConstantInt::get(Type::getInt32Ty(*m_pContext), doubleOne.u32[1]);
-    m_fetchDefaults.pDouble = ConstantVector::get({ pZero, pZero,
-                                                    pZero, pZero,
-                                                    pZero, pZero,
-                                                    pDoubleOne0, pDoubleOne1 });
+    m_fetchDefaults.pDouble64 = ConstantVector::get({ pZero, pZero,
+                                                      pZero, pZero,
+                                                      pZero, pZero,
+                                                      pDoubleOne0, pDoubleOne1 });
 }
 
 // =====================================================================================================================
@@ -605,7 +605,7 @@ Value* VertexFetch::Run(
         }
         else if (bitWidth == 32)
         {
-            pDefaults = m_fetchDefaults.pInt;
+            pDefaults = m_fetchDefaults.pInt32;
         }
         else
         {
@@ -621,12 +621,12 @@ Value* VertexFetch::Run(
         }
         else if (bitWidth == 32)
         {
-            pDefaults = m_fetchDefaults.pFloat;
+            pDefaults = m_fetchDefaults.pFloat32;
         }
         else
         {
             assert(bitWidth == 64);
-            pDefaults = m_fetchDefaults.pDouble;
+            pDefaults = m_fetchDefaults.pDouble64;
         }
     }
     else

--- a/lgc/patch/llpcVertexFetch.h
+++ b/lgc/patch/llpcVertexFetch.h
@@ -128,11 +128,11 @@ private:
     {
         llvm::Constant*   pInt8;      // < 0, 0, 0, 1 >
         llvm::Constant*   pInt16;     // < 0, 0, 0, 1 >
-        llvm::Constant*   pInt;       // < 0, 0, 0, 1 >
+        llvm::Constant*   pInt32;     // < 0, 0, 0, 1 >
         llvm::Constant*   pInt64;     // < 0, 0, 0, 0, 0, 0, 0, 1 >
         llvm::Constant*   pFloat16;   // < 0, 0, 0, 0x3C00 >
-        llvm::Constant*   pFloat;     // < 0, 0, 0, 0x3F800000 >
-        llvm::Constant*   pDouble;    // < 0, 0, 0, 0, 0, 0, 0, 0x3FF00000 >
+        llvm::Constant*   pFloat32;   // < 0, 0, 0, 0x3F800000 >
+        llvm::Constant*   pDouble64;  // < 0, 0, 0, 0, 0, 0, 0, 0x3FF00000 >
     } m_fetchDefaults;
 };
 

--- a/lgc/patch/llpcVertexFetch.h
+++ b/lgc/patch/llpcVertexFetch.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "lgc/llpcBuilder.h"
+#include "lgc/llpcPipeline.h"
 #include "llpcInternal.h"
 #include "llpcIntrinsDefs.h"
 

--- a/lgc/util/llpcBuilderDebug.cpp
+++ b/lgc/util/llpcBuilderDebug.cpp
@@ -38,7 +38,7 @@ namespace lgc
 
 //======================================================================================================================
 // Get pointer to stream for LLPC_OUTS, or nullptr if disabled.
-raw_ostream* GetLgcOuts()
+raw_ostream* getLgcOuts()
 {
     return BuilderContext::GetLgcOuts();
 }

--- a/lgc/util/llpcBuilderDebug.h
+++ b/lgc/util/llpcBuilderDebug.h
@@ -36,9 +36,9 @@ namespace lgc
 {
 
 // Get pointer to stream for LLPC_OUTS, or nullptr if disabled.
-llvm::raw_ostream* GetLgcOuts();
+llvm::raw_ostream* getLgcOuts();
 
 } // lgc
 
 // Output general message
-#define LLPC_OUTS(msg) do if (llvm::raw_ostream* pStream = GetLgcOuts()) { *pStream << msg; } while (false)
+#define LLPC_OUTS(msg) do if (llvm::raw_ostream* pStream = getLgcOuts()) { *pStream << msg; } while (false)

--- a/lgc/util/llpcGfxRegHandler.cpp
+++ b/lgc/util/llpcGfxRegHandler.cpp
@@ -37,9 +37,9 @@ using namespace llvm;
 // =====================================================================================================================
 GfxRegHandler::GfxRegHandler(
     Builder* pBuilder,  // [in] The builder handle
-    Value*   pRegister) // [in] The registered target vec <n x i32>
+    Value*   pReg) // [in] The registered target vec <n x i32>
     :
-    GfxRegHandlerBase(pBuilder, pRegister)
+    GfxRegHandlerBase(pBuilder, pReg)
 {
     m_pOne = pBuilder->getInt32(1);
 }
@@ -113,10 +113,10 @@ static constexpr BitsInfo SqImgSampRegBitsGfx9[static_cast<uint32_t>(SqSampRegs:
 // Helper class for handling Registers defined in SQ_IMG_SAMP_WORD
 SqImgSampRegHandler::SqImgSampRegHandler(
     Builder*      pBuilder,      // [in] Bound builder context
-    Value*        pRegister,     // [in] Bound register vec <n x i32>
+    Value*        pReg,     // [in] Bound register vec <n x i32>
     GfxIpVersion* pGfxIpVersion) // [in] Target GFX IP version
     :
-    GfxRegHandler(pBuilder, pRegister)
+    GfxRegHandler(pBuilder, pReg)
 {
     m_pGfxIpVersion = pGfxIpVersion;
 
@@ -213,10 +213,10 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx10[static_cast<uint32_t>(SqRsrcRegs
 // Helper class for handling Registers defined in SQ_IMG_RSRC_WORD
 SqImgRsrcRegHandler::SqImgRsrcRegHandler(
     Builder*      pBuilder,      // [in] Bound builder context
-    Value*        pRegister,     // [in] Bound register vec <n x i32>
+    Value*        pReg,     // [in] Bound register vec <n x i32>
     GfxIpVersion* pGfxIpVersion) // [in] Current GFX IP version
     :
-    GfxRegHandler(pBuilder, pRegister)
+    GfxRegHandler(pBuilder, pReg)
 {
     m_pGfxIpVersion = pGfxIpVersion;
 

--- a/lgc/util/llpcGfxRegHandler.h
+++ b/lgc/util/llpcGfxRegHandler.h
@@ -75,7 +75,7 @@ struct BitsState
 class GfxRegHandler : public GfxRegHandlerBase
 {
 protected:
-    GfxRegHandler(Builder* pBuilder, llvm::Value* pRegister);
+    GfxRegHandler(Builder* pBuilder, llvm::Value* pReg);
 
     // Common function for getting the current value for the hardware register
     llvm::Value* GetRegCommon(uint32_t regId);
@@ -109,7 +109,7 @@ private:
     BitsState*      m_pBitsState    = nullptr;
 };
 
-// SqImgSampRegisters ID
+// SqImgSampRegs ID
 // Corresponds to SqImgSampRegBitsGfx9
 enum class SqSampRegs
 {
@@ -125,7 +125,7 @@ enum class SqSampRegs
 class SqImgSampRegHandler: public GfxRegHandler
 {
 public:
-    SqImgSampRegHandler(Builder* pBuilder, llvm::Value* pRegister, GfxIpVersion* pGfxIpVersion);
+    SqImgSampRegHandler(Builder* pBuilder, llvm::Value* pReg, GfxIpVersion* pGfxIpVersion);
 
     // Get the current value for the hardware register
     llvm::Value* GetReg(SqSampRegs regId);
@@ -164,7 +164,7 @@ enum class SqRsrcRegs
 class SqImgRsrcRegHandler : public GfxRegHandler
 {
 public:
-    SqImgRsrcRegHandler(Builder* pBuilder, llvm::Value* pRegister, GfxIpVersion* pGfxIpVersion);
+    SqImgRsrcRegHandler(Builder* pBuilder, llvm::Value* pReg, GfxIpVersion* pGfxIpVersion);
 
     // Get the current value for the hardware register
     llvm::Value* GetReg(SqRsrcRegs regId);

--- a/lgc/util/llpcGfxRegHandlerBase.cpp
+++ b/lgc/util/llpcGfxRegHandlerBase.cpp
@@ -64,7 +64,7 @@ void GfxRegHandlerBase::SetRegister(
         m_dwords.push_back(nullptr);
     }
 
-    m_pRegister = pNewRegister;
+    m_pReg = pNewRegister;
     m_dirtyDwords = 0u;
 }
 
@@ -80,7 +80,7 @@ Value* GfxRegHandlerBase::GetRegister()
     {
         if (dirtyMask & 1)
         {
-            m_pRegister = m_pBuilder->CreateInsertElement(m_pRegister,
+            m_pReg = m_pBuilder->CreateInsertElement(m_pReg,
                                                           m_dwords[i],
                                                           m_pBuilder->getInt64(i));
         }
@@ -91,8 +91,8 @@ Value* GfxRegHandlerBase::GetRegister()
     // Set mask as all clean since we've update the registered <nxi32>
     m_dirtyDwords = 0u;
 
-    // Just return updated m_pRegister
-    return m_pRegister;
+    // Just return updated m_pReg
+    return m_pReg;
 }
 
 // =====================================================================================================================

--- a/lgc/util/llpcGfxRegHandlerBase.cpp
+++ b/lgc/util/llpcGfxRegHandlerBase.cpp
@@ -146,9 +146,9 @@ Value* GfxRegHandlerBase::ReplaceBits(
 {
     // mask = ((1 << count) - 1) << offset
     // Result = (pDword & ~mask)|((pNewBits << offset) & mask)
-    uint32_t mask = ((1 << count) - 1) << offset;
-    Value* pMask = m_pBuilder->getInt32(mask);
-    Value* pNotMask = m_pBuilder->getInt32(~mask);
+    uint32_t maskBits = ((1 << count) - 1) << offset;
+    Value* pMask = m_pBuilder->getInt32(maskBits);
+    Value* pNotMask = m_pBuilder->getInt32(~maskBits);
     Value* pBeginBit = m_pBuilder->getInt32(offset);
     pNewBits = m_pBuilder->CreateAnd(m_pBuilder->CreateShl(pNewBits, pBeginBit), pMask);
     return m_pBuilder->CreateOr(m_pBuilder->CreateAnd(pDword, pNotMask), pNewBits);

--- a/lgc/util/llpcGfxRegHandlerBase.h
+++ b/lgc/util/llpcGfxRegHandlerBase.h
@@ -57,10 +57,10 @@ public:
 
 protected:
     // Constructor
-    inline GfxRegHandlerBase(Builder* pBuilder, llvm::Value* pRegister)
+    inline GfxRegHandlerBase(Builder* pBuilder, llvm::Value* pReg)
     {
         m_pBuilder = pBuilder;
-        SetRegister(pRegister);
+        SetRegister(pReg);
     }
 
     // Return new DWORD with replacing the specific range of bits in old DWORD
@@ -103,7 +103,7 @@ private:
     {
         if (m_dwords[index] == nullptr)
         {
-            m_dwords[index] = m_pBuilder->CreateExtractElement(m_pRegister, m_pBuilder->getInt64(index));
+            m_dwords[index] = m_pBuilder->CreateExtractElement(m_pReg, m_pBuilder->getInt64(index));
         }
     }
 
@@ -117,9 +117,9 @@ private:
 
     // Combined <n x i32> vector containing the register value, which does not yet reflect the dwords
     // that are marked as dirty.
-    llvm::Value* m_pRegister;
+    llvm::Value* m_pReg;
 
-    // Bit-mask of dwords whose value was changed but is not yet reflected in m_pRegister.
+    // Bit-mask of dwords whose value was changed but is not yet reflected in m_pReg.
     uint32_t m_dirtyDwords;
 };
 

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -367,11 +367,11 @@ Compiler::Compiler(
     auxCreateInfo.gfxIp           = m_gfxIp;
     auxCreateInfo.hash            = m_optionHash;
     auxCreateInfo.pExecutableName = cl::ExecutableName.c_str();
-    auxCreateInfo.pCacheFilePath  = cl::ShaderCacheFileDir.c_str();
+    auxCreateInfo.cacheFilePath   = cl::ShaderCacheFileDir.c_str();
     if (cl::ShaderCacheFileDir.empty())
     {
 #ifdef WIN_OS
-        auxCreateInfo.pCacheFilePath  = getenv("LOCALAPPDATA");
+        auxCreateInfo.cacheFilePath  = getenv("LOCALAPPDATA");
 #else
         llvm_unreachable("Should never be called!");
 #endif
@@ -1339,7 +1339,7 @@ void GraphicsShaderCacheChecker::UpdateRootUserDateOffset(
     auto result = writer.ReadFromBuffer(pPipelineElf->data(), pPipelineElf->size());
     assert(result == Result::Success);
     (void(result)); // unused
-    writer.UpdateElfBinary(m_pContext, pPipelineElf);
+    writer.updateElfBinary(m_pContext, pPipelineElf);
 }
 
 // =====================================================================================================================
@@ -1407,7 +1407,7 @@ void GraphicsShaderCacheChecker::UpdateAndMerge(
         auto result = writer.ReadFromBuffer(nonFragmentElf.pCode, nonFragmentElf.codeSize);
         assert(result == Result::Success);
         (void(result)); // unused
-        writer.MergeElfBinary(m_pContext, &fragmentElf, pOutputPipelineElf);
+        writer.mergeElfBinary(m_pContext, &fragmentElf, pOutputPipelineElf);
     }
 }
 
@@ -2149,7 +2149,7 @@ void Compiler::LinkRelocatableShaderElf(
             }
         }
 
-        result = writer.LinkGraphicsRelocatableElf({&vsReader, &fsReader}, pContext);
+        result = writer.linkGraphicsRelocatableElf({&vsReader, &fsReader}, pContext);
     }
     else
     {
@@ -2160,14 +2160,14 @@ void Compiler::LinkRelocatableShaderElf(
         {
             return;
         }
-        result = writer.LinkComputeRelocatableElf(csReader, pContext);
+        result = writer.linkComputeRelocatableElf(csReader, pContext);
     }
 
     if (result != Result::Success)
     {
         return;
     }
-    writer.WriteToBuffer(pPipelineElf);
+    writer.writeToBuffer(pPipelineElf);
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -343,7 +343,7 @@ Compiler::Compiler(
 
     if (m_outRedirectCount == 0)
     {
-        RedirectLogOutput(false, optionCount, pOptions);
+        redirectLogOutput(false, optionCount, pOptions);
     }
 
     if (m_instanceCount == 0)
@@ -425,7 +425,7 @@ Compiler::~Compiler()
         -- m_outRedirectCount;
         if (m_outRedirectCount == 0)
         {
-            RedirectLogOutput(true, 0, nullptr);
+            redirectLogOutput(true, 0, nullptr);
         }
 
         ShaderCacheManager::GetShaderCacheManager()->ReleaseShaderCacheObject(m_shaderCache);

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -323,7 +323,7 @@ Result ShaderCache::Init(
             // Build the cache file name and make required directories if necessary
             // cacheFileValid gets initially set based on whether the file exists.
             result = BuildFileName(pAuxCreateInfo->pExecutableName,
-                                   pAuxCreateInfo->pCacheFilePath,
+                                   pAuxCreateInfo->cacheFilePath,
                                    pAuxCreateInfo->gfxIp,
                                    &cacheFileExists);
 

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -412,7 +412,7 @@ Result ShaderCache::BuildFileName(
     assert(pCacheFileExists != nullptr);
     *pCacheFileExists = File::Exists(m_fileFullPath);
     Result result = Result::Success;
-    if ((*pCacheFileExists) == false)
+    if (!*pCacheFileExists)
     {
         length = snprintf(hashedFileName, MaxFilePathLen, "%s%s", pCacheFilePath, CacheFileSubPath);
         std::error_code errCode = sys::fs::create_directories(hashedFileName);

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -89,7 +89,7 @@ struct ShaderCacheAuxCreateInfo
     ShaderCacheMode        shaderCacheMode;    // Mode of shader cache
     GfxIpVersion           gfxIp;              // Graphics IP version info
     MetroHash::Hash        hash;               // Hash code of compilation options
-    const char*            pCacheFilePath;     // root directory of cache file
+    const char*            cacheFilePath;      // root directory of cache file
     const char*            pExecutableName;    // Name of executable file
 };
 

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -67,12 +67,12 @@ namespace Llpc
 // Replace a constant with instructions using a builder.
 void SpirvLower::ReplaceConstWithInsts(
     Context*        pContext,      // [in] The context
-    Constant* const pConst)        // [in/out] The constant to replace with instructions.
+    Constant* const pConstVal)     // [in/out] The constant to replace with instructions.
 
 {
     SmallSet<Constant*, 8> otherConsts;
     Builder* pBuilder = pContext->GetBuilder();
-    for (User* const pUser : pConst->users())
+    for (User* const pUser : pConstVal->users())
     {
         if (Constant* const pOtherConst = dyn_cast<Constant>(pUser))
         {
@@ -89,7 +89,7 @@ void SpirvLower::ReplaceConstWithInsts(
 
     SmallVector<Value*, 8> users;
 
-    for (User* const pUser : pConst->users())
+    for (User* const pUser : pConstVal->users())
     {
         users.push_back(pUser);
     }
@@ -105,7 +105,7 @@ void SpirvLower::ReplaceConstWithInsts(
             const uint32_t incomingValueCount = pPhiNode->getNumIncomingValues();
             for (uint32_t i = 0; i < incomingValueCount; i++)
             {
-                if (pPhiNode->getIncomingValue(i) == pConst)
+                if (pPhiNode->getIncomingValue(i) == pConstVal)
                 {
                     pBuilder->SetInsertPoint(pPhiNode->getIncomingBlock(i)->getTerminator());
                     break;
@@ -117,12 +117,12 @@ void SpirvLower::ReplaceConstWithInsts(
             pBuilder->SetInsertPoint(pInst);
         }
 
-        if (ConstantExpr* const pConstExpr = dyn_cast<ConstantExpr>(pConst))
+        if (ConstantExpr* const pConstExpr = dyn_cast<ConstantExpr>(pConstVal))
         {
             Instruction* const pInsertPos = pBuilder->Insert(pConstExpr->getAsInstruction());
             pInst->replaceUsesOfWith(pConstExpr, pInsertPos);
         }
-        else if (ConstantVector* const pConstVector = dyn_cast<ConstantVector>(pConst))
+        else if (ConstantVector* const pConstVector = dyn_cast<ConstantVector>(pConstVal))
         {
             Value* pResultValue = UndefValue::get(pConstVector->getType());
             for (uint32_t i = 0; i < pConstVector->getNumOperands(); i++)
@@ -141,8 +141,8 @@ void SpirvLower::ReplaceConstWithInsts(
         }
     }
 
-    pConst->removeDeadConstantUsers();
-    pConst->destroyConstant();
+    pConstVal->removeDeadConstantUsers();
+    pConstVal->destroyConstant();
 }
 
 // =====================================================================================================================
@@ -161,9 +161,9 @@ void SpirvLower::RemoveConstantExpr(
         }
     }
 
-    for (Constant* const pConst : constantUsers)
+    for (Constant* const pConstVal : constantUsers)
     {
-        ReplaceConstWithInsts(pContext, pConst);
+        ReplaceConstWithInsts(pContext, pConstVal);
     }
 }
 

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -121,7 +121,7 @@ public:
                           uint32_t                    forceLoopUnrollCount);
 
     static void RemoveConstantExpr(Context* pContext, llvm::GlobalVariable* pGlobal);
-    static void ReplaceConstWithInsts(Context* pContext, llvm::Constant* const pConst);
+    static void ReplaceConstWithInsts(Context* pContext, llvm::Constant* const pConstVal);
 
 protected:
     void Init(llvm::Module* pModule);

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -83,11 +83,9 @@ bool SpirvLowerAccessChain::runOnModule(
 void SpirvLowerAccessChain::visitGetElementPtrInst(
     GetElementPtrInst& getElemPtrInst) // [in] "Getelementptr" instruction
 {
-    auto pGetElemPtrInst = &getElemPtrInst;
-
     // NOTE: Here, we try to coalesce chained "getelementptr" instructions (created from multi-level access chain).
     // Because the metadata is always decorated on top-level pointer value (actually a global variable).
-    const uint32_t addrSpace = pGetElemPtrInst->getType()->getPointerAddressSpace();
+    const uint32_t addrSpace = getElemPtrInst.getType()->getPointerAddressSpace();
     if ((addrSpace == SPIRAS_Private) ||
         (addrSpace == SPIRAS_Input) || (addrSpace == SPIRAS_Output))
     {

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -273,7 +273,7 @@ void SpirvLowerAlgebraTransform::visitBinaryOperator(
 
     // NOTE: We can't do constant folding for the following floating operations if we have floating-point controls that
     // will flush denormals or preserve NaN.
-    if ((m_fp16DenormFlush || m_fp32DenormFlush || m_fp64DenormFlush) == false)
+    if (!m_fp16DenormFlush && !m_fp32DenormFlush && !m_fp64DenormFlush)
     {
         switch (opCode)
         {

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -130,22 +130,22 @@ bool SpirvLowerAlgebraTransform::runOnModule(
                 }
 
                 // ConstantProp instruction if trivially constant.
-                if (Constant* pConst = ConstantFoldInstruction(pInst, dataLayout, &targetLibInfo))
+                if (Constant* pConstVal = ConstantFoldInstruction(pInst, dataLayout, &targetLibInfo))
                 {
-                    LLVM_DEBUG(dbgs() << "Algebriac transform: constant folding: " << *pConst << " from: " << *pInst
+                    LLVM_DEBUG(dbgs() << "Algebriac transform: constant folding: " << *pConstVal << " from: " << *pInst
                         << '\n');
                     if ((pDestType->isHalfTy() && m_fp16DenormFlush) ||
                         (pDestType->isFloatTy() && m_fp32DenormFlush) ||
                         (pDestType->isDoubleTy() && m_fp64DenormFlush))
                     {
                         // Replace denorm value with zero
-                        if (pConst->isFiniteNonZeroFP() && (pConst->isNormalFP() == false))
+                        if (pConstVal->isFiniteNonZeroFP() && (pConstVal->isNormalFP() == false))
                         {
-                            pConst = ConstantFP::get(pDestType, 0.0);
+                            pConstVal = ConstantFP::get(pDestType, 0.0);
                         }
                     }
 
-                    pInst->replaceAllUsesWith(pConst);
+                    pInst->replaceAllUsesWith(pConstVal);
                     if (isInstructionTriviallyDead(pInst, &targetLibInfo))
                     {
                         pInst->eraseFromParent();

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.h
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.h
@@ -59,7 +59,7 @@ private:
     SpirvLowerConstImmediateStore& operator=(const SpirvLowerConstImmediateStore&) = delete;
 
     void ProcessAllocaInsts(llvm::Function* pFunc);
-    llvm::StoreInst* FindSingleStore(llvm::AllocaInst* pAlloca);
+    llvm::StoreInst* FindSingleStore(llvm::AllocaInst* pAllocaInst);
     void ConvertAllocaToReadOnlyGlobal(llvm::StoreInst* pStoreInst);
 };
 

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.h
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.h
@@ -32,6 +32,12 @@
 
 #include "llpcSpirvLower.h"
 
+namespace llvm
+{
+class AllocaInst;
+class StoreInst;
+} // llvm
+
 namespace Llpc
 {
 

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -2041,15 +2041,15 @@ void SpirvLowerGlobal::LowerBufferBlock()
 
         for (User* const pUser : global.users())
         {
-            if (Constant* const pConst = dyn_cast<Constant>(pUser))
+            if (Constant* const pConstVal = dyn_cast<Constant>(pUser))
             {
-                constantUsers.push_back(pConst);
+                constantUsers.push_back(pConstVal);
             }
         }
 
-        for (Constant* const pConst : constantUsers)
+        for (Constant* const pConstVal : constantUsers)
         {
-            ReplaceConstWithInsts(m_pContext, pConst);
+            ReplaceConstWithInsts(m_pContext, pConstVal);
         }
 
         // Record of all the functions that our global is used within.
@@ -2294,15 +2294,15 @@ void SpirvLowerGlobal::LowerPushConsts()
 
         for (User* const pUser : global.users())
         {
-            if (Constant* const pConst = dyn_cast<Constant>(pUser))
+            if (Constant* const pConstVal = dyn_cast<Constant>(pUser))
             {
-                constantUsers.push_back(pConst);
+                constantUsers.push_back(pConstVal);
             }
         }
 
-        for (Constant* const pConst : constantUsers)
+        for (Constant* const pConstVal : constantUsers)
         {
-            ReplaceConstWithInsts(m_pContext, pConst);
+            ReplaceConstWithInsts(m_pContext, pConstVal);
         }
 
         // Record of all the functions that our global is used within.

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -391,7 +391,7 @@ void SpirvLowerGlobal::visitLoadInst(
 
         MDNode* pMetaNode = pInOut->getMetadata(gSPIRVMD::InOut);
         assert(pMetaNode != nullptr);
-        auto pInOutMeta = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
+        auto pInOutMetaVal = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
 
         Value* pVertexIdx = nullptr;
 
@@ -400,11 +400,11 @@ void SpirvLowerGlobal::visitLoadInst(
         {
             bool isVertexIdx = false;
 
-            assert(pInOutMeta->getNumOperands() == 4);
+            assert(pInOutMetaVal->getNumOperands() == 4);
             ShaderInOutMetadata inOutMeta = {};
 
-            inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMeta->getOperand(2))->getZExtValue();
-            inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMeta->getOperand(3))->getZExtValue();
+            inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaVal->getOperand(2))->getZExtValue();
+            inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaVal->getOperand(3))->getZExtValue();
 
             if (inOutMeta.IsBuiltIn)
             {
@@ -426,7 +426,7 @@ void SpirvLowerGlobal::visitLoadInst(
                 pVertexIdx = indexOperands[1];
                 ++operandIdx;
 
-                pInOutMeta = cast<Constant>(pInOutMeta->getOperand(1));
+                pInOutMetaVal = cast<Constant>(pInOutMetaVal->getOperand(1));
             }
         }
 
@@ -435,7 +435,7 @@ void SpirvLowerGlobal::visitLoadInst(
                                           indexOperands,
                                           operandIdx,
                                           0,
-                                          pInOutMeta,
+                                          pInOutMetaVal,
                                           nullptr,
                                           pVertexIdx,
                                           InterpLocUnknown,
@@ -454,7 +454,7 @@ void SpirvLowerGlobal::visitLoadInst(
 
         MDNode* pMetaNode = pInOut->getMetadata(gSPIRVMD::InOut);
         assert(pMetaNode != nullptr);
-        auto pInOutMeta = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
+        auto pInOutMetaVal = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
 
         Value* pLoadValue = UndefValue::get(pInOutTy);
         bool hasVertexIdx = false;
@@ -462,10 +462,10 @@ void SpirvLowerGlobal::visitLoadInst(
         if (pInOutTy->isArrayTy())
         {
             // Arrayed input/output
-            assert(pInOutMeta->getNumOperands() == 4);
+            assert(pInOutMetaVal->getNumOperands() == 4);
             ShaderInOutMetadata inOutMeta = {};
-            inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMeta->getOperand(2))->getZExtValue();
-            inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMeta->getOperand(3))->getZExtValue();
+            inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaVal->getOperand(2))->getZExtValue();
+            inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaVal->getOperand(3))->getZExtValue();
 
             // If the input/output is arrayed, the outermost dimension might for vertex indexing
             if (inOutMeta.IsBuiltIn)
@@ -488,7 +488,7 @@ void SpirvLowerGlobal::visitLoadInst(
             assert(pInOutTy->isArrayTy());
 
             auto pElemTy = pInOutTy->getArrayElementType();
-            auto pElemMeta = cast<Constant>(pInOutMeta->getOperand(1));
+            auto pElemMeta = cast<Constant>(pInOutMetaVal->getOperand(1));
 
             const uint32_t elemCount = pInOutTy->getArrayNumElements();
             for (uint32_t i = 0; i < elemCount; ++i)
@@ -511,7 +511,7 @@ void SpirvLowerGlobal::visitLoadInst(
         {
             pLoadValue = AddCallInstForInOutImport(pInOutTy,
                                                    addrSpace,
-                                                   pInOutMeta,
+                                                   pInOutMetaVal,
                                                    nullptr,
                                                    0,
                                                    nullptr,
@@ -586,7 +586,7 @@ void SpirvLowerGlobal::visitStoreInst(
 
         MDNode* pMetaNode = pOutput->getMetadata(gSPIRVMD::InOut);
         assert(pMetaNode != nullptr);
-        auto pOutputMeta = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
+        auto pOutputMetaVal = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
 
         Value* pVertexIdx = nullptr;
 
@@ -595,10 +595,10 @@ void SpirvLowerGlobal::visitStoreInst(
         {
             bool isVertexIdx = false;
 
-            assert(pOutputMeta->getNumOperands() == 4);
+            assert(pOutputMetaVal->getNumOperands() == 4);
             ShaderInOutMetadata outputMeta = {};
-            outputMeta.U64All[0] = cast<ConstantInt>(pOutputMeta->getOperand(2))->getZExtValue();
-            outputMeta.U64All[1] = cast<ConstantInt>(pOutputMeta->getOperand(3))->getZExtValue();
+            outputMeta.U64All[0] = cast<ConstantInt>(pOutputMetaVal->getOperand(2))->getZExtValue();
+            outputMeta.U64All[1] = cast<ConstantInt>(pOutputMetaVal->getOperand(3))->getZExtValue();
 
             if (outputMeta.IsBuiltIn)
             {
@@ -620,7 +620,7 @@ void SpirvLowerGlobal::visitStoreInst(
                 pVertexIdx = indexOperands[1];
                 ++operandIdx;
 
-                pOutputMeta = cast<Constant>(pOutputMeta->getOperand(1));
+                pOutputMetaVal = cast<Constant>(pOutputMetaVal->getOperand(1));
             }
         }
 
@@ -629,7 +629,7 @@ void SpirvLowerGlobal::visitStoreInst(
                           indexOperands,
                           operandIdx,
                           0,
-                          pOutputMeta,
+                          pOutputMetaVal,
                           nullptr,
                           pVertexIdx,
                           &storeInst);
@@ -645,17 +645,17 @@ void SpirvLowerGlobal::visitStoreInst(
 
         MDNode* pMetaNode = pOutput->getMetadata(gSPIRVMD::InOut);
         assert(pMetaNode != nullptr);
-        auto pOutputMeta = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
+        auto pOutputMetaVal = mdconst::dyn_extract<Constant>(pMetaNode->getOperand(0));
 
         bool hasVertexIdx = false;
 
         // If the input/output is arrayed, the outermost dimension might for vertex indexing
         if (pOutputy->isArrayTy())
         {
-            assert(pOutputMeta->getNumOperands() == 4);
+            assert(pOutputMetaVal->getNumOperands() == 4);
             ShaderInOutMetadata outputMeta = {};
-            outputMeta.U64All[0] = cast<ConstantInt>(pOutputMeta->getOperand(2))->getZExtValue();
-            outputMeta.U64All[1] = cast<ConstantInt>(pOutputMeta->getOperand(3))->getZExtValue();
+            outputMeta.U64All[0] = cast<ConstantInt>(pOutputMetaVal->getOperand(2))->getZExtValue();
+            outputMeta.U64All[1] = cast<ConstantInt>(pOutputMetaVal->getOperand(3))->getZExtValue();
 
             if (outputMeta.IsBuiltIn)
             {
@@ -675,7 +675,7 @@ void SpirvLowerGlobal::visitStoreInst(
         if (hasVertexIdx)
         {
             assert(pOutputy->isArrayTy());
-            auto pElemMeta = cast<Constant>(pOutputMeta->getOperand(1));
+            auto pElemMeta = cast<Constant>(pOutputMetaVal->getOperand(1));
 
             const uint32_t elemCount = pOutputy->getArrayNumElements();
             for (uint32_t i = 0; i < elemCount; ++i)
@@ -697,7 +697,7 @@ void SpirvLowerGlobal::visitStoreInst(
         else
         {
             AddCallInstForOutputExport(pStoreValue,
-                                       pOutputMeta,
+                                       pOutputMetaVal,
                                        nullptr,
                                        0,
                                        InvalidValue,
@@ -1143,7 +1143,7 @@ void SpirvLowerGlobal::LowerInOutInPlace()
 Value* SpirvLowerGlobal::AddCallInstForInOutImport(
     Type*        pInOutTy,          // [in] Type of value imported from input/output
     uint32_t     addrSpace,         // Address space
-    Constant*    pInOutMeta,        // [in] Metadata of this input/output
+    Constant*    pInOutMetaVal,        // [in] Metadata of this input/output
     Value*       pLocOffset,        // [in] Relative location offset, passed from aggregate type
     uint32_t     maxLocOffset,      // Max+1 location offset if variable index has been encountered.
                                     //   For an array built-in with a variable index, this is the array size.
@@ -1172,10 +1172,10 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
         // Array type
         assert(pElemIdx == nullptr);
 
-        assert(pInOutMeta->getNumOperands() == 4);
-        uint32_t stride = cast<ConstantInt>(pInOutMeta->getOperand(0))->getZExtValue();
-        inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMeta->getOperand(2))->getZExtValue();
-        inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMeta->getOperand(3))->getZExtValue();
+        assert(pInOutMetaVal->getNumOperands() == 4);
+        uint32_t stride = cast<ConstantInt>(pInOutMetaVal->getOperand(0))->getZExtValue();
+        inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaVal->getOperand(2))->getZExtValue();
+        inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaVal->getOperand(3))->getZExtValue();
 
         if (inOutMeta.IsBuiltIn)
         {
@@ -1198,14 +1198,14 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                             (m_shaderStage == ShaderStageTessControl) ||
                             (m_shaderStage == ShaderStageTessEval));
 
-                auto pElemMeta = cast<Constant>(pInOutMeta->getOperand(1));
+                auto pElemMeta = cast<Constant>(pInOutMetaVal->getOperand(1));
                 auto pElemTy   = pInOutTy->getArrayElementType();
 
                 const uint64_t elemCount = pInOutTy->getArrayNumElements();
-                for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
+                for (uint32_t idx = 0; idx < elemCount; ++idx)
                 {
                     // Handle array elements recursively
-                    pVertexIdx = ConstantInt::get(Type::getInt32Ty(*m_pContext), elemIdx);
+                    pVertexIdx = ConstantInt::get(Type::getInt32Ty(*m_pContext), idx);
                     auto pElem = AddCallInstForInOutImport(pElemTy,
                                                            addrSpace,
                                                            pElemMeta,
@@ -1216,7 +1216,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                            interpLoc,
                                                            pAuxInterpValue,
                                                            pInsertPos);
-                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { elemIdx }, "", pInsertPos);
+                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { idx }, "", pInsertPos);
                 }
             }
             else
@@ -1245,7 +1245,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
         }
         else
         {
-            auto pElemMeta = cast<Constant>(pInOutMeta->getOperand(1));
+            auto pElemMeta = cast<Constant>(pInOutMetaVal->getOperand(1));
             auto pElemTy   = pInOutTy->getArrayElementType();
 
             const uint64_t elemCount = pInOutTy->getArrayNumElements();
@@ -1254,9 +1254,9 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
             {
                 // NOTE: We are handling vertex indexing of generic inputs of geometry shader. For tessellation shader,
                 // vertex indexing is handled by "load"/"store" instruction lowering.
-                for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
+                for (uint32_t idx = 0; idx < elemCount; ++idx)
                 {
-                    pVertexIdx = ConstantInt::get(Type::getInt32Ty(*m_pContext), elemIdx);
+                    pVertexIdx = ConstantInt::get(Type::getInt32Ty(*m_pContext), idx);
                     auto pElem = AddCallInstForInOutImport(pElemTy,
                                                            addrSpace,
                                                            pElemMeta,
@@ -1267,7 +1267,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                            InterpLocUnknown,
                                                            nullptr,
                                                            pInsertPos);
-                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { elemIdx }, "", pInsertPos);
+                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { idx }, "", pInsertPos);
                 }
             }
             else
@@ -1278,15 +1278,15 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                     pLocOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), 0);
                 }
 
-                for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
+                for (uint32_t idx = 0; idx < elemCount; ++idx)
                 {
                     // Handle array elements recursively
 
-                    // elemLocOffset = locOffset + stride * elemIdx
+                    // elemLocOffset = locOffset + stride * idx
                     Value* pElemLocOffset = BinaryOperator::CreateMul(ConstantInt::get(Type::getInt32Ty(*m_pContext),
                                                                                        stride),
                                                                       ConstantInt::get(Type::getInt32Ty(*m_pContext),
-                                                                                       elemIdx),
+                                                                                       idx),
                                                                       "",
                                                                       pInsertPos);
                     pElemLocOffset = BinaryOperator::CreateAdd(pLocOffset, pElemLocOffset, "", pInsertPos);
@@ -1301,7 +1301,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
                                                            InterpLocUnknown,
                                                            nullptr,
                                                            pInsertPos);
-                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { elemIdx }, "", pInsertPos);
+                    pInOutValue = InsertValueInst::Create(pInOutValue, pElem, { idx }, "", pInsertPos);
                 }
             }
         }
@@ -1316,7 +1316,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
         {
             // Handle structure member recursively
             auto pMemberTy = pInOutTy->getStructElementType(memberIdx);
-            auto pMemberMeta = cast<Constant>(pInOutMeta->getOperand(memberIdx));
+            auto pMemberMeta = cast<Constant>(pInOutMetaVal->getOperand(memberIdx));
 
             auto pMember = AddCallInstForInOutImport(pMemberTy,
                                                      addrSpace,
@@ -1333,9 +1333,9 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
     }
     else
     {
-        Constant* pInOutMetaConst = cast<Constant>(pInOutMeta);
-        inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaConst->getOperand(0))->getZExtValue();
-        inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaConst->getOperand(1))->getZExtValue();
+        Constant* pInOutMetaValConst = cast<Constant>(pInOutMetaVal);
+        inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaValConst->getOperand(0))->getZExtValue();
+        inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaValConst->getOperand(1))->getZExtValue();
 
         assert(inOutMeta.IsLoc || inOutMeta.IsBuiltIn);
 
@@ -1378,15 +1378,15 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
         }
         else
         {
-            uint32_t elemIdx = inOutMeta.Component;
+            uint32_t idx = inOutMeta.Component;
             assert(inOutMeta.Component <= 3);
             if (pInOutTy->getScalarSizeInBits() == 64)
             {
                 assert(inOutMeta.Component % 2 == 0); // Must be even for 64-bit type
-                elemIdx = inOutMeta.Component / 2;
+                idx = inOutMeta.Component / 2;
             }
-            pElemIdx = (pElemIdx == nullptr) ? m_pBuilder->getInt32(elemIdx) :
-                                               m_pBuilder->CreateAdd(pElemIdx, m_pBuilder->getInt32(elemIdx));
+            pElemIdx = (pElemIdx == nullptr) ? m_pBuilder->getInt32(idx) :
+                                               m_pBuilder->CreateAdd(pElemIdx, m_pBuilder->getInt32(idx));
 
             lgc::InOutInfo inOutInfo;
             if (pLocOffset == nullptr)
@@ -1440,7 +1440,7 @@ Value* SpirvLowerGlobal::AddCallInstForInOutImport(
 // Inserts LLVM call instruction to export output.
 void SpirvLowerGlobal::AddCallInstForOutputExport(
     Value*       pOutputValue,      // [in] Value exported to output
-    Constant*    pOutputMeta,       // [in] Metadata of this output
+    Constant*    pOutputMetaVal,       // [in] Metadata of this output
     Value*       pLocOffset,        // [in] Relative location offset, passed from aggregate type
     uint32_t     maxLocOffset,      // Max+1 location offset if variable index has been encountered.
                                     //   For an array built-in with a variable index, this is the array size.
@@ -1466,11 +1466,11 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
         // Array type
         assert(pElemIdx == nullptr);
 
-        assert(pOutputMeta->getNumOperands() == 4);
-        uint32_t stride = cast<ConstantInt>(pOutputMeta->getOperand(0))->getZExtValue();
+        assert(pOutputMetaVal->getNumOperands() == 4);
+        uint32_t stride = cast<ConstantInt>(pOutputMetaVal->getOperand(0))->getZExtValue();
 
-        outputMeta.U64All[0] = cast<ConstantInt>(pOutputMeta->getOperand(2))->getZExtValue();
-        outputMeta.U64All[1] = cast<ConstantInt>(pOutputMeta->getOperand(3))->getZExtValue();
+        outputMeta.U64All[0] = cast<ConstantInt>(pOutputMetaVal->getOperand(2))->getZExtValue();
+        outputMeta.U64All[1] = cast<ConstantInt>(pOutputMetaVal->getOperand(3))->getZExtValue();
 
         if ((m_shaderStage == ShaderStageGeometry) && (emitStreamId != outputMeta.StreamId))
         {
@@ -1504,14 +1504,14 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
                 const uint64_t elemCount = pOutputTy->getArrayNumElements();
                 const uint64_t byteSize = pElemTy->getScalarSizeInBits() / 8;
 
-                for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
+                for (uint32_t idx = 0; idx < elemCount; ++idx)
                 {
                     // Handle array elements recursively
-		  auto pElem = ExtractValueInst::Create(pOutputValue, { elemIdx }, "", pInsertPos);
+		  auto pElem = ExtractValueInst::Create(pOutputValue, { idx }, "", pInsertPos);
 
                     auto pXfbOffset = m_pBuilder->getInt32(outputMeta.XfbOffset +
                                                            outputMeta.XfbExtraOffset +
-                                                           byteSize * elemIdx);
+                                                           byteSize * idx);
                     m_pBuilder->CreateWriteXfbOutput(pElem,
                                                      /*isBuiltIn=*/true,
                                                      builtInId,
@@ -1546,13 +1546,13 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
                 pLocOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), 0);
             }
 
-            auto pElemMeta = cast<Constant>(pOutputMeta->getOperand(1));
+            auto pElemMeta = cast<Constant>(pOutputMetaVal->getOperand(1));
 
             const uint64_t elemCount = pOutputTy->getArrayNumElements();
-            for (uint32_t elemIdx = 0; elemIdx < elemCount; ++elemIdx)
+            for (uint32_t idx = 0; idx < elemCount; ++idx)
             {
                 // Handle array elements recursively
-	      Value* pElem = ExtractValueInst::Create(pOutputValue, { elemIdx }, "", pInsertPos);
+	      Value* pElem = ExtractValueInst::Create(pOutputValue, { idx }, "", pInsertPos);
 
                 Value* pElemLocOffset = nullptr;
                 ConstantInt* pLocOffsetConst = dyn_cast<ConstantInt>(pLocOffset);
@@ -1560,13 +1560,13 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
                 if (pLocOffsetConst != nullptr)
                 {
                     uint32_t locOffset = pLocOffsetConst->getZExtValue();
-                    pElemLocOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), locOffset + stride * elemIdx);
+                    pElemLocOffset = ConstantInt::get(Type::getInt32Ty(*m_pContext), locOffset + stride * idx);
                 }
                 else
                 {
-                    // elemLocOffset = locOffset + stride * elemIdx
+                    // elemLocOffset = locOffset + stride * idx
                     pElemLocOffset = BinaryOperator::CreateMul(ConstantInt::get(Type::getInt32Ty(*m_pContext), stride),
-                                                               ConstantInt::get(Type::getInt32Ty(*m_pContext), elemIdx),
+                                                               ConstantInt::get(Type::getInt32Ty(*m_pContext), idx),
                                                                "",
                                                                pInsertPos);
                     pElemLocOffset = BinaryOperator::CreateAdd(pLocOffset, pElemLocOffset, "", pInsertPos);
@@ -1580,8 +1580,8 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
                                            pElemMeta,
                                            pElemLocOffset,
                                            maxLocOffset,
-                                           xfbOffsetAdjust + (blockArray ? 0 : outputMeta.XfbArrayStride * elemIdx),
-                                           xfbBufferAdjust + (blockArray ? outputMeta.XfbArrayStride * elemIdx : 0),
+                                           xfbOffsetAdjust + (blockArray ? 0 : outputMeta.XfbArrayStride * idx),
+                                           xfbBufferAdjust + (blockArray ? outputMeta.XfbArrayStride * idx : 0),
                                            nullptr,
                                            pVertexIdx,
                                            emitStreamId,
@@ -1598,7 +1598,7 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
         for (uint32_t memberIdx = 0; memberIdx < memberCount; ++memberIdx)
         {
             // Handle structure member recursively
-            auto pMemberMeta = cast<Constant>(pOutputMeta->getOperand(memberIdx));
+            auto pMemberMeta = cast<Constant>(pOutputMetaVal->getOperand(memberIdx));
             Value* pMember = ExtractValueInst::Create(pOutputValue, { memberIdx }, "", pInsertPos);
             AddCallInstForOutputExport(pMember,
                                        pMemberMeta,
@@ -1616,7 +1616,7 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
     {
         // Normal scalar or vector type
         m_pBuilder->SetInsertPoint(pInsertPos);
-        Constant* pInOutMetaConst = cast<Constant>(pOutputMeta);
+        Constant* pInOutMetaConst = cast<Constant>(pOutputMetaVal);
         outputMeta.U64All[0] = cast<ConstantInt>(pInOutMetaConst->getOperand(0))->getZExtValue();
         outputMeta.U64All[1] = cast<ConstantInt>(pInOutMetaConst->getOperand(1))->getZExtValue();
 
@@ -1677,15 +1677,15 @@ void SpirvLowerGlobal::AddCallInstForOutputExport(
         assert(((outputMeta.Index == 1) && (outputMeta.Value == 0)) || (outputMeta.Index == 0));
         assert(pOutputTy->isSingleValueType());
 
-        uint32_t elemIdx = outputMeta.Component;
+        uint32_t idx = outputMeta.Component;
         assert(outputMeta.Component <= 3);
         if (pOutputTy->getScalarSizeInBits() == 64)
         {
             assert(outputMeta.Component % 2 == 0); // Must be even for 64-bit type
-            elemIdx = outputMeta.Component / 2;
+            idx = outputMeta.Component / 2;
         }
-        pElemIdx = (pElemIdx == nullptr) ? m_pBuilder->getInt32(elemIdx) :
-                                           m_pBuilder->CreateAdd(pElemIdx, m_pBuilder->getInt32(elemIdx));
+        pElemIdx = (pElemIdx == nullptr) ? m_pBuilder->getInt32(idx) :
+                                           m_pBuilder->CreateAdd(pElemIdx, m_pBuilder->getInt32(idx));
         pLocOffset = (pLocOffset == nullptr) ? m_pBuilder->getInt32(0) : pLocOffset;
 
         if (outputMeta.IsXfb)
@@ -1736,7 +1736,7 @@ Value* SpirvLowerGlobal::LoadInOutMember(
     const std::vector<Value*>& indexOperands,   // [in] Index operands
     uint32_t                   operandIdx,      // Index of the index operand in processing
     uint32_t                   maxLocOffset,    // Max+1 location offset if variable index has been encountered
-    Constant*                  pInOutMeta,      // [in] Metadata of this input/output member
+    Constant*                  pInOutMetaVal,      // [in] Metadata of this input/output member
     Value*                     pLocOffset,      // [in] Relative location offset of this input/output member
     Value*                     pVertexIdx,      // [in] Input array outermost index used for vertex indexing
     uint32_t                   interpLoc,       // Interpolation location, valid for fragment shader
@@ -1756,13 +1756,13 @@ Value* SpirvLowerGlobal::LoadInOutMember(
         if (pInOutTy->isArrayTy())
         {
             // Array type
-            assert(pInOutMeta->getNumOperands() == 4);
+            assert(pInOutMetaVal->getNumOperands() == 4);
             ShaderInOutMetadata inOutMeta = {};
 
-            inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMeta->getOperand(2))->getZExtValue();
-            inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMeta->getOperand(3))->getZExtValue();
+            inOutMeta.U64All[0] = cast<ConstantInt>(pInOutMetaVal->getOperand(2))->getZExtValue();
+            inOutMeta.U64All[1] = cast<ConstantInt>(pInOutMetaVal->getOperand(3))->getZExtValue();
 
-            auto pElemMeta = cast<Constant>(pInOutMeta->getOperand(1));
+            auto pElemMeta = cast<Constant>(pInOutMetaVal->getOperand(1));
             auto pElemTy   = pInOutTy->getArrayElementType();
 
             if (inOutMeta.IsBuiltIn)
@@ -1789,7 +1789,7 @@ Value* SpirvLowerGlobal::LoadInOutMember(
                 }
 
                 // elemLocOffset = locOffset + stride * elemIdx
-                uint32_t stride = cast<ConstantInt>(pInOutMeta->getOperand(0))->getZExtValue();
+                uint32_t stride = cast<ConstantInt>(pInOutMetaVal->getOperand(0))->getZExtValue();
                 auto pElemIdx = indexOperands[operandIdx + 1];
                 Value* pElemLocOffset = BinaryOperator::CreateMul(ConstantInt::get(Type::getInt32Ty(*m_pContext),
                                                                                    stride),
@@ -1825,7 +1825,7 @@ Value* SpirvLowerGlobal::LoadInOutMember(
             uint32_t memberIdx = cast<ConstantInt>(indexOperands[operandIdx + 1])->getZExtValue();
 
             auto pMemberTy = pInOutTy->getStructElementType(memberIdx);
-            auto pMemberMeta = cast<Constant>(pInOutMeta->getOperand(memberIdx));
+            auto pMemberMeta = cast<Constant>(pInOutMetaVal->getOperand(memberIdx));
 
             return LoadInOutMember(pMemberTy,
                                    addrSpace,
@@ -1849,7 +1849,7 @@ Value* SpirvLowerGlobal::LoadInOutMember(
 
             return AddCallInstForInOutImport(pCompTy,
                                              addrSpace,
-                                             pInOutMeta,
+                                             pInOutMetaVal,
                                              pLocOffset,
                                              maxLocOffset,
                                              pCompIdx,
@@ -1865,7 +1865,7 @@ Value* SpirvLowerGlobal::LoadInOutMember(
         assert(operandIdx == indexOperands.size() - 1);
         return AddCallInstForInOutImport(pInOutTy,
                                          addrSpace,
-                                         pInOutMeta,
+                                         pInOutMetaVal,
                                          pLocOffset,
                                          maxLocOffset,
                                          nullptr,
@@ -1887,7 +1887,7 @@ void SpirvLowerGlobal::StoreOutputMember(
     const std::vector<Value*>& indexOperands,   // [in] Index operands
     uint32_t                   operandIdx,      // Index of the index operand in processing
     uint32_t                   maxLocOffset,    // Max+1 location offset if variable index has been encountered
-    Constant*                  pOutputMeta,     // [in] Metadata of this output member
+    Constant*                  pOutputMetaVal,     // [in] Metadata of this output member
     Value*                     pLocOffset,      // [in] Relative location offset of this output member
     Value*                     pVertexIdx,      // [in] Input array outermost index used for vertex indexing
     Instruction*               pInsertPos)      // [in] Where to insert store instructions
@@ -1898,13 +1898,13 @@ void SpirvLowerGlobal::StoreOutputMember(
     {
         if (pOutputTy->isArrayTy())
         {
-            assert(pOutputMeta->getNumOperands() == 4);
+            assert(pOutputMetaVal->getNumOperands() == 4);
             ShaderInOutMetadata outputMeta = {};
 
-            outputMeta.U64All[0] = cast<ConstantInt>(pOutputMeta->getOperand(2))->getZExtValue();
-            outputMeta.U64All[1] = cast<ConstantInt>(pOutputMeta->getOperand(3))->getZExtValue();
+            outputMeta.U64All[0] = cast<ConstantInt>(pOutputMetaVal->getOperand(2))->getZExtValue();
+            outputMeta.U64All[1] = cast<ConstantInt>(pOutputMetaVal->getOperand(3))->getZExtValue();
 
-            auto pElemMeta = cast<Constant>(pOutputMeta->getOperand(1));
+            auto pElemMeta = cast<Constant>(pOutputMetaVal->getOperand(1));
             auto pElemTy   = pOutputTy->getArrayElementType();
 
             if (outputMeta.IsBuiltIn)
@@ -1933,7 +1933,7 @@ void SpirvLowerGlobal::StoreOutputMember(
                 }
 
                 // elemLocOffset = locOffset + stride * elemIdx
-                uint32_t stride = cast<ConstantInt>(pOutputMeta->getOperand(0))->getZExtValue();
+                uint32_t stride = cast<ConstantInt>(pOutputMetaVal->getOperand(0))->getZExtValue();
                 auto pElemIdx = indexOperands[operandIdx + 1];
                 Value* pElemLocOffset = BinaryOperator::CreateMul(ConstantInt::get(Type::getInt32Ty(*m_pContext),
                                                                                    stride),
@@ -1967,7 +1967,7 @@ void SpirvLowerGlobal::StoreOutputMember(
             uint32_t memberIdx = cast<ConstantInt>(indexOperands[operandIdx + 1])->getZExtValue();
 
             auto pMemberTy = pOutputTy->getStructElementType(memberIdx);
-            auto pMemberMeta = cast<Constant>(pOutputMeta->getOperand(memberIdx));
+            auto pMemberMeta = cast<Constant>(pOutputMetaVal->getOperand(memberIdx));
 
             return StoreOutputMember(pMemberTy,
                                      pStoreValue,
@@ -1986,7 +1986,7 @@ void SpirvLowerGlobal::StoreOutputMember(
             auto pCompIdx = indexOperands[operandIdx + 1];
 
             return AddCallInstForOutputExport(pStoreValue,
-                                              pOutputMeta,
+                                              pOutputMetaVal,
                                               pLocOffset,
                                               maxLocOffset,
                                               InvalidValue,
@@ -2003,7 +2003,7 @@ void SpirvLowerGlobal::StoreOutputMember(
         assert(operandIdx == indexOperands.size() - 1);
 
         return AddCallInstForOutputExport(pStoreValue,
-                                          pOutputMeta,
+                                          pOutputMetaVal,
                                           pLocOffset,
                                           maxLocOffset,
                                           InvalidValue,

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -209,7 +209,7 @@ void SpirvLowerMemoryOp::visitGetElementPtrInst(
 // Checks whether the specified "getelementptr" instruction contains dynamic index and is therefore able to be expanded.
 bool SpirvLowerMemoryOp::NeedExpandDynamicIndex(
     GetElementPtrInst* pGetElemPtr,       // [in] "GetElementPtr" instruction
-    uint32_t*          pOperandIndex,     // [out] Index of the operand that represents a dynamic index
+    uint32_t*          pOperandIndexOut,  // [out] Index of the operand that represents a dynamic index
     uint32_t*          pDynIndexBound     // [out] Upper bound of dynamic index
     ) const
 {
@@ -299,7 +299,7 @@ bool SpirvLowerMemoryOp::NeedExpandDynamicIndex(
         }
     }
 
-    *pOperandIndex = operandIndex;
+    *pOperandIndexOut = operandIndex;
     return needExpand && allowExpand;
 }
 
@@ -415,10 +415,10 @@ void SpirvLowerMemoryOp::ExpandStoreInst(
         Instruction* pCheckStoreInsertPos = &pCheckStoreBlock->getInstList().back();
         Instruction* pStoreInsertPos      = &pStoreBlock->getInstList().front();
 
-        auto pGetElemPtrCount = isType64 ? ConstantInt::get(Type::getInt64Ty(*m_pContext), getElemPtrCount) :
-                                           ConstantInt::get(Type::getInt32Ty(*m_pContext), getElemPtrCount);
+        auto pGetElemPtrCountVal = isType64 ? ConstantInt::get(Type::getInt64Ty(*m_pContext), getElemPtrCount) :
+                                              ConstantInt::get(Type::getInt32Ty(*m_pContext), getElemPtrCount);
 
-        auto pDoStore = new ICmpInst(pCheckStoreInsertPos, ICmpInst::ICMP_ULT, pDynIndex, pGetElemPtrCount);
+        auto pDoStore = new ICmpInst(pCheckStoreInsertPos, ICmpInst::ICMP_ULT, pDynIndex, pGetElemPtrCountVal);
         BranchInst::Create(pStoreBlock, pEndStoreBlock, pDoStore, pCheckStoreInsertPos);
 
         for (uint32_t i = 1; i < getElemPtrCount; ++i)

--- a/llpc/lower/llpcSpirvLowerMemoryOp.h
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.h
@@ -35,6 +35,12 @@
 #include <unordered_set>
 #include "llpcSpirvLower.h"
 
+namespace llvm
+{
+class GetElementPtrInst;
+class StoreInst;
+} // llvm
+
 namespace Llpc
 {
 
@@ -42,9 +48,9 @@ namespace Llpc
 // The structure for store instruction which needs to be expanded.
 struct StoreExpandInfo
 {
-    StoreInst*                          pStoreInst;  ///< "Store" instruction
-    llvm::SmallVector<GetElementPtrInst*, 1>  getElemPtrs; ///< A group of "getelementptr" with constant indices
-    llvm::Value*                              pDynIndex;   ///< Dynamic index of destination.
+    llvm::StoreInst *pStoreInst;                                  ///< "Store" instruction
+    llvm::SmallVector<llvm::GetElementPtrInst *, 1> getElemPtrs;  ///< A group of "getelementptr" with constant indices
+    llvm::Value *pDynIndex;                                       ///< Dynamic index of destination.
 };
 
 // =====================================================================================================================

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -766,14 +766,18 @@ void DoAutoLayoutDesc(
                     }
                     else if (pNode->type != nodeType)
                     {
-                        assert(((nodeType == ResourceMappingNodeType::DescriptorCombinedTexture) ||
-                                     (nodeType == ResourceMappingNodeType::DescriptorResource) ||
-                                     (nodeType == ResourceMappingNodeType::DescriptorTexelBuffer) ||
-                                     (nodeType == ResourceMappingNodeType::DescriptorSampler)) &&
-                                    ((pNode->type == ResourceMappingNodeType::DescriptorCombinedTexture) ||
-                                     (pNode->type == ResourceMappingNodeType::DescriptorResource) ||
-                                     (pNode->type == ResourceMappingNodeType::DescriptorTexelBuffer) ||
-                                     (pNode->type == ResourceMappingNodeType::DescriptorSampler)));
+                        {
+                            assert((nodeType == ResourceMappingNodeType::DescriptorCombinedTexture) ||
+                                         (nodeType == ResourceMappingNodeType::DescriptorResource) ||
+                                         (nodeType == ResourceMappingNodeType::DescriptorTexelBuffer) ||
+                                         (nodeType == ResourceMappingNodeType::DescriptorSampler));
+                        }
+                        {
+                            assert((pNode->type == ResourceMappingNodeType::DescriptorCombinedTexture) ||
+                                   (pNode->type == ResourceMappingNodeType::DescriptorResource) ||
+                                   (pNode->type == ResourceMappingNodeType::DescriptorTexelBuffer) ||
+                                   (pNode->type == ResourceMappingNodeType::DescriptorSampler));
+                        }
 
                         pNode->type = ResourceMappingNodeType::DescriptorCombinedTexture;
                         sizeInDwords = 12 * arraySize;

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1109,22 +1109,47 @@ Type *SPIRVToLLVM::transType(
                    StructType::get(*Context, {transType(SIT->getImageType()),
                                               getBuilder()->GetSamplerDescTy()}));
   }
-#define HANDLE_OPCODE(op) case (op): {                                         \
-    Type *NewTy = transTypeWithOpcode<op>(T, MatrixStride, ColumnMajor,        \
-      ParentIsPointer, ExplicitlyLaidOut);                                     \
-    return ParentIsPointer ? NewTy : mapType(T, NewTy);                        \
+
+  case OpTypeArray: {
+    Type *NewTy = transTypeWithOpcode<OpTypeArray>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
   }
-
-  HANDLE_OPCODE(OpTypeArray);
-  HANDLE_OPCODE(OpTypeBool);
-  HANDLE_OPCODE(OpTypeForwardPointer);
-  HANDLE_OPCODE(OpTypeMatrix);
-  HANDLE_OPCODE(OpTypePointer);
-  HANDLE_OPCODE(OpTypeRuntimeArray);
-  HANDLE_OPCODE(OpTypeStruct);
-  HANDLE_OPCODE(OpTypeVector);
-
-#undef HANDLE_OPCODE
+  case OpTypeBool: {
+    Type *NewTy = transTypeWithOpcode<OpTypeBool>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
+  case OpTypeForwardPointer: {
+    Type *NewTy = transTypeWithOpcode<OpTypeForwardPointer>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
+  case OpTypeMatrix: {
+    Type *NewTy = transTypeWithOpcode<OpTypeMatrix>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
+  case OpTypePointer: {
+    Type *NewTy = transTypeWithOpcode<OpTypePointer>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
+  case OpTypeRuntimeArray: {
+    Type *NewTy = transTypeWithOpcode<OpTypeRuntimeArray>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
+  case OpTypeStruct: {
+    Type *NewTy = transTypeWithOpcode<OpTypeStruct>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
+  case OpTypeVector: {
+    Type *NewTy = transTypeWithOpcode<OpTypeVector>(
+        T, MatrixStride, ColumnMajor, ParentIsPointer, ExplicitlyLaidOut);
+    return ParentIsPointer ? NewTy : mapType(T, NewTy);
+  }
 
   default: {
     llvm_unreachable("Not implemented");
@@ -4760,16 +4785,12 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpLabel:
     return mapValue(BV, BasicBlock::Create(*Context, BV->getName(), F));
 
-#define HANDLE_OPCODE(op) case (op):  \
-  if (BB) {                           \
-    getBuilder()->SetInsertPoint(BB); \
-    updateBuilderDebugLoc(BV, F);     \
-  }                                   \
-  return mapValue(BV, transValueWithOpcode<op>(BV))
-
-  HANDLE_OPCODE(OpVariable);
-
-#undef HANDLE_OPCODE
+  case (OpVariable):
+    if (BB) {
+      getBuilder()->SetInsertPoint(BB);
+      updateBuilderDebugLoc(BV, F);
+    }
+    return mapValue(BV, transValueWithOpcode<OpVariable>(BV));
 
   default:
     // do nothing
@@ -5556,109 +5577,202 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 #endif
 
-#define HANDLE_OPCODE(op) case (op): \
-  return mapValue(BV, transValueWithOpcode<op>(BV))
-
-  HANDLE_OPCODE(OpAtomicLoad);
-  HANDLE_OPCODE(OpAtomicStore);
-  HANDLE_OPCODE(OpAtomicExchange);
-  HANDLE_OPCODE(OpAtomicCompareExchange);
-  HANDLE_OPCODE(OpAtomicIIncrement);
-  HANDLE_OPCODE(OpAtomicIDecrement);
-  HANDLE_OPCODE(OpAtomicIAdd);
-  HANDLE_OPCODE(OpAtomicISub);
-  HANDLE_OPCODE(OpAtomicSMin);
-  HANDLE_OPCODE(OpAtomicUMin);
-  HANDLE_OPCODE(OpAtomicSMax);
-  HANDLE_OPCODE(OpAtomicUMax);
-  HANDLE_OPCODE(OpAtomicAnd);
-  HANDLE_OPCODE(OpAtomicOr);
-  HANDLE_OPCODE(OpAtomicXor);
-  HANDLE_OPCODE(OpCopyMemory);
-  HANDLE_OPCODE(OpLoad);
-  HANDLE_OPCODE(OpStore);
-  HANDLE_OPCODE(OpEndPrimitive);
-  HANDLE_OPCODE(OpEndStreamPrimitive);
-  HANDLE_OPCODE(OpAccessChain);
-  HANDLE_OPCODE(OpArrayLength);
-  HANDLE_OPCODE(OpInBoundsAccessChain);
-  HANDLE_OPCODE(OpPtrAccessChain);
-  HANDLE_OPCODE(OpInBoundsPtrAccessChain);
-  HANDLE_OPCODE(OpImage);
-  HANDLE_OPCODE(OpSampledImage);
-  HANDLE_OPCODE(OpKill);
-  HANDLE_OPCODE(OpReadClockKHR);
-  HANDLE_OPCODE(OpGroupAll);
-  HANDLE_OPCODE(OpGroupAny);
-  HANDLE_OPCODE(OpGroupBroadcast);
-  HANDLE_OPCODE(OpGroupIAdd);
-  HANDLE_OPCODE(OpGroupFAdd);
-  HANDLE_OPCODE(OpGroupFMin);
-  HANDLE_OPCODE(OpGroupUMin);
-  HANDLE_OPCODE(OpGroupSMin);
-  HANDLE_OPCODE(OpGroupFMax);
-  HANDLE_OPCODE(OpGroupUMax);
-  HANDLE_OPCODE(OpGroupSMax);
-  HANDLE_OPCODE(OpGroupNonUniformElect);
-  HANDLE_OPCODE(OpGroupNonUniformAll);
-  HANDLE_OPCODE(OpGroupNonUniformAny);
-  HANDLE_OPCODE(OpGroupNonUniformAllEqual);
-  HANDLE_OPCODE(OpGroupNonUniformBroadcast);
-  HANDLE_OPCODE(OpGroupNonUniformBroadcastFirst);
-  HANDLE_OPCODE(OpGroupNonUniformBallot);
-  HANDLE_OPCODE(OpGroupNonUniformInverseBallot);
-  HANDLE_OPCODE(OpGroupNonUniformBallotBitExtract);
-  HANDLE_OPCODE(OpGroupNonUniformBallotBitCount);
-  HANDLE_OPCODE(OpGroupNonUniformBallotFindLSB);
-  HANDLE_OPCODE(OpGroupNonUniformBallotFindMSB);
-  HANDLE_OPCODE(OpGroupNonUniformShuffle);
-  HANDLE_OPCODE(OpGroupNonUniformShuffleXor);
-  HANDLE_OPCODE(OpGroupNonUniformShuffleUp);
-  HANDLE_OPCODE(OpGroupNonUniformShuffleDown);
-  HANDLE_OPCODE(OpGroupNonUniformIAdd);
-  HANDLE_OPCODE(OpGroupNonUniformFAdd);
-  HANDLE_OPCODE(OpGroupNonUniformIMul);
-  HANDLE_OPCODE(OpGroupNonUniformFMul);
-  HANDLE_OPCODE(OpGroupNonUniformSMin);
-  HANDLE_OPCODE(OpGroupNonUniformUMin);
-  HANDLE_OPCODE(OpGroupNonUniformFMin);
-  HANDLE_OPCODE(OpGroupNonUniformSMax);
-  HANDLE_OPCODE(OpGroupNonUniformUMax);
-  HANDLE_OPCODE(OpGroupNonUniformFMax);
-  HANDLE_OPCODE(OpGroupNonUniformBitwiseAnd);
-  HANDLE_OPCODE(OpGroupNonUniformBitwiseOr);
-  HANDLE_OPCODE(OpGroupNonUniformBitwiseXor);
-  HANDLE_OPCODE(OpGroupNonUniformLogicalAnd);
-  HANDLE_OPCODE(OpGroupNonUniformLogicalOr);
-  HANDLE_OPCODE(OpGroupNonUniformLogicalXor);
-  HANDLE_OPCODE(OpGroupNonUniformQuadBroadcast);
-  HANDLE_OPCODE(OpGroupNonUniformQuadSwap);
-  HANDLE_OPCODE(OpSubgroupBallotKHR);
-  HANDLE_OPCODE(OpSubgroupFirstInvocationKHR);
-  HANDLE_OPCODE(OpSubgroupAllKHR);
-  HANDLE_OPCODE(OpSubgroupAnyKHR);
-  HANDLE_OPCODE(OpSubgroupAllEqualKHR);
-  HANDLE_OPCODE(OpSubgroupReadInvocationKHR);
-  HANDLE_OPCODE(OpGroupIAddNonUniformAMD);
-  HANDLE_OPCODE(OpGroupFAddNonUniformAMD);
-  HANDLE_OPCODE(OpGroupFMinNonUniformAMD);
-  HANDLE_OPCODE(OpGroupUMinNonUniformAMD);
-  HANDLE_OPCODE(OpGroupSMinNonUniformAMD);
-  HANDLE_OPCODE(OpGroupFMaxNonUniformAMD);
-  HANDLE_OPCODE(OpGroupUMaxNonUniformAMD);
-  HANDLE_OPCODE(OpGroupSMaxNonUniformAMD);
-  HANDLE_OPCODE(OpTranspose);
-  HANDLE_OPCODE(OpExtInst);
-  HANDLE_OPCODE(OpMatrixTimesScalar);
-  HANDLE_OPCODE(OpVectorTimesMatrix);
-  HANDLE_OPCODE(OpMatrixTimesVector);
-  HANDLE_OPCODE(OpMatrixTimesMatrix);
-  HANDLE_OPCODE(OpOuterProduct);
-  HANDLE_OPCODE(OpDot);
-  HANDLE_OPCODE(OpDemoteToHelperInvocationEXT);
-  HANDLE_OPCODE(OpIsHelperInvocationEXT);
-
-#undef HANDLE_OPCODE
+  case OpAtomicLoad:
+    return mapValue(BV, transValueWithOpcode<OpAtomicLoad>(BV));
+  case OpAtomicStore:
+    return mapValue(BV, transValueWithOpcode<OpAtomicStore>(BV));
+  case OpAtomicExchange:
+    return mapValue(BV, transValueWithOpcode<OpAtomicExchange>(BV));
+  case OpAtomicCompareExchange:
+    return mapValue(BV, transValueWithOpcode<OpAtomicCompareExchange>(BV));
+  case OpAtomicIIncrement:
+    return mapValue(BV, transValueWithOpcode<OpAtomicIIncrement>(BV));
+  case OpAtomicIDecrement:
+    return mapValue(BV, transValueWithOpcode<OpAtomicIDecrement>(BV));
+  case OpAtomicIAdd:
+    return mapValue(BV, transValueWithOpcode<OpAtomicIAdd>(BV));
+  case OpAtomicISub:
+    return mapValue(BV, transValueWithOpcode<OpAtomicISub>(BV));
+  case OpAtomicSMin:
+    return mapValue(BV, transValueWithOpcode<OpAtomicSMin>(BV));
+  case OpAtomicUMin:
+    return mapValue(BV, transValueWithOpcode<OpAtomicUMin>(BV));
+  case OpAtomicSMax:
+    return mapValue(BV, transValueWithOpcode<OpAtomicSMax>(BV));
+  case OpAtomicUMax:
+    return mapValue(BV, transValueWithOpcode<OpAtomicUMax>(BV));
+  case OpAtomicAnd:
+    return mapValue(BV, transValueWithOpcode<OpAtomicAnd>(BV));
+  case OpAtomicOr:
+    return mapValue(BV, transValueWithOpcode<OpAtomicOr>(BV));
+  case OpAtomicXor:
+    return mapValue(BV, transValueWithOpcode<OpAtomicXor>(BV));
+  case OpCopyMemory:
+    return mapValue(BV, transValueWithOpcode<OpCopyMemory>(BV));
+  case OpLoad:
+    return mapValue(BV, transValueWithOpcode<OpLoad>(BV));
+  case OpStore:
+    return mapValue(BV, transValueWithOpcode<OpStore>(BV));
+  case OpEndPrimitive:
+    return mapValue(BV, transValueWithOpcode<OpEndPrimitive>(BV));
+  case OpEndStreamPrimitive:
+    return mapValue(BV, transValueWithOpcode<OpEndStreamPrimitive>(BV));
+  case OpAccessChain:
+    return mapValue(BV, transValueWithOpcode<OpAccessChain>(BV));
+  case OpArrayLength:
+    return mapValue(BV, transValueWithOpcode<OpArrayLength>(BV));
+  case OpInBoundsAccessChain:
+    return mapValue(BV, transValueWithOpcode<OpInBoundsAccessChain>(BV));
+  case OpPtrAccessChain:
+    return mapValue(BV, transValueWithOpcode<OpPtrAccessChain>(BV));
+  case OpInBoundsPtrAccessChain:
+    return mapValue(BV, transValueWithOpcode<OpInBoundsPtrAccessChain>(BV));
+  case OpImage:
+    return mapValue(BV, transValueWithOpcode<OpImage>(BV));
+  case OpSampledImage:
+    return mapValue(BV, transValueWithOpcode<OpSampledImage>(BV));
+  case OpKill:
+    return mapValue(BV, transValueWithOpcode<OpKill>(BV));
+  case OpReadClockKHR:
+    return mapValue(BV, transValueWithOpcode<OpReadClockKHR>(BV));
+  case OpGroupAll:
+    return mapValue(BV, transValueWithOpcode<OpGroupAll>(BV));
+  case OpGroupAny:
+    return mapValue(BV, transValueWithOpcode<OpGroupAny>(BV));
+  case OpGroupBroadcast:
+    return mapValue(BV, transValueWithOpcode<OpGroupBroadcast>(BV));
+  case OpGroupIAdd:
+    return mapValue(BV, transValueWithOpcode<OpGroupIAdd>(BV));
+  case OpGroupFAdd:
+    return mapValue(BV, transValueWithOpcode<OpGroupFAdd>(BV));
+  case OpGroupFMin:
+    return mapValue(BV, transValueWithOpcode<OpGroupFMin>(BV));
+  case OpGroupUMin:
+    return mapValue(BV, transValueWithOpcode<OpGroupUMin>(BV));
+  case OpGroupSMin:
+    return mapValue(BV, transValueWithOpcode<OpGroupSMin>(BV));
+  case OpGroupFMax:
+    return mapValue(BV, transValueWithOpcode<OpGroupFMax>(BV));
+  case OpGroupUMax:
+    return mapValue(BV, transValueWithOpcode<OpGroupUMax>(BV));
+  case OpGroupSMax:
+    return mapValue(BV, transValueWithOpcode<OpGroupSMax>(BV));
+  case OpGroupNonUniformElect:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformElect>(BV));
+  case OpGroupNonUniformAll:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformAll>(BV));
+  case OpGroupNonUniformAny:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformAny>(BV));
+  case OpGroupNonUniformAllEqual:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformAllEqual>(BV));
+  case OpGroupNonUniformBroadcast:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBroadcast>(BV));
+  case OpGroupNonUniformBroadcastFirst:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBroadcastFirst>(BV));
+  case OpGroupNonUniformBallot:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBallot>(BV));
+  case OpGroupNonUniformInverseBallot:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformInverseBallot>(BV));
+  case OpGroupNonUniformBallotBitExtract:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBallotBitExtract>(BV));
+  case OpGroupNonUniformBallotBitCount:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBallotBitCount>(BV));
+  case OpGroupNonUniformBallotFindLSB:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBallotFindLSB>(BV));
+  case OpGroupNonUniformBallotFindMSB:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBallotFindMSB>(BV));
+  case OpGroupNonUniformShuffle:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformShuffle>(BV));
+  case OpGroupNonUniformShuffleXor:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformShuffleXor>(BV));
+  case OpGroupNonUniformShuffleUp:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformShuffleUp>(BV));
+  case OpGroupNonUniformShuffleDown:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformShuffleDown>(BV));
+  case OpGroupNonUniformIAdd:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformIAdd>(BV));
+  case OpGroupNonUniformFAdd:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformFAdd>(BV));
+  case OpGroupNonUniformIMul:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformIMul>(BV));
+  case OpGroupNonUniformFMul:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformFMul>(BV));
+  case OpGroupNonUniformSMin:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformSMin>(BV));
+  case OpGroupNonUniformUMin:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformUMin>(BV));
+  case OpGroupNonUniformFMin:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformFMin>(BV));
+  case OpGroupNonUniformSMax:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformSMax>(BV));
+  case OpGroupNonUniformUMax:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformUMax>(BV));
+  case OpGroupNonUniformFMax:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformFMax>(BV));
+  case OpGroupNonUniformBitwiseAnd:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBitwiseAnd>(BV));
+  case OpGroupNonUniformBitwiseOr:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBitwiseOr>(BV));
+  case OpGroupNonUniformBitwiseXor:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformBitwiseXor>(BV));
+  case OpGroupNonUniformLogicalAnd:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformLogicalAnd>(BV));
+  case OpGroupNonUniformLogicalOr:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformLogicalOr>(BV));
+  case OpGroupNonUniformLogicalXor:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformLogicalXor>(BV));
+  case OpGroupNonUniformQuadBroadcast:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformQuadBroadcast>(BV));
+  case OpGroupNonUniformQuadSwap:
+    return mapValue(BV, transValueWithOpcode<OpGroupNonUniformQuadSwap>(BV));
+  case OpSubgroupBallotKHR:
+    return mapValue(BV, transValueWithOpcode<OpSubgroupBallotKHR>(BV));
+  case OpSubgroupFirstInvocationKHR:
+    return mapValue(BV, transValueWithOpcode<OpSubgroupFirstInvocationKHR>(BV));
+  case OpSubgroupAllKHR:
+    return mapValue(BV, transValueWithOpcode<OpSubgroupAllKHR>(BV));
+  case OpSubgroupAnyKHR:
+    return mapValue(BV, transValueWithOpcode<OpSubgroupAnyKHR>(BV));
+  case OpSubgroupAllEqualKHR:
+    return mapValue(BV, transValueWithOpcode<OpSubgroupAllEqualKHR>(BV));
+  case OpSubgroupReadInvocationKHR:
+    return mapValue(BV, transValueWithOpcode<OpSubgroupReadInvocationKHR>(BV));
+  case OpGroupIAddNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupIAddNonUniformAMD>(BV));
+  case OpGroupFAddNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupFAddNonUniformAMD>(BV));
+  case OpGroupFMinNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupFMinNonUniformAMD>(BV));
+  case OpGroupUMinNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupUMinNonUniformAMD>(BV));
+  case OpGroupSMinNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupSMinNonUniformAMD>(BV));
+  case OpGroupFMaxNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupFMaxNonUniformAMD>(BV));
+  case OpGroupUMaxNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupUMaxNonUniformAMD>(BV));
+  case OpGroupSMaxNonUniformAMD:
+    return mapValue(BV, transValueWithOpcode<OpGroupSMaxNonUniformAMD>(BV));
+  case OpTranspose:
+    return mapValue(BV, transValueWithOpcode<OpTranspose>(BV));
+  case OpExtInst:
+    return mapValue(BV, transValueWithOpcode<OpExtInst>(BV));
+  case OpMatrixTimesScalar:
+    return mapValue(BV, transValueWithOpcode<OpMatrixTimesScalar>(BV));
+  case OpVectorTimesMatrix:
+    return mapValue(BV, transValueWithOpcode<OpVectorTimesMatrix>(BV));
+  case OpMatrixTimesVector:
+    return mapValue(BV, transValueWithOpcode<OpMatrixTimesVector>(BV));
+  case OpMatrixTimesMatrix:
+    return mapValue(BV, transValueWithOpcode<OpMatrixTimesMatrix>(BV));
+  case OpOuterProduct:
+    return mapValue(BV, transValueWithOpcode<OpOuterProduct>(BV));
+  case OpDot:
+    return mapValue(BV, transValueWithOpcode<OpDot>(BV));
+  case OpDemoteToHelperInvocationEXT:
+    return mapValue(BV, transValueWithOpcode<OpDemoteToHelperInvocationEXT>(BV));
+  case OpIsHelperInvocationEXT:
+    return mapValue(BV, transValueWithOpcode<OpIsHelperInvocationEXT>(BV));
 
   default: {
     auto OC = BV->getOpCode();

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1703,15 +1703,15 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix()
 
                             for (uint32_t column = 0, e = pStoreType->getArrayNumElements(); column < e; column++)
                             {
-                                Value* pColumn = UndefValue::get(pColumnType);
+                                Value* pColumnVal = UndefValue::get(pColumnType);
 
                                 for (uint32_t row = 0; row < rowCount; row++)
                                 {
                                     Value* const pElement = getBuilder()->CreateExtractValue(pStoreValue, { column, row });
-                                    pColumn = getBuilder()->CreateInsertElement(pColumn, pElement, row);
+                                    pColumnVal = getBuilder()->CreateInsertElement(pColumnVal, pElement, row);
                                 }
 
-                                pMatrix = getBuilder()->CreateInsertValue(pMatrix, pColumn, column);
+                                pMatrix = getBuilder()->CreateInsertValue(pMatrix, pColumnVal, column);
                             }
 
                             pStoreValue = pMatrix;
@@ -3066,12 +3066,12 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpArrayLength>(
     StructType* const pStructType = cast<StructType>(pStruct->getType()->getPointerElementType());
     const StructLayout* const pStructLayout = M->getDataLayout().getStructLayout(pStructType);
     const uint32_t offset = static_cast<uint32_t>(pStructLayout->getElementOffset(remappedMemberIndex));
-    Value* const pOffset = getBuilder()->getInt32(offset);
+    Value* const pOffsetVal = getBuilder()->getInt32(offset);
 
     Type* const pMemberType = pStructType->getStructElementType(remappedMemberIndex)->getArrayElementType();
     const uint32_t stride = static_cast<uint32_t>(M->getDataLayout().getTypeSizeInBits(pMemberType) / 8);
 
-    return getBuilder()->CreateUDiv(getBuilder()->CreateSub(pBufferLength, pOffset), getBuilder()->getInt32(stride));
+    return getBuilder()->CreateUDiv(getBuilder()->CreateSub(pBufferLength, pOffsetVal), getBuilder()->getInt32(stride));
 }
 
 // =====================================================================================================================
@@ -3290,9 +3290,9 @@ template<> Value* SPIRVToLLVM::transValueWithOpcode<OpAccessChain>(
             // Always need at least a single index in back.
             indices[index++] = getBuilder()->getInt32(0);
 
-            for (Value* const pIndex : indexArray.slice(split.first))
+            for (Value* const pIndexVal : indexArray.slice(split.first))
             {
-                indices[index++] = pIndex;
+                indices[index++] = pIndexVal;
             }
 
             indices.resize(index);

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -153,14 +153,14 @@ void RedirectLogOutput(
             {
                 std::error_code errCode;
 
-                static raw_fd_ostream dbgFile(cl::LogFileDbgs.c_str(), errCode, sys::fs::F_Text);
+                static raw_fd_ostream newDbgFile(cl::LogFileDbgs.c_str(), errCode, sys::fs::F_Text);
                 assert(!errCode);
                 if (pDbgFile == nullptr)
                 {
-                    dbgFile.SetUnbuffered();
+                    newDbgFile.SetUnbuffered();
                     memcpy((void*)dbgFileBak, (void*)&errs(), sizeof(raw_fd_ostream));
-                    memcpy((void*)&errs(), (void*)&dbgFile, sizeof(raw_fd_ostream));
-                    pDbgFile = &dbgFile;
+                    memcpy((void*)&errs(), (void*)&newDbgFile, sizeof(raw_fd_ostream));
+                    pDbgFile = &newDbgFile;
                 }
             }
         }
@@ -178,14 +178,14 @@ void RedirectLogOutput(
             {
                 std::error_code errCode;
 
-                static raw_fd_ostream outFile(cl::LogFileOuts.c_str(), errCode, sys::fs::F_Text);
+                static raw_fd_ostream newOutFile(cl::LogFileOuts.c_str(), errCode, sys::fs::F_Text);
                 assert(!errCode);
                 if (pOutFile == nullptr)
                 {
-                    outFile.SetUnbuffered();
+                    newOutFile.SetUnbuffered();
                     memcpy((void*)outFileBak, (void*)&outs(), sizeof(raw_fd_ostream));
-                    memcpy((void*)&outs(), (void*)&outFile, sizeof(raw_fd_ostream));
-                    pOutFile = &outFile;
+                    memcpy((void*)&outs(), (void*)&newOutFile, sizeof(raw_fd_ostream));
+                    pOutFile = &newOutFile;
                 }
             }
         }

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -105,7 +105,7 @@ bool EnableErrs()
 // With this method, we can redirect logs in all environments, include both standalone compiler and Vulkan ICD. and we
 // can restore the output on all platform, which is very useful when app crashes or hits an assert.
 // CAUTION: The behavior isn't changed if app outputs logs to STDOUT or STDERR directly.
-void RedirectLogOutput(
+void redirectLogOutput(
     bool              restoreToDefault,   // Restore the default behavior of outs() and errs() if it is true
     uint32_t          optionCount,        // Count of compilation-option strings
     const char*const* pOptions)            // [in] An array of compilation-option strings

--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -53,7 +53,7 @@ bool EnableOuts();
 bool EnableErrs();
 
 // Redirects the output of logs, It affects the behavior of llvm::outs(), dbgs() and errs().
-void RedirectLogOutput(
+void redirectLogOutput(
     bool              restoreToDefault,
     uint32_t          optionCount,
     const char*const* pOptions);

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -567,23 +567,23 @@ void ElfWriter<Elf>::AssembleSymbols()
     }
     pSymbolSection->secHead.sh_size = symSectionSize;
 
-    auto pSymbol = reinterpret_cast<typename Elf::Symbol*>(const_cast<uint8_t*>(pSymbolSection->pData));
+    auto pSymbolToWrite = reinterpret_cast<typename Elf::Symbol*>(const_cast<uint8_t*>(pSymbolSection->pData));
     for (auto& symbol : m_symbols)
     {
         if (symbol.secIdx != InvalidValue)
         {
-            pSymbol->st_name = symbol.nameOffset;
-            pSymbol->st_info.all = symbol.info.all;
-            pSymbol->st_other = 0;
-            pSymbol->st_shndx = symbol.secIdx;
-            pSymbol->st_value = symbol.value;
-            pSymbol->st_size = symbol.size;
-            ++pSymbol;
+            pSymbolToWrite->st_name = symbol.nameOffset;
+            pSymbolToWrite->st_info.all = symbol.info.all;
+            pSymbolToWrite->st_other = 0;
+            pSymbolToWrite->st_shndx = symbol.secIdx;
+            pSymbolToWrite->st_value = symbol.value;
+            pSymbolToWrite->st_size = symbol.size;
+            ++pSymbolToWrite;
         }
     }
 
     assert(pSymbolSection->secHead.sh_size ==
-                static_cast<uint32_t>(reinterpret_cast<uint8_t*>(pSymbol) - pSymbolSection->pData));
+                static_cast<uint32_t>(reinterpret_cast<uint8_t*>(pSymbolToWrite) - pSymbolSection->pData));
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -109,7 +109,7 @@ ElfWriter<Elf>::~ElfWriter()
 // =====================================================================================================================
 // Merge base section and input section into merged section
 template<class Elf>
-void ElfWriter<Elf>::MergeSection(
+void ElfWriter<Elf>::mergeSection(
     const SectionBuffer*    pSection1,          // [in] The first section buffer to merge
     size_t                  section1Size,       // Byte size of the first section
     const char*             pPrefixString1,     // [in] Prefix string of the first section's contents
@@ -210,7 +210,7 @@ public:
 // =====================================================================================================================
 // Merges the map item pair from source map to destination map for llvm::msgpack::MapDocNode.
 template<class Elf>
-void ElfWriter<Elf>::MergeMapItem(
+void ElfWriter<Elf>::mergeMapItem(
     llvm::msgpack::MapDocNode& destMap,    // [in,out] Destination map
     llvm::msgpack::MapDocNode& srcMap,     // [in] Source map
     uint32_t                    key)       // Key to check in source map
@@ -237,7 +237,7 @@ void ElfWriter<Elf>::MergeMapItem(
 // =====================================================================================================================
 // Merges fragment shader related info for meta notes.
 template<class Elf>
-void ElfWriter<Elf>::MergeMetaNote(
+void ElfWriter<Elf>::mergeMetaNote(
     Context*       pContext,       // [in] The first note section to merge
     const ElfNote* pNote1,         // [in] The second note section to merge (contain fragment shader info)
     const ElfNote* pNote2,         // [in] Note section contains fragment shader info
@@ -334,14 +334,14 @@ void ElfWriter<Elf>::MergeMetaNote(
 
     for (uint32_t regNumber : ArrayRef<uint32_t>(PsRegNumbers))
     {
-        MergeMapItem(destRegisters, srcRegisters, regNumber);
+        mergeMapItem(destRegisters, srcRegisters, regNumber);
     }
 
     const uint32_t mmSPI_PS_INPUT_CNTL_0 = 0xa191;
     const uint32_t mmSPI_PS_INPUT_CNTL_31 = 0xa1b0;
     for (uint32_t regNumber = mmSPI_PS_INPUT_CNTL_0; regNumber != mmSPI_PS_INPUT_CNTL_31 + 1; ++regNumber)
     {
-        MergeMapItem(destRegisters, srcRegisters, regNumber);
+        mergeMapItem(destRegisters, srcRegisters, regNumber);
     }
 
     const uint32_t mmSPI_SHADER_USER_DATA_PS_0 = 0x2c0c;
@@ -349,7 +349,7 @@ void ElfWriter<Elf>::MergeMetaNote(
     for (uint32_t regNumber = mmSPI_SHADER_USER_DATA_PS_0;
          regNumber != mmSPI_SHADER_USER_DATA_PS_0 + psUserDataCount; ++regNumber)
     {
-        MergeMapItem(destRegisters, srcRegisters, regNumber);
+        mergeMapItem(destRegisters, srcRegisters, regNumber);
     }
 
     std::string destBlob;
@@ -364,7 +364,7 @@ void ElfWriter<Elf>::MergeMetaNote(
 // =====================================================================================================================
 // Gets symbol according to symbol name, and creates a new one if it doesn't exist.
 template<class Elf>
-ElfSymbol* ElfWriter<Elf>::GetSymbol(
+ElfSymbol* ElfWriter<Elf>::getSymbol(
     const char* pSymbolName)   // [in] Symbol name
 {
     for (auto& symbol : m_symbols)
@@ -393,7 +393,7 @@ ElfSymbol* ElfWriter<Elf>::GetSymbol(
 // =====================================================================================================================
 // Gets note according to noteType.
 template<class Elf>
-ElfNote ElfWriter<Elf>::GetNote(
+ElfNote ElfWriter<Elf>::getNote(
     Util::Abi::PipelineAbiNoteType noteType)  // Note type
 {
     for (auto& note : m_notes)
@@ -411,7 +411,7 @@ ElfNote ElfWriter<Elf>::GetNote(
 // =====================================================================================================================
 // Replaces exist note with input note according to input note type.
 template<class Elf>
-void ElfWriter<Elf>::SetNote(
+void ElfWriter<Elf>::setNote(
     ElfNote* pNote)   // [in] Input note
 {
     for (auto& note : m_notes)
@@ -431,7 +431,7 @@ void ElfWriter<Elf>::SetNote(
 // =====================================================================================================================
 // Replace exist section with input section according to section index
 template<class Elf>
-void ElfWriter<Elf>::SetSection(
+void ElfWriter<Elf>::setSection(
     uint32_t          secIndex,   //  Section index
     SectionBuffer*    pSection)   // [in] Input section
 {
@@ -446,10 +446,10 @@ void ElfWriter<Elf>::SetSection(
 // =====================================================================================================================
 // Determines the size needed for a memory buffer to store this ELF.
 template<class Elf>
-size_t ElfWriter<Elf>::GetRequiredBufferSizeBytes()
+size_t ElfWriter<Elf>::getRequiredBufferSizeBytes()
 {
     // Update offsets and size values
-    CalcSectionHeaderOffset();
+    calcSectionHeaderOffset();
 
     size_t totalBytes = sizeof(typename Elf::FormatHeader);
 
@@ -468,7 +468,7 @@ size_t ElfWriter<Elf>::GetRequiredBufferSizeBytes()
 // =====================================================================================================================
 // Assembles ELF notes and add them to .note section
 template<class Elf>
-void ElfWriter<Elf>::AssembleNotes()
+void ElfWriter<Elf>::assembleNotes()
 {
     if (m_noteSecIdx == InvalidValue)
     {
@@ -507,7 +507,7 @@ void ElfWriter<Elf>::AssembleNotes()
 // =====================================================================================================================
 // Assembles ELF symbols and symbol info to .symtab section
 template<class Elf>
-void ElfWriter<Elf>::AssembleSymbols()
+void ElfWriter<Elf>::assembleSymbols()
 {
     if (m_symSecIdx == InvalidValue)
     {
@@ -590,7 +590,7 @@ void ElfWriter<Elf>::AssembleSymbols()
 // Determines the offset of the section header table by totaling the sizes of each binary chunk written to the ELF file,
 // accounting for alignment.
 template<class Elf>
-void ElfWriter<Elf>::CalcSectionHeaderOffset()
+void ElfWriter<Elf>::calcSectionHeaderOffset()
 {
     uint32_t sharedHdrOffset = 0;
 
@@ -616,16 +616,16 @@ void ElfWriter<Elf>::CalcSectionHeaderOffset()
 // Writes the data out to the given buffer in ELF format. Assumes the buffer has been pre-allocated with adequate
 // space, which can be determined with a call to "GetRequireBufferSizeBytes()".
 template<class Elf>
-void ElfWriter<Elf>::WriteToBuffer(
+void ElfWriter<Elf>::writeToBuffer(
     ElfPackage* pElf)   // [in] Output buffer to write ELF data
 {
     assert(pElf != nullptr);
 
     // Update offsets and size values
-    AssembleNotes();
-    AssembleSymbols();
+    assembleNotes();
+    assembleSymbols();
 
-    const size_t reqSize = GetRequiredBufferSizeBytes();
+    const size_t reqSize = getRequiredBufferSizeBytes();
     pElf->resize(reqSize);
     auto pData = pElf->data();
     memset(pData, 0, reqSize);
@@ -661,15 +661,15 @@ void ElfWriter<Elf>::WriteToBuffer(
 // =====================================================================================================================
 // Copies ELF content from a ElfReader.
 template<class Elf>
-Result ElfWriter<Elf>::CopyFromReader(
+Result ElfWriter<Elf>::copyFromReader(
     const ElfReader<Elf>& reader)   // The ElfReader to copy from.
 {
     Result result = Result::Success;
-    m_header = reader.GetHeader();
-    m_sections.resize(reader.GetSections().size());
-    for (size_t i = 0; i < reader.GetSections().size(); ++i)
+    m_header = reader.getHeader();
+    m_sections.resize(reader.getSections().size());
+    for (size_t i = 0; i < reader.getSections().size(); ++i)
     {
-        auto pSection = reader.GetSections()[i];
+        auto pSection = reader.getSections()[i];
         m_sections[i].secHead = pSection->secHead;
         m_sections[i].pName = pSection->pName;
         auto pData = new uint8_t[pSection->secHead.sh_size + 1];
@@ -678,7 +678,7 @@ Result ElfWriter<Elf>::CopyFromReader(
         m_sections[i].pData = pData;
     }
 
-    m_map = reader.GetMap();
+    m_map = reader.getMap();
     assert(m_header.e_phnum == 0);
 
     m_noteSecIdx = m_map[NoteName];
@@ -750,13 +750,13 @@ Result ElfWriter<Elf>::ReadFromBuffer(
     {
         return result;
     }
-    return CopyFromReader(reader);
+    return copyFromReader(reader);
 }
 
 // =====================================================================================================================
 // Gets section data by section index.
 template<class Elf>
-Result ElfWriter<Elf>::GetSectionDataBySectionIndex(
+Result ElfWriter<Elf>::getSectionDataBySectionIndex(
     uint32_t                 secIdx,          // Section index
     const SectionBuffer**    ppSectionData    // [out] Section data
     ) const
@@ -773,7 +773,7 @@ Result ElfWriter<Elf>::GetSectionDataBySectionIndex(
 // =====================================================================================================================
 // Update descriptor offset to USER_DATA in metaNote.
 template<class Elf>
-void ElfWriter<Elf>::UpdateMetaNote(
+void ElfWriter<Elf>::updateMetaNote(
     Context*       pContext,       // [in] context related to ElfNote
     const ElfNote* pNote,          // [in] Note section to update
     ElfNote*       pNewNote)       // [out] new note section
@@ -858,26 +858,26 @@ void ElfWriter<Elf>::GetSymbolsBySectionIndex(
 // =====================================================================================================================
 // Update descriptor root offset in ELF binary
 template<class Elf>
-void ElfWriter<Elf>::UpdateElfBinary(
+void ElfWriter<Elf>::updateElfBinary(
     Context*          pContext,        // [in] Pipeline context
     ElfPackage*       pPipelineElf)    // [out] Final ELF binary
 {
     // Merge PAL metadata
     ElfNote metaNote = {};
-    metaNote = GetNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
+    metaNote = getNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
 
     assert(metaNote.pData != nullptr);
     ElfNote newMetaNote = {};
-    UpdateMetaNote(pContext, &metaNote, &newMetaNote);
-    SetNote(&newMetaNote);
+    updateMetaNote(pContext, &metaNote, &newMetaNote);
+    setNote(&newMetaNote);
 
-    WriteToBuffer(pPipelineElf);
+    writeToBuffer(pPipelineElf);
 }
 
 // =====================================================================================================================
 // Merge ELF binary of fragment shader and ELF binary of non-fragment shaders into single ELF binary
 template<class Elf>
-void ElfWriter<Elf>::MergeElfBinary(
+void ElfWriter<Elf>::mergeElfBinary(
     Context*          pContext,        // [in] Pipeline context
     const BinaryData* pFragmentElf,    // [in] ELF binary of fragment shader
     ElfPackage*       pPipelineElf)    // [out] Final ELF binary
@@ -908,10 +908,10 @@ void ElfWriter<Elf>::MergeElfBinary(
 
     auto fragmentTextSecIndex = reader.GetSectionIndex(TextName);
     auto nonFragmentSecIndex = GetSectionIndex(TextName);
-    reader.GetSectionDataBySectionIndex(fragmentTextSecIndex, &pFragmentTextSection);
+    reader.getSectionDataBySectionIndex(fragmentTextSecIndex, &pFragmentTextSection);
     reader.GetSymbolsBySectionIndex(fragmentTextSecIndex, fragmentSymbols);
 
-    GetSectionDataBySectionIndex(nonFragmentSecIndex, &pNonFragmentTextSection);
+    getSectionDataBySectionIndex(nonFragmentSecIndex, &pNonFragmentTextSection);
     GetSymbolsBySectionIndex(nonFragmentSecIndex, nonFragmentSymbols);
     ElfSymbol* pFragmentIsaSymbol = nullptr;
     ElfSymbol* pNonFragmentIsaSymbol = nullptr;
@@ -953,14 +953,14 @@ void ElfWriter<Elf>::MergeElfBinary(
             // Modify ISA code
             pFragmentIsaSymbol = &fragmentSymbol;
             ElfSectionBuffer<Elf64::SectionHeader> newSection = {};
-            MergeSection(pNonFragmentTextSection,
+            mergeSection(pNonFragmentTextSection,
                                 isaOffset,
                                 nullptr,
                                 pFragmentTextSection,
                                 pFragmentIsaSymbol->value,
                                 nullptr,
                                 &newSection);
-            SetSection(nonFragmentSecIndex, &newSection);
+            setSection(nonFragmentSecIndex, &newSection);
         }
 
         if (pFragmentIsaSymbol == nullptr)
@@ -970,7 +970,7 @@ void ElfWriter<Elf>::MergeElfBinary(
 
         // Update fragment shader related symbols
         ElfSymbol* pSymbol = nullptr;
-        pSymbol = GetSymbol(fragmentSymbol.pSymName);
+        pSymbol = getSymbol(fragmentSymbol.pSymName);
         pSymbol->secIdx = nonFragmentSecIndex;
         pSymbol->pSecName = nullptr;
         pSymbol->value = isaOffset + fragmentSymbol.value - pFragmentIsaSymbol->value;
@@ -978,10 +978,10 @@ void ElfWriter<Elf>::MergeElfBinary(
     }
 
     // LLPC doesn't use per pipeline internal table, and LLVM backend doesn't add symbols for disassembly info.
-    assert((reader.IsValidSymbol(FragmentIntrlTblSymbolName) == false) &&
-                (reader.IsValidSymbol(FragmentDisassemblySymbolName) == false) &&
-                (reader.IsValidSymbol(FragmentIntrlDataSymbolName) == false) &&
-                (reader.IsValidSymbol(FragmentAmdIlSymbolName) == false));
+    assert((reader.isValidSymbol(FragmentIntrlTblSymbolName) == false) &&
+                (reader.isValidSymbol(FragmentDisassemblySymbolName) == false) &&
+                (reader.isValidSymbol(FragmentIntrlDataSymbolName) == false) &&
+                (reader.isValidSymbol(FragmentAmdIlSymbolName) == false));
     (void(FragmentIntrlTblSymbolName)); // unused
     (void(FragmentDisassemblySymbolName)); // unused
     (void(FragmentIntrlDataSymbolName)); // unused
@@ -992,8 +992,8 @@ void ElfWriter<Elf>::MergeElfBinary(
     auto nonFragmentDisassemblySecIndex = GetSectionIndex(Util::Abi::AmdGpuDisassemblyName);
     ElfSectionBuffer<Elf64::SectionHeader>* pFragmentDisassemblySection = nullptr;
     const ElfSectionBuffer<Elf64::SectionHeader>* pNonFragmentDisassemblySection = nullptr;
-    reader.GetSectionDataBySectionIndex(fragmentDisassemblySecIndex, &pFragmentDisassemblySection);
-    GetSectionDataBySectionIndex(nonFragmentDisassemblySecIndex, &pNonFragmentDisassemblySection);
+    reader.getSectionDataBySectionIndex(fragmentDisassemblySecIndex, &pFragmentDisassemblySection);
+    getSectionDataBySectionIndex(nonFragmentDisassemblySecIndex, &pNonFragmentDisassemblySection);
     if (pNonFragmentDisassemblySection != nullptr)
     {
         assert(pFragmentDisassemblySection != nullptr);
@@ -1020,14 +1020,14 @@ void ElfWriter<Elf>::MergeElfBinary(
                               pDisassemblyEnd - reinterpret_cast<const char*>(pNonFragmentDisassemblySection->pData);
 
         ElfSectionBuffer<Elf64::SectionHeader> newSection = {};
-        MergeSection(pNonFragmentDisassemblySection,
+        mergeSection(pNonFragmentDisassemblySection,
                      disassemblySize,
                      firstIsaSymbolName.c_str(),
                      pFragmentDisassemblySection,
                      fragmentDisassemblyOffset,
                      FragmentIsaSymbolName,
                      &newSection);
-        SetSection(nonFragmentDisassemblySecIndex, &newSection);
+        setSection(nonFragmentDisassemblySecIndex, &newSection);
     }
 
     // Merge LLVM IR disassemble
@@ -1037,8 +1037,8 @@ void ElfWriter<Elf>::MergeElfBinary(
 
     auto fragmentLlvmIrSecIndex = reader.GetSectionIndex(LlvmIrSectionName.c_str());
     auto nonFragmentLlvmIrSecIndex = GetSectionIndex(LlvmIrSectionName.c_str());
-    reader.GetSectionDataBySectionIndex(fragmentLlvmIrSecIndex, &pFragmentLlvmIrSection);
-    GetSectionDataBySectionIndex(nonFragmentLlvmIrSecIndex, &pNonFragmentLlvmIrSection);
+    reader.getSectionDataBySectionIndex(fragmentLlvmIrSecIndex, &pFragmentLlvmIrSection);
+    getSectionDataBySectionIndex(nonFragmentLlvmIrSecIndex, &pNonFragmentLlvmIrSection);
 
     if (pNonFragmentLlvmIrSection != nullptr)
     {
@@ -1067,34 +1067,34 @@ void ElfWriter<Elf>::MergeElfBinary(
                           pLlvmIrEnd - reinterpret_cast<const char*>(pNonFragmentLlvmIrSection->pData);
 
         ElfSectionBuffer<Elf64::SectionHeader> newSection = {};
-        MergeSection(pNonFragmentLlvmIrSection,
+        mergeSection(pNonFragmentLlvmIrSection,
                      llvmIrSize,
                      firstIsaSymbolName.c_str(),
                      pFragmentLlvmIrSection,
                      fragmentLlvmIrOffset,
                      FragmentIsaSymbolName,
                      &newSection);
-        SetSection(nonFragmentLlvmIrSecIndex, &newSection);
+        setSection(nonFragmentLlvmIrSecIndex, &newSection);
     }
 
     // Merge PAL metadata
     ElfNote nonFragmentMetaNote = {};
-    nonFragmentMetaNote = GetNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
+    nonFragmentMetaNote = getNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
 
     assert(nonFragmentMetaNote.pData != nullptr);
     ElfNote fragmentMetaNote = {};
     ElfNote newMetaNote = {};
-    fragmentMetaNote = reader.GetNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
-    MergeMetaNote(pContext, &nonFragmentMetaNote, &fragmentMetaNote, &newMetaNote);
-    SetNote(&newMetaNote);
+    fragmentMetaNote = reader.getNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
+    mergeMetaNote(pContext, &nonFragmentMetaNote, &fragmentMetaNote, &newMetaNote);
+    setNote(&newMetaNote);
 
-    WriteToBuffer(pPipelineElf);
+    writeToBuffer(pPipelineElf);
 }
 
 // =====================================================================================================================
 // Reset the contents to an empty ELF file.
 template<class Elf>
-void ElfWriter<Elf>::Reinitialize()
+void ElfWriter<Elf>::reinitialize()
 {
     m_map.clear();
     m_notes.clear();
@@ -1122,24 +1122,24 @@ void ElfWriter<Elf>::Reinitialize()
 // =====================================================================================================================
 // Link the relocatable ELF readers into a pipeline ELF.
 template<class Elf>
-Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
+Result ElfWriter<Elf>::linkGraphicsRelocatableElf(
     const ArrayRef<ElfReader<Elf>*>& relocatableElfs, // An array of relocatable ELF objects
     Context* pContext)                                // [in] Acquired context
 {
-    Reinitialize();
+    reinitialize();
     assert(relocatableElfs.size() == 2 && "Can only handle VsPs Shaders for now.");
 
     // Get the main data for the header, the parts that change will be updated when writing to buffer.
-    m_header = relocatableElfs[0]->GetHeader();
+    m_header = relocatableElfs[0]->getHeader();
 
     // Copy the contents of the string table
     ElfSectionBuffer<typename Elf::SectionHeader>* pStringTable1 = nullptr;
-    relocatableElfs[0]->GetSectionDataBySectionIndex(relocatableElfs[0]->GetStrtabSecIdx(), &pStringTable1);
+    relocatableElfs[0]->getSectionDataBySectionIndex(relocatableElfs[0]->getStrtabSecIdx(), &pStringTable1);
 
     ElfSectionBuffer<typename Elf::SectionHeader>* pStringTable2 = nullptr;
-    relocatableElfs[1]->GetSectionDataBySectionIndex(relocatableElfs[1]->GetStrtabSecIdx(), &pStringTable2);
+    relocatableElfs[1]->getSectionDataBySectionIndex(relocatableElfs[1]->getStrtabSecIdx(), &pStringTable2);
 
-    MergeSection(pStringTable1,
+    mergeSection(pStringTable1,
                  pStringTable1->secHead.sh_size,
                  nullptr,
                  pStringTable2,
@@ -1149,11 +1149,11 @@ Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
 
     // Merge text sections
     ElfSectionBuffer<typename Elf::SectionHeader>* pTextSection1 = nullptr;
-    relocatableElfs[0]->GetTextSectionData(&pTextSection1);
+    relocatableElfs[0]->getTextSectionData(&pTextSection1);
     ElfSectionBuffer<typename Elf::SectionHeader> *pTextSection2 = nullptr;
-    relocatableElfs[1]->GetTextSectionData(&pTextSection2);
+    relocatableElfs[1]->getTextSectionData(&pTextSection2);
 
-    MergeSection(pTextSection1,
+    mergeSection(pTextSection1,
                  alignTo(pTextSection1->secHead.sh_size, 0x100),
                  nullptr,
                  pTextSection2,
@@ -1163,7 +1163,7 @@ Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
 
     // Build the symbol table.  First set the symbol table section header.
     ElfSectionBuffer<typename Elf::SectionHeader>* pSymbolTableSection = nullptr;
-    relocatableElfs[0]->GetSectionDataBySectionIndex(relocatableElfs[0]->GetSymSecIdx(), &pSymbolTableSection);
+    relocatableElfs[0]->getSectionDataBySectionIndex(relocatableElfs[0]->getSymSecIdx(), &pSymbolTableSection);
     m_sections[m_symSecIdx].secHead = pSymbolTableSection->secHead;
 
     // Now get the symbols that belong in the symbol table.
@@ -1177,7 +1177,7 @@ Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
         {
             // When relocations start being used, we will have to filter out symbols related to relocations.
             // We should be able to filter the BB* symbols as well.
-            ElfSymbol *pNewSym = GetSymbol(sym.pSymName);
+            ElfSymbol *pNewSym = getSymbol(sym.pSymName);
             pNewSym->secIdx = m_textSecIdx;
             pNewSym->pSecName = nullptr;
             pNewSym->value = sym.value + offset;
@@ -1187,7 +1187,7 @@ Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
 
         // Update the offset for the next elf file.
         ElfSectionBuffer<typename Elf::SectionHeader>* pTextSection = nullptr;
-        pElf->GetSectionDataBySectionIndex(relocElfTextSectionId, &pTextSection);
+        pElf->getSectionDataBySectionIndex(relocElfTextSectionId, &pTextSection);
         offset += alignTo(pTextSection->secHead.sh_size, 0x100);
     }
 
@@ -1196,15 +1196,15 @@ Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
 
     // Set the .note section header
     ElfSectionBuffer<typename Elf::SectionHeader>* pNoteSection = nullptr;
-    relocatableElfs[0]->GetSectionDataBySectionIndex(relocatableElfs[0]->GetSectionIndex(NoteName), &pNoteSection);
+    relocatableElfs[0]->getSectionDataBySectionIndex(relocatableElfs[0]->GetSectionIndex(NoteName), &pNoteSection);
     m_sections[m_noteSecIdx].secHead = pNoteSection->secHead;
 
     // Merge and update the .note data
     // The merged note info will be updated using data in the pipeline create info, but nothing needs to be done yet.
-    ElfNote noteInfo1 = relocatableElfs[0]->GetNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
-    ElfNote noteInfo2 = relocatableElfs[1]->GetNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
+    ElfNote noteInfo1 = relocatableElfs[0]->getNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
+    ElfNote noteInfo2 = relocatableElfs[1]->getNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
     m_notes.push_back({});
-    MergeMetaNote(pContext, &noteInfo1, &noteInfo2, &m_notes.back());
+    mergeMetaNote(pContext, &noteInfo1, &noteInfo2, &m_notes.back());
 
     // Merge other sections.  For now, none of the other sections are important, so we will not do anything.
 
@@ -1214,12 +1214,12 @@ Result ElfWriter<Elf>::LinkGraphicsRelocatableElf(
 // =====================================================================================================================
 // Link the compute shader relocatable ELF reader into a pipeline ELF.
 template<class Elf>
-Result ElfWriter<Elf>::LinkComputeRelocatableElf(
+Result ElfWriter<Elf>::linkComputeRelocatableElf(
     const ElfReader<Elf>& relocatableElf,   // [in] Relocatable compute shader elf
     Context* pContext)                      // [in] Acquired context
 {
     // Currently nothing to do, just copy the elf.
-    CopyFromReader(relocatableElf);
+    copyFromReader(relocatableElf);
 
     // Apply relocations
     // There are no relocations to apply yet.

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -65,7 +65,7 @@ public:
 
     ~ElfWriter();
 
-    static void MergeSection(const SectionBuffer* pSection1,
+    static void mergeSection(const SectionBuffer* pSection1,
                              size_t               section1Size,
                              const char*          pPrefixString1,
                              const SectionBuffer* pSection2,
@@ -73,21 +73,21 @@ public:
                              const char*          pPrefixString2,
                              SectionBuffer*       pNewSection);
 
-    static void MergeMetaNote(Context*       pContext,
+    static void mergeMetaNote(Context*       pContext,
                               const ElfNote* pNote1,
                               const ElfNote* pNote2,
                               ElfNote*       pNewNote);
 
-    static void UpdateMetaNote(Context*       pContext,
+    static void updateMetaNote(Context*       pContext,
                                const ElfNote* pNote,
                                ElfNote*       pNewNote);
 
     Result ReadFromBuffer(const void* pBuffer, size_t bufSize);
-    Result CopyFromReader(const ElfReader<Elf>& reader);
+    Result copyFromReader(const ElfReader<Elf>& reader);
 
-    void UpdateElfBinary(Context* pContext, ElfPackage* pPipelineElf);
+    void updateElfBinary(Context* pContext, ElfPackage* pPipelineElf);
 
-    void MergeElfBinary(Context*          pContext,
+    void mergeElfBinary(Context*          pContext,
                         const BinaryData* pFragmentElf,
                         ElfPackage*       pPipelineElf);
 
@@ -98,38 +98,38 @@ public:
         return (pEntry != m_map.end()) ? pEntry->second : InvalidValue;
     }
 
-    void SetSection(uint32_t secIndex, SectionBuffer* pSection);
+    void setSection(uint32_t secIndex, SectionBuffer* pSection);
 
-    ElfSymbol* GetSymbol(const char* pSymbolName);
+    ElfSymbol* getSymbol(const char* pSymbolName);
 
-    ElfNote GetNote(Util::Abi::PipelineAbiNoteType noteType);
+    ElfNote getNote(Util::Abi::PipelineAbiNoteType noteType);
 
-    void SetNote(ElfNote* pNote);
+    void setNote(ElfNote* pNote);
 
-    Result GetSectionDataBySectionIndex(uint32_t secIdx, const SectionBuffer** ppSectionData) const;
+    Result getSectionDataBySectionIndex(uint32_t secIdx, const SectionBuffer** ppSectionData) const;
 
     void GetSymbolsBySectionIndex(uint32_t secIdx, std::vector<ElfSymbol*>& secSymbols);
 
-    void WriteToBuffer(ElfPackage* pElf);
+    void writeToBuffer(ElfPackage* pElf);
 
-    Result LinkGraphicsRelocatableElf(const llvm::ArrayRef<ElfReader<Elf>*>& relocatableElfs, Context *pContext);
+    Result linkGraphicsRelocatableElf(const llvm::ArrayRef<ElfReader<Elf>*>& relocatableElfs, Context *pContext);
 
-    Result LinkComputeRelocatableElf(const ElfReader<Elf>& relocatableElf, Context* pContext);
+    Result linkComputeRelocatableElf(const ElfReader<Elf>& relocatableElf, Context* pContext);
 private:
     ElfWriter(const ElfWriter&) = delete;
     ElfWriter& operator=(const ElfWriter&) = delete;
 
-    static void MergeMapItem(llvm::msgpack::MapDocNode& destMap, llvm::msgpack::MapDocNode& srcMap, uint32_t key);
+    static void mergeMapItem(llvm::msgpack::MapDocNode& destMap, llvm::msgpack::MapDocNode& srcMap, uint32_t key);
 
-    size_t GetRequiredBufferSizeBytes();
+    size_t getRequiredBufferSizeBytes();
 
-    void CalcSectionHeaderOffset();
+    void calcSectionHeaderOffset();
 
-    void AssembleNotes();
+    void assembleNotes();
 
-    void AssembleSymbols();
+    void assembleSymbols();
 
-    void Reinitialize();
+    void reinitialize();
 
     // -----------------------------------------------------------------------------------------------------------------
 

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -38,11 +38,15 @@ namespace llvm { namespace msgpack { class MapDocNode; } }
 namespace Llpc
 {
 
+using Vkgc::BinaryData;
 using Vkgc::ElfNote;
-using Vkgc::ElfSymbol;
 using Vkgc::ElfPackage;
 using Vkgc::ElfReader;
 using Vkgc::ElfSectionBuffer;
+using Vkgc::ElfSymbol;
+using Vkgc::GfxIpVersion;
+using Vkgc::InvalidValue;
+using Vkgc::Result;
 
 // Forward declaration
 class Context;

--- a/llpc/util/llpcEmuLib.cpp
+++ b/llpc/util/llpcEmuLib.cpp
@@ -89,11 +89,11 @@ Function* EmuLib::GetFunction(
         auto pChild = cantFail(archive.archive->findSym(funcName), "Failed in archive symbol search");
         assert(pChild.hasValue());
         // Found the symbol. Get the bitcode for its module.
-        StringRef child = cantFail(pChild->getBuffer(), "Failed in archive module extraction");
+        StringRef childBitcode = cantFail(pChild->getBuffer(), "Failed in archive module extraction");
 
         // Parse the bitcode archive member into a Module.
         auto libModule = cantFail(parseBitcodeFile(
-            MemoryBufferRef(child, ""), *pContext), "Failed to parse archive bitcode");
+            MemoryBufferRef(childBitcode, ""), *pContext), "Failed to parse archive bitcode");
 
         // Find and mark the non-native library functions. A library function is non-native if:
         //   it references llvm.amdgcn.*

--- a/llpc/util/llpcEmuLib.h
+++ b/llpc/util/llpcEmuLib.h
@@ -34,6 +34,7 @@
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <map>
+#include <unordered_map>
 #include <vector>
 
 namespace llvm

--- a/llpc/util/llpcFile.cpp
+++ b/llpc/util/llpcFile.cpp
@@ -175,9 +175,9 @@ Result File::Write(
 // =====================================================================================================================
 // Reads a stream of bytes from the file.
 Result File::Read(
-    void*   pBuffer,     // [out] Buffer to read the file into
-    size_t  bufferSize,  // Size of buffer in bytes
-    size_t* pBytesRead)  // [out] Number of bytes actually read (can be nullptr)
+    void*   pBuffer,        // [out] Buffer to read the file into
+    size_t  bufferSize,     // Size of buffer in bytes
+    size_t* pBytesReadOut)  // [out] Number of bytes actually read (can be nullptr)
 {
     Result result = Result::Success;
 
@@ -202,9 +202,9 @@ Result File::Read(
             result = Result::ErrorUnknown;
         }
 
-        if (pBytesRead != nullptr)
+        if (pBytesReadOut != nullptr)
         {
-            *pBytesRead = bytesRead;
+            *pBytesReadOut = bytesRead;
         }
     }
 
@@ -214,9 +214,9 @@ Result File::Read(
 // =====================================================================================================================
 // Reads a single line (until the next newline) of bytes from the file.
 Result File::ReadLine(
-    void*   pBuffer,     // [out] Buffer to read the file into
-    size_t  bufferSize,  // Size of buffer in bytes
-    size_t* pBytesRead)  // [out] Number of bytes actually read (can be nullptr)
+    void*   pBuffer,        // [out] Buffer to read the file into
+    size_t  bufferSize,     // Size of buffer in bytes
+    size_t* pBytesReadOut)  // [out] Number of bytes actually read (can be nullptr)
 {
     Result result = Result::ErrorInvalidValue;
 
@@ -254,9 +254,9 @@ Result File::ReadLine(
             bytesRead++;
         }
 
-        if (pBytesRead != nullptr)
+        if (pBytesReadOut != nullptr)
         {
-            *pBytesRead = bytesRead;
+            *pBytesReadOut = bytesRead;
         }
     }
 
@@ -341,7 +341,7 @@ void File::Rewind()
 {
     if (m_pFileHandle != nullptr)
     {
-        rewind(m_pFileHandle);
+        ::rewind(m_pFileHandle);
     }
 }
 

--- a/llpc/util/llpcFile.h
+++ b/llpc/util/llpcFile.h
@@ -52,7 +52,7 @@ enum FileAccessMode : uint32_t
 class File
 {
 public:
-    File() : m_pFileHandle(nullptr) { }
+    File() : m_fileHandle(nullptr) { }
 
     // Closes the file if it is still open.
     ~File() { Close(); }
@@ -72,12 +72,12 @@ public:
     void Seek(int32_t offset, bool fromOrigin);
 
     // Returns true if the file is presently open.
-    bool IsOpen() const { return (m_pFileHandle != nullptr); }
+    bool IsOpen() const { return (m_fileHandle != nullptr); }
     // Gets handle of the file
-    const std::FILE* GetHandle() const { return m_pFileHandle; }
+    const std::FILE* GetHandle() const { return m_fileHandle; }
 
 private:
-    std::FILE* m_pFileHandle;      // File handle
+    std::FILE* m_fileHandle;      // File handle
 };
 
 } // Llpc

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -117,13 +117,5 @@ inline uint32_t Log2(
     return logValue;
 }
 
-// ===================================================================================
-// Returns the bits of a floating point value as an unsigned integer.
-inline uint32_t FloatToBits(
-    float f)        // Float to be converted to bits
-{
-    return (*(reinterpret_cast<uint32_t*>(&f)));
-}
-
 } // Llpc
 

--- a/script/switch-coding-style.sh
+++ b/script/switch-coding-style.sh
@@ -1,0 +1,348 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+: # #################################################################################################
+: # Script to perform one-time coding style changes in LLPC/LGC/VKGC
+: #
+: # This script is provided to allow developers with local or unmerged commits to rebase
+: # them on the re-styled codebase.
+: #
+: # The script uses a hacked clang-tidy. So the first step is to get the llvm-project sources
+: # with the clang-tidy hacks from
+: #
+: #   https://github.com/trenouf/llvm-project/tree/clang-tidy-for-llpc-legal
+: #
+: # then do a release build of clang-format, clang-tidy
+: # and clang-apply-replacements. (A debug build results in the tools being too slow.) Ensure
+: # the built tools are on PATH.
+: #
+: # The script assumes you have ccache, so ensure you have that installed. You might like to
+: # increase the cache size from the default 5G by editing ~/.ccache/ccache.conf to include
+: # a line like
+: #
+: #   max_size = 20.0G
+: #
+: # Then, to re-style the entire LLPC/LGC/VKGC tree, cd into the root of the llpc repository
+: # (containing subdirectories llpc, lgc, tool, util, include), and run the script naming
+: # the transformations to perform:
+: #
+: # script/switch_coding_style.sh int32 identifiers braces comparisons parentheses comments format
+: #
+: # To rebase a local or unmerged commit or sequence of commits, you need to run the script
+: # as a gt filter-branch script.
+: #
+: # First, check out the most recent of your sequence of commits, and rebase on the last
+: # upstream commit before the re-styling was applied (i.e. the commit before the one that did
+: # the "int32" change).
+: #
+: # Next, set a variable to how many commits are in your sequence of commits:
+: #
+: # numcommits=`gt log --oneline vulkan-github/dev..HEAD | wc -l`
+: #
+: # (That will be set to 1 if you have a single commit.)
+: #
+: # Run the script on one more commit than that, so your re-styled commit(s) are based on a
+: # re-styled version of upstream:
+: #
+: # gt filter-branch --tree-filter '
+: #     script/switch_coding_style.sh int32 identifiers braces comparisons parentheses comments format
+: # ' HEAD~$((numcommits+1))..HEAD
+: #
+: # Finally, rebase the re-styled commits on the post-re-styled upstream:
+: #
+: # gt rebase HEAD~$numcommits --onto vulkan-github/dev
+: #
+: # #################################################################################################
+
+: # Convert uint32_t to unsigned and int32_t to int ###
+convertInt32() {
+  # Do not convert in SPIR-V files except SPIRVReader.cpp and SPIRVInternal.h.
+  # Do not convert elf reader
+  files=(llpc/translator/lib/SPIRV/SPIRVReader.cpp
+         llpc/translator/lib/SPIRV/SPIRVInternal.h
+         `find include tool util lgc llpc \
+                 -name vkgcElfReader.h -prune -o \
+                 -name test -prune -o \
+                 -name translator -prune -o \
+                 -name \*.cpp -print -o \
+                 -name \*.h -print`)
+  for file in "${files[@]}"; do
+    sed 's/uint32_t/unsigned/g; s/int32_t/int/g' $file >$file.new && mv -f $file.new $file || exit 1
+  done
+}
+
+: # Run clang-tidy with the specified checks.
+: # $1 is the value of the -checks option to use
+do_clang_tidy() {
+  checks="$1"
+
+  cppfiles=(`find tool util lgc llpc llpc/translator/lib/SPIRV/SPIRVReader.cpp \
+                -name test -prune -o \
+                -name translator -prune -o \
+                -name \*.cpp -print`)
+
+  clang_tidy=clang-tidy
+  clang_apply_replacements=clang-apply-replacements
+
+  # Set defines for cmake line.
+  cmakedefs=(-DCMAKE_BUILD_TYPE=Debug
+             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+             -DLLVM_PARALLEL_LINK_JOBS=2
+             -DLLVM_CCACHE_BUILD=1
+            )
+  if [ "${PWD%/api/compiler}" != "$PWD" ]; then
+    # AMD internal directory structure
+    cmakedefs+=(-DXGL_LLVM_SRC_PATH=../icd/imported/llvm-project/llvm
+                -DXGL_VKGC_PATH=../icd/api/compiler
+                -DXGL_LLPC_PATH=../icd/api/compiler/llpc
+                -DXGL_PAL_PATH=../icd/imported/pal
+                -DXGL_SPVGEN_PATH=../tools/spvgen
+                -DVULKAN_HEADER_PATH=../icd/api/include/khronos
+               )
+  fi
+
+  # If this is the first check in this script run, do a cmake build of amdllpc,
+  # asking for a compile_commands.json file.
+  if [ ! -f $build/CMakeCache.txt ]; then
+    (cd $build &&
+      rm -f CMakeCache.txt &&
+      cmake -GNinja "${cmakedefs[@]}" .. &&
+      ninja amdllpc) || exit 1
+  fi
+
+  # Clean up from last time and create directories for fixes:
+  rm -rf $build/fixes &&
+  mkdir -p $build/fixes/lgc/builder &&
+  mkdir -p $build/fixes/llpc/context &&
+  mkdir -p $build/fixes/llpc/imported/metrohash/src &&
+  mkdir -p $build/fixes/llpc/lower &&
+  mkdir -p $build/fixes/lgc/patch &&
+  mkdir -p $build/fixes/lgc/patch/gfx6/chip &&
+  mkdir -p $build/fixes/lgc/patch/gfx9 &&
+  mkdir -p $build/fixes/lgc/patch/gfx9/chip &&
+  mkdir -p $build/fixes/llpc/tool &&
+  mkdir -p $build/fixes/llpc/tool/vfx &&
+  mkdir -p $build/fixes/llpc/translator/lib/SPIRV &&
+  mkdir -p $build/fixes/llpc/translator/lib/SPIRV/libSPIRV &&
+  mkdir -p $build/fixes/llpc/translator/lib/SPIRV/Mangler &&
+  mkdir -p $build/fixes/lgc/util &&
+  mkdir -p $build/fixes/llpc/util &&
+  mkdir -p $build/fixes/tool/dumper &&
+  mkdir -p $build/fixes/tool/vfx &&
+  mkdir -p $build/fixes/util ||
+  exit 1
+
+  # Run parallelized clang-tidy on most source files, exporting fixes to *.cpp.fixes.yaml
+  if ! (cd $build &&
+    for file in "${cppfiles[@]}"; do echo "$file"; done |
+      xargs -t -P`nproc` -IINPUT "$clang_tidy" -checks="$checks" -export-fixes="fixes/INPUT.fixes.yaml" "$srcfrombuild/INPUT"
+  ); then
+    echo "${0##*/}: Error(s) from clang-tidy. (If you can't see any errors above, it might be that it couldn't write the .fixes.yaml file because I forgot to create its directory" >&2
+    exit 1
+  fi
+
+  # Remove empty lines from *.fixes.yaml files. This is a hack to work around a problem with my
+  # clang-tidy readability-declaration-inline-comment code; it inserts a spurious blank line when
+  # moving an inline parameter comment to the block comment at the top of the function. It only does
+  # that when running clang-tidy and clang-apply-replacements separately like we do here. I never
+  # got to the bottom of that problem, so I am hacking it here.
+  # Also canonicalize include file paths so clang-apply-replacements knows to merge multiple
+  # occurrences of the same fix.
+  (cd $build && for file in `find fixes -name \*.yaml`; do
+    sed '
+      /^$/d
+      s/\(FilePath:.*\/\)include\/\.\.\//\1/
+      s/\(FilePath:.*\/\)llpc\/\.\.\//\1/
+    ' $file >$file.new && mv -f $file.new $file || exit 1
+  done) || exit 1
+
+  # Apply the fixes
+  (cd $build &&
+  "$clang_apply_replacements" fixes) ||
+  exit 1
+
+}
+
+: # Rename identifiers
+renameIdentifiers() {
+  # Set up .clang-tidy
+  echo "
+ # Do not modify llpc.h, vkgcDefs.h, anything in the SPIRV library, or vfx.h, or anything in lgc/imported.
+HeaderFilterRegex: '.*/vfx/vfx..*\\.h|.*/dumper/vkgc.*\\.h|.*/util/vkgc.*\\.h|.*/lgc/include/.*\\.h|.*/context/llpc[^/]*\\.h|.*/util/llpc[^/]*\\.h|.*/lower/llpc[^/]*\\.h|.*/builder/llpc[^/]*\\.h|.*/patch.*/llpc[^/]*\\.h|.*/tool/[^/]*\\.h'
+CheckOptions:
+  - { key: readability-identifier-naming.ParameterCase, value: camelBack }
+  - { key: readability-identifier-naming.ParameterRemovePrefixes, value: 'p,b,pfn' }
+  - { key: readability-identifier-naming.VariableCase, value: camelBack }
+  - { key: readability-identifier-naming.VariableRemovePrefixes, value: 'p,b,pfn' }
+  # Need to ignore static field 'ID' because otherwise clang-tidy dives into an llvm
+  # include file and changes 'ID' to 'm_id' there, which is bad.
+  - { key: readability-identifier-naming.ClassMemberIgnoreRegex, value: '^ID|mmSPI_.*$' }
+  - { key: readability-identifier-naming.ClassMemberCase, value: camelBack }
+  - { key: readability-identifier-naming.ClassMemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.ClassMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.ClassConstantCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.StaticVariableCase, value: CamelCase }
+  - { key: readability-identifier-naming.StaticVariableRemovePrefixes, value: 'p,b,pfn,s_,s_p' }
+  - { key: readability-identifier-naming.GlobalVariableIgnoreRegex, value: 'mmSPI_.*' }
+  - { key: readability-identifier-naming.GlobalVariableCase, value: CamelCase }
+  - { key: readability-identifier-naming.GlobalVariableRemovePrefixes, value: 'p,b,pfn,g_,g_p' }
+  - { key: readability-identifier-naming.ConstantMemberIgnoreRegex, value: 'mmSPI_.*' }
+  - { key: readability-identifier-naming.ConstantMemberCase, value: CamelCase }
+  - { key: readability-identifier-naming.ConstantMemberPrefix, value: '' }
+  - { key: readability-identifier-naming.PublicMemberCase, value: camelBack }
+  - { key: readability-identifier-naming.PublicMemberIgnoreRegex, value: '^pSymName$' }
+  - { key: readability-identifier-naming.PublicMemberPrefix, value: '' }
+  - { key: readability-identifier-naming.PublicMemberRemovePrefixes, value: 'p,b,pfn,m_,m_p,m_b' }
+  - { key: readability-identifier-naming.MemberCase, value: camelBack }
+  - { key: readability-identifier-naming.MemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.MemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.MethodCase, value: camelBack }
+  - { key: readability-identifier-naming.MethodIgnoreRegex, value: '^Create$|^CreateACos$|^CreateACosh$|^CreateASin$|^CreateASinh$|^CreateATan$|^CreateATan2$|^CreateATanh$|^CreateBarrier$|^CreateBinaryIntrinsic$|^CreateCosh$|^CreateCrossProduct$|^CreateCubeFace.*$|^CreateDemoteToHelperInvocation$|^CreateDerivative$|^CreateDeterminant$|^CreateDotProduct$|^CreateEmitVertex$|^CreateEndPrimitive$|^CreateExp$|^CreateExtract.*$|^CreateFaceForward$|^CreateFClamp$|^CreateFindSMsb$|^CreateFma$|^CreateFMax$|^CreateFMax3$|^CreateFMid3$|^CreateFMin$|^CreateFMin3$|^CreateFMod$|^CreateFpTruncWithRounding$|^CreateFract$|^CreateFSign$|^CreateGet.*$|^CreateImage.*$|^CreateIndexDescPtr$|^CreateInsertBitField$|^CreateIntrinsic$|^CreateInverseSqrt$|^CreateIs.*$|^CreateKill$|^CreateLdexp$|^CreateLoad.*$|^CreateLog$|^CreateMapToInt32$|^CreateMatrix.*$|^CreateNormalizeVector$|^CreateOuterProduct$|^CreatePower$|^CreateQuantizeToFp16$|^CreateRead.*$|^CreateReflect$|^CreateRefract$|^CreateSAbs$|^CreateSinh$|^CreateSMod$|^CreateSmoothStep$|^CreateSSign$|^CreateSubgroup.*$|^CreateTan$|^CreateTanh$|^CreateTransposeMatrix$|^CreateUnaryIntrinsic$|^CreateVectorTimesMatrix$|^CreateWrite.*Output$|^Serialize$|^Merge$|^Destroy$|^ConvertColorBufferFormatToExportFormat$|^BuildShaderModule$|^BuildGraphicsPipeline$|^BuildComputePipeline$|^BuildRayTracingPipeline$|^IsVertexFormatSupported$|^DumpSpirvBinary$|^BeginPipelineDump$|^EndPipelineDump$|^DumpPipelineBinary$|^DumpPipelineExtraInfo$|^GetShaderHash$|^GetPipelineHash$|^GetPipelineName$|^CreateShaderCache$|^ReadFromBuffer$|^GetSectionIndex$|^GetSymbolsBySectionIndex$|^GetSectionData$' }
+  - { key: readability-identifier-naming.FunctionIgnoreRegex, value: 'EnableOuts|EnableErrs' }
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack }
+  - { key: readability-identifier-naming.TypeCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypeRemovePrefixes, value: PFN_ }
+" >.clang-tidy
+
+  do_clang_tidy '-*,readability-identifier-naming' restricted
+
+}
+
+: # Remove unnecessary braces
+removeBraces() {
+  echo "
+ # Do not modify SPIRV library.
+HeaderFilterRegex: '.*/vfx/vfx.*\\.h|.*/vkgc.*\\.h|.*/lgc/include/.*\.h|.*/include/llpc\.h|.*/context/llpc[^/]*\.h|.*/util/llpc[^/]*\.h|.*/lower/llpc[^/]*\.h|.*/builder/llpc[^/]*\.h|.*/patch.*/llpc[^/]*\.h|.*/tool/*\.h'
+CheckOptions:
+  - { key: readability-braces-around-statements.ShortStatementLines, value: 2 }
+  - { key: readability-braces-around-statements.AddBraces, value: 0 }
+  - { key: readability-braces-around-statements.RemoveUnnecessaryBraces, value: 1 }
+" > .clang-tidy
+
+  do_clang_tidy '-*,readability-braces-around-statements'
+}
+
+: # Remove redundant comparisons with false or nullptr
+removeRedundantComparisons() {
+  echo "
+HeaderFilterRegex: '.*/vfx/vfx.*\\.h|.*/vkgc.*\\.h|.*/lgc/include/.*\.h|.*/include/llpc\.h|.*/context/llpc[^/]*\.h|.*/util/llpc[^/]*\.h|.*/lower/llpc[^/]*\.h|.*/builder/llpc[^/]*\.h|.*/patch.*/llpc[^/]*\.h|.*/tool/*\.h'
+CheckOptions:
+" > .clang-tidy
+
+  do_clang_tidy '-*,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison'
+}
+
+: # Remove redundant parentheses
+removeRedundantParentheses() {
+  echo "
+HeaderFilterRegex: '.*/vfx/vfx.*\\.h|.*/vkgc.*\\.h|.*/lgc/include/.*\.h|.*/include/llpc\.h|.*/context/llpc[^/]*\.h|.*/util/llpc[^/]*\.h|.*/lower/llpc[^/]*\.h|.*/builder/llpc[^/]*\.h|.*/patch.*/llpc[^/]*\.h|.*/tool/*\.h'
+CheckOptions:
+" > .clang-tidy
+
+  do_clang_tidy '-*,readability-redundant-parentheses'
+}
+
+: # Move inline comments on parameters
+moveInlineComments() {
+  echo "
+HeaderFilterRegex: '.*/vfx/vfx.*\\.h|.*/vkgc.*\\.h|.*/lgc/include/.*\.h|.*/include/vkgcDefs\.h|.*/include/llpc\.h|.*/context/llpc[^/]*\.h|.*/util/llpc[^/]*\.h|.*/lower/llpc[^/]*\.h|.*/builder/llpc[^/]*\.h|.*/patch.*/llpc[^/]*\.h|.*/tool/*\.h'
+CheckOptions:
+" > .clang-tidy
+
+  do_clang_tidy '-*,readability-declaration-inline-comment'
+}
+
+: # Apply clang-format
+clangFormat() {
+  clang_format=clang-format
+  for file in `find include util tool llpc lgc llpc/translator/lib/SPIRV/SPIRVReader.cpp llpc/translator/lib/SPIRV/SPIRVInternal.h \
+      -name imported -prune -o \
+      -name test -prune -o \
+      -name translator -prune -o \
+      -name \*.cpp -print -o \
+      -name \*.h -print`; do
+    echo "clang-format $file"
+    "$clang_format" "$file" >"$file".new && mv -f "$file".new "$file" || exit 1
+  done
+}
+
+: # Mainline code
+
+script="${0##*/}"
+
+if [ ! -d llpc -o ! -d lgc ]; then
+  echo "$script: switch LLPC/LGC to new coding style
+Must be run in compiler directory" >&2
+  exit 1
+fi
+
+xgl="$PWD/../xgl"
+srcfrombuild=../../llpc
+if [ ! -d "$xgl" -o ! -d "$xgl/icd" ]; then
+  xgl="$PWD/../../.."
+  srcfrombuild=../icd/api/compiler
+  if [ ! -d "$xgl" -o ! -d "$xgl/icd" ]; then
+    echo "$script: can't find xgl directory" >&2
+    exit 1
+  fi
+fi
+build="$xgl/build-switch-coding-style"
+mkdir -p $build || exit 1
+rm -f $build/CMakeCache.txt
+
+if [ $# -ge 1 ]; then
+  while true; do
+    case "$1" in
+      int32) convertInt32 || exit 1;;
+      identifiers) renameIdentifiers || exit 1;;
+      braces) removeBraces || exit 1;;
+      comparisons) removeRedundantComparisons || exit 1;;
+      parentheses) removeRedundantParentheses || exit 1;;
+      comments) moveInlineComments || exit 1;;
+      format) clangFormat || exit 1;;
+      *) break;;
+    esac
+    shift
+    [ $# -eq 0 ] && exit 0
+  done
+fi
+
+echo "$script: switch LLPC to new coding style
+Run in compiler directory. Modified clang_tidy and clang_apply_replacements must be on path.
+Usage: $script transform...
+where transform is one of:
+
+  int32       Convert uint32_t to unsigned and int32_t to int
+  identifiers Rename identifiers
+  braces      Remove unnecessary braces
+  comparisons Remove redundant comparisons with false or nullptr
+  parentheses Remove redundant parentheses
+  comments    Move parameter/field inline comment up
+  format      Apply clang-format
+
+" >&2
+exit 2
+

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1346,14 +1346,14 @@ OStream& operator<<(
     OStream&          out,      // [out] Output stream
     ElfReader<Elf>&   reader)   // [in] ELF object
 {
-    uint32_t sectionCount = reader.GetSectionCount();
+    uint32_t sectionCount = reader.getSectionCount();
     char formatBuf[256];
 
     for (uint32_t sortIdx = 0; sortIdx < sectionCount; ++sortIdx)
     {
         typename ElfReader<Elf>::SectionBuffer* pSection = nullptr;
         uint32_t secIdx = 0;
-        Result result = reader.GetSectionDataBySortingIndex(sortIdx, &secIdx, &pSection);
+        Result result = reader.getSectionDataBySortingIndex(sortIdx, &secIdx, &pSection);
         assert(result == Result::Success);
         (void(result)); // unused
         if ((strcmp(pSection->pName, ShStrTabName) == 0) ||
@@ -1406,12 +1406,12 @@ OStream& operator<<(
                         << pNode->name << "  size = " << pNode->descSize << ")\n";
 
                     auto pBuffer = pSection->pData + offset + noteHeaderSize + noteNameSize;
-                    reader.InitMsgPackDocument(pBuffer, pNode->descSize);
+                    reader.initMsgPackDocument(pBuffer, pNode->descSize);
 
                     do
                     {
-                        auto pNode = reader.GetMsgNode();
-                        auto msgIterStatus = reader.GetMsgIteratorStatus();
+                        auto pNode = reader.getMsgNode();
+                        auto msgIterStatus = reader.getMsgIteratorStatus();
                         switch (pNode->getKind())
                         {
                         case msgpack::Type::Int:
@@ -1470,7 +1470,7 @@ OStream& operator<<(
                                 if (msgIterStatus == MsgPackIteratorMapPair)
                                 {
                                     out << "\n";
-                                        for (uint32_t i = 0; i < reader.GetMsgMapLevel(); ++i)
+                                        for (uint32_t i = 0; i < reader.getMsgMapLevel(); ++i)
                                         {
                                             out << "    ";
                                         }
@@ -1506,7 +1506,7 @@ OStream& operator<<(
                             }
                         }
 
-                    } while (reader.GetNextMsgNode());
+                    } while (reader.getNextMsgNode());
                     out << "\n";
                     break;
                 }
@@ -1538,13 +1538,13 @@ OStream& operator<<(
         {
             // Output .reloc section
             out << pSection->pName << " (size = " << pSection->secHead.sh_size << " bytes)\n";
-            const uint32_t relocCount = reader.GetRelocationCount();
+            const uint32_t relocCount = reader.getRelocationCount();
             for (uint32_t i = 0; i < relocCount; ++i)
             {
                 ElfReloc reloc = {};
-                reader.GetRelocation(i, &reloc);
+                reader.getRelocation(i, &reloc);
                 ElfSymbol elfSym = {};
-                reader.GetSymbol(reloc.symIdx, &elfSym);
+                reader.getSymbol(reloc.symIdx, &elfSym);
                 auto length = snprintf(formatBuf, sizeof(formatBuf), "    %-35s", elfSym.pSymName);
                 (void(length)); // unused
                 out << "#" << i << "    " << formatBuf

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1720,9 +1720,9 @@ OStream& operator<<(
 // =====================================================================================================================
 // Assistant macros for pipeline dump
 #define CASE_CLASSENUM_TO_STRING(TYPE, ENUM) \
-    case TYPE::ENUM: pString = #ENUM; break;
+    case TYPE::ENUM: string = #ENUM; break;
 #define CASE_ENUM_TO_STRING(ENUM) \
-    case ENUM: pString = #ENUM; break;
+    case ENUM: string = #ENUM; break;
 
 // =====================================================================================================================
 // Translates enum "VkVertexInputRate" to string and output to ostream.
@@ -1730,7 +1730,7 @@ std::ostream& operator<<(
     std::ostream&       out,        // [out] Output stream
     VkVertexInputRate  inputRate)   // Vertex input rate
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (inputRate)
     {
     CASE_ENUM_TO_STRING(VK_VERTEX_INPUT_RATE_VERTEX)
@@ -1740,7 +1740,7 @@ std::ostream& operator<<(
         llvm_unreachable("Should never be called!");
         break;
     }
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1758,7 +1758,7 @@ std::ostream& operator<<(
     std::ostream&           out,            // [out] Output stream
     NggSubgroupSizingType   subgroupSizing) // NGG sub-group sizing type
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (subgroupSizing)
     {
     CASE_CLASSENUM_TO_STRING(NggSubgroupSizingType, Auto)
@@ -1773,7 +1773,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1782,7 +1782,7 @@ std::ostream& operator<<(
     std::ostream&   out,         // [out] Output stream
     NggCompactMode  compactMode) // NGG compaction mode
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (compactMode)
     {
     CASE_ENUM_TO_STRING(NggCompactSubgroup)
@@ -1793,7 +1793,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1802,7 +1802,7 @@ std::ostream& operator<<(
     std::ostream&   out,            // [out] Output stream
     WaveBreakSize   waveBreakSize)  // Wave break size
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (waveBreakSize)
     {
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, None)
@@ -1816,7 +1816,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1825,7 +1825,7 @@ std::ostream& operator<<(
     std::ostream&              out,                         // [out] Output stream
     ShadowDescriptorTableUsage shadowDescriptorTableUsage)  // Shadow descriptor table setting
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (shadowDescriptorTableUsage)
     {
     CASE_CLASSENUM_TO_STRING(ShadowDescriptorTableUsage, Auto)
@@ -1837,7 +1837,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1846,7 +1846,7 @@ std::ostream& operator<<(
     std::ostream&       out,       // [out] Output stream
     VkPrimitiveTopology topology)  // Primitive topology
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (topology)
     {
     CASE_ENUM_TO_STRING(VK_PRIMITIVE_TOPOLOGY_POINT_LIST)
@@ -1867,7 +1867,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1876,7 +1876,7 @@ std::ostream& operator<<(
     std::ostream&       out,            // [out] Output stream
     VkPolygonMode       polygonMode)    // Rendering mode
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (polygonMode)
     {
     CASE_ENUM_TO_STRING(VK_POLYGON_MODE_FILL)
@@ -1890,7 +1890,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1899,7 +1899,7 @@ std::ostream& operator<<(
     std::ostream&       out,         // [out] Output stream
     VkCullModeFlagBits  cullMode)    // Culling mode
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (cullMode)
     {
     CASE_ENUM_TO_STRING(VK_CULL_MODE_NONE)
@@ -1913,7 +1913,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1922,7 +1922,7 @@ std::ostream& operator<<(
     std::ostream&       out,         // [out] Output stream
     VkFrontFace         frontFace)   // Front facing orientation
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (frontFace)
     {
     CASE_ENUM_TO_STRING(VK_FRONT_FACE_COUNTER_CLOCKWISE)
@@ -1934,7 +1934,7 @@ std::ostream& operator<<(
         break;
     }
 
-    return out << pString;
+    return out << string;
 }
 
 // =====================================================================================================================
@@ -1943,7 +1943,7 @@ std::ostream& operator<<(
     std::ostream&       out,     // [out] Output stream
     VkFormat            format)  // Resource format
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (format)
     {
     CASE_ENUM_TO_STRING(VK_FORMAT_UNDEFINED)
@@ -2144,7 +2144,7 @@ std::ostream& operator<<(
         llvm_unreachable("Should never be called!");
         break;
     }
-    return out << pString;
+    return out << string;
 }
 
 } // Vkgc

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -172,8 +172,8 @@ void VKAPI_CALL IPipelineDumper::DumpPipelineExtraInfo(
     void*                     pDumpFile,   // [in] The handle of pipeline dump file
     const char*               pStr)        // [in] Extra string info to dump
 {
-    std::string str(pStr);
-    PipelineDumper::DumpPipelineExtraInfo(reinterpret_cast<PipelineDumpFile*>(pDumpFile), &str);
+    std::string tmpStr(pStr);
+    PipelineDumper::DumpPipelineExtraInfo(reinterpret_cast<PipelineDumpFile*>(pDumpFile), &tmpStr);
 }
 
 // =====================================================================================================================
@@ -196,34 +196,34 @@ uint64_t VKAPI_CALL IPipelineDumper::GetPipelineHash(
 // =====================================================================================================================
 // Get graphics pipeline name.
 void VKAPI_CALL IPipelineDumper::GetPipelineName(
-    const  GraphicsPipelineBuildInfo* pPipelineInfo, // [In]  Info to build this graphics pipeline
-    char*                             pPipeName,     // [Out] The full name of this graphics pipeline
-    const size_t                      nameBufSize)   // Size of the buffer to store pipeline name
+    const  GraphicsPipelineBuildInfo* pGraphicsPipelineInfo,  // [In]  Info to build this graphics pipeline
+    char*                             pPipeNameOut,           // [Out] The full name of this graphics pipeline
+    const size_t                      nameBufSize)            // Size of the buffer to store pipeline name
 {
-    auto hash = PipelineDumper::GenerateHashForGraphicsPipeline(pPipelineInfo, false);
+    auto hash = PipelineDumper::GenerateHashForGraphicsPipeline(pGraphicsPipelineInfo, false);
     PipelineBuildInfo pipelineInfo = {};
-    pipelineInfo.pGraphicsInfo = pPipelineInfo;
+    pipelineInfo.pGraphicsInfo = pGraphicsPipelineInfo;
     std::string pipeName = PipelineDumper::GetPipelineInfoFileName(
         pipelineInfo,
         &hash);
-    snprintf(pPipeName, nameBufSize, "%s", pipeName.c_str());
+    snprintf(pPipeNameOut, nameBufSize, "%s", pipeName.c_str());
 }
 
 // =====================================================================================================================
 // Get compute pipeline name.
 void VKAPI_CALL IPipelineDumper::GetPipelineName(
-    const ComputePipelineBuildInfo* pPipelineInfo, // [In]  Info to build this compute pipeline
-    char*                           pPipeName,     // [Out] The full name of this compute pipeline
-    const size_t                    nameBufSize)   // Size of the buffer to store pipeline name
+    const ComputePipelineBuildInfo* pComputePipelineInfo, // [In]  Info to build this compute pipeline
+    char*                           pPipeNameOut,         // [Out] The full name of this compute pipeline
+    const size_t                    nameBufSize)          // Size of the buffer to store pipeline name
 {
-    auto hash = PipelineDumper::GenerateHashForComputePipeline(pPipelineInfo, false);
+    auto hash = PipelineDumper::GenerateHashForComputePipeline(pComputePipelineInfo, false);
     PipelineBuildInfo pipelineInfo = {};
-    pipelineInfo.pComputeInfo = pPipelineInfo;
+    pipelineInfo.pComputeInfo = pComputePipelineInfo;
 
     std::string pipeName = PipelineDumper::GetPipelineInfoFileName(
         pipelineInfo,
         &hash);
-    snprintf(pPipeName, nameBufSize, "%s", pipeName.c_str());
+    snprintf(pPipeNameOut, nameBufSize, "%s", pipeName.c_str());
 }
 
 // =====================================================================================================================
@@ -843,7 +843,7 @@ void PipelineDumper::DumpGraphicsPipelineInfo(
 {
     DumpVersionInfo(*pDumpFile);
     // Dump pipeline
-    const PipelineShaderInfo* shaderInfo[ShaderStageGfxCount] =
+    const PipelineShaderInfo* shaderInfos[ShaderStageGfxCount] =
     {
         &pPipelineInfo->vs,
         &pPipelineInfo->tcs,
@@ -854,7 +854,7 @@ void PipelineDumper::DumpGraphicsPipelineInfo(
 
     for (uint32_t stage = 0; stage < ShaderStageGfxCount; ++stage)
     {
-        const PipelineShaderInfo* pShaderInfo = shaderInfo[stage];
+        const PipelineShaderInfo* pShaderInfo = shaderInfos[stage];
         if (pShaderInfo->pModuleData == nullptr)
         {
             continue;
@@ -1297,7 +1297,7 @@ void OutputBinary(
     uint32_t       endPos,    // End position
     OStream&       out)       // [out] Output stream
 {
-    const uint32_t* pStartPos = reinterpret_cast<const uint32_t*>(pData + startPos);
+    const uint32_t* pStartData = reinterpret_cast<const uint32_t*>(pData + startPos);
     int32_t dwordCount = (endPos - startPos) / sizeof(uint32_t);
     char formatBuf[256];
     for (int32_t i = 0; i < dwordCount; ++i)
@@ -1308,7 +1308,7 @@ void OutputBinary(
             length = snprintf(formatBuf, sizeof(formatBuf), "    %7u:", startPos + i * 4u);
             out << formatBuf;
         }
-        length = snprintf(formatBuf, sizeof(formatBuf), "%08X", pStartPos[i]);
+        length = snprintf(formatBuf, sizeof(formatBuf), "%08X", pStartData[i]);
         (void(length)); // unused
         out << formatBuf;
 

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -64,6 +64,12 @@ enum PipelineDumpFilters : uint32_t
 class PipelineDumper
 {
 public:
+#if defined(SINGLE_EXTERNAL_METROHASH)
+    typedef Util::MetroHash64 MetroHash64;
+#else
+    typedef MetroHash::MetroHash64 MetroHash64;
+#endif
+
     static void DumpSpirvBinary(const char*                     pDumpDir,
                                 const BinaryData*               pSpirvBin,
                                 MetroHash::Hash*                pHash);
@@ -93,26 +99,14 @@ public:
     static void UpdateHashForPipelineShaderInfo(ShaderStage               stage,
                                                 const PipelineShaderInfo* pShaderInfo,
                                                 bool                      isCacheHash,
-#if defined(SINGLE_EXTERNAL_METROHASH)
-                                                Util::MetroHash64*        pHasher);
-#else
-                                                MetroHash::MetroHash64*   pHasher);
-#endif
+                                                MetroHash64*              pHasher);
 
     static void UpdateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo* pVertexInput,
-#if defined(SINGLE_EXTERNAL_METROHASH)
-                                              Util::MetroHash64*                          pHasher);
-#else
-                                              MetroHash::MetroHash64*                     pHasher);
-#endif
+                                              MetroHash64*                          pHasher);
 
     // Update hash for map object
     template <class MapType>
-#if defined(SINGLE_EXTERNAL_METROHASH)
-    static void UpdateHashForMap(MapType& m, Util::MetroHash64* pHasher)
-#else
-    static void UpdateHashForMap(MapType& m, MetroHash::MetroHash64* pHasher)
-#endif
+    static void UpdateHashForMap(MapType& m, MetroHash64* pHasher)
     {
         pHasher->Update(m.size());
         for (auto mapIt : m)
@@ -125,22 +119,14 @@ public:
     static void UpdateHashForNonFragmentState(
         const GraphicsPipelineBuildInfo* pPipeline,
         bool                             isCacheHash,
-#if defined(SINGLE_EXTERNAL_METROHASH)
-        Util::MetroHash64*               pHasher);
-#else
-        MetroHash::MetroHash64*          pHasher);
-#endif
+        MetroHash64*               pHasher);
 
     static void UpdateHashForFragmentState(
         const GraphicsPipelineBuildInfo* pPipeline,
-#if defined(SINGLE_EXTERNAL_METROHASH)
-        Util::MetroHash64*               pHasher);
-#else
-        MetroHash::MetroHash64*          pHasher);
-#endif
+        MetroHash64*               pHasher);
 
     // Get name of register, or "" if not known
-    static const char* GetRegisterNameString(uint32_t regNumber);
+    static const char* getRegisterNameString(uint32_t regNumber);
 
 private:
     static std::string GetSpirvBinaryFileName(const MetroHash::Hash* pHash);
@@ -169,11 +155,7 @@ private:
 
     static void UpdateHashForResourceMappingNode(const ResourceMappingNode* pUserDataNode,
                                                  bool                       isRootNode,
-#if defined(SINGLE_EXTERNAL_METROHASH)
-                                                 Util::MetroHash64*         pHasher);
-#else
-                                                 MetroHash::MetroHash64*    pHasher);
-#endif
+                                                 MetroHash64*         pHasher);
 };
 
 } // Vkgc

--- a/tool/dumper/vkgcPipelineDumperRegs.cpp
+++ b/tool/dumper/vkgcPipelineDumperRegs.cpp
@@ -423,7 +423,7 @@ const PipelineDumperReg pipelineDumperRegs[] =
 
 // =====================================================================================================================
 // Get name of register, or "" if not known
-const char* PipelineDumper::GetRegisterNameString(
+const char* PipelineDumper::getRegisterNameString(
     uint32_t  regNumber)  // Register number
 {
     for (uint32_t idx = 0, end = sizeof(pipelineDumperRegs) / sizeof(pipelineDumperRegs[0]); idx != end; ++idx)

--- a/tool/vfx/vfxEnumsConverter.cpp
+++ b/tool/vfx/vfxEnumsConverter.cpp
@@ -43,7 +43,7 @@ namespace Vfx
 
 // =====================================================================================================================
 // Gets enum convert map
-static std::map<std::string, int>& GetEnumMap()
+static std::map<std::string, int>& getEnumMap()
 {
     static std::map<std::string, int> EnumMap;
     return EnumMap;
@@ -56,8 +56,8 @@ bool GetEnumValue(
     int&        value)    // [out] Enum value
 {
     bool ret = false;
-    std::map<std::string, int>::iterator it = GetEnumMap().find(pString);
-    if (it != GetEnumMap().end())
+    std::map<std::string, int>::iterator it = getEnumMap().find(pString);
+    if (it != getEnumMap().end())
     {
         value = it->second;
         ret = true;
@@ -65,8 +65,8 @@ bool GetEnumValue(
     return ret;
 }
 
-#define ADD_ENUM_MAP(EnumType, EnumName) GetEnumMap()[#EnumName] = EnumName;
-#define ADD_CLASS_ENUM_MAP(Class, EnumName) GetEnumMap()[#EnumName] =static_cast<int32_t>(Class::EnumName);
+#define ADD_ENUM_MAP(EnumType, EnumName) getEnumMap()[#EnumName] = EnumName;
+#define ADD_CLASS_ENUM_MAP(Class, EnumName) getEnumMap()[#EnumName] =static_cast<int32_t>(Class::EnumName);
 
 // =====================================================================================================================
 // Initializes enum convert map

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -236,14 +236,14 @@ void Section::InitSectionInfo()
 // Gets data type of a member.
 bool Section::GetMemberType(
     uint32_t     lineNum,         // Line No.
-    const char*  pMemberName,     // [in]  Member string name
+    const char*  memberName,     // [in]  Member string name
     MemberType*  pValueType,      // [out] Member data type.
-    std::string* pErrorMsg)       // [out] Error message
+    std::string* errorMsg)       // [out] Error message
 {
     bool result = false;
     for (uint32_t i = 0; i < m_tableSize; ++i)
     {
-        if ((m_pMemberTable[i].pMemberName != nullptr) && strcmp(pMemberName, m_pMemberTable[i].pMemberName) == 0)
+        if ((m_pMemberTable[i].memberName != nullptr) && strcmp(memberName, m_pMemberTable[i].memberName) == 0)
         {
             result = true;
 
@@ -258,7 +258,7 @@ bool Section::GetMemberType(
 
     if (result == false)
     {
-        PARSE_WARNING(*pErrorMsg, lineNum, "Invalid member name: %s", pMemberName);
+        PARSE_WARNING(*errorMsg, lineNum, "Invalid member name: %s", memberName);
     }
 
     return result;
@@ -268,16 +268,16 @@ bool Section::GetMemberType(
 // Is this member a section object.
 bool Section::IsSection(
     uint32_t     lineNum,        // Line number
-    const char*  pMemberName,    // [in] Member name
+    const char*  memberName,    // [in] Member name
     bool*        pOutput,        // [out] Is this memeber a section object
     MemberType*  pType,          // [out] Object type
-    std::string* pErrorMsg)      // [out] Error message
+    std::string* errorMsg)      // [out] Error message
 {
     bool result = false;
 
     for (uint32_t i = 0; i < m_tableSize; ++i)
     {
-        if ((m_pMemberTable[i].pMemberName != nullptr) && strcmp(pMemberName, m_pMemberTable[i].pMemberName) == 0)
+        if ((m_pMemberTable[i].memberName != nullptr) && strcmp(memberName, m_pMemberTable[i].memberName) == 0)
         {
             result = true;
             if (pOutput != nullptr)
@@ -295,7 +295,7 @@ bool Section::IsSection(
 
     if (result == false)
     {
-        PARSE_WARNING(*pErrorMsg, lineNum, "Invalid member name: %s", pMemberName);
+        PARSE_WARNING(*errorMsg, lineNum, "Invalid member name: %s", memberName);
     }
 
     return result;
@@ -312,7 +312,7 @@ void Section::PrintSelf(
         printf("[%s]\n", m_pSectionName);
         for (uint32_t i = 0; i < m_tableSize; ++i)
         {
-            if (m_pMemberTable[i].pMemberName != nullptr)
+            if (m_pMemberTable[i].memberName != nullptr)
             {
                 continue;
             }
@@ -323,7 +323,7 @@ void Section::PrintSelf(
                     Section* pSubObj;
                     std::string dummyMsg;
                     if (GetPtrOfSubSection(0,
-                                           m_pMemberTable[i].pMemberName,
+                                           m_pMemberTable[i].memberName,
                                            m_pMemberTable[i].memberType,
                                            false,
                                            arrayIndex,
@@ -348,33 +348,33 @@ void Section::PrintSelf(
                         case MemberTypeInt:
                         {
                             printf("%s = %d\n",
-                                m_pMemberTable[i].pMemberName,
+                                m_pMemberTable[i].memberName,
                                 *(((int32_t*)(GetMemberAddr(i))) + arrayIndex));
                             break;
                         }
                         case MemberTypeBool:
                         {
                             printf("%s = %d\n",
-                                   m_pMemberTable[i].pMemberName,
+                                   m_pMemberTable[i].memberName,
                                    *(((bool*)(GetMemberAddr(i))) + arrayIndex));
                             break;
                         }
                         case MemberTypeFloat:
                         {
                             printf("%s = %.3f\n",
-                                   m_pMemberTable[i].pMemberName,
+                                   m_pMemberTable[i].memberName,
                                    *(((float*)(GetMemberAddr(i))) + arrayIndex));
                             break;
                         }
                         case MemberTypeFloat16:
                         {
                             float v = (((Float16*)(GetMemberAddr(i))) + arrayIndex)->GetValue();
-                            printf("%s = %.3fhf\n", m_pMemberTable[i].pMemberName, v);
+                            printf("%s = %.3fhf\n", m_pMemberTable[i].memberName, v);
                             break;
                         }
                         case MemberTypeDouble:
                         {
-                            printf("%s = %.3f\n", m_pMemberTable[i].pMemberName, *(((double*)(GetMemberAddr(i))) + arrayIndex));
+                            printf("%s = %.3f\n", m_pMemberTable[i].memberName, *(((double*)(GetMemberAddr(i))) + arrayIndex));
                             break;
                         }
                         case MemberTypeIVec4:
@@ -384,7 +384,7 @@ void Section::PrintSelf(
 
                             if ((pIUFValue->props.isDouble == false) && (pIUFValue->props.isFloat == false))
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t j = 0; j < pIUFValue->props.length; ++j)
                                 {
                                     if (pIUFValue->props.isHex == true)
@@ -407,7 +407,7 @@ void Section::PrintSelf(
 
                             if ((pIUFValue->props.isDouble == false) && (pIUFValue->props.isFloat == false))
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t j = 0; j < pIUFValue->props.length; ++j)
                                 {
                                     if (pIUFValue->props.isHex == true)
@@ -430,7 +430,7 @@ void Section::PrintSelf(
 
                             if ((pIUFValue->props.isDouble == false) && (pIUFValue->props.isFloat == true))
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t j = 0; j < pIUFValue->props.length; ++j)
                                 {
                                     printf(" %.3f", pIUFValue->fVec4[j]);
@@ -446,7 +446,7 @@ void Section::PrintSelf(
 
                             if ((pIUFValue->props.isDouble == false) && (pIUFValue->props.isFloat16 == true))
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t j = 0; j < pIUFValue->props.length; ++j)
                                 {
                                     printf(" %.3fhf", pIUFValue->f16Vec4[j].GetValue());
@@ -462,7 +462,7 @@ void Section::PrintSelf(
 
                             if ((pIUFValue->props.isDouble == true) && (pIUFValue->props.isFloat == false))
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t j = 0; j < pIUFValue->props.length; ++j)
                                 {
                                     printf(" %.3f", pIUFValue->dVec2[j]);
@@ -479,7 +479,7 @@ void Section::PrintSelf(
 
                             if (pIntBufData->size() > 0)
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t i = 0; i < pIntBufData->size(); ++i)
                                 {
                                     printf(" 0x%x", (*pIntBufData)[i]);
@@ -502,7 +502,7 @@ void Section::PrintSelf(
 
                             if (pInt64BufData->size() > 0)
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t i = 0; i < pInt64BufData->size(); i += 2)
                                 {
                                     uVal[0] = (*pInt64BufData)[i];
@@ -525,7 +525,7 @@ void Section::PrintSelf(
                             };
                             if (pFloatBufData->size() > 0)
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
 
                                 for (uint32_t i = 0; i < pFloatBufData->size(); ++i)
                                 {
@@ -547,7 +547,7 @@ void Section::PrintSelf(
                             };
                             if (pFloat16BufData->size() > 0)
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
 
                                 for (uint32_t i = 0; i < pFloat16BufData->size(); ++i)
                                 {
@@ -570,7 +570,7 @@ void Section::PrintSelf(
 
                             if (pDoubleBufData->size() > 1)
                             {
-                                printf("%s =", m_pMemberTable[i].pMemberName);
+                                printf("%s =", m_pMemberTable[i].memberName);
                                 for (uint32_t i = 0; i < pDoubleBufData->size() - 1; i+=2)
                                 {
                                     uVal[0] = (*pDoubleBufData)[i];
@@ -584,7 +584,7 @@ void Section::PrintSelf(
                         case MemberTypeString:
                         {
                             std::string* pStr = static_cast<std::string*>(GetMemberAddr(i));
-                            printf("%s = %s\n", m_pMemberTable[i].pMemberName, pStr->c_str());
+                            printf("%s = %s\n", m_pMemberTable[i].memberName, pStr->c_str());
                             break;
                         }
                         default:
@@ -685,12 +685,12 @@ SectionType Section::GetSectionType(
 // Gets the pointer of sub section according to member name
 bool Section::GetPtrOfSubSection(
     uint32_t     lineNum,         // Line No.
-    const char*  pMemberName,     // [in] Member name
+    const char*  memberName,     // [in] Member name
     MemberType   memberType,      // Member type
     bool         isWriteAccess,   // Whether the sub section will be written
     uint32_t     arrayIndex,      // Array index
     Section**    ptrOut,          // [out] Pointer of sub section
-    std::string* pErrorMsg)       // [out] Error message
+    std::string* errorMsg)       // [out] Error message
 {
     bool result = false;
 
@@ -732,7 +732,7 @@ bool Section::ReadFile(
     bool                  isBinary,         // Whether file is SPIRV binary file
     std::vector<uint8_t>* pBinaryData,      // [out] Binary data
     std::string*          pTextData,        // [out] Text data
-    std::string*          pErrorMsg)        // [out] Error message
+    std::string*          errorMsg)        // [out] Error message
 {
     bool result = true;
 
@@ -749,7 +749,7 @@ bool Section::ReadFile(
     FILE* pInFile = fopen(path.c_str(), isBinary ? "rb" : "r");
     if (pInFile == nullptr)
     {
-        PARSE_ERROR(*pErrorMsg, 0, "Fails to open input file: %s\n", path.c_str());
+        PARSE_ERROR(*errorMsg, 0, "Fails to open input file: %s\n", path.c_str());
         return false;
     }
 
@@ -786,7 +786,7 @@ bool Section::ReadFile(
 // Compiles GLSL source text file (input) to SPIR-V binary file (output).
 bool SectionShader::CompileGlsl(
     const Section* pShaderInfo, // [in] Shader info section
-    std::string*   pErrorMsg)   // [out] Error message
+    std::string*   errorMsg)   // [out] Error message
 {
     int32_t           sourceStringCount = 1;
     const char*const* sourceList[1]     = {};
@@ -801,7 +801,7 @@ bool SectionShader::CompileGlsl(
 
     if (InitSpvGen() == false)
     {
-        PARSE_ERROR(*pErrorMsg, m_lineNum, "Failed to load SPVGEN: cannot compile GLSL\n");
+        PARSE_ERROR(*errorMsg, m_lineNum, "Failed to load SPVGEN: cannot compile GLSL\n");
         return false;
     }
 
@@ -836,7 +836,7 @@ bool SectionShader::CompileGlsl(
     }
     else
     {
-        PARSE_ERROR(*pErrorMsg, m_lineNum, "Fail to compile GLSL\n%s\n", pLog);
+        PARSE_ERROR(*errorMsg, m_lineNum, "Fail to compile GLSL\n%s\n", pLog);
         result = false;
     }
 
@@ -851,14 +851,14 @@ bool SectionShader::CompileGlsl(
 // =====================================================================================================================
 // Assemble Spirv assemble code
 bool SectionShader::AssembleSpirv(
-    std::string* pErrorMsg)  // [out] Error message
+    std::string* errorMsg)  // [out] Error message
 {
     bool result = true;
     const char* pText = shaderSource.c_str();
 
     if (InitSpvGen() == false)
     {
-        PARSE_ERROR(*pErrorMsg, m_lineNum, "Failed to load SPVGEN: cannot assemble SPIR-V assembler source\n");
+        PARSE_ERROR(*errorMsg, m_lineNum, "Failed to load SPVGEN: cannot assemble SPIR-V assembler source\n");
         return false;
     }
 
@@ -875,7 +875,7 @@ bool SectionShader::AssembleSpirv(
     }
     else
     {
-        PARSE_ERROR(*pErrorMsg, m_lineNum, "Fail to Assemble SPIRV\n%s\n", pLog);
+        PARSE_ERROR(*errorMsg, m_lineNum, "Fail to Assemble SPIRV\n%s\n", pLog);
         result = false;
     }
 
@@ -906,7 +906,7 @@ bool SectionShader::IsShaderSourceSection()
 bool SectionShader::CompileShader(
     const std::string&  docFilename,      // [in] File name of parent document
     const Section*      pShaderInfo,      // [in] Shader info sections
-    std::string*        pErrorMsg)        // [out] Error message
+    std::string*        errorMsg)        // [out] Error message
 {
     bool result = false;
     switch (m_shaderType)
@@ -914,36 +914,36 @@ bool SectionShader::CompileShader(
     case Glsl:
     case Hlsl:
         {
-            result = CompileGlsl(pShaderInfo, pErrorMsg);
+            result = CompileGlsl(pShaderInfo, errorMsg);
             break;
         }
     case GlslFile:
     case HlslFile:
         {
-            result = ReadFile(docFilename, fileName, false, &m_spvBin, &shaderSource, pErrorMsg);
+            result = ReadFile(docFilename, fileName, false, &m_spvBin, &shaderSource, errorMsg);
             if (result)
             {
-                CompileGlsl(pShaderInfo, pErrorMsg);
+                CompileGlsl(pShaderInfo, errorMsg);
             }
             break;
         }
     case SpirvAsm:
         {
-            result = AssembleSpirv(pErrorMsg);
+            result = AssembleSpirv(errorMsg);
             break;
         }
     case SpirvAsmFile:
         {
-            result = ReadFile(docFilename, fileName, false, &m_spvBin, &shaderSource, pErrorMsg);
+            result = ReadFile(docFilename, fileName, false, &m_spvBin, &shaderSource, errorMsg);
             if (result)
             {
-                AssembleSpirv(pErrorMsg);
+                AssembleSpirv(errorMsg);
             }
             break;
         }
     case SpirvFile:
         {
-            result = ReadFile(docFilename, fileName, true, &m_spvBin, &shaderSource, pErrorMsg);
+            result = ReadFile(docFilename, fileName, true, &m_spvBin, &shaderSource, errorMsg);
             break;
         }
     default:

--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -183,7 +183,7 @@ Result ElfReader<Elf>::GetSectionData(
 // =====================================================================================================================
 // Gets the count of symbols in the symbol table section.
 template<class Elf>
-uint32_t ElfReader<Elf>::GetSymbolCount() const
+uint32_t ElfReader<Elf>::getSymbolCount() const
 {
     uint32_t symCount = 0;
     if (m_symSecIdx >= 0)
@@ -197,7 +197,7 @@ uint32_t ElfReader<Elf>::GetSymbolCount() const
 // =====================================================================================================================
 // Gets info of the symbol in the symbol table section according to the specified index.
 template<class Elf>
-void ElfReader<Elf>::GetSymbol(
+void ElfReader<Elf>::getSymbol(
     uint32_t   idx,       // Symbol index
     ElfSymbol* pSymbol)   // [out] Info of the symbol
 {
@@ -216,7 +216,7 @@ void ElfReader<Elf>::GetSymbol(
 // =====================================================================================================================
 // Gets the count of relocations in the relocation section.
 template<class Elf>
-uint32_t ElfReader<Elf>::GetRelocationCount()
+uint32_t ElfReader<Elf>::getRelocationCount()
 {
     uint32_t relocCount = 0;
     if (m_relocSecIdx >= 0)
@@ -230,7 +230,7 @@ uint32_t ElfReader<Elf>::GetRelocationCount()
 // =====================================================================================================================
 // Gets info of the relocation in the relocation section according to the specified index.
 template<class Elf>
-void ElfReader<Elf>::GetRelocation(
+void ElfReader<Elf>::getRelocation(
     uint32_t  idx,      // Relocation index
     ElfReloc* pReloc)   // [out] Info of the relocation
 {
@@ -244,7 +244,7 @@ void ElfReader<Elf>::GetRelocation(
 // =====================================================================================================================
 // Gets the count of Elf section.
 template<class Elf>
-uint32_t ElfReader<Elf>::GetSectionCount()
+uint32_t ElfReader<Elf>::getSectionCount()
 {
     return static_cast<uint32_t>(m_sections.size());
 }
@@ -252,7 +252,7 @@ uint32_t ElfReader<Elf>::GetSectionCount()
 // =====================================================================================================================
 // Gets section data by section index.
 template<class Elf>
-Result ElfReader<Elf>::GetSectionDataBySectionIndex(
+Result ElfReader<Elf>::getSectionDataBySectionIndex(
     uint32_t           secIdx,          // Section index
     SectionBuffer**    ppSectionData    // [out] Section data
     ) const
@@ -269,7 +269,7 @@ Result ElfReader<Elf>::GetSectionDataBySectionIndex(
 // =====================================================================================================================
 // Gets section data by sorting index (ordered map).
 template<class Elf>
-Result ElfReader<Elf>::GetSectionDataBySortingIndex(
+Result ElfReader<Elf>::getSectionDataBySortingIndex(
     uint32_t           sortIdx,         // Sorting index
     uint32_t*          pSecIdx,         // [out] Section index
     SectionBuffer**    ppSectionData    // [out] Section data
@@ -304,7 +304,7 @@ void ElfReader<Elf>::GetSymbolsBySectionIndex(
         const char* pStrTab = reinterpret_cast<const char*>(m_sections[m_strtabSecIdx]->pData);
 
         auto symbols = reinterpret_cast<const typename Elf::Symbol*>(pSection->pData);
-        uint32_t symCount = GetSymbolCount();
+        uint32_t symCount = getSymbolCount();
         ElfSymbol symbol = {};
 
         for (uint32_t idx = 0; idx < symCount; ++idx)
@@ -333,14 +333,14 @@ void ElfReader<Elf>::GetSymbolsBySectionIndex(
 // =====================================================================================================================
 // Checks whether the input name is a valid symbol.
 template<class Elf>
-bool ElfReader<Elf>::IsValidSymbol(
+bool ElfReader<Elf>::isValidSymbol(
     const char* pSymbolName)  // [in] Symbol name
 {
     auto& pSection = m_sections[m_symSecIdx];
     const char* pStrTab = reinterpret_cast<const char*>(m_sections[m_strtabSecIdx]->pData);
 
     auto symbols = reinterpret_cast<const typename Elf::Symbol*>(pSection->pData);
-    uint32_t symCount = GetSymbolCount();
+    uint32_t symCount = getSymbolCount();
     bool findSymbol = false;
     for (uint32_t idx = 0; idx < symCount; ++idx)
     {
@@ -357,7 +357,7 @@ bool ElfReader<Elf>::IsValidSymbol(
 // =====================================================================================================================
 // Gets note according to note type
 template<class Elf>
-ElfNote ElfReader<Elf>::GetNote(
+ElfNote ElfReader<Elf>::getNote(
     Util::Abi::PipelineAbiNoteType noteType // Note type
     ) const
 {
@@ -388,7 +388,7 @@ ElfNote ElfReader<Elf>::GetNote(
 // =====================================================================================================================
 // Initialize MsgPack document and related visitor iterators
 template<class Elf>
-void ElfReader<Elf>::InitMsgPackDocument(
+void ElfReader<Elf>::initMsgPackDocument(
     const void* pBuffer,       // [in] Message buffer
     uint32_t    sizeInBytes)   // Buffer size in bytes
 {
@@ -409,7 +409,7 @@ void ElfReader<Elf>::InitMsgPackDocument(
 // =====================================================================================================================
 // Advances the MsgPack context to the next item token and return true if success.
 template<class Elf>
-bool ElfReader<Elf>::GetNextMsgNode()
+bool ElfReader<Elf>::getNextMsgNode()
 {
     if (m_iteratorStack.empty())
     {
@@ -547,7 +547,7 @@ bool ElfReader<Elf>::GetNextMsgNode()
 // =====================================================================================================================
 // Gets MsgPack node.
 template<class Elf>
-const llvm::msgpack::DocNode* ElfReader<Elf>::GetMsgNode() const
+const llvm::msgpack::DocNode* ElfReader<Elf>::getMsgNode() const
 {
     assert(m_iteratorStack.size() > 0);
     auto pCurIter = &(m_iteratorStack.back());
@@ -572,7 +572,7 @@ const llvm::msgpack::DocNode* ElfReader<Elf>::GetMsgNode() const
 // =====================================================================================================================
 // Gets the map level of current message item.
 template<class Elf>
-uint32_t ElfReader<Elf>::GetMsgMapLevel() const
+uint32_t ElfReader<Elf>::getMsgMapLevel() const
 {
     return m_msgPackMapLevel;
 }
@@ -580,7 +580,7 @@ uint32_t ElfReader<Elf>::GetMsgMapLevel() const
 // =====================================================================================================================
 // Gets the status of message packer iterator.
 template<class Elf>
-MsgPackIteratorStatus ElfReader<Elf>::GetMsgIteratorStatus() const
+MsgPackIteratorStatus ElfReader<Elf>::getMsgIteratorStatus() const
 {
     return m_iteratorStack.back().status;
 }

--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -162,7 +162,7 @@ Result ElfReader<Elf>::ReadFromBuffer(
 template<class Elf>
 Result ElfReader<Elf>::GetSectionData(
     const char*  pName,       // [in] Name of the section to look for
-    const void** pData,       // [out] Pointer to section data
+    const void** pSectData,   // [out] Pointer to section data
     size_t*      pDataLength  // [out] Size of the section data
     ) const
 {
@@ -172,7 +172,7 @@ Result ElfReader<Elf>::GetSectionData(
 
     if (pEntry != m_map.end())
     {
-        *pData = m_sections[pEntry->second]->pData;
+        *pSectData = m_sections[pEntry->second]->pData;
         *pDataLength = static_cast<size_t>(m_sections[pEntry->second]->secHead.sh_size);
         result = Result::Success;
     }

--- a/util/vkgcElfReader.h
+++ b/util/vkgcElfReader.h
@@ -445,37 +445,37 @@ public:
     ~ElfReader();
 
     // Gets architecture-specific flags
-    uint32_t GetFlags() const { return m_header.e_flags; }
+    uint32_t getFlags() const { return m_header.e_flags; }
 
     // Gets graphics IP version info (used by ELF dump only)
-    GfxIpVersion GetGfxIpVersion() const { return m_gfxIp; }
+    GfxIpVersion getGfxIpVersion() const { return m_gfxIp; }
 
     Result ReadFromBuffer(const void* pBuffer, size_t* pBufSize);
 
     Result GetSectionData(const char* pName, const void** ppData, size_t* pDataLength) const;
 
-    uint32_t GetSectionCount();
-    Result GetSectionDataBySectionIndex(uint32_t secIdx, SectionBuffer** ppSectionData) const;
-    Result GetSectionDataBySortingIndex(uint32_t sortIdx, uint32_t* pSecIdx, SectionBuffer** ppSectionData) const;
-    Result GetTextSectionData(SectionBuffer** ppSectionData) const
+    uint32_t getSectionCount();
+    Result getSectionDataBySectionIndex(uint32_t secIdx, SectionBuffer** ppSectionData) const;
+    Result getSectionDataBySortingIndex(uint32_t sortIdx, uint32_t* pSecIdx, SectionBuffer** ppSectionData) const;
+    Result getTextSectionData(SectionBuffer** ppSectionData) const
     {
-        return GetSectionDataBySectionIndex(m_textSecIdx, ppSectionData);
+        return getSectionDataBySectionIndex(m_textSecIdx, ppSectionData);
     }
 
     // Determine if a section with the specified name is present in this ELF.
-    bool IsSectionPresent(const char* pName) const { return (m_map.find(pName) != m_map.end()); }
+    bool isSectionPresent(const char* pName) const { return (m_map.find(pName) != m_map.end()); }
 
-    uint32_t GetSymbolCount() const;
-    void GetSymbol(uint32_t idx, ElfSymbol* pSymbol);
+    uint32_t getSymbolCount() const;
+    void getSymbol(uint32_t idx, ElfSymbol* pSymbol);
 
-    bool IsValidSymbol(const char* pSymbolName);
+    bool isValidSymbol(const char* pSymbolName);
 
-    ElfNote GetNote(Util::Abi::PipelineAbiNoteType noteType) const;
+    ElfNote getNote(Util::Abi::PipelineAbiNoteType noteType) const;
 
     void GetSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol>& secSymbols) const;
 
-    uint32_t GetRelocationCount();
-    void GetRelocation(uint32_t idx, ElfReloc* pReloc);
+    uint32_t getRelocationCount();
+    void getRelocation(uint32_t idx, ElfReloc* pReloc);
 
     // Gets the section index for the specified section name.
     int32_t GetSectionIndex(const char* pName) const
@@ -484,47 +484,47 @@ public:
         return (pEntry != m_map.end()) ? pEntry->second : InvalidValue;
     }
 
-    void InitMsgPackDocument(const void* pBuffer, uint32_t sizeInBytes);
+    void initMsgPackDocument(const void* pBuffer, uint32_t sizeInBytes);
 
-    bool GetNextMsgNode();
+    bool getNextMsgNode();
 
-    const llvm::msgpack::DocNode* GetMsgNode() const;
+    const llvm::msgpack::DocNode* getMsgNode() const;
 
-    MsgPackIteratorStatus GetMsgIteratorStatus() const;
+    MsgPackIteratorStatus getMsgIteratorStatus() const;
 
-    uint32_t GetMsgMapLevel() const;
+    uint32_t getMsgMapLevel() const;
 
-    const typename Elf::FormatHeader& GetHeader() const
+    const typename Elf::FormatHeader& getHeader() const
     {
         return m_header;
     }
 
-    const std::map<std::string, uint32_t>& GetMap() const
+    const std::map<std::string, uint32_t>& getMap() const
     {
         return m_map;
     }
 
-    const std::vector<SectionBuffer*>& GetSections() const
+    const std::vector<SectionBuffer*>& getSections() const
     {
         return m_sections;
     }
 
-    int32_t GetSymSecIdx() const
+    int32_t getSymSecIdx() const
     {
         return m_symSecIdx;
     }
 
-    int32_t GetRelocSecIdx() const
+    int32_t getRelocSecIdx() const
     {
         return m_relocSecIdx;
     }
 
-    int32_t GetStrtabSecIdx() const
+    int32_t getStrtabSecIdx() const
     {
         return m_strtabSecIdx;
     }
 
-    int32_t GetTextSecIdx() const
+    int32_t getTextSecIdx() const
     {
         return m_textSecIdx;
     }

--- a/util/vkgcUtil.cpp
+++ b/util/vkgcUtil.cpp
@@ -93,9 +93,9 @@ const char* GetShaderStageAbbreviation(
 // =====================================================================================================================
 // Create directory.
 bool CreateDirectory(
-    const char* pDir)  // [in] the path of directory
+    const char* dir)  // [in] the path of directory
 {
-    int result = mkdir(pDir, S_IRWXU);
+    int result = mkdir(dir, S_IRWXU);
     return (result == 0);
 }
 

--- a/util/vkgcUtil.cpp
+++ b/util/vkgcUtil.cpp
@@ -102,14 +102,14 @@ bool CreateDirectory(
 // =====================================================================================================================
 // Helper macro
 #define CASE_CLASSENUM_TO_STRING(TYPE, ENUM) \
-    case TYPE::ENUM: pString = #ENUM; break;
+    case TYPE::ENUM: string = #ENUM; break;
 
 // =====================================================================================================================
 // Translate enum "ResourceMappingNodeType" to string
 const char* GetResourceMappingNodeTypeName(
     ResourceMappingNodeType type)  // Resource map node type
 {
-    const char* pString = nullptr;
+    const char* string = nullptr;
     switch (type)
     {
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, Unknown)
@@ -130,7 +130,7 @@ const char* GetResourceMappingNodeTypeName(
         llvm_unreachable("Should never be called!");
         break;
     }
-    return pString;
+    return string;
 }
 
 } // Vkgc


### PR DESCRIPTION
Edit: No longer applies: This has "removed 'using namespace llvm'" from PR541 included, which makes a fairly major contribution to the diff.