### PR TITLE
ShaderInputs, moved some VS inputs to InOutBuilder

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -215,6 +215,7 @@ target_sources(LLVMlgc PRIVATE
     patch/PatchPreparePipelineAbi.cpp
     patch/PatchResourceCollect.cpp
     patch/PatchSetupTargetFeatures.cpp
+    patch/ShaderInputs.cpp
     patch/ShaderMerger.cpp
     patch/SystemValues.cpp
     patch/VertexFetch.cpp

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -503,6 +503,9 @@ private:
   llvm::Value *readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo inOutInfo, llvm::Value *vertexIndex,
                            llvm::Value *index, const llvm::Twine &instName);
 
+  // Read vertex shader input
+  llvm::Value *readVsBuiltIn(BuiltInKind builtIn, const llvm::Twine &instName);
+
   // Get the type of a built-in. This overrides the one in Builder to additionally recognize the internal built-ins.
   llvm::Type *getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo);
 

--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -1,0 +1,200 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  ShaderInputs.h
+ * @brief LGC header file: Handling of hardware-determined shader inputs (not user data)
+ *
+ * When it dispatches a wave and starts running a shader, the hardware sets up a number of SGPRs and VGPRs,
+ * depending on which shader stage it is, and some configuration in SPI registers. The enum and class in this
+ * file encapsulate that functionality.
+ *
+ * User data is included in the SGPRs set up at wave dispatch; user data is handled separately and is not
+ * part of the functionality encapsulated here.
+ *
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/CommonDefs.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace llvm {
+class Instruction;
+class LLVMContext;
+class Module;
+class Type;
+} // namespace llvm
+
+namespace lgc {
+
+class PipelineState;
+
+// =====================================================================================================================
+// Internal numbering for shader inputs
+enum class ShaderInput : unsigned {
+  // CS SGPRs
+  WorkgroupId,       // WorkgroupId (v3i32)
+  MultiDispatchInfo, // Multiple dispatch info, include TG_SIZE and etc.
+
+  // FS SGPRs
+  PrimMask, // Primitive mask
+
+  // Appears in hardware HS, ES, VS SGPRs
+  OffChipLdsBase, // Off-chip LDS buffer base
+
+  // Hardware VS SGPRs
+  StreamOutInfo,       // Stream-out info (ID, vertex count, enablement)
+  StreamOutWriteIndex, // Stream-out write index
+  StreamOutOffset0,    // Stream-out offset 0
+  StreamOutOffset1,    // Stream-out offset 1
+  StreamOutOffset2,    // Stream-out offset 2
+  StreamOutOffset3,    // Stream-out offset 3
+
+  // Unmerged hardware GS SGPRs
+  GsVsOffset, // GS to VS offset
+  GsWaveId,   // GS wave ID
+
+  // Unmerged hardware ES SGPRs
+  IsOffChip,  // is_off_chip
+  EsGsOffset, // ES to GS offset
+
+  // Unmerged hardware HS SGPRs
+  TfBufferBase, // TF buffer base
+
+  FirstVgpr, // Enums less than this are SGPRs
+
+  // API VS VGPRs
+  VertexId = FirstVgpr, // Vertex ID
+  RelVertexId,          // Relative vertex ID (auto index)
+  PrimitiveId,          // Primitive ID
+  InstanceId,           // Instance ID
+
+  // Appear in TCS and TES VGPRs
+  PatchId,    // Patch ID
+  RelPatchId, // Relative patch ID (in TCS, control point ID included)
+
+  // TES VGPRs
+  TessCoordX, // X of TessCoord (U) (float)
+  TessCoordY, // Y of TessCoord (V) (float)
+
+  // GS VGPRs
+  EsGsOffset0,   // ES to GS offset (vertex 0)
+  EsGsOffset1,   // ES to GS offset (vertex 1)
+  GsPrimitiveId, // Primitive ID
+  EsGsOffset2,   // ES to GS offset (vertex 2)
+  EsGsOffset3,   // ES to GS offset (vertex 3)
+  EsGsOffset4,   // ES to GS offset (vertex 4)
+  EsGsOffset5,   // ES to GS offset (vertex 5)
+  GsInstanceId,  // Invocation ID
+
+  // FS VGPRs
+  PerspInterpSample,    // Perspective sample (v2f32)
+  PerspInterpCenter,    // Perspective center (v2f32)
+  PerspInterpCentroid,  // Perspective centroid (v2f32)
+  PerspInterpPullMode,  // Perspective pull-mode (v3f32)
+  LinearInterpSample,   // Perspective sample (v2f32)
+  LinearInterpCenter,   // Perspective center (v2f32)
+  LinearInterpCentroid, // Perspective centroid (v2f32)
+  LineStipple,          // Line stipple (float)
+  FragCoordX,           // X of FragCoord (float)
+  FragCoordY,           // Y of FragCoord (float)
+  FragCoordZ,           // Z of FragCoord (float)
+  FragCoordW,           // W of FragCoord (float)
+  FrontFacing,          // Front facing
+  Ancillary,            // Ancillary
+  SampleCoverage,       // Sample coverage
+  FixedXY,              // Fixed X/Y
+
+  // CS VGPRs
+  LocalInvocationId, // LocalInvocationId (v3i32)
+
+  Count
+};
+
+// =====================================================================================================================
+// Class for handling shader inputs (other than user data)
+//
+// From BuilderImpl up to just before PatchEntryPointMutate, static methods in this class can be used to
+// generate code to access shader inputs. That generates an lgc.shader.input.* call for each access.
+//
+// The PatchEntryPointMutate pass creates a ShaderInputs object, and uses a method on it to gather already-
+// generated uses of shader inputs, and another method to create arguments for the shader function based
+// on that, and on usage that will happen after PatchEntryPointMutate.
+//
+// The resulting shader function has input arguments that represent a kind of idealized GFX8 shader,
+// before GFX9+ shader merging and/or GFX10+ NGG primitive shader formation.
+//
+class ShaderInputs {
+public:
+  ShaderInputs() = delete;
+  ShaderInputs(llvm::LLVMContext *context) : m_context(context) {}
+
+  // -------------------------------------------------------------------------------------------------------------------
+  // Static methods called any time
+
+  // Get IR type of a particular shader input
+  static llvm::Type *getInputType(ShaderInput inputKind, llvm::LLVMContext &context);
+
+  // -------------------------------------------------------------------------------------------------------------------
+  // Object methods called during PatchEntryPointMutate
+
+  // Gather usage of shader inputs from before PatchEntryPointMutate
+  void gatherUsage(llvm::Module &module);
+
+  // Fix up uses of shader inputs to use entry args directly
+  void fixupUses(llvm::Module &module);
+
+  // Get argument types for shader inputs
+  uint64_t getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage,
+                           llvm::SmallVectorImpl<llvm::Type *> &argTys);
+
+private:
+  // Usage for one system shader input in one shader stage
+  struct ShaderInputUsage {
+    void enable() { users.push_back(nullptr); }
+    unsigned entryArgIdx = 0;
+    llvm::SmallVector<llvm::Instruction *, 4> users;
+  };
+
+  // Per-shader-stage gathered usage of system shader inputs
+  struct ShaderInputsUsage {
+    std::unique_ptr<ShaderInputUsage> inputs[static_cast<unsigned>(ShaderInput::Count)];
+  };
+
+  // Get ShaderInputsUsage struct for the given shader stage
+  ShaderInputsUsage *getShaderInputsUsage(ShaderStage stage);
+
+  // Get (create if necessary) ShaderInputUsage struct for the given system shader input in the given shader stage
+  ShaderInputUsage *getShaderInputUsage(ShaderStage stage, ShaderInput inputKind) {
+    return getShaderInputUsage(stage, static_cast<unsigned>(inputKind));
+  }
+  ShaderInputUsage *getShaderInputUsage(ShaderStage stage, unsigned inputKind);
+
+  llvm::LLVMContext *m_context;
+  llvm::SmallVector<ShaderInputsUsage, ShaderStageCountInternal> m_shaderInputsUsage;
+};
+
+} // namespace lgc

--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -43,14 +43,17 @@
 #include "llvm/ADT/SmallVector.h"
 
 namespace llvm {
+class CallInst;
 class Instruction;
 class LLVMContext;
 class Module;
 class Type;
+class Value;
 } // namespace llvm
 
 namespace lgc {
 
+class BuilderBase;
 class PipelineState;
 
 // =====================================================================================================================
@@ -156,8 +159,32 @@ public:
   // -------------------------------------------------------------------------------------------------------------------
   // Static methods called any time
 
+  // Get name of a special user data value, one of the UserDataMapping values
+  static const char *getSpecialUserDataName(unsigned kind);
+  static const char *getSpecialUserDataName(UserDataMapping kind) {
+    return getSpecialUserDataName(static_cast<unsigned>(kind));
+  }
+
   // Get IR type of a particular shader input
   static llvm::Type *getInputType(ShaderInput inputKind, llvm::LLVMContext &context);
+
+  // Get name of shader input
+  static const char *getInputName(ShaderInput inputKind);
+
+  // -------------------------------------------------------------------------------------------------------------------
+  // Static methods called before PatchEntryPointMutate
+
+  // Get a special user data value by inserting a call to lgc.special.user.data
+  static llvm::CallInst *getSpecialUserData(UserDataMapping kind, BuilderBase &builder);
+
+  // Get VertexIndex
+  static llvm::Value *getVertexIndex(BuilderBase &builder);
+
+  // Get InstanceIndex
+  static llvm::Value *getInstanceIndex(BuilderBase &builder);
+
+  // Get a shader input value by inserting a call to lgc.shader.input
+  static llvm::Value *getInput(ShaderInput kind, BuilderBase &builder);
 
   // -------------------------------------------------------------------------------------------------------------------
   // Object methods called during PatchEntryPointMutate

--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -25,20 +25,21 @@
 /**
  ***********************************************************************************************************************
  * @file  ShaderInputs.h
- * @brief LGC header file: Handling of hardware-determined shader inputs (not user data)
+ * @brief LGC header file: Handling of hardware-determined shader inputs (not user data, other than special user data)
  *
  * When it dispatches a wave and starts running a shader, the hardware sets up a number of SGPRs and VGPRs,
  * depending on which shader stage it is, and some configuration in SPI registers. The enum and class in this
  * file encapsulate that functionality.
  *
  * User data is included in the SGPRs set up at wave dispatch; user data is handled separately and is not
- * part of the functionality encapsulated here.
+ * part of the functionality encapsulated here, except that a few utility methods for special user data are here.
  *
  ***********************************************************************************************************************
  */
 #pragma once
 
 #include "lgc/CommonDefs.h"
+#include "lgc/state/AbiMetadata.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace llvm {

--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -193,7 +193,7 @@ public:
   void gatherUsage(llvm::Module &module);
 
   // Fix up uses of shader inputs to use entry args directly
-  void fixupUses(llvm::Module &module);
+  void fixupUses(llvm::Module &module, PipelineState *pipelineState);
 
   // Get argument types for shader inputs
   uint64_t getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage,

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -134,8 +134,11 @@ static constexpr char ApiShaderHash[] = ".api_shader_hash";
 static constexpr char HardwareMapping[] = ".hardware_mapping";
 }; // namespace ShaderMetadataKey
 
-/// User data entries can map to physical user data registers.  UserDataMapping describes the
-/// content of the registers.
+} // namespace Abi
+
+} // namespace Util
+
+// User data mapping for special user data values.
 enum class UserDataMapping : unsigned {
   GlobalTable = 0x10000000,       // 32-bit pointer to GPU memory containing the global internal table.
   PerShaderTable = 0x10000001,    // 32-bit pointer to GPU memory containing the per-shader internal table.
@@ -161,12 +164,18 @@ enum class UserDataMapping : unsigned {
   NggCullingData = 0x10000011,    // 64-bit pointer to GPU memory containing the hardware register data needed by
                                   //  some NGG pipelines to perform culling.  This value contains the address of the
                                   //  first of two consecutive registers which provide the full GPU address.
-  Invalid = ~0U                   // Invalid value used internally in LGC.
+
+  // Values used in a user data PAL metadata register to be resolved at link time.
+  // This is part of the "unlinked" ABI, so should arguably be in AbiUnlinked.h.
+  DescriptorSet0 = 0x80000000,   // 32-bit pointer to the descriptor table for descriptor set 0: add N to this value
+                                 //  for descriptor set N
+  DescriptorSetMax = 0x800000FF, // Max descriptor set
+  PushConst0 = 0x80000100,       // Push constant dword 0: add N to this value for push constant dword N
+  PushConstMax = 0x800001FF,     // Max push constant dword
+
+  // Value used internally in LGC.
+  Invalid = ~0U // Invalid value used internally in LGC.
 };
-
-} // namespace Abi
-
-} // namespace Util
 
 // The names of API shader stages used in PAL metadata, in ShaderStage order.
 static const char *const ApiStageNames[] = {".vertex", ".hull", ".domain", ".geometry", ".pixel", ".compute"};

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -77,15 +77,4 @@ const static char DeviceIdx[] = "$deviceIdx";
 
 } // namespace reloc
 
-// =====================================================================================================================
-// Values used in a user data PAL metadata register to be resolved at link time.
-// This "lgc::UserDataMapping" extends "lgc::Abi::Metadata::UserDataMapping" in AbiMetadata.h.
-enum class UserDataMapping : unsigned {
-  DescriptorSet0 = 0x80000000,   // 32-bit pointer to the descriptor table for descriptor set 0: add N to this value
-                                 //  for descriptor set N
-  DescriptorSetMax = 0x800000FF, // Max descriptor set
-  PushConst0 = 0x80000100,       // Push constant dword 0: add N to this value for push constant dword N
-  PushConstMax = 0x800001FF,     // Max push constant dword
-};
-
 } // namespace lgc

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -74,6 +74,10 @@ const static char RootDescriptor[] = "lgc.root.descriptor";
 // Get pointer to a descriptor set table. First arg is the descriptor set number; second arg is the value to use
 // for the high half of the address, or HighAddrPc to use PC.
 const static char DescriptorSet[] = "lgc.descriptor.set";
+// Get special user data input. Arg is UserDataMapping enum value.
+const static char SpecialUserData[] = "lgc.special.user.data.";
+// Get shader input. Arg is ShaderInput enum value.
+const static char ShaderInput[] = "lgc.shader.input.";
 
 const static char LaterCallPrefix[] = "lgc.late.";
 const static char LateLaunderFatPointer[] = "lgc.late.launder.fat.pointer";

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -71,7 +71,7 @@ public:
 
   // Set the PAL metadata SPI register for one user data entry
   void setUserDataEntry(ShaderStage stage, unsigned userDataIndex, unsigned userDataValue, unsigned dwordCount = 1);
-  void setUserDataEntry(ShaderStage stage, unsigned userDataIndex, Util::Abi::UserDataMapping userDataValue,
+  void setUserDataEntry(ShaderStage stage, unsigned userDataIndex, UserDataMapping userDataValue,
                         unsigned dwordCount = 1) {
     setUserDataEntry(stage, userDataIndex, static_cast<unsigned>(userDataValue), dwordCount);
   }

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -144,7 +144,6 @@ struct ResourceUsage {
         unsigned instanceIndex : 1; // Whether gl_InstanceIndex is used
         unsigned baseVertex : 1;    // Whether gl_BaseVertex is used
         unsigned baseInstance : 1;  // Whether gl_BaseInstance is used
-        unsigned drawIndex : 1;     // Whether gl_DrawID is used
         unsigned primitiveId : 1;   // Whether an implicit gl_PrimitiveID is required
         unsigned viewIndex : 1;     // Whether gl_ViewIndex is used
         // Output
@@ -154,9 +153,9 @@ struct ResourceUsage {
         unsigned cullDistance : 4;  // Array size of gl_CullDistance[] (0 means unused)
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
-        unsigned reserved20 : 1;
+        unsigned reserved19 : 1;
 
-        uint64_t unused : 44;
+        uint64_t unused : 45;
       } vs;
 
       // Tessellation control shader
@@ -485,7 +484,6 @@ struct InterfaceData {
         unsigned vertexId;           // Vertex ID
         unsigned relVertexId;        // Relative vertex ID (index of vertex within thread group)
         unsigned instanceId;         // Instance ID
-        unsigned drawIndex;          // Draw index
         unsigned primitiveId;        // Primitive ID
         unsigned viewIndex;          // View Index
         unsigned vbTablePtr;         // Pointer of vertex buffer table

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -29,7 +29,6 @@
  ***********************************************************************************************************************
  */
 #include "ConfigBuilderBase.h"
-#include "lgc/state/AbiMetadata.h"
 #include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"

--- a/lgc/patch/Gfx6Chip.h
+++ b/lgc/patch/Gfx6Chip.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "ConfigBuilderBase.h"
-#include "lgc/state/AbiMetadata.h"
 #include "lgc/state/TargetInfo.h"
 #include <cstdint>
 #include <unordered_map>

--- a/lgc/patch/Gfx9Chip.h
+++ b/lgc/patch/Gfx9Chip.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "ConfigBuilderBase.h"
-#include "lgc/state/AbiMetadata.h"
 #include "lgc/state/TargetInfo.h"
 #include <cstdint>
 #include <unordered_map>

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -30,6 +30,7 @@
  */
 #include "Gfx9ConfigBuilder.h"
 #include "lgc/BuiltIns.h"
+#include "lgc/patch/ShaderInputs.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 #include "llvm/Support/CommandLine.h"
@@ -1742,8 +1743,7 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
     // SPI_SHADER_PGM_HI_GS if we do not provide one. By setting SPI_SHADER_PGM_LO_GS to NggCullingData, we tell
     // PAL that we will not provide it and it is fine to use SPI_SHADER_PGM_LO_GS and SPI_SHADER_PGM_HI_GS as
     // the address of that table.
-    SET_REG(&pConfig->primShaderRegs, SPI_SHADER_PGM_LO_GS,
-            static_cast<unsigned>(Util::Abi::UserDataMapping::NggCullingData));
+    SET_REG(&pConfig->primShaderRegs, SPI_SHADER_PGM_LO_GS, static_cast<unsigned>(UserDataMapping::NggCullingData));
   }
 }
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -186,17 +186,14 @@ bool PatchCopyShader::runOnModule(Module &module) {
   if (!m_pipelineState->getNggControl()->enableNgg) {
     // If no NGG, the copy shader will become a real hardware VS. Set the user data entries in the
     // PAL metadata here.
-    m_pipelineState->getPalMetadata()->setUserDataEntry(ShaderStageCopyShader, 0,
-                                                        Util::Abi::UserDataMapping::GlobalTable);
+    m_pipelineState->getPalMetadata()->setUserDataEntry(ShaderStageCopyShader, 0, UserDataMapping::GlobalTable);
     if (resUsage->inOutUsage.enableXfb) {
-      m_pipelineState->getPalMetadata()->setUserDataEntry(ShaderStageCopyShader,
-                                                          intfData->userDataUsage.gs.copyShaderStreamOutTable,
-                                                          Util::Abi::UserDataMapping::StreamOutTable);
+      m_pipelineState->getPalMetadata()->setUserDataEntry(
+          ShaderStageCopyShader, intfData->userDataUsage.gs.copyShaderStreamOutTable, UserDataMapping::StreamOutTable);
     }
     if (cl::InRegEsGsLdsSize && m_pipelineState->isGsOnChip()) {
-      m_pipelineState->getPalMetadata()->setUserDataEntry(ShaderStageCopyShader,
-                                                          intfData->userDataUsage.gs.copyShaderEsGsLdsSize,
-                                                          Util::Abi::UserDataMapping::EsGsLdsSize);
+      m_pipelineState->getPalMetadata()->setUserDataEntry(
+          ShaderStageCopyShader, intfData->userDataUsage.gs.copyShaderEsGsLdsSize, UserDataMapping::EsGsLdsSize);
     }
   }
 

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -288,7 +288,7 @@ bool PatchEntryPointMutate::runOnModule(Module &module) {
   m_userDataUsage.clear();
 
   // Fix up shader input uses to use entry args.
-  shaderInputs.fixupUses(*m_module);
+  shaderInputs.fixupUses(*m_module, m_pipelineState);
 
   return true;
 }
@@ -980,10 +980,8 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       }
 
       // Draw index.
-      if (vsResUsage->builtInUsage.vs.drawIndex || userDataUsage->isSpecialUserDataUsed(UserDataMapping::DrawIndex)) {
-        specialUserDataArgs.push_back(
-            UserDataArg(builder.getInt32Ty(), UserDataMapping::DrawIndex, &vsIntfData->entryArgIdxs.vs.drawIndex));
-      }
+      if (userDataUsage->isSpecialUserDataUsed(UserDataMapping::DrawIndex))
+        specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), UserDataMapping::DrawIndex));
     }
 
   } else if (m_shaderStage == ShaderStageCompute) {

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1933,16 +1933,8 @@ Value *PatchInOutImportExport::patchVsBuiltInInputImport(Type *inputTy, unsigned
   auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageVertex)->entryArgIdxs.vs;
 
   switch (builtInId) {
-  case BuiltInVertexIndex:
-    return m_vertexFetch->getVertexIndex();
-  case BuiltInInstanceIndex:
-    return m_vertexFetch->getInstanceIndex();
-  case BuiltInBaseVertex:
-    return getFunctionArgument(m_entryPoint, entryArgIdxs.baseVertex);
-  case BuiltInBaseInstance:
-    return getFunctionArgument(m_entryPoint, entryArgIdxs.baseInstance);
-  case BuiltInDrawIndex:
-    return getFunctionArgument(m_entryPoint, entryArgIdxs.drawIndex);
+  // BuiltInVertexIndex, BuiltInInstanceIndex, BuiltInBaseVertex, BuiltInBaseInstance, BuiltInDrawIndex
+  // now handled in InOutBuilder.
   case BuiltInViewIndex:
     return getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
   case BuiltInSubgroupSize:

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1249,10 +1249,7 @@ void PatchResourceCollect::clearInactiveInput() {
   auto &builtInUsage = m_resUsage->builtInUsage;
 
   // Check per-stage built-in usage
-  if (m_shaderStage == ShaderStageVertex) {
-    if (builtInUsage.vs.drawIndex && m_activeInputBuiltIns.find(BuiltInDrawIndex) == m_activeInputBuiltIns.end())
-      builtInUsage.vs.drawIndex = false;
-  } else if (m_shaderStage == ShaderStageTessControl) {
+  if (m_shaderStage == ShaderStageTessControl) {
     if (builtInUsage.tcs.pointSizeIn && m_activeInputBuiltIns.find(BuiltInPointSize) == m_activeInputBuiltIns.end())
       builtInUsage.tcs.pointSizeIn = false;
 

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -25,7 +25,8 @@
 /**
  ***********************************************************************************************************************
  * @file  ShaderInputs.cpp
- * @brief LGC source file: Handling of hardware-determined shader inputs (not user data)
+ * @brief LGC source file: Handling of hardware-determined shader inputs (not user data, other than a few utility
+ *        methods for special user data)
  ***********************************************************************************************************************
  */
 #include "lgc/patch/ShaderInputs.h"

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -1,0 +1,365 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  ShaderInputs.cpp
+ * @brief LGC source file: Handling of hardware-determined shader inputs (not user data)
+ ***********************************************************************************************************************
+ */
+#include "lgc/patch/ShaderInputs.h"
+#include "lgc/state/PipelineState.h"
+#include "lgc/state/ResourceUsage.h"
+
+using namespace lgc;
+using namespace llvm;
+
+// =====================================================================================================================
+// Get IR type of a particular shader input
+//
+// @param kind : The kind of shader input, a ShaderInput enum value
+// @param context : LLVM context for getting types
+Type *ShaderInputs::getInputType(ShaderInput inputKind, LLVMContext &context) {
+  switch (inputKind) {
+  case ShaderInput::WorkgroupId:
+  case ShaderInput::LocalInvocationId:
+    return VectorType::get(Type::getInt32Ty(context), 3);
+
+  case ShaderInput::TessCoordX:
+  case ShaderInput::TessCoordY:
+  case ShaderInput::FragCoordX:
+  case ShaderInput::FragCoordY:
+  case ShaderInput::FragCoordZ:
+  case ShaderInput::FragCoordW:
+  case ShaderInput::LineStipple:
+    return Type::getFloatTy(context);
+
+  case ShaderInput::PerspInterpPullMode:
+    return VectorType::get(Type::getFloatTy(context), 3);
+
+  case ShaderInput::PerspInterpSample:
+  case ShaderInput::PerspInterpCenter:
+  case ShaderInput::PerspInterpCentroid:
+  case ShaderInput::LinearInterpSample:
+  case ShaderInput::LinearInterpCenter:
+  case ShaderInput::LinearInterpCentroid:
+    return VectorType::get(Type::getFloatTy(context), 2);
+
+  default:
+    return Type::getInt32Ty(context);
+  }
+}
+
+// =====================================================================================================================
+// Gather usage of shader inputs from before PatchEntryPointMutate
+//
+// @param module : IR module
+void ShaderInputs::gatherUsage(Module &module) {
+}
+
+// =====================================================================================================================
+// Fix up uses of shader inputs to use entry args directly
+//
+// @param module : IR module
+void ShaderInputs::fixupUses(Module &module) {
+}
+
+// =====================================================================================================================
+// Tables of shader inputs for the various shader stages, separately for SGPRs and VGPRs
+// This represents a kind of idealized GFX8 model, before GFX9+ shader merging or GFX10+ NGG.
+
+struct ShaderInputDesc {
+  ShaderInput inputKind; // Shader input kind
+  size_t entryArgIdx;    // Offset in InterfaceData struct to store entry arg index, else 0
+  bool always;           // True if this register is always added as an argument; false to check usage
+};
+
+// SGPRs: VS as hardware ES
+static const ShaderInputDesc VsAsEsSgprInputs[] = {
+    {ShaderInput::EsGsOffset, offsetof(InterfaceData, entryArgIdxs.vs.esGsOffset), true},
+};
+
+// SGPRs: VS as hardware VS
+static const ShaderInputDesc VsAsVsSgprInputs[] = {
+    {ShaderInput::StreamOutInfo, offsetof(InterfaceData, entryArgIdxs.vs.streamOutData.streamInfo)},
+    {ShaderInput::StreamOutWriteIndex, offsetof(InterfaceData, entryArgIdxs.vs.streamOutData.writeIndex)},
+    {ShaderInput::StreamOutOffset0, offsetof(InterfaceData, entryArgIdxs.vs.streamOutData.streamOffsets[0])},
+    {ShaderInput::StreamOutOffset1, offsetof(InterfaceData, entryArgIdxs.vs.streamOutData.streamOffsets[1])},
+    {ShaderInput::StreamOutOffset2, offsetof(InterfaceData, entryArgIdxs.vs.streamOutData.streamOffsets[2])},
+    {ShaderInput::StreamOutOffset3, offsetof(InterfaceData, entryArgIdxs.vs.streamOutData.streamOffsets[3])},
+};
+
+// SGPRs: TES as hardware ES
+static const ShaderInputDesc TesAsEsSgprInputs[] = {
+    {ShaderInput::OffChipLdsBase, offsetof(InterfaceData, entryArgIdxs.tes.offChipLdsBase)},
+    {ShaderInput::IsOffChip, 0},
+    {ShaderInput::EsGsOffset, offsetof(InterfaceData, entryArgIdxs.tes.esGsOffset), true},
+};
+
+// SGPRs: TES as hardware VS
+static const ShaderInputDesc TesAsVsSgprInputs[] = {
+    {ShaderInput::StreamOutInfo, offsetof(InterfaceData, entryArgIdxs.tes.streamOutData.streamInfo)},
+    {ShaderInput::StreamOutWriteIndex, offsetof(InterfaceData, entryArgIdxs.tes.streamOutData.writeIndex)},
+    {ShaderInput::StreamOutOffset0, offsetof(InterfaceData, entryArgIdxs.tes.streamOutData.streamOffsets[0])},
+    {ShaderInput::StreamOutOffset1, offsetof(InterfaceData, entryArgIdxs.tes.streamOutData.streamOffsets[1])},
+    {ShaderInput::StreamOutOffset2, offsetof(InterfaceData, entryArgIdxs.tes.streamOutData.streamOffsets[2])},
+    {ShaderInput::StreamOutOffset3, offsetof(InterfaceData, entryArgIdxs.tes.streamOutData.streamOffsets[3])},
+    {ShaderInput::OffChipLdsBase, offsetof(InterfaceData, entryArgIdxs.tes.offChipLdsBase)},
+};
+
+// SGPRs: TCS
+static const ShaderInputDesc TcsSgprInputs[] = {
+    {ShaderInput::OffChipLdsBase, offsetof(InterfaceData, entryArgIdxs.tcs.offChipLdsBase)},
+    {ShaderInput::TfBufferBase, offsetof(InterfaceData, entryArgIdxs.tcs.tfBufferBase), true},
+};
+
+// SGPRs: GS
+static const ShaderInputDesc GsSgprInputs[] = {
+    {ShaderInput::GsVsOffset, offsetof(InterfaceData, entryArgIdxs.gs.gsVsOffset), true},
+    {ShaderInput::GsWaveId, offsetof(InterfaceData, entryArgIdxs.gs.waveId), true},
+};
+
+// SGPRs: FS
+static const ShaderInputDesc FsSgprInputs[] = {
+    {ShaderInput::PrimMask, offsetof(InterfaceData, entryArgIdxs.fs.primMask), true},
+};
+
+// SGPRs: CS
+static const ShaderInputDesc CsSgprInputs[] = {
+    {ShaderInput::WorkgroupId, offsetof(InterfaceData, entryArgIdxs.cs.workgroupId), true},
+    {ShaderInput::MultiDispatchInfo, 0, true},
+};
+
+// VGPRs: VS
+static const ShaderInputDesc VsVgprInputs[] = {
+    {ShaderInput::VertexId, offsetof(InterfaceData, entryArgIdxs.vs.vertexId), true},
+    {ShaderInput::RelVertexId, offsetof(InterfaceData, entryArgIdxs.vs.relVertexId), true},
+    {ShaderInput::PrimitiveId, offsetof(InterfaceData, entryArgIdxs.vs.primitiveId), true},
+    {ShaderInput::InstanceId, offsetof(InterfaceData, entryArgIdxs.vs.instanceId), true},
+};
+
+// VGPRs: TCS
+static const ShaderInputDesc TcsVgprInputs[] = {
+    {ShaderInput::PatchId, offsetof(InterfaceData, entryArgIdxs.tcs.patchId), true},
+    {ShaderInput::RelPatchId, offsetof(InterfaceData, entryArgIdxs.tcs.relPatchId), true},
+};
+
+// VGPRs: TES
+static const ShaderInputDesc TesVgprInputs[] = {
+    {ShaderInput::TessCoordX, offsetof(InterfaceData, entryArgIdxs.tes.tessCoordX), true},
+    {ShaderInput::TessCoordY, offsetof(InterfaceData, entryArgIdxs.tes.tessCoordY), true},
+    {ShaderInput::RelPatchId, offsetof(InterfaceData, entryArgIdxs.tes.relPatchId), true},
+    {ShaderInput::PatchId, offsetof(InterfaceData, entryArgIdxs.tes.patchId), true},
+};
+
+// VGPRs: GS
+static const ShaderInputDesc GsVgprInputs[] = {
+    {ShaderInput::EsGsOffset0, offsetof(InterfaceData, entryArgIdxs.gs.esGsOffsets[0]), true},
+    {ShaderInput::EsGsOffset1, offsetof(InterfaceData, entryArgIdxs.gs.esGsOffsets[1]), true},
+    {ShaderInput::GsPrimitiveId, offsetof(InterfaceData, entryArgIdxs.gs.primitiveId), true},
+    {ShaderInput::EsGsOffset2, offsetof(InterfaceData, entryArgIdxs.gs.esGsOffsets[2]), true},
+    {ShaderInput::EsGsOffset3, offsetof(InterfaceData, entryArgIdxs.gs.esGsOffsets[3]), true},
+    {ShaderInput::EsGsOffset4, offsetof(InterfaceData, entryArgIdxs.gs.esGsOffsets[4]), true},
+    {ShaderInput::EsGsOffset5, offsetof(InterfaceData, entryArgIdxs.gs.esGsOffsets[5]), true},
+    {ShaderInput::GsInstanceId, offsetof(InterfaceData, entryArgIdxs.gs.invocationId), true},
+};
+
+// VGPRs: FS
+static const ShaderInputDesc FsVgprInputs[] = {
+    {ShaderInput::PerspInterpSample, offsetof(InterfaceData, entryArgIdxs.fs.perspInterp.sample), true},
+    {ShaderInput::PerspInterpCenter, offsetof(InterfaceData, entryArgIdxs.fs.perspInterp.center), true},
+    {ShaderInput::PerspInterpCentroid, offsetof(InterfaceData, entryArgIdxs.fs.perspInterp.centroid), true},
+    {ShaderInput::PerspInterpPullMode, offsetof(InterfaceData, entryArgIdxs.fs.perspInterp.pullMode), true},
+    {ShaderInput::LinearInterpSample, offsetof(InterfaceData, entryArgIdxs.fs.linearInterp.sample), true},
+    {ShaderInput::LinearInterpCenter, offsetof(InterfaceData, entryArgIdxs.fs.linearInterp.center), true},
+    {ShaderInput::LinearInterpCentroid, offsetof(InterfaceData, entryArgIdxs.fs.linearInterp.centroid), true},
+    {ShaderInput::LineStipple, 0, true},
+    {ShaderInput::FragCoordX, offsetof(InterfaceData, entryArgIdxs.fs.fragCoord.x), true},
+    {ShaderInput::FragCoordY, offsetof(InterfaceData, entryArgIdxs.fs.fragCoord.y), true},
+    {ShaderInput::FragCoordZ, offsetof(InterfaceData, entryArgIdxs.fs.fragCoord.z), true},
+    {ShaderInput::FragCoordW, offsetof(InterfaceData, entryArgIdxs.fs.fragCoord.w), true},
+    {ShaderInput::FrontFacing, offsetof(InterfaceData, entryArgIdxs.fs.frontFacing), true},
+    {ShaderInput::Ancillary, offsetof(InterfaceData, entryArgIdxs.fs.ancillary), true},
+    {ShaderInput::SampleCoverage, offsetof(InterfaceData, entryArgIdxs.fs.sampleCoverage), true},
+    {ShaderInput::FixedXY, 0, true},
+};
+
+// VGPRs: CS
+static const ShaderInputDesc CsVgprInputs[] = {
+    {ShaderInput::LocalInvocationId, offsetof(InterfaceData, entryArgIdxs.cs.localInvocationId), true},
+};
+
+// =====================================================================================================================
+// Get argument types for shader inputs
+//
+// @param pipelineState : Pipeline state
+// @param shaderStage : Shader stage
+// @param [in/out] argTys : Argument types vector to add to
+// @return : Bitmap with bits set for SGPR arguments so caller can set "inreg" attribute on the args
+uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage,
+                                       SmallVectorImpl<Type *> &argTys) {
+
+  bool hasTs = pipelineState->hasShaderStage(ShaderStageTessControl);
+  bool hasGs = pipelineState->hasShaderStage(ShaderStageGeometry);
+
+  uint64_t inRegMask = 0;
+  auto intfData = pipelineState->getShaderInterfaceData(shaderStage);
+  auto resUsage = pipelineState->getShaderResourceUsage(shaderStage);
+  const auto &xfbStrides = resUsage->inOutUsage.xfbStrides;
+  const bool enableXfb = resUsage->inOutUsage.enableXfb;
+
+  // Enable optional shader inputs as required.
+  switch (shaderStage) {
+  case ShaderStageVertex:
+    if (enableXfb && (!hasGs && !hasTs)) {
+      // Stream-out in VS as hardware VS
+      getShaderInputUsage(shaderStage, ShaderInput::StreamOutInfo)->enable();
+      getShaderInputUsage(shaderStage, ShaderInput::StreamOutWriteIndex)->enable();
+      for (unsigned i = 0; i < MaxTransformFeedbackBuffers; ++i) {
+        if (xfbStrides[i] > 0)
+          getShaderInputUsage(shaderStage, static_cast<unsigned>(ShaderInput::StreamOutOffset0) + i)->enable();
+      }
+    }
+    break;
+  case ShaderStageTessControl:
+    if (pipelineState->isTessOffChip()) {
+      // LDS buffer base for off-chip
+      getShaderInputUsage(shaderStage, ShaderInput::OffChipLdsBase)->enable();
+    }
+    break;
+  case ShaderStageTessEval:
+    if (pipelineState->isTessOffChip()) {
+      // LDS buffer base for off-chip
+      getShaderInputUsage(shaderStage, ShaderInput::OffChipLdsBase)->enable();
+      // is_off_chip register. Enabling it here only has an effect when TES is hardware ES.
+      getShaderInputUsage(shaderStage, ShaderInput::IsOffChip)->enable();
+    }
+    if (!hasGs) {
+      // TES as hardware VS: handle stream-out. StreamOutInfo is required for off-chip even if there is no
+      // stream-out.
+      if (pipelineState->isTessOffChip() || enableXfb)
+        getShaderInputUsage(shaderStage, ShaderInput::StreamOutInfo)->enable();
+      if (enableXfb) {
+        getShaderInputUsage(shaderStage, ShaderInput::StreamOutWriteIndex)->enable();
+        for (unsigned i = 0; i < MaxTransformFeedbackBuffers; ++i) {
+          if (xfbStrides[i] > 0)
+            getShaderInputUsage(shaderStage, static_cast<unsigned>(ShaderInput::StreamOutOffset0) + i)->enable();
+        }
+      }
+    }
+    break;
+  default:
+    break;
+  }
+
+  // Determine which of the tables above to use for SGPR and VGPR inputs.
+  ArrayRef<ShaderInputDesc> sgprInputDescs;
+  ArrayRef<ShaderInputDesc> vgprInputDescs;
+
+  switch (shaderStage) {
+  case ShaderStageVertex:
+    if (!hasTs) {
+      if (hasGs)
+        sgprInputDescs = VsAsEsSgprInputs;
+      else
+        sgprInputDescs = VsAsVsSgprInputs;
+    }
+    vgprInputDescs = VsVgprInputs;
+    break;
+  case ShaderStageTessControl:
+    sgprInputDescs = TcsSgprInputs;
+    vgprInputDescs = TcsVgprInputs;
+    break;
+  case ShaderStageTessEval:
+    if (hasGs)
+      sgprInputDescs = TesAsEsSgprInputs;
+    else
+      sgprInputDescs = TesAsVsSgprInputs;
+    vgprInputDescs = TesVgprInputs;
+    break;
+  case ShaderStageGeometry:
+    sgprInputDescs = GsSgprInputs;
+    vgprInputDescs = GsVgprInputs;
+    break;
+  case ShaderStageFragment:
+    sgprInputDescs = FsSgprInputs;
+    vgprInputDescs = FsVgprInputs;
+    break;
+  case ShaderStageCompute:
+    sgprInputDescs = CsSgprInputs;
+    vgprInputDescs = CsVgprInputs;
+    break;
+  default:
+    llvm_unreachable("Invalid shader stage");
+  }
+
+  // Add the type of each used shader input.
+  ArrayRef<ShaderInputDesc> inputDescs = sgprInputDescs;
+  for (unsigned doingVgprs = 0; doingVgprs != 2; ++doingVgprs) {
+    for (const auto &inputDesc : inputDescs) {
+      // Get the ShaderInputUsage for this input, if it exists.
+      ShaderInputsUsage *inputsUsage = getShaderInputsUsage(shaderStage);
+      assert(inputDesc.inputKind < ShaderInput::Count);
+      ShaderInputUsage *inputUsage = &*inputsUsage->inputs[static_cast<unsigned>(inputDesc.inputKind)];
+      // We don't want this input if it is not marked "always" and it is not used.
+      if (!inputDesc.always && (!inputUsage || inputUsage->users.empty()))
+        continue;
+      if (!doingVgprs) {
+        // Mark this arg as "inreg" to get it into an SGPR.
+        inRegMask |= 1ull << argTys.size();
+      }
+      // Store the argument index.
+      if (inputDesc.entryArgIdx != 0)
+        *reinterpret_cast<unsigned *>((reinterpret_cast<char *>(intfData) + inputDesc.entryArgIdx)) = argTys.size();
+      if (inputUsage)
+        inputUsage->entryArgIdx = argTys.size();
+      // Add the argument type.
+      argTys.push_back(getInputType(inputDesc.inputKind, *m_context));
+    }
+    inputDescs = vgprInputDescs;
+  }
+
+  return inRegMask;
+}
+
+// =====================================================================================================================
+// Get ShaderInputsUsage struct for the given shader stage
+//
+// @param stage : Shader stage
+ShaderInputs::ShaderInputsUsage *ShaderInputs::getShaderInputsUsage(ShaderStage stage) {
+  m_shaderInputsUsage.resize(std::max(m_shaderInputsUsage.size(), static_cast<size_t>(stage) + 1));
+  return &m_shaderInputsUsage[stage];
+}
+
+// =====================================================================================================================
+// Get (create if necessary) ShaderInputUsage struct for the given system shader input in the given shader stage
+//
+// @param stage : Shader stage
+// @param inputKind : ShaderInput enum value for the shader input
+ShaderInputs::ShaderInputUsage *ShaderInputs::getShaderInputUsage(ShaderStage stage, unsigned inputKind) {
+  ShaderInputsUsage *inputsUsage = getShaderInputsUsage(stage);
+  if (!inputsUsage->inputs[inputKind])
+    inputsUsage->inputs[inputKind].reset(new ShaderInputUsage());
+  return &*inputsUsage->inputs[inputKind];
+}

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -262,7 +262,7 @@ unsigned PalMetadata::getUserDataReg0(ShaderStage stage) {
 void PalMetadata::setUserDataEntry(ShaderStage stage, unsigned userDataIndex, unsigned userDataValue,
                                    unsigned dwordCount) {
   // If this is the spill table pointer, adjust userDataLimit accordingly.
-  if (userDataValue == static_cast<unsigned>(Util::Abi::UserDataMapping::SpillTable))
+  if (userDataValue == static_cast<unsigned>(UserDataMapping::SpillTable))
     setUserDataLimit();
 
   // Get the start register number of SPI user data registers for this shader stage.
@@ -279,7 +279,7 @@ void PalMetadata::setUserDataEntry(ShaderStage stage, unsigned userDataIndex, un
     *m_userDataLimit = userDataValue + dwordCount;
 
   // Although NumWorkgroupsPtr is a register pair, only the first word has a user data entry.
-  if (userDataValue == static_cast<unsigned>(Util::Abi::UserDataMapping::Workgroup))
+  if (userDataValue == static_cast<unsigned>(UserDataMapping::Workgroup))
     dwordCount = 1;
 
   // Write the register(s)

--- a/llpc/test/shaderdb/ObjInput_TestDrawParams_lit.vert
+++ b/llpc/test/shaderdb/ObjInput_TestDrawParams_lit.vert
@@ -17,13 +17,17 @@ void main()
 // BEGIN_SHADERTEST
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.InstanceIndex{{.*}}
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.DrawIndex{{.*}}
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.VertexIndex{{.*}}
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.BaseInstance{{.*}}
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.BaseVertex{{.*}}
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+
+; SHADERTEST-DAG: [[BASEINSTANCE:%.*]] = call i32 @lgc.special.user.data.BaseInstance(
+; SHADERTEST-DAG: [[INSTANCEID:%.*]] = call i32 @lgc.shader.input.InstanceId(
+; SHADERTEST-DAG: %InstanceIndex = add i32 [[BASEINSTANCE]], [[INSTANCEID]]
+; SHADERTEST-DAG: call i32 @lgc.special.user.data.DrawIndex(
+; SHADERTEST-DAG: [[BASEVERTEX:%.*]] = call i32 @lgc.special.user.data.BaseVertex(
+; SHADERTEST-DAG: [[VERTEXID:%.*]] = call i32 @lgc.shader.input.VertexId(
+; SHADERTEST-DAG: %VertexIndex = add i32 [[BASEVERTEX]], [[VERTEXID]]
+; SHADERTEST-DAG: call i32 @lgc.special.user.data.BaseVertex(
+; SHADERTEST-DAG: call i32 @lgc.special.user.data.BaseInstance(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/ObjInput_TestVsBuiltIn_lit.vert
+++ b/llpc/test/shaderdb/ObjInput_TestVsBuiltIn_lit.vert
@@ -9,10 +9,10 @@ void main()
 // BEGIN_SHADERTEST
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.InstanceIndex{{.*}}
-; SHADERTEST-DAG: call i32 @lgc.input.import.builtin.VertexIndex{{.*}}
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST_DAG: call i32 @lgc.special.user.data.BaseInstance(i32 268435460)
+; SHADERTEST_DAG: call i32 @lgc.shader.input.VertexId(i32 15)
+; SHADERTEST_DAG: call i32 @lgc.special.user.data.BaseVertex(i32 268435459)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
These four commits separate the handling of "shader inputs" (the SGPRs and VGPRs set up by hardware, other than user data) into a ShaderInputs class, then add the ability to use shader inputs and special user data (e.g. vertex buffer table) in passes before PatchEntryPointMutate, then uses that to move some VS inputs from PatchInOutImportExport forward into InOutBuilder.

The immediate point of all that is that I want to move vertex fetch to before PatchEntryPointMutate in subsequent commits.