### PR TITLE
Disable relocatable compute shaders

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -900,6 +900,12 @@ bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineS
 //
 // @param shaderInfo : Shader info for the pipeline to be built
 bool Compiler::canUseRelocatableComputeShaderElf(const PipelineShaderInfo *shaderInfo) {
+  // Relocatable shader cannot get the order of the user data nodes correct.  We have to disable them for compute
+  // shaders until the restriction in PAL has been relaxed.
+  // The tests PipelineCs_StrideReloc.pipe, PipelineCs_RelocCombinedTextureSampler.pipe, PipelineCs_ShaderCache.pipe,
+  // and PipelineCs_RelocConst.pipe must be reenabled when this restriction is removed.
+  return false;
+
   if (!cl::UseRelocatableShaderElf)
     return false;
 

--- a/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
+++ b/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
@@ -1,3 +1,4 @@
+; XFAIL: *
 
 // This test case checks that stride relocation is generated correctly for array of textures.
 ; BEGIN_SHADERTEST

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
@@ -1,3 +1,4 @@
+; XFAIL: *
 
 // This test case checks that two relocation entries are generated for a combined texture sampler descriptor,
 // one for the resource handle offset, and another for the sampler handle offset.

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
@@ -1,3 +1,5 @@
+; XFAIL: *
+
 ; This test case checks that descriptor offset relocation works for buffer descriptors in a compute pipeline.
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
@@ -1,3 +1,5 @@
+; XFAIL: *
+
 ; This test case checks shader cache creation in the standalone compilation mode.
 ; BEGIN_SHADERTEST
 ; RUN: rm -rf %t_dir && \


### PR DESCRIPTION
Relocatable shader cannot get the order of the user data nodes correct
for compute shader, so we must disable it until the restriction in PAL
has been relaxed.

This is based on https://github.com/GPUOpen-Drivers/llpc/pull/730.