### PR TITLE
Update CreateVectorShuffle in anticipation of deprecated changes upst…

### DIFF
--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -776,7 +776,7 @@ Value *ImageBuilder::CreateImageSampleConvertYCbCr(Type *resultTy, unsigned dim,
 
   // Only the first 4 DWORDs are sampler descriptor, we need to extract these values under any condition
   // Init sample descriptor for luma channel
-  Value *samplerDescLuma = CreateShuffleVector(ycbcrSamplerDesc, ycbcrSamplerDesc, ArrayRef<unsigned>{0, 1, 2, 3});
+  Value *samplerDescLuma = CreateShuffleVector(ycbcrSamplerDesc, ycbcrSamplerDesc, ArrayRef<int>{0, 1, 2, 3});
 
   YCbCrSampleInfo sampleInfoLuma = {resultTy, dim, flags, imageDesc, samplerDescLuma, address, instName.str(), true};
 


### PR DESCRIPTION
…ream

CreateVectorShuffle is deprecating unsigned indices - should always be int from
now on.