### PR TITLE
Import debug info translator from upstream

### DIFF
--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -124,6 +124,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
   Function *newFunc = Function::Create(newFuncTy, oldFunc->getLinkage(), "", oldFunc->getParent());
   newFunc->setCallingConv(oldFunc->getCallingConv());
   newFunc->takeName(oldFunc);
+  newFunc->setSubprogram(oldFunc->getSubprogram());
 
   // Transfer code from old function to new function.
   while (!oldFunc->empty()) {

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugCompilationUnit.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugCompilationUnit.spvasm
@@ -1,0 +1,37 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: {{![0-9]*}} = !{i32 {{[0-9]*}}, !"Dwarf Version", i32 4}
+; SHADERTEST: {{![0-9]*}} = !{i32 {{[0-9]*}}, !"Debug Info Version", i32 3}
+; SHADERTEST: {{![0-9]*}} = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D1:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: [[D2:![0-9]*]])
+; SHADERTEST: [[D1]] = !DIFile(filename: "simple.hlsl", directory: ".")
+; SHADERTEST: [[D2]] = !{}
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugDeclare.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugDeclare.spvasm
@@ -1,0 +1,58 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D3:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D4:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: [[D5:![0-9]*]])
+; SHADERTEST: [[D4]] = !DIFile(filename: "simple.hlsl", directory: ".")
+; SHADERTEST: [[D5]] = !{}
+; SHADERTEST: [[D8:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: [[D4]], line: 1, type: [[D9:![0-9]*]], scopeLine: 1, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: [[D3]], templateParams: [[D5]], retainedNodes: [[D11:![0-9]*]])
+; SHADERTEST: [[D9]] = !DISubroutineType(types: [[D10:![0-9]*]])
+; SHADERTEST: [[D10]] = !{null}
+; SHADERTEST: [[D11]] = !{[[D7:![0-9]*]]}
+; SHADERTEST: [[D7]] = !DILocalVariable(name: "foo", scope: [[D8]], file: [[D4]], line: 1, type: [[D12:![0-9]*]])
+; SHADERTEST: [[D12]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D6:![0-9]*]] = !{i32 0}
+; SHADERTEST: [[D13:![0-9]*]] = !DILocation(line: 1, scope: [[D8]])
+; SHADERTEST: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "void main() { float foo; }"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugExpression.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugExpression.spvasm
@@ -1,0 +1,53 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: @llvm.dbg.declare(metadata float addrspace(5)* %0, metadata [[D1:![0-9]*]], metadata !DIExpression(DW_OP_constu, 1, DW_OP_constu, 1, DW_OP_plus)), !dbg [[D2:![0-9]*]]
+; SHADERTEST: [[D1]] = !DILocalVariable(name: "foo", scope: [[D3:![0-9]*]], file: !{{[0-9]*}}, line: 1, type: !{{[0-9]*}})
+; SHADERTEST: [[D2]] = !DILocation(line: 1, scope: [[D3]])
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "void main() { }"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%op0 = OpExtInst %void %DbgExt DebugOperation Constu 1
+%op1 = OpExtInst %void %DbgExt DebugOperation Constu 1
+%op2 = OpExtInst %void %DbgExt DebugOperation Plus
+%expr = OpExtInst %void %DbgExt DebugExpression %op0 %op1 %op2
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugFunctionDeclaration.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugFunctionDeclaration.spvasm
@@ -1,0 +1,58 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !{}
+; SHADERTEST: [[D2:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "v4f_main_f", scope: null, file: !{{[0-9]*}}, line: 12, type: [[D3:![0-9]*]], scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !{{[0-9]*}}, templateParams: [[D1]], declaration: [[D4:![0-9]*]], retainedNodes: !{{[0-9]*}})
+; SHADERTEST: [[D3]] = !DISubroutineType(types: [[D5:![0-9]*]])
+; SHADERTEST: [[D5]] = !{null}
+; SHADERTEST: [[D4]] = !DISubprogram(name: "main", linkageName: "v4f_main_f", scope: null, file: !{{[0-9]*}}, line: 12, type: [[D3]], flags: DIFlagPublic, spFlags: 0, templateParams: [[D1]])
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "struct VS_OUTPUT {
+  float4 pos : SV_POSITION;
+};
+main() {}
+"
+%main_name = OpString "main"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_linkage_name = OpString "v4f_main_f"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
+%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main %main_decl
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugLexicalBlock.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugLexicalBlock.spvasm
@@ -1,0 +1,51 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "struct VS_OUTPUT", scope: [[D2:![0-9]*]], file: !{{[0-9]*}}, line: 1, size: 32, elements: !{{[0-9]*}}, identifier: "struct VS_OUTPUT")
+; SHADERTEST: [[D2]] = !DINamespace(name: "namespace_name", scope: null)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%main_name = OpString "main"
+%foo_name = OpString "foo"
+%ty_name = OpString "struct VS_OUTPUT"
+%namespace_name = OpString "namespace_name"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%main_block = OpExtInst %void %DbgExt DebugLexicalBlock %dbg_src 1 1 %comp_unit %namespace_name
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%opaque = OpExtInst %void %DbgExt DebugTypeComposite %ty_name Class %dbg_src 1 1 %main_block %ty_name %int_32 FlagIsPublic
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %opaque %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugSourceNoText.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugSourceNoText.spvasm
@@ -1,0 +1,39 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: {{![0-9]*}} = !{i32 7, !"Dwarf Version", i32 4}
+; SHADERTEST: {{![0-9]*}} = !{i32 2, !"Debug Info Version", i32 3}
+; SHADERTEST: {{![0-9]*}} = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D1:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: [[D2:![0-9]*]])
+; SHADERTEST: [[D1]] = !DIFile(filename: "simple.hlsl", directory: ".")
+; SHADERTEST: [[D2]] = !{}
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeArray.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeArray.spvasm
@@ -1,0 +1,52 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[D2:![0-9]*]], size: 1024, elements: [[D3:![0-9]*]])
+; SHADERTEST: [[D2]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D3]] = !{[[D4:![0-9]*]]}
+; SHADERTEST: [[D4]] = !DISubrange(count: 32, lowerBound: 0)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %int_32
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_arr_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeEnum.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeEnum.spvasm
@@ -1,0 +1,73 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !DICompositeType(tag: DW_TAG_enumeration_type, name: "enum1", file: !{{[0-9]*}}, line: 1, baseType: [[D2:![0-9]*]], size: 32, flags: DIFlagEnumClass, elements: [[D3:![0-9]*]])
+; SHADERTEST: [[D2]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D3]] = !{[[D4:![0-9]*]], [[D5:![0-9]*]]}
+; SHADERTEST: [[D4]] = !DIEnumerator(name: "value1", value: 0)
+; SHADERTEST: [[D5]] = !DIEnumerator(name: "value2", value: 1)
+; SHADERTEST: [[D6:![0-9]*]] = !DICompositeType(tag: DW_TAG_enumeration_type, name: "enum2", file: !{{[0-9]*}}, line: 1, size: 32, elements: [[D3]])
+; SHADERTEST: [[D7:![0-9]*]] = !DICompositeType(tag: DW_TAG_enumeration_type, name: "enum3", file: !{{[0-9]*}}, line: 1, size: 32, elements: [[D8:![0-9]*]])
+; SHADERTEST: [[D8]] = !{}
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+%enum1_name = OpString "enum1"
+%enum2_name = OpString "enum2"
+%enum3_name = OpString "enum3"
+%enum_value1 = OpString "value1"
+%enum_value2 = OpString "value2"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+%u32_0 = OpConstant %u32 0
+%u32_1 = OpConstant %u32 1
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%none = OpExtInst %void %DbgExt DebugInfoNone
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%enum_info1 = OpExtInst %void %DbgExt DebugTypeEnum %enum1_name %float_info %dbg_src 1 1 %comp_unit %int_32 FlagIsPublic %u32_0 %enum_value1 %u32_1 %enum_value2
+%enum_info2 = OpExtInst %void %DbgExt DebugTypeEnum %enum2_name %none %dbg_src 1 1 %comp_unit %int_32 FlagIsPublic %u32_0 %enum_value1 %u32_1 %enum_value2
+%enum_info3 = OpExtInst %void %DbgExt DebugTypeEnum %enum3_name %none %dbg_src 1 1 %comp_unit %int_32 FlagIsPublic
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%foo_info1 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %enum_info1 %dbg_src 1 10 %main_info FlagIsLocal
+%foo_info2 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %enum_info2 %dbg_src 1 10 %main_info FlagIsLocal
+%foo_info3 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %enum_info3 %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo1 = OpVariable %f32_ptr_function Function
+%decl1 = OpExtInst %void %DbgExt DebugDeclare %foo_info1 %foo1 %null_expr
+%foo2 = OpVariable %f32_ptr_function Function
+%decl2 = OpExtInst %void %DbgExt DebugDeclare %foo_info2 %foo2 %null_expr
+%foo3 = OpVariable %f32_ptr_function Function
+%decl3 = OpExtInst %void %DbgExt DebugDeclare %foo_info3 %foo3 %null_expr
+
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeFunction.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeFunction.spvasm
@@ -1,0 +1,77 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D2:![0-9]*]] = !DISubroutineType(types: [[D3:![0-9]*]])
+; SHADERTEST: [[D3]] = !{null}
+; SHADERTEST: [[D1:![0-9]*]] = !DILocalVariable(name: "foo1", scope: !{{[0-9*]}}, file: !{{[0-9]*}}, line: 1, type: [[D2]])
+; SHADERTEST: [[D4:![0-9]*]] = !DILocalVariable(name: "foo2", scope: !{{[0-9]*}}, file: !{{[0-9]*}}, line: 2, type: [[D5:![0-9]*]])
+; SHADERTEST: [[D5]] = !DISubroutineType(types: [[D6:![0-9]*]])
+; SHADERTEST: [[D6]] = !{[[D7:![0-9]*]]}
+; SHADERTEST: [[D7]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D8:![0-9]*]] = !DILocalVariable(name: "foo3", scope: !{{[0-9*]}}, file: !{{[0-9*]}}, line: 3, type: [[D9:![0-9]*]])
+; SHADERTEST: [[D10:![0-9]*]] = !DISubroutineType(types: [[D11:![0-9]*]])
+; SHADERTEST: [[D11]] = !{[[D7]], [[D7]]}
+; SHADERTEST: [[D12:![0-9]*]] = !DILocalVariable(name: "foo4", scope: !{{[0-9*]}}, file: !{{[0-9*]}}, line: 4, type: [[D13:![0-9]*]])
+; SHADERTEST: [[D13]] = !DISubroutineType(types: [[D14:![0-9]*]])
+; SHADERTEST: [[D14]] = !{null, [[D7]], [[D7]]}
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%main_name = OpString "main"
+%main_linkage_name = OpString "v_main"
+%float_name = OpString "float"
+%foo_name1 = OpString "foo1"
+%foo_name2 = OpString "foo2"
+%foo_name3 = OpString "foo3"
+%foo_name4 = OpString "foo4"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%main_type_info1 = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
+%main_type_info2 = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %float_info
+%main_type_info3 = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %float_info %float_info
+%main_type_info4 = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void %float_info %float_info
+%foo_info1 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name1 %main_type_info1 %dbg_src 1 10 %main_info FlagIsLocal
+%foo_info2 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name2 %main_type_info2 %dbg_src 2 10 %main_info FlagIsLocal
+%foo_info3 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name3 %main_type_info3 %dbg_src 3 10 %main_info FlagIsLocal
+%foo_info4 = OpExtInst %void %DbgExt DebugLocalVariable %foo_name4 %main_type_info4 %dbg_src 4 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo1 = OpVariable %f32_ptr_function Function
+%decl1 = OpExtInst %void %DbgExt DebugDeclare %foo_info1 %foo1 %null_expr
+%foo2 = OpVariable %f32_ptr_function Function
+%decl2 = OpExtInst %void %DbgExt DebugDeclare %foo_info2 %foo1 %null_expr
+%foo3 = OpVariable %f32_ptr_function Function
+%decl3 = OpExtInst %void %DbgExt DebugDeclare %foo_info3 %foo1 %null_expr
+%foo4 = OpVariable %f32_ptr_function Function
+%decl4 = OpExtInst %void %DbgExt DebugDeclare %foo_info4 %foo1 %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeInheritance.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeInheritance.spvasm
@@ -1,0 +1,76 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D10:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "v4f_main_f", scope: null, file: !{{[0-9]*}}, line: 12, type: !{{[0-9]*}}, scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !{{[0-9]*}}, templateParams: !{{[0-9]*}}, retainedNodes: !{{[0-9]*}})
+; SHADERTEST: [[D2:![0-9]*]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[D3:![0-9]*]], size: 128, flags: DIFlagVector, elements: [[D4:![0-9]*]])
+; SHADERTEST: [[D3]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D4]] = !{[[D5:![0-9]*]]}
+; SHADERTEST: [[D5]] = !DISubrange(count: 4, lowerBound: 0)
+; SHADERTEST: !{{[0-9]*}} = !DILocalVariable(name: "foo", scope: !{{[0-9]*}}, file: !{{[0-9]*}}, line: 1, type: [[D1:![0-9]*]])
+; SHADERTEST: [[D1]] = !DIDerivedType(tag: DW_TAG_inheritance, scope: [[D6:![0-9]*]], baseType: [[D7:![0-9]*]], offset: 128, flags: DIFlagPublic, extraData: i32 0)
+; SHADERTEST: [[D6]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Foo", file: !{{[0-9]*}}, line: 1, elements: !{{[0-9]*}}, identifier: "Foo")
+; SHADERTEST: [[D7]] = !DICompositeType(tag: DW_TAG_structure_type, name: "struct VS_OUTPUT", file: !{{[0-9]*}}, line: 1, size: 128, elements: [[D8:![0-9]*]], identifier: "VS_OUTPUT")
+; SHADERTEST: [[D8]] = !{[[D9:![0-9]*]], [[D10]], [[D1]]}
+; SHADERTEST: [[D9]] = !DIDerivedType(tag: DW_TAG_member, name: "pos : SV_POSITION", scope: [[D7]], file: !{{[0-9]*}}, line: 2, baseType: [[D2]], size: 128, flags: DIFlagPublic)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "struct VS_OUTPUT {
+  float4 pos : SV_POSITION;
+};
+struct foo : VS_OUTPUT {
+};
+main() {}
+"
+%VS_OUTPUT_name = OpString "struct VS_OUTPUT"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%foo_type_name = OpString "Foo"
+%VS_OUTPUT_pos_name = OpString "pos : SV_POSITION"
+%VS_OUTPUT_linkage_name = OpString "VS_OUTPUT"
+%main_name = OpString "main"
+%main_linkage_name = OpString "v4f_main_f"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%int_128 = OpConstant %u32 128
+%int_0 = OpConstant %u32 0
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%VS_OUTPUT_info = OpExtInst %void %DbgExt DebugTypeComposite %VS_OUTPUT_name Structure %dbg_src 1 1 %comp_unit %VS_OUTPUT_linkage_name %int_128 FlagIsPublic %VS_OUTPUT_pos_info %main_info %child
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%v4float_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
+%VS_OUTPUT_pos_info = OpExtInst %void %DbgExt DebugTypeMember %VS_OUTPUT_pos_name %v4float_info %dbg_src 2 3 %VS_OUTPUT_info %int_0 %int_128 FlagIsPublic
+%main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %v4float_info %float_info
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main
+%foo_type_info = OpExtInst %void %DbgExt DebugTypeComposite %foo_type_name Structure %dbg_src 1 1 %comp_unit %foo_type_name %int_0 FlagIsPublic
+%child = OpExtInst %void %DbgExt DebugTypeInheritance %foo_type_info %VS_OUTPUT_info %int_128 %int_128 FlagIsPublic
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %child %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypePointer.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypePointer.spvasm
@@ -1,0 +1,53 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[D2:![0-9]*]], dwarfAddressSpace: 5)
+; SHADERTEST: [[D2]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "float4 main(float arg) {
+  float* foo;
+}
+"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%pfloat_info = OpExtInst %void %DbgExt DebugTypePointer %float_info Function FlagIsLocal
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %pfloat_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeQualifier.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeQualifier.spvasm
@@ -1,0 +1,54 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: [[D2:![0-9]*]])
+; SHADERTEST: [[D2]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "float4 main(float arg) {
+  float foo;
+  return float4(0, 0, 0, 0);
+}
+"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%cfloat_info = OpExtInst %void %DbgExt DebugTypeQualifier %float_info ConstType
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %cfloat_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeVector.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypeVector.spvasm
@@ -1,0 +1,52 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D1:![0-9]*]] = !DICompositeType(tag: DW_TAG_array_type, baseType: [[D2:![0-9]*]], size: 128, flags: DIFlagVector, elements: [[D3:![0-9]*]])
+; SHADERTEST: [[D2]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D3]] = !{[[D4:![0-9]*]]}
+; SHADERTEST: [[D4]] = !DISubrange(count: 4, lowerBound: 0)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %vfloat_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypedef.spvasm
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_DebugTypedef.spvasm
@@ -1,0 +1,54 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: [[D2:![0-9]*]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Foo", file: !{{[0-9]*}}, line: 1, baseType: [[D3:![0-9]*]])
+; SHADERTEST: [[D3]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+OpCapability Shader
+OpCapability Float16
+OpCapability Float64
+OpCapability Int16
+OpCapability Int64
+
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+%extinst = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+
+%src = OpString "simple.hlsl"
+%code = OpString "typdef float Foo;
+main() {
+  Foo foo;
+}"
+%float_name = OpString "float"
+%foo_name = OpString "foo"
+%main_name = OpString "main"
+%type_name = OpString "Foo"
+
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%f32 = OpTypeFloat 32
+%int_32 = OpConstant %u32 32
+%f32_ptr_function = OpTypePointer Function %f32
+
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
+%null_expr = OpExtInst %void %DbgExt DebugExpression
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
+%func_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsProtected|FlagIsPrivate %void
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %func_info %dbg_src 1 1 %comp_unit %main_name FlagIsProtected|FlagIsPrivate 1 %main
+%type_info = OpExtInst %void %DbgExt DebugTypedef %type_name %float_info %dbg_src 1 1 %comp_unit
+%foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %type_info %dbg_src 1 10 %main_info FlagIsLocal
+
+%main = OpFunction %void None %func
+%main_entry = OpLabel
+
+%foo = OpVariable %f32_ptr_function Function
+%decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
+
+OpReturn
+OpFunctionEnd

--- a/llpc/test/shaderdb/debug_info/DebugInfo_TestFsBasic.frag
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_TestFsBasic.frag
@@ -19,27 +19,27 @@ void main()
 ; SHADERTEST: !spirv.InOut [[D1:![0-9]*]]
 ; SHADERTEST: !spirv.InOut [[D2:![0-9]*]]
 ; SHADERTEST: !spirv.InOut [[D2]]
-; SHADERTEST: define spir_func void @main() #{{[0-9]*}} !spirv.ExecutionModel [[D3:![0-9]*]] {
+; SHADERTEST: define spir_func void @main() #{{[0-9]*}} !dbg [[D12:![0-9]*]] !spirv.ExecutionModel [[D3:![0-9]*]] {
 ; SHADERTEST: load {{.*}} !dbg [[D4:![0-9]*]]
 ; SHADERTEST: store {{.*}} !dbg [[D4]]
 ; SHADERTEST: load {{.*}} !dbg [[D5:![0-9]*]]
 ; SHADERTEST: store {{.*}} !dbg [[D5]]
 ; SHADERTEST: ret void, !dbg [[D5]]
-; SHADERTEST: !llvm.dbg.cu = !{[[D6:![0-9]*]]}
 ; SHADERTEST: !llvm.module.flags = !{[[D7:![0-9]*]], [[D8:![0-9]*]]}
+; SHADERTEST: !llvm.dbg.cu = !{[[D6:![0-9]*]]}
 ; SHADERTEST: [[D0]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
 ; SHADERTEST: [[D1]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
 ; SHADERTEST: [[D2]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
+; SHADERTEST: [[D7:![0-9]*]] = !{i32 2, !"Dwarf Version", i32 4}
+; SHADERTEST: [[D8:![0-9]*]] = !{i32 2, !"Debug Info Version", i32 3}
 ; SHADERTEST: [[D9:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_C99, file: [[D10:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: [[D11:![0-9]*]])
 ; SHADERTEST: [[D10]] = !DIFile(filename: "spirv.dbg.cu", directory: ".")
 ; SHADERTEST: [[D11]] = !{}
-; SHADERTEST: [[D7:![0-9]*]] = !{i32 2, !"Dwarf Version", i32 4}
-; SHADERTEST: [[D8:![0-9]*]] = !{i32 2, !"Debug Info Version", i32 3}
-; SHADERTEST: [[D3]] = !{i32 4}
-; SHADERTEST: [[D4]] = !DILocation(line: 11, scope: [[D12:![0-9]*]])
 ; SHADERTEST: [[D12]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: [[D13:![0-9]*]], file: [[D13]], type: [[D14:![0-9]*]], spFlags: DISPFlagDefinition, unit: [[D9]], retainedNodes: [[D11]])
 ; SHADERTEST: [[D13]] = !DIFile(filename: "", directory: ".")
 ; SHADERTEST: [[D14]] = !DISubroutineType(types: [[D11]])
+; SHADERTEST: [[D3]] = !{i32 4}
+; SHADERTEST: [[D4]] = !DILocation(line: 11, scope: [[D12]])
 ; SHADERTEST: [[D15:![0-9]*]] = !DILocation(line: 12, scope: [[D12]])
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/debug_info/DebugInfo_TestVsBasic.vert
+++ b/llpc/test/shaderdb/debug_info/DebugInfo_TestVsBasic.vert
@@ -20,7 +20,7 @@ void main()
 ; SHADERTEST: !spirv.InOut [[D1:![0-9]*]]
 ; SHADERTEST: !spirv.InOut [[D2:![0-9]*]]
 ; SHADERTEST: !spirv.InOut [[D3:![0-9]*]]
-; SHADERTEST: define spir_func void @main() #{{[0-9]*}} !spirv.ExecutionModel [[D4:![0-9]*]] {
+; SHADERTEST: define spir_func void @main() #{{[0-9]*}} !dbg [[D15:![0-9]*]] !spirv.ExecutionModel [[D4:![0-9]*]] {
 ; SHADERTEST: load {{.*}} !dbg [[D5:![0-9]*]]
 ; SHADERTEST: store {{.*}} !dbg [[D5]]
 ; SHADERTEST: load {{.*}} !dbg [[D6:![0-9]*]]
@@ -30,22 +30,22 @@ void main()
 ; SHADERTEST: fadd {{.*}} !dbg [[D7]]
 ; SHADERTEST: store {{.*}} !dbg [[D7]]
 ; SHADERTEST: ret void, !dbg [[D8:![0-9]*]]
-; SHADERTEST: !llvm.dbg.cu = !{[[D9:![0-9]*]]}
 ; SHADERTEST: !llvm.module.flags = !{[[D10:![0-9]*]], [[D11:![0-9]*]]}
+; SHADERTEST: !llvm.dbg.cu = !{[[D9:![0-9]*]]}
 ; SHADERTEST: [[D0]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
 ; SHADERTEST: [[D1]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
 ; SHADERTEST: [[D2]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
 ; SHADERTEST: [[D3]] = !{{.*}} i64, i64 }, { i64, i64 },
+; SHADERTEST: [[D10:![0-9]*]] = !{i32 2, !"Dwarf Version", i32 4}
+; SHADERTEST: [[D11:![0-9]*]] = !{i32 2, !"Debug Info Version", i32 3}
 ; SHADERTEST: [[D12:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_C99, file: [[D13:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: [[D14:![0-9]*]])
 ; SHADERTEST: [[D13]] = !DIFile(filename: "spirv.dbg.cu", directory: ".")
 ; SHADERTEST: [[D14]] = !{}
-; SHADERTEST: [[D10:![0-9]*]] = !{i32 2, !"Dwarf Version", i32 4}
-; SHADERTEST: [[D11:![0-9]*]] = !{i32 2, !"Debug Info Version", i32 3}
-; SHADERTEST: [[D4]] = !{i32 0}
-; SHADERTEST: [[D5]] = !DILocation(line: 9, scope: [[D15:![0-9]*]])
 ; SHADERTEST: [[D15]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: [[D16:![0-9]*]], file: [[D16]], type: [[D17:![0-9]*]], spFlags: DISPFlagDefinition, unit: [[D12]], retainedNodes: [[D14]])
 ; SHADERTEST: [[D16]] = !DIFile(filename: "", directory: ".")
 ; SHADERTEST: [[D17]] = !DISubroutineType(types: [[D14]])
+; SHADERTEST: [[D4]] = !{i32 0}
+; SHADERTEST: [[D5]] = !DILocation(line: 9, scope: [[D15]])
 ; SHADERTEST: [[D6:![0-9]*]] = !DILocation(line: 10, scope: [[D15]])
 ; SHADERTEST: [[D7:![0-9]*]] = !DILocation(line: 11, scope: [[D15]])
 ; SHADERTEST: [[D8:![0-9]*]] = !DILocation(line: 13, scope: [[D15]])

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -408,7 +408,10 @@ void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipe
   } else if (shaderStage == ShaderStageFragment) {
     // Set dummy color formats for fragment outputs
     for (auto varId : ArrayRef<SPIRVWord>(inOuts.first, inOuts.second)) {
-      auto var = static_cast<SPIRVVariable *>(module->getValue(varId));
+      auto entry = module->getValue(varId);
+      if (!entry->isVariable())
+        continue;
+      auto var = static_cast<SPIRVVariable *>(entry);
       if (var->getStorageClass() != StorageClassOutput)
         continue;
 

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1,11 +1,11 @@
-//===- LLVMToSPIRVDbgTran.cpp - Converts SPIR-V to LLVM ----------------*- C++ -*-===//
+//===- SPIRVToLLVMDbgTran.cpp - Converts debug info to LLVM -----*- C++ -*-===//
 //
 //                     The LLVM/SPIR-V Translator
 //
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
 //
-// Copyright (c) 2014 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018 Intel Corporation. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,7 +19,7 @@
 // Redistributions in binary form must reproduce the above copyright notice,
 // this list of conditions and the following disclaimers in the documentation
 // and/or other materials provided with the distribution.
-// Neither the names of Advanced Micro Devices, Inc., nor the names of its
+// Neither the names of Intel Corporation, nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // Software without specific prior written permission.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -31,91 +31,956 @@
 // THE SOFTWARE.
 //
 //===----------------------------------------------------------------------===//
-/// \file
-///
-/// This file implements translation of debug info from SPIR-V to LLVM metadata
-///
+//
+// This file implements translation of debug info from SPIR-V to LLVM metadata
+//
 //===----------------------------------------------------------------------===//
+
 #include "SPIRVToLLVMDbgTran.h"
+#include "SPIRVEntry.h"
 #include "SPIRVFunction.h"
 #include "SPIRVInstruction.h"
+#include "SPIRVInternal.h"
+#include "SPIRVReader.h"
+#include "SPIRVType.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/Module.h"
 
-using namespace SPIRV;
+using namespace std;
+using namespace SPIRVDebug::Operand;
 
-SPIRVToLLVMDbgTran::SPIRVToLLVMDbgTran(SPIRVModule *tbm, Module *tm)
-    : m_bm(tbm), m_m(tm), m_spDbg(m_bm), m_builder(*m_m) {
-  m_enable = m_bm->hasDebugInfo();
+namespace SPIRV {
+
+SPIRVToLLVMDbgTran::SPIRVToLLVMDbgTran(SPIRVModule *TBM, Module *TM, SPIRVToLLVM *Reader)
+    : BM(TBM), M(TM), Builder(*M), SPIRVReader(Reader) {
+  Enable = BM->hasDebugInfo();
 }
 
-void SPIRVToLLVMDbgTran::createCompileUnit() {
-  if (!m_enable)
+void SPIRVToLLVMDbgTran::createCompilationUnit() {
+  if (!Enable)
     return;
-  auto file = m_spDbg.getEntryPointFileStr(ExecutionModelVertex, 0);
-  if (file.empty())
-    file = "spirv.dbg.cu"; // File name must be non-empty
-  std::string baseName;
-  std::string path;
-  splitFileName(file, baseName, path);
-  m_builder.createCompileUnit(dwarf::DW_LANG_C99, m_builder.createFile(baseName, path), "spirv", false, "", 0, "",
-                              DICompileUnit::LineTablesOnly);
-}
-
-void SPIRVToLLVMDbgTran::addDbgInfoVersion() {
-  if (!m_enable)
-    return;
-  m_m->addModuleFlag(Module::Warning, "Dwarf Version", dwarf::DWARF_VERSION);
-  m_m->addModuleFlag(Module::Warning, "Debug Info Version", DEBUG_METADATA_VERSION);
-}
-
-DIFile *SPIRVToLLVMDbgTran::getDIFile(const std::string &fileName) {
-  return getOrInsert(m_fileMap, fileName, [=]() -> DIFile * {
-    std::string baseName;
-    std::string path;
-    splitFileName(fileName, baseName, path);
-    return m_builder.createFile(baseName, path);
-  });
-}
-
-DISubprogram *SPIRVToLLVMDbgTran::getDISubprogram(SPIRVFunction *sf, Function *f) {
-  return getOrInsert(m_funcMap, f, [=]() {
-    auto df = getDIFile(m_spDbg.getFunctionFileStr(sf));
-    auto fn = f->getName();
-    auto ln = m_spDbg.getFunctionLineNo(sf);
-    auto spFlags = DISubprogram::SPFlagDefinition;
-    if (Function::isInternalLinkage(f->getLinkage()))
-      spFlags |= DISubprogram::SPFlagLocalToUnit;
-    return m_builder.createFunction(df, fn, fn, df, ln,
-                                    m_builder.createSubroutineType(m_builder.getOrCreateTypeArray(None)), ln,
-                                    DINode::FlagZero, spFlags);
-  });
-}
-
-void SPIRVToLLVMDbgTran::transDbgInfo(SPIRVValue *sv, Value *v) {
-  if (!m_enable || !sv->hasLine())
-    return;
-  if (auto i = dyn_cast<Instruction>(v)) {
-    assert(sv->isInst() && "Invalid instruction");
-    auto si = static_cast<SPIRVInstruction *>(sv);
-    assert(si->getParent() && si->getParent()->getParent() && "Invalid instruction");
-    auto line = sv->getLine();
-    i->setDebugLoc(DebugLoc::get(line->getLine(), line->getColumn(),
-                                 getDISubprogram(si->getParent()->getParent(), i->getParent()->getParent())));
+  std::string FileName;
+  SPIRVFunction *EntryPoint = BM->getEntryPoint(BM->getExecutionModel(), 0U);
+  if (EntryPoint && EntryPoint->hasLine()) {
+    FileName = EntryPoint->getLine()->getFileNameStr();
+  } else {
+    FileName = "spirv.dbg.cu"; // File name must be non-empty
   }
+  M->addModuleFlag(Module::Warning, "Dwarf Version", dwarf::DWARF_VERSION);
+  M->addModuleFlag(Module::Warning, "Debug Info Version", DEBUG_METADATA_VERSION);
+  Builder.createCompileUnit(dwarf::DW_LANG_C99, getDIFile(FileName), "spirv", false, "", 0, "",
+                            DICompileUnit::LineTablesOnly);
+}
+
+DIFile *SPIRVToLLVMDbgTran::getDIFile(const string &FileName) {
+  return getOrInsert(FileMap, FileName, [=]() {
+    SplitFileName Split(FileName);
+    return Builder.createFile(Split.BaseName, Split.Path);
+  });
+}
+
+SPIRVExtInst *SPIRVToLLVMDbgTran::getDbgInst(const SPIRVId Id) {
+  SPIRVEntry *E = BM->getEntry(Id);
+  if (isa<OpExtInst>(E)) {
+    SPIRVExtInst *EI = static_cast<SPIRVExtInst *>(E);
+    if (EI->getExtSetKind() == SPIRV::SPIRVEIS_Debug)
+      return EI;
+  }
+  return nullptr;
+}
+
+const std::string &SPIRVToLLVMDbgTran::getString(const SPIRVId Id) {
+  SPIRVString *String = BM->get<SPIRVString>(Id);
+  assert(String && "Invalid string");
+  return String->getStr();
+}
+
+void SPIRVToLLVMDbgTran::transDbgInfo(SPIRVValue *SV, Value *V) {
+  if (!Enable || !SV->hasLine())
+    return;
+  // A constant sampler does not have a corresponding SPIRVInstruction.
+  if (SV->getOpCode() == OpConstantSampler)
+    return;
+
+  if (Instruction *I = dyn_cast<Instruction>(V)) {
+    SPIRVInstruction *SI = static_cast<SPIRVInstruction *>(SV);
+    I->setDebugLoc(transDebugScope(SI, I));
+  }
+}
+
+DIScope *SPIRVToLLVMDbgTran::getScope(const SPIRVEntry *ScopeInst) {
+  if (ScopeInst->getOpCode() == OpString)
+    return getDIFile(static_cast<const SPIRVString *>(ScopeInst)->getStr());
+  return transDebugInst<DIScope>(static_cast<const SPIRVExtInst *>(ScopeInst));
+}
+
+DICompileUnit *SPIRVToLLVMDbgTran::transCompileUnit(const SPIRVExtInst *DebugInst) {
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+
+  using namespace SPIRVDebug::Operand::CompilationUnit;
+  assert(Ops.size() == OperandCount && "Invalid number of operands");
+  M->addModuleFlag(llvm::Module::Max, "Dwarf Version", Ops[DWARFVersionIdx]);
+  M->addModuleFlag(Module::Warning, "Debug Info Version", DEBUG_METADATA_VERSION);
+  SPIRVExtInst *Source = BM->get<SPIRVExtInst>(Ops[SourceIdx]);
+  SPIRVId FileId = Source->getArguments()[SPIRVDebug::Operand::Source::FileIdx];
+  std::string File = getString(FileId);
+  unsigned SourceLang = Ops[LanguageIdx];
+  CU = Builder.createCompileUnit(SourceLang, getDIFile(File), "spirv", false, "", 0);
+  return CU;
+}
+
+DIBasicType *SPIRVToLLVMDbgTran::transTypeBasic(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeBasic;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() == OperandCount && "Invalid number of operands");
+  StringRef Name = getString(Ops[NameIdx]);
+  auto Tag = static_cast<SPIRVDebug::EncodingTag>(Ops[EncodingIdx]);
+  unsigned Encoding = SPIRV::DbgEncodingMap::rmap(Tag);
+  if (Encoding == 0)
+    return Builder.createUnspecifiedType(Name);
+  uint64_t Size = BM->get<SPIRVConstant>(Ops[SizeIdx])->getZExtIntValue();
+  return Builder.createBasicType(Name, Size, Encoding);
+}
+
+DIDerivedType *SPIRVToLLVMDbgTran::transTypeQualifier(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeQualifier;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() == OperandCount && "Invalid number of operands");
+  DIType *BaseTy = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+  unsigned Tag = SPIRV::DbgTypeQulifierMap::rmap(static_cast<SPIRVDebug::TypeQualifierTag>(Ops[QualifierIdx]));
+  return Builder.createQualifiedType(Tag, BaseTy);
+}
+
+DIType *SPIRVToLLVMDbgTran::transTypePointer(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypePointer;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() == OperandCount && "Invalid number of operands");
+  DIType *PointeeTy = nullptr;
+  if (BM->getEntry(Ops[BaseTypeIdx])->getOpCode() != OpTypeVoid)
+    PointeeTy = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+  Optional<unsigned> AS;
+  if (Ops[StorageClassIdx] != ~0U) {
+    auto SC = static_cast<SPIRVStorageClassKind>(Ops[StorageClassIdx]);
+    AS = SPIRSPIRVAddrSpaceMap::rmap(SC);
+  }
+  DIType *Ty;
+  SPIRVWord Flags = Ops[FlagsIdx];
+  if (Flags & SPIRVDebug::FlagIsLValueReference)
+    Ty = Builder.createReferenceType(dwarf::DW_TAG_reference_type, PointeeTy, 0, 0, AS);
+  else if (Flags & SPIRVDebug::FlagIsRValueReference)
+    Ty = Builder.createReferenceType(dwarf::DW_TAG_rvalue_reference_type, PointeeTy, 0, 0, AS);
+  else
+    Ty = Builder.createPointerType(PointeeTy, BM->getAddressingModel() * 32, 0, AS);
+
+  if (Flags & SPIRVDebug::FlagIsObjectPointer)
+    Ty = Builder.createObjectPointerType(Ty);
+  else if (Flags & SPIRVDebug::FlagIsArtificial)
+    Ty = Builder.createArtificialType(Ty);
+
+  return Ty;
+}
+
+DICompositeType *SPIRVToLLVMDbgTran::transTypeArray(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeArray;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  DIType *BaseTy = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+  size_t TotalCount = 1;
+  SmallVector<llvm::Metadata *, 8> Subscripts;
+  for (size_t I = ComponentCountIdx, E = Ops.size(); I < E; ++I) {
+    SPIRVConstant *C = BM->get<SPIRVConstant>(Ops[I]);
+    int64_t Count = static_cast<int64_t>(C->getZExtIntValue());
+    Subscripts.push_back(Builder.getOrCreateSubrange(0, Count));
+    TotalCount *= static_cast<uint64_t>(Count);
+  }
+  DINodeArray SubscriptArray = Builder.getOrCreateArray(Subscripts);
+  size_t Size = BaseTy->getSizeInBits() * TotalCount;
+  return Builder.createArrayType(Size, 0 /*align*/, BaseTy, SubscriptArray);
+}
+
+DICompositeType *SPIRVToLLVMDbgTran::transTypeVector(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeVector;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  DIType *BaseTy = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+  SPIRVWord Count = Ops[ComponentCountIdx];
+  uint64_t Size = BaseTy->getSizeInBits() * Count;
+
+  SmallVector<llvm::Metadata *, 8> Subscripts;
+  Subscripts.push_back(Builder.getOrCreateSubrange(0, Count));
+  DINodeArray SubscriptArray = Builder.getOrCreateArray(Subscripts);
+
+  return Builder.createVectorType(Size, 0 /*align*/, BaseTy, SubscriptArray);
+}
+
+DICompositeType *SPIRVToLLVMDbgTran::transTypeComposite(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeComposite;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  StringRef Name = getString(Ops[NameIdx]);
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  DIScope *ParentScope = getScope(BM->getEntry(Ops[ParentIdx]));
+
+  uint64_t Size = 0;
+  SPIRVEntry *SizeEntry = BM->getEntry(Ops[SizeIdx]);
+  if (!SizeEntry->isExtInst(SPIRVEIS_Debug, SPIRVDebug::DebugInfoNone)) {
+    Size = BM->get<SPIRVConstant>(Ops[SizeIdx])->getZExtIntValue();
+  }
+
+  uint64_t Align = 0;
+  DIType *DerivedFrom = nullptr;
+  StringRef Identifier;
+  SPIRVEntry *UniqId = BM->get<SPIRVEntry>(Ops[LinkageNameIdx]);
+  if (UniqId->getOpCode() == OpString)
+    Identifier = static_cast<SPIRVString *>(UniqId)->getStr();
+
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if (Ops[FlagsIdx] & SPIRVDebug::FlagIsFwdDecl)
+    Flags |= DINode::FlagFwdDecl;
+  if (Ops[FlagsIdx] & SPIRVDebug::FlagTypePassByValue)
+    Flags |= DINode::FlagTypePassByValue;
+  if (Ops[FlagsIdx] & SPIRVDebug::FlagTypePassByReference)
+    Flags |= DINode::FlagTypePassByReference;
+
+  DICompositeType *CT = nullptr;
+  switch (Ops[TagIdx]) {
+  case SPIRVDebug::Class:
+    CT = Builder.createClassType(ParentScope, Name, File, LineNo, Size, Align, 0, Flags, DerivedFrom,
+                                 DINodeArray() /*elements*/, nullptr /*VTableHolder*/, nullptr /*TemplateParams*/,
+                                 Identifier);
+    break;
+  case SPIRVDebug::Structure:
+    CT = Builder.createStructType(ParentScope, Name, File, LineNo, Size, Align, Flags, DerivedFrom,
+                                  DINodeArray() /*elements*/, 0 /*RunTimeLang*/, nullptr /*VTableHolder*/, Identifier);
+    break;
+  case SPIRVDebug::Union:
+    CT = Builder.createUnionType(ParentScope, Name, File, LineNo, Size, Align, Flags, DINodeArray(), 0 /*RuntimrLang*/,
+                                 Identifier);
+    break;
+  default:
+    llvm_unreachable("Unexpected composite type");
+    break;
+  }
+  DebugInstCache[DebugInst] = CT;
+  SmallVector<llvm::Metadata *, 8> EltTys;
+  for (size_t I = FirstMemberIdx; I < Ops.size(); ++I) {
+    EltTys.push_back(transDebugInst(BM->get<SPIRVExtInst>(Ops[I])));
+  }
+  DINodeArray Elements = Builder.getOrCreateArray(EltTys);
+  Builder.replaceArrays(CT, Elements);
+  assert(CT && "Composite type translation failed.");
+  return CT;
+}
+
+DINode *SPIRVToLLVMDbgTran::transTypeMember(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeMember;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  StringRef Name = getString(Ops[NameIdx]);
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  DIType *BaseType = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  uint64_t OffsetInBits = BM->get<SPIRVConstant>(Ops[OffsetIdx])->getZExtIntValue();
+  unsigned SPIRVFlags = Ops[FlagsIdx];
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if ((SPIRVDebug::FlagAccess & SPIRVFlags) == SPIRVDebug::FlagIsPublic) {
+    Flags |= DINode::FlagPublic;
+  } else if (SPIRVFlags & SPIRVDebug::FlagIsProtected) {
+    Flags |= DINode::FlagProtected;
+  } else if (SPIRVFlags & SPIRVDebug::FlagIsPrivate) {
+    Flags |= DINode::FlagPrivate;
+  }
+  if (SPIRVFlags & SPIRVDebug::FlagIsStaticMember)
+    Flags |= DINode::FlagStaticMember;
+
+  if (Flags & DINode::FlagStaticMember && Ops.size() > MinOperandCount) {
+    SPIRVValue *ConstVal = BM->get<SPIRVValue>(Ops[ValueIdx]);
+    assert(isConstantOpCode(ConstVal->getOpCode()) && "Static member must be a constant");
+    llvm::Value *Val = SPIRVReader->transValue(ConstVal, nullptr, nullptr);
+    return Builder.createStaticMemberType(Scope, Name, File, LineNo, BaseType, Flags, cast<llvm::Constant>(Val));
+  }
+  uint64_t Size = BM->get<SPIRVConstant>(Ops[SizeIdx])->getZExtIntValue();
+  uint64_t Alignment = 0;
+
+  return Builder.createMemberType(Scope, Name, File, LineNo, Size, Alignment, OffsetInBits, Flags, BaseType);
+}
+
+DINode *SPIRVToLLVMDbgTran::transTypeEnum(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeEnum;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  StringRef Name = getString(Ops[NameIdx]);
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  uint64_t SizeInBits = BM->get<SPIRVConstant>(Ops[SizeIdx])->getZExtIntValue();
+  unsigned AlignInBits = 0;
+  SPIRVWord Flags = Ops[FlagsIdx];
+  if (Flags & SPIRVDebug::FlagIsFwdDecl) {
+    return Builder.createForwardDecl(dwarf::DW_TAG_enumeration_type, Name, Scope, File, LineNo, AlignInBits,
+                                     SizeInBits);
+  } else {
+    SmallVector<llvm::Metadata *, 16> Elts;
+    for (size_t I = FirstEnumeratorIdx, E = Ops.size(); I < E; I += 2) {
+      uint64_t Val = BM->get<SPIRVConstant>(Ops[I])->getZExtIntValue();
+      StringRef Name = getString(Ops[I + 1]);
+      Elts.push_back(Builder.createEnumerator(Name, Val));
+    }
+    DINodeArray Enumerators = Builder.getOrCreateArray(Elts);
+    DIType *UnderlyingType = nullptr;
+    SPIRVEntry *E = BM->getEntry(Ops[UnderlyingTypeIdx]);
+    if (!isa<OpTypeVoid>(E))
+      UnderlyingType = transDebugInst<DIType>(static_cast<SPIRVExtInst *>(E));
+    return Builder.createEnumerationType(Scope, Name, File, LineNo, SizeInBits, AlignInBits, Enumerators,
+                                         UnderlyingType, "", UnderlyingType);
+  }
+}
+
+DINode *SPIRVToLLVMDbgTran::transTypeFunction(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeFunction;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  SPIRVWord SPIRVFlags = Ops[FlagsIdx];
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if (SPIRVFlags & SPIRVDebug::FlagIsLValueReference)
+    Flags |= llvm::DINode::FlagLValueReference;
+  if (SPIRVFlags & SPIRVDebug::FlagIsRValueReference)
+    Flags |= llvm::DINode::FlagRValueReference;
+
+  SPIRVEntry *E = BM->getEntry(Ops[ReturnTypeIdx]);
+  MDNode *RT = isa<OpTypeVoid>(E) ? nullptr : transDebugInst(BM->get<SPIRVExtInst>(Ops[ReturnTypeIdx]));
+  SmallVector<llvm::Metadata *, 16> Elements{RT};
+  for (size_t I = FirstParameterIdx, E = Ops.size(); I < E; ++I) {
+    SPIRVEntry *P = BM->getEntry(Ops[I]);
+    MDNode *Param = isa<OpTypeVoid>(P) ? nullptr : transDebugInst(BM->get<SPIRVExtInst>(Ops[I]));
+
+    Elements.push_back(Param);
+  }
+  DITypeRefArray ArgTypes = Builder.getOrCreateTypeArray(Elements);
+  return Builder.createSubroutineType(ArgTypes, Flags);
+}
+
+DINode *SPIRVToLLVMDbgTran::transTypePtrToMember(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::PtrToMember;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
+  SPIRVExtInst *Member = BM->get<SPIRVExtInst>(Ops[MemberTypeIdx]);
+  DIType *PointeeTy = transDebugInst<DIType>(Member);
+  SPIRVExtInst *ContainingTy = BM->get<SPIRVExtInst>(Ops[ParentIdx]);
+  DIType *BaseTy = transDebugInst<DIType>(ContainingTy);
+  return Builder.createMemberPointerType(PointeeTy, BaseTy, 0);
+}
+
+DINode *SPIRVToLLVMDbgTran::transLexicalBlock(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::LexicalBlock;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  DIScope *ParentScope = getScope(BM->getEntry(Ops[ParentIdx]));
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  if (Ops.size() > NameIdx) {
+    StringRef Name = getString(Ops[NameIdx]);
+    return Builder.createNameSpace(ParentScope, Name, false /*inlined namespace*/);
+  }
+  unsigned Column = Ops[ColumnIdx];
+  return Builder.createLexicalBlock(ParentScope, File, LineNo, Column);
+}
+
+DINode *SPIRVToLLVMDbgTran::transLexicalBlockDiscriminator(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::LexicalBlockDiscriminator;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned Disc = Ops[DiscriminatorIdx];
+  DIScope *ParentScope = getScope(BM->getEntry(Ops[ParentIdx]));
+  return Builder.createLexicalBlockFile(ParentScope, File, Disc);
+}
+
+DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::Function;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  StringRef Name = getString(Ops[NameIdx]);
+  DISubroutineType *Ty = transDebugInst<DISubroutineType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  StringRef LinkageName = getString(Ops[LinkageNameIdx]);
+
+  SPIRVWord SPIRVDebugFlags = Ops[FlagsIdx];
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsArtificial)
+    Flags |= llvm::DINode::FlagArtificial;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsExplicit)
+    Flags |= llvm::DINode::FlagExplicit;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsPrototyped)
+    Flags |= llvm::DINode::FlagPrototyped;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsLValueReference)
+    Flags |= llvm::DINode::FlagLValueReference;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsRValueReference)
+    Flags |= llvm::DINode::FlagRValueReference;
+  if ((SPIRVDebugFlags & SPIRVDebug::FlagAccess) == SPIRVDebug::FlagIsPublic)
+    Flags |= llvm::DINode::FlagPublic;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsProtected)
+    Flags |= llvm::DINode::FlagProtected;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsPrivate)
+    Flags |= llvm::DINode::FlagPrivate;
+
+  // TODO: IsDefinition is always true for DebugFunction, but should be false
+  // for DebugFunctionDeclaration.
+  const bool IsDefinition = true;
+  bool IsOptimized = SPIRVDebugFlags & SPIRVDebug::FlagIsOptimized;
+  bool IsLocal = SPIRVDebugFlags & SPIRVDebug::FlagIsLocal;
+  bool IsMainSubprogram = BM->getEntryPoint(Ops[FunctionIdIdx]) != nullptr;
+  DISubprogram::DISPFlags SPFlags =
+      DISubprogram::toSPFlags(IsLocal, IsDefinition, IsOptimized, DISubprogram::SPFlagNonvirtual, IsMainSubprogram);
+
+  unsigned ScopeLine = Ops[ScopeLineIdx];
+
+  // Function declaration descriptor
+  DISubprogram *FD = nullptr;
+  if (Ops.size() > DeclarationIdx) {
+    FD = transDebugInst<DISubprogram>(BM->get<SPIRVExtInst>(Ops[DeclarationIdx]));
+  }
+
+  // Here we create fake array of template parameters. If it was plain nullptr,
+  // the template parameter operand would be removed in DISubprogram::getImpl.
+  // But we want it to be there, because if there is DebugTemplate instruction
+  // refering to this function, TransTemplate method must be able to replace the
+  // template parameter operand, thus it must be in the operands list.
+  SmallVector<llvm::Metadata *, 8> Elts;
+  DINodeArray TParams = Builder.getOrCreateArray(Elts);
+  llvm::DITemplateParameterArray TParamsArray = TParams.get();
+
+  DISubprogram *DIS = nullptr;
+  if ((isa<DICompositeType>(Scope) || isa<DINamespace>(Scope)) && !IsDefinition)
+    DIS = Builder.createMethod(Scope, Name, LinkageName, File, LineNo, Ty, 0, 0, nullptr, Flags, SPFlags, TParamsArray);
+  else
+    DIS =
+        Builder.createFunction(Scope, Name, LinkageName, File, LineNo, Ty, ScopeLine, Flags, SPFlags, TParamsArray, FD);
+  DebugInstCache[DebugInst] = DIS;
+  SPIRVId RealFuncId = Ops[FunctionIdIdx];
+  FuncMap[RealFuncId] = DIS;
+
+  // Function.
+  SPIRVEntry *E = BM->getEntry(Ops[FunctionIdIdx]);
+  if (E->getOpCode() == OpFunction) {
+    SPIRVFunction *BF = static_cast<SPIRVFunction *>(E);
+    llvm::Function *F = SPIRVReader->transFunction(BF);
+    assert(F && "Translation of function failed!");
+    if (!F->hasMetadata())
+      F->setMetadata("dbg", DIS);
+    assert(F->getSubprogram() == DIS || F->getSubprogram() == nullptr);
+    F->setSubprogram(DIS);
+  }
+  return DIS;
+}
+
+DISubprogram *SPIRVToLLVMDbgTran::getDISubprogram(const SPIRVFunction *SF) {
+  auto DIS = FuncMap.find(SF->getId());
+  if (DIS == FuncMap.end()) {
+    return nullptr;
+  }
+  return DIS->second;
+}
+
+DINode *SPIRVToLLVMDbgTran::transFunctionDecl(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::FunctionDeclaration;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() == OperandCount && "Invalid number of operands");
+  // Scope
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  StringRef Name = getString(Ops[NameIdx]);
+  StringRef LinkageName = getString(Ops[LinkageNameIdx]);
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  DISubroutineType *Ty = transDebugInst<DISubroutineType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+
+  SPIRVWord SPIRVDebugFlags = Ops[FlagsIdx];
+  bool IsDefinition = SPIRVDebugFlags & SPIRVDebug::FlagIsDefinition;
+  bool IsOptimized = SPIRVDebugFlags & SPIRVDebug::FlagIsOptimized;
+  bool IsLocal = SPIRVDebugFlags & SPIRVDebug::FlagIsLocal;
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsArtificial)
+    Flags |= llvm::DINode::FlagArtificial;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsExplicit)
+    Flags |= llvm::DINode::FlagExplicit;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsPrototyped)
+    Flags |= llvm::DINode::FlagPrototyped;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsLValueReference)
+    Flags |= llvm::DINode::FlagLValueReference;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsRValueReference)
+    Flags |= llvm::DINode::FlagRValueReference;
+  if ((SPIRVDebugFlags & SPIRVDebug::FlagAccess) == SPIRVDebug::FlagIsPublic)
+    Flags |= llvm::DINode::FlagPublic;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsProtected)
+    Flags |= llvm::DINode::FlagProtected;
+  if (SPIRVDebugFlags & SPIRVDebug::FlagIsPrivate)
+    Flags |= llvm::DINode::FlagPrivate;
+
+  // Here we create fake array of template parameters. If it was plain nullptr,
+  // the template parameter operand would be removed in DISubprogram::getImpl.
+  // But we want it to be there, because if there is DebugTemplate instruction
+  // refering to this function, TransTemplate method must be able to replace the
+  // template parameter operand, thus it must be in the operands list.
+  SmallVector<llvm::Metadata *, 8> Elts;
+  DINodeArray TParams = Builder.getOrCreateArray(Elts);
+  llvm::DITemplateParameterArray TParamsArray = TParams.get();
+
+  DISubprogram *DIS = nullptr;
+  DISubprogram::DISPFlags SPFlags = DISubprogram::toSPFlags(IsLocal, IsDefinition, IsOptimized);
+  if (isa<DICompositeType>(Scope) || isa<DINamespace>(Scope))
+    DIS = Builder.createMethod(Scope, Name, LinkageName, File, LineNo, Ty, 0, 0, nullptr, Flags, SPFlags, TParamsArray);
+  else {
+    // Since a function declaration doesn't have any retained nodes, resolve
+    // the temporary placeholder for them immediately.
+    DIS =
+        Builder.createTempFunctionFwdDecl(Scope, Name, LinkageName, File, LineNo, Ty, 0, Flags, SPFlags, TParamsArray);
+    llvm::TempMDNode FwdDecl(cast<llvm::MDNode>(DIS));
+    DIS = Builder.replaceTemporary(std::move(FwdDecl), DIS);
+  }
+  DebugInstCache[DebugInst] = DIS;
+
+  return DIS;
+}
+
+MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::GlobalVariable;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  StringRef Name = getString(Ops[NameIdx]);
+  DIType *Ty = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  DIScope *Parent = getScope(BM->getEntry(Ops[ParentIdx]));
+  StringRef LinkageName = getString(Ops[LinkageNameIdx]);
+
+  DIDerivedType *StaticMemberDecl = nullptr;
+  if (Ops.size() > MinOperandCount) {
+    StaticMemberDecl = transDebugInst<DIDerivedType>(BM->get<SPIRVExtInst>(Ops[StaticMemberDeclarationIdx]));
+  }
+  bool IsLocal = Ops[FlagsIdx] & SPIRVDebug::FlagIsLocal;
+  bool IsDefinition = Ops[FlagsIdx] & SPIRVDebug::FlagIsDefinition;
+  MDNode *VarDecl = nullptr;
+  if (IsDefinition) {
+    VarDecl = Builder.createGlobalVariableExpression(Parent, Name, LinkageName, File, LineNo, Ty, IsLocal, IsDefinition,
+                                                     nullptr, StaticMemberDecl);
+  } else {
+    VarDecl =
+        Builder.createTempGlobalVariableFwdDecl(Parent, Name, LinkageName, File, LineNo, Ty, IsLocal, StaticMemberDecl);
+    // replaceAllUsesWith call makes VarDecl non-temp.
+    // Otherwise DIBuilder will crash at finalization.
+    llvm::TempMDNode TMP(VarDecl);
+    Builder.replaceTemporary(std::move(TMP), VarDecl);
+  }
+  // If the variable has no initializer Ops[VariableIdx] is OpDebugInfoNone.
+  // Otherwise Ops[VariableIdx] may be a global variable or a constant(C++
+  // static const).
+  if (VarDecl && !getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[VariableIdx])) {
+    SPIRVValue *V = BM->get<SPIRVValue>(Ops[VariableIdx]);
+    Value *Var = SPIRVReader->transValue(V, nullptr, nullptr);
+    llvm::GlobalVariable *GV = dyn_cast_or_null<llvm::GlobalVariable>(Var);
+    if (GV && !GV->hasMetadata())
+      GV->addMetadata("dbg", *VarDecl);
+  }
+  return VarDecl;
+}
+
+DINode *SPIRVToLLVMDbgTran::transLocalVariable(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::LocalVariable;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  StringRef Name = getString(Ops[NameIdx]);
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  DIType *Ty = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if (Ops[FlagsIdx] & SPIRVDebug::FlagIsArtificial)
+    Flags |= DINode::FlagArtificial;
+  if (Ops[FlagsIdx] & SPIRVDebug::FlagIsObjectPointer)
+    Flags |= DINode::FlagObjectPointer;
+
+  if (Ops.size() > ArgNumberIdx)
+    return Builder.createParameterVariable(Scope, Name, Ops[ArgNumberIdx], File, LineNo, Ty, true, Flags);
+  return Builder.createAutoVariable(Scope, Name, File, LineNo, Ty, true, Flags);
+}
+
+DINode *SPIRVToLLVMDbgTran::transTypedef(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::Typedef;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
+
+  DIFile *File = getFile(Ops[SourceIdx]);
+  unsigned LineNo = Ops[LineIdx];
+  StringRef Alias = getString(Ops[NameIdx]);
+  SPIRVEntry *TypeInst = BM->getEntry(Ops[BaseTypeIdx]);
+  DIType *Ty = transDebugInst<DIType>(static_cast<SPIRVExtInst *>(TypeInst));
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  assert(Scope && "Typedef should have a parent scope");
+  return Builder.createTypedef(Ty, Alias, File, LineNo, Scope);
+}
+
+DINode *SPIRVToLLVMDbgTran::transInheritance(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeInheritance;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
+  DIType *Parent = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[ParentIdx]));
+  DIType *Child = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[ChildIdx]));
+  DINode::DIFlags Flags = DINode::FlagZero;
+  if ((Ops[FlagsIdx] & SPIRVDebug::FlagAccess) == SPIRVDebug::FlagIsPublic)
+    Flags |= llvm::DINode::FlagPublic;
+  if ((Ops[FlagsIdx] & SPIRVDebug::FlagAccess) == SPIRVDebug::FlagIsProtected)
+    Flags |= llvm::DINode::FlagProtected;
+  if ((Ops[FlagsIdx] & SPIRVDebug::FlagAccess) == SPIRVDebug::FlagIsPrivate)
+    Flags |= llvm::DINode::FlagPrivate;
+  uint64_t Offset = BM->get<SPIRVConstant>(Ops[OffsetIdx])->getZExtIntValue();
+  return Builder.createInheritance(Child, Parent, Offset, 0, Flags);
+}
+
+DINode *SPIRVToLLVMDbgTran::transTemplateParameter(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TemplateParameter;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
+  StringRef Name = getString(Ops[NameIdx]);
+  SPIRVEntry *ActualType = BM->getEntry(Ops[TypeIdx]);
+  DIType *Ty = nullptr;
+  if (!isa<OpTypeVoid>(ActualType))
+    Ty = transDebugInst<DIType>(static_cast<SPIRVExtInst *>(ActualType));
+  DIScope *Context = nullptr;
+  if (!getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[ValueIdx])) {
+    SPIRVValue *Val = BM->get<SPIRVValue>(Ops[ValueIdx]);
+    Value *V = SPIRVReader->transValue(Val, nullptr, nullptr);
+    return Builder.createTemplateValueParameter(Context, Name, Ty, false, cast<Constant>(V));
+  }
+  return Builder.createTemplateTypeParameter(Context, Name, Ty, false);
+}
+
+DINode *SPIRVToLLVMDbgTran::transTemplateTemplateParameter(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TemplateTemplateParameter;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
+  StringRef Name = getString(Ops[NameIdx]);
+  StringRef TemplName = getString(Ops[TemplateNameIdx]);
+  DIScope *Context = nullptr;
+  return Builder.createTemplateTemplateParameter(Context, Name, nullptr, TemplName);
+}
+
+DINode *SPIRVToLLVMDbgTran::transTemplateParameterPack(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TemplateParameterPack;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  StringRef Name = getString(Ops[NameIdx]);
+  SmallVector<llvm::Metadata *, 8> Elts;
+  for (size_t I = FirstParameterIdx, E = Ops.size(); I < E; ++I) {
+    Elts.push_back(transDebugInst(BM->get<SPIRVExtInst>(Ops[I])));
+  }
+  DINodeArray Pack = Builder.getOrCreateArray(Elts);
+  DIScope *Context = nullptr;
+  return Builder.createTemplateParameterPack(Context, Name, nullptr, Pack);
+}
+
+MDNode *SPIRVToLLVMDbgTran::transTemplate(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::Template;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  const size_t NumOps = Ops.size();
+  assert(NumOps >= MinOperandCount && "Invalid number of operands");
+
+  auto *Templ = BM->get<SPIRVExtInst>(Ops[TargetIdx]);
+  MDNode *D = transDebugInst(Templ);
+
+  SmallVector<llvm::Metadata *, 8> Elts;
+  for (size_t I = FirstParameterIdx; I < NumOps; ++I) {
+    Elts.push_back(transDebugInst(BM->get<SPIRVExtInst>(Ops[I])));
+  }
+  DINodeArray TParams = Builder.getOrCreateArray(Elts);
+
+  if (DICompositeType *Comp = dyn_cast<DICompositeType>(D)) {
+    Builder.replaceArrays(Comp, Comp->getElements(), TParams);
+    return Comp;
+  }
+  if (isa<DISubprogram>(D)) {
+    // This constant matches with one used in
+    // DISubprogram::getRawTemplateParams()
+    const unsigned TemplateParamsIndex = 9;
+    D->replaceOperandWith(TemplateParamsIndex, TParams.get());
+    return D;
+  }
+  llvm_unreachable("Invalid template");
+}
+
+DINode *SPIRVToLLVMDbgTran::transImportedEntry(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::ImportedEntity;
+  const SPIRVWordVec &Ops = DebugInst->getArguments();
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
+  DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
+  unsigned Line = Ops[LineIdx];
+  DIFile *File = getFile(Ops[SourceIdx]);
+  auto *Entity = transDebugInst<DINode>(BM->get<SPIRVExtInst>(Ops[EntityIdx]));
+  if (Ops[TagIdx] == SPIRVDebug::ImportedModule) {
+    if (DIImportedEntity *IE = dyn_cast<DIImportedEntity>(Entity))
+      return Builder.createImportedModule(Scope, IE, File, Line);
+    if (DINamespace *NS = dyn_cast<DINamespace>(Entity))
+      return Builder.createImportedModule(Scope, NS, File, Line);
+  }
+  if (Ops[TagIdx] == SPIRVDebug::ImportedDeclaration) {
+    StringRef Name = getString(Ops[NameIdx]);
+    if (DIGlobalVariableExpression *GVE = dyn_cast<DIGlobalVariableExpression>(Entity))
+      return Builder.createImportedDeclaration(Scope, GVE->getVariable(), File, Line, Name);
+    return Builder.createImportedDeclaration(Scope, Entity, File, Line, Name);
+  }
+  llvm_unreachable("Unexpected kind of imported entity!");
+}
+
+MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
+  const SPIRVWordVec &Args = DebugInst->getArguments();
+  std::vector<int64_t> Ops;
+  for (SPIRVId A : Args) {
+    SPIRVExtInst *O = BM->get<SPIRVExtInst>(A);
+    const SPIRVWordVec &Operands = O->getArguments();
+    auto OpCode = static_cast<SPIRVDebug::ExpressionOpCode>(Operands[0]);
+    Ops.push_back(SPIRV::DbgExpressionOpCodeMap::rmap(OpCode));
+    for (unsigned I = 1, E = Operands.size(); I < E; ++I) {
+      Ops.push_back(Operands[I]);
+    }
+  }
+  ArrayRef<int64_t> Addr(Ops.data(), Ops.size());
+  return Builder.createExpression(Addr);
+}
+
+MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {
+  switch (DebugInst->getExtOp()) {
+  case SPIRVDebug::DebugInfoNone:
+    return nullptr;
+
+  case SPIRVDebug::CompilationUnit:
+    return transCompileUnit(DebugInst);
+
+  case SPIRVDebug::TypeBasic:
+    return transTypeBasic(DebugInst);
+
+  case SPIRVDebug::TypeQualifier:
+    return transTypeQualifier(DebugInst);
+
+  case SPIRVDebug::TypePointer:
+    return transTypePointer(DebugInst);
+
+  case SPIRVDebug::TypeArray:
+    return transTypeArray(DebugInst);
+
+  case SPIRVDebug::TypeVector:
+    return transTypeVector(DebugInst);
+
+  case SPIRVDebug::TypeComposite:
+    return transTypeComposite(DebugInst);
+
+  case SPIRVDebug::TypeMember:
+    return transTypeMember(DebugInst);
+
+  case SPIRVDebug::TypePtrToMember:
+    return transTypePtrToMember(DebugInst);
+
+  case SPIRVDebug::TypeEnum:
+    return transTypeEnum(DebugInst);
+
+  case SPIRVDebug::TypeFunction:
+    return transTypeFunction(DebugInst);
+
+  case SPIRVDebug::LexicalBlock:
+    return transLexicalBlock(DebugInst);
+
+  case SPIRVDebug::LexicalBlockDiscriminator:
+    return transLexicalBlockDiscriminator(DebugInst);
+
+  case SPIRVDebug::Function:
+    return transFunction(DebugInst);
+
+  case SPIRVDebug::FunctionDecl:
+    return transFunctionDecl(DebugInst);
+
+  case SPIRVDebug::GlobalVariable:
+    return transGlobalVariable(DebugInst);
+
+  case SPIRVDebug::LocalVariable:
+    return transLocalVariable(DebugInst);
+
+  case SPIRVDebug::Typedef:
+    return transTypedef(DebugInst);
+
+  case SPIRVDebug::InlinedAt:
+    return transDebugInlined(DebugInst);
+
+  case SPIRVDebug::Inheritance:
+    return transInheritance(DebugInst);
+
+  case SPIRVDebug::TypeTemplateParameter:
+    return transTemplateParameter(DebugInst);
+
+  case SPIRVDebug::TypeTemplateTemplateParameter:
+    return transTemplateTemplateParameter(DebugInst);
+
+  case SPIRVDebug::TypeTemplateParameterPack:
+    return transTemplateParameterPack(DebugInst);
+
+  case SPIRVDebug::TypeTemplate:
+    return transTemplate(DebugInst);
+
+  case SPIRVDebug::ImportedEntity:
+    return transImportedEntry(DebugInst);
+
+  case SPIRVDebug::Operation: // To be translated with transExpression
+  case SPIRVDebug::Source:    // To be used by other instructions
+    return nullptr;
+
+  case SPIRVDebug::Expression:
+    return transExpression(DebugInst);
+
+  default:
+    llvm_unreachable("Not implemented SPIR-V debug instruction!");
+  }
+}
+
+Instruction *SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst, BasicBlock *BB) {
+  auto GetLocalVar = [&](SPIRVId Id) -> std::pair<DILocalVariable *, DebugLoc> {
+    auto *LV = transDebugInst<DILocalVariable>(BM->get<SPIRVExtInst>(Id));
+    DebugLoc DL = DebugLoc::get(LV->getLine(), 0, LV->getScope());
+    return std::make_pair(LV, DL);
+  };
+  auto GetValue = [&](SPIRVId Id) -> Value * {
+    auto *V = BM->get<SPIRVValue>(Id);
+    return SPIRVReader->transValue(V, BB->getParent(), BB);
+  };
+  auto GetExpression = [&](SPIRVId Id) -> DIExpression * {
+    return transDebugInst<DIExpression>(BM->get<SPIRVExtInst>(Id));
+  };
+  SPIRVWordVec Ops = DebugInst->getArguments();
+  switch (DebugInst->getExtOp()) {
+  case SPIRVDebug::Scope:
+  case SPIRVDebug::NoScope:
+    return nullptr;
+  case SPIRVDebug::Declare: {
+    using namespace SPIRVDebug::Operand::DebugDeclare;
+    auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
+    if (getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[VariableIdx])) {
+      // If we don't have the variable(e.g. alloca might be promoted by mem2reg)
+      // we should generate the following IR:
+      // call void @llvm.dbg.declare(metadata !4, metadata !14, metadata !5)
+      // !4 = !{}
+      // DIBuilder::insertDeclare doesn't allow to pass nullptr for the Storage
+      // parameter. To work around this limitation we create a dummy temp
+      // alloca, use it to create llvm.dbg.declare, and then remove the alloca.
+      auto *AI = new AllocaInst(Type::getInt8Ty(M->getContext()), 0, "tmp", BB);
+      auto *DbgDeclare =
+          Builder.insertDeclare(AI, LocalVar.first, GetExpression(Ops[ExpressionIdx]), LocalVar.second, BB);
+      AI->eraseFromParent();
+      return DbgDeclare;
+    }
+    return Builder.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first, GetExpression(Ops[ExpressionIdx]),
+                                 LocalVar.second, BB);
+  }
+  case SPIRVDebug::Value: {
+    using namespace SPIRVDebug::Operand::DebugValue;
+    auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
+    return Builder.insertDbgValueIntrinsic(GetValue(Ops[ValueIdx]), LocalVar.first, GetExpression(Ops[ExpressionIdx]),
+                                           LocalVar.second, BB);
+  }
+  default:
+    llvm_unreachable("Unknown debug intrinsic!");
+  }
+}
+
+DebugLoc SPIRVToLLVMDbgTran::transDebugScope(const SPIRVInstruction *SpirvInst, Instruction *Inst) {
+  unsigned Line = 0;
+  unsigned Col = 0;
+  MDNode *Scope = nullptr;
+  MDNode *InlinedAt = nullptr;
+  if (auto L = SpirvInst->getLine()) {
+    Line = L->getLine();
+    Col = L->getColumn();
+  }
+  if (SPIRVEntry *S = SpirvInst->getDebugScope()) {
+    using namespace SPIRVDebug::Operand::Scope;
+    SPIRVExtInst *DbgScope = static_cast<SPIRVExtInst *>(S);
+    SPIRVWordVec Ops = DbgScope->getArguments();
+    Scope = getScope(BM->getEntry(Ops[ScopeIdx]));
+    if (Ops.size() > InlinedAtIdx)
+      InlinedAt = transDebugInst(BM->get<SPIRVExtInst>(Ops[InlinedAtIdx]));
+    return DebugLoc::get(Line, Col, Scope, InlinedAt);
+  }
+
+  auto *SF = SpirvInst->getParent()->getParent();
+  DISubprogram *Sub = getDISubprogram(SF);
+  if (!Sub) {
+    // There's no debug scope present, so we'll assume the scope is a basic
+    // function. Note that a debug scope will be availbale if full SPIR-V debug
+    // info is present.
+    std::string Filename;
+    unsigned LN = 0;
+    if (SF->hasLine()) {
+      Filename = SF->getLine()->getFileNameStr();
+      LN = SF->getLine()->getLine();
+    }
+    auto DF = getDIFile(Filename);
+    auto *F = Inst->getParent()->getParent();
+    auto FN = F->getName();
+    auto SPFlags = DISubprogram::SPFlagDefinition;
+    if (llvm::Function::isInternalLinkage(F->getLinkage())) {
+      SPFlags |= DISubprogram::SPFlagLocalToUnit;
+    }
+    auto *Ty = Builder.createSubroutineType(Builder.getOrCreateTypeArray(None));
+    Sub = Builder.createFunction(DF, FN, FN, DF, LN, Ty, LN, DINode::FlagZero, SPFlags);
+    FuncMap[SF->getId()] = Sub;
+    assert(F->getSubprogram() == Sub || F->getSubprogram() == nullptr);
+    F->setSubprogram(Sub);
+  }
+  return DebugLoc::get(Line, Col, Sub);
+}
+
+MDNode *SPIRVToLLVMDbgTran::transDebugInlined(const SPIRVExtInst *Inst) {
+  using namespace SPIRVDebug::Operand::InlinedAt;
+  SPIRVWordVec Ops = Inst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  unsigned Line = Ops[LineIdx];
+  unsigned Col = 0; // DebugInlinedAt instruction has no column operand
+  DILocalScope *Scope = cast<DILocalScope>(getScope(BM->getEntry(Ops[ScopeIdx])));
+  DILocation *InlinedAt = nullptr;
+  if (Ops.size() > InlinedIdx) {
+    InlinedAt = transDebugInst<DILocation>(BM->get<SPIRVExtInst>(Ops[InlinedIdx]));
+  }
+  return DILocation::getDistinct(M->getContext(), Line, Col, Scope, InlinedAt);
 }
 
 void SPIRVToLLVMDbgTran::finalize() {
-  if (!m_enable)
+  if (!Enable)
     return;
-  m_builder.finalize();
+  Builder.finalize();
 }
 
-void SPIRVToLLVMDbgTran::splitFileName(const std::string &fileName, std::string &baseName, std::string &path) {
-  auto loc = fileName.find_last_of("/\\");
-  if (loc != std::string::npos) {
-    baseName = fileName.substr(loc + 1);
-    path = fileName.substr(0, loc);
+DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
+  using namespace SPIRVDebug::Operand::Source;
+  SPIRVExtInst *Source = BM->get<SPIRVExtInst>(SourceId);
+  assert(Source->getExtOp() == SPIRVDebug::Source && "DebugSource instruction is expected");
+  SPIRVWordVec SourceArgs = Source->getArguments();
+  assert(SourceArgs.size() == OperandCount && "Invalid number of operands");
+  return getDIFile(getString(SourceArgs[FileIdx]));
+}
+
+SPIRVToLLVMDbgTran::SplitFileName::SplitFileName(const string &FileName) {
+  auto Loc = FileName.find_last_of("/\\");
+  if (Loc != std::string::npos) {
+    BaseName = FileName.substr(Loc + 1);
+    Path = FileName.substr(0, Loc);
   } else {
-    baseName = fileName;
-    path = ".";
+    BaseName = FileName;
+    Path = ".";
   }
 }
+
+} // namespace SPIRV

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -1,0 +1,523 @@
+#ifndef SPIRV_DEBUG_H
+#define SPIRV_DEBUG_H
+#include "SPIRVUtil.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+
+namespace SPIRVDebug {
+
+const unsigned int DebugInfoVersion = 0x00010000;
+
+// clang-format off
+
+enum Instruction {
+  DebugInfoNone                 = 0,
+  CompilationUnit               = 1,
+  TypeBasic                     = 2,
+  TypePointer                   = 3,
+  TypeQualifier                 = 4,
+  TypeArray                     = 5,
+  TypeVector                    = 6,
+  Typedef                       = 7,
+  TypeFunction                  = 8,
+  TypeEnum                      = 9,
+  TypeComposite                 = 10,
+  TypeMember                    = 11,
+  Inheritance                   = 12,
+  TypePtrToMember               = 13,
+  TypeTemplate                  = 14,
+  TypeTemplateParameter         = 15,
+  TypeTemplateParameterPack     = 16,
+  TypeTemplateTemplateParameter = 17,
+  GlobalVariable                = 18,
+  FunctionDecl                  = 19,
+  Function                      = 20,
+  LexicalBlock                  = 21,
+  LexicalBlockDiscriminator     = 22,
+  Scope                         = 23,
+  NoScope                       = 24,
+  InlinedAt                     = 25,
+  LocalVariable                 = 26,
+  InlinedVariable               = 27,
+  Declare                       = 28,
+  Value                         = 29,
+  Operation                     = 30,
+  Expression                    = 31,
+  MacroDef                      = 32,
+  MacroUndef                    = 33,
+  ImportedEntity                = 34,
+  Source                        = 35,
+  InstCount                     = 36
+};
+
+enum Flag {
+  FlagIsPrivate           = 1 << 0,
+  FlagIsProtected         = 1 << 1,
+  FlagIsPublic            = FlagIsPrivate | FlagIsProtected,
+  FlagAccess              = FlagIsPublic,
+  FlagIsLocal             = 1 << 2,
+  FlagIsDefinition        = 1 << 3,
+  FlagIsFwdDecl           = 1 << 4,
+  FlagIsArtificial        = 1 << 5,
+  FlagIsExplicit          = 1 << 6,
+  FlagIsPrototyped        = 1 << 7,
+  FlagIsObjectPointer     = 1 << 8,
+  FlagIsStaticMember      = 1 << 9,
+  FlagIsIndirectVariable  = 1 << 10,
+  FlagIsLValueReference   = 1 << 11,
+  FlagIsRValueReference   = 1 << 12,
+  FlagIsOptimized         = 1 << 13,
+  FlagIsEnumClass         = 1 << 14,
+  FlagTypePassByValue     = 1 << 15,
+  FlagTypePassByReference = 1 << 16,
+};
+
+enum EncodingTag {
+  Unspecified  = 0,
+  Address      = 1,
+  Boolean      = 2,
+  Float        = 3,
+  Signed       = 4,
+  SignedChar   = 5,
+  Unsigned     = 6,
+  UnsignedChar = 7
+};
+
+enum CompositeTypeTag {
+  Class     = 0,
+  Structure = 1,
+  Union     = 2
+};
+
+enum TypeQualifierTag {
+  ConstType    = 0,
+  VolatileType = 1,
+  RestrictType = 2,
+  AtomicType   = 3
+};
+
+enum ExpressionOpCode {
+  Deref      = 0,
+  Plus       = 1,
+  Minus      = 2,
+  PlusUconst = 3,
+  BitPiece   = 4,
+  Swap       = 5,
+  Xderef     = 6,
+  StackValue = 7,
+  Constu     = 8,
+  Fragment   = 9
+};
+
+enum ImportedEntityTag {
+  ImportedModule      = 0,
+  ImportedDeclaration = 1,
+};
+
+namespace Operand {
+
+namespace CompilationUnit {
+enum {
+  SPIRVDebugInfoVersionIdx = 0,
+  DWARFVersionIdx          = 1,
+  SourceIdx                = 2,
+  LanguageIdx              = 3,
+  OperandCount             = 4
+};
+}
+
+namespace Source {
+enum {
+  FileIdx      = 0,
+  TextIdx      = 1,
+  OperandCount = 2
+};
+}
+
+namespace TypeBasic {
+enum {
+  NameIdx      = 0,
+  SizeIdx      = 1,
+  EncodingIdx  = 2,
+  OperandCount = 3
+};
+}
+
+namespace TypePointer {
+enum {
+  BaseTypeIdx     = 0,
+  StorageClassIdx = 1,
+  FlagsIdx        = 2,
+  OperandCount    = 3
+};
+}
+
+namespace TypeQualifier {
+enum {
+  BaseTypeIdx  = 0,
+  QualifierIdx = 1,
+  OperandCount = 2
+};
+}
+
+namespace TypeArray {
+enum {
+  BaseTypeIdx       = 0,
+  ComponentCountIdx = 1,
+  MinOperandCount   = 2
+};
+}
+
+namespace TypeVector = TypeArray;
+
+namespace Typedef {
+enum {
+  NameIdx      = 0,
+  BaseTypeIdx  = 1,
+  SourceIdx    = 2,
+  LineIdx      = 3,
+  ColumnIdx    = 4,
+  ParentIdx    = 5,
+  OperandCount = 6
+};
+}
+
+namespace TypeFunction {
+enum {
+  FlagsIdx          = 0,
+  ReturnTypeIdx     = 1,
+  FirstParameterIdx = 2,
+  MinOperandCount   = 2
+};
+}
+
+namespace TypeEnum {
+enum {
+  NameIdx            = 0,
+  UnderlyingTypeIdx  = 1,
+  SourceIdx          = 2,
+  LineIdx            = 3,
+  ColumnIdx          = 4,
+  ParentIdx          = 5,
+  SizeIdx            = 6,
+  FlagsIdx           = 7,
+  FirstEnumeratorIdx = 8,
+  MinOperandCount    = 8
+};
+}
+
+namespace TypeComposite {
+enum {
+  NameIdx         = 0,
+  TagIdx          = 1,
+  SourceIdx       = 2,
+  LineIdx         = 3,
+  ColumnIdx       = 4,
+  ParentIdx       = 5,
+  LinkageNameIdx  = 6,
+  SizeIdx         = 7,
+  FlagsIdx        = 8,
+  FirstMemberIdx  = 9,
+  MinOperandCount = 9
+};
+}
+
+namespace TypeMember {
+enum {
+  NameIdx         = 0,
+  TypeIdx         = 1,
+  SourceIdx       = 2,
+  LineIdx         = 3,
+  ColumnIdx       = 4,
+  ParentIdx       = 5,
+  OffsetIdx       = 6,
+  SizeIdx         = 7,
+  FlagsIdx        = 8,
+  ValueIdx        = 9,
+  MinOperandCount = 9
+};
+}
+
+namespace TypeInheritance {
+enum {
+  ChildIdx     = 0,
+  ParentIdx    = 1,
+  OffsetIdx    = 2,
+  SizeIdx      = 3,
+  FlagsIdx     = 4,
+  OperandCount = 5
+};
+}
+
+namespace PtrToMember {
+enum {
+  MemberTypeIdx = 0,
+  ParentIdx     = 1,
+  OperandCount  = 2
+};
+}
+
+namespace Template {
+enum {
+  TargetIdx         = 0,
+  FirstParameterIdx = 1,
+  MinOperandCount   = 1
+};
+}
+
+namespace TemplateParameter {
+enum {
+  NameIdx      = 0,
+  TypeIdx      = 1,
+  ValueIdx     = 2,
+  SourceIdx    = 3,
+  LineIdx      = 4,
+  ColumnIdx    = 5,
+  OperandCount = 6
+};
+}
+
+namespace TemplateTemplateParameter {
+enum {
+  NameIdx         = 0,
+  TemplateNameIdx = 1,
+  SourceIdx       = 2,
+  LineIdx         = 3,
+  ColumnIdx       = 4,
+  OperandCount    = 5
+};
+}
+
+namespace TemplateParameterPack {
+enum {
+  NameIdx           = 0,
+  SourceIdx         = 1,
+  LineIdx           = 2,
+  ColumnIdx         = 3,
+  FirstParameterIdx = 4,
+  MinOperandCount   = 4
+};
+}
+
+namespace GlobalVariable {
+enum {
+  NameIdx                    = 0,
+  TypeIdx                    = 1,
+  SourceIdx                  = 2,
+  LineIdx                    = 3,
+  ColumnIdx                  = 4,
+  ParentIdx                  = 5,
+  LinkageNameIdx             = 6,
+  VariableIdx                = 7,
+  FlagsIdx                   = 8,
+  StaticMemberDeclarationIdx = 9,
+  MinOperandCount            = 9
+};
+}
+
+namespace FunctionDeclaration {
+enum {
+  NameIdx        = 0,
+  TypeIdx        = 1,
+  SourceIdx      = 2,
+  LineIdx        = 3,
+  ColumnIdx      = 4,
+  ParentIdx      = 5,
+  LinkageNameIdx = 6,
+  FlagsIdx       = 7,
+  OperandCount   = 8
+};
+}
+
+namespace Function {
+enum {
+  NameIdx         = 0,
+  TypeIdx         = 1,
+  SourceIdx       = 2,
+  LineIdx         = 3,
+  ColumnIdx       = 4,
+  ParentIdx       = 5,
+  LinkageNameIdx  = 6,
+  FlagsIdx        = 7,
+  ScopeLineIdx    = 8,
+  FunctionIdIdx   = 9,
+  DeclarationIdx  = 10,
+  MinOperandCount = 10
+};
+}
+
+namespace LexicalBlock {
+enum {
+  SourceIdx       = 0,
+  LineIdx         = 1,
+  ColumnIdx       = 2,
+  ParentIdx       = 3,
+  NameIdx         = 4,
+  MinOperandCount = 4
+};
+}
+
+namespace LexicalBlockDiscriminator {
+enum {
+  SourceIdx        = 0,
+  DiscriminatorIdx = 1,
+  ParentIdx        = 2,
+  OperandCount     = 3
+};
+}
+
+namespace Scope {
+enum {
+  ScopeIdx        = 0,
+  InlinedAtIdx    = 1,
+  MinOperandCount = 1
+};
+}
+
+namespace NoScope {
+// No operands
+}
+
+namespace InlinedAt {
+enum {
+  LineIdx         = 0,
+  ScopeIdx        = 1,
+  InlinedIdx      = 2,
+  MinOperandCount = 2
+};
+}
+
+namespace LocalVariable {
+enum {
+  NameIdx         = 0,
+  TypeIdx         = 1,
+  SourceIdx       = 2,
+  LineIdx         = 3,
+  ColumnIdx       = 4,
+  ParentIdx       = 5,
+  FlagsIdx        = 6,
+  ArgNumberIdx    = 7,
+  MinOperandCount = 7
+};
+}
+
+namespace InlinedVariable {
+enum {
+  VariableIdx  = 0,
+  InlinedIdx   = 1,
+  OperandCount = 2
+};
+}
+
+namespace DebugDeclare {
+enum {
+  DebugLocalVarIdx = 0,
+  VariableIdx      = 1,
+  ExpressionIdx    = 2,
+  OperandCount     = 3
+};
+}
+
+namespace DebugValue {
+enum {
+  DebugLocalVarIdx     = 0,
+  ValueIdx             = 1,
+  ExpressionIdx        = 2,
+  FirstIndexOperandIdx = 3,
+  MinOperandCount      = 3
+};
+}
+
+namespace Operation {
+enum {
+  OpCodeIdx = 0
+};
+static std::map<ExpressionOpCode, unsigned> OpCountMap {
+  { Deref,      1 },
+  { Plus,       1 },
+  { Minus,      1 },
+  { PlusUconst, 2 },
+  { BitPiece,   3 },
+  { Swap,       1 },
+  { Xderef,     1 },
+  { StackValue, 1 },
+  { Constu,     2 },
+  { Fragment,   3 }
+};
+}
+
+namespace ImportedEntity {
+enum {
+  NameIdx      = 0,
+  TagIdx       = 1,
+  SourceIdx    = 3,
+  EntityIdx    = 4,
+  LineIdx      = 5,
+  ColumnIdx    = 6,
+  ParentIdx    = 7,
+  OperandCount = 8
+};
+}
+
+} // namespace Operand
+} // namespace SPIRVDebug
+
+using namespace llvm;
+
+namespace SPIRV {
+typedef SPIRVMap<dwarf::TypeKind, SPIRVDebug::EncodingTag> DbgEncodingMap;
+template <>
+inline void DbgEncodingMap::init() {
+  add(static_cast<dwarf::TypeKind>(0), SPIRVDebug::Unspecified);
+  add(dwarf::DW_ATE_address,           SPIRVDebug::Address);
+  add(dwarf::DW_ATE_boolean,           SPIRVDebug::Boolean);
+  add(dwarf::DW_ATE_float,             SPIRVDebug::Float);
+  add(dwarf::DW_ATE_signed,            SPIRVDebug::Signed);
+  add(dwarf::DW_ATE_signed_char,       SPIRVDebug::SignedChar);
+  add(dwarf::DW_ATE_unsigned,          SPIRVDebug::Unsigned);
+  add(dwarf::DW_ATE_unsigned_char,     SPIRVDebug::UnsignedChar);
+}
+
+typedef SPIRVMap<dwarf::Tag, SPIRVDebug::TypeQualifierTag> DbgTypeQulifierMap;
+template <>
+inline void DbgTypeQulifierMap::init() {
+  add(dwarf::DW_TAG_const_type,    SPIRVDebug::ConstType);
+  add(dwarf::DW_TAG_volatile_type, SPIRVDebug::VolatileType);
+  add(dwarf::DW_TAG_restrict_type, SPIRVDebug::RestrictType);
+  add(dwarf::DW_TAG_atomic_type,   SPIRVDebug::AtomicType);
+}
+
+typedef SPIRVMap<dwarf::Tag, SPIRVDebug::CompositeTypeTag> DbgCompositeTypeMap;
+template <>
+inline void DbgCompositeTypeMap::init() {
+  add(dwarf::DW_TAG_class_type,     SPIRVDebug::Class);
+  add(dwarf::DW_TAG_structure_type, SPIRVDebug::Structure);
+  add(dwarf::DW_TAG_union_type,     SPIRVDebug::Union);
+}
+
+typedef SPIRVMap<dwarf::LocationAtom, SPIRVDebug::ExpressionOpCode>
+  DbgExpressionOpCodeMap;
+template <>
+inline void DbgExpressionOpCodeMap::init() {
+  add(dwarf::DW_OP_deref,         SPIRVDebug::Deref);
+  add(dwarf::DW_OP_plus,          SPIRVDebug::Plus);
+  add(dwarf::DW_OP_minus,         SPIRVDebug::Minus);
+  add(dwarf::DW_OP_plus_uconst,   SPIRVDebug::PlusUconst);
+  add(dwarf::DW_OP_bit_piece,     SPIRVDebug::BitPiece);
+  add(dwarf::DW_OP_swap,          SPIRVDebug::Swap);
+  add(dwarf::DW_OP_xderef,        SPIRVDebug::Xderef);
+  add(dwarf::DW_OP_stack_value,   SPIRVDebug::StackValue);
+  add(dwarf::DW_OP_constu,        SPIRVDebug::Constu);
+  add(dwarf::DW_OP_LLVM_fragment, SPIRVDebug::Fragment);
+}
+
+typedef SPIRVMap<dwarf::Tag, SPIRVDebug::ImportedEntityTag>
+  DbgImportedEntityMap;
+template <>
+inline void DbgImportedEntityMap::init() {
+  add(dwarf::DW_TAG_imported_module,      SPIRVDebug::ImportedModule);
+  add(dwarf::DW_TAG_imported_declaration, SPIRVDebug::ImportedDeclaration);
+}
+
+} // namespace SPIRV
+
+#endif // SPIRV_DEBUG_H

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -304,6 +304,16 @@ bool SPIRVEntry::hasLinkageType() const {
   return OpCode == OpFunction || OpCode == OpVariable;
 }
 
+bool SPIRVEntry::isExtInst(const SPIRVExtInstSetKind InstSet, const SPIRVWord ExtOp) const {
+  if (isExtInst()) {
+    const SPIRVExtInst *EI = static_cast<const SPIRVExtInst *>(this);
+    if (EI->getExtSetKind() == InstSet) {
+      return EI->getExtOp() == ExtOp;
+    }
+  }
+  return false;
+}
+
 SPIRVLinkageTypeKind SPIRVEntry::getLinkageType() const {
   assert(hasLinkageType());
   DecorateMapType::const_iterator Loc =

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -249,6 +249,8 @@ public:
   bool hasLinkageType() const;
   bool isAtomic() const { return isAtomicOpCode(OpCode); }
   bool isBasicBlock() const { return isLabel(); }
+  bool isExtInst() const { return OpCode == OpExtInst; }
+  bool isExtInst(const SPIRVExtInstSetKind InstSet, const SPIRVWord ExtOp) const;
   bool isBuiltinCall() const { return OpCode == OpExtInst; }
   bool isDecorate() const { return OpCode == OpDecorate; }
   bool isMemberDecorate() const { return OpCode == OpMemberDecorate; }

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -82,6 +82,7 @@ enum SPIRVExtInstSetKind {
   SPIRVEIS_GcnShaderAMD,
   SPIRVEIS_ShaderTrinaryMinMaxAMD,
   SPIRVEIS_NonSemanticInfo,
+  SPIRVEIS_Debug,
   SPIRVEIS_Count,
 };
 
@@ -115,6 +116,7 @@ template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
   add(SPIRVEIS_GcnShaderAMD, "SPV_AMD_gcn_shader");
   add(SPIRVEIS_ShaderTrinaryMinMaxAMD, "SPV_AMD_shader_trinary_minmax");
   add(SPIRVEIS_NonSemanticInfo, "SPV_KHR_non_semantic_info");
+  add(SPIRVEIS_Debug, "OpenCL.DebugInfo.100");
 }
 typedef SPIRVMap<SPIRVExtInstSetKind, std::string> SPIRVBuiltinSetNameMap;
 

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -40,9 +40,9 @@
 #ifndef SPIRV_LIBSPIRV_SPIRVEXTINST_H
 #define SPIRV_LIBSPIRV_SPIRVEXTINST_H
 
+#include "SPIRV.debug.h"
 #include "SPIRVEnum.h"
 #include "SPIRVUtil.h"
-
 #include <string>
 #include <vector>
 
@@ -199,6 +199,44 @@ SPIRV_DEF_NAMEMAP(ShaderTrinaryMinMaxAMDExtOpKind,
 
 typedef uint32_t NonSemanticInfoExtOpKind;
 
+typedef SPIRVDebug::Instruction SPIRVDebugExtOpKind;
+template <> inline void SPIRVMap<SPIRVDebugExtOpKind, std::string>::init() {
+  add(SPIRVDebug::DebugInfoNone, "DebugInfoNone");
+  add(SPIRVDebug::CompilationUnit, "DebugCompileUnit");
+  add(SPIRVDebug::Source, "DebugSource");
+  add(SPIRVDebug::TypeBasic, "DebugTypeBasic");
+  add(SPIRVDebug::TypePointer, "DebugTypePointer");
+  add(SPIRVDebug::TypeArray, "DebugTypeArray");
+  add(SPIRVDebug::TypeVector, "DebugTypeVector");
+  add(SPIRVDebug::TypeQualifier, "DebugTypeQualifier");
+  add(SPIRVDebug::TypeFunction, "DebugTypeFunction");
+  add(SPIRVDebug::TypeComposite, "DebugTypeComposite");
+  add(SPIRVDebug::TypeMember, "DebugTypeMember");
+  add(SPIRVDebug::TypeEnum, "DebugTypeEnum");
+  add(SPIRVDebug::Typedef, "DebugTypedef");
+  add(SPIRVDebug::TypeTemplateParameter, "DebugTemplateParameter");
+  add(SPIRVDebug::TypeTemplateParameterPack, "DebugTemplateParameterPack");
+  add(SPIRVDebug::TypeTemplateTemplateParameter, "DebugTemplateTemplateParameter");
+  add(SPIRVDebug::TypeTemplate, "DebugTemplate");
+  add(SPIRVDebug::TypePtrToMember, "DebugTypePtrToMember,");
+  add(SPIRVDebug::Inheritance, "DebugInheritance");
+  add(SPIRVDebug::Function, "DebugFunction");
+  add(SPIRVDebug::FunctionDecl, "DebugFunctionDecl");
+  add(SPIRVDebug::LexicalBlock, "DebugLexicalBlock");
+  add(SPIRVDebug::LexicalBlockDiscriminator, "LexicalBlockDiscriminator");
+  add(SPIRVDebug::LocalVariable, "DebugLocalVariable");
+  add(SPIRVDebug::InlinedVariable, "DebugInlinedVariable");
+  add(SPIRVDebug::GlobalVariable, "DebugGlobalVariable");
+  add(SPIRVDebug::Declare, "DebugDeclare");
+  add(SPIRVDebug::Value, "DebugValue");
+  add(SPIRVDebug::Scope, "DebugScope");
+  add(SPIRVDebug::NoScope, "DebugNoScope");
+  add(SPIRVDebug::InlinedAt, "DebugInlinedAt");
+  add(SPIRVDebug::ImportedEntity, "DebugImportedEntity");
+  add(SPIRVDebug::Expression, "DebugExpression");
+  add(SPIRVDebug::Operation, "DebugOperation");
+}
+SPIRV_DEF_NAMEMAP(SPIRVDebugExtOpKind, SPIRVDebugExtOpMap)
 }
 
 #endif // SPIRV_LIBSPIRV_SPIRVEXTINST_H

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -104,6 +104,7 @@ void SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
   addBasicBlock(BB);
 
   Decoder.setScope(BB);
+  SPIRVEntry *DebugScope = nullptr;
   while (Decoder.getWordCountAndOpCode()) {
     if (Decoder.OpCode == OpFunctionEnd || Decoder.OpCode == OpLabel) {
       break;
@@ -120,8 +121,16 @@ void SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
 
     SPIRVInstruction *Inst =
         static_cast<SPIRVInstruction *>(Decoder.getEntry());
-    if ((Inst != nullptr) && Inst->getOpCode() != OpUndef)
+    if ((Inst != nullptr) && Inst->getOpCode() != OpUndef) {
+      if (Inst->isExtInst(SPIRVEIS_Debug, SPIRVDebug::Scope)) {
+        DebugScope = Inst;
+      } else if (Inst->isExtInst(SPIRVEIS_Debug, SPIRVDebug::NoScope)) {
+        DebugScope = nullptr;
+      } else {
+        Inst->setDebugScope(DebugScope);
+      }
       BB->addInstruction(Inst);
+    }
   }
   Decoder.setScope(this);
 }

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -149,11 +149,16 @@ public:
       setModule(TheBB->getModule());
   }
 
+  void setDebugScope(SPIRVEntry *Scope) { DebugScope = Scope; }
+
+  SPIRVEntry *getDebugScope() const { return DebugScope; }
+
 protected:
   void validate() const override { SPIRVValue::validate(); }
 
 private:
   SPIRVBasicBlock *BB;
+  SPIRVEntry *DebugScope = nullptr;
 };
 
 class SPIRVInstTemplateBase : public SPIRVInstruction {
@@ -1625,7 +1630,7 @@ public:
     assert(BB && "Invalid BB");
   }
   SPIRVFunctionCallGeneric() : SPIRVInstruction(OC) {}
-  const std::vector<SPIRVWord> &getArguments() { return Args; }
+  const std::vector<SPIRVWord> &getArguments() const { return Args; }
   std::vector<SPIRVValue *> getArgumentValues() { return getValues(Args); }
   std::vector<SPIRVType *> getArgumentValueTypes() const {
     std::vector<SPIRVType *> ArgTypes;
@@ -1682,15 +1687,14 @@ public:
   void setExtOp(unsigned ExtOC) { ExtOp = ExtOC; }
   SPIRVId getExtSetId() const { return ExtSetId; }
   SPIRVWord getExtOp() const { return ExtOp; }
+  SPIRVExtInstSetKind getExtSetKind() const { return ExtSetKind; }
   void setExtSetKindById() {
     assert(Module && "Invalid module");
     ExtSetKind = Module->getBuiltinSet(ExtSetId);
-    assert((ExtSetKind == SPIRVEIS_GLSL ||
-            ExtSetKind == SPIRVEIS_ShaderBallotAMD ||
-            ExtSetKind == SPIRVEIS_ShaderExplicitVertexParameterAMD ||
-            ExtSetKind == SPIRVEIS_GcnShaderAMD ||
-            ExtSetKind == SPIRVEIS_ShaderTrinaryMinMaxAMD ||
-            ExtSetKind == SPIRVEIS_NonSemanticInfo) &&
+    assert((ExtSetKind == SPIRVEIS_GLSL || ExtSetKind == SPIRVEIS_ShaderBallotAMD ||
+            ExtSetKind == SPIRVEIS_ShaderExplicitVertexParameterAMD || ExtSetKind == SPIRVEIS_GcnShaderAMD ||
+            ExtSetKind == SPIRVEIS_ShaderTrinaryMinMaxAMD || ExtSetKind == SPIRVEIS_NonSemanticInfo ||
+            ExtSetKind == SPIRVEIS_Debug) &&
            "not supported");
   }
   void decode(std::istream &I) override {
@@ -1715,6 +1719,9 @@ public:
     case SPIRVEIS_NonSemanticInfo:
       getDecoder(I) >> ExtOpNonSemanticInfo;
       break;
+    case SPIRVEIS_Debug:
+      getDecoder(I) >> ExtOpDebug;
+      break;
     default:
       assert(0 && "not supported");
       getDecoder(I) >> ExtOp;
@@ -1738,6 +1745,7 @@ protected:
     GcnShaderAMDExtOpKind ExtOpGcnShaderAMD;
     ShaderTrinaryMinMaxAMDExtOpKind ExtOpShaderTrinaryMinMaxAMD;
     NonSemanticInfoExtOpKind ExtOpNonSemanticInfo;
+    SPIRVDebugExtOpKind ExtOpDebug;
   };
   SPIRVExtInstSetKind ExtSetKind;
 };

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -135,10 +135,13 @@ public:
   virtual SPIRVEntryPoint *getEntryPoint(SPIRVId) const = 0;
   virtual SPIRVEntryPoint *
   getEntryPoint(SPIRVExecutionModelKind, const char *) const = 0;
+  virtual bool isEntryPoint(SPIRVExecutionModelKind ExecModel, SPIRVId EP) const = 0;
 
   virtual unsigned short getGeneratorId() const = 0;
   virtual unsigned short getGeneratorVer() const = 0;
   virtual SPIRVWord getSPIRVVersion() const = 0;
+
+  virtual const std::vector<SPIRVExtInst *> &getDebugInstVec() const = 0;
 
   // Module changing functions
   virtual bool importBuiltinSet(const std::string &, SPIRVId *) = 0;
@@ -347,18 +350,6 @@ protected:
   bool ValidateCapability;
 };
 
-class SPIRVDbgInfo {
-public:
-  SPIRVDbgInfo(SPIRVModule *TM);
-  std::string getEntryPointFileStr(SPIRVExecutionModelKind, unsigned);
-  std::string getFunctionFileStr(SPIRVFunction *);
-  unsigned getFunctionLineNo(SPIRVFunction *);
-
-private:
-  std::unordered_map<SPIRVFunction *, SPIRVLine *> FuncMap;
-  const std::string ModuleFileStr;
-  SPIRVModule *M;
-};
 } // namespace SPIRV
 
 #endif // SPIRV_LIBSPIRV_SPIRVMODULE_H

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -71,6 +71,7 @@ SPIRV_DEF_ENCDEC(Op)
 SPIRV_DEF_ENCDEC(Capability)
 SPIRV_DEF_ENCDEC(Decoration)
 SPIRV_DEF_ENCDEC(GLSLExtOpKind)
+SPIRV_DEF_ENCDEC(SPIRVDebugExtOpKind)
 SPIRV_DEF_ENCDEC(LinkageType)
 
 // Read a string with padded 0's at the end so that they form a stream of

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -117,6 +117,7 @@ SPIRV_DEC_ENCDEC(Op)
 SPIRV_DEC_ENCDEC(Capability)
 SPIRV_DEC_ENCDEC(Decoration)
 SPIRV_DEC_ENCDEC(GLSLExtOpKind)
+SPIRV_DEC_ENCDEC(SPIRVDebugExtOpKind)
 SPIRV_DEC_ENCDEC(LinkageType)
 
 const SPIRVDecoder &operator>>(const SPIRVDecoder &I, std::string &Str);

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1167,7 +1167,11 @@ void outputBinary(const uint8_t *data, unsigned startPos, unsigned endPos, OStre
       snprintf(formatBuf, sizeof(formatBuf), "    %7u:", startPos + i * 4u);
       out << formatBuf;
     }
-    snprintf(formatBuf, sizeof(formatBuf), "%08X", startData[i]);
+    // 'data' may not be aligned to sizeof(unsigned) so use a temporary to avoid
+    // undefined behaviour.
+    unsigned alignedData;
+    memcpy(&alignedData, startData + i, sizeof(alignedData));
+    snprintf(formatBuf, sizeof(formatBuf), "%08X", alignedData);
     out << formatBuf;
 
     if (i % 8 == 7)


### PR DESCRIPTION
This change mainly copies in the debug info translation logic from upstream and fits it into the local copy of SPIRV-LLVM-Translator. The upstream logic is modified so that existing debug info support in the LLPC copy is preserved. New tests are added, though they are not exhaustive so will be expanded upon in in the future