### PR TITLE
Limit the maximum times a Context can be reused

### DIFF
--- a/llpc/context/llpcContext.h
+++ b/llpc/context/llpcContext.h
@@ -56,7 +56,15 @@ public:
   bool isInUse() const { return m_isInUse; }
 
   // Set context in-use flag.
-  void setInUse(bool inUse) { m_isInUse = inUse; }
+  void setInUse(bool inUse) {
+    if (!m_isInUse && inUse) {
+      ++m_useCount;
+    }
+    m_isInUse = inUse;
+  }
+
+  // Get the number of times this context is used.
+  unsigned getUseCount() const { return m_useCount; }
 
   // Attaches pipeline context to LLPC context.
   void attachPipelineContext(PipelineContext *pipelineContext) { m_pipelineContext = pipelineContext; }
@@ -142,6 +150,8 @@ private:
   std::unique_ptr<llvm::TargetMachine> m_targetMachine; // Target machine
   bool m_scalarBlockLayout = false;                     // scalarBlockLayout option from last pipeline compile
   bool m_robustBufferAccess = false;                    // robustBufferAccess option from last pipeline compile
+
+  unsigned m_useCount = 0; // Number of times this context is used.
 };
 
 } // namespace Llpc


### PR DESCRIPTION
The compiler currently holds a pool of `llpc::Context` to avoid recreating them during each pipeline/shader module compilation. However this reuse leads to memory leaks since `LlvmContext` does not free up the small temporary objects generated during compilation. All these allocations are made from a pool that only gets freed when the `LlvmContext` is teared down.

This has lead to an OOM in our internal tool that need to compile hundreds of thousands of pipeline in a single run.

This PR fixes this issue by introducing a compiler option to limit the maximum times a `Context` may be reused. If it reaches the limit (default to 100 times), the context will be freed and recreated to free up the internal llvm memory. This has successfully bounded the memory consumption and allowed our internal tool to run.