### PR TITLE
Re-enable backend transform for kills

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -145,6 +145,7 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-atomic-optimizations", "1");
   setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
+  setOptionDefault("amdgpu-conditional-discard-transformations", "1");
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The transform was disabled in #682, but has been fixed since.