### PR TITLE
Add missing include

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 
 #define DEBUG_TYPE "lgc-context"


### PR DESCRIPTION
Include TargetMachine.h because the implicit dependency in CommandFlags.h
was fixed in LLVM and now the explicit inclusion is required.