### PR TITLE
Relocation for Root Descriptor offset

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "llpcPipelineContext.h"
+#include "../interface/lgc/LgcContext.h"
 #include "SPIRVInternal.h"
 #include "llpcCompiler.h"
 #include "llpcDebug.h"
@@ -343,7 +344,8 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
 #endif
 
       shaderOptions.useSiScheduler = EnableSiScheduler || shaderInfo->options.useSiScheduler;
-      shaderOptions.updateDescInElf = shaderInfo->options.updateDescInElf;
+      shaderOptions.updateDescInElf =
+          shaderInfo->options.updateDescInElf || pipeline->getLgcContext()->buildingRelocatableElf();
       shaderOptions.unrollThreshold = shaderInfo->options.unrollThreshold;
 
       pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);

--- a/llpc/test/shaderdb/PipelineCs_RelocConst.pipe
+++ b/llpc/test/shaderdb/PipelineCs_RelocConst.pipe
@@ -15,6 +15,8 @@
 ; SHADERTEST1: %[[BUFFFERDESCADDR:[0-9]+]] = add i64 %{{[0-9]+}}, %[[RELOCONSTEXT]]
 ; SHADERTEST1: %[[BUFFERDESCPTR:[0-9]+]] = inttoptr i64 %[[BUFFFERDESCADDR]] {{.*}}
 ; SHADERTEST1: %{{[0-9]+}} = load <4 x i32>, <4 x i32> addrspace(4)* %[[BUFFERDESCPTR]], align 16, !invariant.load !{{.*}}
+; SHADERTEST1: COMPUTE_USER_DATA_{{.}} 0x0000000000000006
+; SHADERTEST1: COMPUTE_USER_DATA_{{.}} 0x0000000000000007
 ; SHADERTEST1: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -40,7 +42,7 @@ void main() {
 [CsInfo]
 entryPoint = main
 userDataNode[0].type = DescriptorTableVaPtr
-userDataNode[0].offsetInDwords = 0
+userDataNode[0].offsetInDwords = 6
 userDataNode[0].sizeInDwords = 1
 userDataNode[0].set = 0
 userDataNode[0].next[0].type = DescriptorBuffer
@@ -49,7 +51,7 @@ userDataNode[0].next[0].sizeInDwords = 8
 userDataNode[0].next[0].set = 0
 userDataNode[0].next[0].binding = 0
 userDataNode[1].type = DescriptorTableVaPtr
-userDataNode[1].offsetInDwords = 1
+userDataNode[1].offsetInDwords = 7
 userDataNode[1].sizeInDwords = 1
 userDataNode[1].set = 1
 userDataNode[1].next[0].type = DescriptorBuffer

--- a/llpc/test/shaderdb/PipelineVsFs_RelocConst.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_RelocConst.pipe
@@ -19,6 +19,8 @@
 ; SHADERTEST1: %[[BUFFFERDESCADDR:[0-9]+]] = add i64 %{{[0-9]+}}, %[[RELOCONSTEXT]]
 ; SHADERTEST1: %[[BUFFERDESCPTR:[0-9]+]] = inttoptr i64 %[[BUFFFERDESCADDR]] {{.*}}
 ; SHADERTEST1: %{{[0-9]+}} = load <4 x i32>, <4 x i32> addrspace(4)* %[[BUFFERDESCPTR]], align 16, !invariant.load !{{.*}}
+; SHADERTEST1-DAG: SPI_SHADER_USER_DATA_VS_{{.}} 0x000000000000000B
+; SHADERTEST1-DAG: SPI_SHADER_USER_DATA_PS_{{.}} 0x000000000000000B
 ; SHADERTEST1: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -50,7 +52,7 @@ userDataNode[0].offsetInDwords = 0
 userDataNode[0].sizeInDwords = 1
 userDataNode[0].indirectUserDataCount = 0
 userDataNode[1].type = DescriptorTableVaPtr
-userDataNode[1].offsetInDwords = 1
+userDataNode[1].offsetInDwords = 11
 userDataNode[1].sizeInDwords = 1
 userDataNode[1].set = 0
 userDataNode[1].next[0].type = DescriptorBuffer
@@ -112,7 +114,7 @@ colorBuffer[0].channelWriteMask = 15
 colorBuffer[0].blendEnable = 1
 colorBuffer[0].blendSrcAlphaToColor = 1
 userDataNode[0].type = DescriptorTableVaPtr
-userDataNode[0].offsetInDwords = 1
+userDataNode[0].offsetInDwords = 11
 userDataNode[0].sizeInDwords = 1
 userDataNode[0].set = 0
 userDataNode[0].next[0].type = DescriptorBuffer

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -196,6 +196,60 @@ void ElfWriter<Elf>::mergeMapItem(llvm::msgpack::MapDocNode &destMap, llvm::msgp
 }
 
 // =====================================================================================================================
+// Update descriptor offset to USER_DATA in metaNote, in place in the messagepack document.
+//
+// @param context : context related to ElfNote
+// @param document : [in, out] The parsed message pack document of the metadata note.
+static void updateRootDescriptorRegisters(Context *context, msgpack::Document &document) {
+  auto pipeline = document.getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0];
+  auto registers = pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::Registers].getMap(true);
+  const unsigned mmSpiShaderUserDataVs0 = 0x2C4C;
+  const unsigned mmSpiShaderUserDataPs0 = 0x2c0c;
+  const unsigned mmComputeUserData0 = 0x2E40;
+  unsigned userDataBaseRegisters[] = {mmSpiShaderUserDataVs0, mmSpiShaderUserDataPs0, mmComputeUserData0};
+  const unsigned vsPsUserDataCount = context->getGfxIpVersion().major < 9 ? 16 : 32;
+  unsigned userDataCount[] = {vsPsUserDataCount, vsPsUserDataCount, 16};
+  for (auto stage = 0; stage < sizeof(userDataBaseRegisters) / sizeof(unsigned); ++stage) {
+    unsigned baseRegister = userDataBaseRegisters[stage];
+    unsigned registerCount = userDataCount[stage];
+    for (unsigned i = 0; i < registerCount; ++i) {
+      unsigned key = baseRegister + i;
+      auto keyNode = registers.getDocument()->getNode(key);
+      auto keyIt = registers.find(keyNode);
+      if (keyIt != registers.end()) {
+        assert(keyIt->first.getUInt() == key);
+        // Reloc Descriptor user data value is consisted by DescRelocMagic | set.
+        unsigned regValue = keyIt->second.getUInt();
+        if (DescRelocMagic == (regValue & DescRelocMagicMask)) {
+          const PipelineShaderInfo *shaderInfo = nullptr;
+          if (baseRegister == mmComputeUserData0) {
+            auto pipelineInfo = reinterpret_cast<const ComputePipelineBuildInfo *>(context->getPipelineBuildInfo());
+            shaderInfo = &pipelineInfo->cs;
+          } else {
+            auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
+            shaderInfo = baseRegister == mmSpiShaderUserDataVs0 ? &pipelineInfo->vs : &pipelineInfo->fs;
+          }
+          unsigned set = regValue & DescSetMask;
+          for (unsigned j = 0; j < shaderInfo->userDataNodeCount; ++j) {
+            if (shaderInfo->pUserDataNodes[j].type == ResourceMappingNodeType::DescriptorTableVaPtr &&
+                set == shaderInfo->pUserDataNodes[j].tablePtr.pNext[0].srdRange.set) {
+              // If it's descriptor user data, then update its offset to it.
+              unsigned value = shaderInfo->pUserDataNodes[j].offsetInDwords;
+              keyIt->second = registers.getDocument()->getNode(value);
+              // Update userDataLimit if neccessary
+              unsigned userDataLimit = pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::UserDataLimit].getUInt();
+              pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::UserDataLimit] =
+                  document.getNode(std::max(userDataLimit, value + 1));
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// =====================================================================================================================
 // Merges fragment shader related info for meta notes.
 //
 // @param pContext : The first note section to merge
@@ -300,6 +354,8 @@ void ElfWriter<Elf>::mergeMetaNote(Context *pContext, const ElfNote *pNote1, con
   unsigned psUserDataCount = pContext->getGfxIpVersion().major < 9 ? 16 : 32;
   for (unsigned regNumber = mmSpiShaderUserDataPs0; regNumber != mmSpiShaderUserDataPs0 + psUserDataCount; ++regNumber)
     mergeMapItem(destRegisters, srcRegisters, regNumber);
+
+  updateRootDescriptorRegisters(pContext, destDocument);
 
   std::string destBlob;
   destDocument.writeToBlob(destBlob);
@@ -724,41 +780,7 @@ template <class Elf> void ElfWriter<Elf>::updateMetaNote(Context *pContext, cons
   assert(success);
   (void(success)); // unused
 
-  auto pipeline = document.getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0];
-
-  auto registers = pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::Registers].getMap(true);
-
-  const unsigned mmSpiShaderUserDataPs0 = 0x2c0c;
-  unsigned psUserDataBase = mmSpiShaderUserDataPs0;
-  unsigned psUserDataCount = pContext->getGfxIpVersion().major < 9 ? 16 : 32;
-  auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(pContext->getPipelineBuildInfo());
-
-  for (unsigned i = 0; i < psUserDataCount; ++i) {
-    unsigned key = psUserDataBase + i;
-    auto keyNode = registers.getDocument()->getNode(key);
-    auto keyIt = registers.find(keyNode);
-    if (keyIt != registers.end()) {
-      assert(keyIt->first.getUInt() == key);
-      // Reloc Descriptor user data value is consisted by DescRelocMagic | set.
-      unsigned regValue = keyIt->second.getUInt();
-      if (DescRelocMagic == (regValue & DescRelocMagicMask)) {
-        unsigned set = regValue & DescSetMask;
-        for (unsigned j = 0; j < pipelineInfo->fs.userDataNodeCount; ++j) {
-          if (pipelineInfo->fs.pUserDataNodes[j].type == ResourceMappingNodeType::DescriptorTableVaPtr &&
-              set == pipelineInfo->fs.pUserDataNodes[j].tablePtr.pNext[0].srdRange.set) {
-            // If it's descriptor user data, then update its offset to it.
-            unsigned value = pipelineInfo->fs.pUserDataNodes[j].offsetInDwords;
-            keyIt->second = registers.getDocument()->getNode(value);
-            // Update userDataLimit if neccessary
-            unsigned userDataLimit = pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::UserDataLimit].getUInt();
-            pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::UserDataLimit] =
-                document.getNode(std::max(userDataLimit, value + 1));
-            break;
-          }
-        }
-      }
-    }
-  }
+  updateRootDescriptorRegisters(pContext, document);
 
   std::string blob;
   document.writeToBlob(blob);
@@ -1364,6 +1386,12 @@ Result ElfWriter<Elf>::linkComputeRelocatableElf(const ElfReader<Elf> &relocatab
     relocations.push_back(relocEntry);
   }
   fixUpRelocations(this, relocations, context, false);
+
+  // Update root descriptor register value in metadata note
+  ElfNote metadataNote = getNote(Util::Abi::PipelineAbiNoteType::PalMetadata);
+  ElfNote updatedNote;
+  updateMetaNote(context, &metadataNote, &updatedNote);
+  setNote(&updatedNote);
 
   return Result::Success;
 }


### PR DESCRIPTION
This PR adds relocation for root descriptor offsets.

There are two places where I am not certain if the change is doing the right thing:
1. I disabled `useFixedLayout` when relocatable shader elf is being built. This makes sure that we always emit descriptor set value during initial compute shader elf generation.
2. I am not sure whether the existing code determines whether or not to spill a root descriptor based on PipelineInfo. If that this case, should we make the spill/non-spill decision a relocatable entry as well? This PR does not address this issue.