### PR TITLE
Fix memory leak in PatchInOutImportExport

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -122,6 +122,12 @@ bool PatchInOutImportExport::runOnModule(Module &module) {
 
       // Now process the call and return instructions.
       visit(*m_entryPoint);
+
+      delete m_fragColorExport;
+      m_fragColorExport = nullptr;
+
+      delete m_vertexFetch;
+      m_vertexFetch = nullptr;
     }
   }
 
@@ -136,12 +142,6 @@ bool PatchInOutImportExport::runOnModule(Module &module) {
     callInst->eraseFromParent();
   }
   m_exportCalls.clear();
-
-  delete m_fragColorExport;
-  m_fragColorExport = nullptr;
-
-  delete m_vertexFetch;
-  m_vertexFetch = nullptr;
 
   for (auto &fragColors : m_expFragColors)
     fragColors.clear();

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -506,8 +506,6 @@ static void cleanupCompileInfo(CompileInfo *compileInfo) {
 
   if (compileInfo->pipelineInfoFile)
     Vfx::vfxCloseDoc(compileInfo->pipelineInfoFile);
-
-  memset(compileInfo, 0, sizeof(*compileInfo));
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The top of tree llpc leaks a lot of memory. This is one of them and we are still investigating the remaining leaks.