### PR TITLE
Allow for different Clang versions

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -88,7 +88,7 @@ function(lgc_set_compiler_options PROJECT_NAME)
                     -Wno-class-memaccess
                 )
             endif()
-        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
             target_compile_options("${PROJECT_NAME}" PRIVATE
                 -Wno-covered-switch-default
                 -Wno-extra-semi

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -95,7 +95,7 @@ function(llpc_set_compiler_options PROJECT_NAME)
                     -Wno-format-truncation
                 )
             endif()
-        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
             target_compile_options("${PROJECT_NAME}" PRIVATE
                 -Wno-covered-switch-default
                 -Wno-extra-semi


### PR DESCRIPTION
The recent "Cleanup compiler options" change broke detection of some
versions of Clang where the ID is "SomethingClang" rather than just
"Clang". Fixed.

Change-Id: I3ab85e8b13965f41020aa2ca8c967154f75f9115