### PR TITLE
PatchBufferOp: fix and improve GetBufferDescLength lowering

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2635,12 +2635,12 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpArrayLength>(SPIRVValue *
   const StructLayout *const structLayout = m_m->getDataLayout().getStructLayout(structType);
   const unsigned offset = static_cast<unsigned>(structLayout->getElementOffset(remappedMemberIndex));
   Value *const offsetVal = getBuilder()->getInt32(offset);
-  Value *const bufferLength = getBuilder()->CreateGetBufferDescLength(pStruct, offsetVal);
+  Value *const arrayBytes = getBuilder()->CreateGetBufferDescLength(pStruct, offsetVal);
 
   Type *const memberType = structType->getStructElementType(remappedMemberIndex)->getArrayElementType();
   const unsigned stride = static_cast<unsigned>(m_m->getDataLayout().getTypeSizeInBits(memberType) / 8);
 
-  return getBuilder()->CreateUDiv(bufferLength, getBuilder()->getInt32(stride));
+  return getBuilder()->CreateUDiv(arrayBytes, getBuilder()->getInt32(stride));
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Since d717e0bd62 ("Hanlde the behavior of getting array length for
a null descriptor"), the implementation of OpArrayLength no longer
subtracts the runtime array's offset, relying on the
GetBufferDescLength implementation to do so. However, that
implementation only did the subtraction in the allowNullDescriptor
case.

Furthermore, the implementation of the allowNullDescriptor is
rather expensive: it shouldn't be necessary to check all dwords
of the descriptor. Instead, just clamping the array length to 0
should do the trick (which has the side effect of likely being
more robust in practice when applications use buffers that are
non-null but too small -- this case seems underspecified in
SPIR-V and Vulkan, so clamping should be fine).

Fixes: d717e0bd62 ("Hanlde the behavior of getting array length for a null descriptor")