### PR TITLE
Change the check of NGG culling feasibility

### DIFF
--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -67,7 +67,8 @@ private:
   bool checkGsOnChipValidity();
 
   // Sets NGG control settings
-  void setNggControl();
+  void setNggControl(llvm::Module *module);
+  bool canUseNggCulling(llvm::Module *module);
   void buildNggCullingControlRegister(NggControl &nggControl);
   unsigned getVerticesPerPrimitive() const;
 


### PR DESCRIPTION
1. Add a new method canUseNggCulling() to do NGG culling feasibility
   check. We might have more cases in the future to disable NGG
   culling. They should stay in this method.

2. Add more checks of gl_Position. NGG culling should be disabled in
   following cases:
   - gl_Position is absent
   - gl_Posistion is from constant or undefined values

Change-Id: Ia3387e17f573cbfb3ffad5498c49cb283196b3d0