### PR TITLE
Tidy up descriptor offset relocation changes

### DIFF
--- a/lgc/builder/BuilderBase.cpp
+++ b/lgc/builder/BuilderBase.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "lgc/BuilderBase.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 using namespace lgc;
 using namespace llvm;
@@ -66,4 +67,13 @@ CallInst *BuilderBase::createNamedCall(StringRef funcName, Type *retTy, ArrayRef
   call->setAttributes(func->getAttributes());
 
   return call;
+}
+
+// =====================================================================================================================
+// Emits a amdgcn.reloc.constant intrinsic that represents a relocatable i32 value with the given symbol name
+//
+// @param symbolName : Name of the relocation symbol associated with this relocation
+Value *BuilderBase::CreateRelocationConstant(const Twine &symbolName) {
+  auto mdNode = MDNode::get(getContext(), MDString::get(getContext(), symbolName.str()));
+  return CreateIntrinsic(Intrinsic::amdgcn_reloc_constant, {}, {MetadataAsValue::get(getContext(), mdNode)});
 }

--- a/lgc/include/lgc/util/Internal.h
+++ b/lgc/include/lgc/util/Internal.h
@@ -31,8 +31,6 @@
 #pragma once
 
 #include "lgc/CommonDefs.h"
-#include "../interface/lgc/BuilderBase.h"
-
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -76,9 +74,6 @@ llvm::CallInst *emitCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::Arra
 // type and its parameters.
 llvm::CallInst *emitCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
                          llvm::ArrayRef<llvm::Attribute::AttrKind> attribs, llvm::BasicBlock *insertAtEnd);
-
-// Emits a amdgcn.reloc.constant intrinsics that represents a relocatable value with the given symbol name.
-llvm::CallInst* emitRelocationConstant(llvm::IRBuilderBase *builder, const llvm::Twine &symbolName);
 
 // Adds LLVM-style type mangling suffix for the specified return type and args to the name.
 void addTypeMangling(llvm::Type *returnTy, llvm::ArrayRef<llvm::Value *> args, std::string &name);

--- a/lgc/interface/lgc/BuilderBase.h
+++ b/lgc/interface/lgc/BuilderBase.h
@@ -55,6 +55,11 @@ public:
   // @param attribs : Function attributes
   llvm::CallInst *createNamedCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
                                   llvm::ArrayRef<llvm::Attribute::AttrKind> attribs);
+
+  // Emits a amdgcn.reloc.constant intrinsic that represents an i32 relocatable value with the given symbol name
+  //
+  // @param symbolName : Name of the relocation symbol associated with this relocation
+  llvm::Value *CreateRelocationConstant(const llvm::Twine &symbolName);
 };
 
 } // namespace lgc

--- a/lgc/patch/PatchDescriptorLoad.h
+++ b/lgc/patch/PatchDescriptorLoad.h
@@ -65,9 +65,9 @@ private:
   void processDescriptorGetPtr(llvm::CallInst *descPtrCall, llvm::StringRef descPtrCallName);
   llvm::Value *getDescPtrAndStride(ResourceNodeType resType, unsigned descSet, unsigned binding,
                                    const ResourceNode *topNode, const ResourceNode *node, bool shadow,
-                                   llvm::IRBuilder<> &builder);
+                                   BuilderBase &builder);
   llvm::Value *getDescPtr(ResourceNodeType resType, unsigned descSet, unsigned binding, const ResourceNode *topNode,
-                          const ResourceNode *node, bool shadow, llvm::IRBuilder<> &builder);
+                          const ResourceNode *node, bool shadow, BuilderBase &builder);
 
   void processDescriptorIndex(llvm::CallInst *call);
   void processLoadDescFromPtr(llvm::CallInst *loadFromPtr);

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -41,7 +41,6 @@
 
 #include "lgc/BuilderBase.h"
 #include "lgc/util/Internal.h"
-#include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "llpc-internal"
 
@@ -81,17 +80,6 @@ CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, Arra
                    BasicBlock *insertAtEnd) {
   BuilderBase builder(insertAtEnd);
   return builder.createNamedCall(funcName, retTy, args, attribs);
-}
-
-// =====================================================================================================================
-// Emits a amdgcn.reloc.constant intrinsics that represents a relocatable value with the given symbol name.
-//
-// @param builder : [in,out] An IRBuilder for instruction insertion
-// @param symbolName : Name of the relocation symbol associated with this relocation
-llvm::CallInst *emitRelocationConstant(llvm::IRBuilderBase *builder, const llvm::Twine &symbolName) {
-  auto mdNode = llvm::MDNode::get(builder->getContext(), llvm::MDString::get(builder->getContext(), symbolName.str()));
-  return builder->CreateIntrinsic(llvm::Intrinsic::amdgcn_reloc_constant, {},
-                                  {llvm::MetadataAsValue::get(builder->getContext(), mdNode)});
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -1143,15 +1143,15 @@ bool getDescriptorOffsetRelocationValue(Context *context, RelocationEntry relocE
   if (isGraphicsPipeline) {
     auto pPipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
     *value = getDescriptorResourceOffset(descSet, binding, type, pPipelineInfo->vs.pUserDataNodes,
-                                          pPipelineInfo->vs.userDataNodeCount);
+                                         pPipelineInfo->vs.userDataNodeCount);
     if (*value == InvalidValue) {
       *value = getDescriptorResourceOffset(descSet, binding, type, pPipelineInfo->fs.pUserDataNodes,
-                                            pPipelineInfo->fs.userDataNodeCount);
+                                           pPipelineInfo->fs.userDataNodeCount);
     }
   } else {
     auto pPipelineInfo = reinterpret_cast<const ComputePipelineBuildInfo *>(context->getPipelineBuildInfo());
     *value = getDescriptorResourceOffset(descSet, binding, type, pPipelineInfo->cs.pUserDataNodes,
-                                          pPipelineInfo->cs.userDataNodeCount);
+                                         pPipelineInfo->cs.userDataNodeCount);
   }
 
   return *value != InvalidValue;
@@ -1177,15 +1177,15 @@ bool getDescriptorStrideRelocationValue(Context *context, RelocationEntry relocE
   if (isGraphicsPipeline) {
     auto pPipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
     *value = getDescriptorResourceStride(descSet, binding, pPipelineInfo->vs.pUserDataNodes,
-                                          pPipelineInfo->vs.userDataNodeCount);
+                                         pPipelineInfo->vs.userDataNodeCount);
     if (*value == InvalidValue) {
       *value = getDescriptorResourceStride(descSet, binding, pPipelineInfo->fs.pUserDataNodes,
-                                            pPipelineInfo->fs.userDataNodeCount);
+                                           pPipelineInfo->fs.userDataNodeCount);
     }
   } else {
     auto pPipelineInfo = reinterpret_cast<const ComputePipelineBuildInfo *>(context->getPipelineBuildInfo());
     *value = getDescriptorResourceStride(descSet, binding, pPipelineInfo->cs.pUserDataNodes,
-                                          pPipelineInfo->cs.userDataNodeCount);
+                                         pPipelineInfo->cs.userDataNodeCount);
   }
 
   return *value != InvalidValue;
@@ -1198,8 +1198,7 @@ bool getDescriptorStrideRelocationValue(Context *context, RelocationEntry relocE
 // @param relocEntry : The relocation entry to fixup
 // @param isGraphicsPipeline : Whether we are processing a compute or graphics pipeline
 // @param value : [out] The value of the relocation
-bool getRelocationSymbolValue(Context *context, RelocationEntry relocEntry, bool isGraphicsPipeline,
-                              unsigned *value) {
+bool getRelocationSymbolValue(Context *context, RelocationEntry relocEntry, bool isGraphicsPipeline, unsigned *value) {
   if (strncmp(relocEntry.name, "doff_", 5) == 0) {
     return getDescriptorOffsetRelocationValue(context, relocEntry, isGraphicsPipeline, value);
   } else if (strncmp(relocEntry.name, "dstride_", 8) == 0) {
@@ -1246,8 +1245,7 @@ void fixUpRelocations(ElfWriter<Elf> *writer, const std::vector<RelocationEntry>
 // @param relocatableElfs : An array of relocatable ELF objects
 // @param context : Acquired context
 template <class Elf>
-Result ElfWriter<Elf>::linkGraphicsRelocatableElf(const ArrayRef<ElfReader<Elf> *> &relocatableElfs,
-                                                  Context *context) {
+Result ElfWriter<Elf>::linkGraphicsRelocatableElf(const ArrayRef<ElfReader<Elf> *> &relocatableElfs, Context *context) {
   reinitialize();
   assert(relocatableElfs.size() == 2 && "Can only handle VsPs Shaders for now.");
 

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -97,7 +97,7 @@ public:
 
   Result getSectionDataBySectionIndex(unsigned secIdx, const SectionBuffer **ppSectionData) const;
 
-  Result getSectionData(const char* pName, const void** ppData, size_t* pDataLength) const;
+  Result getSectionData(const char *pName, const void **ppData, size_t *pDataLength) const;
 
   void GetSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol *> &secSymbols);
 

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -77,8 +77,7 @@ public:
   static void DumpPipelineExtraInfo(PipelineDumpFile *binaryFile, const std::string *str);
 
   static MetroHash::Hash generateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
-                                                        bool isRelocatableShader,
-                                                        unsigned stage = ShaderStageInvalid);
+                                                         bool isRelocatableShader, unsigned stage = ShaderStageInvalid);
 
   static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline, bool isCacheHash,
                                                         bool isRelocatableShader);

--- a/util/vkgcElfReader.h
+++ b/util/vkgcElfReader.h
@@ -355,9 +355,9 @@ struct ElfSymbol {
 struct ElfReloc {
   uint64_t offset; // Location
   uint32_t symIdx; // Index of this symbol in the symbol table
-  uint32_t type; // Type of this relocation
+  uint32_t type;   // Type of this relocation
   bool useExplicitAddend; // Whether an explicit addend is used
-  uint32_t addend; // The value of the explicit addend
+  uint32_t addend;        // The value of the explicit addend
 };
 
 // Represents info of ELF note


### PR DESCRIPTION
* Moved emitRelocationConstant from Internal to
BuilderBase::CreateRelocationConstant
* Also subsumed the reformatting of the same change from #594.

Change-Id: Ifc3e332af22e0cdac138517cf363622caaca11f3