### PR TITLE
Re-enable unused variable warnings

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -71,7 +71,6 @@ function(lgc_set_compiler_options PROJECT_NAME)
             -fno-rtti
             -fPIC
             -std=c++14
-            -Wno-unused
             -Wno-ignored-qualifiers
             -Wno-missing-field-initializers
             -Wno-invalid-offsetof           # offsetof within non-standard-layout type 'x' is undefined

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -76,7 +76,6 @@ function(llpc_set_compiler_options PROJECT_NAME)
             -fno-rtti
             -fPIC
             -std=c++14
-            -Wno-unused
             -Wno-ignored-qualifiers
             -Wno-missing-field-initializers
             -Wno-invalid-offsetof           # offsetof within non-standard-layout type 'x' is undefined

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -882,14 +882,11 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
 
   // NOTE: If input is LLVM IR, read it now. There is now only ever one IR module representing the
   // whole pipeline.
-  bool isLlvmBc = false;
   const PipelineShaderInfo *shaderInfoEntry = shaderInfo[0] ? shaderInfo[0] : shaderInfo.back();
   if (shaderInfoEntry) {
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfoEntry->pModuleData);
-    if (moduleData && moduleData->binType == BinaryType::LlvmBc) {
-      isLlvmBc = true;
+    if (moduleData && moduleData->binType == BinaryType::LlvmBc)
       pipelineModule.reset(context->loadLibary(&moduleData->binCode).release());
-    }
   }
 
   // If not IR input, run the per-shader passes, including SPIR-V translation, and then link the modules

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -344,6 +344,7 @@ Result ShaderCache::buildFileName(const char *executableName, const char *cacheF
       result = Result::Success;
   }
 
+  ((void)length);
   return result;
 }
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5235,12 +5235,9 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &funcName, SPIR
   Type *retTy = bi->hasType() ? transType(retBTy) : Type::getVoidTy(*m_context);
   std::vector<Type *> argTys = transTypeVector(SPIRVInstruction::getOperandTypes(ops));
   std::vector<Value *> args = transValue(ops, bb->getParent(), bb);
-  bool hasFuncPtrArg = false;
   for (auto &i : argTys) {
-    if (isa<FunctionType>(i)) {
+    if (isa<FunctionType>(i))
       i = PointerType::get(i, SPIRAS_Private);
-      hasFuncPtrArg = true;
-    }
   }
   std::string mangledName(funcName);
   appendTypeMangling(nullptr, args, mangledName);


### PR DESCRIPTION
It looks like these warnings got accidentally disabled in a recent
commit to tidy up compile options.

Also fixed some errors it threw up.

Change-Id: I671aafe218a732d961560dfbd677397bec027cdd