### PR TITLE
Fix two issues reported by CTS dEQP-VK.glsl.builtin.precision_double.*

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -137,7 +137,7 @@ public:
   llvm::Value *CreatePower(llvm::Value *x, llvm::Value *y, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateExp(llvm::Value *x, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateLog(llvm::Value *x, const llvm::Twine &instName = "") override final;
-  llvm::Value *CreateInverseSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
+  llvm::Value *CreateSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
 
   // General arithmetic operations.
   llvm::Value *CreateSAbs(llvm::Value *x, const llvm::Twine &instName = "") override final;

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -92,8 +92,8 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "exp";
   case Log:
     return "log";
-  case InverseSqrt:
-    return "inverse.sqrt";
+  case Sqrt:
+    return "sqrt";
   case SAbs:
     return "sabs";
   case FSign:
@@ -609,12 +609,12 @@ Value *BuilderRecorder::CreateLog(Value *x, const Twine &instName) {
 }
 
 // =====================================================================================================================
-// Create inverse square root operation
+// Create square root operation
 //
 // @param x : Input value X
 // @param instName : Name to give final instruction
-Value *BuilderRecorder::CreateInverseSqrt(Value *x, const Twine &instName) {
-  return record(InverseSqrt, x->getType(), x, instName);
+Value *BuilderRecorder::CreateSqrt(Value *x, const Twine &instName) {
+  return record(Sqrt, x->getType(), x, instName);
 }
 
 // =====================================================================================================================
@@ -1860,7 +1860,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Cosh:
     case Determinant:
     case Exp:
-    case InverseSqrt:
+    case Sqrt:
     case Log:
     case MatrixInverse:
     case Opcode::CrossProduct:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -102,7 +102,7 @@ public:
     Power,
     Exp,
     Log,
-    InverseSqrt,
+    Sqrt,
     SAbs,
     FSign,
     SSign,
@@ -281,7 +281,7 @@ public:
   llvm::Value *CreatePower(llvm::Value *x, llvm::Value *y, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateExp(llvm::Value *x, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateLog(llvm::Value *x, const llvm::Twine &instName = "") override final;
-  llvm::Value *CreateInverseSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
+  llvm::Value *CreateSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
 
   // General arithmetic operations.
   llvm::Value *CreateSAbs(llvm::Value *x, const llvm::Twine &instName = "") override final;

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -298,8 +298,8 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     return m_builder->CreateLog(args[0]);
   }
 
-  case BuilderRecorder::InverseSqrt: {
-    return m_builder->CreateInverseSqrt(args[0]);
+  case BuilderRecorder::Sqrt: {
+    return m_builder->CreateSqrt(args[0]);
   }
 
   case BuilderRecorder::SAbs: {

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -395,11 +395,11 @@ public:
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateLog(llvm::Value *x, const llvm::Twine &instName = "") = 0;
 
-  // Create an inverse square root operation for a scalar or vector FP type
+  // Create a square root operation for a scalar or vector FP type
   //
   // @param x : Input value X
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateInverseSqrt(llvm::Value *x, const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateSqrt(llvm::Value *x, const llvm::Twine &instName = "") = 0;
 
   // Create "signed integer abs" operation for a scalar or vector integer value.
   //

--- a/llpc/test/shaderdb/OpExtInst_TestInverseSqrtDouble_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestInverseSqrtDouble_lit.frag
@@ -20,9 +20,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(double
+; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract double (...) @lgc.create.sqrt.f64(double
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract double 1.000000e+00, %[[SQRT]]
-; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x double> @llvm.sqrt.v3f64(<3 x double>
+; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.sqrt.v3f64(<3 x double>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <3 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>, %[[SQRT3]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestInverseSqrtFloat_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestInverseSqrtFloat_lit.frag
@@ -20,9 +20,9 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(float
+; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.sqrt.f32(float
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn float 1.000000e+00, %[[SQRT]]
-; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.sqrt.v3f32(<3 x float>
+; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.sqrt.v3f32(<3 x float>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %[[SQRT3]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestInverseSqrtVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestInverseSqrtVec4Const_lit.frag
@@ -14,7 +14,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT4:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.sqrt.v4f32(<4 x float>
+; SHADERTEST: %[[SQRT4:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.sqrt.v4f32(<4 x float>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %[[SQRT4]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestLengthDouble_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestLengthDouble_lit.frag
@@ -22,7 +22,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.fabs.f64(double
 ; SHADERTEST: = call reassoc nnan nsz arcp contract double (...) @lgc.create.dot.product.f64(<3 x double>
-; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(double
+; SHADERTEST: = call reassoc nnan nsz arcp contract double (...) @lgc.create.sqrt.f64(double
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestSqrtDouble_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestSqrtDouble_lit.frag
@@ -20,11 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(
-; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> @llvm.sqrt.v3f64(
-; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(
-; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.sqrt.f64(
+; SHADERTEST: = call reassoc nnan nsz arcp contract double (...) @lgc.create.sqrt.f64(
+; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.sqrt.v3f64(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestSqrtFloat_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestSqrtFloat_lit.frag
@@ -20,11 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.sqrt.v3f32(
-; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.sqrt.v3f32(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestSqrtVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestSqrtVec4Const_lit.frag
@@ -13,11 +13,7 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.sqrt.v4f32(
-; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sqrt.f32(
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.sqrt.v4f32(
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestExponentialFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestExponentialFuncs_lit.frag
@@ -38,8 +38,8 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.log.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.exp2.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.log2.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.sqrt.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.sqrt.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.sqrt.v3f16(<3 x half>
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.sqrt.v3f16(<3 x half>
 ; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn <3 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00>,
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestGeometryFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestGeometryFuncs_lit.frag
@@ -61,18 +61,18 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call {{.*}} half @llvm.fabs.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<2 x half>
-; SHADERTEST: = call {{.*}} half @llvm.sqrt.f16(half
+; SHADERTEST: = call {{.*}} half (...) @lgc.create.sqrt.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<3 x half>
-; SHADERTEST: = call {{.*}} half @llvm.sqrt.f16(half
+; SHADERTEST: = call {{.*}} half (...) @lgc.create.sqrt.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<4 x half>
-; SHADERTEST: = call {{.*}} half @llvm.sqrt.f16(half
+; SHADERTEST: = call {{.*}} half (...) @lgc.create.sqrt.f16(half
 ; SHADERTEST: = call {{.*}} half @llvm.fabs.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<2 x half>
-; SHADERTEST: = call {{.*}} half @llvm.sqrt.f16(half
+; SHADERTEST: = call {{.*}} half (...) @lgc.create.sqrt.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<3 x half>
-; SHADERTEST: = call {{.*}} half @llvm.sqrt.f16(half
+; SHADERTEST: = call {{.*}} half (...) @lgc.create.sqrt.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<4 x half>
-; SHADERTEST: = call {{.*}} half @llvm.sqrt.f16(half
+; SHADERTEST: = call {{.*}} half (...) @lgc.create.sqrt.f16(half
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<3 x half> %{{.*}}, <3 x half> %{{.*}})
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<4 x half> %{{.*}}, <4 x half> %{{.*}})
 ; SHADERTEST: = call {{.*}} half (...) @lgc.create.dot.product.f16(<2 x half> %{{.*}}, <2 x half> %{{.*}})

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7247,11 +7247,11 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450Sqrt:
     // Square root
-    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::sqrt, args[0]);
+    return getBuilder()->CreateSqrt(args[0]);
 
   case GLSLstd450InverseSqrt: {
     // Inverse square root
-    Value *sqrt = getBuilder()->CreateUnaryIntrinsic(Intrinsic::sqrt, args[0]);
+    auto sqrt = getBuilder()->CreateSqrt(args[0]);
     return getBuilder()->CreateFDiv(ConstantFP::get(sqrt->getType(), 1.0), sqrt);
   }
 
@@ -7501,7 +7501,7 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
     if (!isa<VectorType>(args[0]->getType()))
       return getBuilder()->CreateUnaryIntrinsic(Intrinsic::fabs, args[0]);
     Value *dot = getBuilder()->CreateDotProduct(args[0], args[0]);
-    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::sqrt, dot);
+    return getBuilder()->CreateSqrt(dot);
   }
 
   case GLSLstd450Distance: {
@@ -7510,7 +7510,7 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
     if (!isa<VectorType>(diff->getType()))
       return getBuilder()->CreateUnaryIntrinsic(Intrinsic::fabs, diff);
     Value *dot = getBuilder()->CreateDotProduct(diff, diff);
-    return getBuilder()->CreateUnaryIntrinsic(Intrinsic::sqrt, dot);
+    return getBuilder()->CreateSqrt(dot);
   }
 
   case GLSLstd450Cross:


### PR DESCRIPTION
1. Remove the method CreateInverseSqrt() in builder. It is not used.
   Rather, add a new method CreateSqrt() to replace LLVM intrinsic
   llvm.sqrt.*.

2. CreateSqrt() invokes LLVM intrinsic for fp16 and fp32 types. For
   fp64, the result value returned by HW instruction v_sqrt_f64 is
   not precise as expected. The SPIR-V spec requires 2ULP but HW
   could achieve 2^29ULP. We use Newton's method with one iteration
   to improve the precision.

3. For LDEXP, if the result value is denormal, the SPIR-V spec allows
   us to flush it to zero. HW v_ldexp_f64 returns rounded denormal
   rather than truncated denormal, which is not expected by the spec.
   Thus, we flush the result value to zero to meet spec's expectation.

Change-Id: Icd1e7d9d026636ac471bb82496d01985cf1add23