### PR TITLE
[CI] Build amdvlk base image on the main repo only

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build-and-push-amdvlk:
     name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
+    if: github.repository == 'GPUOpen-Drivers/llpc'
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:


### PR DESCRIPTION
Based on
https://github.community/t5/GitHub-Actions/Run-scheduled-workflows-only-from-the-main-repository/m-p/45855#M6361.

This fixes #546.