### PR TITLE
Set SkipUniformRegions for StructurizeCGF pass

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -141,6 +141,7 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-atomic-optimizations", "1");
   setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("amdgpu-conditional-discard-transformations", "1");
+  setOptionDefault("structurizecfg-skip-uniform-regions", "1");
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The default for the SkipUniformRegions option for the LLVM StructurizeCFG pass
was recently changed from true to false - this was to avoid bad effects seen
with some compute workloads. However, this change impacted the performance of
some shaders.

This change uses the LLVM option -structurizecfg-skip-uniform-regions to
set the value of SkipUniformRegions to true for shaders, thereby restoring
the performance for the impacted shaders.