### PR TITLE
No user data layout for shader compile

### DIFF
--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -139,5 +139,6 @@ static const unsigned InternalPerShaderTable = 0x10000001;
 static const unsigned DescRelocMagic = 0xA5A5A500;
 static const unsigned DescRelocMagicMask = 0xFFFFFF00;
 static const unsigned DescSetMask = 0x000000FF;
+static const unsigned DescRelocPushConst = 0xA5A5A600;
 
 } // namespace lgc

--- a/lgc/patch/SystemValues.h
+++ b/lgc/patch/SystemValues.h
@@ -114,9 +114,6 @@ private:
   // Explicitly set the DATA_FORMAT of ring buffer descriptor.
   llvm::Value *setRingBufferDataFormat(llvm::Value *bufDesc, unsigned dataFormat, BuilderBase &builder) const;
 
-  // Find resource node by type
-  const ResourceNode *findResourceNodeByType(ResourceNodeType type);
-
   // Find resource node by descriptor set ID
   unsigned findResourceNodeByDescSet(unsigned descSet);
 

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -124,7 +124,7 @@ public:
                                          unsigned forceLoopUnrollCount, ElfPackage *pipelineElf);
 
   Result buildPipelineInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
-                               unsigned forceLoopUnrollCount, ElfPackage *pipelineElf);
+                               unsigned forceLoopUnrollCount, bool unlinked, ElfPackage *pipelineElf);
 
   // Gets the count of compiler instance.
   static unsigned getInstanceCount() { return m_instanceCount; }

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -190,7 +190,8 @@ ShaderHash PipelineContext::getShaderHashCode(ShaderStage stage) const {
 // Set pipeline state in Pipeline object for middle-end
 //
 // @param [in/out] pipeline : Middle-end pipeline object
-void PipelineContext::setPipelineState(Pipeline *pipeline) const {
+// @param unlinked : Do not provide some state to LGC, so offsets are generated as relocs
+void PipelineContext::setPipelineState(Pipeline *pipeline, bool unlinked) const {
   // Give the shader stage mask to the middle-end. We need to translate the Vkgc::ShaderStage bit numbers
   // to lgc::ShaderStage bit numbers.
   unsigned stageMask = getShaderStageMask();
@@ -204,8 +205,10 @@ void PipelineContext::setPipelineState(Pipeline *pipeline) const {
   // Give the pipeline options to the middle-end.
   setOptionsInPipeline(pipeline);
 
-  // Give the user data nodes to the middle-end.
-  setUserDataInPipeline(pipeline);
+  if (!unlinked) {
+    // Give the user data nodes to the middle-end.
+    setUserDataInPipeline(pipeline);
+  }
 
   if (isGraphics()) {
     // Set vertex input descriptions to the middle-end.

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -133,7 +133,7 @@ public:
   virtual const PipelineOptions *getPipelineOptions() const = 0;
 
   // Set pipeline state in lgc::Pipeline object for middle-end
-  void setPipelineState(lgc::Pipeline *pipeline) const;
+  void setPipelineState(lgc::Pipeline *pipeline, bool unlinked) const;
 
   // Get ShaderFpMode struct for the given shader stage
   ShaderFpMode &getShaderFpMode(ShaderStage stage) { return m_shaderFpModes[stage]; }

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -56,8 +56,6 @@ struct ResourceNodeSet {
 };
 
 // -auto-layout-desc: automatically create descriptor layout based on resource usages
-//
-// NOTE: This option is deprecated and will be ignored, and is present only for compatibility.
 static cl::opt<bool> AutoLayoutDesc("auto-layout-desc",
                                     cl::desc("Automatically create descriptor layout based on resource usages"));
 
@@ -538,6 +536,10 @@ void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipe
       colorTarget->channelWriteMask = (1U << elemCount) - 1;
     }
   }
+
+  // Only auto-layout descriptors if -auto-layout-desc is on.
+  if (!AutoLayoutDesc)
+    return;
 
   // Collect ResourceMappingNode entries in sets.
   std::map<unsigned, ResourceNodeSet> resNodeSets;


### PR DESCRIPTION
Only the top two commits are for this PR. Other commits are from other unmerged PRs.

Building on those other PRs that enabled shader compilation without user data layout, this PR actually switches to doing shader compilation without user data layout. In LGC, relocs for user data are now only generated if there is no user data layout.