### PR TITLE
Fix win build broken from PR670

### DIFF
--- a/lgc/builder/YCbCrAddressHandler.cpp
+++ b/lgc/builder/YCbCrAddressHandler.cpp
@@ -76,7 +76,7 @@ void YCbCrAddressHandler::genBaseAddress(unsigned planeCount) {
 
     // GFX10 hardware calculate pipe banck xor
     // SEE: Gfx10Lib::HwlComputePipeBankXor in pal\src\core\imported\addrlib\src\gfx10\gfx10addrlib.cpp
-    auto gfx10HwlComputePipeBankXor = [this](unsigned surfIdx) -> Value * {
+    auto gfx10HwlComputePipeBankXor = [&](unsigned surfIdx) -> Value * {
       return m_builder->getInt32(XorBankRot3b[surfIdx % xorPatternLen] << (pipesLog2 + columnBits));
     };
 


### PR DESCRIPTION
- error C3493: 'xorPatternLen' cannot be implicitly captured
  because no default capture mode has been specified

Signed-off-by: Jiajun Xie <jiaxie@amd.com>