### PR TITLE
Fix coding issues that are left by coding style transition

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -195,8 +195,8 @@ enum class ResourceMappingNodeType : unsigned {
 struct ResourceMappingNode {
   ResourceMappingNodeType type; ///< Type of this node
 
-  unsigned sizeInDwords;   ///< Size of this node in DWORD
-  unsigned offsetInDwords; ///< Offset of this node (from the beginning of the resource mapping table) in DWORD
+  unsigned sizeInDwords;   ///< Size of this node in dword
+  unsigned offsetInDwords; ///< Offset of this node (from the beginning of the resource mapping table) in dword
 
   union {
     /// Info for generic descriptor nodes (DescriptorResource, DescriptorSampler, DescriptorCombinedTexture,
@@ -213,7 +213,7 @@ struct ResourceMappingNode {
     } tablePtr;
     /// Info for hierarchical nodes (IndirectUserDataVaPtr)
     struct {
-      unsigned sizeInDwords; ///< Size of the pointed table in DWORDS
+      unsigned sizeInDwords; ///< Size of the pointed table in dwords
     } userDataPtr;
   };
 };

--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -33,7 +33,7 @@
 #include "lgc/state/TargetInfo.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-arith"
+#define DEBUG_TYPE "lgc-builder-impl-arith"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -37,7 +37,7 @@
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include <set>
 
-#define DEBUG_TYPE "llpc-builder"
+#define DEBUG_TYPE "lgc-builder"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -426,8 +426,6 @@ private:
   // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
   llvm::Value *handleFragCoordViewIndex(llvm::Value *coord, unsigned flags, unsigned &dim);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   enum ImgDataFormat {
     IMG_DATA_FORMAT_32 = 4,
     IMG_DATA_FORMAT_32_32 = 11,

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -35,7 +35,7 @@
 #include "lgc/state/ShaderModes.h"
 #include "lgc/util/Internal.h"
 
-#define DEBUG_TYPE "llpc-builder-recorder"
+#define DEBUG_TYPE "lgc-builder-recorder"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -303,7 +303,7 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
 // BuilderRecordedMetadataKinds constructor : get the metadata kind IDs
 //
 // @param context : LLVM context
-BuilderRecorderMetadataKinds::BuilderRecorderMetadataKinds(llvm::LLVMContext &context) {
+BuilderRecorderMetadataKinds::BuilderRecorderMetadataKinds(LLVMContext &context) {
   opcodeMetaKindId = context.getMDKindID(BuilderCallOpcodeMetadataName);
 }
 

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -553,8 +553,6 @@ private:
   llvm::Instruction *record(Opcode opcode, llvm::Type *returnTy, llvm::ArrayRef<llvm::Value *> args,
                             const llvm::Twine &instName, llvm::ArrayRef<llvm::Attribute::AttrKind> attribs = {});
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   PipelineState *m_pipelineState;             // PipelineState; nullptr for shader compile
   std::unique_ptr<ShaderModes> m_shaderModes; // ShaderModes for a shader compile
   bool m_omitOpcodes;                         // Omit opcodes on lgc.create.* function declarations

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -34,7 +34,7 @@
 #include "lgc/util/Internal.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-builder-replayer"
+#define DEBUG_TYPE "lgc-builder-replayer"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -54,8 +54,6 @@ public:
 
   bool runOnModule(Module &module) override;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID;
 
 private:

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -48,7 +48,7 @@ public:
   BuilderReplayer() : ModulePass(ID) {}
   BuilderReplayer(Pipeline *pipeline);
 
-  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
+  void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
     analysisUsage.addRequired<PipelineStateWrapper>();
   }
 
@@ -67,7 +67,7 @@ private:
   std::unique_ptr<Builder> m_builder;                 // The LLPC builder that the builder
                                                       //  calls are being replayed on.
   std::map<Function *, ShaderStage> m_shaderStageMap; // Map function -> shader stage
-  llvm::Function *m_enclosingFunc = nullptr;          // Last function written with current
+  Function *m_enclosingFunc = nullptr;                // Last function written with current
                                                       //  shader stage
 };
 

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -36,7 +36,7 @@
 #include "lgc/util/Internal.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-desc"
+#define DEBUG_TYPE "lgc-builder-impl-desc"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -776,7 +776,7 @@ Value *ImageBuilder::CreateImageSampleConvertYCbCr(Type *resultTy, unsigned dim,
     return cast<ConstantInt>(CreateExtractElement(convertingSamplerDesc, idx))->getZExtValue();
   };
 
-  // Extract YCbCr meta data, which is the last 4 DWORDs of convertingSamplerDesc
+  // Extract YCbCr meta data, which is the last 4 dwords of convertingSamplerDesc
   SamplerYCbCrConversionMetaData yCbCrMetaData;
   yCbCrMetaData.word0.u32All = getYCbCrMetaElement(4);
   yCbCrMetaData.word1.u32All = getYCbCrMetaElement(5);
@@ -797,7 +797,7 @@ Value *ImageBuilder::CreateImageSampleConvertYCbCr(Type *resultTy, unsigned dim,
   dim = prepareCoordinate(dim, coord, projective, address[ImageAddressIdxDerivativeX],
                           address[ImageAddressIdxDerivativeY], coords, derivatives);
 
-  // Only the first 4 DWORDs are sampler descriptor, we need to extract these values under any condition
+  // Only the first 4 dwords are sampler descriptor, we need to extract these values under any condition
   // Init sample descriptor for luma channel
   Value *samplerDescLuma = CreateShuffleVector(convertingSamplerDesc, convertingSamplerDesc, ArrayRef<int>{0, 1, 2, 3});
 
@@ -852,7 +852,7 @@ Value *ImageBuilder::CreateImageGather(Type *resultTy, unsigned dim, unsigned fl
     needDescPatch = preprocessIntegerImageGather(dim, imageDesc, coord);
   }
 
-  // Only the first 4 DWORDs are sampler descriptor, we need to extract these values under any condition
+  // Only the first 4 dwords are sampler descriptor, we need to extract these values under any condition
   samplerDesc = CreateShuffleVector(samplerDesc, samplerDesc, ArrayRef<int>{0, 1, 2, 3});
 
   Value *result = nullptr;
@@ -1408,7 +1408,7 @@ Value *ImageBuilder::CreateImageGetLod(unsigned dim, unsigned flags, Value *imag
   SmallVector<Value *, 6> derivatives;
   dim = prepareCoordinate(dim, coord, nullptr, nullptr, nullptr, coords, derivatives);
 
-  // Only the first 4 DWORDs are sampler descriptor, we need to extract these values under any condition
+  // Only the first 4 dwords are sampler descriptor, we need to extract these values under any condition
   samplerDesc = CreateShuffleVector(samplerDesc, samplerDesc, ArrayRef<int>{0, 1, 2, 3});
 
   SmallVector<Value *, 9> args;

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -35,7 +35,7 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-image"
+#define DEBUG_TYPE "lgc-builder-impl-image"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -33,7 +33,7 @@
 #include "lgc/state/PipelineState.h"
 #include "lgc/util/Internal.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-inout"
+#define DEBUG_TYPE "lgc-builder-impl-inout"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/MatrixBuilder.cpp
+++ b/lgc/builder/MatrixBuilder.cpp
@@ -30,7 +30,7 @@
  */
 #include "BuilderImpl.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-matrix"
+#define DEBUG_TYPE "lgc-builder-impl-matrix"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -32,7 +32,7 @@
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-misc"
+#define DEBUG_TYPE "lgc-builder-impl-misc"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -35,7 +35,7 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
-#define DEBUG_TYPE "llpc-builder-impl-subgroup"
+#define DEBUG_TYPE "lgc-builder-impl-subgroup"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -74,8 +74,6 @@ private:
   llvm::Value *convertToFloat(llvm::Value *value, bool signedness, llvm::Instruction *insertPos) const;
   llvm::Value *convertToInt(llvm::Value *value, bool signedness, llvm::Instruction *insertPos) const;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   PipelineState *m_pipelineState; // Pipeline state
   llvm::LLVMContext *m_context;   // LLVM context
 };

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -117,8 +117,6 @@ public:
 protected:
   void init(llvm::Module *module);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::Module *m_module;       // LLVM module to be run on
   llvm::LLVMContext *m_context; // Associated LLVM context of the LLVM module that passes run on
   ShaderStage m_shaderStage;    // Shader stage

--- a/lgc/include/lgc/state/IntrinsDefs.h
+++ b/lgc/include/lgc/state/IntrinsDefs.h
@@ -393,7 +393,7 @@ union SpiPsInputAddr {
   unsigned u32All;
 };
 
-// Represents the first DWORD of buffer descriptor SQ_BUF_RSRC_WORD0.
+// Represents the first dword of buffer descriptor SQ_BUF_RSRC_WORD0.
 union SqBufRsrcWord0 {
   struct {
     unsigned baseAddress : 32;
@@ -402,7 +402,7 @@ union SqBufRsrcWord0 {
   unsigned u32All;
 };
 
-// Represents the second DWORD of buffer descriptor SQ_BUF_RSRC_WORD1.
+// Represents the second dword of buffer descriptor SQ_BUF_RSRC_WORD1.
 union SqBufRsrcWord1 {
   struct {
     unsigned baseAddressHi : 16;
@@ -414,7 +414,7 @@ union SqBufRsrcWord1 {
   unsigned u32All;
 };
 
-// Represents the third DWORD of buffer descriptor SQ_BUF_RSRC_WORD2.
+// Represents the third dword of buffer descriptor SQ_BUF_RSRC_WORD2.
 union SqBufRsrcWord2 {
   struct {
     unsigned numRecords : 32;
@@ -423,7 +423,7 @@ union SqBufRsrcWord2 {
   unsigned u32All;
 };
 
-// Represents the forth DWORD of buffer descriptor SQ_BUF_RSRC_WORD3.
+// Represents the forth dword of buffer descriptor SQ_BUF_RSRC_WORD3.
 union SqBufRsrcWord3 {
   struct {
     unsigned dstSelX : 3;

--- a/lgc/include/lgc/state/PipelineShaders.h
+++ b/lgc/include/lgc/state/PipelineShaders.h
@@ -56,8 +56,6 @@ private:
   PipelineShaders(const PipelineShaders &) = delete;
   PipelineShaders &operator=(const PipelineShaders &) = delete;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::Function *m_entryPoints[ShaderStageCountInternal];       // The entry-point for each shader stage.
   std::map<const llvm::Function *, ShaderStage> m_entryPointMap; // Map from shader entry-point to shader stage.
 };

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -380,7 +380,6 @@ private:
   void recordGraphicsState(llvm::Module *module);
   void readGraphicsState(llvm::Module *module);
 
-  // -----------------------------------------------------------------------------------------------------------------
   bool m_noReplayer = false;                            // True if no BuilderReplayer needed
   bool m_emitLgc = false;                               // Whether -emit-lgc is on
   bool m_unlinked = false;                              // Whether generating an unlinked half-pipeline ELF
@@ -421,8 +420,6 @@ public:
 
   // Set the PipelineState.
   void setPipelineState(PipelineState *pipelineState) { m_pipelineState = pipelineState; }
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   static char ID; // ID of this pass
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -351,35 +351,35 @@ struct ResourceUsage {
 
     struct {
       struct {
-        unsigned inVertexStride;           // Stride of vertices of input patch (in DWORD, correspond to
+        unsigned inVertexStride;           // Stride of vertices of input patch (in dword, correspond to
                                            // "lsStride")
-        unsigned outVertexStride;          // Stride of vertices of output patch (in DWORD, correspond to
+        unsigned outVertexStride;          // Stride of vertices of output patch (in dword, correspond to
                                            // "hsCpStride")
-        unsigned patchCountPerThreadGroup; // Count of patches per thread group (in DWORD, correspond to
+        unsigned patchCountPerThreadGroup; // Count of patches per thread group (in dword, correspond to
                                            // "hsNumPatch")
         // On-chip caculation factors
         struct {
           unsigned outPatchStart;   // Offset into LDS where vertices of output patches start
-                                    // (in DWORD, correspond to "hsOutputBase")
-          unsigned patchConstStart; // Offset into LDS where patch constants start (in DWORD,
+                                    // (in dword, correspond to "hsOutputBase")
+          unsigned patchConstStart; // Offset into LDS where patch constants start (in dword,
                                     // correspond to "patchConstBase")
         } onChip;
 
         // Off-chip caculation factors
         struct {
           unsigned outPatchStart;   // Offset into LDS where vertices of output patches start
-                                    // (in DWORD, correspond to "hsOutputBase")
-          unsigned patchConstStart; // Offset into LDS where patch constants start (in DWORD,
+                                    // (in dword, correspond to "hsOutputBase")
+          unsigned patchConstStart; // Offset into LDS where patch constants start (in dword,
                                     // correspond to "patchConstBase")
         } offChip;
 
-        unsigned inPatchSize; // size of an input patch size (in DWORD)
+        unsigned inPatchSize; // size of an input patch size (in dword)
 
-        unsigned outPatchSize; // Size of an output patch output (in DWORD, correspond to
+        unsigned outPatchSize; // Size of an output patch output (in dword, correspond to
                                // "patchOutputSize")
 
-        unsigned patchConstSize;   // Size of an output patch constants (in DWORD)
-        unsigned tessFactorStride; // Size of tess factor stride (in DWORD)
+        unsigned patchConstSize;   // Size of an output patch constants (in dword)
+        unsigned tessFactorStride; // Size of tess factor stride (in dword)
 
       } calcFactor;
     } tcs = {};
@@ -401,8 +401,8 @@ struct ResourceUsage {
       unsigned rasterStream = 0;
 
       struct {
-        unsigned esGsRingItemSize;   // Size of each vertex written to the ES -> GS Ring, in DWORDs.
-        unsigned gsVsRingItemSize;   // Size of each primitive written to the GS -> VS Ring, in DWORDs.
+        unsigned esGsRingItemSize;   // Size of each vertex written to the ES -> GS Ring, in dwords.
+        unsigned gsVsRingItemSize;   // Size of each primitive written to the GS -> VS Ring, in dwords.
         unsigned esVertsPerSubgroup; // Number of vertices ES exports.
         unsigned gsPrimsPerSubgroup; // Number of prims GS exports.
         unsigned esGsLdsSize;        // ES -> GS ring LDS size (GS in)

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -50,7 +50,7 @@ struct GpuProperty {
   unsigned ldsSizePerThreadGroup;             // LDS size per thread group
   unsigned gsOnChipDefaultPrimsPerSubgroup;   // Default target number of primitives per subgroup for GS on-chip mode.
   unsigned gsOnChipDefaultLdsSizePerSubgroup; // Default value for the maximum LDS size per subgroup for
-  unsigned gsOnChipMaxLdsSize;                // Max LDS size used by GS on-chip mode (in DWORDs)
+  unsigned gsOnChipMaxLdsSize;                // Max LDS size used by GS on-chip mode (in dwords)
   unsigned ldsSizeDwordGranularityShift;      // Amount of bits used to shift the LDS_SIZE register field
 
   // TODO: Setup gsPrimBufferDepth from hardware config option, will be done in another change.
@@ -60,7 +60,7 @@ struct GpuProperty {
   unsigned tessOffChipLdsBufferSize;  // Off-chip Tess Buffer Size
   unsigned maxSgprsAvailable;         // Number of max available SGPRs
   unsigned maxVgprsAvailable;         // Number of max available VGPRs
-  unsigned tessFactorBufferSizePerSe; // Size of the tessellation-factor buffer per SE, in DWORDs.
+  unsigned tessFactorBufferSizePerSe; // Size of the tessellation-factor buffer per SE, in dwords.
   bool supportShaderPowerProfiling;   // Hardware supports Shader Profiling for Power
   bool supportSpiPrefPriority;        // Hardware supports SPI shader preference priority
 

--- a/lgc/include/lgc/util/GfxRegHandler.h
+++ b/lgc/include/lgc/util/GfxRegHandler.h
@@ -85,10 +85,10 @@ protected:
     m_bitsState[regId].isModified = 1;
   }
 
-  // Get combined data from two seperate DWORDs
+  // Get combined data from two seperate dwords
   llvm::Value *getRegCombine(unsigned regIdLo, unsigned regIdHi);
 
-  // Set data into two seperate DWORDs
+  // Set data into two seperate dwords
   void setRegCombine(unsigned regIdLo, unsigned regIdHi, llvm::Value *reg);
 
   // Get current value state for the hardware register

--- a/lgc/include/lgc/util/GfxRegHandlerBase.h
+++ b/lgc/include/lgc/util/GfxRegHandlerBase.h
@@ -35,7 +35,7 @@
 
 namespace lgc {
 
-// General bits info for indexed DWORD
+// General bits info for indexed dword
 struct BitsInfo {
   unsigned index;
   unsigned offset;
@@ -59,19 +59,19 @@ protected:
     setRegister(reg);
   }
 
-  // Return new DWORD with replacing the specific range of bits in old DWORD
+  // Return new dword with replacing the specific range of bits in old dword
   llvm::Value *replaceBits(llvm::Value *dword, unsigned offset, unsigned count, llvm::Value *newBits);
 
-  // Return the size of registered DWORDs
+  // Return the size of registered dwords
   inline unsigned getDwordsCount() { return m_dwords.size(); }
 
-  // Get indexed DWORD
+  // Get indexed dword
   inline llvm::Value *getDword(unsigned index) {
     extractDwordIfNecessary(index);
     return m_dwords[index];
   }
 
-  // Set indexed DWORD
+  // Set indexed dword
   inline void setDword(unsigned index, llvm::Value *dword) {
     // Set the whole 32bits data
     m_dwords[index] = dword;
@@ -79,17 +79,17 @@ protected:
     m_dirtyDwords |= 1 << index;
   }
 
-  // Return if the specific DWORD is modified or not
+  // Return if the specific dword is modified or not
   inline bool isDwordModified(unsigned index) { return (m_dirtyDwords & (1 << index)); }
 
-  // Get data from a range of bits in indexed DWORD according to BitsInfo
+  // Get data from a range of bits in indexed dword according to BitsInfo
   llvm::Value *getBits(const BitsInfo &bitsInfo);
 
-  // Set data to a range of bits in indexed DWORD according to BitsInfo
+  // Set data to a range of bits in indexed dword according to BitsInfo
   void setBits(const BitsInfo &bitsInfo, llvm::Value *newBits);
 
 private:
-  // Load indexed DWORD from <n x i32> vector, if the specific DWORD is nullptr
+  // Load indexed dword from <n x i32> vector, if the specific dword is nullptr
   inline void extractDwordIfNecessary(unsigned index) {
     if (!m_dwords[index])
       m_dwords[index] = m_builder->CreateExtractElement(m_reg, m_builder->getInt64(index));

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1518,8 +1518,6 @@ public:
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateSubgroupMbcnt(llvm::Value *const mask, const llvm::Twine &instName = "") = 0;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
 protected:
   Builder(LgcContext *builderContext);
 
@@ -1529,8 +1527,6 @@ protected:
 
   // Get a constant of FP or vector of FP type from the given APFloat, converting APFloat semantics where necessary
   llvm::Constant *getFpConstant(llvm::Type *ty, llvm::APFloat value);
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   bool m_isBuilderRecorder = false;               // Whether this is a BuilderRecorder
   ShaderStage m_shaderStage = ShaderStageInvalid; // Current shader stage being built.
@@ -1555,8 +1551,6 @@ private:
   Builder() = delete;
   Builder(const Builder &) = delete;
   Builder &operator=(const Builder &) = delete;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   LgcContext *m_builderContext; // Builder context
 };

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -124,7 +124,6 @@ private:
 
   LgcContext(llvm::LLVMContext &context, unsigned palAbiVersion);
 
-  // -----------------------------------------------------------------------------------------------------------------
   static llvm::raw_ostream *m_llpcOuts;           // nullptr or stream for LLPC_OUTS
   llvm::LLVMContext &m_context;                   // LLVM context
   llvm::TargetMachine *m_targetMachine = nullptr; // Target machine

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -44,7 +44,7 @@ using namespace llvm;
 //
 // @param [in/out] module : LLVM module
 // @param pipelineState : Pipeline state
-ConfigBuilderBase::ConfigBuilderBase(llvm::Module *module, PipelineState *pipelineState)
+ConfigBuilderBase::ConfigBuilderBase(Module *module, PipelineState *pipelineState)
     : m_module(module), m_pipelineState(pipelineState) {
   m_context = &module->getContext();
 
@@ -313,7 +313,7 @@ void ConfigBuilderBase::appendConfig(unsigned key, unsigned value) {
 /// Append an array of entries to the PAL register metadata. Invalid keys are filtered out.
 ///
 /// @param [in] config The array of register metadata entries.
-void ConfigBuilderBase::appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config) {
+void ConfigBuilderBase::appendConfig(ArrayRef<PalMetadataNoteEntry> config) {
   unsigned count = 0;
 
   for (const auto &entry : config) {

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -35,7 +35,7 @@
 #include "lgc/state/TargetInfo.h"
 #include "llvm/IR/Constants.h"
 
-#define DEBUG_TYPE "llpc-config-builder-base"
+#define DEBUG_TYPE "lgc-config-builder-base"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -94,8 +94,6 @@ protected:
     appendConfig({reinterpret_cast<const PalMetadataNoteEntry *>(&config), sizeof(T) / sizeof(PalMetadataNoteEntry)});
   }
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::Module *m_module;         // LLVM module being processed
   llvm::LLVMContext *m_context;   // LLVM context
   PipelineState *m_pipelineState; // Pipeline state
@@ -114,7 +112,6 @@ private:
   // Set PIPELINE_HASH (called once for the whole pipeline)
   void setPipelineHash();
 
-  // -----------------------------------------------------------------------------------------------------------------
   llvm::msgpack::Document *m_document;                 // The MsgPack document
   llvm::msgpack::MapDocNode m_pipelineNode;            // MsgPack map node for amdpal.pipelines[0]
   llvm::msgpack::MapDocNode m_apiShaderNodes[ShaderStageNativeStageCount];

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -36,7 +36,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 
-#define DEBUG_TYPE "llpc-frag-color-export"
+#define DEBUG_TYPE "lgc-frag-color-export"
 
 using namespace llvm;
 

--- a/lgc/patch/Gfx6Chip.cpp
+++ b/lgc/patch/Gfx6Chip.cpp
@@ -30,7 +30,7 @@
  */
 #include "Gfx6Chip.h"
 
-#define DEBUG_TYPE "llpc-gfx6-chip"
+#define DEBUG_TYPE "lgc-gfx6-chip"
 
 namespace lgc {
 

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -707,15 +707,15 @@ void ConfigBuilder::buildLsRegConfig(ShaderStage shaderStage, T *pConfig) {
     const unsigned wavesPerThreadGroup = (threadGroupSize + waveSize - 1) / waveSize;
 
     if (wavesPerThreadGroup > 1) {
-      constexpr unsigned minLdsSizeWa = 1024; // 4KB in DWORDs.
+      constexpr unsigned minLdsSizeWa = 1024; // 4KB in dwords.
       ldsSizeInDwords = std::max(ldsSizeInDwords, minLdsSizeWa);
     }
   }
 
   unsigned ldsSize = 0;
 
-  // NOTE: On GFX6, granularity for the LDS_SIZE field is 64. The range is 0~128 which allocates 0 to 8K DWORDs.
-  // On GFX7+, granularity for the LDS_SIZE field is 128. The range is 0~128 which allocates 0 to 16K DWORDs.
+  // NOTE: On GFX6, granularity for the LDS_SIZE field is 64. The range is 0~128 which allocates 0 to 8K dwords.
+  // On GFX7+, granularity for the LDS_SIZE field is 128. The range is 0~128 which allocates 0 to 16K dwords.
   const unsigned ldsSizeDwordGranularityShift =
       m_pipelineState->getTargetInfo().getGpuProperty().ldsSizeDwordGranularityShift;
   const unsigned ldsSizeDwordGranularity = 1u << ldsSizeDwordGranularityShift;

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -34,7 +34,7 @@
 #include "lgc/state/TargetInfo.h"
 #include "llvm/Support/CommandLine.h"
 
-#define DEBUG_TYPE "llpc-gfx6-config-builder"
+#define DEBUG_TYPE "lgc-gfx6-config-builder"
 
 using namespace llvm;
 

--- a/lgc/patch/Gfx9Chip.cpp
+++ b/lgc/patch/Gfx9Chip.cpp
@@ -31,7 +31,7 @@
 #include "Gfx9Chip.h"
 #include "llvm/Support/ErrorHandling.h"
 
-#define DEBUG_TYPE "llpc-gfx9-chip"
+#define DEBUG_TYPE "lgc-gfx9-chip"
 
 namespace lgc {
 

--- a/lgc/patch/Gfx9Chip.h
+++ b/lgc/patch/Gfx9Chip.h
@@ -206,7 +206,7 @@ constexpr unsigned OnChipGsMaxPrimPerSubgroup = 255;
 constexpr unsigned OnChipGsMaxPrimPerSubgroupAdj = 127;
 constexpr unsigned OnChipGsMaxEsVertsPerSubgroup = 255;
 
-// Default value for the maximum LDS size per GS subgroup, in DWORD's.
+// Default value for the maximum LDS size per GS subgroup, in dword's.
 constexpr unsigned DefaultLdsSizePerSubgroup = 8192;
 
 constexpr unsigned EsVertsOffchipGsOrTess = 250;

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -34,7 +34,7 @@
 #include "lgc/state/TargetInfo.h"
 #include "llvm/Support/CommandLine.h"
 
-#define DEBUG_TYPE "llpc-gfx9-config-builder"
+#define DEBUG_TYPE "lgc-gfx9-config-builder"
 
 using namespace llvm;
 

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1117,7 +1117,7 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   SET_REG_FIELD(&pConfig->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR, userDataCount);
 
   // NOTE: On GFX7+, granularity for the LDS_SIZE field is 128. The range is 0~128 which allocates 0 to 16K
-  // DWORDs.
+  // dwords.
   const auto &calcFactor = tcsResUsage->inOutUsage.tcs.calcFactor;
   unsigned ldsSizeInDwords =
       calcFactor.onChip.patchConstStart + calcFactor.patchConstSize * calcFactor.patchCountPerThreadGroup;

--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -41,7 +41,7 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 
-#define DEBUG_TYPE "llpc-ngg-lds-manager"
+#define DEBUG_TYPE "lgc-ngg-lds-manager"
 
 using namespace llvm;
 

--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -54,33 +54,33 @@ const unsigned NggLdsManager::LdsRegionSizes[LdsRegionCount] = {
     //
     // LDS region size for ES-only
     //
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionDistribPrimId
-    // 4 DWORDs (vec4) per thread
+    // 4 dwords (vec4) per thread
     SizeOfVec4 * Gfx9::NggMaxThreadsPerSubgroup,              // LdsRegionPosData
-    // 1 BYTE (uint8) per thread
+    // 1 byte (uint8) per thread
     Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionDrawFlag
-    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
+    // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
     SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionPrimCountInWaves
-    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
+    // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
     SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionVertCountInWaves
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCullDistance
-    // 1 BYTE (uint8) per thread
+    // 1 byte (uint8) per thread
     Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionVertThreadIdMap
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactVertexId
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactInstanceId
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactPrimId
-    // 1 DWORD (float) per thread
+    // 1 dword (float) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactTessCoordX
-    // 1 DWORD (float) per thread
+    // 1 dword (float) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactTessCoordY
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactPatchId
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactRelPatchId
 
     //
@@ -88,11 +88,11 @@ const unsigned NggLdsManager::LdsRegionSizes[LdsRegionCount] = {
     //
     // ES-GS ring size is dynamically calculated (don't use it)
     InvalidValue,                                             // LdsRegionEsGsRing
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionOutPrimData
-    // 1 DWORD per wave (8 potential waves) + 1 DWORD for the entire sub-group
+    // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
     SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionOutVertCountInWaves
-    // 1 DWORD (uint32) per thread
+    // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionOutVertThreadIdMap
     // GS-VS ring size is dynamically calculated (don't use it)
     InvalidValue,                                             // LdsRegionGsVsRing
@@ -177,8 +177,8 @@ NggLdsManager::NggLdsManager(Module *module, PipelineState *pipelineState, IRBui
     // +------------+-----------------------+------------------------------+-----------------------------+------------+
     //
 
-    // NOTE: We round ES-GS LDS size to 4-DWORD alignment. This is for later LDS read/write operations of mutilple
-    // DWORDs (such as DS128).
+    // NOTE: We round ES-GS LDS size to 4-dword alignment. This is for later LDS read/write operations of mutilple
+    // dwords (such as DS128).
     const unsigned esGsRingLdsSize = alignTo(calcFactor.esGsLdsSize, 4u) * SizeOfDword;
     const unsigned gsVsRingLdsSize =
         calcFactor.gsOnChipLdsSize * SizeOfDword - esGsRingLdsSize - calcGsExtraLdsSize(m_pipelineState);
@@ -418,8 +418,8 @@ void NggLdsManager::writeValueToLds(Value *writeValue, Value *ldsOffset, bool us
 void NggLdsManager::atomicOpWithLds(AtomicRMWInst::BinOp atomicOp, Value *atomicValue, Value *ldsOffset) {
   assert(atomicValue->getType()->isIntegerTy(32));
 
-  // NOTE: LDS variable is defined as a pointer to i32 array. The LDS offset here has to be casted to DWORD offset
-  // from BYTE offset.
+  // NOTE: LDS variable is defined as a pointer to i32 array. The LDS offset here has to be casted to dword offset
+  // from byte offset.
   ldsOffset = m_builder->CreateLShr(ldsOffset, 2);
 
   Value *atomicPtr = m_builder->CreateGEP(m_lds, {m_builder->getInt32(0), ldsOffset});

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -115,8 +115,6 @@ private:
   NggLdsManager(const NggLdsManager &) = delete;
   NggLdsManager &operator=(const NggLdsManager &) = delete;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static const unsigned LdsRegionSizes[LdsRegionCount]; // LDS sizes for all LDS region types (in BYTEs)
   static const char *m_ldsRegionNames[LdsRegionCount];  // Name strings for all LDS region types
 

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -86,7 +86,7 @@ enum NggLdsRegionType {
   // clang-format on
 };
 
-// Size of a DWORD
+// Size of a dword
 static const unsigned SizeOfDword = sizeof(unsigned);
 
 // =====================================================================================================================
@@ -115,7 +115,7 @@ private:
   NggLdsManager(const NggLdsManager &) = delete;
   NggLdsManager &operator=(const NggLdsManager &) = delete;
 
-  static const unsigned LdsRegionSizes[LdsRegionCount]; // LDS sizes for all LDS region types (in BYTEs)
+  static const unsigned LdsRegionSizes[LdsRegionCount]; // LDS sizes for all LDS region types (in bytes)
   static const char *m_ldsRegionNames[LdsRegionCount];  // Name strings for all LDS region types
 
   PipelineState *m_pipelineState; // Pipeline state
@@ -123,7 +123,7 @@ private:
 
   llvm::GlobalValue *m_lds; // Global variable to model NGG LDS
 
-  unsigned m_ldsRegionStart[LdsRegionCount]; // Start LDS offsets for all available LDS region types (in BYTEs)
+  unsigned m_ldsRegionStart[LdsRegionCount]; // Start LDS offsets for all available LDS region types (in bytes)
 
   unsigned m_waveCountInSubgroup; // Wave count in sub-group
 

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -45,7 +45,7 @@
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#define DEBUG_TYPE "llpc-ngg-prim-shader"
+#define DEBUG_TYPE "lgc-ngg-prim-shader"
 
 using namespace llvm;
 

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3316,7 +3316,7 @@ Function *NggPrimShader::mutateCopyShader(Module *pModule) {
 // @param threadIdInSubgroup : Thread ID in sub-group
 // @param emitVerts : Counter of GS emitted vertices for this stream
 void NggPrimShader::exportGsOutput(Value *output, unsigned location, unsigned compIdx, unsigned streamId,
-                                   llvm::Value *threadIdInSubgroup, Value *emitVerts) {
+                                   Value *threadIdInSubgroup, Value *emitVerts) {
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageGeometry);
   if (resUsage->inOutUsage.gs.rasterStream != streamId) {
     // NOTE: Only export those outputs that belong to the rasterization stream.

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -246,7 +246,7 @@ private:
   bool m_hasTes; // Whether the pipeline has tessellation evaluation shader
   bool m_hasGs;  // Whether the pipeline has geometry shader
 
-  // Base offsets (in DWORDS) of GS output vertex streams in GS-VS ring
+  // Base offsets (in dwords) of GS output vertex streams in GS-VS ring
   uint32_t m_gsStreamBases[MaxGsStreams];
 
   std::unique_ptr<llvm::IRBuilder<>> m_builder; // LLVM IR builder

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -91,8 +91,7 @@ namespace lgc {
 // @param patchTimer : Timer to time patch passes with, nullptr if not timing
 // @param optTimer : Timer to time LLVM optimization passes with, nullptr if not timing
 void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr, ModulePass *replayerPass,
-                      llvm::Timer *patchTimer, llvm::Timer *optTimer,
-                      Pipeline::CheckShaderCacheFunc checkShaderCacheFunc)
+                      Timer *patchTimer, Timer *optTimer, Pipeline::CheckShaderCacheFunc checkShaderCacheFunc)
 // Callback function to check shader cache
 {
   // Start timer for patching passes.

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -61,7 +61,7 @@
 #include "llvm/Transforms/Scalar/Scalarizer.h"
 #include "llvm/Transforms/Utils.h"
 
-#define DEBUG_TYPE "llpc-patch"
+#define DEBUG_TYPE "lgc-patch"
 
 using namespace llvm;
 

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -917,13 +917,13 @@ void PatchBufferOp::postVisitMemCpyInst(MemCpyInst &memCpyInst) {
   // causes LLVM's optimizations and our AMDGPU backend to crawl (and generate worse code!).
   if (!lengthConstant || constantLength > MinMemOpLoopBytes) {
     // NOTE: We want to perform our memcpy operation on the greatest stride of bytes possible (load/storing up to
-    // DWORDx4 or 16 bytes per loop iteration). If we have a constant length, we check if the the alignment and
+    // dwordx4 or 16 bytes per loop iteration). If we have a constant length, we check if the the alignment and
     // number of bytes to copy lets us load/store 16 bytes per loop iteration, and if not we check 8, then 4, then
     // 2. Worst case we have to load/store a single byte per loop.
     unsigned stride = !lengthConstant ? 1 : 16;
 
     while (stride != 1) {
-      // We only care about DWORD alignment (4 bytes) so clamp the max check here to that.
+      // We only care about dword alignment (4 bytes) so clamp the max check here to that.
       const unsigned minStride = std::min(stride, 4u);
       if (destAlignment.valueOrOne() >= minStride && srcAlignment.valueOrOne() >= minStride && (constantLength % stride) == 0)
         break;
@@ -1046,13 +1046,13 @@ void PatchBufferOp::postVisitMemSetInst(MemSetInst &memSetInst) {
   // causes LLVM's optimizations and our AMDGPU backend to crawl (and generate worse code!).
   if (!lengthConstant || constantLength > MinMemOpLoopBytes) {
     // NOTE: We want to perform our memset operation on the greatest stride of bytes possible (load/storing up to
-    // DWORDx4 or 16 bytes per loop iteration). If we have a constant length, we check if the the alignment and
+    // dwordx4 or 16 bytes per loop iteration). If we have a constant length, we check if the the alignment and
     // number of bytes to copy lets us load/store 16 bytes per loop iteration, and if not we check 8, then 4, then
     // 2. Worst case we have to load/store a single byte per loop.
     unsigned stride = !lengthConstant ? 1 : 16;
 
     while (stride != 1) {
-      // We only care about DWORD alignment (4 bytes) so clamp the max check here to that.
+      // We only care about dword alignment (4 bytes) so clamp the max check here to that.
       const unsigned minStride = std::min(stride, 4u);
       if (destAlignment.valueOrOne() >= minStride && (constantLength % stride) == 0)
         break;

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -44,7 +44,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 
-#define DEBUG_TYPE "llpc-patch-buffer-op"
+#define DEBUG_TYPE "lgc-patch-buffer-op"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchBufferOp.h
+++ b/lgc/patch/PatchBufferOp.h
@@ -70,8 +70,6 @@ public:
   void visitICmpInst(llvm::ICmpInst &icmpInst);
   void visitPtrToIntInst(llvm::PtrToIntInst &ptrToIntInst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
@@ -89,8 +87,6 @@ private:
                               llvm::Instruction *const insertPos);
   void postVisitMemCpyInst(llvm::MemCpyInst &memCpyInst);
   void postVisitMemSetInst(llvm::MemSetInst &memSetInst);
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   using Replacement = std::pair<llvm::Value *, llvm::Value *>;
   llvm::DenseMap<llvm::Value *, Replacement> m_replacementMap; // The replacement map.

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -32,7 +32,7 @@
 #include "lgc/state/PipelineShaders.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-patch-check-shader-cache"
+#define DEBUG_TYPE "lgc-patch-check-shader-cache"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchCheckShaderCache.h
+++ b/lgc/patch/PatchCheckShaderCache.h
@@ -55,15 +55,11 @@ public:
   // removed.
   void setCallbackFunction(Pipeline::CheckShaderCacheFunc callbackFunc) { m_callbackFunc = callbackFunc; }
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
   PatchCheckShaderCache(const PatchCheckShaderCache &) = delete;
   PatchCheckShaderCache &operator=(const PatchCheckShaderCache &) = delete;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   Pipeline::CheckShaderCacheFunc m_callbackFunc;
 };

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -87,8 +87,6 @@ private:
   void exportGenericOutput(Value *outputValue, unsigned location, unsigned streamId, BuilderBase &builder);
   void exportBuiltInOutput(Value *outputValue, BuiltInKind builtInId, unsigned streamId, BuilderBase &builder);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   // Low part of global internal table pointer
   static const unsigned EntryArgIdxInternalTablePtrLow = 0;
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -41,7 +41,7 @@
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-patch-copy-shader"
+#define DEBUG_TYPE "lgc-patch-copy-shader"
 
 namespace llvm {
 namespace cl {

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -325,8 +325,8 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
         }
         unsigned bitWidth = compTy->getScalarSizeInBits();
         // NOTE: Currently, to simplify the design of load/store data from GS-VS ring, we always extend
-        // BYTE/WORD to DWORD and store DWORD to GS-VS ring. So for 8-bit/16-bit data type, the actual byte size
-        // is based on number of DWORDs.
+        // byte/word to dword and store dword to GS-VS ring. So for 8-bit/16-bit data type, the actual byte size
+        // is based on number of dwords.
         bitWidth = bitWidth < 32 ? 32 : bitWidth;
         unsigned byteSize = bitWidth / 8 * compCount;
 
@@ -577,8 +577,8 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
       XfbOutInfo *xfbOutInfo = reinterpret_cast<XfbOutInfo *>(&xfbOutsInfo[locIter->first]);
 
       if (xfbOutInfo->is16bit) {
-        // NOTE: For 16-bit transform feedback output, the value is 32-bit DWORD loaded from GS-VS ring
-        // buffer. The high WORD is always zero while the low WORD contains the data value. We have to
+        // NOTE: For 16-bit transform feedback output, the value is 32-bit dword loaded from GS-VS ring
+        // buffer. The high word is always zero while the low word contains the data value. We have to
         // do some casting operations before store it to transform feedback buffer (tightly packed).
         auto outputTy = outputValue->getType();
         assert(outputTy->isFPOrFPVectorTy() && outputTy->getScalarSizeInBits() == 32);

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -138,7 +138,7 @@ private:
   };
 
   // Gather user data usage in all shaders.
-  void gatherUserDataUsage(llvm::Module *module);
+  void gatherUserDataUsage(Module *module);
 
   // Fix up user data uses.
   void fixupUserDataUses(Module &module);
@@ -168,7 +168,7 @@ private:
   bool m_hasGs;                             // Whether the pipeline has geometry shader
   PipelineState *m_pipelineState = nullptr; // Pipeline state from PipelineStateWrapper pass
   // Per-HW-shader-stage gathered user data usage information.
-  llvm::SmallVector<std::unique_ptr<UserDataUsage>, ShaderStageCount> m_userDataUsage;
+  SmallVector<std::unique_ptr<UserDataUsage>, ShaderStageCount> m_userDataUsage;
 };
 
 // =====================================================================================================================

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -48,7 +48,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
-#define DEBUG_TYPE "llpc-patch-entry-point-mutate"
+#define DEBUG_TYPE "lgc-patch-entry-point-mutate"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -41,7 +41,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <unordered_set>
 
-#define DEBUG_TYPE "llpc-patch-in-out-import-export"
+#define DEBUG_TYPE "lgc-patch-in-out-import-export"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -61,8 +61,6 @@ public:
   void visitCallInst(llvm::CallInst &callInst);
   void visitReturnInst(llvm::ReturnInst &retInst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
@@ -203,8 +201,6 @@ private:
   llvm::Value *getWorkgroupSize();
   llvm::Value *getInLocalInvocationId(llvm::Instruction *insertPos);
   llvm::Value *getDeviceIndex(llvm::Instruction *insertPos);
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   GfxIpVersion m_gfxIp;                     // Graphics IP version info
   PipelineSystemValues m_pipelineSysValues; // Cache of ShaderSystemValues objects, one per shader stage

--- a/lgc/patch/PatchIntrinsicSimplify.cpp
+++ b/lgc/patch/PatchIntrinsicSimplify.cpp
@@ -44,7 +44,7 @@
 #include "llvm/InitializePasses.h"
 #include <math.h>
 
-#define DEBUG_TYPE "llpc-patch-intrinsic-simplify"
+#define DEBUG_TYPE "lgc-patch-intrinsic-simplify"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchIntrinsicSimplify.h
+++ b/lgc/patch/PatchIntrinsicSimplify.h
@@ -61,8 +61,6 @@ public:
   void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override;
   bool runOnFunction(llvm::Function &func) override;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
   PatchIntrinsicSimplify(const PatchIntrinsicSimplify &) = delete;
@@ -75,8 +73,6 @@ private:
   llvm::Value *simplifyTrigonometric(llvm::IntrinsicInst &intrinsicCall) const;
   bool canSimplify(llvm::IntrinsicInst &intrinsicCall) const;
   llvm::Value *simplify(llvm::IntrinsicInst &intrinsicCall) const;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   llvm::ScalarEvolution *m_scalarEvolution = nullptr;
   llvm::LLVMContext *m_context = nullptr;

--- a/lgc/patch/PatchLlvmIrInclusion.cpp
+++ b/lgc/patch/PatchLlvmIrInclusion.cpp
@@ -32,7 +32,7 @@
 #include "lgc/state/Abi.h"
 #include "llvm/IR/Constants.h"
 
-#define DEBUG_TYPE "llpc-patch-llvm-ir-inclusion"
+#define DEBUG_TYPE "lgc-patch-llvm-ir-inclusion"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchLlvmIrInclusion.h
+++ b/lgc/patch/PatchLlvmIrInclusion.h
@@ -44,8 +44,6 @@ public:
 
   void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override { analysisUsage.setPreservesAll(); }
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:

--- a/lgc/patch/PatchLoadScalarizer.cpp
+++ b/lgc/patch/PatchLoadScalarizer.cpp
@@ -36,7 +36,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-#define DEBUG_TYPE "llpc-patch-load-scalarizer"
+#define DEBUG_TYPE "lgc-patch-load-scalarizer"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/patch/PatchLoadScalarizer.cpp
+++ b/lgc/patch/PatchLoadScalarizer.cpp
@@ -137,7 +137,7 @@ void PatchLoadScalarizer::visitLoadInst(LoadInst &loadInst) {
 
     Value *loadValue = UndefValue::get(loadTy);
     Type *newLoadPtrTy = PointerType::get(compTy, addrSpace);
-    llvm::SmallVector<llvm::Value *, 4> loadComps;
+    SmallVector<Value *, 4> loadComps;
 
     loadComps.resize(compCount);
 

--- a/lgc/patch/PatchLoadScalarizer.h
+++ b/lgc/patch/PatchLoadScalarizer.h
@@ -47,15 +47,11 @@ public:
 
   void visitLoadInst(llvm::LoadInst &loadInst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
   PatchLoadScalarizer(const PatchLoadScalarizer &) = delete;
   PatchLoadScalarizer &operator=(const PatchLoadScalarizer &) = delete;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   llvm::SmallVector<llvm::Instruction *, 8> m_instsToErase; // Instructions to erase
   std::unique_ptr<llvm::IRBuilder<>> m_builder;             // The IRBuilder.

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -53,7 +53,7 @@ public:
   static char ID;
   PatchNullFragShader() : Patch(ID) {}
 
-  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
+  void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
     analysisUsage.addRequired<PipelineStateWrapper>();
   }
 
@@ -78,7 +78,7 @@ ModulePass *lgc::createPatchNullFragShader() {
 // Run the pass on the specified LLVM module.
 //
 // @param [in,out] module : LLVM module to be run on
-bool PatchNullFragShader::runOnModule(llvm::Module &module) {
+bool PatchNullFragShader::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Null-Frag-Shader\n");
 
   Patch::init(&module);

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -39,7 +39,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-patch-null-frag-shader"
+#define DEBUG_TYPE "lgc-patch-null-frag-shader"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/patch/PatchPeepholeOpt.cpp
+++ b/lgc/patch/PatchPeepholeOpt.cpp
@@ -39,7 +39,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-#define DEBUG_TYPE "llpc-patch-peephole-opt"
+#define DEBUG_TYPE "lgc-patch-peephole-opt"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/patch/PatchPeepholeOpt.h
+++ b/lgc/patch/PatchPeepholeOpt.h
@@ -67,15 +67,11 @@ public:
   void moveAfter(llvm::Instruction &move, llvm::Instruction &after) const;
   void insertAfter(llvm::Instruction &insert, llvm::Instruction &after) const;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
   PatchPeepholeOpt(const PatchPeepholeOpt &) = delete;
   PatchPeepholeOpt &operator=(const PatchPeepholeOpt &) = delete;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   llvm::SmallVector<llvm::Instruction *, 8> m_instsToErase;
 };

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -39,7 +39,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-patch-prepare-pipeline-abi"
+#define DEBUG_TYPE "lgc-patch-prepare-pipeline-abi"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -74,8 +74,6 @@ private:
 
   void addAbiMetadata(Module &module);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   PipelineState *m_pipelineState;     // Pipeline state
   PipelineShaders *m_pipelineShaders; // API shaders in the pipeline
 

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -45,7 +45,7 @@
 #include <algorithm>
 #include <functional>
 
-#define DEBUG_TYPE "llpc-patch-resource-collect"
+#define DEBUG_TYPE "lgc-patch-resource-collect"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -446,7 +446,7 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
         static_cast<unsigned>((1 << m_pipelineState->getTargetInfo().getGpuProperty().ldsSizeDwordGranularityShift)));
 
     // Use the client-specified amount of LDS space per subgroup. If they specified zero, they want us to choose a
-    // reasonable default. The final amount must be 128-DWORD aligned.
+    // reasonable default. The final amount must be 128-dword aligned.
 
     unsigned maxLdsSize = m_pipelineState->getTargetInfo().getGpuProperty().gsOnChipDefaultLdsSizePerSubgroup;
 
@@ -527,8 +527,8 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
       const unsigned gsVsRingItemSize =
           hasGs ? std::max(1u, 4 * gsResUsage->inOutUsage.outputMapLocCount * geometryMode.outputVertices) : 0;
 
-      const unsigned esExtraLdsSize = NggLdsManager::calcEsExtraLdsSize(m_pipelineState) / 4; // In DWORDs
-      const unsigned gsExtraLdsSize = NggLdsManager::calcGsExtraLdsSize(m_pipelineState) / 4; // In DWORDs
+      const unsigned esExtraLdsSize = NggLdsManager::calcEsExtraLdsSize(m_pipelineState) / 4; // In dwords
+      const unsigned gsExtraLdsSize = NggLdsManager::calcGsExtraLdsSize(m_pipelineState) / 4; // In dwords
 
       // NOTE: Primitive amplification factor must be at least 1. And for NGG GS mode, we force number of output
       // primitives to be equal to that of output vertices regardless of the output primitive type by emitting
@@ -723,7 +723,7 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
       unsigned gsOnChipLdsSize = alignTo(esGsLdsSize + esGsExtraLdsDwords, ldsSizeDwordGranularity);
 
       // Use the client-specified amount of LDS space per sub-group. If they specified zero, they want us to
-      // choose a reasonable default. The final amount must be 128-DWORD aligned.
+      // choose a reasonable default. The final amount must be 128-dword aligned.
       // TODO: Accept DefaultLdsSizePerSubgroup from panel setting
       unsigned maxLdsSize = Gfx9::DefaultLdsSizePerSubgroup;
 

--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -57,8 +57,6 @@ public:
   virtual bool runOnModule(llvm::Module &module) override;
   virtual void visitCallInst(llvm::CallInst &callInst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
@@ -94,8 +92,6 @@ private:
   void scalarizeForInOutPacking(llvm::Module *module);
   void scalarizeGenericInput(llvm::CallInst *call);
   void scalarizeGenericOutput(llvm::CallInst *call);
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   PipelineShaders *m_pipelineShaders; // Pipeline shaders
   PipelineState *m_pipelineState;     // Pipeline state

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -35,7 +35,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-patch-setup-target-features"
+#define DEBUG_TYPE "lgc-patch-setup-target-features"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -38,7 +38,7 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 
-#define DEBUG_TYPE "llpc-shader-merger"
+#define DEBUG_TYPE "lgc-shader-merger"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/patch/ShaderMerger.h
+++ b/lgc/patch/ShaderMerger.h
@@ -92,8 +92,6 @@ private:
   llvm::FunctionType *generateLsHsEntryPointType(uint64_t *inRegMask) const;
   llvm::FunctionType *generateEsGsEntryPointType(uint64_t *inRegMask) const;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   PipelineState *m_pipelineState; // Pipeline state
   llvm::LLVMContext *m_context;   // LLVM context
   GfxIpVersion m_gfxIp;           // Graphics IP version info

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -240,7 +240,7 @@ Value *ShaderSystemValues::getGsVsRingBufDesc(unsigned streamId) {
       // Patch GS-VS ring buffer descriptor stride for GS output
       Value *gsVsRingBufDescElem1 = builder.CreateExtractElement(desc, (uint64_t)1);
 
-      // Clear stride in SRD DWORD1
+      // Clear stride in SRD dword1
       SqBufRsrcWord1 strideClearMask = {};
       strideClearMask.u32All = UINT32_MAX;
       strideClearMask.bits.stride = 0;

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -35,7 +35,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/CommandLine.h"
 
-#define DEBUG_TYPE "llpc-system-values"
+#define DEBUG_TYPE "lgc-system-values"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/patch/SystemValues.h
+++ b/lgc/patch/SystemValues.h
@@ -117,8 +117,6 @@ private:
   // Find resource node by descriptor set ID
   unsigned findResourceNodeByDescSet(unsigned descSet);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::Function *m_entryPoint = nullptr; // Shader entrypoint
   llvm::LLVMContext *m_context;           // LLVM context
   PipelineState *m_pipelineState;         // Pipeline state

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -36,7 +36,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 
-#define DEBUG_TYPE "llpc-vertex-fetch"
+#define DEBUG_TYPE "lgc-vertex-fetch"
 
 using namespace llvm;
 

--- a/lgc/patch/VertexFetch.h
+++ b/lgc/patch/VertexFetch.h
@@ -96,8 +96,6 @@ private:
 
   bool needSecondVertexFetch(const VertexInputDescription *inputDesc) const;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::Module *m_module;                // LLVM module
   llvm::LLVMContext *m_context;          // LLVM context
   ShaderSystemValues *m_shaderSysValues; // ShaderSystemValues object for getting vertex buffer pointer from

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -45,6 +45,8 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetOptions.h"
 
+#define DEBUG_TYPE "lgc-context"
+
 using namespace lgc;
 using namespace llvm;
 

--- a/lgc/state/PipelineShaders.cpp
+++ b/lgc/state/PipelineShaders.cpp
@@ -35,7 +35,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-pipeline-shaders"
+#define DEBUG_TYPE "lgc-pipeline-shaders"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -990,7 +990,7 @@ class PipelineStateClearer : public ModulePass {
 public:
   PipelineStateClearer() : ModulePass(ID) {}
 
-  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
+  void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
     analysisUsage.addRequired<PipelineStateWrapper>();
   }
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -996,8 +996,6 @@ public:
 
   bool runOnModule(Module &module) override;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 };
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -40,7 +40,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "llpc-pipeline-state"
+#define DEBUG_TYPE "lgc-pipeline-state"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/state/ShaderModes.cpp
+++ b/lgc/state/ShaderModes.cpp
@@ -33,7 +33,7 @@
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PipelineState.h"
 
-#define DEBUG_TYPE "llpc-shader-modes"
+#define DEBUG_TYPE "lgc-shader-modes"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/util/GfxRegHandler.cpp
+++ b/lgc/util/GfxRegHandler.cpp
@@ -63,9 +63,9 @@ Value *GfxRegHandler::getRegCommon(unsigned regId) {
 }
 
 // =====================================================================================================================
-// Get combined data from two seperate DWORDs
-// Note: The return type is one DWORD, it doesn't support two DWORDs for now.
-// TODO: Expand to support 2-DWORDs combination result.
+// Get combined data from two seperate dwords
+// Note: The return type is one dword, it doesn't support two dwords for now.
+// TODO: Expand to support 2-dwords combination result.
 //
 // @param regIdLo : The ID of low part register
 // @param regIdHi : Reg ID of high part register
@@ -76,8 +76,8 @@ Value *GfxRegHandler::getRegCombine(unsigned regIdLo, unsigned regIdHi) {
 }
 
 // =====================================================================================================================
-// Set register value into two seperate DWORDs
-// Note: The input pRegValue only supports one DWORD
+// Set register value into two seperate dwords
+// Note: The input pRegValue only supports one dword
 //
 // @param regIdLo : The ID of low part register
 // @param regIdHi : Reg ID of high part register

--- a/lgc/util/GfxRegHandlerBase.cpp
+++ b/lgc/util/GfxRegHandlerBase.cpp
@@ -37,8 +37,8 @@ using namespace llvm;
 
 // =====================================================================================================================
 // Set register:
-//   - Clear old DWORDs vector
-//   - Fill DWORDs vector with nullptr
+//   - Clear old dwords vector
+//   - Fill dwords vector with nullptr
 //   - Init dirty mask to all clean
 //
 // @param newRegister : A <n x i32> vector
@@ -48,10 +48,10 @@ void GfxRegHandlerBase::setRegister(Value *newRegister) {
   if (auto vectorTy = dyn_cast<VectorType>(newRegister->getType())) {
     unsigned count = vectorTy->getNumElements();
 
-    // Clear previously stored DWORDs
+    // Clear previously stored dwords
     m_dwords.clear();
 
-    // Resize to specific number of DWORDs
+    // Resize to specific number of dwords
     for (unsigned i = 0; i < count; i++)
       m_dwords.push_back(nullptr);
   } else {
@@ -65,11 +65,11 @@ void GfxRegHandlerBase::setRegister(Value *newRegister) {
 
 // =====================================================================================================================
 // Get register
-//   - Overwrite DWORDs in <n x i32> register if marked as dirty
+//   - Overwrite dwords in <n x i32> register if marked as dirty
 Value *GfxRegHandlerBase::getRegister() {
   unsigned dirtyMask = m_dirtyDwords;
 
-  // Overwrite if the specific DWORD is being masked as dirty
+  // Overwrite if the specific dword is being masked as dirty
   for (unsigned i = 0; dirtyMask > 0; dirtyMask >>= 1) {
     if (dirtyMask & 1) {
       m_reg = m_builder->CreateInsertElement(m_reg, m_dwords[i], m_builder->getInt64(i));
@@ -86,7 +86,7 @@ Value *GfxRegHandlerBase::getRegister() {
 }
 
 // =====================================================================================================================
-// Get data from a range of bits in indexed DWORD according to BitsInfo
+// Get data from a range of bits in indexed dword according to BitsInfo
 //
 // @param bitsInfo : The BitsInfo of data
 Value *GfxRegHandlerBase::getBits(const BitsInfo &bitsInfo) {
@@ -101,7 +101,7 @@ Value *GfxRegHandlerBase::getBits(const BitsInfo &bitsInfo) {
 }
 
 // =====================================================================================================================
-// Set data to a range of bits in indexed DWORD according to BitsInfo
+// Set data to a range of bits in indexed dword according to BitsInfo
 //
 // @param bitsInfo : The BitsInfo of data's high part
 // @param newBits : The new bits to set
@@ -116,9 +116,9 @@ void GfxRegHandlerBase::setBits(const BitsInfo &bitsInfo, Value *newBits) {
 }
 
 // =====================================================================================================================
-// Return new DWORD which is replaced [offset, offset + count) with pNewBits
+// Return new dword which is replaced [offset, offset + count) with pNewBits
 //
-// @param dword : Target DWORD
+// @param dword : Target dword
 // @param offset : The first bit to be replaced
 // @param count : The number of bits should be replaced
 // @param newBits : The new bits to replace specified ones

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -42,7 +42,7 @@
 #include "lgc/BuilderBase.h"
 #include "lgc/util/Internal.h"
 
-#define DEBUG_TYPE "llpc-internal"
+#define DEBUG_TYPE "lgc-internal"
 
 using namespace llvm;
 

--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -69,14 +69,14 @@ public:
   ~PassManagerImpl() override {}
 
   void setPassIndex(unsigned *passIndex) override { m_passIndex = passIndex; }
-  void add(llvm::Pass *pass) override;
+  void add(Pass *pass) override;
   void stop() override;
 
 private:
   bool m_stopped = false;                     // Whether we have already stopped adding new passes.
-  llvm::AnalysisID m_dumpCfgAfter = nullptr;  // -dump-cfg-after pass id
-  llvm::AnalysisID m_printModule = nullptr;   // Pass id of dump pass "Print Module IR"
-  llvm::AnalysisID m_jumpThreading = nullptr; // Pass id of opt pass "Jump Threading"
+  AnalysisID m_dumpCfgAfter = nullptr;        // -dump-cfg-after pass id
+  AnalysisID m_printModule = nullptr;         // Pass id of dump pass "Print Module IR"
+  AnalysisID m_jumpThreading = nullptr;       // Pass id of opt pass "Jump Threading"
   unsigned *m_passIndex = nullptr;            // Pass Index
 };
 

--- a/lgc/util/StartStopTimer.cpp
+++ b/lgc/util/StartStopTimer.cpp
@@ -33,7 +33,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/Timer.h"
 
-#define DEBUG_TYPE "llpc-start-stop-timer"
+#define DEBUG_TYPE "lgc-start-stop-timer"
 
 using namespace llvm;
 using namespace lgc;

--- a/lgc/util/StartStopTimer.cpp
+++ b/lgc/util/StartStopTimer.cpp
@@ -54,8 +54,6 @@ private:
   StartStopTimer(const StartStopTimer &) = delete;
   StartStopTimer &operator=(const StartStopTimer &) = delete;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   Timer *m_timer;  // The timer to start or stop when the pass is run
   bool m_starting; // True to start the timer, false to stop it
 };

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -166,7 +166,7 @@ static cl::opt<bool> UseBuilderRecorder("use-builder-recorder",
 
 namespace Llpc {
 
-llvm::sys::Mutex Compiler::m_contextPoolMutex;
+sys::Mutex Compiler::m_contextPoolMutex;
 std::vector<Context *> *Compiler::m_contextPool = nullptr;
 
 // Enumerates modes used in shader replacement
@@ -198,7 +198,7 @@ static void fatalErrorHandler(void *userData, const std::string &reason, bool ge
 
 // =====================================================================================================================
 // Handler for diagnosis in pass run, derived from the standard one.
-class LlpcDiagnosticHandler : public llvm::DiagnosticHandler {
+class LlpcDiagnosticHandler : public DiagnosticHandler {
   bool handleDiagnostics(const DiagnosticInfo &diagInfo) override {
     if (EnableOuts() || EnableErrs()) {
       if (diagInfo.getSeverity() == DS_Error || diagInfo.getSeverity() == DS_Warning) {
@@ -849,7 +849,7 @@ bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineS
 //
 // @param shaderInfo : Shader info for the pipeline to be built
 bool Compiler::canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo) const {
-  if (!llvm::cl::UseRelocatableShaderElf)
+  if (!cl::UseRelocatableShaderElf)
     return false;
 
   bool useRelocatableShaderElf = true;

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -162,8 +162,6 @@ private:
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo) const;
   bool canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo) const;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   std::vector<std::string> m_options;           // Compilation options
   MetroHash::Hash m_optionHash;                 // Hash code of compilation options
   GfxIpVersion m_gfxIp;                         // Graphics IP version info

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -106,7 +106,7 @@ std::unique_ptr<Module> Context::loadLibary(const BinaryData *lib) {
     LLPC_ERRS("Fails to load LLVM bitcode \n");
   } else {
     libModule = std::move(*moduleOrErr);
-    if (llvm::Error errCode = libModule->materializeAll()) {
+    if (Error errCode = libModule->materializeAll()) {
       LLPC_ERRS("Fails to materialize \n");
       libModule = nullptr;
     }

--- a/llpc/context/llpcContext.h
+++ b/llpc/context/llpcContext.h
@@ -130,8 +130,6 @@ private:
   Context(const Context &) = delete;
   Context &operator=(const Context &) = delete;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   GfxIpVersion m_gfxIp;                                  // Graphics IP version info
   PipelineContext *m_pipelineContext;                    // Pipeline-specific context
   EmuLib m_glslEmuLib;                                   // LLVM library for GLSL emulation

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -158,8 +158,6 @@ protected:
   // Gets dummy vertex attribute info
   virtual std::vector<VkVertexInputAttributeDescription> *getDummyVertexAttributes() { return nullptr; }
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   GfxIpVersion m_gfxIp;           // Graphics IP version info
   MetroHash::Hash m_pipelineHash; // Pipeline hash code
   MetroHash::Hash m_cacheHash;    // Cache hash code
@@ -189,8 +187,6 @@ private:
 
   // Give the color export state to the middle-end.
   void setColorExportState(lgc::Pipeline *pipeline) const;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   ShaderFpMode m_shaderFpModes[ShaderStageCountInternal] = {};
   bool m_unlinked = false; // Whether we are building an "unlinked" half-pipeline ELF

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -169,8 +169,6 @@ private:
   void resetRuntimeCache();
   void getBuildTime(BuildUniqueId *buildId);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::sys::Mutex m_lock; // Read/Write lock for access to the shader cache hash map
   File m_onDiskFile;       // File for on-disk storage of the cache
   bool m_disableCache;     // Whether disable cache completely

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -147,9 +147,8 @@ void SpirvLower::removeConstantExpr(Context *context, GlobalVariable *global) {
 // @param [in/out] passMgr : Pass manager to add passes to
 // @param lowerTimer : Timer to time lower passes with, nullptr if not timing
 // @param forceLoopUnrollCount : 0 or force loop unroll count
-void SpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassManager &passMgr, llvm::Timer *lowerTimer,
-                           unsigned forceLoopUnrollCount
-                           ) {
+void SpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassManager &passMgr, Timer *lowerTimer,
+                           unsigned forceLoopUnrollCount) {
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
   context->getLgcContext()->preparePassManager(&passMgr);
 

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -112,8 +112,6 @@ public:
 protected:
   void init(llvm::Module *module);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   llvm::Module *m_module;       // LLVM module to be run on
   Context *m_context;           // Associated LLPC context of the LLVM module that passes run on
   ShaderStage m_shaderStage;    // Shader stage

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -99,7 +99,7 @@ void SpirvLowerAccessChain::visitGetElementPtrInst(GetElementPtrInst &getElemPtr
 //
 // @param getElemPtr : "getelementptr" instruction in the bottom to do coalescing
 // @param addrSpace : Address space of the pointer value of "getelementptr"
-llvm::GetElementPtrInst *SpirvLowerAccessChain::tryToCoalesceChain(GetElementPtrInst *getElemPtr, unsigned addrSpace) {
+GetElementPtrInst *SpirvLowerAccessChain::tryToCoalesceChain(GetElementPtrInst *getElemPtr, unsigned addrSpace) {
   GetElementPtrInst *coalescedGetElemPtr = getElemPtr;
 
   std::stack<User *> chainedInsts;              // Order: from top to bottom

--- a/llpc/lower/llpcSpirvLowerAccessChain.h
+++ b/llpc/lower/llpcSpirvLowerAccessChain.h
@@ -44,8 +44,6 @@ public:
   virtual bool runOnModule(llvm::Module &module);
   virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElemPtrInst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -391,7 +391,7 @@ void SpirvLowerAlgebraTransform::disableFastMath(Value *value) {
     if (isa<FPMathOperator>(*it)) {
       // Reset fast math flags to default
       auto inst = cast<Instruction>(*it);
-      llvm::FastMathFlags fastMathFlags;
+      FastMathFlags fastMathFlags;
       inst->copyFastMathFlags(fastMathFlags);
     }
 

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.h
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.h
@@ -53,8 +53,6 @@ public:
   virtual void visitFPTruncInst(llvm::FPTruncInst &fptruncInst);
   void flushDenormIfNeeded(llvm::Instruction *inst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.h
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.h
@@ -47,8 +47,6 @@ public:
 
   virtual bool runOnModule(llvm::Module &module);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -862,7 +862,7 @@ void SpirvLowerGlobal::lowerInOutInPlace() {
     m_instVisitFlags.checkStore = true;
   visit(m_module);
 
-  llvm::DenseSet<GetElementPtrInst *> getElemInsts;
+  DenseSet<GetElementPtrInst *> getElemInsts;
 
   // Remove unnecessary "load" instructions
   for (auto loadInst : m_loadInsts) {

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -51,8 +51,6 @@ public:
   virtual void visitLoadInst(llvm::LoadInst &loadInst);
   virtual void visitStoreInst(llvm::StoreInst &storeInst);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
@@ -94,8 +92,6 @@ private:
   void interpolateInputElement(unsigned interpLoc, llvm::Value *interpInfo, llvm::CallInst &callInst);
 
   llvm::Value *toInt32Value(llvm::Value *value, llvm::Instruction *insertPos);
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   std::unordered_map<llvm::Value *, llvm::Value *> m_globalVarProxyMap; // Proxy map for lowering global variables
   std::unordered_map<llvm::Value *, llvm::Value *> m_inputProxyMap;     // Proxy map for lowering inputs

--- a/llpc/lower/llpcSpirvLowerInstMetaRemove.h
+++ b/llpc/lower/llpcSpirvLowerInstMetaRemove.h
@@ -42,8 +42,6 @@ public:
 
   virtual bool runOnModule(llvm::Module &module);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:

--- a/llpc/lower/llpcSpirvLowerLoopUnrollControl.cpp
+++ b/llpc/lower/llpcSpirvLowerLoopUnrollControl.cpp
@@ -92,7 +92,7 @@ bool SpirvLowerLoopUnrollControl::runOnModule(Module &module) {
     if (shaderOptions->forceLoopUnrollCount > 0)
       m_forceLoopUnrollCount = shaderOptions->forceLoopUnrollCount;
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
-    m_disableLicm = shaderOptions->disableLicm | llvm::cl::DisableLicm;
+    m_disableLicm = shaderOptions->disableLicm | cl::DisableLicm;
 #endif
   }
 
@@ -119,7 +119,7 @@ bool SpirvLowerLoopUnrollControl::runOnModule(Module &module) {
         // one operand pointing to itself, meaning that the SPIR-V did not
         // have an unroll or don't-unroll directive, so we can add the force
         // unroll count metadata.
-        llvm::Metadata *unrollCountMeta[] = {
+        Metadata *unrollCountMeta[] = {
             MDString::get(*m_context, "llvm.loop.unroll.count"),
             ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(*m_context), m_forceLoopUnrollCount))};
         MDNode *loopUnrollCountMetaNode = MDNode::get(*m_context, unrollCountMeta);

--- a/llpc/lower/llpcSpirvLowerLoopUnrollControl.h
+++ b/llpc/lower/llpcSpirvLowerLoopUnrollControl.h
@@ -43,8 +43,6 @@ public:
 
   virtual bool runOnModule(llvm::Module &module);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:

--- a/llpc/lower/llpcSpirvLowerMemoryOp.h
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.h
@@ -58,7 +58,6 @@ public:
   virtual bool runOnModule(llvm::Module &module);
   virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElementPtrInst);
   virtual void visitExtractElementInst(llvm::ExtractElementInst &extractElementInst);
-  // -----------------------------------------------------------------------------------------------------------------
 
   static char ID; // ID of this pass
 

--- a/llpc/lower/llpcSpirvLowerResourceCollect.h
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.h
@@ -71,8 +71,6 @@ public:
   void visitCalls(llvm::Module &module);
   llvm::Value *findCallAndGetIndexValue(llvm::Module &module, llvm::CallInst *const targetCall);
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static char ID; // ID of this pass
 
 private:
@@ -83,8 +81,6 @@ private:
   const llvm::Type *getFlattenArrayElementType(const llvm::Type *ty) const;
 
   void collectResourceNodeData(const GlobalVariable *global);
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   bool m_collectDetailUsage; // If enabled, collect detailed usages of resource node datas and FS output infos
   std::map<ResourceNodeDataKey, ResourceMappingNodeType, ResNodeDataSortingComparer> m_resNodeDatas; // Resource

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -56,7 +56,7 @@ ModulePass *Llpc::createSpirvLowerTranslator(ShaderStage stage, const PipelineSh
 // Run the pass on the specified LLVM module.
 //
 // @param [in,out] module : LLVM module to be run on (empty on entry)
-bool SpirvLowerTranslator::runOnModule(llvm::Module &module) {
+bool SpirvLowerTranslator::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Translator\n");
 
   SpirvLower::init(&module);

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -969,12 +969,12 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
     pipelineInfo->options.robustBufferAccess = RobustBufferAccess;
 
     void *pipelineDumpHandle = nullptr;
-    if (llvm::cl::EnablePipelineDump) {
+    if (cl::EnablePipelineDump) {
       PipelineDumpOptions dumpOptions = {};
-      dumpOptions.pDumpDir = llvm::cl::PipelineDumpDir.c_str();
-      dumpOptions.filterPipelineDumpByType = llvm::cl::FilterPipelineDumpByType;
-      dumpOptions.filterPipelineDumpByHash = llvm::cl::FilterPipelineDumpByHash;
-      dumpOptions.dumpDuplicatePipelines = llvm::cl::DumpDuplicatePipelines;
+      dumpOptions.pDumpDir = cl::PipelineDumpDir.c_str();
+      dumpOptions.filterPipelineDumpByType = cl::FilterPipelineDumpByType;
+      dumpOptions.filterPipelineDumpByHash = cl::FilterPipelineDumpByHash;
+      dumpOptions.dumpDuplicatePipelines = cl::DumpDuplicatePipelines;
 
       PipelineBuildInfo localPipelineInfo = {};
       localPipelineInfo.pGraphicsInfo = pipelineInfo;
@@ -990,7 +990,7 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
     result = compiler->BuildGraphicsPipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
 
     if (result == Result::Success) {
-      if (llvm::cl::EnablePipelineDump) {
+      if (cl::EnablePipelineDump) {
         Vkgc::BinaryData pipelineBinary = {};
         pipelineBinary.codeSize = pipelineOut->pipelineBin.codeSize;
         pipelineBinary.pCode = pipelineOut->pipelineBin.pCode;
@@ -1035,12 +1035,12 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
     pipelineInfo->options.robustBufferAccess = RobustBufferAccess;
 
     void *pipelineDumpHandle = nullptr;
-    if (llvm::cl::EnablePipelineDump) {
+    if (cl::EnablePipelineDump) {
       PipelineDumpOptions dumpOptions = {};
-      dumpOptions.pDumpDir = llvm::cl::PipelineDumpDir.c_str();
-      dumpOptions.filterPipelineDumpByType = llvm::cl::FilterPipelineDumpByType;
-      dumpOptions.filterPipelineDumpByHash = llvm::cl::FilterPipelineDumpByHash;
-      dumpOptions.dumpDuplicatePipelines = llvm::cl::DumpDuplicatePipelines;
+      dumpOptions.pDumpDir = cl::PipelineDumpDir.c_str();
+      dumpOptions.filterPipelineDumpByType = cl::FilterPipelineDumpByType;
+      dumpOptions.filterPipelineDumpByHash = cl::FilterPipelineDumpByHash;
+      dumpOptions.dumpDuplicatePipelines = cl::DumpDuplicatePipelines;
       PipelineBuildInfo localPipelineInfo = {};
       localPipelineInfo.pComputeInfo = pipelineInfo;
       pipelineDumpHandle = Vkgc::IPipelineDumper::BeginPipelineDump(&dumpOptions, localPipelineInfo);
@@ -1055,7 +1055,7 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
     result = compiler->BuildComputePipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
 
     if (result == Result::Success) {
-      if (llvm::cl::EnablePipelineDump) {
+      if (cl::EnablePipelineDump) {
         Vkgc::BinaryData pipelineBinary = {};
         pipelineBinary.codeSize = pipelineOut->pipelineBin.codeSize;
         pipelineBinary.pCode = pipelineOut->pipelineBin.pCode;
@@ -1362,7 +1362,7 @@ static Result processPipeline(ICompiler *compiler, ArrayRef<std::string> inFiles
 
       if (result == Result::Success) {
         // Translate LLVM module to LLVM bitcode
-        llvm::SmallString<1024> bitcodeBuf;
+        SmallString<1024> bitcodeBuf;
         raw_svector_ostream bitcodeStream(bitcodeBuf);
         WriteBitcodeToFile(*module.get(), bitcodeStream);
         void *code = new uint8_t[bitcodeBuf.size()];

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -467,9 +467,9 @@ void eraseIfNoUse(Value *V);
 /// Metadata for shader inputs and outputs, valid for scalar or vector type.
 union ShaderInOutMetadata {
   struct {
-    // BYTE 0~1
+    // Byte 0~1
     uint64_t Value : 16; // Generic location or SPIR-V built-in ID
-    // BYTE 2
+    // Byte 2
     uint64_t Index : 1;      // Output index for dual source blending
     uint64_t IsLoc : 1;      // Whether value is a location
     uint64_t IsBuiltIn : 1;  // Whether value is a SPIR-V built-in ID
@@ -477,26 +477,26 @@ union ShaderInOutMetadata {
     uint64_t Signedness : 1; // Signedness of the input/output, valid
                              // for integer (0 - unsigned, 1 - signed)
     uint64_t InterpMode : 2; // Interpolation mode (fragment shader)
-    // BYTE 3
+    // Byte 3
     uint64_t InterpLoc : 3; // Interpolation location (fragment
                             // shader)
     uint64_t PerPatch : 1;  // Whether this is a per-patch input/
                             // output (tessellation shader)
     uint64_t StreamId : 2;  // ID of output stream (geometry shader)
     uint64_t XfbBuffer : 2; // Transform feedback buffer ID
-    // BYTE 4~5
+    // Byte 4~5
     uint64_t IsXfb : 1;      // Whether this is for transform feedback
     uint64_t XfbOffset : 15; // Transform feedback offset
-    // BYTE 6~7
+    // Byte 6~7
     uint64_t XfbStride : 16; // Transform feedback stride
-    // BYTE 8~9
+    // Byte 8~9
     uint64_t IsBlockArray : 1;    // Whether we are handling block array
     uint64_t XfbArrayStride : 16; // Transform feedback array stride (for
                                   //   block array, it's flatten dimension
                                   //   of an element (1 if element is not
                                   //   sub-array; for non block array, it's
                                   //   occupied byte count of an element)
-    // BYTE 10~11
+    // Byte 10~11
     uint64_t XfbExtraOffset : 16; // Transform feedback extra offset
   };
   uint64_t U64All[2];

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7015,7 +7015,7 @@ Constant *SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecora
 
       inOutDec.Value.Loc += width <= 32 * 4 ? 1 : 2;
       unsigned alignment = 32;
-      unsigned baseStride = 4; // Strides in (BYTES)
+      unsigned baseStride = 4; // Strides in (bytes)
       inOutDec.XfbExtraOffset += (((width + alignment - 1) / alignment) * baseStride);
     }
 

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -169,7 +169,7 @@ void ElfWriter<Elf>::mergeSection(const SectionBuffer *pSection1, size_t section
 
 // =====================================================================================================================
 // A woarkaround to support erase in llvm::msgpack::MapDocNode.
-class MapDocNode : public llvm::msgpack::MapDocNode {
+class MapDocNode : public msgpack::MapDocNode {
 public:
   MapTy::iterator erase(MapTy::iterator where) { return Map->erase(where); }
 };
@@ -181,7 +181,7 @@ public:
 // @param srcMap : Source map
 // @param key : Key to check in source map
 template <class Elf>
-void ElfWriter<Elf>::mergeMapItem(llvm::msgpack::MapDocNode &destMap, llvm::msgpack::MapDocNode &srcMap, unsigned key) {
+void ElfWriter<Elf>::mergeMapItem(msgpack::MapDocNode &destMap, msgpack::MapDocNode &srcMap, unsigned key) {
   auto srcKeyNode = srcMap.getDocument()->getNode(key);
   auto srcIt = srcMap.find(srcKeyNode);
   if (srcIt != srcMap.end()) {

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -131,8 +131,6 @@ private:
 
   void reinitialize();
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   GfxIpVersion m_gfxIp;                  // Graphics IP version info (used by ELF dump only)
   typename Elf::FormatHeader m_header;   // ELF header
   std::map<std::string, unsigned> m_map; // Map between section name and section index

--- a/llpc/util/llpcShaderModuleHelper.h
+++ b/llpc/util/llpcShaderModuleHelper.h
@@ -35,7 +35,7 @@
 
 namespace Llpc {
 
-// Represents the special header of SPIR-V token stream (the first DWORD).
+// Represents the special header of SPIR-V token stream (the first dword).
 struct SpirvHeader {
   unsigned magicNumber;    // Magic number of SPIR-V module
   unsigned spvVersion;     // SPIR-V version number

--- a/llpc/util/llpcTimerProfiler.cpp
+++ b/llpc/util/llpcTimerProfiler.cpp
@@ -142,7 +142,7 @@ void TimerProfiler::startStopTimer(TimerKind timerKind, bool start) {
 // Gets a specific timer. Returns nullptr if TimePassesIsEnabled isn't enabled.
 //
 // @param timerKind : Kind of phase timer
-llvm::Timer *TimerProfiler::getTimer(TimerKind timerKind) {
+Timer *TimerProfiler::getTimer(TimerKind timerKind) {
   return TimePassesIsEnabled || cl::EnableTimerProfile ? &m_phaseTimers[timerKind] : nullptr;
 }
 

--- a/llpc/util/llpcTimerProfiler.h
+++ b/llpc/util/llpcTimerProfiler.h
@@ -72,16 +72,12 @@ public:
 
   static const llvm::StringMap<llvm::TimeRecord> &getDummyTimeRecords();
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   static const unsigned PipelineTimerEnableMask = ((1 << TimerCount) - 1);
   static const unsigned ShaderModuleTimerEnableMask = ((1 << TimerTranslate) | (1 << TimerLower));
 
 private:
   TimerProfiler(const TimerProfiler &) = delete;
   TimerProfiler &operator=(const TimerProfiler &) = delete;
-
-  // -----------------------------------------------------------------------------------------------------------------
 
   llvm::TimerGroup m_total;              // TimeGroup for total time
   llvm::TimerGroup m_phases;             // TimeGroup for each phase

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -78,7 +78,7 @@ public:
   void unlock() { m_mutex.unlock(); }
 
 private:
-  llvm::sys::Mutex m_mutex;
+  sys::Mutex m_mutex;
 };
 
 // Mutex for pipeline dump

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1008,7 +1008,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
 
         // TODO: We should query descriptor size from patch
 
-        // The second part of DescriptorRangeValue is YCbCrMetaData, which is 4 DWORDS.
+        // The second part of DescriptorRangeValue is YCbCrMetaData, which is 4 dwords.
         // The hasher should be updated when the content changes, this is because YCbCrMetaData
         // is engaged in pipeline compiling.
         const unsigned descriptorSize =

--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -457,7 +457,7 @@ template <class Elf> bool ElfReader<Elf>::getNextMsgNode() {
 
 // =====================================================================================================================
 // Gets MsgPack node.
-template <class Elf> const llvm::msgpack::DocNode *ElfReader<Elf>::getMsgNode() const {
+template <class Elf> const msgpack::DocNode *ElfReader<Elf>::getMsgNode() const {
   assert(m_iteratorStack.size() > 0);
   auto curIter = &(m_iteratorStack.back());
   if (curIter->status == MsgPackIteratorArrayValue)

--- a/util/vkgcElfReader.h
+++ b/util/vkgcElfReader.h
@@ -479,8 +479,6 @@ private:
   ElfReader(const ElfReader &) = delete;
   ElfReader &operator=(const ElfReader &) = delete;
 
-  // -----------------------------------------------------------------------------------------------------------------
-
   GfxIpVersion m_gfxIp; // Graphics IP version info (used by ELF dump only)
 
   typename Elf::FormatHeader m_header;     // ELF header


### PR DESCRIPTION
- Remove "llvm::" prefix in cpp sources files.
- Change BYTE/WORD/DWORD naming to byte/word/dword
- Change DEBUG_TYPE from "llpc-" to "lgc-" for LGC source files
- Remove unnecessary separate lines
