### PR TITLE
Upstream re-factor for getVectorElementType and CreateShuffleVector d…

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -764,7 +764,7 @@ Value *ArithBuilder::CreateExtractExponent(Value *value, const Twine &instName) 
 // @param y : Input value Y
 // @param instName : Name to give instruction(s)
 Value *ArithBuilder::CreateCrossProduct(Value *x, Value *y, const Twine &instName) {
-  assert(x->getType() == y->getType() && x->getType()->getVectorNumElements() == 3);
+  assert(x->getType() == y->getType() && cast<VectorType>(x->getType())->getNumElements() == 3);
 
   Value *left = UndefValue::get(x->getType());
   Value *right = UndefValue::get(x->getType());
@@ -1217,7 +1217,7 @@ Value *ArithBuilder::createFMix(Value *x, Value *y, Value *a, const Twine &instN
   if (auto vectorResultTy = dyn_cast<VectorType>(ySubX->getType())) {
     // pX, pY => vector, but pA => scalar
     if (!isa<VectorType>(a->getType()))
-      a = CreateVectorSplat(vectorResultTy->getVectorNumElements(), a);
+      a = CreateVectorSplat(vectorResultTy->getNumElements(), a);
   }
 
   FastMathFlags fastMathFlags = getFastMathFlags();

--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -148,7 +148,7 @@ Value *Builder::CreateMapToInt32(PFN_MapToInt32Func mapFunc, ArrayRef<Value *> m
 
   if (mappedArgs[0]->getType()->isVectorTy()) {
     // For vectors we extract each vector component and map them individually.
-    const unsigned compCount = type->getVectorNumElements();
+    const unsigned compCount = cast<VectorType>(type)->getNumElements();
 
     SmallVector<Value *, 4> results;
 
@@ -235,9 +235,9 @@ Type *Builder::getTransposedMatrixTy(Type *const matrixType) const {
   assert(columnVectorType->isVectorTy());
 
   const unsigned columnCount = matrixType->getArrayNumElements();
-  const unsigned rowCount = columnVectorType->getVectorNumElements();
+  const unsigned rowCount = cast<VectorType>(columnVectorType)->getNumElements();
 
-  return ArrayType::get(VectorType::get(columnVectorType->getVectorElementType(), columnCount), rowCount);
+  return ArrayType::get(VectorType::get(cast<VectorType>(columnVectorType)->getElementType(), columnCount), rowCount);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -345,7 +345,7 @@ ShaderModes *BuilderRecorder::getShaderModes() {
 // @param vector2 : The vector 2
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateDotProduct(Value *const vector1, Value *const vector2, const Twine &instName) {
-  Type *const scalarType = vector1->getType()->getVectorElementType();
+  Type *const scalarType = cast<VectorType>(vector1->getType())->getElementType();
   return record(Opcode::DotProduct, scalarType, {vector1, vector2}, instName);
 }
 
@@ -407,7 +407,7 @@ Value *BuilderRecorder::CreateMatrixTimesScalar(Value *const matrix, Value *cons
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateVectorTimesMatrix(Value *const vector, Value *const matrix, const Twine &instName) {
   Type *const matrixType = matrix->getType();
-  Type *const compType = matrixType->getArrayElementType()->getVectorElementType();
+  Type *const compType = cast<VectorType>(cast<ArrayType>(matrixType)->getElementType())->getElementType();
   const unsigned columnCount = matrixType->getArrayNumElements();
   Type *const resultTy = VectorType::get(compType, columnCount);
   return record(Opcode::VectorTimesMatrix, resultTy, {vector, matrix}, instName);
@@ -421,8 +421,8 @@ Value *BuilderRecorder::CreateVectorTimesMatrix(Value *const vector, Value *cons
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateMatrixTimesVector(Value *const matrix, Value *const vector, const Twine &instName) {
   Type *const columnType = matrix->getType()->getArrayElementType();
-  Type *const compType = columnType->getVectorElementType();
-  const unsigned rowCount = columnType->getVectorNumElements();
+  Type *const compType = cast<VectorType>(columnType)->getElementType();
+  const unsigned rowCount = cast<VectorType>(columnType)->getNumElements();
   Type *const vectorType = VectorType::get(compType, rowCount);
   return record(Opcode::MatrixTimesVector, vectorType, {matrix, vector}, instName);
 }
@@ -447,7 +447,7 @@ Value *BuilderRecorder::CreateMatrixTimesMatrix(Value *const matrix1, Value *con
 // @param vector2 : The vector 2
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateOuterProduct(Value *const vector1, Value *const vector2, const Twine &instName) {
-  const unsigned colCount = vector2->getType()->getVectorNumElements();
+  const unsigned colCount = cast<VectorType>(vector2->getType())->getNumElements();
   Type *const resultTy = ArrayType::get(vector1->getType(), colCount);
   return record(Opcode::OuterProduct, resultTy, {vector1, vector2}, instName);
 }
@@ -458,7 +458,8 @@ Value *BuilderRecorder::CreateOuterProduct(Value *const vector1, Value *const ve
 // @param matrix : Matrix
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateDeterminant(Value *const matrix, const Twine &instName) {
-  return record(Determinant, matrix->getType()->getArrayElementType()->getVectorElementType(), matrix, instName);
+  return record(Determinant, cast<VectorType>(cast<ArrayType>(matrix->getType())->getElementType())->getElementType(),
+                matrix, instName);
 }
 
 // =====================================================================================================================
@@ -1439,9 +1440,9 @@ Value *BuilderRecorder::CreateReadBuiltInInput(BuiltInKind builtIn, InOutInfo in
   Type *resultTy = getBuiltInTy(builtIn, inputInfo);
   if (index) {
     if (isa<ArrayType>(resultTy))
-      resultTy = resultTy->getArrayElementType();
+      resultTy = cast<ArrayType>(resultTy)->getElementType();
     else
-      resultTy = resultTy->getVectorElementType();
+      resultTy = cast<VectorType>(resultTy)->getElementType();
   }
   return record(Opcode::ReadBuiltInInput, resultTy,
                 {
@@ -1468,9 +1469,9 @@ Value *BuilderRecorder::CreateReadBuiltInOutput(BuiltInKind builtIn, InOutInfo o
   Type *resultTy = getBuiltInTy(builtIn, outputInfo);
   if (index) {
     if (isa<ArrayType>(resultTy))
-      resultTy = resultTy->getArrayElementType();
+      resultTy = cast<ArrayType>(resultTy)->getElementType();
     else
-      resultTy = resultTy->getVectorElementType();
+      resultTy = cast<VectorType>(resultTy)->getElementType();
   }
   return record(Opcode::ReadBuiltInOutput, resultTy,
                 {

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -477,7 +477,7 @@ Value *InOutBuilder::evalIjOffsetSmooth(Value *offset) {
   // Adjust each coefficient by offset.
   Value *adjusted = adjustIj(pullModel, offset);
   // Extract <I/W, J/W, 1/W> part of that
-  Value *ijDivW = CreateShuffleVector(adjusted, adjusted, ArrayRef<unsigned>{0, 1});
+  Value *ijDivW = CreateShuffleVector(adjusted, adjusted, ArrayRef<int>{0, 1});
   Value *rcpW = CreateExtractElement(adjusted, 2);
   // Get W by making a reciprocal of 1/W
   Value *w = CreateFDiv(ConstantFP::get(getFloatTy(), 1.0), rcpW);
@@ -648,7 +648,7 @@ Value *InOutBuilder::readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo i
     if (isa<ArrayType>(resultTy))
       resultTy = resultTy->getArrayElementType();
     else
-      resultTy = resultTy->getVectorElementType();
+      resultTy = cast<VectorType>(resultTy)->getElementType();
   }
 
   // Handle the subgroup mask built-ins directly.
@@ -757,9 +757,9 @@ Instruction *InOutBuilder::CreateWriteBuiltInOutput(Value *valueToWrite, BuiltIn
   Type *expectedTy = getBuiltInTy(builtIn, outputInfo);
   if (index) {
     if (isa<ArrayType>(expectedTy))
-      expectedTy = expectedTy->getArrayElementType();
+      expectedTy = cast<ArrayType>(expectedTy)->getElementType();
     else
-      expectedTy = expectedTy->getVectorElementType();
+      expectedTy = cast<VectorType>(expectedTy)->getElementType();
   }
   assert(expectedTy == valueToWrite->getType() ||
          ((builtIn == BuiltInClipDistance || builtIn == BuiltInCullDistance) &&

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -80,8 +80,8 @@ Value *FragColorExport::run(Value *output, unsigned location, Instruction *inser
   const bool signedness =
       (outputType == BasicType::Int8 || outputType == BasicType::Int16 || outputType == BasicType::Int);
 
-  auto compTy = outputTy->isVectorTy() ? outputTy->getVectorElementType() : outputTy;
-  unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() : 1;
+  auto compTy = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getElementType() : outputTy;
+  unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
 
   Value *comps[4] = {nullptr};
   if (compCount == 1)
@@ -361,7 +361,7 @@ Value *FragColorExport::run(Value *output, unsigned location, Instruction *inser
 ExportFormat FragColorExport::computeExportFormat(Type *outputTy, unsigned location) const {
   GfxIpVersion gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
   auto gpuWorkarounds = &m_pipelineState->getTargetInfo().getGpuWorkarounds();
-  unsigned outputMask = outputTy->isVectorTy() ? (1 << outputTy->getVectorNumElements()) - 1 : 1;
+  unsigned outputMask = outputTy->isVectorTy() ? (1 << cast<VectorType>(outputTy)->getNumElements()) - 1 : 1;
   const auto cbState = &m_pipelineState->getColorExportState();
   const auto target = &m_pipelineState->getColorExportFormat(location);
   // NOTE: Alpha-to-coverage only takes effect for outputs from color target 0.

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -2801,11 +2801,11 @@ void NggPrimShader::runEsOrEsVariant(Module *module, StringRef entryName, Argume
 
     auto esArgTy = esArg->getType();
     if (esArgTy->isVectorTy()) {
-      assert(esArgTy->getVectorElementType()->isIntegerTy());
+      assert(cast<VectorType>(esArgTy)->getElementType()->isIntegerTy());
 
-      const unsigned userDataSize = esArgTy->getVectorNumElements();
+      const unsigned userDataSize = cast<VectorType>(esArgTy)->getNumElements();
 
-      std::vector<unsigned> shuffleMask;
+      std::vector<int> shuffleMask;
       for (unsigned i = 0; i < userDataSize; ++i)
         shuffleMask.push_back(userDataIdx + i);
 
@@ -3116,11 +3116,11 @@ Value *NggPrimShader::runGsVariant(Module *module, Argument *sysValueStart, Basi
 
     auto gsArgTy = gsArg->getType();
     if (gsArgTy->isVectorTy()) {
-      assert(gsArgTy->getVectorElementType()->isIntegerTy());
+      assert(cast<VectorType>(gsArgTy)->getElementType()->isIntegerTy());
 
-      const unsigned userDataSize = gsArgTy->getVectorNumElements();
+      const unsigned userDataSize = cast<VectorType>(gsArgTy)->getNumElements();
 
-      std::vector<unsigned> shuffleMask;
+      std::vector<int> shuffleMask;
       for (unsigned i = 0; i < userDataSize; ++i)
         shuffleMask.push_back(userDataIdx + i);
 
@@ -3476,13 +3476,13 @@ void NggPrimShader::exportGsOutput(Value *output, unsigned location, unsigned co
       assert(bitWidth == 16);
       Type *castTy = m_builder->getInt16Ty();
       if (outputTy->isVectorTy())
-        castTy = VectorType::get(m_builder->getInt16Ty(), outputTy->getVectorNumElements());
+        castTy = VectorType::get(m_builder->getInt16Ty(), cast<VectorType>(outputTy)->getNumElements());
       output = m_builder->CreateBitCast(output, castTy);
     }
 
     Type *extTy = m_builder->getInt32Ty();
     if (outputTy->isVectorTy())
-      extTy = VectorType::get(m_builder->getInt32Ty(), outputTy->getVectorNumElements());
+      extTy = VectorType::get(m_builder->getInt32Ty(), cast<VectorType>(outputTy)->getNumElements());
     output = m_builder->CreateZExt(output, extTy);
   } else
     assert(bitWidth == 32 || bitWidth == 64);
@@ -3546,7 +3546,7 @@ Value *NggPrimShader::importGsOutput(Type *outputTy, unsigned location, unsigned
 
   if (origOutputTy != outputTy) {
     assert(origOutputTy->isArrayTy() && outputTy->isVectorTy() &&
-           origOutputTy->getArrayNumElements() == outputTy->getVectorNumElements());
+           origOutputTy->getArrayNumElements() == cast<VectorType>(outputTy)->getNumElements());
 
     // <n x Ty> -> [n x Ty]
     const unsigned elemCount = origOutputTy->getArrayNumElements();

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -438,11 +438,11 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
   Type *elemTy = loadTy;
 
   if (loadTy->isArrayTy()) {
-    elemCount = loadTy->getArrayNumElements();
-    elemTy = loadTy->getArrayElementType();
+    elemCount = cast<ArrayType>(loadTy)->getNumElements();
+    elemTy = cast<ArrayType>(loadTy)->getElementType();
   } else if (loadTy->isVectorTy()) {
-    elemCount = loadTy->getVectorNumElements();
-    elemTy = loadTy->getVectorElementType();
+    elemCount = cast<VectorType>(loadTy)->getNumElements();
+    elemTy = cast<VectorType>(loadTy)->getElementType();
   }
   assert(elemTy->isIntegerTy(32) || elemTy->isFloatTy()); // Must be 32-bit type
 
@@ -559,7 +559,7 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
         auto outputTy = outputValue->getType();
         assert(outputTy->isFPOrFPVectorTy() && outputTy->getScalarSizeInBits() == 32);
 
-        const unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() : 1;
+        const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
         if (compCount > 1) {
           outputValue = builder.CreateBitCast(outputValue, VectorType::get(builder.getInt32Ty(), compCount));
           outputValue = builder.CreateTrunc(outputValue, VectorType::get(builder.getInt16Ty(), compCount));

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1460,7 +1460,7 @@ Value *PatchInOutImportExport::patchGsGenericInputImport(Type *inputTy, unsigned
                                                          Value *vertexIdx, Instruction *insertPos) {
   assert(vertexIdx);
 
-  const unsigned compCount = inputTy->isVectorTy() ? inputTy->getVectorNumElements() : 1;
+  const unsigned compCount = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getNumElements() : 1;
   const unsigned bitWidth = inputTy->getScalarSizeInBits();
 
   Type *origInputTy = inputTy;
@@ -1565,9 +1565,9 @@ Value *PatchInOutImportExport::patchFsGenericInputImport(Type *inputTy, unsigned
 
   Attribute::AttrKind attribs[] = {Attribute::ReadNone};
 
-  Type *basicTy = inputTy->isVectorTy() ? inputTy->getVectorElementType() : inputTy;
+  Type *basicTy = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getElementType() : inputTy;
 
-  const unsigned compCout = inputTy->isVectorTy() ? inputTy->getVectorNumElements() : 1;
+  const unsigned compCout = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getNumElements() : 1;
   const unsigned bitWidth = inputTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
 
@@ -1742,7 +1742,7 @@ void PatchInOutImportExport::patchVsGenericOutputExport(Value *output, unsigned 
         // For 64-bit data type, the component indexing must multiply by 2
         compIdx *= 2;
 
-        unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() * 2 : 2;
+        unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() * 2 : 2;
 
         outputTy = VectorType::get(Type::getFloatTy(*m_context), compCount);
         output = new BitCastInst(output, outputTy, "", insertPos);
@@ -1791,7 +1791,7 @@ void PatchInOutImportExport::patchTesGenericOutputExport(Value *output, unsigned
       // For 64-bit data type, the component indexing must multiply by 2
       compIdx *= 2;
 
-      unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() * 2 : 2;
+      unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() * 2 : 2;
       outputTy = VectorType::get(Type::getFloatTy(*m_context), compCount);
 
       output = new BitCastInst(output, outputTy, "", insertPos);
@@ -1822,7 +1822,7 @@ void PatchInOutImportExport::patchGsGenericOutputExport(Value *output, unsigned 
     compIdx *= 2;
 
     if (outputTy->isVectorTy())
-      outputTy = VectorType::get(Type::getFloatTy(*m_context), outputTy->getVectorNumElements() * 2);
+      outputTy = VectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(outputTy)->getNumElements() * 2);
     else
       outputTy = VectorType::get(Type::getFloatTy(*m_context), 2);
 
@@ -1830,7 +1830,7 @@ void PatchInOutImportExport::patchGsGenericOutputExport(Value *output, unsigned 
   } else
     assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32);
 
-  const unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() : 1;
+  const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
   // NOTE: Currently, to simplify the design of load/store data from GS-VS ring, we always extend BYTE/WORD to DWORD and
   // store DWORD to GS-VS ring. So for 8-bit/16-bit data type, the actual byte size is based on number of DWORDs.
   unsigned byteSize = (outputTy->getScalarSizeInBits() / 8) * compCount;
@@ -1864,8 +1864,8 @@ void PatchInOutImportExport::patchFsGenericOutputExport(Value *output, unsigned 
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32);
   (void(bitWidth)); // unused
 
-  auto compTy = outputTy->isVectorTy() ? outputTy->getVectorElementType() : outputTy;
-  unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() : 1;
+  auto compTy = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getElementType() : outputTy;
+  unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
 
   std::vector<Value *> outputComps;
   for (unsigned i = 0; i < compCount; ++i) {
@@ -3442,7 +3442,7 @@ void PatchInOutImportExport::patchXfbOutputExport(Value *output, unsigned xfbBuf
   unsigned xfbStride = xfbStrides[xfbBuffer];
 
   auto outputTy = output->getType();
-  unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() : 1;
+  unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
   unsigned bitWidth = outputTy->getScalarSizeInBits();
 
   xfbOffset = xfbOffset + xfbExtraOffset;
@@ -3596,7 +3596,7 @@ void PatchInOutImportExport::createStreamOutBufferStoreFunction(Value *storeValu
 
   auto storeTy = storeValue->getType();
 
-  unsigned compCount = storeTy->isVectorTy() ? storeTy->getVectorNumElements() : 1;
+  unsigned compCount = storeTy->isVectorTy() ? cast<VectorType>(storeTy)->getNumElements() : 1;
   assert(compCount <= 4);
 
   const uint64_t bitWidth = storeTy->getScalarSizeInBits();
@@ -3827,7 +3827,7 @@ void PatchInOutImportExport::storeValueToStreamOutBuffer(Value *storeValue, unsi
                                                          Instruction *insertPos) {
   auto storeTy = storeValue->getType();
 
-  unsigned compCount = storeTy->isVectorTy() ? storeTy->getVectorNumElements() : 1;
+  unsigned compCount = storeTy->isVectorTy() ? cast<VectorType>(storeTy)->getNumElements() : 1;
   assert(compCount <= 4);
 
   const uint64_t bitWidth = storeTy->getScalarSizeInBits();
@@ -3911,15 +3911,16 @@ void PatchInOutImportExport::storeValueToEsGsRing(Value *storeValue, unsigned lo
 
   Type *elemTy = storeTy;
   if (storeTy->isArrayTy())
-    elemTy = storeTy->getArrayElementType();
+    elemTy = cast<ArrayType>(storeTy)->getElementType();
   else if (storeTy->isVectorTy())
-    elemTy = storeTy->getVectorElementType();
+    elemTy = cast<VectorType>(storeTy)->getElementType();
 
   const uint64_t bitWidth = elemTy->getScalarSizeInBits();
   assert((elemTy->isFloatingPointTy() || elemTy->isIntegerTy()) && (bitWidth == 8 || bitWidth == 16 || bitWidth == 32));
 
   if (storeTy->isArrayTy() || storeTy->isVectorTy()) {
-    const unsigned elemCount = storeTy->isArrayTy() ? storeTy->getArrayNumElements() : storeTy->getVectorNumElements();
+    const unsigned elemCount =
+        storeTy->isArrayTy() ? cast<ArrayType>(storeTy)->getNumElements() : cast<VectorType>(storeTy)->getNumElements();
 
     for (unsigned i = 0; i < elemCount; ++i) {
       Value *storeElem = nullptr;
@@ -4001,9 +4002,9 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
                                                      Value *vertexIdx, Instruction *insertPos) {
   Type *elemTy = loadTy;
   if (loadTy->isArrayTy())
-    elemTy = loadTy->getArrayElementType();
+    elemTy = cast<ArrayType>(loadTy)->getElementType();
   else if (loadTy->isVectorTy())
-    elemTy = loadTy->getVectorElementType();
+    elemTy = cast<VectorType>(loadTy)->getElementType();
 
   const uint64_t bitWidth = elemTy->getScalarSizeInBits();
   assert((elemTy->isFloatingPointTy() || elemTy->isIntegerTy()) && (bitWidth == 8 || bitWidth == 16 || bitWidth == 32));
@@ -4011,7 +4012,8 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
   Value *loadValue = UndefValue::get(loadTy);
 
   if (loadTy->isArrayTy() || loadTy->isVectorTy()) {
-    const unsigned elemCount = loadTy->isArrayTy() ? loadTy->getArrayNumElements() : loadTy->getVectorNumElements();
+    const unsigned elemCount =
+        loadTy->isArrayTy() ? cast<ArrayType>(loadTy)->getNumElements() : cast<VectorType>(loadTy)->getNumElements();
 
     for (unsigned i = 0; i < elemCount; ++i) {
       auto loadElem =
@@ -4090,9 +4092,9 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
 
   Type *elemTy = storeTy;
   if (storeTy->isArrayTy())
-    elemTy = storeTy->getArrayElementType();
+    elemTy = cast<ArrayType>(storeTy)->getElementType();
   else if (storeTy->isVectorTy())
-    elemTy = storeTy->getVectorElementType();
+    elemTy = cast<VectorType>(storeTy)->getElementType();
 
   const unsigned bitWidth = elemTy->getScalarSizeInBits();
   assert((elemTy->isFloatingPointTy() || elemTy->isIntegerTy()) && (bitWidth == 8 || bitWidth == 16 || bitWidth == 32));
@@ -4109,7 +4111,8 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
   }
 
   if (storeTy->isArrayTy() || storeTy->isVectorTy()) {
-    const unsigned elemCount = storeTy->isArrayTy() ? storeTy->getArrayNumElements() : storeTy->getVectorNumElements();
+    const unsigned elemCount =
+        storeTy->isArrayTy() ? cast<ArrayType>(storeTy)->getNumElements() : cast<VectorType>(storeTy)->getNumElements();
 
     for (unsigned i = 0; i < elemCount; ++i) {
       Value *storeElem = nullptr;
@@ -4342,7 +4345,7 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
   assert(readTy->isSingleValueType());
 
   // Read DWORDs from LDS
-  const unsigned compCount = readTy->isVectorTy() ? readTy->getVectorNumElements() : 1;
+  const unsigned compCount = readTy->isVectorTy() ? cast<VectorType>(readTy)->getNumElements() : 1;
   const unsigned bitWidth = readTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
   const unsigned numChannels = compCount * (bitWidth == 64 ? 2 : 1);
@@ -4437,7 +4440,7 @@ void PatchInOutImportExport::writeValueToLds(Value *writeValue, Value *ldsOffset
   auto writeTy = writeValue->getType();
   assert(writeTy->isSingleValueType());
 
-  const unsigned compCout = writeTy->isVectorTy() ? writeTy->getVectorNumElements() : 1;
+  const unsigned compCout = writeTy->isVectorTy() ? cast<VectorType>(writeTy)->getNumElements() : 1;
   const unsigned bitWidth = writeTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
   const unsigned numChannels = compCout * (bitWidth == 64 ? 2 : 1);
@@ -5122,7 +5125,7 @@ void PatchInOutImportExport::addExportInstForGenericOutput(Value *output, unsign
 
   auto &inOutUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage;
 
-  const unsigned compCount = outputTy->isVectorTy() ? outputTy->getVectorNumElements() : 1;
+  const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
   const unsigned bitWidth = outputTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
 

--- a/lgc/patch/PatchLoadScalarizer.cpp
+++ b/lgc/patch/PatchLoadScalarizer.cpp
@@ -132,7 +132,7 @@ void PatchLoadScalarizer::visitLoadInst(LoadInst &loadInst) {
     if (compCount > m_scalarThreshold)
       return;
 
-    Type *compTy = loadTy->getVectorElementType();
+    Type *compTy = cast<VectorType>(loadTy)->getElementType();
     uint64_t compSize = loadInst.getModule()->getDataLayout().getTypeStoreSize(compTy);
 
     Value *loadValue = UndefValue::get(loadTy);

--- a/lgc/patch/PatchPeepholeOpt.cpp
+++ b/lgc/patch/PatchPeepholeOpt.cpp
@@ -179,16 +179,16 @@ void PatchPeepholeOpt::visitBitCast(BitCastInst &bitCast) {
 
     // Bit cast the LHS of the original shuffle.
     Value *const shuffleVectorLhs = shuffleVector->getOperand(0);
-    Type *const bitCastLhsType = VectorType::get(bitCast.getDestTy()->getVectorElementType(),
-                                                 shuffleVectorLhs->getType()->getVectorNumElements());
+    Type *const bitCastLhsType = VectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
+                                                 cast<VectorType>(shuffleVectorLhs->getType())->getNumElements());
     BitCastInst *const bitCastLhs =
         new BitCastInst(shuffleVectorLhs, bitCastLhsType, shuffleVectorLhs->getName() + ".bitcast");
     insertAfter(*bitCastLhs, *shuffleVector);
 
     // Bit cast the RHS of the original shuffle.
     Value *const shuffleVectorRhs = shuffleVector->getOperand(1);
-    Type *const bitCastRhsType = VectorType::get(bitCast.getDestTy()->getVectorElementType(),
-                                                 shuffleVectorRhs->getType()->getVectorNumElements());
+    Type *const bitCastRhsType = VectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
+                                                 cast<VectorType>(shuffleVectorRhs->getType())->getNumElements());
     BitCastInst *const bitCastRhs =
         new BitCastInst(shuffleVectorRhs, bitCastRhsType, shuffleVectorRhs->getName() + ".bitcast");
     insertAfter(*bitCastRhs, *bitCastLhs);
@@ -482,10 +482,10 @@ void PatchPeepholeOpt::visitPHINode(PHINode &phiNode) {
     Type *const type = phiNode.getType();
 
     // The number of elements in the vector type (which will result in N new scalar PHI nodes).
-    const unsigned numElements = type->getVectorNumElements();
+    const unsigned numElements = cast<VectorType>(type)->getNumElements();
 
     // The element type of the vector.
-    Type *const elementType = type->getVectorElementType();
+    Type *const elementType = cast<VectorType>(type)->getElementType();
 
     Value *result = UndefValue::get(type);
 

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2798,8 +2798,8 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
   }
 
   // Now we know we're reading a vector.
-  Type *elementTy = resultTy->getVectorElementType();
-  unsigned scalarizeBy = resultTy->getVectorNumElements();
+  Type *elementTy = cast<VectorType>(resultTy)->getElementType();
+  unsigned scalarizeBy = cast<VectorType>(resultTy)->getNumElements();
 
   // Find trivially unused elements.
   // This is not quite as good as the previous version of this code that scalarized in the

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -309,9 +309,9 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
 
       auto lsArgTy = lsArg->getType();
       if (lsArgTy->isVectorTy()) {
-        assert(lsArgTy->getVectorElementType()->isIntegerTy());
+        assert(cast<VectorType>(lsArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = lsArgTy->getVectorNumElements();
+        const unsigned userDataSize = cast<VectorType>(lsArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)
@@ -392,9 +392,9 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
 
       auto hsArgTy = hsArg->getType();
       if (hsArgTy->isVectorTy()) {
-        assert(hsArgTy->getVectorElementType()->isIntegerTy());
+        assert(cast<VectorType>(hsArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = hsArgTy->getVectorNumElements();
+        const unsigned userDataSize = cast<VectorType>(hsArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)
@@ -745,9 +745,9 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
 
       auto esArgTy = esArg->getType();
       if (esArgTy->isVectorTy()) {
-        assert(esArgTy->getVectorElementType()->isIntegerTy());
+        assert(cast<VectorType>(esArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = esArgTy->getVectorNumElements();
+        const unsigned userDataSize = cast<VectorType>(esArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)
@@ -904,9 +904,9 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
 
       auto gsArgTy = gsArg->getType();
       if (gsArgTy->isVectorTy()) {
-        assert(gsArgTy->getVectorElementType()->isIntegerTy());
+        assert(cast<VectorType>(gsArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = gsArgTy->getVectorNumElements();
+        const unsigned userDataSize = cast<VectorType>(gsArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -190,12 +190,12 @@ bool canBitCast(const Type *ty1, const Type *ty2) {
   if (ty1 == ty2)
     valid = true;
   else if (ty1->isSingleValueType() && ty2->isSingleValueType()) {
-    const Type *compTy1 = ty1->isVectorTy() ? ty1->getVectorElementType() : ty1;
-    const Type *compTy2 = ty2->isVectorTy() ? ty2->getVectorElementType() : ty2;
+    const Type *compTy1 = ty1->isVectorTy() ? cast<VectorType>(ty1)->getElementType() : ty1;
+    const Type *compTy2 = ty2->isVectorTy() ? cast<VectorType>(ty2)->getElementType() : ty2;
     if ((compTy1->isFloatingPointTy() || compTy1->isIntegerTy()) &&
         (compTy2->isFloatingPointTy() || compTy2->isIntegerTy())) {
-      const unsigned compCount1 = ty1->isVectorTy() ? ty1->getVectorNumElements() : 1;
-      const unsigned compCount2 = ty2->isVectorTy() ? ty2->getVectorNumElements() : 1;
+      const unsigned compCount1 = ty1->isVectorTy() ? cast<VectorType>(ty1)->getNumElements() : 1;
+      const unsigned compCount2 = ty2->isVectorTy() ? cast<VectorType>(ty2)->getNumElements() : 1;
 
       valid = compCount1 * compTy1->getScalarSizeInBits() == compCount2 * compTy2->getScalarSizeInBits();
     }

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -338,8 +338,9 @@ void SpirvLowerAlgebraTransform::visitFPTruncInst(FPTruncInst &fptruncInst) {
     if (srcTy->getScalarType()->isDoubleTy() && destTy->getScalarType()->isHalfTy()) {
       // NOTE: doubel -> float16 conversion is done in backend compiler with RTE rounding. Thus, we have to split
       // it with two phases to disable such lowering if we need RTZ rounding.
-      auto floatTy = srcTy->isVectorTy() ? VectorType::get(Type::getFloatTy(*m_context), srcTy->getVectorNumElements())
-                                         : Type::getFloatTy(*m_context);
+      auto floatTy = srcTy->isVectorTy()
+                         ? VectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(srcTy)->getNumElements())
+                         : Type::getFloatTy(*m_context);
       auto floatValue = new FPTruncInst(src, floatTy, "", &fptruncInst);
       auto dest = new FPTruncInst(floatValue, destTy, "", &fptruncInst);
 

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1418,7 +1418,7 @@ Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, cons
                              vertexIdx, interpLoc, auxInterpValue, insertPos);
     } else if (inOutTy->isVectorTy()) {
       // Vector type
-      auto compTy = inOutTy->getVectorElementType();
+      auto compTy = cast<VectorType>(inOutTy)->getElementType();
 
       assert(operandIdx + 1 == indexOperands.size() - 1);
       auto compIdx = indexOperands[operandIdx + 1];

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -116,8 +116,8 @@ void SpirvLowerMemoryOp::visitExtractElementInst(ExtractElementInst &extractElem
     auto addrSpace = loadPtr->getType()->getPointerAddressSpace();
 
     if (addrSpace == SPIRAS_Local || addrSpace == SPIRAS_Uniform) {
-      auto srcTy = src->getType();
-      auto castTy = ArrayType::get(srcTy->getVectorElementType(), srcTy->getVectorNumElements());
+      auto srcTy = cast<VectorType>(src->getType());
+      auto castTy = ArrayType::get(srcTy->getElementType(), srcTy->getNumElements());
       auto castPtrTy = castTy->getPointerTo(addrSpace);
       auto castPtr = new BitCastInst(loadPtr, castPtrTy, "", &extractElementInst);
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), extractElementInst.getOperand(1)};
@@ -212,15 +212,15 @@ bool SpirvLowerMemoryOp::needExpandDynamicIndex(GetElementPtrInst *getElemPtr, u
           // Check the upper bound of dynamic index
           if (isa<ArrayType>(indexedTy)) {
             auto arrayTy = dyn_cast<ArrayType>(indexedTy);
-            if (arrayTy->getArrayNumElements() > MaxDynIndexBound) {
+            if (arrayTy->getNumElements() > MaxDynIndexBound) {
               // Skip expand if array size greater than threshold
               allowExpand = false;
             } else
-              *dynIndexBound = arrayTy->getArrayNumElements();
+              *dynIndexBound = arrayTy->getNumElements();
           } else if (isa<VectorType>(indexedTy)) {
             // Always expand for vector
             auto vectorTy = dyn_cast<VectorType>(indexedTy);
-            *dynIndexBound = vectorTy->getVectorNumElements();
+            *dynIndexBound = vectorTy->getNumElements();
           } else {
             llvm_unreachable("Should never be called!");
             allowExpand = false;

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -209,7 +209,7 @@ bool SpirvLowerResourceCollect::runOnModule(Module &module) {
       // Collect basic types of fragment outputs
       BasicType basicTy = BasicType::Unknown;
 
-      const auto compTy = globalTy->isVectorTy() ? globalTy->getVectorElementType() : globalTy;
+      const auto compTy = globalTy->isVectorTy() ? cast<VectorType>(globalTy)->getElementType() : globalTy;
       const unsigned bitWidth = compTy->getScalarSizeInBits();
       const bool signedness = (inOutMeta.Signedness != 0);
 
@@ -236,7 +236,7 @@ bool SpirvLowerResourceCollect::runOnModule(Module &module) {
 
       fsOutInfo.location = location;
       fsOutInfo.location = index;
-      fsOutInfo.componentCount = globalTy->isVectorTy() ? globalTy->getVectorNumElements() : 1;
+      fsOutInfo.componentCount = globalTy->isVectorTy() ? cast<VectorType>(globalTy)->getNumElements() : 1;
       ;
       fsOutInfo.basicType = basicTy;
       m_fsOutInfos.push_back(fsOutInfo);

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1372,7 +1372,7 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix() {
           } else {
             // If we get here it means we are doing a subsequent GEP on a matrix row.
             assert(remappedValue->getType()->isVectorTy());
-            assert(remappedValue->getType()->getVectorElementType()->isPointerTy());
+            assert(cast<VectorType>(remappedValue->getType())->getElementType()->isPointerTy());
             valueMap[getElemPtr] = getBuilder()->CreateExtractElement(remappedValue, indices[1]);
           }
 
@@ -1395,7 +1395,7 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix() {
 
             Value *newLoad = UndefValue::get(load->getType());
 
-            for (unsigned i = 0; i < pointerType->getVectorNumElements(); i++) {
+            for (unsigned i = 0; i < cast<VectorType>(pointerType)->getNumElements(); i++) {
               Value *const pointerElem = getBuilder()->CreateExtractElement(pointer, i);
 
               LoadInst *const newLoadElem = getBuilder()->CreateLoad(pointerElem, load->isVolatile());
@@ -1464,7 +1464,7 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix() {
             Type *const pointerType = pointer->getType();
             assert(pointerType->isVectorTy());
 
-            for (unsigned i = 0; i < pointerType->getVectorNumElements(); i++) {
+            for (unsigned i = 0; i < cast<VectorType>(pointerType)->getNumElements(); i++) {
               Value *storeValueElem = store->getValueOperand();
 
               if (storeValueElem->getType()->isArrayTy())
@@ -4324,7 +4324,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     auto scalar = transValue(vts->getScalar(), f, bb);
     auto vector = transValue(vts->getVector(), f, bb);
     assert(vector->getType()->isVectorTy() && "Invalid type");
-    unsigned vecSize = vector->getType()->getVectorNumElements();
+    unsigned vecSize = cast<VectorType>(vector->getType())->getNumElements();
     auto newVec = getBuilder()->CreateVectorSplat(vecSize, scalar, scalar->getName());
     newVec->takeName(scalar);
     auto scale = getBuilder()->CreateFMul(vector, newVec, "scale");
@@ -4368,7 +4368,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
           // NOTE: It is allowed to construct a vector from several "smaller"
           // scalars or vectors, such as vec4 = (vec2, vec2) or vec4 = (float,
           // vec3).
-          auto compCount = constituents[i]->getType()->getVectorNumElements();
+          auto compCount = cast<VectorType>(constituents[i]->getType())->getNumElements();
           for (unsigned j = 0; j < compCount; ++j) {
             auto comp = ExtractElementInst::Create(constituents[i], ConstantInt::get(*m_context, APInt(32, j)), "", bb);
             v = InsertElementInst::Create(v, comp, ConstantInt::get(*m_context, APInt(32, idx)), "", bb);
@@ -4491,7 +4491,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     auto newVecCompCount = vs->getComponents().size();
 
     IntegerType *int32Ty = IntegerType::get(*m_context, 32);
-    Type *newVecTy = VectorType::get(v1->getType()->getVectorElementType(), newVecCompCount);
+    Type *newVecTy = VectorType::get(cast<VectorType>(v1->getType())->getElementType(), newVecCompCount);
     Value *newVec = UndefValue::get(newVecTy);
 
     for (size_t i = 0; i < newVecCompCount; ++i) {
@@ -4649,7 +4649,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     if (!isa<VectorType>(val->getType()))
       return val;
     Value *result = getBuilder()->CreateExtractElement(val, uint64_t(0));
-    for (unsigned i = 1, e = val->getType()->getVectorNumElements(); i != e; ++i) {
+    for (unsigned i = 1, e = cast<VectorType>(val->getType())->getNumElements(); i != e; ++i) {
       Value *elem = getBuilder()->CreateExtractElement(val, i);
       if (oc == OpAny)
         result = getBuilder()->CreateOr(result, elem);
@@ -5398,8 +5398,8 @@ void SPIRVToLLVM::setupImageAddressOperands(SPIRVInstruction *bi, unsigned maskI
       addr[lgc::Builder::ImageAddressIdxProjective] = getBuilder()->CreateExtractElement(coord, numCoords);
     }
     if (numCoords < coordVecTy->getNumElements()) {
-      static const unsigned Indexes[] = {0, 1, 2, 3};
-      coord = getBuilder()->CreateShuffleVector(coord, coord, ArrayRef<unsigned>(Indexes).slice(0, numCoords));
+      static const int Indexes[] = {0, 1, 2, 3};
+      coord = getBuilder()->CreateShuffleVector(coord, coord, ArrayRef<int>(Indexes).slice(0, numCoords));
       addr[lgc::Builder::ImageAddressIdxCoordinate] = coord;
     }
   }
@@ -5529,10 +5529,11 @@ void SPIRVToLLVM::handleImageFetchReadWriteCoord(SPIRVInstruction *bi, Extracted
     if (isa<VectorType>(coord->getType())) {
       if (!isa<VectorType>(offset->getType())) {
         offset = getBuilder()->CreateInsertElement(Constant::getNullValue(coord->getType()), offset, uint64_t(0));
-      } else if (coord->getType()->getVectorNumElements() != offset->getType()->getVectorNumElements()) {
+      } else if (cast<VectorType>(coord->getType())->getNumElements() !=
+                 cast<VectorType>(offset->getType())->getNumElements()) {
         offset = getBuilder()->CreateShuffleVector(
             offset, Constant::getNullValue(offset->getType()),
-            ArrayRef<unsigned>({0, 1, 2, 3}).slice(0, coord->getType()->getVectorNumElements()));
+            ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements()));
       }
     }
     coord = getBuilder()->CreateAdd(coord, offset);
@@ -5672,12 +5673,12 @@ Value *SPIRVToLLVM::transSPIRVImageAtomicOpFromInst(SPIRVInstruction *bi, BasicB
   // For a multi-sampled image, put the sample ID on the end.
   if (imageInfo.desc->MS) {
     sampleNum = getBuilder()->CreateInsertElement(UndefValue::get(coord->getType()), sampleNum, uint64_t(0));
-    SmallVector<unsigned, 4> idxs;
+    SmallVector<int, 4> idxs;
     idxs.push_back(0);
     idxs.push_back(1);
     if (imageInfo.desc->Arrayed)
       idxs.push_back(2);
-    idxs.push_back(coord->getType()->getVectorNumElements());
+    idxs.push_back(cast<VectorType>(coord->getType())->getNumElements());
     coord = getBuilder()->CreateShuffleVector(coord, sampleNum, idxs);
   }
 
@@ -5994,7 +5995,7 @@ Value *SPIRVToLLVM::transSPIRVImageFetchReadFromInst(SPIRVInstruction *bi, Basic
       sampleNum = getBuilder()->CreateInsertElement(UndefValue::get(coord->getType()), sampleNum, uint64_t(0));
       coord = getBuilder()->CreateShuffleVector(
           coord, sampleNum,
-          ArrayRef<unsigned>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements() + 1));
+          ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements() + 1));
     }
   }
 
@@ -6042,7 +6043,7 @@ Value *SPIRVToLLVM::transSPIRVImageWriteFromInst(SPIRVInstruction *bi, BasicBloc
     sampleNum = getBuilder()->CreateInsertElement(UndefValue::get(coord->getType()), sampleNum, uint64_t(0));
     coord = getBuilder()->CreateShuffleVector(
         coord, sampleNum,
-        ArrayRef<unsigned>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements() + 1));
+        ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements() + 1));
   }
 
   // Do the image store.


### PR DESCRIPTION
…eprecation

Upstream LLVM is removing/deprecating getVectorElementType and
getVectorNumElements (in favour of a cast to VectorType and use of
getElementType and getNumElements)

CreateShuffleVector with unsigned indices is also being deprecated so adjusted
those as well.