### PR TITLE
Add experimental pipeline cache support to shader cache

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -63,6 +63,11 @@
 #define Vkgc Llpc
 #endif
 
+// Enables experimental pipeline caching using the LLPC shader cache.
+#ifndef LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+#define LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES 0
+#endif
+
 //**
 //**********************************************************************************************************************
 //* @page VersionHistory
@@ -573,8 +578,8 @@ struct GraphicsPipelineBuildInfo {
   void *pInstance;                ///< Vulkan instance object
   void *pUserData;                ///< User data
   OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
-  IShaderCache *pShaderCache; ///< Shader cache, used to search for the compiled shader data
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+  IShaderCache *shaderCache; ///< Shader cache, used to search for the compiled shader data
 #endif
   PipelineShaderInfo vs;  ///< Vertex shader
   PipelineShaderInfo tcs; ///< Tessellation control shader
@@ -632,8 +637,8 @@ struct ComputePipelineBuildInfo {
   void *pInstance;                ///< Vulkan instance object
   void *pUserData;                ///< User data
   OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
-  IShaderCache *pShaderCache; ///< Shader cache, used to search for the compiled shader data
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+  IShaderCache *shaderCache; ///< Shader cache, used to search for the compiled shader data
 #endif
   unsigned deviceIndex;    ///< Device index for device group
   PipelineShaderInfo cs;   ///< Compute shader

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -158,6 +158,11 @@ if(ICD_BUILD_LLPC)
     target_compile_definitions(llpc PRIVATE ICD_BUILD_LLPC)
 endif()
 
+option(LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES "Use experimental shader cache for pipeline caching instead of PAL pipeline caching?" OFF)
+if(LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES)
+    target_compile_definitions(llpc PRIVATE LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES=1)
+endif()
+
 if(ICD_BUILD_LLPC)
     if(XGL_LLVM_UPSTREAM)
         target_compile_definitions(llpc PRIVATE XGL_LLVM_UPSTREAM)
@@ -312,6 +317,10 @@ if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
 endif()
 
 target_compile_definitions(amdllpc PRIVATE ICD_BUILD_LLPC)
+
+if(LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES)
+    target_compile_definitions(amdllpc PRIVATE LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES=1)
+endif()
 
 target_include_directories(amdllpc
 PUBLIC

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -134,7 +134,7 @@ public:
 
   static MetroHash::Hash generateHashForCompileOptions(unsigned optionCount, const char *const *options);
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
   virtual Result CreateShaderCache(const ShaderCacheCreateInfo *pCreateInfo, IShaderCache **ppShaderCache);
 #endif
 

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -131,6 +131,12 @@ public:
 
   virtual Result Merge(unsigned srcCacheCount, const IShaderCache **ppSrcCaches);
 
+#if LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+  Result StorePipelineBinary(const void *pHash, size_t pipelineBinarySize, const void *pPipelineBinary) override;
+
+  Result RetrievePipeline(const void *pHash, size_t *pPipelineBinarySize, const void **ppPipelineBinary) override;
+#endif // LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+
   ShaderEntryState findShader(MetroHash::Hash hash, bool allocateOnMiss, CacheEntryHandle *phEntry);
 
   void insertShader(CacheEntryHandle hEntry, const void *blob, size_t size);

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -155,6 +155,34 @@ public:
   ///          memory cannot be allocated.
   virtual Result Merge(unsigned srcCacheCount, const IShaderCache **ppSrcCaches) = 0;
 
+#if LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+  /// Hashes used by these two functions are really MetroHash::Hash.
+  /// We don't use the LLPC typedef directly because XGL doesn't have its definition.
+  /// We don't use the XGL typedef either to avoid depending on the XGL code.
+
+  /// Stores the pipeline binary in the shader cache.
+  ///
+  /// @param [in]  pHash               Pointer to the pipeline's hash (MetroHash::Hash *).
+  /// @param [in]  pipelineBinarySize  Pipeline blob size in bytes.
+  /// @param [in]  pPipelineBinary     Pointer to the pipeline blob.
+  ///
+  /// @returns Success if the pipeline was stored in the cache, OutOfMemory if the internal allocator
+  ///          memory cannot be allocated.
+  virtual Result StorePipelineBinary(const void *pHash, size_t pipelineBinarySize, const void *pPipelineBinary) = 0;
+
+  /// Retrieves a matching pipeline binary from the shader cache, if found.
+  /// Results is returned through |pPipelineBinarySize| and |ppPielineBinary|.
+  ///
+  /// @param [in]      pHash                Pointer to the pipeline's hash (MetroHash::Hash *).
+  /// @param [in,out]  pPipelineBinarySize  Pipeline blob size in bytes. If ppPipelineBinary is null,
+  ///                                       the necessary allocation sized will be written to pPipelineBinarySize.
+  /// @param [in,out]  ppPipelineBinary     Pointer to a writable storage large enough to store the deserialized
+  ///                                       pipeline, or null.
+  ///
+  /// @returns Success if the pipelie was founds, ErrorUnavailable if not found, ErrorUnknown otherwise.
+  virtual Result RetrievePipeline(const void *pHash, size_t *pPipelineBinarySize, const void **ppPipelineBinary) = 0;
+#endif // LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
+
   /// Frees all resources associated with this object.
   virtual void Destroy() = 0;
 
@@ -226,7 +254,7 @@ public:
   virtual Result BuildComputePipeline(const ComputePipelineBuildInfo *pPipelineInfo,
                                       ComputePipelineBuildOut *pPipelineOut, void *pPipelineDumpFile = nullptr) = 0;
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES
   /// Creates a shader cache object with the requested properties.
   ///
   /// @param [in]  pCreateInfo    Create info of the shader cache.

--- a/tool/dumper/CMakeLists.txt
+++ b/tool/dumper/CMakeLists.txt
@@ -134,6 +134,10 @@ if(ICD_BUILD_LLPC)
     target_compile_definitions(dumper PRIVATE ICD_BUILD_LLPC)
 endif()
 
+if(LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES)
+    target_compile_definitions(dumper PRIVATE LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES=1)
+endif()
+
 # metrohash
 target_link_libraries(dumper PUBLIC metrohash)
 target_compile_definitions(dumper PUBLIC SINGLE_EXTERNAL_METROHASH)

--- a/tool/vfx/CMakeLists.txt
+++ b/tool/vfx/CMakeLists.txt
@@ -35,6 +35,10 @@ if(LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
     target_compile_definitions(vfx PRIVATE PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION})
 endif()
 
+if(LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES)
+    target_compile_definitions(vfx PRIVATE LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES=1)
+endif()
+
 target_sources(vfx PRIVATE
     vfxParser.cpp
     vfxPipelineDoc.cpp


### PR DESCRIPTION
This extends the existing ShaderCache in LLPC and enables it to store pipelines, as an alternative to the PAL pipeline binary cache.

The `LLPC_USE_EXPERIMENTAL_SHADER_CACHE_PIPELINES` enables this feature, while `LLPC_HAS_LZ4` enables pipeline compression. Both are off by default.
Note that this requires XGL changes to work.

Tested with the LunarG VulkanSamples' pipeline_cache application on Vega.