### PR TITLE
Dumper: Removed assert that .note is 4-aligned

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1203,7 +1203,6 @@ OStream &operator<<(OStream &out, ElfReader<Elf> &reader) {
       const unsigned noteHeaderSize = sizeof(NoteHeader) - 8;
       while (offset < section->secHead.sh_size) {
         const NoteHeader *node = reinterpret_cast<const NoteHeader *>(section->data + offset);
-        assert((uint64_t(node) & 3) == 0);
         const unsigned noteNameSize = alignTo(node->nameSize, 4);
         switch (static_cast<unsigned>(node->type)) {
         case static_cast<unsigned>(Util::Abi::PipelineAbiNoteType::HsaIsa): {


### PR DESCRIPTION
It turns out that AMD's internal compiler generates ELFs with a
misaligned .note section.

Probably the proper fix is to modify the ELF dumper here to not rely on
.note being 4 aligned.

Change-Id: Icc37108ed64acb071c90bb6267c90d9986b21237