### PR TITLE
Use #define instead of constexpr

### DIFF
--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -42,7 +42,9 @@ using namespace Vkgc;
 
 namespace {
 
-static constexpr unsigned R_AMDGPU_ABS32 = 6;
+// R_AMDGPU_ABS32 is only used in asserts, so it is unused in release builds, which does not work well with -Werror.
+// Therefore, this is a define instead of a constexpr.
+#define R_AMDGPU_ABS32 6
 // Descriptor size
 static constexpr unsigned DescriptorSizeResource = 8 * sizeof(unsigned);
 static constexpr unsigned DescriptorSizeSampler = 4 * sizeof(unsigned);


### PR DESCRIPTION
R_AMDGPU_ABS32 is only used inside an assert, so in release builds it is
unused, leading to an error if -Werror is enabled.
Using a #define instead lets it compile fine in both modes.