### PR TITLE
Fix Game rage2 corruption

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -306,6 +306,7 @@ struct ShaderModuleUsage {
   bool useHelpInvocation;      ///< Whether fragment shader has helper-invocation for subgroup
   bool useSpecConstant;        ///< Whether specializaton constant is used
   bool keepUnusedFunctions;    ///< Whether to keep unused function
+  bool useIsNan;               ///< Whether IsNan is used
 };
 
 /// Represents common part of shader module data

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestCommonFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestCommonFuncs_lit.frag
@@ -49,25 +49,25 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.fabs.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fsign.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.floor.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.trunc.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.rint.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.ceil.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fract.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fmod.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.trunc.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> @llvm.fabs.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.fsign.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> @llvm.floor.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> @llvm.trunc.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> @llvm.rint.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> @llvm.ceil.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.fract.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.fmod.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> @llvm.trunc.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fmin.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fclamp.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fmix.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.smooth.step.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.fmix.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.smooth.step.v3f16(<3 x half>
 ; SHADERTEST: = call <3 x i1> (...) @lgc.create.isnan.v3i1(<3 x half>
 ; SHADERTEST: = call <3 x i1> (...) @lgc.create.isinf.v3i1(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fma.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.fma.v3f16(<3 x half>
 ; SHADERTEST: = call <3 x half> (...) @lgc.create.extract.significand.v3f16(<3 x half>
 ; SHADERTEST: = call <3 x i16> (...) @lgc.create.extract.exponent.v3i16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.ldexp.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nsz arcp contract afn <3 x half> (...) @lgc.create.ldexp.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.fmax.v3f16(<3 x half>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1235,7 +1235,9 @@ FastMathFlags SPIRVToLLVM::getFastMathFlags(SPIRVValue *bv) {
   }
   // Enable "no NaN" and "no signed zeros" only if there isn't any floating point control flags
   if (m_fpControlFlags.U32All == 0) {
-    fmf.setNoNaNs();
+    if (!m_moduleUsage->useIsNan)
+      fmf.setNoNaNs();
+
     fmf.setNoSignedZeros(allowContract);
   }
   return fmf;

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -117,6 +117,10 @@ Result ShaderModuleHelper::collectInfoFromSpirvBinary(const BinaryData *spvBinCo
       shaderModuleUsage->useSpecConstant = true;
       break;
     }
+    case OpIsNan: {
+      shaderModuleUsage->useIsNan = true;
+      break;
+    }
     case OpEntryPoint: {
       ShaderEntryName entry = {};
       // The fourth word is start of the name string of the entry-point


### PR DESCRIPTION
Llpc assume "No Nan" optimization of fastmathflag when float control flag is not set,
therefore IsNan is removed in the later pass of "Combine redundant instructions".

In the case when spirv used IsNan op, the app writer already assume there could be occasion of float nan data.
so we can not set "No Nan" fastmathflag.