### PR TITLE
Allow multiple llvm paths

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -64,7 +64,11 @@ if(ICD_BUILD_LLPC)
     # confict with PAL
     #set(LLVM_OPTIMIZED_TABLEGEN ON CACHE BOOL Force)
 
-    set(XGL_LLVM_SRC_PATH ${PROJECT_SOURCE_DIR}/../../llvm-project/llvm CACHE PATH "Specify the path to the LLVM.")
+    if(EXISTS ${PROJECT_SOURCE_DIR}/../../llvm-project/llvm)
+        set(XGL_LLVM_SRC_PATH ${PROJECT_SOURCE_DIR}/../../llvm-project/llvm CACHE PATH "Specify the path to the LLVM.")
+    elseif(EXISTS ${PROJECT_SOURCE_DIR}/../../../imported/llvm-project/llvm)
+        set(XGL_LLVM_SRC_PATH ${PROJECT_SOURCE_DIR}/../../../imported/llvm-project/llvm CACHE PATH "Specify the path to the LLVM.")
+    endif()
 
     add_subdirectory(${XGL_LLVM_SRC_PATH} ${PROJECT_BINARY_DIR}/llvm)
     set(XGL_LLVM_BUILD_PATH ${PROJECT_BINARY_DIR}/llvm)


### PR DESCRIPTION
This makes it possible to build the driver in other directory
configurations (with additional changes in other projects).