### PR TITLE
Fix amdllpc seg faulting in internal build

### DIFF
--- a/tool/vfx/vfxPipelineDoc.h
+++ b/tool/vfx/vfxPipelineDoc.h
@@ -35,11 +35,14 @@
 
 namespace Vfx {
 
+extern void initVkSections();
+
 // =====================================================================================================================
 // Represents the pipeline state result of Vfx parser
 class PipelineDocument : public Document {
 public:
   PipelineDocument() {
+    initVkSections();
     memset(&m_pipelineState, 0, sizeof(m_pipelineState));
     memset(&m_vertexInputState, 0, sizeof(m_vertexInputState));
   };

--- a/tool/vfx/vfxRenderDoc.h
+++ b/tool/vfx/vfxRenderDoc.h
@@ -33,11 +33,16 @@
 
 namespace Vfx {
 
+extern void initRenderSections();
+
 // =====================================================================================================================
 // Represents the render state result of Vfx parser
 class RenderDocument : public Document {
 public:
-  RenderDocument() { memset(&m_renderState, 0, sizeof(m_renderState)); };
+  RenderDocument() {
+    initRenderSections();
+    memset(&m_renderState, 0, sizeof(m_renderState));
+  };
 
   virtual unsigned getMaxSectionCount(SectionType type);
 

--- a/tool/vfx/vfxRenderSection.cpp
+++ b/tool/vfx/vfxRenderSection.cpp
@@ -70,7 +70,11 @@ public:
   }
 };
 
-static RenderSectionParserInit renderSectionParserInit;
+// =====================================================================================================================
+// Initialize Render document special sections.
+void initRenderSections() {
+  static RenderSectionParserInit init;
+}
 
 } // namespace Vfx
 #endif

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -19,10 +19,10 @@ StrToMemberAddr SectionNggState::m_addrTable[SectionNggState::MemberCount];
 StrToMemberAddr SectionExtendedRobustness::m_addrTable[SectionExtendedRobustness::MemberCount];
 
 // =====================================================================================================================
-// Dummy class used to initialize all VKGC sepcial sections
-class VkgcSectionParserInit {
+// Dummy class used to initialize all VK sepcial sections
+class VkSectionParserInit {
 public:
-  VkgcSectionParserInit() {
+  VkSectionParserInit() {
     initEnumMap();
 
     // Sections for PipelineDocument
@@ -79,6 +79,11 @@ public:
   }
 };
 
-static VkgcSectionParserInit vkgcSectionParserInit;
+// =====================================================================================================================
+// Initialize VK pipleine special sections.
+void initVkSections() {
+  static VkSectionParserInit init;
+}
+
 } // namespace Vfx
 #endif


### PR DESCRIPTION
Root cause: VkSectionParserInit is constructed before ParserInit in some compilers, it causes Section::m_sectionInfo is used before it is initialized.
Solution: move document special section initialization code to helper functions, and call these helper functions  when create document object.