### PR TITLE
Fix clang-10 warning

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -111,7 +111,7 @@ private:
 
 // =====================================================================================================================
 // Internal implementation of the LGC interface for ELF linking.
-class ElfLinkerImpl : public ElfLinker {
+class ElfLinkerImpl final : public ElfLinker {
 public:
   // Constructor given PipelineState and ELFs to link
   ElfLinkerImpl(PipelineState *pipelineState, ArrayRef<MemoryBufferRef> elfs);


### PR DESCRIPTION
lgc/elfLinker/ElfLinker.cpp:120:29: error: class with destructor marked 'final' cannot be inherited from [-Werror,-Wfinal-dtor-non-final-class]
  ~ElfLinkerImpl() override final;
                            ^