### PR TITLE
Tweak a test to tolerate alloca alignment

### DIFF
--- a/llpc/test/shaderdb/ObjConstant_TestStruct_lit.frag
+++ b/llpc/test/shaderdb/ObjConstant_TestStruct_lit.frag
@@ -29,8 +29,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: alloca { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> }, addrspace(5)
-; SHADERTEST: alloca <4 x float>, addrspace(5)
+; SHADERTEST: alloca { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> },{{.*}} addrspace(5)
+; SHADERTEST: alloca <4 x float>,{{.*}} addrspace(5)
 ; SHADERTEST: store { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> } { [3 x <3 x float>] [<3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 5.000000e-01, float 5.000000e-01, float 5.000000e-01>, <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>], [3 x <3 x float>] [<3 x float> <float 1.000000e+00, float 0.000000e+00, float 0.000000e+00>, <3 x float> <float 0.000000e+00, float 1.000000e+00, float 0.000000e+00>, <3 x float> <float 0.000000e+00, float 0.000000e+00, float 1.000000e+00>], i32 1, <2 x i32> <i32 5, i32 5> }, { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> } addrspace(5)* %{{[0-9]*}}
 ; SHADERTEST: load i32, i32 addrspace(5)* %{{[0-9]*}}
 ; SHADERTEST: trunc i32 %{{[0-9]*}} to i1


### PR DESCRIPTION
This is to cope with an upstream LLVM change that causes us to start
putting "align 16" on these alloca instructions.