### PR TITLE
Fixed gl_Position accuracy after llpc.* to lgc.* name change

### DIFF
--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -313,10 +313,10 @@ void SpirvLowerAlgebraTransform::visitCallInst(CallInst &callInst) {
     auto calleeName = callee->getName();
     unsigned builtIn = InvalidValue;
     Value *valueWritten = nullptr;
-    if (calleeName.startswith("llpc.output.export.builtin.")) {
+    if (calleeName.startswith("lgc.output.export.builtin.")) {
       builtIn = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
       valueWritten = callInst.getOperand(callInst.getNumArgOperands() - 1);
-    } else if (calleeName.startswith("llpc.call.write.builtin")) {
+    } else if (calleeName.startswith("lgc.create.write.builtin")) {
       builtIn = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
       valueWritten = callInst.getOperand(0);
     }


### PR DESCRIPTION
My change "Changed llpc.* funcs to lgc.* funcs" broke the code in
LowerSpirvAlgebraTransform that removes fast math flags from ops that
calculate gl_Position, which caused visual artifacts in at least one
game. Fixed.

Change-Id: I7d789ba39d96df53b430ac0591b3e585867e1e15