### PR TITLE
Set PAL metadata user data entries directly from PatchEntryPointMutate

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -220,6 +220,7 @@ target_sources(LLVMlgc PRIVATE
 target_sources(LLVMlgc PRIVATE
     state/Compiler.cpp
     state/LgcContext.cpp
+    state/PalMetadata.cpp
     state/PipelineShaders.cpp
     state/PipelineState.cpp
     state/ResourceUsage.cpp

--- a/lgc/include/lgc/state/Abi.h
+++ b/lgc/include/lgc/state/Abi.h
@@ -26,6 +26,9 @@
  ***********************************************************************************************************************
  * @file  Abi.h
  * @brief LLPC header file: contains declarations for parts of PAL pipeline ABI
+ *
+ * This file contains declarations for the PAL pipeline ABI, other than declarations relating to PAL metadata,
+ * which are in AbiMetadata.h. It is a copy of a subset of palPipelineAbi.h in PAL.
  ***********************************************************************************************************************
  */
 #pragma once

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -26,6 +26,10 @@
  ***********************************************************************************************************************
  * @file  AbiMetadata.h
  * @brief LLPC header file: contains declaration of keys used as PAL ABI metadata
+ *
+ * This file contains declarations for PAL ABI metadata. (Non-metadata PAL ABI declarations are in Abi.h.)
+ * It is a copy of a subset of g_palPipelineAbiMetadata.h in PAL, together with some other PAL metadata
+ * related declarations.
  ***********************************************************************************************************************
  */
 #pragma once
@@ -165,5 +169,9 @@ static const char *const ApiStageNames[] = {".vertex", ".hull", ".domain", ".geo
 
 // The names of hardware shader stages used in PAL metadata, in Util::Abi::HardwareStage order.
 static const char *const HwStageNames[] = {".ls", ".hs", ".es", ".gs", ".vs", ".ps", ".cs"};
+
+// The name of the metadata node containing PAL metadata. This name is part of the interface from LGC into
+// the LLVM AMDGPU back-end when compiling for PAL ABI.
+static const char PalMetadataName[] = "amdgpu.pal.metadata.msgpack";
 
 } // namespace lgc

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -68,7 +68,8 @@ enum class HardwareStage : unsigned {
   Vs,     ///< Hardware VS stage
   Ps,     ///< Hardware PS stage
   Cs,     ///< Hardware CS stage
-  Count
+  Count,
+  Invalid = ~0U
 };
 
 // Used to represent hardware shader stage.
@@ -173,5 +174,25 @@ static const char *const HwStageNames[] = {".ls", ".hs", ".es", ".gs", ".vs", ".
 // The name of the metadata node containing PAL metadata. This name is part of the interface from LGC into
 // the LLVM AMDGPU back-end when compiling for PAL ABI.
 static const char PalMetadataName[] = "amdgpu.pal.metadata.msgpack";
+
+// PAL metadata SPI register numbers for the start of user data.
+//
+// Note on LS/HS confusion:
+// <=GFX8 claims LS registers are from 0x2D4C and HS registers are from 0x2D0C
+// GFX9 claims LS registers are from 0x2D0C, and the LS-HS merged shader uses them
+// GFX10 claims HS registers are from 0x2D0C, and the LS-HS merged shader uses them.
+// So here we call the registers from 0x2D0C "HS" and have the LS-HS merged shader using them, for
+// consistency. That contradicts the GFX9 docs, but has the same effect.
+//
+// First the ones that only apply up to GFX8
+constexpr unsigned int mmSPI_SHADER_USER_DATA_LS_0 = 0x2D4C;
+// Up to GFX9 only
+constexpr unsigned int mmSPI_SHADER_USER_DATA_ES_0 = 0x2CCC; // For GXF9, used for ES-GS merged shader
+// Then the ones that apply to all hardware.
+constexpr unsigned int mmCOMPUTE_USER_DATA_0 = 0x2E40;
+constexpr unsigned int mmSPI_SHADER_USER_DATA_GS_0 = 0x2C8C; // For GFX10, used for ES-GS merged shader and NGG
+constexpr unsigned int mmSPI_SHADER_USER_DATA_HS_0 = 0x2D0C; // For GFX9+, Used for LS-HS merged shader
+constexpr unsigned int mmSPI_SHADER_USER_DATA_PS_0 = 0x2C0C;
+constexpr unsigned int mmSPI_SHADER_USER_DATA_VS_0 = 0x2C4C;
 
 } // namespace lgc

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -1,0 +1,69 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PalMetadata.h
+ * @brief LLPC header file: PalMetadata class for manipulating PAL metadata
+ *
+ * The PalMetadata object can be retrieved using PipelineState::getPalMetadata(), and is used by various parts
+ * of LGC to write information to PAL metadata at the time the information is generated. The PalMetadata object
+ * is carried through the middle-end, and serialized to IR metadata at the end of the middle-end (or at the
+ * point -stop-before etc stops compilation, if earlier).
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+namespace llvm {
+class Module;
+namespace msgpack {
+class Document;
+} // namespace msgpack
+} // namespace llvm
+
+namespace lgc {
+
+// =====================================================================================================================
+// Class for manipulating PAL metadata through LGC
+class PalMetadata {
+public:
+  // Constructors
+  PalMetadata();
+  PalMetadata(llvm::Module *module);
+  PalMetadata(const PalMetadata &) = delete;
+  PalMetadata &operator=(const PalMetadata &) = delete;
+
+  ~PalMetadata();
+
+  // Record the PAL metadata into IR metadata in the specified module.
+  void record(llvm::Module *module);
+
+  // Get the MsgPack document for explicit manipulation. Only ConfigBuilder* uses this.
+  llvm::msgpack::Document *getDocument() { return m_document; }
+
+private:
+  llvm::msgpack::Document *m_document;
+};
+
+} // namespace lgc

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -57,6 +57,7 @@ void initializePipelineStateWrapperPass(PassRegistry &);
 
 namespace lgc {
 
+class PalMetadata;
 class TargetInfo;
 
 llvm::ModulePass *createPipelineStateClearer();
@@ -120,7 +121,7 @@ class PipelineState final : public Pipeline {
 public:
   PipelineState(LgcContext *builderContext, bool emitLgc = false) : Pipeline(builderContext), m_emitLgc(emitLgc) {}
 
-  ~PipelineState() override final {}
+  ~PipelineState() override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Implementations of Pipeline methods exposed to the front-end
@@ -247,6 +248,9 @@ public:
 
   // Gets interface data of the specified shader stage
   InterfaceData *getShaderInterfaceData(ShaderStage shaderStage);
+
+  // Accessor for PAL metadata
+  PalMetadata *getPalMetadata();
 
   // -----------------------------------------------------------------------------------------------------------------
   // Utility methods
@@ -395,6 +399,7 @@ private:
   RasterizerState m_rasterizerState = {};                                      // Rasterizer state
   std::unique_ptr<ResourceUsage> m_resourceUsage[ShaderStageCompute + 1] = {}; // Per-shader ResourceUsage
   std::unique_ptr<InterfaceData> m_interfaceData[ShaderStageCompute + 1] = {}; // Per-shader InterfaceData
+  PalMetadata *m_palMetadata = nullptr;                                        // PAL metadata object
 };
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -448,7 +448,6 @@ struct InterfaceData {
   static const unsigned UserDataUnmapped = InvalidValue;
 
   unsigned userDataCount = 0;                  // User data count
-  unsigned userDataMap[MaxUserDataCount] = {}; // User data map (from SGPR No. to API logical ID)
 
   struct {
     unsigned resNodeIdx = InvalidValue; // Resource node index for push constant
@@ -461,37 +460,11 @@ struct InterfaceData {
 
   // Usage of user data registers for internal-use variables
   struct {
-    union {
-      // Vertex shader
-      struct {
-        unsigned baseVertex;        // Base vertex
-        unsigned baseInstance;      // Base instance
-        unsigned drawIndex;         // Draw index
-        unsigned vbTablePtr;        // Pointer of vertex buffer table
-        unsigned viewIndex;         // View Index
-        unsigned streamOutTablePtr; // Pointer of stream-out buffer table
-        unsigned esGsLdsSize;       // ES -> GS ring LDS size for GS on-chip mode (for GFX9 and NGG)
-      } vs;
-
-      struct {
-        unsigned viewIndex;         // View Index
-        unsigned streamOutTablePtr; // Pointer of stream-out buffer table
-        unsigned esGsLdsSize;       // ES -> GS ring LDS size for GS on-chip mode (for NGG)
-      } tes;
-
-      // Geometry shader
-      struct {
-        unsigned esGsLdsSize;              // ES -> GS ring LDS size for GS on-chip mode (for GFX8 and NGG)
-        unsigned viewIndex;                // View Index
-        unsigned copyShaderEsGsLdsSize;    // ES -> GS ring LDS size (for copy shader)
-        unsigned copyShaderStreamOutTable; // Stream-out table (for copy shader)
-      } gs;
-
-      // Compute shader
-      struct {
-        unsigned numWorkgroupsPtr; // Pointer of NumWorkGroups
-      } cs;
-    };
+    // Geometry shader
+    struct {
+      unsigned copyShaderEsGsLdsSize;    // ES -> GS ring LDS size (for copy shader)
+      unsigned copyShaderStreamOutTable; // Stream-out table (for copy shader)
+    } gs;
 
     unsigned spillTable; // Spill table user data map
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -181,11 +181,12 @@ enum class ResourceNodeType : unsigned {
   DescriptorBuffer,          ///< Generic descriptor: buffer, including uniform buffer and shader storage buffer
   DescriptorTableVaPtr,      ///< Descriptor table VA pointer
   IndirectUserDataVaPtr,     ///< Indirect user data VA pointer
-  PushConst,                 ///< Push constant
+  PushConst,                 ///< Push constant; only a single PushConst in the root table is allowed
   DescriptorBufferCompact,   ///< Compact buffer descriptor, only contains the buffer address
   StreamOutTableVaPtr,       ///< Stream-out buffer table VA pointer
   DescriptorReserved12,
   DescriptorYCbCrSampler, ///< Generic descriptor: YCbCr sampler
+  InlineBuffer,           ///< Inline buffer, with descriptor set and binding
   Count,                  ///< Count of resource mapping node types.
 };
 

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -45,7 +45,7 @@ using namespace llvm;
 // @param [in/out] module : LLVM module
 // @param pipelineState : Pipeline state
 ConfigBuilderBase::ConfigBuilderBase(llvm::Module *module, PipelineState *pipelineState)
-    : m_module(module), m_pipelineState(pipelineState), m_userDataLimit(0), m_spillThreshold(UINT32_MAX) {
+    : m_module(module), m_pipelineState(pipelineState) {
   m_context = &module->getContext();
 
   m_hasVs = m_pipelineState->hasShaderStage(ShaderStageVertex);
@@ -286,18 +286,6 @@ void ConfigBuilderBase::setEsGsLdsSize(unsigned value) {
 }
 
 // =====================================================================================================================
-// Set USER_DATA_LIMIT (called once for the whole pipeline)
-void ConfigBuilderBase::setUserDataLimit() {
-  m_pipelineNode[Util::Abi::PipelineMetadataKey::UserDataLimit] = m_document->getNode(m_userDataLimit);
-}
-
-// =====================================================================================================================
-// Set SPILL_THRESHOLD (called once for the whole pipeline)
-void ConfigBuilderBase::setSpillThreshold() {
-  m_pipelineNode[Util::Abi::PipelineMetadataKey::SpillThreshold] = m_document->getNode(m_spillThreshold);
-}
-
-// =====================================================================================================================
 // Set PIPELINE_HASH (called once for the whole pipeline)
 void ConfigBuilderBase::setPipelineHash() {
   const auto &options = m_pipelineState->getOptions();
@@ -346,8 +334,6 @@ void ConfigBuilderBase::appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config
 // Finish ConfigBuilder processing by writing into the PalMetadata document
 void ConfigBuilderBase::writePalMetadata() {
   // Set whole-pipeline values.
-  setUserDataLimit();
-  setSpillThreshold();
   setPipelineHash();
 
   // Generating MsgPack metadata.

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -30,8 +30,8 @@
  */
 #pragma once
 
-#include "AbiMetadata.h"
 #include "lgc/CommonDefs.h"
+#include "lgc/state/AbiMetadata.h"
 #include "lgc/state/TargetInfo.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 
@@ -122,7 +122,7 @@ private:
   void setPipelineHash();
 
   // -----------------------------------------------------------------------------------------------------------------
-  std::unique_ptr<llvm::msgpack::Document> m_document; // The MsgPack document
+  llvm::msgpack::Document *m_document;                 // The MsgPack document
   llvm::msgpack::MapDocNode m_pipelineNode;            // MsgPack map node for amdpal.pipelines[0]
   llvm::msgpack::MapDocNode m_apiShaderNodes[ShaderStageNativeStageCount];
   // MsgPack map node for each API shader's node in

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -106,18 +106,11 @@ protected:
   bool m_hasTes; // Whether the pipeline has tessellation evaluation shader
   bool m_hasGs;  // Whether the pipeline has geometry shader
 
-  unsigned m_userDataLimit;  // User data limit for shaders seen so far
-  unsigned m_spillThreshold; // Spill threshold for shaders seen so far
-
 private:
   // Get the MsgPack map node for the specified API shader in the ".shaders" map
   llvm::msgpack::MapDocNode getApiShaderNode(unsigned apiStage);
   // Get the MsgPack map node for the specified HW shader in the ".hardware_stages" map
   llvm::msgpack::MapDocNode getHwShaderNode(Util::Abi::HardwareStage hwStage);
-  // Set USER_DATA_LIMIT (called once for the whole pipeline)
-  void setUserDataLimit();
-  // Set SPILL_THRESHOLD (called once for the whole pipeline)
-  void setSpillThreshold();
   // Set PIPELINE_HASH (called once for the whole pipeline)
   void setPipelineHash();
 

--- a/lgc/patch/Gfx6Chip.h
+++ b/lgc/patch/Gfx6Chip.h
@@ -30,8 +30,8 @@
  */
 #pragma once
 
-#include "AbiMetadata.h"
 #include "ConfigBuilderBase.h"
+#include "lgc/state/AbiMetadata.h"
 #include "lgc/state/TargetInfo.h"
 #include <cstdint>
 #include <unordered_map>

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -29,7 +29,6 @@
  ***********************************************************************************************************************
  */
 #include "Gfx6ConfigBuilder.h"
-#include "AbiMetadata.h"
 #include "lgc/BuiltIns.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"

--- a/lgc/patch/Gfx6ConfigBuilder.h
+++ b/lgc/patch/Gfx6ConfigBuilder.h
@@ -73,8 +73,6 @@ private:
 
   void buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *config);
 
-  void buildUserDataConfig(ShaderStage shaderStage, unsigned startUserData);
-
   template <typename T> void setupVgtTfParam(T *config);
 };
 

--- a/lgc/patch/Gfx9Chip.h
+++ b/lgc/patch/Gfx9Chip.h
@@ -30,8 +30,8 @@
  */
 #pragma once
 
-#include "AbiMetadata.h"
 #include "ConfigBuilderBase.h"
+#include "lgc/state/AbiMetadata.h"
 #include "lgc/state/TargetInfo.h"
 #include <cstdint>
 #include <unordered_map>

--- a/lgc/patch/Gfx9ConfigBuilder.h
+++ b/lgc/patch/Gfx9ConfigBuilder.h
@@ -77,8 +77,6 @@ private:
 
   void buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *config);
 
-  void buildUserDataConfig(ShaderStage shaderStage1, ShaderStage shaderStage2, unsigned startUserData);
-
   void setupVgtTfParam(LsHsRegConfig *config);
 
   bool getShaderWgpMode(ShaderStage shaderStage) const;

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -146,7 +146,6 @@ FunctionType *NggPrimShader::generatePrimShaderEntryPointType(uint64_t *inRegMas
       if (m_hasTes) {
         userDataCount = std::max(tesIntfData->userDataCount, userDataCount);
 
-        assert(tesIntfData->userDataUsage.tes.viewIndex == gsIntfData->userDataUsage.gs.viewIndex);
         if (gsIntfData->spillTable.sizeInDwords > 0 && tesIntfData->spillTable.sizeInDwords == 0) {
           tesIntfData->userDataUsage.spillTable = userDataCount;
           ++userDataCount;
@@ -157,7 +156,6 @@ FunctionType *NggPrimShader::generatePrimShaderEntryPointType(uint64_t *inRegMas
       if (m_hasVs) {
         userDataCount = std::max(vsIntfData->userDataCount, userDataCount);
 
-        assert(vsIntfData->userDataUsage.vs.viewIndex == gsIntfData->userDataUsage.gs.viewIndex);
         if (gsIntfData->spillTable.sizeInDwords > 0 && vsIntfData->spillTable.sizeInDwords == 0) {
           vsIntfData->userDataUsage.spillTable = userDataCount;
           ++userDataCount;

--- a/lgc/patch/PatchDescriptorLoad.cpp
+++ b/lgc/patch/PatchDescriptorLoad.cpp
@@ -475,7 +475,7 @@ Value *PatchDescriptorLoad::loadBufferDescriptor(unsigned descSet, unsigned bind
   }
 
   // Normal buffer descriptor load.
-  // Find the descriptor node, either a DescriptorBuffer or PushConst (inline buffer).
+  // Find the descriptor node, either a DescriptorBuffer or InlineBuffer.
   const ResourceNode *topNode = nullptr;
   const ResourceNode *node = nullptr;
   std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::DescriptorBuffer, descSet, binding);
@@ -513,7 +513,7 @@ Value *PatchDescriptorLoad::loadBufferDescriptor(unsigned descSet, unsigned bind
   descPtr = getDescPtr(ResourceNodeType::DescriptorBuffer, descSet, binding, topNode, node,
                        /*shadow=*/false, builder);
 
-  if (node && node->type == ResourceNodeType::PushConst) {
+  if (node && node->type == ResourceNodeType::InlineBuffer) {
     // Inline buffer.
     return buildInlineBufferDesc(descPtr, builder);
   }

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -28,7 +28,6 @@
 * @brief LLPC source file: contains declaration and implementation of class lgc::PatchPreparePipelineAbi.
 ***********************************************************************************************************************
 */
-#include "AbiMetadata.h"
 #include "Gfx6ConfigBuilder.h"
 #include "Gfx9ConfigBuilder.h"
 #include "ShaderMerger.h"

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -32,6 +32,7 @@
 #include "Gfx9ConfigBuilder.h"
 #include "ShaderMerger.h"
 #include "lgc/patch/Patch.h"
+#include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
@@ -129,6 +130,9 @@ bool PatchPreparePipelineAbi::runOnModule(Module &module) {
     setAbiEntryNames(module);
 
     addAbiMetadata(module);
+
+    // TODO Shader compilation: Only do this if doing a whole-pipeline compilation
+    m_pipelineState->getPalMetadata()->finalizePipeline();
   }
 
   return true; // Modified the module.

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -489,7 +489,6 @@ FunctionType *ShaderMerger::generateEsGsEntryPointType(uint64_t *inRegMask) cons
   if (hasTs) {
     if (m_hasTes) {
       const auto tesIntfData = m_pipelineState->getShaderInterfaceData(ShaderStageTessEval);
-      assert(tesIntfData->userDataUsage.tes.viewIndex == intfData->userDataUsage.gs.viewIndex);
       if (intfData->spillTable.sizeInDwords > 0 && tesIntfData->spillTable.sizeInDwords == 0) {
         tesIntfData->userDataUsage.spillTable = userDataCount;
         ++userDataCount;
@@ -499,7 +498,6 @@ FunctionType *ShaderMerger::generateEsGsEntryPointType(uint64_t *inRegMask) cons
   } else {
     if (m_hasVs) {
       const auto vsIntfData = m_pipelineState->getShaderInterfaceData(ShaderStageVertex);
-      assert(vsIntfData->userDataUsage.vs.viewIndex == intfData->userDataUsage.gs.viewIndex);
       if (intfData->spillTable.sizeInDwords > 0 && vsIntfData->spillTable.sizeInDwords == 0) {
         vsIntfData->userDataUsage.spillTable = userDataCount;
         ++userDataCount;

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -1,0 +1,98 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PalMetadata.cpp
+ * @brief LLPC source file: PalMetadata class for manipulating PAL metadata
+ *
+ * The PalMetadata object can be retrieved using PipelineState::getPalMetadata(), and is used by various parts
+ * of LGC to write information to PAL metadata at the time the information is generated. The PalMetadata object
+ * is carried through the middle-end, and serialized to IR metadata at the end of the middle-end (or at the
+ * point -stop-before etc stops compilation, if earlier).
+ ***********************************************************************************************************************
+ */
+#include "lgc/state/PalMetadata.h"
+#include "lgc/state/AbiMetadata.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+#define DEBUG_TYPE "lgc-pal-metadata"
+
+using namespace lgc;
+using namespace llvm;
+
+// =====================================================================================================================
+// Construct empty object
+PalMetadata::PalMetadata() {
+  m_document = new msgpack::Document;
+}
+
+// =====================================================================================================================
+// Constructor given pipeline IR module. This reads the already-existing PAL metadata if any.
+//
+// @param module : Pipeline IR module
+PalMetadata::PalMetadata(Module *module) {
+  m_document = new msgpack::Document;
+  NamedMDNode *namedMd = module->getNamedMetadata(PalMetadataName);
+  if (namedMd && namedMd->getNumOperands()) {
+    // The IR named metadata node contains an MDTuple containing an MDString containing the msgpack data.
+    auto mdTuple = dyn_cast<MDTuple>(namedMd->getOperand(0));
+    if (mdTuple && mdTuple->getNumOperands()) {
+      if (auto mdString = dyn_cast<MDString>(mdTuple->getOperand(0))) {
+        bool success = m_document->readFromBlob(mdString->getString(), /*multi=*/false);
+        assert(success && "Bad PAL metadata format");
+        ((void)success);
+      }
+    }
+  }
+}
+
+// =====================================================================================================================
+// Destructor
+PalMetadata::~PalMetadata() {
+  delete m_document;
+}
+
+// =====================================================================================================================
+// Record the PAL metadata into IR metadata in the specified module. This is used both for passing the PAL metadata
+// to the AMDGPU back-end, and when compilation stops early due to -stop-before etc.
+//
+// @param module : Pipeline IR module
+void PalMetadata::record(Module *module) {
+  // Add the metadata version number.
+  auto versionNode = m_document->getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Version].getArray(true);
+  versionNode[0] = m_document->getNode(Util::Abi::PipelineMetadataMajorVersion);
+  versionNode[1] = m_document->getNode(Util::Abi::PipelineMetadataMinorVersion);
+
+  // Write the MsgPack document into an IR metadata node.
+  // The IR named metadata node contains an MDTuple containing an MDString containing the msgpack data.
+  std::string blob;
+  m_document->writeToBlob(blob);
+  MDString *abiMetaString = MDString::get(module->getContext(), blob);
+  MDNode *abiMetaNode = MDNode::get(module->getContext(), abiMetaString);
+  NamedMDNode *namedMeta = module->getOrInsertNamedMetadata(PalMetadataName);
+  namedMeta->addOperand(abiMetaNode);
+}

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -34,8 +34,8 @@
  ***********************************************************************************************************************
  */
 #include "lgc/state/PalMetadata.h"
-#include "lgc/state/AbiMetadata.h"
-#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "lgc/state/PipelineState.h"
+#include "lgc/state/TargetInfo.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 
@@ -46,15 +46,16 @@ using namespace llvm;
 
 // =====================================================================================================================
 // Construct empty object
-PalMetadata::PalMetadata() {
+PalMetadata::PalMetadata(PipelineState *pipelineState) : m_pipelineState(pipelineState) {
   m_document = new msgpack::Document;
+  initialize();
 }
 
 // =====================================================================================================================
 // Constructor given pipeline IR module. This reads the already-existing PAL metadata if any.
 //
 // @param module : Pipeline IR module
-PalMetadata::PalMetadata(Module *module) {
+PalMetadata::PalMetadata(PipelineState *pipelineState, Module *module) : m_pipelineState(pipelineState) {
   m_document = new msgpack::Document;
   NamedMDNode *namedMd = module->getNamedMetadata(PalMetadataName);
   if (namedMd && namedMd->getNumOperands()) {
@@ -68,12 +69,28 @@ PalMetadata::PalMetadata(Module *module) {
       }
     }
   }
+  initialize();
 }
 
 // =====================================================================================================================
 // Destructor
 PalMetadata::~PalMetadata() {
   delete m_document;
+}
+
+// =====================================================================================================================
+// Initialize the PalMetadata object after reading in already-existing PAL metadata if any
+void PalMetadata::initialize() {
+  // Pre-find (or create) heavily used nodes.
+  m_pipelineNode =
+      m_document->getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0].getMap(true);
+  m_registers = m_pipelineNode[".registers"].getMap(true);
+  m_userDataLimit = &m_pipelineNode[Util::Abi::PipelineMetadataKey::UserDataLimit];
+  if (m_userDataLimit->getKind() == msgpack::Type::Nil)
+    *m_userDataLimit = m_document->getNode(0U);
+  m_spillThreshold = &m_pipelineNode[Util::Abi::PipelineMetadataKey::SpillThreshold];
+  if (m_spillThreshold->getKind() == msgpack::Type::Nil)
+    *m_spillThreshold = m_document->getNode(UINT_MAX);
 }
 
 // =====================================================================================================================
@@ -95,4 +112,149 @@ void PalMetadata::record(Module *module) {
   MDNode *abiMetaNode = MDNode::get(module->getContext(), abiMetaString);
   NamedMDNode *namedMeta = module->getOrInsertNamedMetadata(PalMetadataName);
   namedMeta->addOperand(abiMetaNode);
+}
+
+// =====================================================================================================================
+// Get the first user data register number for the given shader stage, taking into account what shader
+// stages are present in the pipeline, and whether NGG is enabled. The first time this is called must be
+// after PatchResourceCollect has run.
+//
+// @param stage : ShaderStage
+unsigned PalMetadata::getUserDataReg0(ShaderStage stage) {
+  if (m_userDataRegMapping[stage] != 0)
+    return m_userDataRegMapping[stage];
+
+  // Mapping not yet initialized.
+  // Set up ShaderStage -> user data register mapping.
+  m_userDataRegMapping[ShaderStageCompute] = mmCOMPUTE_USER_DATA_0;
+  m_userDataRegMapping[ShaderStageFragment] = mmSPI_SHADER_USER_DATA_PS_0;
+
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major < 9) {
+    // <=GFX8: No merged shaders.
+    m_userDataRegMapping[ShaderStageCopyShader] = mmSPI_SHADER_USER_DATA_VS_0;
+    m_userDataRegMapping[ShaderStageGeometry] = mmSPI_SHADER_USER_DATA_GS_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageGeometry))
+      m_userDataRegMapping[ShaderStageTessEval] = mmSPI_SHADER_USER_DATA_ES_0;
+    else
+      m_userDataRegMapping[ShaderStageTessEval] = mmSPI_SHADER_USER_DATA_VS_0;
+    m_userDataRegMapping[ShaderStageTessControl] = mmSPI_SHADER_USER_DATA_HS_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageTessControl))
+      m_userDataRegMapping[ShaderStageVertex] = mmSPI_SHADER_USER_DATA_LS_0;
+    else if (m_pipelineState->hasShaderStage(ShaderStageGeometry))
+      m_userDataRegMapping[ShaderStageVertex] = mmSPI_SHADER_USER_DATA_ES_0;
+    else
+      m_userDataRegMapping[ShaderStageVertex] = mmSPI_SHADER_USER_DATA_VS_0;
+
+  } else if (m_pipelineState->getTargetInfo().getGfxIpVersion().major == 9) {
+    // GFX9: Merged shaders, and merged ES-GS user data goes into ES registers.
+    m_userDataRegMapping[ShaderStageCopyShader] = mmSPI_SHADER_USER_DATA_VS_0;
+    m_userDataRegMapping[ShaderStageGeometry] = mmSPI_SHADER_USER_DATA_ES_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageGeometry))
+      m_userDataRegMapping[ShaderStageTessEval] = m_userDataRegMapping[ShaderStageGeometry];
+    else
+      m_userDataRegMapping[ShaderStageTessEval] = mmSPI_SHADER_USER_DATA_VS_0;
+    m_userDataRegMapping[ShaderStageTessControl] = mmSPI_SHADER_USER_DATA_HS_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageTessControl))
+      m_userDataRegMapping[ShaderStageVertex] = m_userDataRegMapping[ShaderStageTessControl];
+    else if (m_pipelineState->hasShaderStage(ShaderStageGeometry))
+      m_userDataRegMapping[ShaderStageVertex] = m_userDataRegMapping[ShaderStageGeometry];
+    else
+      m_userDataRegMapping[ShaderStageVertex] = mmSPI_SHADER_USER_DATA_VS_0;
+
+  } else if (!m_pipelineState->getNggControl()->enableNgg) {
+    // GFX10+ not NGG: Same as GFX9, except ES-GS user data goes into GS registers.
+    m_userDataRegMapping[ShaderStageCopyShader] = mmSPI_SHADER_USER_DATA_VS_0;
+    m_userDataRegMapping[ShaderStageGeometry] = mmSPI_SHADER_USER_DATA_GS_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageGeometry))
+      m_userDataRegMapping[ShaderStageTessEval] = m_userDataRegMapping[ShaderStageGeometry];
+    else
+      m_userDataRegMapping[ShaderStageTessEval] = mmSPI_SHADER_USER_DATA_VS_0;
+    m_userDataRegMapping[ShaderStageTessControl] = mmSPI_SHADER_USER_DATA_HS_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageTessControl))
+      m_userDataRegMapping[ShaderStageVertex] = m_userDataRegMapping[ShaderStageTessControl];
+    else if (m_pipelineState->hasShaderStage(ShaderStageGeometry))
+      m_userDataRegMapping[ShaderStageVertex] = m_userDataRegMapping[ShaderStageGeometry];
+    else
+      m_userDataRegMapping[ShaderStageVertex] = mmSPI_SHADER_USER_DATA_VS_0;
+
+  } else {
+    // GFX10+ NGG
+    m_userDataRegMapping[ShaderStageGeometry] = mmSPI_SHADER_USER_DATA_GS_0;
+    m_userDataRegMapping[ShaderStageTessEval] = m_userDataRegMapping[ShaderStageGeometry];
+    m_userDataRegMapping[ShaderStageTessControl] = mmSPI_SHADER_USER_DATA_HS_0;
+    if (m_pipelineState->hasShaderStage(ShaderStageTessControl))
+      m_userDataRegMapping[ShaderStageVertex] = m_userDataRegMapping[ShaderStageTessControl];
+    else
+      m_userDataRegMapping[ShaderStageVertex] = m_userDataRegMapping[ShaderStageGeometry];
+  }
+
+  return m_userDataRegMapping[stage];
+}
+
+// =====================================================================================================================
+// Set the PAL metadata SPI register for a number of consecutive user data entries
+//
+// @param stage : ShaderStage
+// @param userDataIndex : User data index 0-15 or 0-31 depending on HW and shader stage
+// @param userDataValue : Value to store in that entry, one of:
+//                        - a 0-based integer for the root user data dword offset
+//                        - DescRelocMagic+set_number for an unlinked descriptor set number
+//                        - one of the UserDataMapping values, e.g. UserDataMapping::GlobalTable
+// @param dwordCount : Number of user data entries to set
+void PalMetadata::setUserDataEntry(ShaderStage stage, unsigned userDataIndex, unsigned userDataValue,
+                                   unsigned dwordCount) {
+  // If this is the spill table pointer, adjust userDataLimit accordingly.
+  if (userDataValue == static_cast<unsigned>(Util::Abi::UserDataMapping::SpillTable))
+    setUserDataLimit();
+
+  // Get the start register number of SPI user data registers for this shader stage.
+  unsigned userDataReg = getUserDataReg0(stage);
+
+  // Assert that the supplied user data index is not too big.
+  assert(userDataIndex + dwordCount <= 32 &&
+         (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 || stage != ShaderStageCompute ||
+          userDataIndex + dwordCount <= 16) &&
+         "Out of range user data index");
+
+  // Update userDataLimit if userData is a 0-based integer for root user data dword offset.
+  if (userDataValue < InterfaceData::MaxSpillTableSize && userDataValue + dwordCount > m_userDataLimit->getUInt())
+    *m_userDataLimit = m_document->getNode(userDataValue + dwordCount);
+
+  // Write the register(s)
+  userDataReg += userDataIndex;
+  while (dwordCount--)
+    m_registers[m_document->getNode(userDataReg++)] = m_document->getNode(userDataValue++);
+}
+
+// =====================================================================================================================
+// Mark that the user data spill table is used at the given offset. The SpillThreshold PAL metadata entry is
+// set to the minimum of any call to this function in any shader.
+//
+// @param dwordOffset : Dword offset that the spill table is used at
+void PalMetadata::setUserDataSpillUsage(unsigned dwordOffset) {
+  if (dwordOffset < m_spillThreshold->getUInt())
+    *m_spillThreshold = m_document->getNode(dwordOffset);
+}
+
+// =====================================================================================================================
+// Finalize PAL metadata for pipeline.
+// TODO Shader compilation: The idea is that this will be called at the end of a pipeline compilation, or in
+// an ELF link, but not at the end of a shader/half-pipeline compile.
+void PalMetadata::finalizePipeline() {
+  // If there are root user data nodes but none of them are used, adjust userDataLimit accordingly.
+  if (m_userDataLimit->getUInt() == 0 && !m_pipelineState->getUserDataNodes().empty())
+    setUserDataLimit();
+}
+
+// =====================================================================================================================
+// Set userDataLimit to maximum (the size of the root user data table, excluding vertex buffer and streamout).
+// This is called if spill is in use, or if there are root user data nodes but none of them are used (PAL does
+// not like userDataLimit being 0 if there are any root user data nodes).
+void PalMetadata::setUserDataLimit() {
+  unsigned userDataLimit = 0;
+  for (auto &node : m_pipelineState->getUserDataNodes()) {
+    if (node.type != ResourceNodeType::IndirectUserDataVaPtr && node.type != ResourceNodeType::StreamOutTableVaPtr)
+      userDataLimit = std::max(userDataLimit, node.offsetInDwords + node.sizeInDwords);
+  }
+  *m_userDataLimit = m_document->getNode(userDataLimit);
 }

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -94,7 +94,7 @@ unsigned PipelineState::getPalAbiVersion() const {
 // Get PalMetadata object, creating an empty one if necessary
 PalMetadata *PipelineState::getPalMetadata() {
   if (!m_palMetadata)
-    m_palMetadata = new PalMetadata;
+    m_palMetadata = new PalMetadata(this);
   return m_palMetadata;
 }
 
@@ -147,7 +147,7 @@ void PipelineState::readState(Module *module) {
   readColorExportState(module);
   readGraphicsState(module);
   if (!m_palMetadata)
-    m_palMetadata = new PalMetadata(module);
+    m_palMetadata = new PalMetadata(this, module);
 }
 
 // =====================================================================================================================

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -527,7 +527,7 @@ void PipelineState::readUserDataNodes(Module *module) {
 // For nodeType == Unknown, the function finds any node of the given set,binding.
 // For nodeType == Resource, it matches Resource or CombinedTexture.
 // For nodeType == Sampler, it matches Sampler or CombinedTexture.
-// For nodeType == Buffer, it matches Buffer, BufferCompact or PushConst (the latter in an inner table only).
+// For nodeType == Buffer, it matches Buffer, BufferCompact or InlineBuffer.
 // For other nodeType, only a node of the specified type is returned.
 // Returns {topNode, node} where "node" is the found user data node, and "topNode" is the top-level user data
 // node that contains it (or is equal to it).
@@ -544,7 +544,7 @@ PipelineState::findResourceNode(ResourceNodeType nodeType, unsigned descSet, uns
           if (nodeType == ResourceNodeType::Unknown || nodeType == innerNode.type ||
               (nodeType == ResourceNodeType::DescriptorBuffer &&
                (innerNode.type == ResourceNodeType::DescriptorBufferCompact ||
-                innerNode.type == ResourceNodeType::PushConst)) ||
+                innerNode.type == ResourceNodeType::InlineBuffer)) ||
               ((innerNode.type == ResourceNodeType::DescriptorCombinedTexture ||
                 innerNode.type == ResourceNodeType::DescriptorYCbCrSampler) &&
                (nodeType == ResourceNodeType::DescriptorResource ||
@@ -907,6 +907,7 @@ const char *PipelineState::getResourceNodeTypeName(ResourceNodeType type) {
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, DescriptorBufferCompact)
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, StreamOutTableVaPtr)
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, DescriptorReserved12)
+    CASE_CLASSENUM_TO_STRING(ResourceNodeType, InlineBuffer)
     break;
   default:
     llvm_unreachable("Should never be called!");

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -68,6 +68,5 @@ ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
 
 // =====================================================================================================================
 InterfaceData::InterfaceData() {
-  memset(userDataMap, InterfaceData::UserDataUnmapped, sizeof(userDataMap));
   entryArgIdxs.spillTable = InvalidValue;
 }

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -178,7 +178,7 @@ private:
   // Give the user data nodes and descriptor range values to the middle-end.
   void setUserDataInPipeline(lgc::Pipeline *pipeline) const;
   void setUserDataNodesTable(llvm::LLVMContext &context, llvm::ArrayRef<ResourceMappingNode> nodes,
-                             const ImmutableNodesMap &immutableNodesMap, lgc::ResourceNode *destTable,
+                             const ImmutableNodesMap &immutableNodesMap, bool isRoot, lgc::ResourceNode *destTable,
                              lgc::ResourceNode *&destInnerTable) const;
 
   // Give the graphics pipeline state to the middle-end.


### PR DESCRIPTION
Please only review the top three commits here. The others are from other unmerged PRs.

This change is to prepare for future commits that will allow shader compilation without user data layout.