### PR TITLE
Support writing multiPlane image descriptor

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -417,8 +417,17 @@ private:
 
   enum ImgDataFormat {
     IMG_DATA_FORMAT_32 = 4,
+    IMG_DATA_FORMAT_8_8_8_8 = 10,
     IMG_DATA_FORMAT_32_32 = 11,
     IMG_DATA_FORMAT_32_32_32_32 = 14,
+    IMG_DATA_FORMAT_GB_GR__CORE = 32,
+    IMG_DATA_FORMAT_BG_RG__CORE = 33,
+  };
+
+  enum ImgFmt {
+    IMG_FMT_8_8_8_8_UNORM__GFX10CORE = 56,
+    IMG_FMT_GB_GR_UNORM__GFX10CORE = 147,
+    IMG_FMT_BG_RG_UNORM__GFX10CORE = 151,
   };
 
   static const unsigned AtomicOpCompareSwap = 1;

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -771,6 +771,13 @@ Value *ImageBuilder::CreateImageSampleConvertYCbCr(Type *resultTy, unsigned dim,
 
   // Init YCbCrConverterer
   YCbCrConverter YCbCrConverter(this, yCbCrMetaData, &sampleInfoLuma, &gfxIp);
+
+  // Set image descriptor for chroma channel
+  for (unsigned planeIdx = 1; planeIdx < yCbCrMetaData.word1.planes; ++planeIdx) {
+    imageDesc = CreateExtractValue(imageDescArray, planeIdx);
+    YCbCrConverter.SetImgDescChroma(planeIdx, imageDesc);
+  }
+
   // Set sample coordinate ST and convert to UV and IJ coordinates
   YCbCrConverter.setCoord(coords[0], coords[1]);
   // Sample image source data

--- a/lgc/builder/YCbCrConverter.h
+++ b/lgc/builder/YCbCrConverter.h
@@ -227,6 +227,12 @@ public:
   // Generate image descriptor for chroma channel
   void genImgDescChroma();
 
+  // Set image descriptor for chroma channel
+  void SetImgDescChroma(unsigned planeIndex, llvm::Value *imageDesc);
+
+  // Get image descriptor for chroma channel
+  llvm::Value *GetImgDescChroma(unsigned planeIndex);
+
   // Convert from YCbCr to RGBA color space
   llvm::Value *convertColorSpace();
 


### PR DESCRIPTION
- Currently is only being used for ycbcr conversion sampler
- Stride is ResourceDescriptorSize * multiPlaneCount
- The second and thrid plane's descriptor locates based on
  the first plane descriptor addr + ResourceDescriptorSize

Signed-off-by: Jiajun Xie <jiaxie@amd.com>