### PR TITLE
Refactor canUseRelocationShaderElf functions

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -846,69 +846,65 @@ static bool hasUnrelocatableDescriptorNode(const ResourceMappingNode *nodes, uns
 // Returns true if a graphics pipeline can be built out of the given shader info.
 //
 // @param shaderInfo : Shader info for the pipeline to be built
-bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineShaderInfo *> &shaderInfo) const {
+bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineShaderInfo *> &shaderInfo) {
   if (!cl::UseRelocatableShaderElf)
     return false;
 
-  bool useRelocatableShaderElf = true;
   for (unsigned stage = 0; stage < shaderInfo.size(); ++stage) {
     if (stage != ShaderStageVertex && stage != ShaderStageFragment) {
       if (shaderInfo[stage] && shaderInfo[stage]->pModuleData)
-        useRelocatableShaderElf = false;
+        return false;
     } else if (!shaderInfo[stage] || !shaderInfo[stage]->pModuleData) {
       // TODO: Generate pass-through shaders when the fragment or vertex shaders are missing.
-      useRelocatableShaderElf = false;
+      return false;
     } else {
       // Check UserDataNode for unsupported Descriptor types.
-      useRelocatableShaderElf =
-          !hasUnrelocatableDescriptorNode(shaderInfo[stage]->pUserDataNodes, shaderInfo[stage]->userDataNodeCount);
+      if (hasUnrelocatableDescriptorNode(shaderInfo[stage]->pUserDataNodes, shaderInfo[stage]->userDataNodeCount))
+        return false;
     }
   }
 
-  if (useRelocatableShaderElf && shaderInfo[0]) {
+  if (shaderInfo[0]) {
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo[0]->pModuleData);
     if (moduleData && moduleData->binType != BinaryType::Spirv)
-      useRelocatableShaderElf = false;
+      return false;
   }
 
-  if (useRelocatableShaderElf && cl::RelocatableShaderElfLimit != -1) {
-    static unsigned RelocatableElfCounter = 0;
-    if (RelocatableElfCounter >= cl::RelocatableShaderElfLimit)
-      useRelocatableShaderElf = false;
+  if (cl::RelocatableShaderElfLimit != -1) {
+    if (m_relocatablePipelineCompilations >= cl::RelocatableShaderElfLimit)
+      return false;
     else
-      ++RelocatableElfCounter;
+      ++m_relocatablePipelineCompilations;
   }
-  return useRelocatableShaderElf;
+  return true;
 }
 
 // =====================================================================================================================
 // Returns true if a compute pipeline can be built out of the given shader info.
 //
 // @param shaderInfo : Shader info for the pipeline to be built
-bool Compiler::canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo) const {
+bool Compiler::canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo) {
   if (!cl::UseRelocatableShaderElf)
     return false;
 
-  bool useRelocatableShaderElf = true;
-  if (useRelocatableShaderElf && shaderInfo) {
+  if (shaderInfo) {
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo->pModuleData);
     if (moduleData && moduleData->binType != BinaryType::Spirv)
-      useRelocatableShaderElf = false;
+      return false;
     else {
       // Check UserDataNode for unsupported Descriptor types.
-      useRelocatableShaderElf =
-          !hasUnrelocatableDescriptorNode(shaderInfo->pUserDataNodes, shaderInfo->userDataNodeCount);
+      if (hasUnrelocatableDescriptorNode(shaderInfo->pUserDataNodes, shaderInfo->userDataNodeCount))
+        return false;
     }
   }
 
-  if (useRelocatableShaderElf && cl::RelocatableShaderElfLimit != -1) {
-    static unsigned RelocatableElfCounter = 0;
-    if (RelocatableElfCounter >= cl::RelocatableShaderElfLimit)
-      useRelocatableShaderElf = false;
+  if (cl::RelocatableShaderElfLimit != -1) {
+    if (m_relocatablePipelineCompilations >= cl::RelocatableShaderElfLimit)
+      return false;
     else
-      ++RelocatableElfCounter;
+      ++m_relocatablePipelineCompilations;
   }
-  return useRelocatableShaderElf;
+  return true;
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -159,8 +159,8 @@ private:
 
   bool runPasses(lgc::PassManager *passMgr, llvm::Module *module) const;
   void linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context);
-  bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo) const;
-  bool canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo) const;
+  bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo);
+  bool canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo);
 
   std::vector<std::string> m_options;           // Compilation options
   MetroHash::Hash m_optionHash;                 // Hash code of compilation options
@@ -170,6 +170,7 @@ private:
   ShaderCachePtr m_shaderCache;                 // Shader cache
   static llvm::sys::Mutex m_contextPoolMutex;   // Mutex for context pool access
   static std::vector<Context *> *m_contextPool; // Context pool
+  unsigned m_relocatablePipelineCompilations;   // The number of pipelines compiled using relocatable shader elf
 };
 
 // Convert front-end LLPC shader stage to middle-end LGC shader stage


### PR DESCRIPTION
Two small changes.  First I removed the variable with the return value,
and just do early returns.  This makes the code easier to read.

Second I removed the static variable that would count the number of
pipelines compiled with relocatable shader, and replaced it with a
member variable.  This way the graphics and compute pipelines can share
the counter.  Makes debugging easier.