### PR TITLE
Update test to allow for new InstCombine sinking

### DIFF
--- a/llpc/test/shaderdb/ObjInput_TestIndexingInterpOfInputArray_lit.frag
+++ b/llpc/test/shaderdb/ObjInput_TestIndexingInterpOfInputArray_lit.frag
@@ -59,7 +59,6 @@ void main()
 ; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32
 ; SHADERTEST: = call <4 x float> @lgc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 4, i32 0, i32 0, i32 0, <2 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST-COUNT-2: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
 ; SHADERTEST: call {{.*}}float @llvm.amdgcn.wqm.f32


### PR DESCRIPTION
Upstream llvm has some additional sinking functionality that requires a change
in this test. The change seems to be an improvement in this case, and it is the
only test that shows a difference (surprisingly).

The instructions that are removed from the check are actually sunk to the bottom
of the shader, but it is tricky to have a test that works before and after the
merge, so I've removed these instructions altogether from the check. I think it
is reasonably safe to do. We could add the instructions back once the merge has
happened if any reviewers think it is worthwhile.