### PR TITLE
Use llvm.loop.disable_nonforced metadata where appropriate

### DIFF
--- a/llpc/lower/llpcSpirvLowerLoopUnrollControl.cpp
+++ b/llpc/lower/llpcSpirvLowerLoopUnrollControl.cpp
@@ -124,6 +124,10 @@ bool SpirvLowerLoopUnrollControl::runOnModule(Module &module) {
             ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(*m_context), m_forceLoopUnrollCount))};
         MDNode *loopUnrollCountMetaNode = MDNode::get(*m_context, unrollCountMeta);
         loopMetaNode = MDNode::concatenate(loopMetaNode, MDNode::get(*m_context, loopUnrollCountMetaNode));
+        // We also disable all nonforced loop transformations to ensure our transformation is not blocked
+        llvm::Metadata *nonforcedMeta[] = {MDString::get(*m_context, "llvm.loop.disable_nonforced")};
+        MDNode *nonforcedMetaNode = MDNode::get(*m_context, nonforcedMeta);
+        loopMetaNode = MDNode::concatenate(loopMetaNode, MDNode::get(*m_context, nonforcedMetaNode));
       }
       if (m_disableLicm) {
         MDNode *licmDisableNode = MDNode::get(*m_context, MDString::get(*m_context, "llvm.licm.disable"));

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1134,9 +1134,14 @@ void SPIRVToLLVM::setLLVMLoopMetadata(SPIRVLoopMerge *lm, BranchInst *bi) {
   if (mDs.empty())
     return;
 
+  // We disable all nonforced loop transformations to ensure our transformation is not blocked
+  std::vector<llvm::Metadata *> mDnf;
+  mDnf.push_back(llvm::MDString::get(*m_context, "llvm.loop.disable_nonforced"));
+
   SmallVector<llvm::Metadata *, 2> metadata;
   metadata.push_back(llvm::MDNode::get(*m_context, self));
   metadata.push_back(llvm::MDNode::get(*m_context, mDs));
+  metadata.push_back(llvm::MDNode::get(*m_context, mDnf));
 
   llvm::MDNode *node = llvm::MDNode::get(*m_context, metadata);
   node->replaceOperandWith(0, node);


### PR DESCRIPTION
When explicit loop metadata is used, e.g. llvm.loop.unroll.count, it is advised that
lvm.loop.disable_nonforced is also used. This disables all optional loop transformations
unless explicitly instructed using other transformation metadata - mandatory
canonicalisations will still be performed.

This change simply adds the disable_nonforced metadata whenever LLPC adds explicit loop
metadata.