### PR TITLE
llpcBatchBufferOp: Downgrade -Wdeprecated-declarations to a warning

### DIFF
--- a/lgc/patch/llpcPatchBufferOp.cpp
+++ b/lgc/patch/llpcPatchBufferOp.cpp
@@ -50,6 +50,10 @@
 using namespace llvm;
 using namespace lgc;
 
+//FIXME: Override -Werror temporarily to synchronize with LLVM updates. Remove this as soon as LLVM is updated and we
+//       can remove the use of getParamAlignment.
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
+
 namespace lgc
 {
 


### PR DESCRIPTION
There is a pending LLVM change that deprecates getParamAlignment in
favor of getParamAlign, using the new type-safe MaybeAlign wrapper.

Adding the LLVM change causes some CI builds to fail with a deprecation
warning-turned-error due to -Werror. This is mitigated by this commit.
Since getParamAlign is introduced in the same LLVM commit as the
deprecation, there is unfortunately no way to properly fix LLPC
ahead of time: instead, we'll have to change the uses of
getParamAlignment to getParamAlign once the LLVM commit has propagated
to all relevant locations.