### PR TITLE
Don't leave holes in PS input metadata

### DIFF
--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -959,8 +959,10 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   for (unsigned i = 0; i < interpInfo->size(); ++i) {
     const auto &interpInfoElem = (*interpInfo)[i];
-    if (m_pipelineState->isUnlinked() && interpInfoElem.loc == InvalidFsInterpInfo.loc)
+    if (m_pipelineState->isUnlinked() && interpInfoElem.loc == InvalidFsInterpInfo.loc) {
+      appendConfig(mmSPI_PS_INPUT_CNTL_0 + i, i);
       continue;
+    }
     assert((interpInfoElem.loc == InvalidFsInterpInfo.loc && interpInfoElem.flat == InvalidFsInterpInfo.flat &&
             interpInfoElem.custom == InvalidFsInterpInfo.custom &&
             interpInfoElem.is16bit == InvalidFsInterpInfo.is16bit &&

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1901,8 +1901,11 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   for (unsigned i = 0; i < interpInfo->size(); ++i) {
     auto interpInfoElem = (*interpInfo)[i];
-    if (m_pipelineState->isUnlinked() && interpInfoElem.loc == InvalidFsInterpInfo.loc)
+
+    if (m_pipelineState->isUnlinked() && interpInfoElem.loc == InvalidFsInterpInfo.loc) {
+      appendConfig(mmSPI_PS_INPUT_CNTL_0 + i, i);
       continue;
+    }
     if ((interpInfoElem.loc == InvalidFsInterpInfo.loc && interpInfoElem.flat == InvalidFsInterpInfo.flat &&
          interpInfoElem.custom == InvalidFsInterpInfo.custom && interpInfoElem.is16bit == InvalidFsInterpInfo.is16bit))
       interpInfoElem.loc = i;

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_FillPsInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_FillPsInput.pipe
@@ -1,0 +1,110 @@
+; This test checks that the PS_INPUT_CNTL entries are contineous.  Tests fail
+; when there is they not not start at 0 or there is a gap.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -use-relocatable-shader-elf -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: PalMetadata
+; SHADERTEST: SPI_PS_INPUT_CNTL_0
+; SHADERTEST-NEXT: SPI_PS_INPUT_CNTL_1
+; SHADERTEST-NEXT: SPI_PS_INPUT_CNTL_2
+; SHADERTEST-NEXT: SPI_PS_INPUT_CNTL_3
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main" %3 %4 %5
+               OpSource GLSL 450
+               OpDecorate %3 Location 0
+               OpMemberDecorate %_struct_6 0 BuiltIn Position
+               OpDecorate %_struct_6 Block
+               OpDecorate %5 Location 3
+       %void = OpTypeVoid
+          %8 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+          %3 = OpVariable %_ptr_Input_v3float Input
+        %int = OpTypeInt 32 1
+    %v4float = OpTypeVector %float 4
+    %float_1 = OpConstant %float 1
+  %_struct_6 = OpTypeStruct %v4float
+%_ptr_Output__struct_6 = OpTypePointer Output %_struct_6
+          %4 = OpVariable %_ptr_Output__struct_6 Output
+      %int_0 = OpConstant %int 0
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %5 = OpVariable %_ptr_Output_v3float Output
+          %2 = OpFunction %void None %8
+         %19 = OpLabel
+         %20 = OpLoad %v3float %3
+         %21 = OpCompositeConstruct %v4float %20 %float_1
+         %22 = OpAccessChain %_ptr_Output_v4float %4 %int_0
+               OpStore %22 %21
+               OpStore %5 %20
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %3 %4 %5
+               OpExecutionMode %2 OriginUpperLeft
+               OpSource GLSL 450
+               OpDecorate %3 Location 3
+               OpDecorate %4 Location 0
+               OpDecorate %5 Location 1
+       %void = OpTypeVoid
+          %7 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+    %v4float = OpTypeVector %float 4
+    %float_1 = OpConstant %float 1
+    %float_0 = OpConstant %float 0
+          %3 = OpVariable %_ptr_Input_v3float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %4 = OpVariable %_ptr_Output_v4float Output
+          %5 = OpVariable %_ptr_Output_v4float Output
+         %15 = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+          %2 = OpFunction %void None %7
+         %16 = OpLabel
+         %17 = OpLoad %v3float %3
+         %18 = OpLoad %v4float %4
+         %19 = OpVectorShuffle %v4float %18 %17 4 5 6 3
+               OpStore %4 %19
+               OpStore %5 %15
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+colorBuffer[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[1].channelWriteMask = 15
+colorBuffer[1].blendEnable = 0
+colorBuffer[1].blendSrcAlphaToColor = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 32
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0


### PR DESCRIPTION
If there are missing entried for PS_INPUT_CNTL then the shader do not
work.  We need to make sure that if we use PS_INPUT_CNTL_<N> then we
also have an entry for PS_INTPU_CNTL_<M> for all M < N.