### PR TITLE
Changes in preparation for upstream LLVM merge

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -553,7 +553,7 @@ void PatchBufferOp::visitLoadInst(LoadInst &loadInst) {
 
     LoadInst *const newLoad = m_builder->CreateLoad(loadPointer);
     newLoad->setVolatile(loadInst.isVolatile());
-    newLoad->setAlignment(MaybeAlign(loadInst.getAlignment()));
+    newLoad->setAlignment(Align(loadInst.getAlignment()));
     newLoad->setOrdering(loadInst.getOrdering());
     newLoad->setSyncScopeID(loadInst.getSyncScopeID());
     copyMetadata(newLoad, &loadInst);
@@ -1346,7 +1346,7 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
     if (isLoad) {
       LoadInst *const newLoad = m_builder->CreateLoad(pointer);
       newLoad->setVolatile(loadInst->isVolatile());
-      newLoad->setAlignment(MaybeAlign(alignment));
+      newLoad->setAlignment(Align(alignment));
       newLoad->setOrdering(ordering);
       newLoad->setSyncScopeID(syncScopeID);
       copyMetadata(newLoad, loadInst);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -4072,7 +4072,7 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
       Value *loadPtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
       auto loadInst = new LoadInst(loadPtr->getType()->getPointerElementType(), loadPtr, "", false, insertPos);
-      loadInst->setAlignment(MaybeAlign(m_lds->getAlignment()));
+      loadInst->setAlignment(Align(m_lds->getAlignment()));
       loadValue = loadInst;
 
       if (bitWidth == 8)
@@ -4434,7 +4434,7 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
       Value *loadPtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
       auto loadTy = loadPtr->getType()->getPointerElementType();
       auto loadInst = new LoadInst(loadTy, loadPtr, "", false, insertPos);
-      loadInst->setAlignment(MaybeAlign(m_lds->getAlignment()));
+      loadInst->setAlignment(Align(m_lds->getAlignment()));
       loadValues[i] = loadInst;
 
       if (bitWidth == 8)

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -369,7 +369,7 @@ Value *ShaderSystemValues::getStreamOutBufDesc(unsigned xfbBuffer) {
 
     auto streamOutBufDesc = new LoadInst(streamOutBufDescTy, streamOutBufDescPtr, "", insertPos);
     streamOutBufDesc->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(streamOutBufDesc->getContext(), {}));
-    streamOutBufDesc->setAlignment(MaybeAlign(16));
+    streamOutBufDesc->setAlignment(Align(16));
 
     m_streamOutBufDescs[xfbBuffer] = streamOutBufDesc;
   }

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -686,7 +686,7 @@ Value *VertexFetch::loadVertexBufferDescriptor(unsigned binding, Instruction *in
 
   auto vbDesc = new LoadInst(vbDescTy, vbDescPtr, "", insertPos);
   vbDesc->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(vbDesc->getContext(), {}));
-  vbDesc->setAlignment(MaybeAlign(16));
+  vbDesc->setAlignment(Align(16));
 
   return vbDesc;
 }

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -1331,7 +1331,7 @@ static Result processPipeline(ICompiler *compiler, ArrayRef<std::string> inFiles
       SMDiagnostic errDiag;
 
       // Load LLVM IR
-      std::unique_ptr<Module> module = parseAssemblyFile(inFile, errDiag, context, nullptr, false);
+      std::unique_ptr<Module> module = parseAssemblyFile(inFile, errDiag, context, nullptr);
       if (!module.get()) {
         std::string errMsg;
         raw_string_ostream errStream(errMsg);


### PR DESCRIPTION
A couple of API changes that need to be handled prior to upstream merge.

API for parseAssemblyFile has changed slightly (no option for UpgradeDebugInfo
now)

Load and Store instructions have changed their Alignment from MaybeAlign to
Align.

All these changes work with older versions.