### PR TITLE
Moved PAL metadata setting from pipeline state to PalMetadata::finali…

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -196,4 +196,39 @@ constexpr unsigned int mmSPI_SHADER_USER_DATA_HS_0 = 0x2D0C; // For GFX9+, Used 
 constexpr unsigned int mmSPI_SHADER_USER_DATA_PS_0 = 0x2C0C;
 constexpr unsigned int mmSPI_SHADER_USER_DATA_VS_0 = 0x2C4C;
 
+// Other SPI register numbers in PAL metadata
+constexpr unsigned int mmPA_CL_CLIP_CNTL = 0xA204;
+
+// Register bitfield layout.
+
+// PA_CL_CLIP_CNTL register
+union PA_CL_CLIP_CNTL {
+  struct {
+    unsigned int UCP_ENA_0 : 1;
+    unsigned int UCP_ENA_1 : 1;
+    unsigned int UCP_ENA_2 : 1;
+    unsigned int UCP_ENA_3 : 1;
+    unsigned int UCP_ENA_4 : 1;
+    unsigned int UCP_ENA_5 : 1;
+    unsigned int : 7;
+    unsigned int PS_UCP_Y_SCALE_NEG : 1;
+    unsigned int PS_UCP_MODE : 2;
+    unsigned int CLIP_DISABLE : 1;
+    unsigned int UCP_CULL_ONLY_ENA : 1;
+    unsigned int BOUNDARY_EDGE_FLAG_ENA : 1;
+    unsigned int DX_CLIP_SPACE_DEF : 1;
+    unsigned int DIS_CLIP_ERR_DETECT : 1;
+    unsigned int VTX_KILL_OR : 1;
+    unsigned int DX_RASTERIZATION_KILL : 1;
+    unsigned int : 1;
+    unsigned int DX_LINEAR_ATTR_CLIP_ENA : 1;
+    unsigned int VTE_VPORT_PROVOKE_DISABLE : 1;
+    unsigned int ZCLIP_NEAR_DISABLE : 1;
+    unsigned int ZCLIP_FAR_DISABLE : 1;
+    unsigned int ZCLIP_PROG_NEAR_ENA : 1; // GFX9+
+    unsigned int : 3;
+  } bits, bitfields;
+  unsigned int u32All;
+};
+
 } // namespace lgc

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -76,6 +76,9 @@ public:
   // set to the minimum of any call to this function in any shader.
   void setUserDataSpillUsage(unsigned dwordOffset);
 
+  // Set a register value in PAL metadata. If the register is already set, this ORs in the value.
+  void setRegister(unsigned regNum, unsigned value);
+
   // Finalize PAL metadata for pipeline.
   // TODO Shader compilation: The idea is that this will be called at the end of a pipeline compilation, or in
   // an ELF link, but not at the end of a shader/half-pipeline compile.

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -286,16 +286,6 @@ void ConfigBuilderBase::setEsGsLdsSize(unsigned value) {
 }
 
 // =====================================================================================================================
-// Set PIPELINE_HASH (called once for the whole pipeline)
-void ConfigBuilderBase::setPipelineHash() {
-  const auto &options = m_pipelineState->getOptions();
-
-  auto pipelineHashNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::InternalPipelineHash].getArray(true);
-  pipelineHashNode[0] = m_document->getNode(options.hash[0]);
-  pipelineHashNode[1] = m_document->getNode(options.hash[1]);
-}
-
-// =====================================================================================================================
 /// Append a single entry to the PAL register metadata.
 ///
 /// @param [in] key The metadata key (usually a register address).
@@ -333,9 +323,6 @@ void ConfigBuilderBase::appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config
 // =====================================================================================================================
 // Finish ConfigBuilder processing by writing into the PalMetadata document
 void ConfigBuilderBase::writePalMetadata() {
-  // Set whole-pipeline values.
-  setPipelineHash();
-
   // Generating MsgPack metadata.
   // Add the register values to the MsgPack document. The value is ORed in because an earlier pass may have
   // already set some bits in the same register.

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -111,8 +111,6 @@ private:
   llvm::msgpack::MapDocNode getApiShaderNode(unsigned apiStage);
   // Get the MsgPack map node for the specified HW shader in the ".hardware_stages" map
   llvm::msgpack::MapDocNode getHwShaderNode(Util::Abi::HardwareStage hwStage);
-  // Set PIPELINE_HASH (called once for the whole pipeline)
-  void setPipelineHash();
 
   // -----------------------------------------------------------------------------------------------------------------
   llvm::msgpack::Document *m_document;                 // The MsgPack document


### PR DESCRIPTION
…zePipeline

With shader/half-pipeline compilation and ELF linking, this change means
that these pipeline state items do not need to be known until ELF
linking time:

* Pipeline hash
* depthClipEnable
* rasterizerDiscardEnable
* usrClipPlaneMask

Also disabled generation of VS-related metadata in an FS-only shader
compilation.

Change-Id: Icfe8349dc4bc3520abdfa5d43bce216f0eb8f37d