### PR TITLE
ArrayIndex is missed for some memberType

### DIFF
--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -372,19 +372,19 @@ bool VfxParser::parseKeyValue(char *key, char *valueStr, unsigned lineNum, Secti
       case MemberTypeInt: {
         result = parseInt(valueStr, lineNum, &value);
         if (result)
-          result = accessedSectionObject->set(lineNum, memberName, &(value.iVec4[0]));
+          result = accessedSectionObject->set(lineNum, memberName, arrayIndex, &(value.iVec4[0]));
         break;
       }
       case MemberTypeFloat: {
         result = parseFloat16(valueStr, lineNum, &value);
         if (result)
-          result = accessedSectionObject->set(lineNum, memberName, &(value.f16Vec4[0]));
+          result = accessedSectionObject->set(lineNum, memberName, arrayIndex, &(value.f16Vec4[0]));
         break;
       }
       case MemberTypeDouble: {
         result = parseDouble(valueStr, lineNum, &value);
         if (result)
-          result = accessedSectionObject->set(lineNum, memberName, &(value.dVec2[0]));
+          result = accessedSectionObject->set(lineNum, memberName, arrayIndex, &(value.dVec2[0]));
         break;
       }
       case MemberTypeBool: {
@@ -392,7 +392,7 @@ bool VfxParser::parseKeyValue(char *key, char *valueStr, unsigned lineNum, Secti
         if (result) {
           static_assert(sizeof(uint8_t) == sizeof(bool), "");
           uint8_t boolValue = value.iVec4[0] ? 1 : 0;
-          result = accessedSectionObject->set(lineNum, memberName, &boolValue);
+          result = accessedSectionObject->set(lineNum, memberName, arrayIndex, &boolValue);
         }
         break;
       }

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -1147,7 +1147,7 @@ public:
 
 private:
   SectionNggState m_nggState;
-  static const unsigned MemberCount = 23;
+  static const unsigned MemberCount = 24;
   static StrToMemberAddr m_addrTable[MemberCount];
   SubState m_state;
   SectionColorBuffer m_colorBuffer[Vkgc::MaxColorTargets]; // Color buffer
@@ -1178,7 +1178,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 4;
+  static const unsigned MemberCount = 5;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
When we want to parse array of basic memberType like, MemberTypeInt, MemberTypeBool, the vfxParser
always parse the array value to the array index 0, should use the arrayIndex to set array value