### PR TITLE
Use backend optimization for kills

### DIFF
--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -97,7 +97,7 @@ llvm::FunctionPass *createPatchIntrinsicSimplify();
 llvm::ModulePass *createPatchLlvmIrInclusion();
 llvm::FunctionPass *createPatchLoadScalarizer();
 llvm::ModulePass *createPatchNullFragShader();
-llvm::FunctionPass *createPatchPeepholeOpt(bool enableDiscardOpt = false);
+llvm::FunctionPass *createPatchPeepholeOpt();
 llvm::ModulePass *createPatchPreparePipelineAbi(bool onlySetCallingConvs);
 llvm::ModulePass *createPatchPushConstOp();
 llvm::ModulePass *createPatchResourceCollect();

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -274,7 +274,7 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
     passMgr.add(createFloat2IntPass());
     passMgr.add(createLoopRotatePass());
     passMgr.add(createCFGSimplificationPass(1, true, true, true, true));
-    passMgr.add(createPatchPeepholeOpt(true));
+    passMgr.add(createPatchPeepholeOpt());
     passMgr.add(createInstSimplifyLegacyPass());
     passMgr.add(createLoopUnrollPass(optLevel));
     passMgr.add(createInstructionCombiningPass(2));
@@ -304,7 +304,7 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
                                // is when you have bit casts whose source is a PHI - we want to make sure that the PHI
                                // does not have an i8 type before the scalarizer is called, otherwise a different kind
                                // of PHI mess is generated.
-                               passMgr.add(createPatchPeepholeOpt(true));
+                               passMgr.add(createPatchPeepholeOpt());
 
                                // Run the scalarizer as it helps our register pressure in the backend significantly. The
                                // scalarizer allows us to much more easily identify dead parts of vectors that we do not

--- a/lgc/patch/PatchPeepholeOpt.h
+++ b/lgc/patch/PatchPeepholeOpt.h
@@ -53,9 +53,7 @@ namespace lgc {
 //
 class PatchPeepholeOpt final : public llvm::FunctionPass, public llvm::InstVisitor<PatchPeepholeOpt> {
 public:
-  explicit PatchPeepholeOpt(bool enKillOpt);
-
-  PatchPeepholeOpt() : FunctionPass(ID) {}
+  PatchPeepholeOpt();
 
   bool runOnFunction(llvm::Function &function) override;
 
@@ -65,7 +63,6 @@ public:
   void visitICmp(llvm::ICmpInst &iCmp);
   void visitExtractElement(llvm::ExtractElementInst &extractElement);
   void visitPHINode(llvm::PHINode &phiNode);
-  void visitCallInst(llvm::CallInst &callInst);
 
   void moveAfter(llvm::Instruction &move, llvm::Instruction &after) const;
   void insertAfter(llvm::Instruction &insert, llvm::Instruction &after) const;
@@ -81,7 +78,6 @@ private:
   // -----------------------------------------------------------------------------------------------------------------
 
   llvm::SmallVector<llvm::Instruction *, 8> m_instsToErase;
-  bool m_enableDiscardOpt; // Whether to enable the optimization for "kill" intrinsic
 };
 
 } // namespace lgc

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -140,6 +140,7 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
   setOptionDefault("use-gpu-divergence-analysis", "1");
+  setOptionDefault("amdgpu-conditional-discard-transformations", "1");
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Replace LLPC optimization guarded by an option
("enable-discard-opt") with LLVM optimization enabled at
all times ("amdgpu-conditional-discard-transformations").

The LLPC option will be a no-op after this commit and will be
removed eventually.