### PR TITLE
Don't assert on ViewIndex in TES

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1276,6 +1276,8 @@ unsigned InOutBuilder::getBuiltInValidMask(BuiltInKind builtIn, bool isOutput) {
                (1 << ShaderStageGeometry) | (1 << ShaderStageFragment) | (1 << ShaderStageCompute),
     V = (1 << ShaderStageVertex),
     VDG = (1 << ShaderStageVertex) | (1 << ShaderStageTessEval) | (1 << ShaderStageGeometry),
+    VHDGP = (1 << ShaderStageVertex) | (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) |
+            (1 << ShaderStageGeometry) | (1 << ShaderStageFragment),
   };
 
   unsigned validMask = 0;

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -102,7 +102,7 @@ BUILTIN(TessCoord, 13, N, D, v3f32)         // (u,v,w) coord of tessellated vert
 BUILTIN(TessLevelInner, 12, H, D, a2f32)    // Tessellation inner levels
 BUILTIN(TessLevelOuter, 11, H, D, a4f32)    // Tessellation outer levels
 BUILTIN(VertexIndex, 42, N, V, i32)         // Index of current vertex
-BUILTIN(ViewIndex, 4440, N, P, i32)         // View index
+BUILTIN(ViewIndex, 4440, N, VHDGP, i32)     // View index
 BUILTIN(ViewportIndex, 10, MVDG, P, i32)    // Viewport index
 BUILTIN(WorkgroupId, 26, N, TMC, v3i32)     // ID of global workgroup
 BUILTIN(WorkgroupSize, 25, N, C, v3i32)     // Size of global workgroup


### PR DESCRIPTION
ViewIndex appears to be valid in a TES, and is used by conformance tests
including dEQP-VK.multiview.index.tesellation_shader.15. Don't assert on
it.

Change-Id: I032efdad6e5b25db7f838c96a53441919ab42559