### PR TITLE
Disable kill transformations

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -142,7 +142,6 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
   setOptionDefault("use-gpu-divergence-analysis", "1");
-  setOptionDefault("amdgpu-conditional-discard-transformations", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
 }
 


### PR DESCRIPTION
Temporarily disable kill transformations as enabling them has
caused a correctness regression that needs to be investigated.