### PR TITLE
switch to use MetroHash128

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -485,7 +485,7 @@ Result Compiler::BuildShaderModule(
 
     // Calculate the hash code of input data
     MetroHash::Hash hash = {};
-    MetroHash64::Hash(reinterpret_cast<const uint8_t*>(pShaderInfo->shaderBin.pCode),
+    MetroHash128::Hash(reinterpret_cast<const uint8_t*>(pShaderInfo->shaderBin.pCode),
         pShaderInfo->shaderBin.codeSize,
         hash.bytes);
 
@@ -551,7 +551,7 @@ Result Compiler::BuildShaderModule(
 
         // Calculate SPIR-V cache hash
         MetroHash::Hash cacheHash = {};
-        MetroHash64::Hash(reinterpret_cast<const uint8_t*>(moduleDataEx.common.binCode.pCode),
+        MetroHash128::Hash(reinterpret_cast<const uint8_t*>(moduleDataEx.common.binCode.pCode),
             moduleDataEx.common.binCode.codeSize,
             cacheHash.bytes);
         static_assert(sizeof(moduleDataEx.common.cacheHash) == sizeof(cacheHash), "Unexpected value!");
@@ -589,7 +589,7 @@ Result Compiler::BuildShaderModule(
                     moduleEntryData.pEntryName = entryNames[i].pName;
                     moduleEntry.entryOffset = moduleBinary.size();
                     MetroHash::Hash entryNamehash = {};
-                    MetroHash64::Hash(reinterpret_cast<const uint8_t*>(entryNames[i].pName),
+                    MetroHash128::Hash(reinterpret_cast<const uint8_t*>(entryNames[i].pName),
                         strlen(entryNames[i].pName),
                         entryNamehash.bytes);
                     memcpy(moduleEntry.entryNameHash, entryNamehash.dwords, sizeof(entryNamehash));
@@ -1086,7 +1086,7 @@ Result Compiler::BuildPipelineInternal(
                 MetroHash::Hash entryNameHash = {};
 
                 assert(pShaderInfo->pEntryTarget != nullptr);
-                MetroHash64::Hash(reinterpret_cast<const uint8_t*>(pShaderInfo->pEntryTarget),
+                MetroHash128::Hash(reinterpret_cast<const uint8_t*>(pShaderInfo->pEntryTarget),
                                   strlen(pShaderInfo->pEntryTarget),
                                   entryNameHash.bytes);
 
@@ -1783,7 +1783,7 @@ MetroHash::Hash Compiler::GenerateHashForCompileOptions(
         }
     }
 
-    MetroHash64 hasher;
+    MetroHash128 hasher;
 
     // Build hash code from effecting options
     for (auto option : effectingOptions)
@@ -2047,8 +2047,8 @@ void Compiler::BuildShaderCacheHash(
     MetroHash::Hash*            pFragmentHash,      // [out] Hash code of fragment shader
     MetroHash::Hash*            pNonFragmentHash)   // [out] Hash code of all non-fragment shader
 {
-    MetroHash64 fragmentHasher;
-    MetroHash64 nonFragmentHasher;
+    MetroHash128 fragmentHasher;
+    MetroHash128 nonFragmentHasher;
     auto pPipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo*>(pContext->GetPipelineBuildInfo());
     auto pPipelineOptions = pContext->GetPipelineContext()->GetPipelineOptions();
 
@@ -2061,7 +2061,7 @@ void Compiler::BuildShaderCacheHash(
         }
 
         auto pShaderInfo = pContext->GetPipelineShaderInfo(stage);
-        MetroHash64 hasher;
+        MetroHash128 hasher;
 
         // Update common shader info
         PipelineDumper::UpdateHashForPipelineShaderInfo(stage, pShaderInfo, true, &hasher);

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -121,7 +121,7 @@ void VKAPI_CALL IPipelineDumper::DumpSpirvBinary(
     const BinaryData*               pSpirvBin)  // [in] SPIR-V binary
 {
     MetroHash::Hash hash = {};
-    MetroHash64::Hash(reinterpret_cast<const uint8_t*>(pSpirvBin->pCode),
+    MetroHash128::Hash(reinterpret_cast<const uint8_t*>(pSpirvBin->pCode),
                       pSpirvBin->codeSize,
                       hash.bytes);
     PipelineDumper::DumpSpirvBinary(pDumpDir, pSpirvBin, &hash);
@@ -877,7 +877,7 @@ MetroHash::Hash PipelineDumper::GenerateHashForGraphicsPipeline(
     uint32_t                        stage)        // [in] The stage for which we are building the hash.
                                                   // ShaderStageInvalid if building for the entire pipeline.
 {
-    MetroHash64 hasher;
+    MetroHash128 hasher;
 
     switch (stage)
     {
@@ -934,7 +934,7 @@ MetroHash::Hash PipelineDumper::GenerateHashForComputePipeline(
     bool                            isCacheHash  // TRUE if the hash is used by shader cache
     )
 {
-    MetroHash64 hasher;
+    MetroHash128 hasher;
 
     UpdateHashForPipelineShaderInfo(ShaderStageCompute, &pPipeline->cs, isCacheHash, &hasher);
     hasher.Update(pPipeline->deviceIndex);
@@ -955,7 +955,7 @@ MetroHash::Hash PipelineDumper::GenerateHashForComputePipeline(
 // Updates hash code context for vertex input state
 void PipelineDumper::UpdateHashForVertexInputState(
     const VkPipelineVertexInputStateCreateInfo* pVertexInput,  // [in] Vertex input state
-    MetroHash64*                                pHasher)       // [in,out] Haher to generate hash code
+    MetroHash128*                                pHasher)       // [in,out] Haher to generate hash code
 {
     if ((pVertexInput != nullptr) && (pVertexInput->vertexBindingDescriptionCount > 0))
     {
@@ -987,7 +987,7 @@ void PipelineDumper::UpdateHashForVertexInputState(
 void PipelineDumper::UpdateHashForNonFragmentState(
     const GraphicsPipelineBuildInfo* pPipeline,     // [in] Info to build a graphics pipeline
     bool                             isCacheHash,   // TRUE if the hash is used by shader cache
-    MetroHash64*                     pHasher)       // [in,out] Hasher to generate hash code
+    MetroHash128*                     pHasher)       // [in,out] Hasher to generate hash code
 {
     auto pIaState = &pPipeline->iaState;
     pHasher->Update(pIaState->topology);
@@ -1059,7 +1059,7 @@ void PipelineDumper::UpdateHashForNonFragmentState(
 // Update hash code from fragment pipeline state
 void PipelineDumper::UpdateHashForFragmentState(
     const GraphicsPipelineBuildInfo* pPipeline,     // [in] Info to build a graphics pipeline
-    MetroHash64*                     pHasher)       // [in,out] Hasher to generate hash code
+    MetroHash128*                     pHasher)       // [in,out] Hasher to generate hash code
 {
     auto pRsState = &pPipeline->rsState;
     pHasher->Update(pRsState->innerCoverage);
@@ -1088,7 +1088,7 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
     ShaderStage               stage,           // shader stage
     const PipelineShaderInfo* pShaderInfo,     // [in] Shader info in specified shader stage
     bool                      isCacheHash,     // TRUE if the hash is used by shader cache
-    MetroHash64*              pHasher          // [in,out] Haher to generate hash code
+    MetroHash128*              pHasher          // [in,out] Haher to generate hash code
     )
 {
     if (pShaderInfo->pModuleData)
@@ -1199,7 +1199,7 @@ void PipelineDumper::UpdateHashForPipelineShaderInfo(
 void PipelineDumper::UpdateHashForResourceMappingNode(
     const ResourceMappingNode* pUserDataNode,    // [in] Resource mapping node
     bool                       isRootNode,       // TRUE if the node is in root level
-    MetroHash64*               pHasher           // [in,out] Haher to generate hash code
+    MetroHash128*               pHasher           // [in,out] Haher to generate hash code
     )
 {
     pHasher->Update(pUserDataNode->type);
@@ -1597,7 +1597,7 @@ OStream& operator<<(
                     out << "    " << symbols[symIdx].pSymName
                         << " (offset = " << symbols[symIdx].value << "  size = " << symbols[symIdx].size;
                     MetroHash::Hash hash = {};
-                    MetroHash64::Hash(
+                    MetroHash128::Hash(
                         reinterpret_cast<const uint8_t*>(
                             VoidPtrInc(pSection->pData, static_cast<size_t>(symbols[symIdx].value))),
                         symbols[symIdx].size,
@@ -1645,7 +1645,7 @@ OStream& operator<<(
                         out << "    " << symbols[symIdx].pSymName
                             << " (offset = " << symbols[symIdx].value << "  size = " << symbols[symIdx].size;
                         MetroHash::Hash hash = {};
-                        MetroHash64::Hash(
+                        MetroHash128::Hash(
                             reinterpret_cast<const uint8_t*>(
                                 VoidPtrInc(pSection->pData, static_cast<size_t>(symbols[symIdx].value))),
                             symbols[symIdx].size,
@@ -1698,7 +1698,7 @@ OStream& operator<<(
                         << " (offset = " << symbols[symIdx].value << "  size = " << symbols[symIdx].size;
 
                     MetroHash::Hash hash = {};
-                    MetroHash64::Hash(
+                    MetroHash128::Hash(
                         reinterpret_cast<const uint8_t*>(
                             VoidPtrInc(pSection->pData, static_cast<size_t>(symbols[symIdx].value))),
                         symbols[symIdx].size,

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -37,7 +37,7 @@
 #if !defined(SINGLE_EXTERNAL_METROHASH)
 namespace MetroHash
 {
-    class MetroHash64;
+    class MetroHash128;
     struct Hash;
 };
 #endif
@@ -94,24 +94,24 @@ public:
                                                 const PipelineShaderInfo* pShaderInfo,
                                                 bool                      isCacheHash,
 #if defined(SINGLE_EXTERNAL_METROHASH)
-                                                Util::MetroHash64*        pHasher);
+                                                Util::MetroHash128*        pHasher);
 #else
-                                                MetroHash::MetroHash64*   pHasher);
+                                                MetroHash::MetroHash128*   pHasher);
 #endif
 
     static void UpdateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo* pVertexInput,
 #if defined(SINGLE_EXTERNAL_METROHASH)
-                                              Util::MetroHash64*                          pHasher);
+                                              Util::MetroHash128*                          pHasher);
 #else
-                                              MetroHash::MetroHash64*                     pHasher);
+                                              MetroHash::MetroHash128*                     pHasher);
 #endif
 
     // Update hash for map object
     template <class MapType>
 #if defined(SINGLE_EXTERNAL_METROHASH)
-    static void UpdateHashForMap(MapType& m, Util::MetroHash64* pHasher)
+    static void UpdateHashForMap(MapType& m, Util::MetroHash128* pHasher)
 #else
-    static void UpdateHashForMap(MapType& m, MetroHash::MetroHash64* pHasher)
+    static void UpdateHashForMap(MapType& m, MetroHash::MetroHash128* pHasher)
 #endif
     {
         pHasher->Update(m.size());
@@ -126,17 +126,17 @@ public:
         const GraphicsPipelineBuildInfo* pPipeline,
         bool                             isCacheHash,
 #if defined(SINGLE_EXTERNAL_METROHASH)
-        Util::MetroHash64*               pHasher);
+        Util::MetroHash128*               pHasher);
 #else
-        MetroHash::MetroHash64*          pHasher);
+        MetroHash::MetroHash128*          pHasher);
 #endif
 
     static void UpdateHashForFragmentState(
         const GraphicsPipelineBuildInfo* pPipeline,
 #if defined(SINGLE_EXTERNAL_METROHASH)
-        Util::MetroHash64*               pHasher);
+        Util::MetroHash128*               pHasher);
 #else
-        MetroHash::MetroHash64*          pHasher);
+        MetroHash::MetroHash128*          pHasher);
 #endif
 
     // Get name of register, or "" if not known
@@ -170,9 +170,9 @@ private:
     static void UpdateHashForResourceMappingNode(const ResourceMappingNode* pUserDataNode,
                                                  bool                       isRootNode,
 #if defined(SINGLE_EXTERNAL_METROHASH)
-                                                 Util::MetroHash64*         pHasher);
+                                                 Util::MetroHash128*         pHasher);
 #else
-                                                 MetroHash::MetroHash64*    pHasher);
+                                                 MetroHash::MetroHash128*    pHasher);
 #endif
 };
 


### PR DESCRIPTION
align to pipeline binary cache, which will be easy to be unified later.

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>