### PR TITLE
Add PipelineState patching in llpcElfWriter linking

### DIFF
--- a/llpc/test/shaderdb/PipelineVsFs_MetaPatching.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_MetaPatching.pipe
@@ -1,0 +1,106 @@
+
+// This test case checks that metadata patching works correctly during vs/fs pipeline linking.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1: PA_CL_CLIP_CNTL 0x000000000D480005
+; END_SHADERTEST
+
+[VsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform UniformBufferObject {
+    mat4 model;
+    mat4 view;
+    vec4 proj;
+} ubo;
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 1) in vec3 inColor;
+
+layout(location = 0) out vec3 fragColor;
+
+void main() {
+    gl_Position = ubo.proj;
+    fragColor = inColor;
+}
+
+
+[VsInfo]
+entryPoint = main
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 0
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].set = 0
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 3
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 0
+userDataNode[1].next[0].binding = 0
+
+trapPresent = 0
+debugMode = 0
+enablePerformanceData = 0
+vgprLimit = 0
+sgprLimit = 0
+maxThreadGroupsPerComputeUnit = 0
+
+[FsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform UniformBufferObject {
+    mat4 model;
+    mat4 view;
+    vec4 proj;
+} ubo;
+
+layout(location = 0) in vec3 fragColor;
+layout(location = 0) out vec4 outputColor;
+void main() {
+    outputColor = vec4(fragColor, 1.0) + ubo.proj;
+}
+
+[FsInfo]
+entryPoint = main
+trapPresent = 0
+debugMode = 0
+enablePerformanceData = 0
+vgprLimit = 0
+sgprLimit = 0
+maxThreadGroupsPerComputeUnit = 0
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+patchControlPoints = 0
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 0
+rasterizerDiscardEnable = 1
+perSampleShading = 1
+numSamples = 8
+samplePatternIdx = 48
+usrClipPlaneMask = 5
+includeDisassembly = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 1
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 1
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 3
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0


### PR DESCRIPTION
This PR adds patching of pipeline states into the value of PA_CL_CLIP_CNTL register during the linking step of relocatable pipeline compilation.

Three pipeline settings are implemented here: u`srClipPlaneMask`, `zClipEnable` and `rasterizaerDiscardEnable`.