### PR TITLE
AMDLLPC specifies wrong primitive topology for tessellation

### DIFF
--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -387,7 +387,7 @@ void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipe
     pipelineInfo->iaState.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
   } else if (shaderStage == ShaderStageTessControl || shaderStage == ShaderStageTessEval) {
     // Set primitive topology and patch control points
-    pipelineInfo->iaState.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    pipelineInfo->iaState.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
     pipelineInfo->iaState.patchControlPoints = 3;
   } else if (shaderStage == ShaderStageGeometry) {
     // Set primitive topology


### PR DESCRIPTION
The primitive topology ought to be VK_PRIMITIVE_TOPOLOGY_PATCH_LIST.

Change-Id: Iaa0ae90c5b05073c627037e8328a63f44a9c00c5