### PR TITLE
Fixed 'Improved interface for building "unlinked" ELF' fix

### DIFF
--- a/lgc/patch/PatchDescriptorLoad.cpp
+++ b/lgc/patch/PatchDescriptorLoad.cpp
@@ -29,7 +29,6 @@
  ***********************************************************************************************************************
  */
 #include "PatchDescriptorLoad.h"
-#include "lgc/LgcContext.h"
 #include "lgc/state/TargetInfo.h"
 #include "lgc/util/Internal.h"
 #include "llvm/IR/IRBuilder.h"

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -31,7 +31,6 @@
 #include "PatchEntryPointMutate.h"
 #include "Gfx6Chip.h"
 #include "Gfx9Chip.h"
-#include "lgc/LgcContext.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/TargetInfo.h"
@@ -309,8 +308,7 @@ FunctionType *PatchEntryPointMutate::generateEntryPointType(uint64_t *inRegMask)
   unsigned availUserDataCount = maxUserDataCount - userDataIdx;
   unsigned requiredRemappedUserDataCount = 0; // Maximum required user data
   unsigned requiredUserDataCount = 0;         // Maximum required user data without remapping
-  bool useFixedLayout =
-      (m_shaderStage == ShaderStageCompute && !m_pipelineState->getLgcContext()->buildingRelocatableElf());
+  bool useFixedLayout = m_shaderStage == ShaderStageCompute && !m_pipelineState->isUnlinked();
   bool reserveVbTable = false;
   bool reserveStreamOutTable = false;
   bool reserveEsGsLdsSize = false;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -33,7 +33,6 @@
 #include "llpcCompiler.h"
 #include "llpcDebug.h"
 #include "lgc/Builder.h"
-#include "lgc/LgcContext.h"
 #include "lgc/Pipeline.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
@@ -367,8 +366,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
 #endif
 
       shaderOptions.useSiScheduler = EnableSiScheduler || shaderInfo->options.useSiScheduler;
-      shaderOptions.updateDescInElf =
-          shaderInfo->options.updateDescInElf || pipeline->getLgcContext()->buildingRelocatableElf();
+      shaderOptions.updateDescInElf = shaderInfo->options.updateDescInElf;
       shaderOptions.unrollThreshold = shaderInfo->options.unrollThreshold;
 
       pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);


### PR DESCRIPTION
I accidentally merged an out-of-date version of PR628, which probably
causes a build failure after github auto-rebased it. This commit fixes
it.

Change-Id: Ic0ddfe4b25e40ef9290ec6ef0f549e7f00d9bb4f