### PR TITLE
Support nonuniform decorate sampledImage object

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -537,6 +537,8 @@ SPIRVEntry *SPIRVModuleImpl::addEntry(SPIRVEntry *Entry) {
     if (exist(Id, &Mapped)) {
       if (Mapped->getOpCode() == OpForward) {
         replaceForward(static_cast<SPIRVForward *>(Mapped), Entry);
+        if (Entry->getOpCode() == OpCopyObject)
+          static_cast<SPIRVCopyObject *>(Entry)->propagateNonUniform();
       } else if (Mapped->getOpCode() == OpTypeForwardPointer) {
         replaceForwardPointer(static_cast<SPIRVTypeForwardPointer *>(Mapped),
                               static_cast<SPIRVTypePointer *>(Entry));

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -63,4 +63,8 @@ void SPIRVValue::setCoherent(bool IsCoherent) {
   addDecorate(new SPIRVDecorate(DecorationCoherent, this));
 }
 
+void SPIRVValue::setNonUniform() {
+  addDecorate(new SPIRVDecorate(DecorationNonUniform, this));
+}
+
 } // namespace SPIRV

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -96,6 +96,8 @@ public:
   virtual bool isCoherent();
   void setCoherent(bool IsCoherent = true);
 
+  virtual void setNonUniform();
+
   void validate() const override {
     SPIRVEntry::validate();
     assert((!hasType() || Type) && "Invalid type");


### PR DESCRIPTION
- gslang and CTS are modified to follow the spec of the usage of nonuniform decoration. The spec said "if an instruction loads from or stores to a resource(including atomics and image instructions) and the resource descriptor being accessed is not dynamically uniform, then the operand corresponding to that resource(e.g.the pointer or sampled image operand) must be decorated with NonUniform.(e.g.texture(nonuniformEXT(sampler2D(uTex[Index], uSamp)), vec2(0.5)))
- This change propagates the nonuniform from an OpCopyObject with OpTypeSampledImage until the last index of OpAccessChain.