### PR TITLE
Run cppcheck on PRs

### DIFF
--- a/.github/workflows/check-cppcheck-llpc.yml
+++ b/.github/workflows/check-cppcheck-llpc.yml
@@ -1,0 +1,20 @@
+name: Static code check
+
+on:
+  pull_request:
+
+jobs:
+  cppcheck:
+    name: cppcheck
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Setup environment
+        run: |
+          sudo apt-get install -yqq cppcheck
+      - name: Checkout LLPC
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git .
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
+          git checkout ${GITHUB_SHA}
+      - name: Run cppcheck
+        run: cppcheck -q -j$(( $(nproc) * 4 )) --error-exitcode=1 .


### PR DESCRIPTION
Add a CI run with cppcheck, a static C++ code analyzer.

Only the ‘Run cppcheck on PRs’ commit is part of the pr, the other one is from #712.