### PR TITLE
Handle pushconst reloc in elf linker

### DIFF
--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -30,6 +30,7 @@
  */
 #include "RelocHandler.h"
 #include "lgc/state/AbiUnlinked.h"
+#include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 
@@ -141,6 +142,12 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
   }
   if (name == reloc::DeviceIdx) {
     value = m_pipelineState->getDeviceIndex();
+    return true;
+  }
+  if (name == reloc::Pushconst) {
+    auto *pushConstantNode = m_pipelineState->findPushConstantResourceNode();
+    value = pushConstantNode->offsetInDwords;
+    getPipelineState()->getPalMetadata()->setUserDataSpillUsage(pushConstantNode->offsetInDwords);
     return true;
   }
 

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -75,6 +75,10 @@ const static char SamplePatternIdx[] = "$samplePatternIdx";
 // The value of the relocation is deviceIdx from the pipeline state.
 const static char DeviceIdx[] = "$deviceIdx";
 
+// Pushconst offset is "pushconst"
+// The value of the relocation is the offset of the pushconst reource node in the pipeline state.
+const static char Pushconst[] = "pushconst";
+
 } // namespace reloc
 
 } // namespace lgc

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -216,6 +216,9 @@ public:
   // Get user data nodes
   llvm::ArrayRef<ResourceNode> getUserDataNodes() const { return m_userDataNodes; }
 
+  // Find the push constant resource node
+  const ResourceNode *findPushConstantResourceNode() const;
+
   // Find the resource node for the given set,binding
   std::pair<const ResourceNode *, const ResourceNode *> findResourceNode(ResourceNodeType nodeType, unsigned descSet,
                                                                          unsigned binding) const;

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -34,6 +34,7 @@
 #include "lgc/BuilderBase.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/patch/ShaderInputs.h"
+#include "lgc/state/AbiUnlinked.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineShaders.h"
@@ -522,7 +523,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
           byteOffset = UndefValue::get(builder.getInt32Ty());
         } else {
           // Unlinked shader compilation: Use a reloc.
-          byteOffset = builder.CreateRelocationConstant("pushconst");
+          byteOffset = builder.CreateRelocationConstant(reloc::Pushconst);
         }
         replacementVal = builder.CreateGEP(builder.getInt8Ty(), spillTable, byteOffset);
       }

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -541,6 +541,17 @@ void PipelineState::readUserDataNodes(Module *module) {
 }
 
 // =====================================================================================================================
+// Returns the resource node for the push constant.
+const ResourceNode *PipelineState::findPushConstantResourceNode() const {
+  for (const ResourceNode &node : getUserDataNodes()) {
+    if (node.type == ResourceNodeType::PushConst) {
+      return &node;
+    }
+  }
+  return nullptr;
+}
+
+// =====================================================================================================================
 // Find the resource node for the given {set,binding}.
 // For nodeType == Unknown, the function finds any node of the given set,binding.
 // For nodeType == Resource, it matches Resource or CombinedTexture.


### PR DESCRIPTION
We generate a pushconst relocation for the offset of the push constant
in the spill area, but it is not handled in the linker.  This is fixed in
this commit.