### PR TITLE
Add pipeline option to use relocatable shaders.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -256,14 +256,16 @@ enum class ShadowDescriptorTableUsage : unsigned {
 
 /// Represents per pipeline options.
 struct PipelineOptions {
-  bool includeDisassembly;      ///< If set, the disassembly for all compiled shaders will be included in
-                                ///  the pipeline ELF.
-  bool scalarBlockLayout;       ///< If set, allows scalar block layout of types.
-  bool reconfigWorkgroupLayout; ///< If set, allows automatic workgroup reconfigure to take place on compute shaders.
-  bool includeIr;               ///< If set, the IR for all compiled shaders will be included in the pipeline ELF.
-  bool robustBufferAccess;      ///< If set, out of bounds accesses to buffer or private array will be handled.
-                                ///  for now this option is used by LLPC shader and affects only the private array,
-                                ///  the out of bounds accesses will be skipped with this setting.
+  bool includeDisassembly;         ///< If set, the disassembly for all compiled shaders will be included in
+                                   ///  the pipeline ELF.
+  bool scalarBlockLayout;          ///< If set, allows scalar block layout of types.
+  bool reconfigWorkgroupLayout;    ///< If set, allows automatic workgroup reconfigure to take place on compute shaders.
+  bool includeIr;                  ///< If set, the IR for all compiled shaders will be included in the pipeline ELF.
+  bool robustBufferAccess;         ///< If set, out of bounds accesses to buffer or private array will be handled.
+                                   ///  for now this option is used by LLPC shader and affects only the private array,
+                                   ///  the out of bounds accesses will be skipped with this setting.
+  bool enableRelocatableShaderElf; ///< If set, the pipeline will be compiled by compiling each shader separately, and
+                                   ///  then linking them, when possible.  When not possible this option is ignored.
 
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.

--- a/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
+++ b/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
@@ -2,7 +2,7 @@
 
 // This test case checks that stride relocation is generated correctly for array of textures.
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
   // Test that correct relocated offsets are in the linked texture fetching code.
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
   // Matching the texture index
@@ -12,7 +12,7 @@
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST1-DAG: ![[METADATANODE1:[0-9]+]] = !{!"doff_0_0_r"}
 ; SHADERTEST1-DAG: ![[METADATANODE2:[0-9]+]] = !{!"doff_0_0_s"}

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
@@ -3,7 +3,7 @@
 // This test case checks that two relocation entries are generated for a combined texture sampler descriptor,
 // one for the resource handle offset, and another for the sampler handle offset.
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
   // Test that correct relocated offsets are in the linked texture fetching code.
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
   // Matching the relocation entry for the resource descriptor
@@ -19,7 +19,7 @@
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST1-DAG: ![[METADATANODE1:[0-9]+]] = !{!"doff_0_0_r"}
 ; SHADERTEST1-DAG: ![[METADATANODE2:[0-9]+]] = !{!"doff_0_0_s"}

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
@@ -2,14 +2,14 @@
 
 ; This test case checks that descriptor offset relocation works for buffer descriptors in a compute pipeline.
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
 ; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 16 {{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST1-DAG: ![[METADATANODE:[0-9]+]] = !{!"doff_0_0_b"}
 ; SHADERTEST1-DAG: %[[RELOCONST:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE]])

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
@@ -7,7 +7,7 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
 ; RUN:         -build-shader-cache -shader-cache-mode=2 \
 ; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
-; RUN:         -use-relocatable-shader-elf \
+; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=CREATE %s
 ; REQUIRES: llpc-shader-cache
 ; CREATE: Building pipeline with relocatable shader elf.
@@ -29,7 +29,7 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
 ; RUN:         -build-shader-cache -shader-cache-mode=4 \
 ; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
-; RUN:         -use-relocatable-shader-elf \
+; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=LOAD %s
 ; REQUIRES: llpc-shader-cache
 ; LOAD: Building pipeline with relocatable shader elf.
@@ -45,7 +45,7 @@
 ; RUN:         -vgpr-limit=64 \
 ; RUN:         -build-shader-cache -shader-cache-mode=3 \
 ; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
-; RUN:         -use-relocatable-shader-elf \
+; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=MODIFY %s
 ; REQUIRES: llpc-shader-cache
 ; MODIFY: Building pipeline with relocatable shader elf.

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_FillPsInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_FillPsInput.pipe
@@ -2,7 +2,7 @@
 ; when there is they not not start at 0 or there is a gap.
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -use-relocatable-shader-elf -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST: PalMetadata
 ; SHADERTEST: SPI_PS_INPUT_CNTL_0
 ; SHADERTEST-NEXT: SPI_PS_INPUT_CNTL_1

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocConst.pipe
@@ -2,7 +2,7 @@
 // This test case checks that descriptor offset relocation works for buffer descriptors in a vs/fs pipeline.
 // Also check that the user data limit is set correctly.
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_vs_main>:
 ; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 12 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
@@ -12,7 +12,7 @@
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -use-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST1-DAG: ![[METADATANODE:[0-9]+]] = !{!"doff_0_0_b"}
 ; SHADERTEST1-DAG: %[[RELOCONST:[0-9]+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[METADATANODE]])

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestRelocatableInOutMapping.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestRelocatableInOutMapping.pipe
@@ -2,7 +2,7 @@
 ; match the mapping for the inputs of the fragment shader.
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -use-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST: (VS) Output: loc = 0  =>  Mapped = [[loc0:[0-9]+]]
 ; SHADERTEST: (VS) Output: loc = 1  =>  Mapped = [[loc1:[0-9]+]]
 ; SHADERTEST: (VS) Output: loc = 3  =>  Mapped = [[loc3:[0-9]+]]

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestRelocatableSeparateCompilation.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestRelocatableSeparateCompilation.pipe
@@ -2,7 +2,7 @@
 ; It shows that the shaders were compiled individually and then linked.
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -use-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-EMPTY:
 ; SHADERTEST-NEXT: ; ModuleID = 'lgcPipeline'

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -234,6 +234,10 @@ static cl::opt<std::string> SpvGenDir("spvgen-dir", cl::desc("Directory to load 
 static cl::opt<bool> RobustBufferAccess("robust-buffer-access", cl::desc("Validate if the index is out of bounds"),
                                         cl::init(false));
 
+static cl::opt<bool> EnableRelocatableShaderElf("enable-relocatable-shader-elf",
+                                                cl::desc("Compile pipelines using relocatable shader elf"),
+                                                cl::init(false));
+
 // -check-auto-layout-compatible: check if auto descriptor layout got from spv file is commpatible with real layout
 static cl::opt<bool> CheckAutoLayoutCompatible(
     "check-auto-layout-compatible",
@@ -968,6 +972,7 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
       pipelineInfo->iaState.patchControlPoints = 3;
 
     pipelineInfo->options.robustBufferAccess = RobustBufferAccess;
+    pipelineInfo->options.enableRelocatableShaderElf = EnableRelocatableShaderElf;
 
     void *pipelineDumpHandle = nullptr;
     if (cl::EnablePipelineDump) {
@@ -1034,6 +1039,7 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
     pipelineInfo->pfnOutputAlloc = allocateBuffer;
     pipelineInfo->unlinked = compileInfo->unlinked;
     pipelineInfo->options.robustBufferAccess = RobustBufferAccess;
+    pipelineInfo->options.enableRelocatableShaderElf = EnableRelocatableShaderElf;
 
     void *pipelineDumpHandle = nullptr;
     if (cl::EnablePipelineDump) {


### PR DESCRIPTION
We want to move to a pipeline option to tell LLPC to use relocable
shaders.  This involves

1) Deprecating the current command line option in llpcCompiler.  I do
not want to remove it yet because that is the only way to currently
enable relocatable shader when using LLPC with an existing xgl driver.
Once xgl has been updated to use the pipeline option this option can be
removed.

2) Adding the pipeline options.

3) Adding a command line option to amdllpc to enable relocatable
shaders.

4) Update tests to use amdllpc's command line option instead of the
depracated one.

Note that we could wait on 3 & 4, and have amdllpc reuse the same
option as before.  I have no strong feelings about that.