### PR TITLE
Switch PatchDescriptorLoad offsets to bytes

### DIFF
--- a/llpc/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestDynDescSpill_lit.pipe
@@ -5,8 +5,8 @@
 ; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0, i1 false,
 ; SHADERTEST: load <4 x i32>, <4 x i32> addrspace(7)* %{{.*}}, align 16
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = getelementptr{{.*}} i32, {{.*}} %{{.*}}, i64 4
-; SHADERTEST: %{{.*}} = bitcast i32 addrspace(4)* %{{.*}} to <4 x i32> {{.*}}
+; SHADERTEST: %{{.*}} = getelementptr inbounds [512 x i8], [512 x i8] {{.*}} %{{.*}}, i64 0, i64 80
+; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %{{.*}} to <4 x i32> {{.*}}
 ; SHADERTEST: %{{.*}} = load <4 x i32>, <4 x i32> {{.*}} %{{.*}}, align 16
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; END_SHADERTEST


### PR DESCRIPTION
In the recent PatchDescriptorLoad revamp, the code deals with descriptor
offsets in a descriptor table in dwords. This commit changes it to deal
in bytes, as that makes it easier to add on future code to allow the
offset to be a reloc for shader compilation.

Change-Id: I96066dca3764f9ddb7d7865414cf9cd48e5bd475