### PR TITLE
Fix the user data limit calculation when linking

### DIFF
--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -357,7 +357,8 @@ void PalMetadata::fixUpRegisters() {
             report_fatal_error("Descriptor set " + Twine(descSet) + " not found");
           value = descSetNodes[descSet]->offsetInDwords;
           it->second = value;
-          userDataLimit = std::max(userDataLimit, value);
+          unsigned extent = value + descSetNodes[descSet]->sizeInDwords;
+          userDataLimit = std::max(userDataLimit, extent);
         } else {
           unsigned pushConstOffset = value - static_cast<unsigned>(UserDataMapping::PushConst0);
           if (pushConstOffset <= static_cast<unsigned>(UserDataMapping::DescriptorSetMax) -
@@ -367,7 +368,8 @@ void PalMetadata::fixUpRegisters() {
               report_fatal_error("Push constant not found or not big enough");
             value = pushConstNode->offsetInDwords + pushConstOffset;
             it->second = value;
-            userDataLimit = std::max(userDataLimit, value);
+            unsigned extent = pushConstNode->offsetInDwords + pushConstNode->sizeInDwords;
+            userDataLimit = std::max(userDataLimit, extent);
           }
         }
         ++it;

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocConst.pipe
@@ -1,5 +1,6 @@
 
 // This test case checks that descriptor offset relocation works for buffer descriptors in a vs/fs pipeline.
+// Also check that the user data limit is set correctly.
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_vs_main>:
@@ -21,6 +22,7 @@
 ; SHADERTEST1: %{{[0-9]+}} = load <4 x i32>, <4 x i32> addrspace(4)* %[[BUFFERDESCPTR]], align 16
 ; SHADERTEST1-DAG: SPI_SHADER_USER_DATA_VS_{{.}} 0x000000000000000B
 ; SHADERTEST1-DAG: SPI_SHADER_USER_DATA_PS_{{.}} 0x000000000000000B
+; SHADERTEST1: .user_data_limit: 0x000000000000000C
 ; SHADERTEST1: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
The limit must extend to the end of the descriptor not just to the start.