### PR TITLE
Add an option to emit instruction encodings as asm comments

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -69,6 +69,9 @@ static cl::opt<bool> EmitLlvmBc("emit-llvm-bc", cl::desc("Emit LLVM bitcode inst
 static cl::opt<bool> EmitLgc("emit-lgc", cl::desc("Emit LLVM assembly suitable for input to LGC (middle-end compiler)"),
                              cl::init(false));
 
+// -show-encoding: show the instruction encoding when emitting assembler. This mirrors llvm-mc behaviour
+static cl::opt<bool> ShowEncoding("show-encoding", cl::desc("Show instruction encodings"), cl::init(false));
+
 // =====================================================================================================================
 // Initialize the middle-end. This must be called before the first LgcContext::Create, although you are
 // allowed to call it again after that. It must also be called before LLVM command-line processing, so
@@ -138,6 +141,13 @@ LgcContext *LgcContext::Create(LLVMContext &context, StringRef gpuName, unsigned
   // Allow no signed zeros - this enables omod modifiers (div:2, mul:2)
   TargetOptions targetOpts;
   targetOpts.NoSignedZerosFPMath = true;
+
+  // Enable instruction encoding output - outputs hex in comment mirroring
+  // llvm-mc behaviour
+  if (ShowEncoding) {
+    targetOpts.MCOptions.ShowMCEncoding = true;
+    targetOpts.MCOptions.AsmVerbose = true;
+  }
 
   builderContext->m_targetMachine =
       target->createTargetMachine(triple, gpuName, "", targetOpts, Optional<Reloc::Model>());


### PR DESCRIPTION
This mirrors a facility that llvm-mc has to do the same thing (and uses the same
option name: -show-encoding)

This decorates the asm output as follows:

s_lshr_b32 s0, s1, 15           ; encoding: [0x01,0x8f,0x00,0x90]
s_add_i32 s1, s0, 3             ; encoding: [0x00,0x83,0x01,0x81]
v_cvt_f32_u32_e32 v0, s1        ; encoding: [0x01,0x0c,0x00,0x7e]

This is sometimes useful when you want to confirm that the instruction encoding
really is what you think it is