### PR TITLE
Update VectorType::get to remove deprecated variant

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1285,7 +1285,7 @@ unsigned Compiler::ConvertColorBufferFormatToExportFormat(const ColorTarget *tar
   state.alphaToCoverageEnable = enableAlphaToCoverage;
   pipeline->setColorExportState(format, state);
 
-  Type *outputTy = VectorType::get(Type::getFloatTy(*context), countPopulation(target->channelWriteMask));
+  Type *outputTy = FixedVectorType::get(Type::getFloatTy(*context), countPopulation(target->channelWriteMask));
   unsigned exportFormat = pipeline->computeExportFormat(outputTy, 0);
 
   pipeline.reset(nullptr);

--- a/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
+++ b/llpc/lower/llpcSpirvLowerAlgebraTransform.cpp
@@ -339,7 +339,7 @@ void SpirvLowerAlgebraTransform::visitFPTruncInst(FPTruncInst &fptruncInst) {
       // NOTE: doubel -> float16 conversion is done in backend compiler with RTE rounding. Thus, we have to split
       // it with two phases to disable such lowering if we need RTZ rounding.
       auto floatTy = srcTy->isVectorTy()
-                         ? VectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(srcTy)->getNumElements())
+                         ? FixedVectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(srcTy)->getNumElements())
                          : Type::getFloatTy(*m_context);
       auto floatValue = new FPTruncInst(src, floatTy, "", &fptruncInst);
       auto dest = new FPTruncInst(floatValue, destTy, "", &fptruncInst);

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1080,7 +1080,7 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
         // NOTE: Glslang has a bug. For gl_SubGroupXXXMaskARB, they are implemented as "uint64_t" while
         // for gl_subgroupXXXMask they are "uvec4". And the SPIR-V enumerants "BuiltInSubgroupXXXMaskKHR"
         // and "BuiltInSubgroupXXXMask" share the same numeric values.
-        inOutValue = m_builder->CreateBitCast(inOutValue, VectorType::get(inOutTy, 2));
+        inOutValue = m_builder->CreateBitCast(inOutValue, FixedVectorType::get(inOutTy, 2));
         inOutValue = m_builder->CreateExtractElement(inOutValue, uint64_t(0));
       }
       if (inOutValue->getType()->isIntegerTy(1)) {


### PR DESCRIPTION
LLVM updates have removed the VectorType::get variant with a defaulted third
argument. Instead, FixedVectorType::get is preferred.

Test before and after the change in LLVM, both work.