### PR TITLE
Improved interface for building "unlinked" ELF

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -625,6 +625,7 @@ struct GraphicsPipelineBuildInfo {
 
   NggState nggState;       ///< NGG state used for tuning and debugging
   PipelineOptions options; ///< Per pipeline tuning/debugging options
+  bool unlinked;           ///< True to build an "unlinked" half-pipeline ELF
 };
 
 /// Represents info to build a compute pipeline.
@@ -638,6 +639,7 @@ struct ComputePipelineBuildInfo {
   unsigned deviceIndex;    ///< Device index for device group
   PipelineShaderInfo cs;   ///< Compute shader
   PipelineOptions options; ///< Per pipeline tuning options
+  bool unlinked;           ///< True to build an "unlinked" half-pipeline ELF
 };
 
 // =====================================================================================================================

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -306,7 +306,7 @@ void InOutBuilder::markGenericInputOutputUsage(bool isOutput, unsigned location,
 
   if (!isOutput || m_shaderStage != ShaderStageGeometry) {
     bool keepAllLocations = false;
-    if (getLgcContext()->buildingRelocatableElf()) {
+    if (getPipelineState()->isUnlinked()) {
       if (m_shaderStage == ShaderStageVertex && isOutput)
         keepAllLocations = true;
       if (m_shaderStage == ShaderStageFragment && !isOutput)

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -153,7 +153,7 @@ public:
                         const RasterizerState &rsState) override final;
 
   // Link the individual shader IR modules into a single pipeline module
-  llvm::Module *irLink(llvm::ArrayRef<std::pair<llvm::Module *, ShaderStage>> modules) override final;
+  llvm::Module *irLink(llvm::ArrayRef<std::pair<llvm::Module *, ShaderStage>> modules, bool unlinked) override final;
 
   // Generate pipeline module
   void generate(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
@@ -172,6 +172,9 @@ public:
   // Accessors for context information
   const TargetInfo &getTargetInfo() const;
   unsigned getPalAbiVersion() const;
+
+  // Return the "unlinked" flag, true if generating an unlinked half-pipeline ELF.
+  bool isUnlinked() const { return m_unlinked; }
 
   // Clear the pipeline state IR metadata.
   void clear(llvm::Module *module);
@@ -370,6 +373,7 @@ private:
   // -----------------------------------------------------------------------------------------------------------------
   bool m_noReplayer = false;                            // True if no BuilderReplayer needed
   bool m_emitLgc = false;                               // Whether -emit-lgc is on
+  bool m_unlinked = false;                              // Whether generating an unlinked half-pipeline ELF
   unsigned m_stageMask = 0;                             // Mask of active shader stages
   Options m_options = {};                               // Per-pipeline options
   std::vector<ShaderOptions> m_shaderOptions;           // Per-shader options

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -106,9 +106,6 @@ public:
   // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
   void addTargetPasses(lgc::PassManager &passMgr, llvm::Timer *codeGenTimer, llvm::raw_pwrite_stream &outStream);
 
-  void setBuildRelocatableElf(bool buildRelocatableElf) { m_buildRelocatableElf = buildRelocatableElf; }
-  bool buildingRelocatableElf() { return m_buildRelocatableElf; }
-
   // Utility method to create a start/stop timer pass
   static llvm::ModulePass *createStartStopTimer(llvm::Timer *timer, bool starting);
 
@@ -132,7 +129,6 @@ private:
   llvm::LLVMContext &m_context;                   // LLVM context
   llvm::TargetMachine *m_targetMachine = nullptr; // Target machine
   TargetInfo *m_targetInfo = nullptr;             // Target info
-  bool m_buildRelocatableElf = false;             // Flag indicating whether we are building relocatable ELF
   unsigned m_palAbiVersion = 0xFFFFFFFF;          // PAL pipeline ABI version to compile for
 };
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -561,7 +561,13 @@ public:
   // Returns the pipeline module, or nullptr on link failure.
   //
   // @param modules : Array of {module, shaderStage} pairs
-  virtual llvm::Module *irLink(llvm::ArrayRef<std::pair<llvm::Module *, ShaderStage>> modules) = 0;
+  // @param unlinked : True if generating an "unlinked" half-pipeline ELF that then needs further linking to
+  //                   generate a pipeline ELF. In that case, using the methods above to set pipeline state items
+  //                   (setUserDataNodes, setDeviceIndex, setVertexInputDescriptions, setColorExportState,
+  //                   setGraphicsState) becomes optional, as LGC will generate relocs or user data entries
+  //                   that are fixed up in the ELF link step.
+  //                   TODO: That isn't implemented yet.
+  virtual llvm::Module *irLink(llvm::ArrayRef<std::pair<llvm::Module *, ShaderStage>> modules, bool unlinked) = 0;
 
   // Typedef of function passed in to Generate to check the shader cache.
   // Returns the updated shader stage mask, allowing the client to decide not to compile shader stages

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -1008,6 +1008,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   for (unsigned i = 0; i < interpInfo->size(); ++i) {
     const auto &interpInfoElem = (*interpInfo)[i];
+    if (m_pipelineState->isUnlinked() && interpInfoElem.loc == InvalidFsInterpInfo.loc)
+      continue;
     assert((interpInfoElem.loc == InvalidFsInterpInfo.loc && interpInfoElem.flat == InvalidFsInterpInfo.flat &&
             interpInfoElem.custom == InvalidFsInterpInfo.custom &&
             interpInfoElem.is16bit == InvalidFsInterpInfo.is16bit) == false);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1963,6 +1963,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   for (unsigned i = 0; i < interpInfo->size(); ++i) {
     auto interpInfoElem = (*interpInfo)[i];
+    if (m_pipelineState->isUnlinked() && interpInfoElem.loc == InvalidFsInterpInfo.loc)
+      continue;
     if ((interpInfoElem.loc == InvalidFsInterpInfo.loc && interpInfoElem.flat == InvalidFsInterpInfo.flat &&
          interpInfoElem.custom == InvalidFsInterpInfo.custom && interpInfoElem.is16bit == InvalidFsInterpInfo.is16bit))
       interpInfoElem.loc = i;

--- a/lgc/patch/PatchDescriptorLoad.cpp
+++ b/lgc/patch/PatchDescriptorLoad.cpp
@@ -200,7 +200,7 @@ Value *PatchDescriptorLoad::getDescPtrAndStride(ResourceNodeType resType, unsign
 
   if (!stride) {
     // Stride is not determinable just from the descriptor type requested by the Builder call.
-    if (m_pipelineState->getLgcContext()->buildingRelocatableElf()) {
+    if (m_pipelineState->isUnlinked()) {
       // Shader compilation: Get byte stride using a reloc.
       stride = builder.CreateRelocationConstant("dstride_" + Twine(descSet) + "_" + Twine(binding));
     } else {
@@ -292,7 +292,7 @@ Value *PatchDescriptorLoad::getDescPtr(ResourceNodeType resType, unsigned descSe
 
   // Add on the byte offset of the descriptor.
   Value *offset = nullptr;
-  bool useRelocationForOffsets = !node || m_pipelineState->getLgcContext()->buildingRelocatableElf();
+  bool useRelocationForOffsets = !node || m_pipelineState->isUnlinked();
   if (useRelocationForOffsets) {
     // Get the offset for the descriptor using a reloc. The reloc symbol name
     // needs to contain the descriptor set and binding, and, for image, fmask or sampler, whether it is

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1253,8 +1253,8 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
       }
     }
 
-    if (m_pipelineState->getLgcContext()->buildingRelocatableElf()) {
-      // If we are building relocatable shaders, it is possible there are
+    if (m_pipelineState->isUnlinked()) {
+      // If we are building unlinked relocatable shaders, it is possible there are
       // generic outputs that are not written to.  We need to count them in
       // the export count.
       auto resUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage);
@@ -2424,7 +2424,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
   }
   // Handle internal-use built-ins for sample position emulation
   case BuiltInNumSamples: {
-    if (m_pipelineState->getLgcContext()->buildingRelocatableElf()) {
+    if (m_pipelineState->isUnlinked()) {
       input = builder.CreateRelocationConstant("$numSamples");
     } else {
       input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getRasterizerState().numSamples);
@@ -2432,7 +2432,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
     break;
   }
   case BuiltInSamplePatternIdx: {
-    if (m_pipelineState->getLgcContext()->buildingRelocatableElf()) {
+    if (m_pipelineState->isUnlinked()) {
       input = builder.CreateRelocationConstant("$samplePatternIdx");
     } else {
       input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getRasterizerState().samplePatternIdx);
@@ -5745,7 +5745,7 @@ Value *PatchInOutImportExport::getInLocalInvocationId(Instruction *insertPos) {
 //
 // @param insertPos : Where to insert instructions.
 Value *PatchInOutImportExport::getDeviceIndex(Instruction *insertPos) {
-  if (m_pipelineState->getLgcContext()->buildingRelocatableElf()) {
+  if (m_pipelineState->isUnlinked()) {
     BuilderBase builder(*m_context);
     builder.SetInsertPoint(insertPos);
     return builder.CreateRelocationConstant("$deviceIdx");

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -44,18 +44,6 @@
 using namespace lgc;
 using namespace llvm;
 
-namespace llvm {
-
-namespace cl {
-
-// -disable-null-frag-shader: disable to generate null fragment shader
-opt<bool> DisableNullFragShader("disable-null-frag-shader", cl::desc("Disable to add a null fragment shader"),
-                                cl::init(false));
-
-} // namespace cl
-
-} // namespace llvm
-
 namespace lgc {
 
 // =====================================================================================================================
@@ -97,11 +85,9 @@ bool PatchNullFragShader::runOnModule(llvm::Module &module) {
 
   PipelineState *pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
 
-  if (cl::DisableNullFragShader || pipelineState->getLgcContext()->buildingRelocatableElf()) {
-    // NOTE: If the option -disable-null-frag-shader is set to TRUE, we skip this pass. This is done by
-    // standalone compiler.
+  // Do not add a null fragment shader if generating an unlinked half-pipeline ELF.
+  if (pipelineState->isUnlinked())
     return false;
-  }
 
   const bool hasCs = pipelineState->hasShaderStage(ShaderStageCompute);
   const bool hasVs = pipelineState->hasShaderStage(ShaderStageVertex);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1258,10 +1258,9 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
 // =====================================================================================================================
 // Clears inactive (those actually unused) inputs.
 void PatchResourceCollect::clearInactiveInput() {
-  bool buildingRelocatableElf = m_pipelineState->getLgcContext()->buildingRelocatableElf();
   // Clear those inactive generic inputs, remove them from location mappings
   if (m_pipelineState->isGraphics() && !m_hasDynIndexedInput && m_shaderStage != ShaderStageTessEval &&
-      !buildingRelocatableElf) {
+      !m_pipelineState->isUnlinked()) {
     // TODO: Here, we keep all generic inputs of tessellation evaluation shader. This is because corresponding
     // generic outputs of tessellation control shader might involve in output import and dynamic indexing, which
     // is easy to cause incorrectness of location mapping.
@@ -1559,7 +1558,7 @@ void PatchResourceCollect::matchGenericInOut() {
   auto &perPatchOutLocMap = inOutUsage.perPatchOutputLocMap;
 
   // Do input/output matching
-  if (!m_pipelineState->getLgcContext()->buildingRelocatableElf() && m_shaderStage != ShaderStageFragment) {
+  if (!m_pipelineState->isUnlinked() && m_shaderStage != ShaderStageFragment) {
     const auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
 
     // Do normal input/output matching
@@ -1644,7 +1643,7 @@ void PatchResourceCollect::matchGenericInOut() {
   if (!inLocMap.empty()) {
     assert(inOutUsage.inputMapLocCount == 0);
     for (auto &locMap : inLocMap) {
-      assert(locMap.second == InvalidValue || m_pipelineState->getLgcContext()->buildingRelocatableElf());
+      assert(locMap.second == InvalidValue || m_pipelineState->isUnlinked());
       // NOTE: For vertex shader, the input location mapping is actually trivial.
       locMap.second = m_shaderStage == ShaderStageVertex ? locMap.first : nextMapLoc++;
       inOutUsage.inputMapLocCount = std::max(inOutUsage.inputMapLocCount, locMap.second + 1);

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -53,7 +53,10 @@ ModulePass *createBuilderReplayer(Pipeline *pipeline);
 // Link shader IR modules into a pipeline module.
 //
 // @param modules : Array of {module, shaderStage} pairs. Modules are freed
-Module *PipelineState::irLink(ArrayRef<std::pair<Module *, ShaderStage>> modules) {
+// @param unlinked : True if generating an "unlinked" half-pipeline ELF that then needs further linking to
+//                   generate a pipeline ELF
+Module *PipelineState::irLink(ArrayRef<std::pair<Module *, ShaderStage>> modules, bool unlinked) {
+  m_unlinked = unlinked;
   // Processing for each shader module before linking.
   IRBuilder<> builder(getContext());
   for (auto moduleAndStage : modules) {

--- a/llpc/context/llpcComputeContext.cpp
+++ b/llpc/context/llpcComputeContext.cpp
@@ -47,6 +47,7 @@ namespace Llpc {
 ComputeContext::ComputeContext(GfxIpVersion gfxIp, const ComputePipelineBuildInfo *pipelineInfo,
                                MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash)
     : PipelineContext(gfxIp, pipelineHash, cacheHash), m_pipelineInfo(pipelineInfo) {
+  setUnlinked(pipelineInfo->unlinked);
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -51,6 +51,7 @@ GraphicsContext::GraphicsContext(GfxIpVersion gfxIp, const GraphicsPipelineBuild
                                  MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash)
     : PipelineContext(gfxIp, pipelineHash, cacheHash), m_pipelineInfo(pipelineInfo), m_stageMask(0),
       m_activeStageCount(0), m_gsOnChip(false) {
+  setUnlinked(pipelineInfo->unlinked);
   const PipelineShaderInfo *shaderInfo[ShaderStageGfxCount] = {
       &pipelineInfo->vs, &pipelineInfo->tcs, &pipelineInfo->tes, &pipelineInfo->gs, &pipelineInfo->fs,
   };

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -142,6 +142,12 @@ public:
   // VkFormat is not supported.
   static std::pair<lgc::BufDataFormat, lgc::BufNumFormat> mapVkFormat(VkFormat format, bool isColorExport);
 
+  // Set whether we are building a relocatable (unlinked) ElF
+  void setUnlinked(bool unlinked) { m_unlinked = unlinked; }
+
+  // Get whether we are building a relocatable (unlinked) ElF
+  bool isUnlinked() const { return m_unlinked; }
+
 protected:
   // Gets dummy vertex input create info
   virtual VkPipelineVertexInputStateCreateInfo *getDummyVertexInputInfo() { return nullptr; }
@@ -187,6 +193,7 @@ private:
   // -----------------------------------------------------------------------------------------------------------------
 
   ShaderFpMode m_shaderFpModes[ShaderStageCountInternal] = {};
+  bool m_unlinked = false; // Whether we are building an "unlinked" half-pipeline ELF
 };
 
 } // namespace Llpc


### PR DESCRIPTION
The front-end LLPC interface now has an "unlinked" flag in
GraphicsPipelineBuildInfo and ComputePipelineBuildInfo, so that amdllpc
can set it for a non-pipeline compile, and also set it for a pipeline
compile where the new -unlinked option is specified.

(I did not bump the LLPC version for this interface change, as it does
not break compatibility between old driver and new LLPC.)

Inside the front-end, there is a new "unlinked" flag in PipelineContext.
As well as being set by the above, it is set by
buildPipelineWithRelocatableElf.

The front-end signals to LGC that it wants an "unlinked" half-pipeline
ELF via a new flag arg in Pipeline::irLink.

That flag is stored in PipelineState, replacing the flag in LgcContext.
It is also serialized from there, which means you can write an LGC lit
test with it set.

An unlinked ELF does not have a null fragment shader added, so all of
the above subsumes the --disable-null-frag-shader option previously used
to stop a null fragment shader being added for a single shader compile
from amdllpc.

Change-Id: I6369fdaeee0fffe909a7e1ba9c514982e086791c