### PR TITLE
Ensure new denormal mode attributes are set

### DIFF
--- a/llpc/docs/amdllpc.md
+++ b/llpc/docs/amdllpc.md
@@ -46,7 +46,6 @@ amdllpc [<options>...] [<files>...]
 | `-enable-si-scheduler`           | Enable target option si-scheduler	      |                               |
 | `-disable-gs-onchip`             | Disable geometry shader on-chip mode	      |                               |
 | `-enable-tess-offchip`           | Enable tessellation off-chip mode	      |                               |
-| `-disable-fp32-denormals`        | Disable target option fp32-denormals	      |                               |
 | `-disable-llvm-patch`	           | Disable the patch for LLVM back-end issues	      |                               |
 | `-disable-lower-opt`             | Disable optimization for SPIR-V lowering	      |                               |
 | `-disable-licm`                  | Disable LLVM LICM pass	      |                               |


### PR DESCRIPTION
Ensure new denormal mode attributes denormal-fp-math
and denormal-fp-math-f32 are set. The target features
will be deprecated in https://reviews.llvm.org/D71358.

The backend will switch the default denormal handling
mode to on in https://reviews.llvm.org/D71357. Request
denormal flushing behavior explicitly to preserve the
old behavior.

Remove DisableFp32Denormals option as it is now unused.