### PR TITLE
Add disableLoopUnroll to pipeline shader options

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -69,6 +69,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     40.1 | Added disableLoopUnroll to PipelineShaderOptions                                                      |
 //* |     40.0 | Added DescriptorReserved12, which moves DescriptorYCbCrSampler down to 13                             |
 //* |     39.0 | Non-LLPC-specific XGL code should #include vkcgDefs.h instead of llpc.h                               |
 //* |     38.3 | Added shadowDescriptorTableUsage and shadowDescriptorTablePtrHigh to PipelineOptions                  |
@@ -475,6 +476,9 @@ struct PipelineShaderOptions {
 
   /// The threshold for load scalarizer.
   unsigned scalarThreshold;
+
+  /// Forcibly disable loop unrolling - overrides any explicit unroll directives
+  bool disableLoopUnroll;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/llpc/lower/llpcSpirvLowerLoopUnrollControl.h
+++ b/llpc/lower/llpcSpirvLowerLoopUnrollControl.h
@@ -51,6 +51,7 @@ private:
 
   unsigned m_forceLoopUnrollCount; // Forced loop unroll count
   bool m_disableLicm;              // Disable LLVM LICM pass
+  bool m_disableLoopUnroll;        // Forcibly disable loop unroll
 };
 
 } // namespace Llpc

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -520,6 +520,7 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
 #endif
   dumpFile << "options.unrollThreshold = " << shaderInfo->options.unrollThreshold << "\n";
   dumpFile << "options.scalarThreshold = " << shaderInfo->options.scalarThreshold << "\n";
+  dumpFile << "options.disableLoopUnroll = " << shaderInfo->options.disableLoopUnroll << "\n";
 
   dumpFile << "\n";
 }
@@ -1051,6 +1052,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
 #endif
       hasher->Update(options.unrollThreshold);
       hasher->Update(options.scalarThreshold);
+      hasher->Update(options.disableLoopUnroll);
     }
   }
 }

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1041,6 +1041,7 @@ public:
 #endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -1049,7 +1050,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 18;
+  static const unsigned MemberCount = 19;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Previously loop unrolling could be disabled by use of the forceLoopUnrollCount
pipeline option with a value of 1. However, this is not applied ito loops that
already have explicit loop metadata (e.g. Unroll or DontUnroll).

The new disableLoopUnroll option is applied to loops whether or not there is
existing metadata. This allows explicit hints to be overridden when appropriate.

The forceLoopUnrollCount=1 option can continue to be used in cases where
existing metadata should be preserved.