### PR TITLE
Fixed converting immutable sampler detection

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -185,7 +185,10 @@ enum class ResourceNodeType : unsigned {
   DescriptorBufferCompact,   ///< Compact buffer descriptor, only contains the buffer address
   StreamOutTableVaPtr,       ///< Stream-out buffer table VA pointer
   DescriptorReserved12,
-  DescriptorYCbCrSampler, ///< Generic descriptor: YCbCr sampler
+  DescriptorYCbCrSampler, ///< Generic descriptor: combined texture, combining resource descriptor with
+                          ///  space for a sampler descriptor (starting with resource descriptor), but the 4-dword
+                          ///  sampler descriptor is ignored and overridden with an 8-dword immutable YCbCr converting
+                          ///  sampler
   InlineBuffer,           ///< Inline buffer, with descriptor set and binding
   Count,                  ///< Count of resource mapping node types.
 };


### PR DESCRIPTION
ImageBuilder::CreateImageSample has code to detect that its sampler is a
converting immutable sampler, so it can call CreateImageSampleConvert.
However that detection code was completely broken. Fixed.

Change-Id: I9be56eec0feec87624a363505f0cd6d91ea7a034