### PR TITLE
Remove waTessIncorrectRelativeIndex workaround

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1032,9 +1032,6 @@ void ConfigBuilder::buildVsRegConfig(ShaderStage shaderStage, T *pConfig) {
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
   }
 
-  if (m_pipelineState->getTargetInfo().getGpuWorkarounds().gfx10.waTessIncorrectRelativeIndex)
-    disableVertexReuse = true;
-
   SET_REG_FIELD(&pConfig->vsRegs, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
 
   useLayer = useLayer || m_pipelineState->getInputAssemblyState().enableMultiView;


### PR DESCRIPTION
This workaround is mishandled here, which will disable vertex reuse.
The result is that VS waves may be doubled.
And there is already code which does similar but better job in driver.