### PR TITLE
Rewrite part of small primitive filter algorithm

### DIFF
--- a/lgc/include/lgc/state/Abi.h
+++ b/lgc/include/lgc/state/Abi.h
@@ -117,6 +117,8 @@ struct PrimShaderRenderCb {
   unsigned primitiveRestartEnable; ///< Enable resetting of a triangle strip using a special index.
   unsigned primitiveRestartIndex;  ///< Value used to determine if a primitive restart is triggered
   unsigned matchAllBits;           ///< When comparing restart indices, this limits number of bits
+  unsigned enableConservativeRasterization; ///< Conservative rasterization is enabled, triggering special logic
+                                            ///  for culling.
 };
 
 /// This struct defines the expected layout in memory when 'contiguousCbs' is set


### PR DESCRIPTION
With several experiments done by internal compiler team, original
algorithm has some defects. The screen coordinate calculation and
clamping are not correct. Also, conservative rasterization is not
involved. So this change correct all these aspects.

1. Rewrite the algorithm and make new comments describing the basic
   processing. Also, revise algorithm comments for other culling as
   well.

2. Add conservative rasterization flag to PAL ABI interface. PAL has
   already added it but we make a LLPC local copy that is stale. Make
   const buffer look-up table changes at the same time.

3. Check W to determine if this culling should be enabled.

4. Fix the failed cases reported by the group: VK.pipeline.multisample.
   mixed_attachment_samples.verify_programmable_locations.*.

Change-Id: If57809ef7e1f81b1525c4d729bd8e4f88f52b8a2