### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+
+[*.cmake]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Editorconfig is a file that tells editors about basic formatting styles.
The config is honored by default by GitHub, Visual Studio and others, plugins exist for basically every editor out there (Visual Studio Code, Emacs, Vim, Eclipse to name a few).
This makes it easier to work with projects with different indentation styles.

More information about the config format and editors is here: https://editorconfig.org