### PR TITLE
Hanlde the behavior of getting array length for a null descriptor

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -73,6 +73,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     40.2 | Added flag nullDescriptor in PipelineOptions to support VK_EXT_robustness2                            |
 //* |     40.1 | Added disableLoopUnroll to PipelineShaderOptions                                                      |
 //* |     40.0 | Added DescriptorReserved12, which moves DescriptorYCbCrSampler down to 13                             |
 //* |     39.0 | Non-LLPC-specific XGL code should #include vkcgDefs.h instead of llpc.h                               |
@@ -266,6 +267,8 @@ struct PipelineOptions {
 
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
+  bool nullDescriptor;                                   ///< If set, support VK_EXT_robustness2 to give defined
+                                                         ///  behavior for null descriptor
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -286,7 +286,7 @@ public:
   llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *pushConstantsTy, const llvm::Twine &instName) override final;
 
   // Create a buffer length query based on the specified descriptor.
-  llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc,
+  llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
                                          const llvm::Twine &instName = "") override final;
 
 private:

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1096,8 +1096,8 @@ Value *BuilderRecorder::CreateLoadPushConstantsPtr(Type *pushConstantsTy, const 
 //
 // @param bufferDesc : The buffer descriptor to query.
 // @param instName : Name to give instruction(s).
-Value *BuilderRecorder::CreateGetBufferDescLength(Value *const bufferDesc, const Twine &instName) {
-  return record(Opcode::GetBufferDescLength, getInt32Ty(), {bufferDesc}, instName);
+Value *BuilderRecorder::CreateGetBufferDescLength(Value *const bufferDesc, Value *offset, const Twine &instName) {
+  return record(Opcode::GetBufferDescLength, getInt32Ty(), {bufferDesc, offset}, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -364,7 +364,7 @@ public:
 
   llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *pushConstantsTy, const llvm::Twine &instName) override final;
 
-  llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc,
+  llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
                                          const llvm::Twine &instName = "") override final;
 
   // -----------------------------------------------------------------------------------------------------------------

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -454,7 +454,8 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   }
 
   case BuilderRecorder::Opcode::GetBufferDescLength: {
-    return m_builder->CreateGetBufferDescLength(args[0]);
+    return m_builder->CreateGetBufferDescLength(args[0],  // buffer descriptor
+                                                args[1]); // offset
   }
 
   // Replayer implementations of ImageBuilder methods

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -494,12 +494,11 @@ Value *DescBuilder::scalarizeIfUniform(Value *value, bool isNonUniform) {
 //
 // @param bufferDesc : The buffer descriptor to query.
 // @param instName : Name to give instruction(s).
-Value *DescBuilder::CreateGetBufferDescLength(Value *const bufferDesc, const Twine &instName) {
+Value *DescBuilder::CreateGetBufferDescLength(Value *const bufferDesc, Value *offset, const Twine &instName) {
   // In future this should become a full LLVM intrinsic, but for now we patch in a late intrinsic that is cleaned up
   // in patch buffer op.
   std::string callName = lgcName::LateBufferLength;
-  addTypeMangling(nullptr, bufferDesc, callName);
-  return CreateNamedCall(callName, getInt32Ty(), bufferDesc, Attribute::ReadNone);
+  return CreateNamedCall(lgcName::LateBufferLength, getInt32Ty(), {bufferDesc, offset}, Attribute::ReadNone);
 }
 
 // =====================================================================================================================

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -757,11 +757,14 @@ public:
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *pushConstantsTy, const llvm::Twine &instName = "") = 0;
 
-  // Create a buffer length query based on the specified descriptor.
+  // Create a buffer length query based on the specified descriptor, subtracting an offset from the length. The result
+  // is 0 for a null descriptor when allowNullDescriptor is enabled.
   //
   // @param bufferDesc : The buffer descriptor to query.
+  // @param offset: The offset to subtract from the buffer length.
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
+                                                 const llvm::Twine &instName = "") = 0;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Image operations

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -115,6 +115,7 @@ struct Options {
   unsigned nggPrimsPerSubgroup;        // How to determine NGG prims per subgroup
   unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
                                        //   ShadowDescriptorTableDisable to disable shadow descriptor tables
+  unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1851,6 +1851,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
     fragmentHasher.Update(pipelineOptions->reconfigWorkgroupLayout);
     fragmentHasher.Update(pipelineOptions->includeIr);
     fragmentHasher.Update(pipelineOptions->robustBufferAccess);
+    fragmentHasher.Update(pipelineOptions->nullDescriptor);
     PipelineDumper::updateHashForFragmentState(pipelineInfo, &fragmentHasher);
     fragmentHasher.Finalize(fragmentHash->bytes);
   }

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -301,6 +301,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
     }
   }
 
+  options.allowNullDescriptor = getPipelineOptions()->nullDescriptor;
   pipeline->setOptions(options);
 
   // Give the shader options (including the hash) to the middle-end.

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2631,17 +2631,16 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpArrayLength>(SPIRVValue *
   const unsigned remappedMemberIndex =
       lookupRemappedTypeElements(spvStruct->getType()->getPointerElementType(), memberIndex);
 
-  Value *const bufferLength = getBuilder()->CreateGetBufferDescLength(pStruct);
-
   StructType *const structType = cast<StructType>(pStruct->getType()->getPointerElementType());
   const StructLayout *const structLayout = m_m->getDataLayout().getStructLayout(structType);
   const unsigned offset = static_cast<unsigned>(structLayout->getElementOffset(remappedMemberIndex));
   Value *const offsetVal = getBuilder()->getInt32(offset);
+  Value *const bufferLength = getBuilder()->CreateGetBufferDescLength(pStruct, offsetVal);
 
   Type *const memberType = structType->getStructElementType(remappedMemberIndex)->getArrayElementType();
   const unsigned stride = static_cast<unsigned>(m_m->getDataLayout().getTypeSizeInBits(memberType) / 8);
 
-  return getBuilder()->CreateUDiv(getBuilder()->CreateSub(bufferLength, offsetVal), getBuilder()->getInt32(stride));
+  return getBuilder()->CreateUDiv(bufferLength, getBuilder()->getInt32(stride));
 }
 
 // =====================================================================================================================

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -621,6 +621,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
   dumpFile << "options.reconfigWorkgroupLayout = " << options->reconfigWorkgroupLayout << "\n";
   dumpFile << "options.shadowDescriptorTableUsage = " << options->shadowDescriptorTableUsage << "\n";
   dumpFile << "options.shadowDescriptorTablePtrHigh = " << options->shadowDescriptorTablePtrHigh << "\n";
+  dumpFile << "options.nullDescriptor = " << options->nullDescriptor << "\n";
 }
 
 // =====================================================================================================================
@@ -833,6 +834,7 @@ MetroHash::Hash PipelineDumper::generateHashForComputePipeline(const ComputePipe
   hasher.Update(pipeline->options.robustBufferAccess);
   hasher.Update(pipeline->options.shadowDescriptorTableUsage);
   hasher.Update(pipeline->options.shadowDescriptorTablePtrHigh);
+  hasher.Update(pipeline->options.nullDescriptor);
 
   MetroHash::Hash hash = {};
   hasher.Finalize(hash.bytes);
@@ -933,6 +935,7 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     hasher->Update(pipeline->options.reconfigWorkgroupLayout);
     hasher->Update(pipeline->options.shadowDescriptorTableUsage);
     hasher->Update(pipeline->options.shadowDescriptorTablePtrHigh);
+    hasher->Update(pipeline->options.nullDescriptor);
   }
 }
 

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -991,6 +991,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, nullDescriptor, MemberTypeBool, false);
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
@@ -998,7 +999,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 7;
+  static const unsigned MemberCount = 8;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
VK_EXT_robustness2 supports for "null descriptors". This change give defined behavior for null descriptor to get the length of itself espcially there is a variable sized array.
- Add nullDescriptor in PipelineOptions to guard the implementation for supporting null descriptor.
- Add allowNullDescriptor option in lgc::Options
- Add a new second argument for the byte offset of variable array in Builder::CreateGetBufferDescLength. The result is clamped at 0 if the offset is greater than the buffer length and allowNullDescriptor is on.