### PR TITLE
Reorganize the contents of doCulling()

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -147,6 +147,9 @@ private:
   llvm::Value *doDppUpdate(llvm::Value *oldValue, llvm::Value *srcValue, unsigned dppCtrl, unsigned rowMask,
                            unsigned bankMask, bool boundCtrl = false);
 
+  llvm::Value *fetchVertexPositionData(llvm::Value *vertexId);
+  llvm::Value *fetchCullDistanceSignMask(llvm::Value *vertexId);
+
   // Checks if NGG culling operations are enabled
   bool enableCulling() const {
     return m_nggControl->enableBackfaceCulling || m_nggControl->enableFrustumCulling ||
@@ -155,8 +158,6 @@ private:
   }
 
   llvm::BasicBlock *createBlock(llvm::Function *parent, const llvm::Twine &blockName = "");
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   static const unsigned NullPrim = (1u << 31); // Null primitive data (invalid)
 


### PR DESCRIPTION
Add two helpers to encapsulate the operations of fetching vertex position data
and cull distance sign mask: fetchVertexPositionData() and
fetchCullDistanceSignMask(). The motivation of doing this is to support future
NGG GS culling. The whole processing of doCulling() could be totally shared.

Change-Id: I4a6aefc5b2547ad82c5afadce3df892b69f0f643