### PR TITLE
Fix issues with coherent

### DIFF
--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -465,7 +465,15 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
     imageDescArgIndex = args.size();
     args.push_back(imageDesc);
     args.push_back(getInt32(tfe));
-    args.push_back(getInt32(((flags & ImageFlagCoherent) ? 1 : 0) | ((flags & ImageFlagVolatile) ? 2 : 0)));
+
+    // glc/dlc bits
+    CoherentFlag coherent = {};
+    if (flags & (ImageFlagCoherent | ImageFlagVolatile)) {
+      coherent.bits.glc = true;
+      if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 10)
+        coherent.bits.dlc = true;
+    }
+    args.push_back(getInt32(coherent.u32All));
 
     // Get the intrinsic ID from the load intrinsic ID table and call it.
     auto table = mipLevel ? &ImageLoadMipIntrinsicTable[0] : &ImageLoadIntrinsicTable[0];
@@ -626,7 +634,13 @@ Value *ImageBuilder::CreateImageStore(Value *texel, unsigned dim, unsigned flags
     imageDescArgIndex = args.size();
     args.push_back(imageDesc);
     args.push_back(getInt32(0)); // tfe/lwe
-    args.push_back(getInt32(((flags & ImageFlagCoherent) ? 1 : 0) | ((flags & ImageFlagVolatile) ? 2 : 0)));
+
+    // glc bit
+    CoherentFlag coherent = {};
+    if (flags & (ImageFlagCoherent | ImageFlagVolatile)) {
+      coherent.bits.glc = true;
+    }
+    args.push_back(getInt32(coherent.u32All));
 
     // Get the intrinsic ID from the store intrinsic ID table and call it.
     auto table = mipLevel ? &ImageStoreMipIntrinsicTable[0] : &ImageStoreIntrinsicTable[0];
@@ -1045,8 +1059,14 @@ Value *ImageBuilder::CreateImageSampleGather(Type *resultTy, unsigned dim, unsig
   bool tfe = isa<StructType>(resultTy);
   args.push_back(getInt32(tfe));
 
-  // glc/slc bits
-  args.push_back(getInt32(((flags & ImageFlagCoherent) ? 1 : 0) | ((flags & ImageFlagVolatile) ? 2 : 0)));
+  // glc/dlc bits
+  CoherentFlag coherent = {};
+  if (flags & (ImageFlagCoherent | ImageFlagVolatile)) {
+    coherent.bits.glc = true;
+    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 10)
+      coherent.bits.dlc = true;
+  }
+  args.push_back(getInt32(coherent.u32All));
 
   // Search the intrinsic ID table.
   auto table = isSample ? &ImageSampleIntrinsicTable[0] : &ImageGather4IntrinsicTable[0];

--- a/llpc/test/shaderdb/ObjImage_TestMemoryQualifier_lit.frag
+++ b/llpc/test/shaderdb/ObjImage_TestMemoryQualifier_lit.frag
@@ -16,13 +16,13 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 0, i32 0, <8 x i32>
+; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 0, i32 1, <8 x i32>
 ; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 0, <8 x i32>
-; SHADERTEST: call void (...) @lgc.create.image.store(<4 x float> %{{[^,]*}}, i32 1, i32 0, <8 x i32>
+; SHADERTEST: call void (...) @lgc.create.image.store(<4 x float> %{{[^,]*}}, i32 1, i32 3, <8 x i32>
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
-; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 0, i32 0, <8 x i32>
+; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 0, i32 1, <8 x i32>
 ; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 0, <8 x i32>
-; SHADERTEST: call void (...) @lgc.create.image.store(<4 x float> %{{[^,]*}}, i32 1, i32 0, <8 x i32>
+; SHADERTEST: call void (...) @lgc.create.image.store(<4 x float> %{{[^,]*}}, i32 1, i32 3, <8 x i32>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageRead_TestMemoryQualifier_lit.comp
+++ b/llpc/test/shaderdb/OpImageRead_TestMemoryQualifier_lit.comp
@@ -28,15 +28,15 @@ void main()
 ; SHADERTEST: call {{.*}} @"lgc.create.get.image.desc.ptr{{.*}}(i32 0, i32 1
 ; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 0, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <2 x i32> <i32 2, i32 2>)
 ; SHADERTEST: call {{.*}} @"lgc.create.get.image.desc.ptr{{.*}}(i32 0, i32 2
-; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 0, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <2 x i32> <i32 3, i32 3>)
+; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 1, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <2 x i32> <i32 3, i32 3>)
 ; SHADERTEST: call {{.*}} @"lgc.create.get.image.desc.ptr{{.*}}(i32 0, i32 3
-; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 0, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <2 x i32> <i32 4, i32 4>)
+; SHADERTEST: call reassoc nnan nsz arcp contract <4 x float> (...) @lgc.create.image.load.v4f32(i32 1, i32 3, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <2 x i32> <i32 4, i32 4>)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
 ; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 1, i32 1,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 2, i32 2,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 3, i32 3, <8 x i32> %{{[-0-9A-Za0z_.]+}}, i32 0, i32 0)
-; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 4, i32 4, <8 x i32> %{{[-0-9A-Za0z_.]+}}, i32 0, i32 0)
+; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 3, i32 3, <8 x i32> %{{[-0-9A-Za0z_.]+}}, i32 0, i32 1)
+; SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 4, i32 4, <8 x i32> %{{[-0-9A-Za0z_.]+}}, i32 0, i32 1)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2305,6 +2305,8 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpCopyMemory>(SPIRVValue *c
     if (isSystemScope)
       isCoherent = true;
   }
+  if (spvCopyMemory->getMemoryAccessMask(true) & MemoryAccessNonPrivatePointerKHRMask)
+    isCoherent = true;
 
   if (spvCopyMemory->getMemoryAccessMask(false) & MemoryAccessMakePointerAvailableKHRMask) {
     SPIRVWord spvId = spvCopyMemory->getMakeAvailableScope(false);
@@ -2316,6 +2318,8 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpCopyMemory>(SPIRVValue *c
     if (isSystemScope)
       isCoherent = true;
   }
+  if (spvCopyMemory->getMemoryAccessMask(false) & MemoryAccessNonPrivatePointerKHRMask)
+    isCoherent = true;
 
   bool isNonTemporal = spvCopyMemory->SPIRVMemoryAccess::isNonTemporal(true);
 
@@ -2384,6 +2388,8 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpLoad>(SPIRVValue *const s
     if (isSystemScope)
       isCoherent = true;
   }
+  if (spvLoad->getMemoryAccessMask(true) & MemoryAccessNonPrivatePointerKHRMask)
+    isCoherent = true;
 
   const bool isNonTemporal = spvLoad->SPIRVMemoryAccess::isNonTemporal(true);
 
@@ -2538,6 +2544,8 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpStore>(SPIRVValue *const 
     if (isSystemScope)
       isCoherent = true;
   }
+  if (spvStore->getMemoryAccessMask(false) & MemoryAccessNonPrivatePointerKHRMask)
+    isCoherent = true;
 
   const bool isNonTemporal = spvStore->SPIRVMemoryAccess::isNonTemporal(false);
 
@@ -5334,6 +5342,15 @@ void SPIRVToLLVM::getImageDesc(SPIRVValue *bImageInst, ExtractedImageInfo *info)
     return;
   }
 
+  if (bImageInst->getOpCode() == OpLoad) {
+    SPIRVLoad *load = static_cast<SPIRVLoad *>(bImageInst);
+
+    if (load->getSrc()->isCoherent())
+      info->flags |= lgc::Builder::ImageFlagCoherent;
+    if (load->getSrc()->isVolatile())
+      info->flags |= lgc::Builder::ImageFlagVolatile;
+  }
+
   // We need to scan back through OpImage/OpSampledImage just to find any
   // NonUniform decoration.
   SPIRVValue *scanBackInst = bImageInst;
@@ -5487,8 +5504,10 @@ void SPIRVToLLVM::setupImageAddressOperands(SPIRVInstruction *bi, unsigned maskI
     }
 
     // NonPrivateTexelKHR (0x400)
-    if (mask & ImageOperandsNonPrivateTexelKHRMask)
+    if (mask & ImageOperandsNonPrivateTexelKHRMask) {
       mask &= ~ImageOperandsNonPrivateTexelKHRMask;
+      imageInfo->flags |= lgc::Builder::ImageFlagCoherent;
+    }
 
     // VolatileTexelKHR (0x800)
     if (mask & ImageOperandsVolatileTexelKHRMask) {

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -379,6 +379,8 @@ public:
       ++DestMaskCount;
     if (TheMemoryAccess[0] & MemoryAccessMakePointerVisibleKHRMask)
       ++DestMaskCount;
+    if (TheMemoryAccess[0] & MemoryAccessNonPrivatePointerKHRMask)
+      ++DestMaskCount;
 
     // If HasBothMasks is false, the only one mask applies to both Source and Target
     // Otherwise, the first applies to Target and the second applies to Source
@@ -404,6 +406,11 @@ public:
       if (TheMemoryAccess[MaskIdx] & MemoryAccessMakePointerVisibleKHRMask) {
         assert(TheMemoryAccess.size() > Idx && "Scope operand is missing");
         MemoryAccess[I].MakeVisibleScope = TheMemoryAccess[Idx++];
+      }
+
+      if (TheMemoryAccess[MaskIdx] & MemoryAccessNonPrivatePointerKHRMask) {
+        // Note: Scope operand is not expected.
+        MemoryAccess[I].NonPrivatePointerScope = TheMemoryAccess[Idx++];
       }
     }
   }
@@ -438,7 +445,9 @@ protected:
     SPIRVWord Alignment = 0;
     SPIRVId MakeAvailableScope = SPIRVID_INVALID;
     SPIRVId MakeVisibleScope = SPIRVID_INVALID;
-  }MemoryAccess[2]; //[0]:destination, [1]:source
+    SPIRVId NonPrivatePointerScope = SPIRVID_INVALID;
+
+  } MemoryAccess[2]; // [0]:destination, [1]:source
 };
 
 class SPIRVVariable : public SPIRVInstruction {


### PR DESCRIPTION
Make image load/store respect "coherent".

Set memory as "coherent" if accesses are decorated with NonPrivatePointer
or ImageOperandsNonPrivateTexel.