### PR TITLE
Add CMake option to enable ShaderCache

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -63,6 +63,10 @@
 #define Vkgc Llpc
 #endif
 
+#ifndef LLPC_ENABLE_SHADER_CACHE
+#define LLPC_ENABLE_SHADER_CACHE 0
+#endif
+
 //**
 //**********************************************************************************************************************
 //* @page VersionHistory
@@ -573,7 +577,7 @@ struct GraphicsPipelineBuildInfo {
   void *pInstance;                ///< Vulkan instance object
   void *pUserData;                ///< User data
   OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
   IShaderCache *pShaderCache; ///< Shader cache, used to search for the compiled shader data
 #endif
   PipelineShaderInfo vs;  ///< Vertex shader
@@ -633,7 +637,7 @@ struct ComputePipelineBuildInfo {
   void *pInstance;                ///< Vulkan instance object
   void *pUserData;                ///< User data
   OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
   IShaderCache *pShaderCache; ///< Shader cache, used to search for the compiled shader data
 #endif
   unsigned deviceIndex;    ///< Device index for device group

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -196,6 +196,11 @@ if(ICD_BUILD_LLPC)
     target_compile_definitions(llpc PRIVATE ICD_BUILD_LLPC)
 endif()
 
+option(LLPC_ENABLE_SHADER_CACHE "Enable experimental shader cache" OFF)
+if(LLPC_ENABLE_SHADER_CACHE)
+    target_compile_definitions(llpc PRIVATE LLPC_ENABLE_SHADER_CACHE=1)
+endif()
+
 if(ICD_BUILD_LLPC)
     if(XGL_LLVM_UPSTREAM)
         target_compile_definitions(llpc PRIVATE XGL_LLVM_UPSTREAM)
@@ -349,6 +354,10 @@ if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
 endif()
 
 target_compile_definitions(amdllpc PRIVATE ICD_BUILD_LLPC)
+
+if(LLPC_ENABLE_SHADER_CACHE)
+    target_compile_definitions(amdllpc PRIVATE LLPC_ENABLE_SHADER_CACHE=1)
+endif()
 
 target_include_directories(amdllpc
 PUBLIC

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -134,7 +134,7 @@ public:
 
   static MetroHash::Hash generateHashForCompileOptions(unsigned optionCount, const char *const *options);
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
   virtual Result CreateShaderCache(const ShaderCacheCreateInfo *pCreateInfo, IShaderCache **ppShaderCache);
 #endif
 

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -226,7 +226,7 @@ public:
   virtual Result BuildComputePipeline(const ComputePipelineBuildInfo *pPipelineInfo,
                                       ComputePipelineBuildOut *pPipelineOut, void *pPipelineDumpFile = nullptr) = 0;
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
   /// Creates a shader cache object with the requested properties.
   ///
   /// @param [in]  pCreateInfo    Create info of the shader cache.

--- a/tool/dumper/CMakeLists.txt
+++ b/tool/dumper/CMakeLists.txt
@@ -143,6 +143,10 @@ else()
     target_compile_definitions(dumper PUBLIC SINGLE_EXTERNAL_METROHASH)
 endif()
 
+if(LLPC_ENABLE_SHADER_CACHE)
+    target_compile_definitions(dumper PRIVATE LLPC_ENABLE_SHADER_CACHE=1)
+endif()
+
 target_link_libraries(dumper PRIVATE cwpack)
 
 target_include_directories(dumper

--- a/tool/vfx/CMakeLists.txt
+++ b/tool/vfx/CMakeLists.txt
@@ -35,6 +35,10 @@ if(LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
     target_compile_definitions(vfx PRIVATE PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION})
 endif()
 
+if(LLPC_ENABLE_SHADER_CACHE)
+    target_compile_definitions(vfx PRIVATE LLPC_ENABLE_SHADER_CACHE=1)
+endif()
+
 target_sources(vfx PRIVATE
     vfxParser.cpp
     vfxPipelineDoc.cpp


### PR DESCRIPTION
This will be used for offline creation of relocatable shader caches,
sent as a separate PR.