### PR TITLE
Fix cppcheck lints

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1379,18 +1379,18 @@ Result Compiler::BuildGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline
 
   if (result == Result::Success) {
     void *allocBuf = nullptr;
-    if (pipelineInfo->pfnOutputAlloc)
+    if (pipelineInfo->pfnOutputAlloc) {
       allocBuf = pipelineInfo->pfnOutputAlloc(pipelineInfo->pInstance, pipelineInfo->pUserData, elfBin.codeSize);
-    else {
+
+      uint8_t *code = static_cast<uint8_t *>(allocBuf);
+      memcpy(code, elfBin.pCode, elfBin.codeSize);
+
+      pipelineOut->pipelineBin.codeSize = elfBin.codeSize;
+      pipelineOut->pipelineBin.pCode = code;
+    } else {
       // Allocator is not specified
       result = Result::ErrorInvalidPointer;
     }
-
-    uint8_t *code = static_cast<uint8_t *>(allocBuf);
-    memcpy(code, elfBin.pCode, elfBin.codeSize);
-
-    pipelineOut->pipelineBin.codeSize = elfBin.codeSize;
-    pipelineOut->pipelineBin.pCode = code;
   }
 
   return result;

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -215,8 +215,8 @@ Result ShaderModuleHelper::optimizeSpirv(const BinaryData *spirvBinIn, BinaryDat
     success =
         spvOptimizeSpirv(pSpirvBinIn->codeSize, pSpirvBinIn->pCode, 0, nullptr, &optBinSize, &pOptBin, 4096, logBuf);
     if (success == false) {
-            LLPC_ERROR("Failed to optimize SPIR-V (" <<
-                       GetShaderStageName(static_cast<ShaderStage>(shaderStage) << " shader): " << logBuf);
+      LLPC_ERROR("Failed to optimize SPIR-V ("
+                 << GetShaderStageName(static_cast<ShaderStage>(shaderStage) << " shader): " << logBuf));
     }
   }
 #endif


### PR DESCRIPTION
Fixes
- Possible nullptr in memcpy
- Missing parenthesis if `LLPC_ENABLE_SPIRV_OPT` is enabled