### PR TITLE
Add lookup table to store layout offsets of primitive shader const buffer

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -50,6 +50,51 @@ struct ExpData {
   llvm::Value *expValue; // Export value
 };
 
+// Represents constant buffer offsets (in bytes) of viewport controls in primitive shader table.
+// NOTE: The layout structure is defined by @ref Util::Abi::PrimShaderVportCb.
+struct PrimShaderVportCbLookupTable {
+  // Viewport transform scale
+  unsigned paClVportXscale;
+  unsigned paClVportXoffset;
+  unsigned paClVportYscale;
+  unsigned paClVportYoffset;
+  // Viewport width/height
+  unsigned vportWidth;
+  unsigned vportHeight;
+};
+
+// Represents a collection of constant buffer offsets (in bytes) in primitive shader table.
+// NOTE: The layout structure is defined by @ref Util::Abi::PrimShaderCbLayout.
+struct PrimShaderCbLayoutLookupTable {
+  // GS addressed used for jump from ES
+  unsigned gsAddressLo;
+  unsigned gsAddressHi;
+  // Viewport transform controls
+  unsigned paClVteCntl;
+  // Float-to-fixed-vertex conversion controls
+  unsigned paSuVtxCntl;
+  // Clip space controls
+  unsigned paClClipCntl;
+  // Culling controls
+  unsigned paSuScModeCntl;
+  // Various frustum culling controls
+  unsigned paClGbHorzClipAdj; // Horizontal adjacent culling control
+  unsigned paClGbVertClipAdj; // Vertical adjacent culling control
+  unsigned paClGbHorzDiscAdj; // Horizontal discard culling control
+  unsigned paClGbVertDiscAdj; // Vertical discard culling control
+  // Run-time handling primitive type
+  unsigned vgtPrimitiveType;
+  // Number of MSAA samples
+  unsigned msaaNumSamples;
+  // Render state
+  unsigned primitiveRestartEnable;
+  unsigned primitiveRestartIndex;
+  unsigned matchAllBits;
+  unsigned enableConservativeRasterization;
+  // Viewport controls
+  PrimShaderVportCbLookupTable vportControls[Util::Abi::MaxViewports];
+};
+
 // =====================================================================================================================
 // Represents the manager of NGG primitive shader.
 class NggPrimShader {
@@ -67,6 +112,8 @@ private:
 
   llvm::FunctionType *generatePrimShaderEntryPointType(uint64_t *inRegMask) const;
   llvm::Function *generatePrimShaderEntryPoint(llvm::Module *module);
+
+  void buildPrimShaderCbLayoutLookupTable();
 
   void constructPrimShaderWithoutGs(llvm::Module *module);
   void constructPrimShaderWithGs(llvm::Module *module);
@@ -166,6 +213,8 @@ private:
   GfxIpVersion m_gfxIp;           // Graphics IP version info
 
   const NggControl *m_nggControl; // NGG control settings
+
+  PrimShaderCbLayoutLookupTable m_cbLayoutTable; // Layout lookup table of primitive shader constant buffer
 
   NggLdsManager *m_ldsManager; // NGG LDS manager
 


### PR DESCRIPTION
Primitive shader table is implemented as a const buffer (CB). The entries
of this table storing run-time info used by NGG culling. Previously,
layout offsets are calculated when the entries are used. In the future, we
calculate all offsets at the creation time of NGG primitive shader class.

This severs the purpose of allowing PAL to change the CB layout in the
future flexibly. And LGC's actions will be just to change the calculation
in the new function buildPrimShaderCbLayoutLookupTable().

Change-Id: I8f20f895578157d908c52afc8513c8017fa95a4f