### PR TITLE
Redesign NGG GS work flow

### DIFF
--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -100,7 +100,6 @@ const static char NggEsEntryVariantPos[] = "lgc.ngg.ES.variant.pos";
 const static char NggEsEntryVariantParam[] = "lgc.ngg.ES.variant.param";
 
 const static char NggGsEntryPoint[] = "lgc.ngg.GS.main";
-const static char NggGsEntryVariant[] = "lgc.ngg.GS.variant";
 const static char NggGsOutputExport[] = "lgc.ngg.GS.output.export.";
 const static char NggGsOutputImport[] = "lgc.ngg.GS.output.import.";
 const static char NggGsEmit[] = "lgc.ngg.GS.emit";

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -74,10 +74,8 @@ enum NggLdsRegionType {
   //
   LdsRegionEsGsRing,            // ES-GS ring
   LdsRegionOutPrimData,         // GS output primitive data
-  LdsRegionOutVertCountInWaves, // GS output vertex count accumulated per wave (8 potential waves) and per
-                                //   sub-group for each stream (4 GS streams)
-  LdsRegionOutVertOffset,       // GS output vertex (exported vertex data) offset in GS-VS ring
-                                //   (overlapped with the region of exported primitive data, LDS reused)
+  LdsRegionOutVertCountInWaves, // GS output vertex count accumulated per wave (8 potential waves) and per sub-group
+  LdsRegionOutVertThreadIdMap,  // GS output vertex thread ID map (compacted -> uncompacted)
   LdsRegionGsVsRing,            // GS-VS ring
 
   LdsRegionGsBeginRange = LdsRegionEsGsRing,


### PR DESCRIPTION
The processing is something like this:

 ```
NGG_GS() {
   Initialize thread/wave info

   if (threadIdInWave < vertCountInWave)
     Run ES

   if (threadIdInSubgroup < primCountInSubgroup)
     Initialize primitive connectivity data (0x80000000)
   if (threadIdInSubgroup < maxVertOutInSubgroup)
     Initialize draw flags of output vertices
   if (threadIdInSubgroup < waveCount + 1)
     Initialize per-wave and per-subgroup count of output vertices
   Barrier

   if (threadIdInWave < primCountInWave)
     Run GS
   Barrier

   if (culling && threadIdInSubgroup < primCountInSubgroup)
     Do culling and reset draw flags of output vertices
   Barrier

   if (threadIdInSubgroup < maxVertOutInSubgroup)
     Read draw flags of output vertices and compute draw mask

   if (threadIdInWave < waveCount - waveId)
     Accumulate per-wave and per-subgroup count of output vertices
   Barrier
   Read per-subgroup count of output vertices

   if (threadIdInSubgroup < maxVertOutInSubgroup &&
       vertex compaction && vertex is drawed)
     Setup vertex thread ID map (uncompacted -> compacted)
     Setup vertex thread ID reverse map (compacted -> uncompacted)

   if (waveId == 0)
     NGG allocation request (GS_ALLOC_REQ)
   Barrier

   if (threadIdInSubgroup < primCountInSubgroup)
     Do primitive connectivity data export

   if (threadIdInSubgroup < vertCountInSubgroup)
     Run copy shader
 }
```

The major differences compared with original one are:

1. Create three LDS regions to store draw flags of output vertices, vertex ID
   mapping (uncompacted -> compacted, compacted -> uncompacted). This is to
   simplify vertex compaction even if culling isn't enabled. Note that
   different GS primitive threads can emit different numbers of vertices (see
   the case VK.geometry.basic.output_10_and_100). Thus, vertex compaction is
   still needed. Original design avoids vertex ID mapping by using subgroup
   inclusive add. This will inevitably introduce two loops in later phases to
   correct vertex ID for primitive export and calculate vertex attribute data
   offset for vertex export.

2. Simplify GS mutation. With new design, GS doesn't return any info
   (originally GS return output vertex/primitive count info) and we don't have
   to mutate GS by cloning a new function. Function cloning is time-consuming.

3. Redesign the GS-VS ring layout. GS-VS ring is managed by shader and
   hareware for legacy pipeline. For NGG, the ring is fully controlled by
   shader. Original layout is unable to directly fetch vertex attribute data
   in copy shader by vertex thread ID in multi-stream cases. This needs
   additional vertex attribute offset calculation in a loop. We now group all
   vertices of the same stream.

The new layout is something like this (shader takes over it):

```
  +----------+----+----------+----+----------+----+----------+
  | Vertex 0 | .. | Vertex N | .. | Vertex 0 | .. | Vertex N |
  +----------+----+----------+----+----------+----+----------+
  |<------ Primitive 0 ----->| .. |<------ Primitive M ----->|
  |<----------------------- Stream i ----------------------->|

  +----------+----------+----------+----------+
  | Stream 0 | Stream 1 | Stream 2 | Stream 3 |
  +----------+----------+----------+----------+
  |<--------------- GS-VS ring -------------->|

  (M = prims_per_subgroup, N = max_vertices)
```

By contrast, GS-VS ring layout of non-NGG is something like this (conform to
hardware design):

```
  +----------+----+----------+----+----------+----+----------+
  | Vertex 0 | .. | Vertex N | .. | Vertex 0 | .. | Vertex N |
  +----------+----+----------+----+----------+----+----------+
  |<-------- Stream 0 ------>| .. |<-------- Stream 3 ------>|
  |<---------------------- Primitive i --------------------->|

  +-------------+----+-------------+
  | Primitive 0 | .. | Primitive M |
  +-------------+----+-------------+
  |<--------- GS-VS ring --------->|

  (M = prims_per_subgroup, N = max_vertices)
```

4. Primitive connectivity data are initialized to 0x80000000 before GS
   execution. However, the initialization is based on GS threads in wave. In
   the case dEQP-VK.geometry.basic.output_128, this will add many LDS write
   instructions (ds_write2_b32) for each output primitive. Rather, we can use
   the threads of output primitive to do this. This is the same case for
   output vertex draw flags and output vertex count per wavs.

5. The case dEQP-VK.geometry.layered.1d_array.render_different_content
   introduce oustanding vertices with this sequence 0 -> 1 -> CUT -> 2 ->
   3 -> 4 -> 5 for triangle_strip. Original design had additional processing
   to handle vertex 0 and 1. With the introduction of draw flags, we can now
   easily identify such vertices and needn't special processing in GS_EMIT
   and GS_CUT.

Change-Id: I5b52834e7d715f129532ad32c90090b42087fd92