### PR TITLE
Declare BuiltInKind as unsigned

### DIFF
--- a/lgc/interface/lgc/BuiltIns.h
+++ b/lgc/interface/lgc/BuiltIns.h
@@ -34,7 +34,7 @@
 namespace lgc {
 
 // Define built-in kind enum.
-enum BuiltInKind {
+enum BuiltInKind : unsigned {
 #define BUILTIN(name, number, out, in, type) BuiltIn##name = number,
 #include "lgc/BuiltInDefs.h"
 #undef BUILTIN


### PR DESCRIPTION
This fixes undefined behavior when assigning values to the enum that are
not declared explicitly.

Fixes #636