### PR TITLE
Remove codes handling subgroup compaction

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -61,8 +61,6 @@ const unsigned NggLdsManager::LdsRegionSizes[LdsRegionCount] = {
     // 1 byte (uint8) per thread
     Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionDrawFlag
     // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
-    SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionPrimCountInWaves
-    // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
     SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionVertCountInWaves
     // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCullDistance
@@ -109,7 +107,6 @@ const char *NggLdsManager::m_ldsRegionNames[LdsRegionCount] = {
     "Distributed primitive ID",             // LdsRegionDistribPrimId
     "Vertex position data",                 // LdsRegionPosData
     "Draw flag",                            // LdsRegionDrawFlag
-    "Primitive count in waves",             // LdsRegionPrimCountInWaves
     "Vertex count in waves",                // LdsRegionVertCountInWaves
     "Cull distance",                        // LdsRegionCullDistance
     "Vertex thread ID map",                 // LdsRegionVertThreadIdMap

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -49,7 +49,6 @@ enum NggLdsRegionType {
                               //   position data in NGG non pass-through mode)
   LdsRegionPosData,           // Position data to export
   LdsRegionDrawFlag,          // Draw flag indicating whether the vertex survives
-  LdsRegionPrimCountInWaves,  // Primitive count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionVertCountInWaves,  // Vertex count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionCullDistance,      // Aggregated sign value of cull distance (bitmask)
 


### PR DESCRIPTION
Subgroup compaction is deprecated since its performance gain is not
satisfying. Vertex compaction becomes the default mode. Thus, remove
all codes handling subgroup compaction.

This change is not functional, just a clean-up one.

Change-Id: Ide4649d263c00cf5c07a1b08247ea43a48e5b000