### PR TITLE
Fixed compatibility breakage in ElfReader

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1115,7 +1115,7 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, unsigned stageM
 void GraphicsShaderCacheChecker::updateRootUserDateOffset(ElfPackage *pipelineElf) {
   ElfWriter<Elf64> writer(m_context->getGfxIpVersion());
   // Load ELF binary
-  auto result = writer.readFromBuffer(pipelineElf->data(), pipelineElf->size());
+  auto result = writer.ReadFromBuffer(pipelineElf->data(), pipelineElf->size());
   assert(result == Result::Success);
   (void(result)); // unused
   writer.updateElfBinary(m_context, pipelineElf);
@@ -1171,7 +1171,7 @@ void GraphicsShaderCacheChecker::updateAndMerge(Result result, ElfPackage *outpu
 
     // Merge and store the result in pPipelineElf
     ElfWriter<Elf64> writer(m_context->getGfxIpVersion());
-    auto result = writer.readFromBuffer(nonFragmentElf.pCode, nonFragmentElf.codeSize);
+    auto result = writer.ReadFromBuffer(nonFragmentElf.pCode, nonFragmentElf.codeSize);
     assert(result == Result::Success);
     (void(result)); // unused
     writer.mergeElfBinary(m_context, &fragmentElf, outputPipelineElf);
@@ -1774,14 +1774,14 @@ void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipe
     ElfReader<Elf64> fsReader(m_gfxIp);
     if (!shaderElfs[ShaderStageVertex].empty()) {
       size_t codeSize = shaderElfs[ShaderStageVertex].size_in_bytes();
-      result = vsReader.readFromBuffer(shaderElfs[ShaderStageVertex].data(), &codeSize);
+      result = vsReader.ReadFromBuffer(shaderElfs[ShaderStageVertex].data(), &codeSize);
       if (result != Result::Success)
         return;
     }
 
     if (!shaderElfs[ShaderStageFragment].empty()) {
       size_t codeSize = shaderElfs[ShaderStageFragment].size_in_bytes();
-      result = fsReader.readFromBuffer(shaderElfs[ShaderStageFragment].data(), &codeSize);
+      result = fsReader.ReadFromBuffer(shaderElfs[ShaderStageFragment].data(), &codeSize);
       if (result != Result::Success)
         return;
     }
@@ -1790,7 +1790,7 @@ void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipe
   } else {
     ElfReader<Elf64> csReader(m_gfxIp);
     size_t codeSize = shaderElfs[ShaderStageCompute].size_in_bytes();
-    result = csReader.readFromBuffer(shaderElfs[ShaderStageCompute].data(), &codeSize);
+    result = csReader.ReadFromBuffer(shaderElfs[ShaderStageCompute].data(), &codeSize);
     if (result != Result::Success)
       return;
     result = writer.linkComputeRelocatableElf(csReader, context);

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -872,7 +872,7 @@ static Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *c
   // -filetype=asm.
   ElfReader<Elf64> reader(compileInfo->gfxIp);
   size_t readSize = 0;
-  if (reader.readFromBuffer(pipelineBin->pCode, &readSize) == Result::Success) {
+  if (reader.ReadFromBuffer(pipelineBin->pCode, &readSize) == Result::Success) {
     LLPC_OUTS("===============================================================================\n");
     LLPC_OUTS("// LLPC final ELF info\n");
     LLPC_OUTS(reader);

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -74,7 +74,7 @@ public:
 
   static void updateMetaNote(Context *context, const ElfNote *note, ElfNote *newNote);
 
-  Result readFromBuffer(const void *buffer, size_t bufSize);
+  Result ReadFromBuffer(const void *buffer, size_t bufSize);
   Result copyFromReader(const ElfReader<Elf> &reader);
 
   void updateElfBinary(Context *context, ElfPackage *pipelineElf);
@@ -82,7 +82,7 @@ public:
   void mergeElfBinary(Context *context, const BinaryData *fragmentElf, ElfPackage *pipelineElf);
 
   // Gets the section index for the specified section name.
-  int getSectionIndex(const char *name) const {
+  int GetSectionIndex(const char *name) const {
     auto entry = m_map.find(name);
     return entry != m_map.end() ? entry->second : InvalidValue;
   }
@@ -99,7 +99,7 @@ public:
 
   Result getSectionData(const char* pName, const void** ppData, size_t* pDataLength) const;
 
-  void getSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol *> &secSymbols);
+  void GetSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol *> &secSymbols);
 
   void writeToBuffer(ElfPackage *elf);
 
@@ -109,7 +109,7 @@ public:
 
   unsigned getRelocationCount();
 
-  void getRelocation(unsigned idx, ElfReloc *reloc);
+  void getRelocation(unsigned idx, Vkgc::ElfReloc *reloc);
 
   Result linkGraphicsRelocatableElf(const llvm::ArrayRef<ElfReader<Elf> *> &relocatableElfs, Context *context);
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -551,7 +551,7 @@ void PipelineDumper::DumpPipelineBinary(PipelineDumpFile *dumpFile, GfxIpVersion
   if (dumpFile) {
     ElfReader<Elf64> reader(gfxIp);
     size_t codeSize = pipelineBin->codeSize;
-    auto result = reader.readFromBuffer(pipelineBin->pCode, &codeSize);
+    auto result = reader.ReadFromBuffer(pipelineBin->pCode, &codeSize);
     assert(result == Result::Success);
     (void(result)); // unused
 
@@ -1350,7 +1350,7 @@ OStream &operator<<(OStream &out, ElfReader<Elf> &reader) {
       out << section->name << " (size = " << section->secHead.sh_size << " bytes)\n";
 
       std::vector<ElfSymbol> symbols;
-      reader.getSymbolsBySectionIndex(secIdx, symbols);
+      reader.GetSymbolsBySectionIndex(secIdx, symbols);
       unsigned symIdx = 0;
       unsigned startPos = 0;
       unsigned endPos = 0;
@@ -1389,7 +1389,7 @@ OStream &operator<<(OStream &out, ElfReader<Elf> &reader) {
         out << section->name << " (size = " << section->secHead.sh_size << " bytes)\n";
 
         std::vector<ElfSymbol> symbols;
-        reader.getSymbolsBySectionIndex(secIdx, symbols);
+        reader.GetSymbolsBySectionIndex(secIdx, symbols);
         unsigned symIdx = 0;
         unsigned startPos = 0;
         unsigned endPos = 0;
@@ -1428,7 +1428,7 @@ OStream &operator<<(OStream &out, ElfReader<Elf> &reader) {
           << " bytes)\n";
 
       std::vector<ElfSymbol> symbols;
-      reader.getSymbolsBySectionIndex(secIdx, symbols);
+      reader.GetSymbolsBySectionIndex(secIdx, symbols);
 
       unsigned symIdx = 0;
       unsigned startPos = 0;

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -80,8 +80,8 @@ public:
                                                         bool isRelocatableShader,
                                                         unsigned stage = ShaderStageInvalid);
 
-  static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline,
-                                                        bool isRelocatableShader, bool isCacheHash);
+  static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline, bool isCacheHash,
+                                                        bool isRelocatableShader);
 
   static std::string getPipelineInfoFileName(PipelineBuildInfo pipelineInfo, const MetroHash::Hash *hash);
 

--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -72,7 +72,7 @@ template <class Elf> ElfReader<Elf>::~ElfReader() {
 //
 // @param buffer : Input ELF data buffer
 // @param [out] bufSize : Size of the given read buffer (determined from the ELF header)
-template <class Elf> Result ElfReader<Elf>::readFromBuffer(const void *buffer, size_t *bufSize) {
+template <class Elf> Result ElfReader<Elf>::ReadFromBuffer(const void *buffer, size_t *bufSize) {
   assert(buffer);
 
   Result result = Result::Success;
@@ -134,10 +134,10 @@ template <class Elf> Result ElfReader<Elf>::readFromBuffer(const void *buffer, s
   }
 
   // Get section index
-  m_symSecIdx = getSectionIndex(SymTabName);
-  m_relocSecIdx = getSectionIndex(RelocName);
-  m_strtabSecIdx = getSectionIndex(StrTabName);
-  m_textSecIdx = getSectionIndex(TextName);
+  m_symSecIdx = GetSectionIndex(SymTabName);
+  m_relocSecIdx = GetSectionIndex(RelocName);
+  m_strtabSecIdx = GetSectionIndex(StrTabName);
+  m_textSecIdx = GetSectionIndex(TextName);
 
   return result;
 }
@@ -149,7 +149,7 @@ template <class Elf> Result ElfReader<Elf>::readFromBuffer(const void *buffer, s
 // @param [out] sectData : Pointer to section data
 // @param [out] dataLength : Size of the section data
 template <class Elf>
-Result ElfReader<Elf>::getSectionData(const char *name, const void **sectData, size_t *dataLength) const {
+Result ElfReader<Elf>::GetSectionData(const char *name, const void **sectData, size_t *dataLength) const {
   Result result = Result::ErrorInvalidValue;
 
   auto entry = m_map.find(name);
@@ -267,7 +267,7 @@ Result ElfReader<Elf>::getSectionDataBySortingIndex(unsigned sortIdx, unsigned *
 // @param secIdx : Section index
 // @param [out] secSymbols : ELF symbols
 template <class Elf>
-void ElfReader<Elf>::getSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol> &secSymbols) const {
+void ElfReader<Elf>::GetSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol> &secSymbols) const {
   if (secIdx < m_sections.size() && m_symSecIdx >= 0) {
     auto &section = m_sections[m_symSecIdx];
     const char *strTab = reinterpret_cast<const char *>(m_sections[m_strtabSecIdx]->data);

--- a/util/vkgcElfReader.h
+++ b/util/vkgcElfReader.h
@@ -408,9 +408,15 @@ public:
   // Gets graphics IP version info (used by ELF dump only)
   GfxIpVersion getGfxIpVersion() const { return m_gfxIp; }
 
-  Result readFromBuffer(const void *buffer, size_t *bufSize);
+  // Reads ELF data in from the given buffer into the context.
+  // NOTE: Do not change the name or API of this method as it is used by AMD internal code and we need to
+  // maintain compatibility.
+  Result ReadFromBuffer(const void *buffer, size_t *bufSize);
 
-  Result getSectionData(const char *name, const void **ppData, size_t *dataLength) const;
+  // Retrieves the section data for the specified section name, if it exists.
+  // NOTE: Do not change the name or API of this method as it is used by AMD internal code and we need to
+  // maintain compatibility.
+  Result GetSectionData(const char *name, const void **ppData, size_t *dataLength) const;
 
   uint32_t getSectionCount();
   Result getSectionDataBySectionIndex(uint32_t secIdx, SectionBuffer **ppSectionData) const;
@@ -429,13 +435,18 @@ public:
 
   ElfNote getNote(Util::Abi::PipelineAbiNoteType noteType) const;
 
-  void getSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol> &secSymbols) const;
+  // Gets all associated symbols by section index.
+  // NOTE: Do not change the name or API of this method as it is used by AMD internal code and we need to
+  // maintain compatibility.
+  void GetSymbolsBySectionIndex(uint32_t secIndx, std::vector<ElfSymbol> &secSymbols) const;
 
   uint32_t getRelocationCount() const;
   void getRelocation(uint32_t idx, ElfReloc *reloc) const;
 
   // Gets the section index for the specified section name.
-  int32_t getSectionIndex(const char *name) const {
+  // NOTE: Do not change the name or API of this method as it is used by AMD internal code and we need to
+  // maintain compatibility.
+  int32_t GetSectionIndex(const char *name) const {
     auto entry = m_map.find(name);
     return (entry != m_map.end()) ? entry->second : InvalidValue;
   }


### PR DESCRIPTION
The change "Make Descriptor Offsets Relocatable" also fixed some method
names in ElfReader to the new camelBack standard. However that breaks
AMD internal builds, because we have internal code using those methods
for which we need to maintain some backward compatibility.

Also fixed a couple of other build problems.

Change-Id: I5617636cbd91ca55493bec41d9e2b669605bd84b