### PR TITLE
Bump the maximum shader-chache-file-dir length

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -352,14 +352,22 @@ Compiler::Compiler(GfxIpVersion gfxIp, unsigned optionCount, const char *const *
   auxCreateInfo.gfxIp = m_gfxIp;
   auxCreateInfo.hash = m_optionHash;
   auxCreateInfo.executableName = cl::ExecutableName.c_str();
-  auxCreateInfo.cacheFilePath = cl::ShaderCacheFileDir.c_str();
+
+  const char *shaderCachePath = cl::ShaderCacheFileDir.c_str();
   if (cl::ShaderCacheFileDir.empty()) {
 #ifdef WIN_OS
-    auxCreateInfo.cacheFilePath = getenv("LOCALAPPDATA");
+    shaderCachePath = getenv("LOCALAPPDATA");
+    assert(shaderCachePath);
 #else
     llvm_unreachable("Should never be called!");
 #endif
   }
+
+  if (strlen(shaderCachePath) >= Llpc::MaxFilePathLen) {
+    LLPC_ERRS("The shader-cache-file-dir exceed the maximum length (" << Llpc::MaxFilePathLen << ")\n");
+    llvm_unreachable("ShaderCacheFileDir is too long");
+  }
+  auxCreateInfo.cacheFilePath = shaderCachePath;
 
   m_shaderCache = ShaderCacheManager::getShaderCacheManager()->getShaderCacheObject(&createInfo, &auxCreateInfo);
 

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -112,7 +112,7 @@ struct ShaderCacheSerializedHeader {
   size_t shaderDataEnd;  // Offset to the end of shader data
 };
 
-constexpr unsigned MaxFilePathLen = 256;
+constexpr unsigned MaxFilePathLen = 512;
 
 typedef void *CacheEntryHandle;
 


### PR DESCRIPTION
Add an assertion that checks if the provided path fits the buffer.
This fixes test failures in sandboxed builds.