### PR TITLE
Init ResourceUsage to prevent invalid values

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -180,6 +180,7 @@ target_sources(LLVMlgc PRIVATE
     builder/InOutBuilder.cpp
     builder/MatrixBuilder.cpp
     builder/MiscBuilder.cpp
+    builder/ResourceUsage.cpp
     builder/SubgroupBuilder.cpp
     builder/YCbCrAddressHandler.cpp
 )

--- a/lgc/builder/ResourceUsage.cpp
+++ b/lgc/builder/ResourceUsage.cpp
@@ -1,0 +1,73 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcResourceUsage.cpp
+ * @brief LLPC source file: contains implementation of ResourceUsage and InterfaceData.
+ ***********************************************************************************************************************
+ */
+#include "lgc/state/ResourceUsage.h"
+
+using namespace lgc;
+
+// =====================================================================================================================
+ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
+  if (shaderStage == ShaderStageVertex) {
+    // NOTE: For vertex shader, PAL expects base vertex and base instance in user data,
+    // even if they are not used in shader.
+    builtInUsage.vs.baseVertex = true;
+    builtInUsage.vs.baseInstance = true;
+  } else if (shaderStage == ShaderStageTessControl) {
+    auto &calcFactor = inOutUsage.tcs.calcFactor;
+
+    calcFactor.inVertexStride = InvalidValue;
+    calcFactor.outVertexStride = InvalidValue;
+    calcFactor.patchCountPerThreadGroup = InvalidValue;
+    calcFactor.offChip.outPatchStart = InvalidValue;
+    calcFactor.offChip.patchConstStart = InvalidValue;
+    calcFactor.onChip.outPatchStart = InvalidValue;
+    calcFactor.onChip.patchConstStart = InvalidValue;
+    calcFactor.outPatchSize = InvalidValue;
+    calcFactor.patchConstSize = InvalidValue;
+  } else if (shaderStage == ShaderStageGeometry) {
+    inOutUsage.gs.rasterStream = 0;
+    inOutUsage.gs.calcFactor = {};
+  } else if (shaderStage == ShaderStageFragment) {
+    for (uint32_t i = 0; i < MaxColorTargets; ++i) {
+      inOutUsage.fs.expFmts[i] = EXP_FORMAT_ZERO;
+      inOutUsage.fs.outputTypes[i] = BasicType::Unknown;
+    }
+
+    inOutUsage.fs.cbShaderMask = 0;
+    inOutUsage.fs.dummyExport = true;
+    inOutUsage.fs.isNullFs = false;
+  }
+}
+
+// =====================================================================================================================
+InterfaceData::InterfaceData() {
+  memset(userDataMap, InterfaceData::UserDataUnmapped, sizeof(userDataMap));
+  entryArgIdxs.spillTable = InvalidValue;
+}

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -367,10 +367,6 @@ private:
   void recordGraphicsState(llvm::Module *module);
   void readGraphicsState(llvm::Module *module);
 
-  // Initialization of ResourceUsage and InterfaceData.
-  static void initShaderResourceUsage(ShaderStage shaderStage, ResourceUsage *resUsage);
-  static void initShaderInterfaceData(InterfaceData *intfData);
-
   // -----------------------------------------------------------------------------------------------------------------
   bool m_noReplayer = false;                            // True if no BuilderReplayer needed
   unsigned m_stageMask = 0;                             // Mask of active shader stages

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "lgc/state/Defs.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/util/Internal.h"
 #include <unordered_map>
@@ -112,14 +113,14 @@ enum class WorkgroupLayout : unsigned {
 //
 // NOTE: All fields must be initialized in InitShaderResourceUsage().
 struct ResourceUsage {
-  std::unordered_set<uint64_t> descPairs; // Pairs of descriptor set/binding
-  unsigned pushConstSizeInBytes;          // Push constant size (in bytes)
-  bool resourceWrite;                     // Whether shader does resource-write operations (UAV)
-  bool resourceRead;                      // Whether shader does resource-read operrations (UAV)
-  bool perShaderTable;                    // Whether per shader stage table is used
-  unsigned numSgprsAvailable;             // Number of available SGPRs
-  unsigned numVgprsAvailable;             // Number of available VGPRs
-  bool useImages;                         // Whether images are used
+  std::unordered_set<uint64_t> descPairs;  // Pairs of descriptor set/binding
+  unsigned pushConstSizeInBytes = 0;       // Push constant size (in bytes)
+  bool resourceWrite = false;              // Whether shader does resource-write operations (UAV)
+  bool resourceRead = false;               // Whether shader does resource-read operrations (UAV)
+  bool perShaderTable = false;             // Whether per shader stage table is used
+  unsigned numSgprsAvailable = UINT32_MAX; // Number of available SGPRs
+  unsigned numVgprsAvailable = UINT32_MAX; // Number of available VGPRs
+  bool useImages = false;                  // Whether images are used
 
   // Usage of built-ins
   struct {
@@ -298,7 +299,7 @@ struct ResourceUsage {
       } allStage;
     };
 
-  } builtInUsage;
+  } builtInUsage = {};
 
   // Usage of generic input/output
   struct {
@@ -320,22 +321,22 @@ struct ResourceUsage {
     std::map<unsigned, unsigned> perPatchBuiltInOutputLocMap;
 
     // Transform feedback strides
-    unsigned xfbStrides[MaxTransformFeedbackBuffers];
+    unsigned xfbStrides[MaxTransformFeedbackBuffers] = {};
 
     // Transform feedback enablement
-    bool enableXfb;
+    bool enableXfb = false;
 
     // Stream to transform feedback buffers
-    unsigned streamXfbBuffers[MaxGsStreams];
+    unsigned streamXfbBuffers[MaxGsStreams] = {};
 
     // Count of mapped location for inputs/outputs (including those special locations to which the built-ins
     // are mapped)
-    unsigned inputMapLocCount;
-    unsigned outputMapLocCount;
-    unsigned perPatchInputMapLocCount;
-    unsigned perPatchOutputMapLocCount;
+    unsigned inputMapLocCount = 0;
+    unsigned outputMapLocCount = 0;
+    unsigned perPatchInputMapLocCount = 0;
+    unsigned perPatchOutputMapLocCount = 0;
 
-    unsigned expCount; // Export count (number of "exp" instructions) for generic outputs
+    unsigned expCount = 0; // Export count (number of "exp" instructions) for generic outputs
 
     struct {
       struct {
@@ -370,7 +371,7 @@ struct ResourceUsage {
         unsigned tessFactorStride; // Size of tess factor stride (in DWORD)
 
       } calcFactor;
-    } tcs;
+    } tcs = {};
 
     struct {
       // Map from IDs of built-in outputs to locations of generic outputs (used by copy shader to export built-in
@@ -386,7 +387,7 @@ struct ResourceUsage {
       std::map<unsigned, unsigned> xfbOutsInfo;
 
       // ID of the vertex stream sent to rasterizor
-      unsigned rasterStream;
+      unsigned rasterStream = 0;
 
       struct {
         unsigned esGsRingItemSize;   // Size of each vertex written to the ES -> GS Ring.
@@ -398,9 +399,9 @@ struct ResourceUsage {
         unsigned inputVertices;      // Number of GS input vertices
         unsigned primAmpFactor;      // GS primitive amplification factor
         bool enableMaxVertOut;       // Whether to allow each GS instance to emit maximum vertices (NGG)
-      } calcFactor;
+      } calcFactor = {};
 
-      unsigned outLocCount[MaxGsStreams];
+      unsigned outLocCount[MaxGsStreams] = {};
     } gs;
 
     struct {
@@ -420,6 +421,8 @@ struct ResourceUsage {
       bool isNullFs;                          // Is null FS, so should set final cbShaderMask to 0
     } fs;
   } inOutUsage;
+
+  ResourceUsage(ShaderStage shaderStage);
 };
 
 // Represents stream-out data
@@ -444,16 +447,16 @@ struct InterfaceData {
   static const unsigned CsStartUserData = 2;
   static const unsigned UserDataUnmapped = InvalidValue;
 
-  unsigned userDataCount;                 // User data count
-  unsigned userDataMap[MaxUserDataCount]; // User data map (from SGPR No. to API logical ID)
+  unsigned userDataCount = 0;                  // User data count
+  unsigned userDataMap[MaxUserDataCount] = {}; // User data map (from SGPR No. to API logical ID)
 
   struct {
-    unsigned resNodeIdx; // Resource node index for push constant
+    unsigned resNodeIdx = InvalidValue; // Resource node index for push constant
   } pushConst;
 
   struct {
-    unsigned sizeInDwords;   // Spill table size in dwords
-    unsigned offsetInDwords; // Start offset of Spill table
+    unsigned sizeInDwords = 0;              // Spill table size in dwords
+    unsigned offsetInDwords = InvalidValue; // Start offset of Spill table
   } spillTable;
 
   // Usage of user data registers for internal-use variables
@@ -492,7 +495,7 @@ struct InterfaceData {
 
     unsigned spillTable; // Spill table user data map
 
-  } userDataUsage;
+  } userDataUsage = {};
 
   // Indices of the arguments in shader entry-point
   struct {
@@ -587,7 +590,9 @@ struct InterfaceData {
     unsigned spillTable;                       // Spill table
     bool initialized;                          // Whether entryArgIdxs has been initialized
                                                //   by PatchEntryPointMutate
-  } entryArgIdxs;
+  } entryArgIdxs = {};
+
+  InterfaceData();
 };
 
 } // namespace lgc


### PR DESCRIPTION
In some cases, fields stay uninitialized but are read.
This bug was found by ubsan.