### PR TITLE
Add culling to NGG GS

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -120,7 +120,7 @@ private:
 
   void initWaveThreadInfo(llvm::Value *mergedGroupInfo, llvm::Value *mergedWaveInfo);
 
-  llvm::Value *doCulling(llvm::Module *module);
+  llvm::Value *doCulling(llvm::Module *module, llvm::Value *vertexId0, llvm::Value *vertexId1, llvm::Value *vertexId2);
   void doParamCacheAllocRequest();
   void doPrimitiveExportWithoutGs(llvm::Value *cullFlag = nullptr);
   void doPrimitiveExportWithGs(llvm::Value *vertexId);
@@ -144,7 +144,7 @@ private:
                       llvm::Value *threadIdInSubgroup, llvm::Value *emitVerts);
 
   llvm::Value *importGsOutput(llvm::Type *outputTy, unsigned location, unsigned compIdx, unsigned streamId,
-                              llvm::Value *threadIdInSubgroup);
+                              llvm::Value *vertexOffset);
 
   void processGsEmit(llvm::Module *module, unsigned streamId, llvm::Value *threadIdInSubgroup,
                      llvm::Value *emitVertsPtr, llvm::Value *outVertsPtr);
@@ -191,6 +191,7 @@ private:
 
   llvm::Value *fetchVertexPositionData(llvm::Value *vertexId);
   llvm::Value *fetchCullDistanceSignMask(llvm::Value *vertexId);
+  llvm::Value *calcVertexItemOffset(unsigned streamId, llvm::Value *vertexId);
 
   unsigned getOutputVerticesPerPrimitive() const;
 


### PR DESCRIPTION
This is the last phase of NGG GS support.

1. Add blocks to handle culling. The processing is something like this:

```
  if (culling && valid primitive &
      threadIdInSubgroup < primCountInSubgroup) {
    Do culling (run culling algorithms)
    if (primitive culled)
      Nullify primitive connectivity data
  }
  Barrier
```

2. Rewrite the processing function doCulling(). The three vertex IDs
   are passed to this function and are calculated outside it. This is
   because the vertex IDs are obtained differently in ES-only and
   ES-GS cases. For ES-GS case, null primitive could be produced after
   GS execution and there is no valid vertex ID.

3. Add a helper calculation function calcVertexItemOffset() to
   calculate the starting LDS offset in GS-VS ring (given a vertex ID
   in subgroup). Also, this could simplify several code pieces that
   need this calculation and make it maintained easily.

4. Also, fix the mistaken vertex offsets in fetchVertexPositionData()
   and fetchCullDistanceSignMask(). In ES-GS case, we don't add the
   base offset of GS-VS ring. This leads to wrong fetched value from
   LDS.

All cases in dEQP-VK.geometry.* pass with classical backface culling
enabled.

Change-Id: I6fbad712224b2565369a1739438733f45e4ba5ab