### PR TITLE
Fix amdllpc -gfxip option parsing

### DIFF
--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -389,11 +389,15 @@ static Result init(int argc, char *argv[], ICompiler **ppCompiler) {
         gfxipStr = arg.slice(1, StringRef::npos);
       else
         continue;
-      if (!gfxipStr.consumeInteger(10, ParsedGfxIp.major) && gfxipStr.startswith(".")) {
-        gfxipStr = gfxipStr.slice(1, StringRef::npos);
-        if (!gfxipStr.consumeInteger(10, ParsedGfxIp.minor) && gfxipStr.startswith(".")) {
+      if (!gfxipStr.consumeInteger(10, ParsedGfxIp.major)) {
+        ParsedGfxIp.minor = 0;
+        ParsedGfxIp.stepping = 0;
+        if (gfxipStr.startswith(".")) {
           gfxipStr = gfxipStr.slice(1, StringRef::npos);
-          gfxipStr.consumeInteger(10, ParsedGfxIp.stepping);
+          if (!gfxipStr.consumeInteger(10, ParsedGfxIp.minor) && gfxipStr.startswith(".")) {
+            gfxipStr = gfxipStr.slice(1, StringRef::npos);
+            gfxipStr.consumeInteger(10, ParsedGfxIp.stepping);
+          }
         }
       }
       break;


### PR DESCRIPTION
This fixes it so that unspecified parts of the version are assumed to be
zero, so e.g. -gfxip=9 means 9.0.0. Previously it meant 9.0.2, because
of information leaking through from the default value of 8.0.2.