### PR TITLE
Stop using confusing ShadowDescriptorTable::Disable inside LGC

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -260,8 +260,7 @@ Value *DescBuilder::CreateGetFmaskDescPtr(unsigned descSet, unsigned binding, co
   // look. Later code will use relocs.
   const ResourceNode *topNode = nullptr;
   const ResourceNode *node = nullptr;
-  bool shadow =
-      m_pipelineState->getOptions().shadowDescriptorTable != static_cast<unsigned>(ShadowDescriptorTable::Disable);
+  bool shadow = m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable;
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::DescriptorFmask, descSet, binding);
     if (!node && shadow) {
@@ -427,10 +426,9 @@ Value *DescBuilder::getDescPtr(ResourceNodeType resType, unsigned descSet, unsig
     // Get the descriptor table pointer for the set, which might be passed as a user SGPR to the shader.
     // The args to the lgc.descriptor.set call are:
     // - descriptor set number
-    // - value for high 32 bits of pointer; ShadowDescriptorTable::Disable to use PC
+    // - value for high 32 bits of pointer; HighAddrPc to use PC
     // TODO Shader compilation: For the "shadow" case, the high half of the address needs to be a reloc.
-    unsigned highHalf = shadow ? m_pipelineState->getOptions().shadowDescriptorTable
-                               : static_cast<unsigned>(ShadowDescriptorTable::Disable);
+    unsigned highHalf = shadow ? m_pipelineState->getOptions().shadowDescriptorTable : HighAddrPc;
     descPtr = CreateNamedCall(lgcName::DescriptorSet, getInt8Ty()->getPointerTo(ADDR_SPACE_CONST),
                               {getInt32(descSet), getInt32(highHalf)}, Attribute::ReadNone);
   }

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -72,7 +72,7 @@ const static char PushConst[] = "lgc.push.const";
 // The arg is the dword offset of the node in the root user data layout.
 const static char RootDescriptor[] = "lgc.root.descriptor";
 // Get pointer to a descriptor set table. First arg is the descriptor set number; second arg is the value to use
-// for the high half of the address, or ShadowDescriptorTable::Disable to use PC.
+// for the high half of the address, or HighAddrPc to use PC.
 const static char DescriptorSet[] = "lgc.descriptor.set";
 
 const static char LaterCallPrefix[] = "lgc.late.";
@@ -114,6 +114,9 @@ const static char CopyShaderEntryPoint[] = "lgc.shader.COPY.main";
 const static char NullFsEntryPoint[] = "lgc.shader.FS.null.main";
 
 } // namespace lgcName
+
+// Value for high half of address that means "use PC".
+const static unsigned HighAddrPc = ~0U;
 
 // Well-known metadata names
 const static char MetaNameUniform[] = "amdgpu.uniform";

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -91,10 +91,8 @@ enum class WaveBreak : unsigned {
   DrawTime = 0xF, ///< Choose wave break size per draw
 };
 
-// Values for shadowDescriptorTable pipeline option.
-enum class ShadowDescriptorTable : unsigned {
-  Disable = ~0U // Disable shadow descriptor tables
-};
+// Value for shadowDescriptorTable pipeline option.
+static const unsigned ShadowDescriptorTableDisable = ~0U;
 
 // Middle-end per-pipeline options to pass to SetOptions.
 // The front-end should zero-initialize it with "= {}" in case future changes add new fields.
@@ -116,7 +114,7 @@ struct Options {
   unsigned nggVertsPerSubgroup;        // How to determine NGG verts per subgroup
   unsigned nggPrimsPerSubgroup;        // How to determine NGG prims per subgroup
   unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
-                                       //   ShadowDescriptorTable::Disable to disable shadow descriptor tables
+                                       //   ShadowDescriptorTableDisable to disable shadow descriptor tables
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -189,13 +189,13 @@ public:
   // Extend an i32 into a 64-bit pointer
   //
   // @param addr32 : Address as 32-bit value
-  // @param highHalf : Value to use for high half; ShadowDescriptorTable::Disable to use PC
+  // @param highHalf : Value to use for high half; HighAddrPc to use PC
   // @param ptrTy : Type to cast pointer to
   // @param builder : IRBuilder to use, already set to the required insert point
   // @return : 64-bit pointer value
   Instruction *extend(Value *addr32, unsigned highHalf, Type *ptrTy, IRBuilder<> &builder) {
     Value *ptr = nullptr;
-    if (highHalf == static_cast<unsigned>(ShadowDescriptorTable::Disable)) {
+    if (highHalf == HighAddrPc) {
       // Extend with PC.
       ptr = builder.CreateInsertElement(getPc(), addr32, uint64_t(0));
     } else {
@@ -434,8 +434,8 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
       builder.SetInsertPoint(addressExtender.getFirstInsertionPt());
       Argument *arg = func.getArg(userDataUsage->spillTable.entryArgIdx);
       arg->setName("spillTable");
-      spillTable = addressExtender.extend(arg, static_cast<unsigned>(ShadowDescriptorTable::Disable),
-                                          builder.getInt8Ty()->getPointerTo(ADDR_SPACE_CONST), builder);
+      spillTable =
+          addressExtender.extend(arg, HighAddrPc, builder.getInt8Ty()->getPointerTo(ADDR_SPACE_CONST), builder);
     }
 
     // Handle direct uses of the spill table that were generated in DescBuilder.

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -513,5 +513,5 @@ unsigned ShaderSystemValues::findResourceNodeByDescSet(unsigned descSet) {
 // =====================================================================================================================
 // Test if shadow descriptor table is enabled
 bool ShaderSystemValues::isShadowDescTableEnabled() const {
-  return m_pipelineState->getOptions().shadowDescriptorTable != static_cast<unsigned>(ShadowDescriptorTable::Disable);
+  return m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable;
 }

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -245,14 +245,14 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
     options.shadowDescriptorTable = getPipelineOptions()->shadowDescriptorTablePtrHigh;
     break;
   case Vkgc::ShadowDescriptorTableUsage::Disable:
-    options.shadowDescriptorTable = static_cast<unsigned>(ShadowDescriptorTable::Disable);
+    options.shadowDescriptorTable = ShadowDescriptorTableDisable;
     break;
   }
 
   // Shadow descriptor command line options override pipeline options.
   if (EnableShadowDescriptorTable.getNumOccurrences() > 0) {
     if (!EnableShadowDescriptorTable)
-      options.shadowDescriptorTable = static_cast<unsigned>(ShadowDescriptorTable::Disable);
+      options.shadowDescriptorTable = ShadowDescriptorTableDisable;
     else
       options.shadowDescriptorTable = ShadowDescTablePtrHigh;
   }


### PR DESCRIPTION
ShadowDescriptorTable::Disable was the value of the
shadowDescriptorTable pipeline option to disable shadow descriptors.
Confusingly, I was also using that value in other places in LGC where
the high half of an address is provided to mean "get the high half from
PC".

This commit separates that usage into a new HighAddrPc. For the pipeline
option, it also changes ShadowDescriptorTable::Disable to
ShadowDescriptorTableDisable, as there was no particular need for it to
be an enum class, and it saves some casts.

Change-Id: Ib46c410f24c098d9471798f66f5b050118b72bdf