### PR TITLE
Fix stride relocation regression

### DIFF
--- a/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
+++ b/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
@@ -1,0 +1,67 @@
+
+// This test case checks that stride relocation is generated correctly for array of textures.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+  // Test that correct relocated offsets are in the linked texture fetching code.
+; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
+  // Matching the texture index
+; SHADERTEST-DAG: v_readfirstlane_b32 s[[TEXINDEX:[0-9]+]], v{{[0-9]+}} //{{.*}}
+  // Check that correct stride value is multiplied onto the index
+; SHADERTEST-DAG: s_mul_i32 s{{[0-9]+}}, s[[TEXINDEX]], 48 //{{.*}}
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST1-DAG: ![[METADATANODE1:[0-9]+]] = !{!"doff_0_0_r"}
+; SHADERTEST1-DAG: ![[METADATANODE2:[0-9]+]] = !{!"doff_0_0_s"}
+; SHADERTEST1-DAG: ![[METADATANODE3:[0-9]+]] = !{!"dstride_0_0"}
+
+; SHADERTEST1-DAG: %[[RELOCONST1:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE1]])
+; SHADERTEST1-DAG: %[[RELOCONST2:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE2]])
+; SHADERTEST1-DAG: %[[RELOCONST3:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE3]])
+; SHADERTEST1: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[CsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(set = 1, binding = 0, std430) buffer OUT
+{
+    vec4 o;
+};
+
+layout(set = 0, binding = 0) uniform sampler2D texSampler[64];
+
+layout(local_size_x = 2, local_size_y = 3) in;
+void main() {
+    o = texture(texSampler[gl_GlobalInvocationID.x], vec2(0.0, 0.0));
+}
+
+
+[CsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorCombinedTexture
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 12
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorCombinedTexture
+userDataNode[0].next[1].offsetInDwords = 16
+userDataNode[0].next[1].sizeInDwords = 12
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 1
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].set = 1
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 16
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 1
+userDataNode[1].next[0].binding = 0

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -1120,13 +1120,13 @@ static unsigned getDescriptorResourceStride(unsigned descSet, unsigned binding, 
 
     switch (resource->type) {
     case ResourceMappingNodeType::DescriptorSampler:
-      return DescriptorSizeSampler / 4;
+      return DescriptorSizeSampler;
       break;
     case ResourceMappingNodeType::DescriptorResource:
     case ResourceMappingNodeType::DescriptorFmask:
-      return DescriptorSizeResource / 4;
+      return DescriptorSizeResource;
     case ResourceMappingNodeType::DescriptorCombinedTexture:
-      return (DescriptorSizeResource + DescriptorSizeSampler) / 4;
+      return (DescriptorSizeResource + DescriptorSizeSampler);
     default:
       llvm_unreachable("Unexpected resource node type");
       break;


### PR DESCRIPTION
The descriptor stride was at some point refactored to be number of bytes instead of number of dwords, but the fixup logic has not been updated with the refactoring. This PR patches up this issue.