### PR TITLE
Iterate over users of functions instead of visiting the whole module

### DIFF
--- a/llpc/lower/llpcSpirvLowerInstMetaRemove.h
+++ b/llpc/lower/llpcSpirvLowerInstMetaRemove.h
@@ -31,18 +31,16 @@
 #pragma once
 
 #include "llpcSpirvLower.h"
-#include "llvm/IR/InstVisitor.h"
 
 namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for removing the instruction metadata.
-class SpirvLowerInstMetaRemove : public SpirvLower, public llvm::InstVisitor<SpirvLowerInstMetaRemove> {
+class SpirvLowerInstMetaRemove : public SpirvLower {
 public:
   SpirvLowerInstMetaRemove();
 
   virtual bool runOnModule(llvm::Module &module);
-  virtual void visitCallInst(llvm::CallInst &callInst);
 
   // -----------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This should make the LowerInstMetaRemove pass more efficient, especially
when the module is large or when there aren't many calls to remove.