### PR TITLE
Renamed BuilderBase::createNamedCall -> CreateNamedCall

### DIFF
--- a/lgc/builder/BuilderBase.cpp
+++ b/lgc/builder/BuilderBase.cpp
@@ -42,8 +42,9 @@ using namespace llvm;
 // @param retTy : Return type of the callee
 // @param args : Arguments to pass to the callee
 // @param attribs : Function attributes
-CallInst *BuilderBase::createNamedCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args,
-                                       ArrayRef<Attribute::AttrKind> attribs) {
+// @param instName : Name to give instruction
+CallInst *BuilderBase::CreateNamedCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args,
+                                       ArrayRef<Attribute::AttrKind> attribs, const Twine &instName) {
   Module *module = GetInsertBlock()->getParent()->getParent();
   Function *func = dyn_cast_or_null<Function>(module->getFunction(funcName));
   if (!func) {
@@ -62,7 +63,7 @@ CallInst *BuilderBase::createNamedCall(StringRef funcName, Type *retTy, ArrayRef
       func->addFnAttr(attrib);
   }
 
-  auto call = CreateCall(func, args);
+  auto call = CreateCall(func, args, instName);
   call->setCallingConv(CallingConv::C);
   call->setAttributes(func->getAttributes());
 

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -114,7 +114,7 @@ Value *DescBuilder::CreateLoadDescFromPtr(Value *descPtr, const Twine &instName)
   // Use llpc.descriptor.load.from.ptr.
   std::string name = lgcName::DescriptorLoadFromPtr;
   addTypeMangling(descPtr->getType(), {}, name);
-  auto desc = createNamedCall(name, cast<StructType>(descPtr->getType())->getElementType(0)->getPointerElementType(),
+  auto desc = CreateNamedCall(name, cast<StructType>(descPtr->getType())->getElementType(0)->getPointerElementType(),
                               descPtr, {});
   desc->setName(instName);
   return desc;
@@ -215,7 +215,7 @@ Value *DescBuilder::CreateLoadPushConstantsPtr(Type *pushConstantsTy, const Twin
   // generate the code directly.
   std::string callName = lgcName::DescriptorLoadSpillTable;
   addTypeMangling(pushConstantsPtrTy, {}, callName);
-  auto pushConstantsLoadCall = createNamedCall(callName, pushConstantsPtrTy, {}, {});
+  auto pushConstantsLoadCall = CreateNamedCall(callName, pushConstantsPtrTy, {}, {});
   pushConstantsLoadCall->setName(instName);
   return pushConstantsLoadCall;
 }

--- a/lgc/interface/lgc/BuilderBase.h
+++ b/lgc/interface/lgc/BuilderBase.h
@@ -53,8 +53,9 @@ public:
   // @param retTy : Return type of the callee
   // @param args : Arguments to pass to the callee
   // @param attribs : Function attributes
-  llvm::CallInst *createNamedCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
-                                  llvm::ArrayRef<llvm::Attribute::AttrKind> attribs);
+  // @param instName : Name to give instruction
+  llvm::CallInst *CreateNamedCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
+                                  llvm::ArrayRef<llvm::Attribute::AttrKind> attribs, const llvm::Twine &instName = "");
 
   // Emits a amdgcn.reloc.constant intrinsic that represents an i32 relocatable value with the given symbol name
   //

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -451,7 +451,7 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
     // real instructions when when NGG primitive shader is generated.
     std::string callName(lgcName::NggGsOutputImport);
     callName += getTypeName(loadTy);
-    return builder.createNamedCall(callName, loadTy,
+    return builder.CreateNamedCall(callName, loadTy,
                                    {builder.getInt32(location), builder.getInt32(0), builder.getInt32(streamId)}, {});
   }
 
@@ -576,7 +576,7 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
 
       std::string instName(lgcName::OutputExportXfb);
       addTypeMangling(nullptr, args, instName);
-      builder.createNamedCall(instName, builder.getVoidTy(), args, {});
+      builder.CreateNamedCall(instName, builder.getVoidTy(), args, {});
     }
   }
 
@@ -587,7 +587,7 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
     std::string instName(lgcName::OutputExportGeneric);
     instName += getTypeName(outputTy);
 
-    builder.createNamedCall(instName, builder.getVoidTy(), {builder.getInt32(location), outputValue}, {});
+    builder.CreateNamedCall(instName, builder.getVoidTy(), {builder.getInt32(location), outputValue}, {});
   }
 }
 
@@ -617,7 +617,7 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
       Value *args[] = {builder.getInt32(xfbOutInfo->xfbBuffer), builder.getInt32(xfbOutInfo->xfbOffset),
                        builder.getInt32(0), outputValue};
       addTypeMangling(nullptr, args, instName);
-      builder.createNamedCall(instName, builder.getVoidTy(), args, {});
+      builder.CreateNamedCall(instName, builder.getVoidTy(), args, {});
     }
   }
 
@@ -626,7 +626,7 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
     callName += PipelineState::getBuiltInName(builtInId);
     Value *args[] = {builder.getInt32(builtInId), outputValue};
     addTypeMangling(nullptr, args, callName);
-    builder.createNamedCall(callName, builder.getVoidTy(), args, {});
+    builder.CreateNamedCall(callName, builder.getVoidTy(), args, {});
   }
 }
 

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2710,7 +2710,7 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
     std::string callName(lgcName::OutputExportGeneric);
     addTypeMangling(builder.getVoidTy(), args, callName);
 
-    builder.createNamedCall(callName, builder.getVoidTy(), args, {});
+    builder.CreateNamedCall(callName, builder.getVoidTy(), args, {});
 
     outputLocMap[consectiveLocation] = InvalidValue;
     ++consectiveLocation;
@@ -2789,7 +2789,7 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
     for (unsigned i = 0; i != 2; ++i) {
       args[elemIdxArgIdx] = builder.getInt32(elemIdx * 2 + i);
       result = builder.CreateInsertElement(
-          result, builder.createNamedCall(callName, builder.getInt32Ty(), args, Attribute::ReadOnly), i);
+          result, builder.CreateNamedCall(callName, builder.getInt32Ty(), args, Attribute::ReadOnly), i);
     }
     result = builder.CreateBitCast(result, call->getType());
     call->replaceAllUsesWith(result);
@@ -2847,7 +2847,7 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
       continue; // Omit trivially unused element
     args[elemIdxArgIdx] = builder.getInt32(elemIdx + i);
 
-    CallInst *element = builder.createNamedCall(callName, elementTy, args, Attribute::ReadOnly);
+    CallInst *element = builder.CreateNamedCall(callName, elementTy, args, Attribute::ReadOnly);
     result = builder.CreateInsertElement(result, element, i);
     if (elementTy->getPrimitiveSizeInBits() == 64) {
       // If scalarizing with 64 bit elements, further split each element.
@@ -2905,7 +2905,7 @@ void PatchResourceCollect::scalarizeGenericOutput(CallInst *call) {
       callName = lgcName::OutputExportGeneric;
       addTypeMangling(nullptr, args, callName);
     }
-    builder.createNamedCall(callName, builder.getVoidTy(), args, {});
+    builder.CreateNamedCall(callName, builder.getVoidTy(), args, {});
   }
 
   call->eraseFromParent();

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -633,7 +633,7 @@ Instruction *ShaderSystemValues::loadDescFromDriverTable(unsigned tableOffset, B
       builder.getInt32(tableOffset),
       builder.getInt32(0),
   };
-  return builder.createNamedCall(lgcName::DescriptorLoadBuffer, VectorType::get(Type::getInt32Ty(*m_context), 4), args,
+  return builder.CreateNamedCall(lgcName::DescriptorLoadBuffer, VectorType::get(Type::getInt32Ty(*m_context), 4), args,
                                  {});
 }
 

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -62,7 +62,7 @@ namespace lgc {
 CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, ArrayRef<Attribute::AttrKind> attribs,
                    Instruction *insertPos) {
   BuilderBase builder(insertPos);
-  return builder.createNamedCall(funcName, retTy, args, attribs);
+  return builder.CreateNamedCall(funcName, retTy, args, attribs);
 }
 
 // =====================================================================================================================
@@ -79,7 +79,7 @@ CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, Arra
 CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, ArrayRef<Attribute::AttrKind> attribs,
                    BasicBlock *insertAtEnd) {
   BuilderBase builder(insertAtEnd);
-  return builder.createNamedCall(funcName, retTy, args, attribs);
+  return builder.CreateNamedCall(funcName, retTy, args, attribs);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Unlike other methods, Builder methods named Create* are supposed to be
in CamelCase not camelBack, for consistency with IRBuilder. In the
recent identifier naming change, CreateNamedCall accidentally got
changed to createNamedCall. This commit changes it back again.

Also added an instName arg like the other Create* methods.

Change-Id: I06d4fb153dfc6509bc1e9bd89c84ec6be765d188