### PR TITLE
Ensure the association of functions with DI subprograms

### DIFF
--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -124,6 +124,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
   Function *newFunc = Function::Create(newFuncTy, oldFunc->getLinkage(), "", oldFunc->getParent());
   newFunc->setCallingConv(oldFunc->getCallingConv());
   newFunc->takeName(oldFunc);
+  newFunc->setSubprogram(oldFunc->getSubprogram());
 
   // Transfer code from old function to new function.
   while (!oldFunc->empty()) {

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -77,7 +77,7 @@ DIFile *SPIRVToLLVMDbgTran::getDIFile(const std::string &fileName) {
 }
 
 DISubprogram *SPIRVToLLVMDbgTran::getDISubprogram(SPIRVFunction *sf, Function *f) {
-  return getOrInsert(m_funcMap, f, [=]() {
+  auto* sp = getOrInsert(m_funcMap, f, [=]() {
     auto df = getDIFile(m_spDbg.getFunctionFileStr(sf));
     auto fn = f->getName();
     auto ln = m_spDbg.getFunctionLineNo(sf);
@@ -88,6 +88,9 @@ DISubprogram *SPIRVToLLVMDbgTran::getDISubprogram(SPIRVFunction *sf, Function *f
                                     m_builder.createSubroutineType(m_builder.getOrCreateTypeArray(None)), ln,
                                     DINode::FlagZero, spFlags);
   });
+  assert(f->getSubprogram() == sp || f->getSubprogram() == nullptr);
+  f->setSubprogram(sp);
+  return sp;
 }
 
 void SPIRVToLLVMDbgTran::transDbgInfo(SPIRVValue *sv, Value *v) {

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -77,7 +77,7 @@ DIFile *SPIRVToLLVMDbgTran::getDIFile(const std::string &fileName) {
 }
 
 DISubprogram *SPIRVToLLVMDbgTran::getDISubprogram(SPIRVFunction *sf, Function *f) {
-  auto* sp = getOrInsert(m_funcMap, f, [=]() {
+  auto *sp = getOrInsert(m_funcMap, f, [=]() {
     auto df = getDIFile(m_spDbg.getFunctionFileStr(sf));
     auto fn = f->getName();
     auto ln = m_spDbg.getFunctionLineNo(sf);


### PR DESCRIPTION
This allows debug information to survive all the way to the end of the compiler pipeline.

It's a partial fix for issue #513, in that I can successfully acquire ELFs with DWARF info, and/or assembly with `.file`/`.loc` directives. What it doesn't fix is the source files losing their names, and `#line` GLSL directives not being followed in terms of files, which is important for my use case.