### PR TITLE
Update for upstream LLVM change 836ce9db7f1 [opaque pointer types] Re…

### DIFF
--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -1168,8 +1168,8 @@ Value *SubgroupBuilder::createPermLane16(Value *const origValue, Value *const up
                                                           int32Ty, int1Ty, int1Ty);
 
     // TODO: Once GFX10 intrinsic amdgcn_permlane16 has been upstreamed, used CreateIntrinsic here.
-    return builder.CreateCall(function.getCallee(), {mappedArgs[0], mappedArgs[1], passthroughArgs[0],
-                                                     passthroughArgs[1], passthroughArgs[2], passthroughArgs[3]});
+    return builder.CreateCall(function, {mappedArgs[0], mappedArgs[1], passthroughArgs[0],
+                                         passthroughArgs[1], passthroughArgs[2], passthroughArgs[3]});
   };
 
   return CreateMapToInt32(
@@ -1202,8 +1202,8 @@ Value *SubgroupBuilder::createPermLaneX16(Value *const origValue, Value *const u
                                                           int32Ty, int1Ty, int1Ty);
 
     // TODO: Once GFX10 intrinsic amdgcn_permlanex16 has been upstreamed, used CreateIntrinsic here.
-    return builder.CreateCall(function.getCallee(), {mappedArgs[0], mappedArgs[1], passthroughArgs[0],
-                                                     passthroughArgs[1], passthroughArgs[2], passthroughArgs[3]});
+    return builder.CreateCall(function, {mappedArgs[0], mappedArgs[1], passthroughArgs[0],
+                                         passthroughArgs[1], passthroughArgs[2], passthroughArgs[3]});
   };
 
   return CreateMapToInt32(

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -820,7 +820,8 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       if (emitStream != InvalidValue) {
         // Increment emit vertex counter
         auto emitCounterPtr = m_pipelineSysValues.get(m_entryPoint)->getEmitCounterPtr()[emitStream];
-        Value *emitCounter = new LoadInst(emitCounterPtr, "", &callInst);
+        auto emitCounterTy = emitCounterPtr->getType()->getPointerElementType();
+        Value *emitCounter = new LoadInst(emitCounterTy, emitCounterPtr, "", &callInst);
         emitCounter =
             BinaryOperator::CreateAdd(emitCounter, ConstantInt::get(Type::getInt32Ty(*m_context), 1), "", &callInst);
         new StoreInst(emitCounter, emitCounterPtr, &callInst);
@@ -4030,7 +4031,7 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
     {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
       Value *loadPtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
-      auto loadInst = new LoadInst(loadPtr, "", false, insertPos);
+      auto loadInst = new LoadInst(loadPtr->getType()->getPointerElementType(), loadPtr, "", false, insertPos);
       loadInst->setAlignment(MaybeAlign(m_lds->getAlignment()));
       loadValue = loadInst;
 
@@ -4143,7 +4144,8 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
     Value *gsVsOffset = getFunctionArgument(m_entryPoint, entryArgIdxs.gs.gsVsOffset);
 
     auto emitCounterPtr = m_pipelineSysValues.get(m_entryPoint)->getEmitCounterPtr()[streamId];
-    auto emitCounter = new LoadInst(emitCounterPtr, "", insertPos);
+    auto emitCounterTy = emitCounterPtr->getType()->getPointerElementType();
+    auto emitCounter = new LoadInst(emitCounterTy, emitCounterPtr, "", insertPos);
 
     auto ringOffset = calcGsVsRingOffsetForOutput(location, compIdx, streamId, emitCounter, gsVsOffset, insertPos);
 
@@ -4389,7 +4391,8 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
     for (unsigned i = 0; i < numChannels; ++i) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ldsOffset};
       Value *loadPtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
-      auto loadInst = new LoadInst(loadPtr, "", false, insertPos);
+      auto loadTy = loadPtr->getType()->getPointerElementType();
+      auto loadInst = new LoadInst(loadTy, loadPtr, "", false, insertPos);
       loadInst->setAlignment(MaybeAlign(m_lds->getAlignment()));
       loadValues[i] = loadInst;
 

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -388,7 +388,8 @@ Value *ShaderSystemValues::getNumWorkgroups() {
 
     auto numWorkgroupPtr =
         getFunctionArgument(m_entryPoint, intfData->entryArgIdxs.cs.numWorkgroupsPtr, "numWorkgroupsPtr");
-    auto numWorkgroups = new LoadInst(numWorkgroupPtr, "", insertPos);
+    auto numWorkgroupTy = numWorkgroupPtr->getType()->getPointerElementType();
+    auto numWorkgroups = new LoadInst(numWorkgroupTy, numWorkgroupPtr, "", insertPos);
     numWorkgroups->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(insertPos->getContext(), {}));
     m_numWorkgroups = numWorkgroups;
   }
@@ -454,8 +455,9 @@ Value *ShaderSystemValues::getStreamOutBufDesc(unsigned xfbBuffer) {
 
     auto streamOutBufDescPtr = GetElementPtrInst::Create(nullptr, streamOutTablePtr, idxs, "", insertPos);
     streamOutBufDescPtr->setMetadata(MetaNameUniform, MDNode::get(streamOutBufDescPtr->getContext(), {}));
+    auto streamOutBufDescTy = streamOutBufDescPtr->getType()->getPointerElementType();
 
-    auto streamOutBufDesc = new LoadInst(streamOutBufDescPtr, "", insertPos);
+    auto streamOutBufDesc = new LoadInst(streamOutBufDescTy, streamOutBufDescPtr, "", insertPos);
     streamOutBufDesc->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(streamOutBufDesc->getContext(), {}));
     streamOutBufDesc->setAlignment(MaybeAlign(16));
 
@@ -601,7 +603,7 @@ Value *ShaderSystemValues::getResourceNodeValue(unsigned resNodeIdx) {
     auto resNodePtr = BitCastInst::CreatePointerCast(elemPtr, resNodePtrTy, "", insertPos);
     resNodePtr->setMetadata(MetaNameUniform, MDNode::get(resNodePtr->getContext(), {}));
 
-    resNodeValue = new LoadInst(resNodePtr, "", insertPos);
+    resNodeValue = new LoadInst(resNodePtrTy->getPointerElementType(), resNodePtr, "", insertPos);
   }
   assert(resNodeValue);
   return resNodeValue;

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -678,8 +678,9 @@ Value *VertexFetch::loadVertexBufferDescriptor(unsigned binding, Instruction *in
   auto vbTablePtr = m_shaderSysValues->getVertexBufTablePtr();
   auto vbDescPtr = GetElementPtrInst::Create(nullptr, vbTablePtr, idxs, "", insertPos);
   vbDescPtr->setMetadata(MetaNameUniform, MDNode::get(vbDescPtr->getContext(), {}));
+  auto vbDescTy = vbDescPtr->getType()->getPointerElementType();
 
-  auto vbDesc = new LoadInst(vbDescPtr, "", insertPos);
+  auto vbDesc = new LoadInst(vbDescTy, vbDescPtr, "", insertPos);
   vbDesc->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(vbDesc->getContext(), {}));
   vbDesc->setAlignment(MaybeAlign(16));
 


### PR DESCRIPTION
…move deprecated Instruction/IRBuilder APIs.

Stop using deprecated overloads of LoadInst constructor and
IRBuilder::CreateCall that are removed by the upstream commit.