### PR TITLE
Explicitly set vulkan header patch for spvgen

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -403,6 +403,10 @@ endif()
 ### Add Subdirectories #################################################################################################
 if(ICD_BUILD_LLPC)
 # SPVGEN
+if(XGL_ICD_PATH)
+    set(VULKAN_HEADER_PATH "${XGL_ICD_PATH}/api/include/khronos" CACHE PATH "${PROJECT_NAME} override." FORCE)
+endif()
+
 if(EXISTS ${PROJECT_SOURCE_DIR}/../../spvgen)
     set(XGL_SPVGEN_PATH ${PROJECT_SOURCE_DIR}/../../spvgen CACHE PATH "Specify the path to SPVGEN.")
 else()


### PR DESCRIPTION
This allows spvgen to pick up vulkan headers from xgl when being built
as part of amdvlk, no matter where in the filesystem it is.