### PR TITLE
Fix -spirv-gen-fast-math=0 breakage from pull #675

### DIFF
--- a/llpc/test/shaderdb/OpExtInst_TestFrexpDouble_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestFrexpDouble_lit.frag
@@ -23,13 +23,13 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 
-; SHADERTEST: = call reassoc nnan nsz arcp contract double (...) @lgc.create.extract.significand.f64(double
+; SHADERTEST: = call double (...) @lgc.create.extract.significand.f64(double
 ; SHADERTEST: = call i32 (...) @lgc.create.extract.exponent.i32(double
-; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.extract.significand.v3f64(<3 x double>
+; SHADERTEST: = call <3 x double> (...) @lgc.create.extract.significand.v3f64(<3 x double>
 ; SHADERTEST: = call <3 x i32> (...) @lgc.create.extract.exponent.v3i32(<3 x double>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpExtInst_TestFrexpFloat_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestFrexpFloat_lit.frag
@@ -22,13 +22,13 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.extract.significand.f32(float
+; SHADERTEST: = call float (...) @lgc.create.extract.significand.f32(float
 ; SHADERTEST: = call i32 (...) @lgc.create.extract.exponent.i32(float
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.extract.significand.v3f32(<3 x float>
+; SHADERTEST: = call <3 x float> (...) @lgc.create.extract.significand.v3f32(<3 x float>
 ; SHADERTEST: = call <3 x i32> (...) @lgc.create.extract.exponent.v3i32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpExtInst_TestFrexpStructDouble_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestFrexpStructDouble_lit.frag
@@ -17,10 +17,10 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract double (...) @lgc.create.extract.significand.f64(double
+; SHADERTEST: = call double (...) @lgc.create.extract.significand.f64(double
 ; SHADERTEST: = call i32 (...) @lgc.create.extract.exponent.i32(double
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call double @llvm.amdgcn.frexp.mant.f64(double %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestFrexpStructFloat_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestFrexpStructFloat_lit.frag
@@ -15,10 +15,10 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.extract.significand.f32(float
+; SHADERTEST: = call float (...) @lgc.create.extract.significand.f32(float
 ; SHADERTEST: = call i32 (...) @lgc.create.extract.exponent.i32(float
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.frexp.mant.f32(float %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestFrexpStructVec4_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestFrexpStructVec4_lit.frag
@@ -15,16 +15,16 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.extract.significand.v4f32(<4 x float>
+; SHADERTEST: = call <4 x float> (...) @lgc.create.extract.significand.v4f32(<4 x float>
 ; SHADERTEST: = call <4 x i32> (...) @lgc.create.extract.exponent.v4i32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST-DAG: = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float
+; SHADERTEST-DAG: = call float @llvm.amdgcn.frexp.mant.f32(float
 ; SHADERTEST-DAG: = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float
-; SHADERTEST-DAG: = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float
+; SHADERTEST-DAG: = call float @llvm.amdgcn.frexp.mant.f32(float
 ; SHADERTEST-DAG: = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float
-; SHADERTEST-DAG: = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float
+; SHADERTEST-DAG: = call float @llvm.amdgcn.frexp.mant.f32(float
 ; SHADERTEST-DAG: = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float
-; SHADERTEST-DAG: = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float
+; SHADERTEST-DAG: = call float @llvm.amdgcn.frexp.mant.f32(float
 ; SHADERTEST-DAG: = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestPackSnorm2x16_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackSnorm2x16_lit.frag
@@ -17,8 +17,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[CLAMP:.*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.fclamp.v2f32(<2 x float> %{{.*}}, <2 x float> <float -1.000000e+00, float -1.000000e+00>, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
-; SHADERTEST: %[[SCALE:.*]] = fmul reassoc nnan nsz arcp contract afn <2 x float> %[[CLAMP]], <float 3.276700e+04, float 3.276700e+04>
+; SHADERTEST: %[[CLAMP:.*]] = call <2 x float> (...) @lgc.create.fclamp.v2f32(<2 x float> %{{.*}}, <2 x float> <float -1.000000e+00, float -1.000000e+00>, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: %[[SCALE:.*]] = fmul <2 x float> %[[CLAMP]], <float 3.276700e+04, float 3.276700e+04>
 ; SHADERTEST: %[[CONV:.*]] = fptosi <2 x float> %[[SCALE]] to <2 x i16>
 ; SHADERTEST: = bitcast <2 x i16> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpExtInst_TestPackSnorm4x8_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackSnorm4x8_lit.frag
@@ -17,9 +17,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[CLAMP:.*]] = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.fclamp.v4f32(<4 x float> %{{.*}}, <4 x float> <float -1.000000e+00, float -1.000000e+00, float -1.000000e+00, float -1.000000e+00>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
-; SHADERTEST: %[[SCALE:.*]] = fmul reassoc nnan nsz arcp contract afn <4 x float> %[[CLAMP]], <float 1.270000e+02, float 1.270000e+02, float 1.270000e+02, float 1.270000e+02>
-; SHADERTEST: %[[RINT:.*]] = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.rint.v4f32(<4 x float> %[[SCALE]])
+; SHADERTEST: %[[CLAMP:.*]] = call <4 x float> (...) @lgc.create.fclamp.v4f32(<4 x float> %{{.*}}, <4 x float> <float -1.000000e+00, float -1.000000e+00, float -1.000000e+00, float -1.000000e+00>, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: %[[SCALE:.*]] = fmul <4 x float> %[[CLAMP]], <float 1.270000e+02, float 1.270000e+02, float 1.270000e+02, float 1.270000e+02>
+; SHADERTEST: %[[RINT:.*]] = call <4 x float> @llvm.rint.v4f32(<4 x float> %[[SCALE]])
 ; SHADERTEST: %[[CONV:.*]] = fptosi <4 x float> %[[RINT]] to <4 x i8>
 ; SHADERTEST: = bitcast <4 x i8> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpExtInst_TestPackUnorm2x16_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackUnorm2x16_lit.frag
@@ -17,8 +17,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[CLAMP:.*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.fclamp.v2f32(<2 x float> %1, <2 x float> zeroinitializer, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
-; SHADERTEST: %[[SCALE:.*]] = fmul reassoc nnan nsz arcp contract afn <2 x float> %[[CLAMP]], <float 6.553500e+04, float 6.553500e+04>
+; SHADERTEST: %[[CLAMP:.*]] = call <2 x float> (...) @lgc.create.fclamp.v2f32(<2 x float> %1, <2 x float> zeroinitializer, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: %[[SCALE:.*]] = fmul <2 x float> %[[CLAMP]], <float 6.553500e+04, float 6.553500e+04>
 ; SHADERTEST: %[[CONV:.*]] = fptoui <2 x float> %[[SCALE]] to <2 x i16>
 ; SHADERTEST: = bitcast <2 x i16> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpExtInst_TestPackUnorm4x8_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackUnorm4x8_lit.frag
@@ -17,8 +17,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[CLAMP:.*]] = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.fclamp.v4f32(<4 x float> %{{.*}}, <4 x float> zeroinitializer, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
-; SHADERTEST: %[[SCALE:.*]] = fmul reassoc nnan nsz arcp contract afn <4 x float> %[[CLAMP]], <float 2.550000e+02, float 2.550000e+02, float 2.550000e+02, float 2.550000e+02>
+; SHADERTEST: %[[CLAMP:.*]] = call <4 x float> (...) @lgc.create.fclamp.v4f32(<4 x float> %{{.*}}, <4 x float> zeroinitializer, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: %[[SCALE:.*]] = fmul <4 x float> %[[CLAMP]], <float 2.550000e+02, float 2.550000e+02, float 2.550000e+02, float 2.550000e+02>
 ; SHADERTEST: %[[CONV:.*]] = fptoui <4 x float> %[[SCALE]] to <4 x i8>
 ; SHADERTEST: = bitcast <4 x i8> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpExtInst_TestPow2_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPow2_lit.frag
@@ -16,7 +16,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.power.f32(float 2.000000e+00, float
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.frexp.mant.f32(float
+; SHADERTEST: = call float @llvm.amdgcn.frexp.mant.f32(float
 ; SHADERTEST: = call i32 @llvm.amdgcn.frexp.exp.i32.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.exp2.f32(float
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestCommonFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestCommonFuncs_lit.frag
@@ -65,7 +65,7 @@ void main()
 ; SHADERTEST: = call <3 x i1> (...) @lgc.create.isnan.v3i1(<3 x half>
 ; SHADERTEST: = call <3 x i1> (...) @lgc.create.isinf.v3i1(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fma.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.extract.significand.v3f16(<3 x half>
+; SHADERTEST: = call <3 x half> (...) @lgc.create.extract.significand.v3f16(<3 x half>
 ; SHADERTEST: = call <3 x i16> (...) @lgc.create.extract.exponent.v3i16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.ldexp.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fmax.v3f16(<3 x half>


### PR DESCRIPTION
Pull #675 broke setFastMathFlags(SPIRVValue *) so that when
-spirv-gen-fast-math=0 is used, it would no longer clear the fast math
flags, so you might get some flags left over from translating a previous
instruction. In practice this meant that the nnan flag was left on after
an fmin/max/min3/max3/clamp instruction.