### PR TITLE
Put option defaults into LgcContext so driver does not need to set them

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -90,11 +90,9 @@ enum class WaveBreak : unsigned {
   DrawTime = 0xF, ///< Choose wave break size per draw
 };
 
-/// Values for shadowDescriptorTableUsage pipeline option.
-enum class ShadowDescriptorTableUsage : unsigned {
-  Auto = 0, ///< Use 0 for auto setting so null initialized structures default to auto.
-  Enable = 1,
-  Disable = 2,
+// Values for shadowDescriptorTable pipeline option.
+enum class ShadowDescriptorTable : unsigned {
+  Disable = ~0U // Disable shadow descriptor tables
 };
 
 // Middle-end per-pipeline options to pass to SetOptions.
@@ -116,8 +114,8 @@ struct Options {
   NggSubgroupSizing nggSubgroupSizing; // NGG subgroup sizing type
   unsigned nggVertsPerSubgroup;        // How to determine NGG verts per subgroup
   unsigned nggPrimsPerSubgroup;        // How to determine NGG prims per subgroup
-  ShadowDescriptorTableUsage shadowDescriptorTableUsage; // Shadow descriptor table setting
-  unsigned shadowDescriptorTablePtrHigh;                 // High part of VA ptr.
+  unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
+                                       //   ShadowDescriptorTable::Disable to disable shadow descriptor tables
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/patch/SystemValues.h
+++ b/lgc/patch/SystemValues.h
@@ -172,10 +172,6 @@ private:
   llvm::Instruction *m_streamOutTablePtr;       // Stream-out buffer table pointer
   llvm::Instruction *m_spillTablePtr = nullptr; // Spill table pointer
   llvm::Instruction *m_pc = nullptr;            // Program counter as <2 x i32>
-
-  bool m_enableShadowDescTable = true;   // Enable shadow descriptor table
-  unsigned m_shadowDescTablePtrHigh = 2; // High part of VA for shadow table pointer
-                                         // 2 is a dummy value for use in offline compiling
 };
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -70,14 +70,14 @@ static cl::opt<unsigned> WavesPerEu("waves-per-eu", cl::desc("Maximum number of 
 
 // -enable-load-scalarizer: Enable the optimization for load scalarizer.
 static cl::opt<bool> EnableScalarLoad("enable-load-scalarizer",
-                                      cl::desc("Enable the optimization for load scalarizer."), cl::init(false));
+                                      cl::desc("Enable the optimization for load scalarizer."), cl::init(true));
 
 // The max threshold of load scalarizer.
 static const unsigned MaxScalarThreshold = 0xFFFFFFFF;
 
 // -scalar-threshold: Set the vector size threshold for load scalarizer.
 static cl::opt<unsigned> ScalarThreshold("scalar-threshold", cl::desc("The threshold for load scalarizer"),
-                                         cl::init(MaxScalarThreshold));
+                                         cl::init(3));
 
 // -enable-si-scheduler: enable target option si-scheduler
 static cl::opt<bool> EnableSiScheduler("enable-si-scheduler", cl::desc("Enable target option si-scheduler"),

--- a/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicDouble_lit.vert
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicDouble_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call <2 x i32> @llvm.amdgcn.raw.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)

--- a/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicFloat_lit.vert
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicFloat_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)

--- a/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicInt_lit.vert
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicInt_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)

--- a/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicUint_lit.vert
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestStoreBasicUint_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestAlign_lit.frag
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestAlign_lit.frag
@@ -25,7 +25,7 @@ void main()
 
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC.*}} pipeline patching results
 ; SHADERTEST-DAG: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 0, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicDouble_lit.vert
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicDouble_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 64, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicFloat_lit.vert
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicFloat_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 32, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicInt_lit.vert
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicInt_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 32, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicUint_lit.vert
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestLoadBasicUint_lit.vert
@@ -19,7 +19,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 32, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestLoadMixedMatrixStyle_lit.frag
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestLoadMixedMatrixStyle_lit.frag
@@ -17,7 +17,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-LABEL: call <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32> %{{[0-9]*}}, i32 0, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestLoadRowMajorMatrix_lit.frag
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestLoadRowMajorMatrix_lit.frag
@@ -15,7 +15,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-DAG: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 20, i32 0)

--- a/llpc/test/shaderdb/ObjUniformBlock_TestOffset_lit.frag
+++ b/llpc/test/shaderdb/ObjUniformBlock_TestOffset_lit.frag
@@ -25,7 +25,7 @@ void main()
 
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-DAG: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 128, i32 0)

--- a/llpc/test/shaderdb/OpExtInst_TestIntBitsToFloat_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestIntBitsToFloat_lit.frag
@@ -15,7 +15,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = bitcast <3 x i32> %{{.*}} to <3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results

--- a/llpc/test/shaderdb/OpLoad_TestMatrix_lit.frag
+++ b/llpc/test/shaderdb/OpLoad_TestMatrix_lit.frag
@@ -24,7 +24,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: load <3 x float>, <3 x float>
 

--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -1,5 +1,5 @@
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results

--- a/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestSharedVarLoadStore_lit.comp
+++ b/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestSharedVarLoadStore_lit.comp
@@ -41,7 +41,7 @@ void main()
 }
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-load-scalarizer=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST-COUNT-4: getelementptr [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 {{%[0-9]+}}, i32 {{[0-3]}}


### PR DESCRIPTION
Before this commit, both the driver (compiler_solution_llpc.cpp) and
amdllpc.cpp needed to set the same set of LLVM options. With this
commit:

* The scalarizer-related options are LLPC options, so I changed the
option defaults to what the code above currently sets.
* The other (unconditionally-set) ones now have default values set in
LGCContext.
* I removed the amdllpc option-setting code as it is no longer needed.
The driver code for unconditional options can be removed too.
* That will leave the options set in the driver conditionally on the
app profile. They should be removed in the future by them becoming
tuning options.

A further benefit of this is that the lgc utility does not need extra
command line options to behave in a way that is consistent with running
LGC as part of amdllpc.

Change-Id: I4353af365dd239cba08959b6d1e4c606d14431e3