### PR TITLE
Enable use of fetch shader

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -190,7 +190,8 @@ ShaderHash PipelineContext::getShaderHashCode(ShaderStage stage) const {
 // Set pipeline state in Pipeline object for middle-end
 //
 // @param [in/out] pipeline : Middle-end pipeline object
-// @param unlinked : Do not provide some state to LGC, so offsets are generated as relocs
+// @param unlinked : Do not provide some state to LGC, so offsets are generated as relocs, and a fetch shader
+//                   is needed
 void PipelineContext::setPipelineState(Pipeline *pipeline, bool unlinked) const {
   // Give the shader stage mask to the middle-end. We need to translate the Vkgc::ShaderStage bit numbers
   // to lgc::ShaderStage bit numbers.
@@ -211,8 +212,10 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, bool unlinked) const 
   }
 
   if (isGraphics()) {
-    // Set vertex input descriptions to the middle-end.
-    setVertexInputDescriptions(pipeline);
+    if (!unlinked) {
+      // Set vertex input descriptions to the middle-end.
+      setVertexInputDescriptions(pipeline);
+    }
 
     // Give the color export state to the middle-end.
     setColorExportState(pipeline);

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -1,0 +1,283 @@
+; Test that a fetch shader for 1 input is handled correctly.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -use-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; Skip to the patching results for the fetch shader
+; SHADERTEST-LABEL: LLPC pipeline patching results
+; Check the inputs to the vertex shader.  This should be all of the regular inputs.  There is one vertex attribute being passed in: The vector at the end.
+; SHADERTEST: define amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %0, i32 inreg %1, i32 inreg %descSet0, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 %VertexId, i32 %5, i32 %6, i32 %InstanceId, <4 x float> %vertex0.0)
+; SHADERTEST-LABEL: LGC glue shader results
+; Check the inputs to the fetch shader.  This should match the vertex shader except:
+; - there are extra inreg inputs because its determination of how many SGPR inputs
+;   there are is conservative;
+; - there is no VGPR input for the vertex input that the fetch shader generates.
+; SHADERTEST: define amdgpu_vs { i32,{{.*}}, i32, float, float, float, float, <4 x float> } @_amdgpu_vs_main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %VertexBufferTable, i32 inreg %BaseVertex, i32 inreg %BaseInstance,{{.*}}, i32 inreg %{{.*}}, float %VertexId, float %{{.*}}, float %{{.*}}, float %InstanceId) {
+; Check that the attribute is loaded.
+; SHADERTEST:  [[f0:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 0, i32 0, i32 immarg 116, i32 immarg 0)
+; SHADERTEST:  [[f1:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 4, i32 0, i32 immarg 116, i32 immarg 0)
+; SHADERTEST:  [[f2:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 8, i32 0, i32 immarg 116, i32 immarg 0)
+; SHADERTEST:  [[vectmp0:%.*]] = insertelement <4 x i32> <i32 undef, i32 undef, i32 undef, i32 1065353216>, i32 [[f0]], i32 0
+; SHADERTEST:  [[vectmp1:%.*]] = insertelement <4 x i32> [[vectmp0]], i32 [[f1]], i32 1
+; SHADERTEST:  [[vecf:%.*]] = insertelement <4 x i32> [[vectmp1]], i32 [[f2]], i32 2
+; Check that the attribute is cast to float so that it will be placed in a VGPR
+; SHADERTEST:  %vertex0.0 = bitcast <4 x i32> [[vecf]] to <4 x float>
+; Check that the attribute is inserted into the return value, and returned.
+; SHADERTEST:  [[retval:%.*]] = insertvalue {{.*}}, <4 x float> %vertex0.0
+; SHADERTEST:  ret {{.*}} [[retval]]
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; Check that the fetch shader loads the inputs into the correct registers.
+; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; SHADERTEST2: Disassembly of section .text:
+; SHADERTEST2: 0000000000000000 <_amdgpu_vs_main>
+; SHADERTEST2-DAG: v_mov_b32_e32 v7, 1.0
+; SHADERTEST2-DAG: tbuffer_load_format_x v4, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  dfmt:4, nfmt:7, 0 idxen
+; SHADERTEST2-DAG: tbuffer_load_format_x v5, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  dfmt:4, nfmt:7, 0 idxen offset:4
+; SHADERTEST2-DAG: tbuffer_load_format_x v6, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  dfmt:4, nfmt:7, 0 idxen offset:8
+; Identify the start of the vertex shader
+; SHADERTEST2: s_getpc_b64 s[0:1]
+; Identify the start of the fragment shader, and check its alignment at the same time.
+; SHADERTEST2: 00 <_amdgpu_ps_main>
+; END_SHADERTEST
+
+
+
+[Version]
+version = 40
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %pos
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "projection"
+               OpMemberName %UBO 1 "model"
+               OpMemberName %UBO 2 "gradientPos"
+               OpName %ubo "ubo"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpName %_ ""
+               OpName %pos "pos"
+               OpMemberDecorate %UBO 0 ColMajor
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 0 MatrixStride 16
+               OpMemberDecorate %UBO 1 ColMajor
+               OpMemberDecorate %UBO 1 Offset 64
+               OpMemberDecorate %UBO 1 MatrixStride 16
+               OpMemberDecorate %UBO 2 Offset 128
+               OpDecorate %UBO Block
+               OpDecorate %ubo DescriptorSet 0
+               OpDecorate %ubo Binding 0
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %pos Location 0
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+        %UBO = OpTypeStruct %mat4v4float %mat4v4float %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+%gl_PerVertex = OpTypeStruct %v4float
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_mat4v4float = OpTypePointer Uniform %mat4v4float
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+        %pos = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+    %float_1 = OpConstant %float 1
+       %main = OpFunction %void None %9
+         %21 = OpLabel
+         %22 = OpAccessChain %_ptr_Uniform_mat4v4float %ubo %int_0
+         %23 = OpLoad %mat4v4float %22
+         %24 = OpLoad %v4float %pos
+         %25 = OpCompositeInsert %v4float %float_1 %24 3
+         %26 = OpMatrixTimesVector %v4float %23 %25
+         %27 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 4
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorCombinedTexture
+userDataNode[0].next[1].offsetInDwords = 4
+userDataNode[0].next[1].sizeInDwords = 12
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 1
+userDataNode[0].next[2].type = DescriptorBuffer
+userDataNode[0].next[2].offsetInDwords = 16
+userDataNode[0].next[2].sizeInDwords = 4
+userDataNode[0].next[2].set = 0
+userDataNode[0].next[2].binding = 2
+userDataNode[1].type = IndirectUserDataVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].indirectUserDataCount = 4
+
+options.trapPresent = 0
+options.debugMode = 0
+options.enablePerformanceData = 0
+options.allowReZ = 0
+options.vgprLimit = 0
+options.sgprLimit = 0
+options.maxThreadGroupsPerComputeUnit = 0
+options.waveSize = 0
+options.wgpMode = 0
+options.waveBreakSize = DrawTime
+options.forceLoopUnrollCount = 0
+options.useSiScheduler = 0
+options.updateDescInElf = 0
+options.allowVaryWaveSize = 0
+options.enableLoadScalarizer = 0
+options.disableLicm = 0
+options.unrollThreshold = 0
+options.scalarThreshold = 0
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %outFragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %outFragColor "outFragColor"
+               OpDecorate %outFragColor Location 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%outFragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantComposite %v4float %float_0 %float_1 %float_0 %float_1
+       %main = OpFunction %void None %5
+         %12 = OpLabel
+               OpStore %outFragColor %11
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 4
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorCombinedTexture
+userDataNode[0].next[1].offsetInDwords = 4
+userDataNode[0].next[1].sizeInDwords = 12
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 1
+userDataNode[0].next[2].type = DescriptorBuffer
+userDataNode[0].next[2].offsetInDwords = 16
+userDataNode[0].next[2].sizeInDwords = 4
+userDataNode[0].next[2].set = 0
+userDataNode[0].next[2].binding = 2
+
+options.trapPresent = 0
+options.debugMode = 0
+options.enablePerformanceData = 0
+options.allowReZ = 0
+options.vgprLimit = 0
+options.sgprLimit = 0
+options.maxThreadGroupsPerComputeUnit = 0
+options.waveSize = 0
+options.wgpMode = 0
+options.waveBreakSize = DrawTime
+options.forceLoopUnrollCount = 0
+options.useSiScheduler = 0
+options.updateDescInElf = 0
+options.allowVaryWaveSize = 0
+options.enableLoadScalarizer = 0
+options.disableLicm = 0
+options.unrollThreshold = 0
+options.scalarThreshold = 0
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+patchControlPoints = 0
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 0
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 0
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactSubgroup
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 0
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.reconfigWorkgroupLayout = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 44
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 12
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[2].offset = 20
+attribute[3].location = 3
+attribute[3].binding = 0
+attribute[3].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[3].offset = 32

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -297,8 +297,8 @@ void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipe
 
   // Shader stage specific processing
   auto inOuts = entryPoint->getInOuts();
-  if (shaderStage == ShaderStageVertex) {
-    // Create dummy vertex info
+  if (shaderStage == ShaderStageVertex && AutoLayoutDesc) {
+    // Create dummy vertex info (only if -auto-layout-desc is on).
     auto vertexBindings = new std::vector<VkVertexInputBindingDescription>;
     auto vertexAttribs = new std::vector<VkVertexInputAttributeDescription>;
 


### PR DESCRIPTION
1. When compiling a shader, do not auto-generate vertex fetch info
   unless -auto-layout-desc is on, so the compiled VS is fetchless.

2. When compiling a pipeline with -use-relocatable-shader-elf, do not
   pass vertex fetch info to LGC, so the compiled VS is fetchless, and
   the linker adds a fetch shader.

3. Added slightly modified version of single-input fetch shader test
   from #518.

Change-Id: Id30aecedfbbea24e7ac471e6b4e0e7c6f8435dbe
