### PR TITLE
Prepare for LLVM MsgPack change

### DIFF
--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -332,8 +332,8 @@ void ConfigBuilderBase::writePalMetadata() {
     auto key = m_document->getNode(entry.key);
     auto &regEntry = registers[key];
     unsigned oredValue = entry.value;
-    if (regEntry.getKind() != msgpack::Type::Nil)
-      oredValue = regEntry.getInt();
+    if (regEntry.getKind() == msgpack::Type::UInt)
+      oredValue = regEntry.getUInt();
     regEntry = m_document->getNode(oredValue);
   }
 }

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -86,10 +86,10 @@ void PalMetadata::initialize() {
       m_document->getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0].getMap(true);
   m_registers = m_pipelineNode[".registers"].getMap(true);
   m_userDataLimit = &m_pipelineNode[Util::Abi::PipelineMetadataKey::UserDataLimit];
-  if (m_userDataLimit->getKind() == msgpack::Type::Nil)
+  if (m_userDataLimit->isEmpty() || m_userDataLimit->getKind() == msgpack::Type::Nil)
     *m_userDataLimit = m_document->getNode(0U);
   m_spillThreshold = &m_pipelineNode[Util::Abi::PipelineMetadataKey::SpillThreshold];
-  if (m_spillThreshold->getKind() == msgpack::Type::Nil)
+  if (m_spillThreshold->isEmpty() || m_spillThreshold->getKind() == msgpack::Type::Nil)
     *m_spillThreshold = m_document->getNode(UINT_MAX);
 }
 


### PR DESCRIPTION
The forthcoming LLVM change D79671 separates the idea of an empty
MsgPack node from a nil one. That requires some changes in LGC to cope.

Change-Id: I10b215d677c0ff69bccaaf614bac863030a1e54b