### PR TITLE
Fix volatile not propagate to the fat pointer LLVM IR load and store

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2082,6 +2082,10 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpLoad>(SPIRVValue *const s
   }
 
   bool isVolatile = spvLoad->SPIRVMemoryAccess::isVolatile(true);
+  const Vkgc::ExtendedRobustness &extendedRobustness =
+      static_cast<Llpc::Context *>(m_context)->getPipelineContext()->getPipelineOptions()->extendedRobustness;
+  if (extendedRobustness.nullDescriptor || extendedRobustness.robustBufferAccess)
+    isVolatile |= spvLoad->getSrc()->isVolatile();
 
   // We don't require volatile on address spaces that become non-pointers.
   switch (spvLoad->getSrc()->getType()->getPointerStorageClass()) {
@@ -2238,6 +2242,10 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpStore>(SPIRVValue *const 
   SPIRVStore *const spvStore = static_cast<SPIRVStore *>(spvValue);
 
   bool isVolatile = spvStore->SPIRVMemoryAccess::isVolatile(false);
+  const Vkgc::ExtendedRobustness &extendedRobustness =
+      static_cast<Llpc::Context *>(m_context)->getPipelineContext()->getPipelineOptions()->extendedRobustness;
+  if (extendedRobustness.nullDescriptor || extendedRobustness.robustBufferAccess)
+    isVolatile = spvStore->getDst()->isVariable();
 
   // We don't require volatile on address spaces that become non-pointers.
   switch (spvStore->getDst()->getType()->getPointerStorageClass()) {


### PR DESCRIPTION
- The original volatile check by SPIRVMemoryAccess::isVolatile() in transValueWithOpcode<OpLoad/OpStore> will miss "volatile" qualified for buffer block in glsl source. So LLVM does the peehole and buffer load may be removed by optimization. Some tests of  VK_EXT_robustness2 expose the bug.
- This change appends SPIRVValue::isVolatile() to ensure "volatie" set correctly.