### PR TITLE
[CI] Continue running remaining jobs despite failures.

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -10,6 +10,7 @@ jobs:
     if: github.repository == 'GPUOpen-Drivers/llpc'
     runs-on: ${{ matrix.host-os }}
     strategy:
+      fail-fast: false
       matrix:
         host-os:        ["ubuntu-18.04"]
         image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -12,6 +12,7 @@ jobs:
     name: "Features: ${{ matrix.feature-set }}, assertions: ${{ matrix.assertions }}"
     runs-on: ${{ matrix.host-os }}
     strategy:
+      fail-fast: false
       matrix:
         host-os:             ["ubuntu-18.04"]
         base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]


### PR DESCRIPTION
This disables the default fail-fast behavior which kills all
github actions jobs after a single one fails. The motivation is to
better diagnose failures in the presence of `-Werror` and broken
trunk, like in
https://github.com/GPUOpen-Drivers/llpc/commit/ff90ae47205965cd9f8152ed86da6edeb081f41f.

For example, this allows all gcc builds to continue and report final
status even when clang builds fail.
Relevant docs:
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast.