### PR TITLE
Hack to fix GPUOpen CI lit testing

### DIFF
--- a/llpc/test/CMakeLists.txt
+++ b/llpc/test/CMakeLists.txt
@@ -40,6 +40,10 @@ if(DEFINED XGL_LLVM_SRC_PATH)
 endif()
 
 if(DEFINED LLVM_DIR)
+  # Hack to allow for LLVM_DIR being set incorrectly in GPUOpen CI builds.
+  if(NOT EXISTS ${LLVM_DIR}/LLVMConfig)
+    string(REPLACE llvm/lib/cmake llpc/llvm/lib/cmake LLVM_DIR ${LLVM_DIR})
+  endif()
   set(BUILD_EXTERNAL NO)
 else()
   set(BUILD_EXTERNAL YES)


### PR DESCRIPTION
The recent merge from the AMD internal branch moved the location where
LLVM is built. This commit allows LLPC lit tests to work in a CI build,
without changing the CI build script.

This can be reverted once the CI script is fixed.

Change-Id: Ife7e4189dd95793043461d33467c6a444a057d4c