### PR TITLE
[CI] Add CI configurations for assertions, clang, and sanitizers

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -6,16 +6,18 @@ on:
 
 jobs:
   build-and-push-amdvlk:
-    name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
+    name: "Features: ${{ matrix.feature-set }}, assertions: ${{ matrix.assertions }}"
     if: github.repository == 'GPUOpen-Drivers/llpc'
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
-        host-os:      ["ubuntu-latest"]
-        base-image:   ["gcr.io/stadia-open-source/amdvlk_dev_release:nightly"]
-        branch:       [dev]
-        config:       [Release]
-        generator:    [Ninja]
+        host-os:        ["ubuntu-18.04"]
+        image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
+        branch:         [dev]
+        config:         [Release]
+        assertions:     ["OFF", "ON"]
+        feature-set:    ["+gcc", "+clang"]
+        generator:      [Ninja]
     steps:
       - name: Checkout LLPC
         run: |
@@ -30,12 +32,23 @@ jobs:
       - name: Setup Docker to use the GCR
         run: |
           gcloud auth configure-docker
+      - name: Generate Docker image tag string
+        run: |
+          CONFIG_LOWER=$(echo "${{ matrix.config }}" | tr "[:upper:]" "[:lower:]")
+          FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
+          ASSERTS_LOWER=$(echo "${{ matrix.assertions }}" | tr "[:upper:]" "[:lower:]")
+          TAG=$(printf "${{ matrix.image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER" "$ASSERTS_LOWER")
+          echo "::set-env name=IMAGE_TAG::$TAG"
       - name: Build and Test AMDVLK with Docker
-        run: docker build . --file docker/amdvlk.Dockerfile
-                            --build-arg BRANCH="${{ matrix.branch }}"
-                            --build-arg CONFIG="${{ matrix.config }}"
-                            --build-arg GENERATOR="${{ matrix.generator }}"
-                            --tag ${{ matrix.base-image }}
+        run: |
+          echo "IMAGE_TAG: $IMAGE_TAG"
+          docker build . --file docker/amdvlk.Dockerfile \
+                         --build-arg BRANCH="${{ matrix.branch }}" \
+                         --build-arg CONFIG="${{ matrix.config }}" \
+                         --build-arg ASSERTIONS="${{ matrix.assertions }}" \
+                         --build-arg FEATURES="${{ matrix.feature-set }}" \
+                         --build-arg GENERATOR="${{ matrix.generator }}" \
+                         --tag "$IMAGE_TAG"
       - name: Push the new image
         run: |
-          docker push ${{ matrix.base-image }}
+          docker push "$IMAGE_TAG"

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -9,27 +9,34 @@ on:
 
 jobs:
   build-and-test:
-    name: Branch ${{ matrix.branch }}, base image ${{ matrix.base-image }}, config ${{ matrix.config }}
+    name: "Features: ${{ matrix.feature-set }}, assertions: ${{ matrix.assertions }}"
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
-        host-os:      ["ubuntu-latest"]
-        base-image:   ["gcr.io/stadia-open-source/amdvlk_dev_release:nightly"]
-        branch:       [dev]
-        config:       [Release]
-        generator:    [Ninja]
+        host-os:             ["ubuntu-18.04"]
+        base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
+        config:              [Release]
+        assertions:          ["OFF", "ON"]
+        feature-set:         ["+gcc", "+clang"]
     steps:
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
           git checkout ${GITHUB_SHA}
-      - name: Fetch the latest prebuilt AMDVLK
+      - name: Generate Docker base image tag string
         run: |
-          docker pull "${{ matrix.base-image }}"
+          CONFIG_LOWER=$(echo "${{ matrix.config }}" | tr "[:upper:]" "[:lower:]")
+          FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
+          ASSERTS_LOWER=$(echo "${{ matrix.assertions }}" | tr "[:upper:]" "[:lower:]")
+          TAG=$(printf "${{ matrix.base-image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER" "$ASSERTS_LOWER")
+          echo "IMAGE_TAG: $TAG"
+          echo "::set-env name=IMAGE_TAG::$TAG"
+      - name: Fetch the latest prebuilt AMDVLK
+        run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
         run: docker build . --file docker/llpc.Dockerfile
-                            --build-arg AMDVLK_IMAGE="${{ matrix.base-image }}"
+                            --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"

--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -3,14 +3,18 @@
 # Contains the base image used for incremental builds of llpc.
 # Sample invocation:
 #    docker build . --file docker/amdvlk.Dockerfile               \
-#                   --build-arg CONFIG=Release                    \
 #                   --build-arg BRANCH=dev                        \
+#                   --build-arg CONFIG=Release                    \
+#                   --build-arg ASSERTIONS=ON                     \
+#                   --build-arg FEATURES="+clang+sanitizers"      \
 #                   --build-arg GENERATOR=Ninja                   \
 #                   --tag kuhar/amdvlk:nightly
 #
 # Required arguments:
-# - CONFIG: Debug or Release
 # - BRANCH: The base AMDVLK branch to use (e.g., master, dev, releases/<name>)
+# - CONFIG: Debug or Release
+# - ASSERTIONS: OFF or ON
+# - FEATURES: A '+'-spearated set of features to enable
 # - GENERATOR: CMake generator to use (e.g., "Unix Makefiles", Ninja)
 #
 
@@ -18,18 +22,23 @@ FROM ubuntu:18.04
 
 ARG BRANCH
 ARG CONFIG
+ARG ASSERTIONS
+ARG FEATURES
 ARG GENERATOR
 
 # Install required packages.
 RUN apt-get update \
     && apt-get install -yqq --no-install-recommends \
-    	build-essential cmake gcc g++ ninja-build binutils-gold \
-    	python python-distutils-extra python3 python3-distutils \
-    	libssl-dev libx11-dev libxcb1-dev x11proto-dri2-dev libxcb-dri3-dev \
-    	libxcb-dri2-0-dev libxcb-present-dev libxshmfence-dev libxrandr-dev \
-    	git repo curl vim-tiny \
+       build-essential cmake gcc g++ ninja-build binutils-gold \
+       clang-9 libclang-common-9-dev lld-9 \
+       python python-distutils-extra python3 python3-distutils \
+       libssl-dev libx11-dev libxcb1-dev x11proto-dri2-dev libxcb-dri3-dev \
+       libxcb-dri2-0-dev libxcb-present-dev libxshmfence-dev libxrandr-dev \
+       git repo curl vim-tiny \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 10
+    && update-alternatives --install /usr/bin/ld ld /usr/bin/ld.gold 10 \
+    && update-alternatives --install /usr/bin/lld lld /usr/bin/lld-9 10 \
+    && update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-9 10
 
 # Checkout all repositories. Replace llpc with the version in LLPC_SOURCE_DIR.
 WORKDIR /vulkandriver
@@ -40,11 +49,27 @@ RUN repo init -u https://github.com/GPUOpen-Drivers/AMDVLK.git -b "$BRANCH" \
 
 # Build LLPC.
 WORKDIR /vulkandriver/builds/ci-build
-RUN cmake "/vulkandriver/drivers/xgl" \
+RUN EXTRA_FLAGS="" \
+    && if echo "$FEATURES" | grep -q "+gcc" ; then \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_C_COMPILER=gcc"; \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_CXX_COMPILER=g++"; \
+       fi \
+    && if echo "$FEATURES" | grep -q "+clang" ; then \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_C_COMPILER=clang-9"; \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_CXX_COMPILER=clang++-9"; \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DLLVM_USE_LINKER=lld"; \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"; \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld"; \
+       fi \
+    && echo "Extra CMake flags: $EXTRA_FLAGS" \
+    && cmake "/vulkandriver/drivers/xgl" \
           -G "$GENERATOR" \
           -DXGL_BUILD_LIT=ON \
           -DCMAKE_BUILD_TYPE="$CONFIG" \
+          -DLLVM_ENABLE_ASSERTIONS="$ASSERTIONS" \
           -DLLPC_ENABLE_WERROR=ON \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          $EXTRA_FLAGS \
     && cmake --build . \
     && cmake --build . --target amdllpc \
     && cmake --build . --target spvgen \


### PR DESCRIPTION
This extends the current public CI infrastructure with 5 new build
configurations. Each of configuration has its own base image cached
in GCR. This way each incremental CI build doesn't have to know about
the precise CMake invocation and resumes from whatever configuration
its base imgage used.

GitHub actions offer 10 free concurrent CI jobs, so this should
significanly slow down the public CI, with 4 workers still unused.