### PR TITLE
Fix formatting issues in NggLdsManager

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -50,78 +50,86 @@ namespace lgc {
 // =====================================================================================================================
 // Initialize static members
 const unsigned NggLdsManager::LdsRegionSizes[LdsRegionCount] = {
+    // clang-format off
+    //
     // LDS region size for ES-only
+    //
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionDistribPrimId
+    // 4 DWORDs (vec4) per thread
+    SizeOfVec4 * Gfx9::NggMaxThreadsPerSubgroup,              // LdsRegionPosData
+    // 1 BYTE (uint8) per thread
+    Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionDrawFlag
+    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
+    SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionPrimCountInWaves
+    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
+    SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionVertCountInWaves
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCullDistance
+    // 1 BYTE (uint8) per thread
+    Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionVertThreadIdMap
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactVertexId
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactInstanceId
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactPrimId
+    // 1 DWORD (float) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactTessCoordX
+    // 1 DWORD (float) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactTessCoordY
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactPatchId
+    // 1 DWORD (uint32) per thread
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactRelPatchId
 
-    // 1 DWORD (unsigned) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionDistribPrimId
-                                                  // 4 DWORDs (vec4) per thread
-    SizeOfVec4 *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionPosData
-                                                // 1 BYTE (uint8_t) per thread
-    Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionDrawFlag
-                                    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
-    SizeOfDword *Gfx9::NggMaxWavesPerSubgroup +
-        SizeOfDword, // LdsRegionPrimCountInWaves
-                     // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
-    SizeOfDword *Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionVertCountInWaves
-                                                             // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCullDistance
-                                                 // 1 BYTE (uint8_t) per thread
-    Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionVertThreadIdMap
-                                    // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactVertexId
-                                                 // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactInstanceId
-                                                 // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactPrimId
-                                                 // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactTessCoordX
-                                                 // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactTessCoordY
-                                                 // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactPatchId
-                                                 // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionCompactRelPatchId
-
+    //
     // LDS region size for ES-GS
-
+    //
     // ES-GS ring size is dynamically calculated (don't use it)
-    InvalidValue, // LdsRegionEsGsRing
-                  // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionOutPrimData
-                                                 // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire
-                                                 // sub-group (4 GS streams)
+    InvalidValue,                                             // LdsRegionEsGsRing
+    // 1 DWORD (uint32) per thread
+    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup,              // LdsRegionOutPrimData
+    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group (4 GS streams)
     MaxGsStreams *(SizeOfDword *Gfx9::NggMaxWavesPerSubgroup + SizeOfDword), // LdsRegionOutVertCountInWaves
-                                                                             // 1 DWORD (unsigned) per thread
-    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup, // LdsRegionOutVertOffset
-                                                 // GS-VS ring size is dynamically calculated (don't use it)
-    InvalidValue, // LdsRegionGsVsRing
+    // 1 DWORD (uint32) per thread
+    SizeOfDword *Gfx9::NggMaxThreadsPerSubgroup,              // LdsRegionOutVertOffset
+    // GS-VS ring size is dynamically calculated (don't use it)
+    InvalidValue,                                             // LdsRegionGsVsRing
+    // clang-format on
 };
 
 // =====================================================================================================================
 // Initialize static members
 const char *NggLdsManager::m_ldsRegionNames[LdsRegionCount] = {
+    // clang-format off
+    //
     // LDS region name for ES-only
-    "Distributed primitive ID",          // LdsRegionDistribPrimId
-    "Vertex position data",              // LdsRegionPosData
-    "Draw flag",                         // LdsRegionDrawFlag
-    "Primitive count in waves",          // LdsRegionPrimCountInWaves
-    "Vertex count in waves",             // LdsRegionVertCountInWaves
-    "Cull distance",                     // LdsRegionCullDistance
-    "Vertex thread ID map",              // LdsRegionVertThreadIdMap
-    "Compacted vertex ID (VS)",          // LdsRegionCompactVertexId
-    "Compacted instance ID (VS)",        // LdsRegionCompactInstanceId
-    "Compacted primitive ID (VS)",       // LdsRegionCompactPrimId
-    "Compacted tesscoord X (TES)",       // LdsRegionCompactTessCoordX
-    "Compacted tesscoord Y (TES)",       // LdsRegionCompactTessCoordY
-    "Compacted patch ID (TES)",          // LdsRegionCompactPatchId
-    "Compacted relative patch ID (TES)", // LdsRegionCompactRelPatchId
+    //
+    "Distributed primitive ID",             // LdsRegionDistribPrimId
+    "Vertex position data",                 // LdsRegionPosData
+    "Draw flag",                            // LdsRegionDrawFlag
+    "Primitive count in waves",             // LdsRegionPrimCountInWaves
+    "Vertex count in waves",                // LdsRegionVertCountInWaves
+    "Cull distance",                        // LdsRegionCullDistance
+    "Vertex thread ID map",                 // LdsRegionVertThreadIdMap
+    "Compacted vertex ID (VS)",             // LdsRegionCompactVertexId
+    "Compacted instance ID (VS)",           // LdsRegionCompactInstanceId
+    "Compacted primitive ID (VS)",          // LdsRegionCompactPrimId
+    "Compacted tesscoord X (TES)",          // LdsRegionCompactTessCoordX
+    "Compacted tesscoord Y (TES)",          // LdsRegionCompactTessCoordY
+    "Compacted patch ID (TES)",             // LdsRegionCompactPatchId
+    "Compacted relative patch ID (TES)",    // LdsRegionCompactRelPatchId
 
+    //
     // LDS region name for ES-GS
-    "ES-GS ring",                   // LdsRegionEsGsRing
-    "GS out primitive data",        // LdsRegionOutPrimData
-    "GS out vertex count in waves", // LdsRegionOutVertCountInWaves
-    "GS out vertex offset",         // LdsRegionOutVertOffset
-    "GS-VS ring",                   // LdsRegionGsVsRing
+    //
+    "ES-GS ring",                           // LdsRegionEsGsRing
+    "GS out primitive data",                // LdsRegionOutPrimData
+    "GS out vertex count in waves",         // LdsRegionOutVertCountInWaves
+    "GS out vertex offset",                 // LdsRegionOutVertOffset
+    "GS-VS ring",                           // LdsRegionGsVsRing
+    // clang-format on
 };
 
 // =====================================================================================================================

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -41,7 +41,10 @@ class PipelineState;
 
 // Enumerates the types of LDS regions used in NGG.
 enum NggLdsRegionType {
+  // clang-format off
+  //
   // LDS region for ES only (no GS)
+  //
   LdsRegionDistribPrimId = 0, // Distributed primitive ID (a special region, overlapped with the region of
                               //   position data in NGG non pass-through mode)
   LdsRegionPosData,           // Position data to export
@@ -49,7 +52,8 @@ enum NggLdsRegionType {
   LdsRegionPrimCountInWaves,  // Primitive count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionVertCountInWaves,  // Vertex count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionCullDistance,      // Aggregated sign value of cull distance (bitmask)
-                         // Below regions are for vertex compaction
+
+  // Below regions are for vertex compaction
   LdsRegionVertThreadIdMap,   // Vertex thread ID map (uncompacted -> compacted)
   LdsRegionCompactVertexId,   // Vertex ID (VS only)
   LdsRegionCompactInstanceId, // Instance ID (VS only)
@@ -65,7 +69,9 @@ enum NggLdsRegionType {
   LdsRegionEsBeginRange = LdsRegionDistribPrimId,
   LdsRegionEsEndRange = LdsRegionCompactRelPatchId,
 
+  //
   // LDS region for ES-GS
+  //
   LdsRegionEsGsRing,            // ES-GS ring
   LdsRegionOutPrimData,         // GS output primitive data
   LdsRegionOutVertCountInWaves, // GS output vertex count accumulated per wave (8 potential waves) and per
@@ -79,6 +85,7 @@ enum NggLdsRegionType {
 
   // Total
   LdsRegionCount
+  // clang-format on
 };
 
 // Size of a DWORD


### PR DESCRIPTION
The LDS region table is messy after code formatting. Re-format it
manually.

Change-Id: Id939cfb06e5c58ad6ba820577b2e83db2b83d1fd