### PR TITLE
Update to FixedVectorType::get in LGC

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -56,7 +56,7 @@ Value *ArithBuilder::CreateCubeFaceCoord(Value *coord, const Twine &instName) {
   Value *cubeTc = CreateIntrinsic(Intrinsic::amdgcn_cubetc, {}, {coordX, coordY, coordZ}, nullptr);
   Value *tcDivMa = CreateFMul(recipMa, cubeTc);
   Value *resultY = CreateFAdd(tcDivMa, ConstantFP::get(getFloatTy(), 0.5));
-  Value *result = CreateInsertElement(UndefValue::get(VectorType::get(getFloatTy(), 2)), resultX, uint64_t(0));
+  Value *result = CreateInsertElement(UndefValue::get(FixedVectorType::get(getFloatTy(), 2)), resultX, uint64_t(0));
   result = CreateInsertElement(result, resultY, 1, instName);
   return result;
 }
@@ -227,7 +227,7 @@ Value *ArithBuilder::CreateSMod(Value *dividend, Value *divisor, const Twine &in
       if (divisorConst->getZExtValue() <= 0xFFFF) {
         // Get a non-constant 0 value. (We know the top 17 bits of the 64-bit PC is always zero.)
         Value *pc = CreateIntrinsic(Intrinsic::amdgcn_s_getpc, {}, {});
-        Value *pcHi = CreateExtractElement(CreateBitCast(pc, VectorType::get(getInt32Ty(), 2)), 1);
+        Value *pcHi = CreateExtractElement(CreateBitCast(pc, FixedVectorType::get(getInt32Ty(), 2)), 1);
         Value *nonConstantZero = CreateLShr(pcHi, getInt32(15));
         if (auto vecTy = dyn_cast<VectorType>(divisor->getType()))
           nonConstantZero = CreateVectorSplat(vecTy->getNumElements(), nonConstantZero);

--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -128,7 +128,7 @@ const ComputeShaderMode &Builder::getComputeShaderMode() {
 // @param maybeVecTy : Possible vector type to get number of elements from
 Type *Builder::getConditionallyVectorizedTy(Type *elementTy, Type *maybeVecTy) {
   if (auto vecTy = dyn_cast<VectorType>(maybeVecTy))
-    return VectorType::get(elementTy, vecTy->getNumElements());
+    return FixedVectorType::get(elementTy, vecTy->getNumElements());
   return elementTy;
 }
 
@@ -167,7 +167,7 @@ Value *Builder::CreateMapToInt32(PFN_MapToInt32Func mapFunc, ArrayRef<Value *> m
       results.push_back(CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs));
     }
 
-    Value *result = UndefValue::get(VectorType::get(results[0]->getType(), compCount));
+    Value *result = UndefValue::get(FixedVectorType::get(results[0]->getType(), compCount));
 
     for (unsigned i = 0; i < compCount; i++)
       result = CreateInsertElement(result, results[i], i);
@@ -184,7 +184,7 @@ Value *Builder::CreateMapToInt32(PFN_MapToInt32Func mapFunc, ArrayRef<Value *> m
   } else if (type->isIntegerTy() && type->getIntegerBitWidth() < 32) {
     SmallVector<Value *, 4> newMappedArgs;
 
-    Type *const vectorType = VectorType::get(type, type->getPrimitiveSizeInBits() == 16 ? 2 : 4);
+    Type *const vectorType = FixedVectorType::get(type, type->getPrimitiveSizeInBits() == 16 ? 2 : 4);
     Value *const undef = UndefValue::get(vectorType);
 
     for (Value *const mappedArg : mappedArgs) {
@@ -198,7 +198,7 @@ Value *Builder::CreateMapToInt32(PFN_MapToInt32Func mapFunc, ArrayRef<Value *> m
     SmallVector<Value *, 4> castMappedArgs;
 
     for (Value *const mappedArg : mappedArgs)
-      castMappedArgs.push_back(CreateBitCast(mappedArg, VectorType::get(getInt32Ty(), 2)));
+      castMappedArgs.push_back(CreateBitCast(mappedArg, FixedVectorType::get(getInt32Ty(), 2)));
 
     Value *result = UndefValue::get(castMappedArgs[0]->getType());
 
@@ -243,7 +243,8 @@ Type *Builder::getTransposedMatrixTy(Type *const matrixType) const {
   const unsigned columnCount = matrixType->getArrayNumElements();
   const unsigned rowCount = cast<VectorType>(columnVectorType)->getNumElements();
 
-  return ArrayType::get(VectorType::get(cast<VectorType>(columnVectorType)->getElementType(), columnCount), rowCount);
+  return ArrayType::get(FixedVectorType::get(cast<VectorType>(columnVectorType)->getElementType(), columnCount),
+                        rowCount);
 }
 
 // =====================================================================================================================
@@ -257,25 +258,25 @@ PointerType *Builder::getBufferDescTy(Type *pointeeTy) {
 // =====================================================================================================================
 // Get the type of an image descriptor
 VectorType *Builder::getImageDescTy() {
-  return VectorType::get(getInt32Ty(), 8);
+  return FixedVectorType::get(getInt32Ty(), 8);
 }
 
 // =====================================================================================================================
 // Get the type of an fmask descriptor
 VectorType *Builder::getFmaskDescTy() {
-  return VectorType::get(getInt32Ty(), 8);
+  return FixedVectorType::get(getInt32Ty(), 8);
 }
 
 // =====================================================================================================================
 // Get the type of a texel buffer descriptor
 VectorType *Builder::getTexelBufferDescTy() {
-  return VectorType::get(getInt32Ty(), 4);
+  return FixedVectorType::get(getInt32Ty(), 4);
 }
 
 // =====================================================================================================================
 // Get the type of a sampler descriptor
 VectorType *Builder::getSamplerDescTy() {
-  return VectorType::get(getInt32Ty(), 4);
+  return FixedVectorType::get(getInt32Ty(), 4);
 }
 
 // =====================================================================================================================
@@ -365,17 +366,17 @@ Type *Builder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
   case TypeCode::i64:
     return getInt64Ty();
   case TypeCode::v2f32:
-    return VectorType::get(getFloatTy(), 2);
+    return FixedVectorType::get(getFloatTy(), 2);
   case TypeCode::v3f32:
-    return VectorType::get(getFloatTy(), 3);
+    return FixedVectorType::get(getFloatTy(), 3);
   case TypeCode::v4f32:
-    return VectorType::get(getFloatTy(), 4);
+    return FixedVectorType::get(getFloatTy(), 4);
   case TypeCode::v3i32:
-    return VectorType::get(getInt32Ty(), 3);
+    return FixedVectorType::get(getInt32Ty(), 3);
   case TypeCode::v4i32:
-    return VectorType::get(getInt32Ty(), 4);
+    return FixedVectorType::get(getInt32Ty(), 4);
   case TypeCode::a4v3f32:
-    return ArrayType::get(VectorType::get(getFloatTy(), 3), 4);
+    return ArrayType::get(FixedVectorType::get(getFloatTy(), 3), 4);
   default:
     llvm_unreachable("Should never be called!");
     return nullptr;

--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -270,7 +270,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
         assert((vecTy->getNumElements() % 4) == 0);
         waterfallEndTy = getInt32Ty();
         if (vecTy->getNumElements() != 4)
-          waterfallEndTy = VectorType::get(getInt32Ty(), vecTy->getNumElements() / 4);
+          waterfallEndTy = FixedVectorType::get(getInt32Ty(), vecTy->getNumElements() / 4);
         resultValue = cast<Instruction>(CreateBitCast(resultValue, waterfallEndTy, instName));
         useOfNonUniformInst = &resultValue->getOperandUse(0);
       }
@@ -301,7 +301,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
 Value *BuilderImplBase::scalarize(Value *value, std::function<Value *(Value *)> callback) {
   if (auto vecTy = dyn_cast<VectorType>(value->getType())) {
     Value *result0 = callback(CreateExtractElement(value, uint64_t(0)));
-    Value *result = UndefValue::get(VectorType::get(result0->getType(), vecTy->getNumElements()));
+    Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
     result = CreateInsertElement(result, result0, uint64_t(0));
     for (unsigned idx = 1, end = vecTy->getNumElements(); idx != end; ++idx)
       result = CreateInsertElement(result, callback(CreateExtractElement(value, idx)), idx);
@@ -321,7 +321,8 @@ Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Val
   if (auto vecTy = dyn_cast<VectorType>(value->getType())) {
     Value *inComps = CreateShuffleVector(value, value, ArrayRef<int>{0, 1});
     Value *resultComps = callback(inComps);
-    Value *result = UndefValue::get(VectorType::get(resultComps->getType()->getScalarType(), vecTy->getNumElements()));
+    Value *result =
+        UndefValue::get(FixedVectorType::get(resultComps->getType()->getScalarType(), vecTy->getNumElements()));
     result = CreateInsertElement(result, CreateExtractElement(resultComps, uint64_t(0)), uint64_t(0));
     if (vecTy->getNumElements() > 1)
       result = CreateInsertElement(result, CreateExtractElement(resultComps, 1), 1);
@@ -338,7 +339,7 @@ Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Val
   }
 
   // For the scalar case, we need to create a vec2.
-  Value *inComps = UndefValue::get(VectorType::get(value->getType(), 2));
+  Value *inComps = UndefValue::get(FixedVectorType::get(value->getType(), 2));
   inComps = CreateInsertElement(inComps, value, uint64_t(0));
   inComps = CreateInsertElement(inComps, Constant::getNullValue(value->getType()), 1);
   Value *result = callback(inComps);
@@ -354,7 +355,7 @@ Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Val
 Value *BuilderImplBase::scalarize(Value *value0, Value *value1, std::function<Value *(Value *, Value *)> callback) {
   if (auto vecTy = dyn_cast<VectorType>(value0->getType())) {
     Value *result0 = callback(CreateExtractElement(value0, uint64_t(0)), CreateExtractElement(value1, uint64_t(0)));
-    Value *result = UndefValue::get(VectorType::get(result0->getType(), vecTy->getNumElements()));
+    Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
     result = CreateInsertElement(result, result0, uint64_t(0));
     for (unsigned idx = 1, end = vecTy->getNumElements(); idx != end; ++idx) {
       result = CreateInsertElement(result,
@@ -378,7 +379,7 @@ Value *BuilderImplBase::scalarize(Value *value0, Value *value1, Value *value2,
   if (auto vecTy = dyn_cast<VectorType>(value0->getType())) {
     Value *result0 = callback(CreateExtractElement(value0, uint64_t(0)), CreateExtractElement(value1, uint64_t(0)),
                               CreateExtractElement(value2, uint64_t(0)));
-    Value *result = UndefValue::get(VectorType::get(result0->getType(), vecTy->getNumElements()));
+    Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
     result = CreateInsertElement(result, result0, uint64_t(0));
     for (unsigned idx = 1, end = vecTy->getNumElements(); idx != end; ++idx) {
       result = CreateInsertElement(result,

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -409,7 +409,7 @@ Value *BuilderRecorder::CreateVectorTimesMatrix(Value *const vector, Value *cons
   Type *const matrixType = matrix->getType();
   Type *const compType = cast<VectorType>(cast<ArrayType>(matrixType)->getElementType())->getElementType();
   const unsigned columnCount = matrixType->getArrayNumElements();
-  Type *const resultTy = VectorType::get(compType, columnCount);
+  Type *const resultTy = FixedVectorType::get(compType, columnCount);
   return record(Opcode::VectorTimesMatrix, resultTy, {vector, matrix}, instName);
 }
 
@@ -423,7 +423,7 @@ Value *BuilderRecorder::CreateMatrixTimesVector(Value *const matrix, Value *cons
   Type *const columnType = matrix->getType()->getArrayElementType();
   Type *const compType = cast<VectorType>(columnType)->getElementType();
   const unsigned rowCount = cast<VectorType>(columnType)->getNumElements();
-  Type *const vectorType = VectorType::get(compType, rowCount);
+  Type *const vectorType = FixedVectorType::get(compType, rowCount);
   return record(Opcode::MatrixTimesVector, vectorType, {matrix, vector}, instName);
 }
 
@@ -624,7 +624,7 @@ Value *BuilderRecorder::CreateInverseSqrt(Value *x, const Twine &instName) {
 // @param coord : Input coordinate <3 x float>
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateCubeFaceCoord(Value *coord, const Twine &instName) {
-  return record(Opcode::CubeFaceCoord, VectorType::get(coord->getType()->getScalarType(), 2), coord, instName);
+  return record(Opcode::CubeFaceCoord, FixedVectorType::get(coord->getType()->getScalarType(), 2), coord, instName);
 }
 
 // =====================================================================================================================
@@ -1302,7 +1302,7 @@ Value *BuilderRecorder::CreateImageQuerySize(unsigned dim, unsigned flags, Value
   unsigned compCount = getImageQuerySizeComponentCount(dim);
   Type *resultTy = getInt32Ty();
   if (compCount > 1)
-    resultTy = VectorType::get(resultTy, compCount);
+    resultTy = FixedVectorType::get(resultTy, compCount);
   return record(Opcode::ImageQuerySize, resultTy, {getInt32(dim), getInt32(flags), imageDesc, lod}, instName);
 }
 
@@ -1319,7 +1319,7 @@ Value *BuilderRecorder::CreateImageQuerySize(unsigned dim, unsigned flags, Value
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateImageGetLod(unsigned dim, unsigned flags, Value *imageDesc, Value *samplerDesc,
                                           Value *coord, const Twine &instName) {
-  return record(Opcode::ImageGetLod, VectorType::get(getFloatTy(), 2),
+  return record(Opcode::ImageGetLod, FixedVectorType::get(getFloatTy(), 2),
                 {getInt32(dim), getInt32(flags), imageDesc, samplerDesc, coord}, instName);
 }
 
@@ -1575,7 +1575,7 @@ Value *BuilderRecorder::CreateSubgroupBroadcastFirst(Value *const value, const T
 // @param value : The value to contribute
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateSubgroupBallot(Value *const value, const Twine &instName) {
-  return record(Opcode::SubgroupBallot, VectorType::get(getInt32Ty(), 4), value, instName);
+  return record(Opcode::SubgroupBallot, FixedVectorType::get(getInt32Ty(), 4), value, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -88,7 +88,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
       if (node->type == ResourceNodeType::DescriptorBufferCompact)
         byteSize = DescriptorSizeBufferCompact;
       unsigned dwordSize = byteSize / 4;
-      Type *descTy = VectorType::get(getInt32Ty(), dwordSize);
+      Type *descTy = FixedVectorType::get(getInt32Ty(), dwordSize);
       std::string callName = lgcName::RootDescriptor;
       addTypeMangling(descTy, {}, callName);
       unsigned dwordOffset = cast<ConstantInt>(descIndex)->getZExtValue() * dwordSize;
@@ -391,7 +391,7 @@ Value *DescBuilder::getDescPtrAndStride(ResourceNodeType resType, unsigned descS
   }
 
   // Cast the pointer to the right type and create and return the struct.
-  descPtr = CreateBitCast(descPtr, VectorType::get(getInt32Ty(), byteSize / 4)->getPointerTo(ADDR_SPACE_CONST));
+  descPtr = CreateBitCast(descPtr, FixedVectorType::get(getInt32Ty(), byteSize / 4)->getPointerTo(ADDR_SPACE_CONST));
   Value *descPtrStruct =
       CreateInsertValue(UndefValue::get(StructType::get(getContext(), {descPtr->getType(), getInt32Ty()})), descPtr, 0);
   descPtrStruct = CreateInsertValue(descPtrStruct, stride, 1);
@@ -508,7 +508,7 @@ Value *DescBuilder::CreateGetBufferDescLength(Value *const bufferDesc, Value *of
 Value *DescBuilder::buildInlineBufferDesc(Value *descPtr) {
   // Bitcast the pointer to v2i32
   descPtr = CreatePtrToInt(descPtr, getInt64Ty());
-  descPtr = CreateBitCast(descPtr, VectorType::get(getInt32Ty(), 2));
+  descPtr = CreateBitCast(descPtr, FixedVectorType::get(getInt32Ty(), 2));
 
   return buildBufferCompactDesc(descPtr);
 }
@@ -526,7 +526,7 @@ Value *DescBuilder::buildBufferCompactDesc(Value *desc) {
 
   // Build normal buffer descriptor
   // Dword 0
-  Value *bufDesc = UndefValue::get(VectorType::get(getInt32Ty(), 4));
+  Value *bufDesc = UndefValue::get(FixedVectorType::get(getInt32Ty(), 4));
   bufDesc = CreateInsertElement(bufDesc, descElem0, uint64_t(0));
 
   // Dword 1

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -444,8 +444,8 @@ Value *InOutBuilder::modifyAuxInterpValue(Value *auxInterpValue, InOutInfo input
         resUsage->builtInUsage.fs.centroid = true;
       }
 
-      auxInterpValue =
-          emitCall(evalInstName, VectorType::get(getFloatTy(), 2), {evalArg}, Attribute::ReadOnly, &*GetInsertPoint());
+      auxInterpValue = emitCall(evalInstName, FixedVectorType::get(getFloatTy(), 2), {evalArg}, Attribute::ReadOnly,
+                                &*GetInsertPoint());
     } else {
       // Generate code to evaluate the I,J coordinates.
       if (inputInfo.getInterpLoc() == InOutInfo::InterpLocSample)
@@ -495,7 +495,7 @@ Value *InOutBuilder::evalIjOffsetSmooth(Value *offset) {
 // @param value : Value to adjust, float or vector of float
 // @param offset : Offset to adjust by, <2 x float> or <2 x half>
 Value *InOutBuilder::adjustIj(Value *value, Value *offset) {
-  offset = CreateFPExt(offset, VectorType::get(getFloatTy(), 2));
+  offset = CreateFPExt(offset, FixedVectorType::get(getFloatTy(), 2));
   Value *offsetX = CreateExtractElement(offset, uint64_t(0));
   Value *offsetY = CreateExtractElement(offset, 1);
   if (auto vecTy = dyn_cast<VectorType>(value->getType())) {
@@ -683,7 +683,7 @@ Value *InOutBuilder::readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo i
       llvm_unreachable("Should never be called!");
     }
     if (getPipelineState()->getShaderWaveSize(m_shaderStage) == 64) {
-      result = CreateInsertElement(Constant::getNullValue(VectorType::get(getInt64Ty(), 2)), result, uint64_t(0));
+      result = CreateInsertElement(Constant::getNullValue(FixedVectorType::get(getInt64Ty(), 2)), result, uint64_t(0));
       result = CreateBitCast(result, resultTy);
     } else
       result = CreateInsertElement(ConstantInt::getNullValue(resultTy), result, uint64_t(0));
@@ -842,9 +842,9 @@ Type *InOutBuilder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
   switch (static_cast<unsigned>(builtIn)) {
   case BuiltInSamplePosOffset:
   case BuiltInInterpLinearCenter:
-    return VectorType::get(getFloatTy(), 2);
+    return FixedVectorType::get(getFloatTy(), 2);
   case BuiltInInterpPullMode:
-    return VectorType::get(getFloatTy(), 3);
+    return FixedVectorType::get(getFloatTy(), 3);
   default:
     return Builder::getBuiltInTy(builtIn, inOutInfo);
   }

--- a/lgc/builder/MatrixBuilder.cpp
+++ b/lgc/builder/MatrixBuilder.cpp
@@ -54,7 +54,7 @@ Value *MatrixBuilder::CreateTransposeMatrix(Value *const matrix, const Twine &in
 
   Type *const elementType = cast<VectorType>(columnVectorType)->getElementType();
 
-  Type *const newColumnVectorType = VectorType::get(elementType, columnCount);
+  Type *const newColumnVectorType = FixedVectorType::get(elementType, columnCount);
   Type *const newMatrixType = ArrayType::get(newColumnVectorType, rowCount);
 
   SmallVector<Value *, 4> columns;
@@ -117,7 +117,7 @@ Value *MatrixBuilder::CreateVectorTimesMatrix(Value *const vector, Value *const 
   Type *const matrixTy = matrix->getType();
   Type *const compTy = cast<VectorType>(cast<ArrayType>(matrixTy)->getElementType())->getElementType();
   const unsigned columnCount = matrixTy->getArrayNumElements();
-  Type *const resultTy = VectorType::get(compTy, columnCount);
+  Type *const resultTy = FixedVectorType::get(compTy, columnCount);
   Value *result = UndefValue::get(resultTy);
 
   for (unsigned column = 0; column < columnCount; column++) {

--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -168,7 +168,7 @@ Value *SubgroupBuilder::CreateSubgroupBallot(Value *const value, const Twine &in
   Value *ballot = createGroupBallot(value);
 
   // Ballot expects a <4 x i32> return, so we need to turn the i64 into that.
-  ballot = CreateBitCast(ballot, VectorType::get(getInt32Ty(), 2));
+  ballot = CreateBitCast(ballot, FixedVectorType::get(getInt32Ty(), 2));
 
   ElementCount elementCount = cast<VectorType>(ballot->getType())->getElementCount();
   return CreateShuffleVector(ballot, ConstantVector::getSplat(elementCount, getInt32(0)), ArrayRef<int>{0, 1, 2, 3});
@@ -1062,7 +1062,7 @@ Value *SubgroupBuilder::CreateSubgroupMbcnt(Value *const mask, const Twine &inst
   // Check that the type is definitely an i64.
   assert(mask->getType()->isIntegerTy(64));
 
-  Value *const masks = CreateBitCast(mask, VectorType::get(getInt32Ty(), 2));
+  Value *const masks = CreateBitCast(mask, FixedVectorType::get(getInt32Ty(), 2));
   Value *const maskLow = CreateExtractElement(masks, getInt32(0));
   Value *const maskHigh = CreateExtractElement(masks, getInt32(1));
   CallInst *const mbcntLo = CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {maskLow, getInt32(0)});

--- a/lgc/builder/YCbCrConverter.cpp
+++ b/lgc/builder/YCbCrConverter.cpp
@@ -271,7 +271,7 @@ Value *YCbCrConverter::reconstructLinearXYChromaSample(XYChromaSampleInfo &xyChr
 // @param coords : The ST coordinates
 // @param ycbcrInfo : YCbCr smaple information
 Value *YCbCrConverter::createImageSampleInternal(SmallVectorImpl<Value *> &coordsIn, YCbCrSampleInfo *ycbcrInfo) {
-  Value *coords = m_builder->CreateInsertElement(UndefValue::get(VectorType::get(coordsIn[0]->getType(), 2)),
+  Value *coords = m_builder->CreateInsertElement(UndefValue::get(FixedVectorType::get(coordsIn[0]->getType(), 2)),
                                                  coordsIn[0], uint64_t(0));
 
   coords = m_builder->CreateInsertElement(coords, coordsIn[1], uint64_t(1));
@@ -467,7 +467,7 @@ Value *YCbCrConverter::rangeExpand(SamplerYCbCrRange range, const unsigned *chan
     float row0Num = static_cast<float>(0x1u << (channelBits[0] - 0x1u)) / ((0x1u << channelBits[0]) - 1u);
     float row2Num = static_cast<float>(0x1u << (channelBits[2] - 0x1u)) / ((0x1u << channelBits[2]) - 1u);
 
-    Value *convVec1 = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
+    Value *convVec1 = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
     convVec1 = m_builder->CreateInsertElement(convVec1, ConstantFP::get(m_builder->getFloatTy(), row0Num), uint64_t(0));
     convVec1 = m_builder->CreateInsertElement(convVec1, ConstantFP::get(m_builder->getFloatTy(), 0.0f), uint64_t(1));
     convVec1 = m_builder->CreateInsertElement(convVec1, ConstantFP::get(m_builder->getFloatTy(), row2Num), uint64_t(2));
@@ -485,7 +485,7 @@ Value *YCbCrConverter::rangeExpand(SamplerYCbCrRange range, const unsigned *chan
     float row1Num = static_cast<float>((0x1u << channelBits[1]) - 1u) / (219u * (0x1u << (channelBits[1] - 8)));
     float row2Num = static_cast<float>((0x1u << channelBits[2]) - 1u) / (224u * (0x1u << (channelBits[2] - 8)));
 
-    Value *convVec1 = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
+    Value *convVec1 = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
     convVec1 = m_builder->CreateInsertElement(convVec1, ConstantFP::get(m_builder->getFloatTy(), row0Num), uint64_t(0));
     convVec1 = m_builder->CreateInsertElement(convVec1, ConstantFP::get(m_builder->getFloatTy(), row1Num), uint64_t(1));
     convVec1 = m_builder->CreateInsertElement(convVec1, ConstantFP::get(m_builder->getFloatTy(), row2Num), uint64_t(2));
@@ -497,7 +497,7 @@ Value *YCbCrConverter::rangeExpand(SamplerYCbCrRange range, const unsigned *chan
     row1Num = static_cast<float>(16u * (0x1u << (channelBits[1] - 8))) / (219u * (0x1u << (channelBits[1] - 8)));
     row2Num = static_cast<float>(128u * (0x1u << (channelBits[2] - 8))) / (224u * (0x1u << (channelBits[2] - 8)));
 
-    Value *convVec2 = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
+    Value *convVec2 = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
     convVec2 = m_builder->CreateInsertElement(convVec2, ConstantFP::get(m_builder->getFloatTy(), row0Num), uint64_t(0));
     convVec2 = m_builder->CreateInsertElement(convVec2, ConstantFP::get(m_builder->getFloatTy(), row1Num), uint64_t(1));
     convVec2 = m_builder->CreateInsertElement(convVec2, ConstantFP::get(m_builder->getFloatTy(), row2Num), uint64_t(2));
@@ -719,12 +719,12 @@ Value *YCbCrConverter::convertColor(Type *resultTy, SamplerYCbCrModelConversion 
                                     unsigned *channelBits, Value *imageOp) {
   Value *subImage = m_builder->CreateShuffleVector(imageOp, imageOp, ArrayRef<int>{0, 1, 2});
 
-  Value *minVec = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
+  Value *minVec = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
   minVec = m_builder->CreateInsertElement(minVec, ConstantFP::get(m_builder->getFloatTy(), -0.5), uint64_t(0));
   minVec = m_builder->CreateInsertElement(minVec, ConstantFP::get(m_builder->getFloatTy(), 0.0), uint64_t(1));
   minVec = m_builder->CreateInsertElement(minVec, ConstantFP::get(m_builder->getFloatTy(), -0.5), uint64_t(2));
 
-  Value *maxVec = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
+  Value *maxVec = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
   maxVec = m_builder->CreateInsertElement(maxVec, ConstantFP::get(m_builder->getFloatTy(), 0.5), uint64_t(0));
   maxVec = m_builder->CreateInsertElement(maxVec, ConstantFP::get(m_builder->getFloatTy(), 1.0), uint64_t(1));
   maxVec = m_builder->CreateInsertElement(maxVec, ConstantFP::get(m_builder->getFloatTy(), 0.5), uint64_t(2));
@@ -760,9 +760,9 @@ Value *YCbCrConverter::convertColor(Type *resultTy, SamplerYCbCrModelConversion 
     // inputVec = RangeExpaned(C'_rgba)
     Value *inputVec = m_builder->CreateFClamp(rangeExpand(range, channelBits, subImage), minVec, maxVec);
 
-    Value *row0 = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
-    Value *row1 = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
-    Value *row2 = UndefValue::get(VectorType::get(m_builder->getFloatTy(), 3));
+    Value *row0 = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
+    Value *row1 = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
+    Value *row2 = UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 3));
 
     if (colorModel == SamplerYCbCrModelConversion::YCbCr601) {
 

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -97,7 +97,7 @@ Value *FragColorExport::run(Value *output, unsigned location, Instruction *inser
 
   const auto undefFloat = UndefValue::get(Type::getFloatTy(*m_context));
   const auto undefFloat16 = UndefValue::get(Type::getHalfTy(*m_context));
-  const auto undefFloat16x2 = UndefValue::get(VectorType::get(Type::getHalfTy(*m_context), 2));
+  const auto undefFloat16x2 = UndefValue::get(FixedVectorType::get(Type::getHalfTy(*m_context), 2));
 
   switch (expFmt) {
   case EXP_FORMAT_ZERO: {
@@ -202,11 +202,11 @@ Value *FragColorExport::run(Value *output, unsigned location, Instruction *inser
       Attribute::AttrKind attribs[] = {Attribute::ReadNone};
 
       // Do packing
-      comps[0] = emitCall("llvm.amdgcn.cvt.pkrtz", VectorType::get(Type::getHalfTy(*m_context), 2),
+      comps[0] = emitCall("llvm.amdgcn.cvt.pkrtz", FixedVectorType::get(Type::getHalfTy(*m_context), 2),
                           {comps[0], comps[1]}, attribs, insertPos);
 
       if (compCount > 2) {
-        comps[1] = emitCall("llvm.amdgcn.cvt.pkrtz", VectorType::get(Type::getHalfTy(*m_context), 2),
+        comps[1] = emitCall("llvm.amdgcn.cvt.pkrtz", FixedVectorType::get(Type::getHalfTy(*m_context), 2),
                             {comps[2], comps[3]}, attribs, insertPos);
       } else
         comps[1] = undefFloat16x2;
@@ -235,10 +235,10 @@ Value *FragColorExport::run(Value *output, unsigned location, Instruction *inser
         expFmt == EXP_FORMAT_SNORM16_ABGR ? "llvm.amdgcn.cvt.pknorm.i16" : "llvm.amdgcn.cvt.pknorm.u16";
 
     for (unsigned i = 0; i < compCount; i += 2) {
-      Value *packedComps =
-          emitCall(funcName, VectorType::get(Type::getInt16Ty(*m_context), 2), {comps[i], comps[i + 1]}, {}, insertPos);
+      Value *packedComps = emitCall(funcName, FixedVectorType::get(Type::getInt16Ty(*m_context), 2),
+                                    {comps[i], comps[i + 1]}, {}, insertPos);
 
-      packedComps = new BitCastInst(packedComps, VectorType::get(Type::getHalfTy(*m_context), 2), "", insertPos);
+      packedComps = new BitCastInst(packedComps, FixedVectorType::get(Type::getHalfTy(*m_context), 2), "", insertPos);
 
       comps[i] =
           ExtractElementInst::Create(packedComps, ConstantInt::get(Type::getInt32Ty(*m_context), 0), "", insertPos);
@@ -271,10 +271,10 @@ Value *FragColorExport::run(Value *output, unsigned location, Instruction *inser
     StringRef funcName = expFmt == EXP_FORMAT_SINT16_ABGR ? "llvm.amdgcn.cvt.pk.i16" : "llvm.amdgcn.cvt.pk.u16";
 
     for (unsigned i = 0; i < compCount; i += 2) {
-      Value *packedComps =
-          emitCall(funcName, VectorType::get(Type::getInt16Ty(*m_context), 2), {comps[i], comps[i + 1]}, {}, insertPos);
+      Value *packedComps = emitCall(funcName, FixedVectorType::get(Type::getInt16Ty(*m_context), 2),
+                                    {comps[i], comps[i + 1]}, {}, insertPos);
 
-      packedComps = new BitCastInst(packedComps, VectorType::get(Type::getHalfTy(*m_context), 2), "", insertPos);
+      packedComps = new BitCastInst(packedComps, FixedVectorType::get(Type::getHalfTy(*m_context), 2), "", insertPos);
 
       comps[i] =
           ExtractElementInst::Create(packedComps, ConstantInt::get(Type::getInt32Ty(*m_context), 0), "", insertPos);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -359,7 +359,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
     assert(byteSize % 4 == 0);
     unsigned dwordSize = byteSize / 4;
     Value *outputValue =
-        loadValueFromGsVsRing(VectorType::get(builder.getFloatTy(), dwordSize), loc, streamId, builder);
+        loadValueFromGsVsRing(FixedVectorType::get(builder.getFloatTy(), dwordSize), loc, streamId, builder);
     exportGenericOutput(outputValue, loc, streamId, builder);
   }
 
@@ -367,7 +367,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
   std::vector<std::pair<BuiltInKind, Type *>> builtInPairs;
 
   if (builtInUsage.position)
-    builtInPairs.push_back(std::make_pair(BuiltInPosition, VectorType::get(builder.getFloatTy(), 4)));
+    builtInPairs.push_back(std::make_pair(BuiltInPosition, FixedVectorType::get(builder.getFloatTy(), 4)));
 
   if (builtInUsage.pointSize)
     builtInPairs.push_back(std::make_pair(BuiltInPointSize, builder.getFloatTy()));
@@ -525,18 +525,18 @@ Value *PatchCopyShader::loadGsVsRingBufferDescriptor(BuilderBase &builder) {
   Value *internalTablePtrLow = getFunctionArgument(entryPoint, EntryArgIdxInternalTablePtrLow);
 
   Value *pc = builder.CreateIntrinsic(Intrinsic::amdgcn_s_getpc, {}, {});
-  pc = builder.CreateBitCast(pc, VectorType::get(builder.getInt32Ty(), 2));
+  pc = builder.CreateBitCast(pc, FixedVectorType::get(builder.getInt32Ty(), 2));
 
   auto internalTablePtrHigh = builder.CreateExtractElement(pc, 1);
 
-  auto undef = UndefValue::get(VectorType::get(builder.getInt32Ty(), 2));
+  auto undef = UndefValue::get(FixedVectorType::get(builder.getInt32Ty(), 2));
   Value *internalTablePtr = builder.CreateInsertElement(undef, internalTablePtrLow, uint64_t(0));
   internalTablePtr = builder.CreateInsertElement(internalTablePtr, internalTablePtrHigh, 1);
   internalTablePtr = builder.CreateBitCast(internalTablePtr, builder.getInt64Ty());
 
   auto gsVsRingBufDescPtr = builder.CreateAdd(internalTablePtr, builder.getInt64(SiDrvTableVsRingInOffs << 4));
 
-  auto int32x4PtrTy = PointerType::get(VectorType::get(builder.getInt32Ty(), 4), ADDR_SPACE_CONST);
+  auto int32x4PtrTy = PointerType::get(FixedVectorType::get(builder.getInt32Ty(), 4), ADDR_SPACE_CONST);
   gsVsRingBufDescPtr = builder.CreateIntToPtr(gsVsRingBufDescPtr, int32x4PtrTy);
   cast<Instruction>(gsVsRingBufDescPtr)
       ->setMetadata(MetaNameUniform, MDNode::get(gsVsRingBufDescPtr->getContext(), {}));
@@ -582,9 +582,9 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
 
         const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
         if (compCount > 1) {
-          outputValue = builder.CreateBitCast(outputValue, VectorType::get(builder.getInt32Ty(), compCount));
-          outputValue = builder.CreateTrunc(outputValue, VectorType::get(builder.getInt16Ty(), compCount));
-          outputValue = builder.CreateBitCast(outputValue, VectorType::get(builder.getHalfTy(), compCount));
+          outputValue = builder.CreateBitCast(outputValue, FixedVectorType::get(builder.getInt32Ty(), compCount));
+          outputValue = builder.CreateTrunc(outputValue, FixedVectorType::get(builder.getInt16Ty(), compCount));
+          outputValue = builder.CreateBitCast(outputValue, FixedVectorType::get(builder.getHalfTy(), compCount));
         } else {
           outputValue = builder.CreateBitCast(outputValue, builder.getInt32Ty());
           outputValue = new TruncInst(outputValue, builder.getInt16Ty());

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -917,7 +917,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
     // Emulate gl_NumWorkGroups via user data registers.
     // Later code needs to ensure that this starts on an even numbered register.
     if (builtInUsage.cs.numWorkgroups || userDataUsage->isSpecialUserDataUsed(UserDataMapping::Workgroup)) {
-      auto numWorkgroupsPtrTy = PointerType::get(VectorType::get(builder.getInt32Ty(), 3), ADDR_SPACE_CONST);
+      auto numWorkgroupsPtrTy = PointerType::get(FixedVectorType::get(builder.getInt32Ty(), 3), ADDR_SPACE_CONST);
       specialUserDataArgs.push_back(
           UserDataArg(numWorkgroupsPtrTy, UserDataMapping::Workgroup, &entryArgIdxs.cs.numWorkgroupsPtr));
     }
@@ -1155,14 +1155,14 @@ unsigned PatchEntryPointMutate::addUserDataArg(SmallVectorImpl<UserDataArg> &use
     // With useFixedLayout, we need a padding arg before the node's arg.
     assert(userDataValue + InterfaceData::CsStartUserData > userDataSize);
     userDataArgs.push_back(UserDataArg(
-        VectorType::get(builder.getInt32Ty(), userDataValue + InterfaceData::CsStartUserData - userDataSize),
+        FixedVectorType::get(builder.getInt32Ty(), userDataValue + InterfaceData::CsStartUserData - userDataSize),
         UserDataMapping::Invalid, nullptr, /*isPadding=*/true));
     userDataSize = userDataValue + InterfaceData::CsStartUserData;
   }
   // Now the node arg itself.
   Type *argTy = builder.getInt32Ty();
   if (sizeInDwords != 1)
-    argTy = VectorType::get(argTy, sizeInDwords);
+    argTy = FixedVectorType::get(argTy, sizeInDwords);
   userDataArgs.push_back(UserDataArg(argTy, userDataValue, argIndex));
   userDataSize += sizeInDwords;
   return userDataSize;
@@ -1299,7 +1299,7 @@ void PatchEntryPointMutate::determineUnspilledUserDataArgs(ArrayRef<UserDataArg>
     if (!spillTableArg.empty()) {
       if (userDataIdx != userDataEnd) {
         assert(userDataIdx <= userDataEnd);
-        unspilledArgs.push_back(UserDataArg(VectorType::get(builder.getInt32Ty(), userDataEnd - userDataIdx),
+        unspilledArgs.push_back(UserDataArg(FixedVectorType::get(builder.getInt32Ty(), userDataEnd - userDataIdx),
                                             UserDataMapping::Invalid, nullptr, /*padding=*/true));
       }
       unspilledArgs.push_back(spillTableArg.front());

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1346,7 +1346,7 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
         else {
           const auto compTy = expFragColor[0]->getType();
 
-          output = UndefValue::get(VectorType::get(compTy, compCount));
+          output = UndefValue::get(FixedVectorType::get(compTy, compCount));
           for (unsigned i = 0; i < compCount; ++i) {
             assert(expFragColor[i]->getType() == compTy);
             output = InsertElementInst::Create(output, expFragColor[i],
@@ -1449,7 +1449,7 @@ Value *PatchInOutImportExport::patchGsGenericInputImport(Type *inputTy, unsigned
     compIdx *= 2; // For 64-bit data type, the component indexing must multiply by 2
 
     // Cast 64-bit data type to float vector
-    inputTy = VectorType::get(Type::getFloatTy(*m_context), compCount * 2);
+    inputTy = FixedVectorType::get(Type::getFloatTy(*m_context), compCount * 2);
   } else
     assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32);
 
@@ -1571,7 +1571,7 @@ Value *PatchInOutImportExport::patchFsGenericInputImport(Type *inputTy, unsigned
   else
     interpTy = Type::getFloatTy(*m_context);
   if (numChannels > 1)
-    interpTy = VectorType::get(interpTy, numChannels);
+    interpTy = FixedVectorType::get(interpTy, numChannels);
   Value *interp = UndefValue::get(interpTy);
 
   unsigned startChannel = 0;
@@ -1738,7 +1738,7 @@ void PatchInOutImportExport::patchVsGenericOutputExport(Value *output, unsigned 
 
         unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() * 2 : 2;
 
-        outputTy = VectorType::get(Type::getFloatTy(*m_context), compCount);
+        outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), compCount);
         output = new BitCastInst(output, outputTy, "", insertPos);
       } else
         assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32);
@@ -1786,7 +1786,7 @@ void PatchInOutImportExport::patchTesGenericOutputExport(Value *output, unsigned
       compIdx *= 2;
 
       unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() * 2 : 2;
-      outputTy = VectorType::get(Type::getFloatTy(*m_context), compCount);
+      outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), compCount);
 
       output = new BitCastInst(output, outputTy, "", insertPos);
     } else
@@ -1816,9 +1816,9 @@ void PatchInOutImportExport::patchGsGenericOutputExport(Value *output, unsigned 
     compIdx *= 2;
 
     if (outputTy->isVectorTy())
-      outputTy = VectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(outputTy)->getNumElements() * 2);
+      outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(outputTy)->getNumElements() * 2);
     else
-      outputTy = VectorType::get(Type::getFloatTy(*m_context), 2);
+      outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), 2);
 
     output = new BitCastInst(output, outputTy, "", insertPos);
   } else
@@ -2357,7 +2357,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
     auto primMask = getFunctionArgument(m_entryPoint, entryArgIdxs.primMask);
     auto ij = getFunctionArgument(m_entryPoint, entryArgIdxs.linearInterp.center);
 
-    ij = new BitCastInst(ij, VectorType::get(Type::getFloatTy(*m_context), 2), "", insertPos);
+    ij = new BitCastInst(ij, FixedVectorType::get(Type::getFloatTy(*m_context), 2), "", insertPos);
     auto iCoord = ExtractElementInst::Create(ij, ConstantInt::get(Type::getInt32Ty(*m_context), 0), "", insertPos);
     auto jCoord = ExtractElementInst::Create(ij, ConstantInt::get(Type::getInt32Ty(*m_context), 1), "", insertPos);
 
@@ -3443,7 +3443,7 @@ void PatchInOutImportExport::patchXfbOutputExport(Value *output, unsigned xfbBuf
     // Cast 64-bit output to 32-bit
     compCount *= 2;
     bitWidth = 32;
-    outputTy = VectorType::get(Type::getFloatTy(*m_context), compCount);
+    outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), compCount);
     output = new BitCastInst(output, outputTy, "", insertPos);
   }
   assert(bitWidth == 16 || bitWidth == 32);
@@ -3538,13 +3538,13 @@ void PatchInOutImportExport::createStreamOutBufferStoreFunction(Value *storeValu
   // }
 
   Type *argTys[] = {
-      storeValue->getType(),                            // %storeValue
-      VectorType::get(Type::getInt32Ty(*m_context), 4), // %streamOutBufDesc
-      Type::getInt32Ty(*m_context),                     // %writeIndex
-      Type::getInt32Ty(*m_context),                     // %threadId
-      Type::getInt32Ty(*m_context),                     // %vertexCount
-      Type::getInt32Ty(*m_context),                     // %xfbOffset
-      Type::getInt32Ty(*m_context)                      // %streamOffset
+      storeValue->getType(),                                 // %storeValue
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 4), // %streamOutBufDesc
+      Type::getInt32Ty(*m_context),                          // %writeIndex
+      Type::getInt32Ty(*m_context),                          // %threadId
+      Type::getInt32Ty(*m_context),                          // %vertexCount
+      Type::getInt32Ty(*m_context),                          // %xfbOffset
+      Type::getInt32Ty(*m_context)                           // %streamOffset
   };
   auto funcTy = FunctionType::get(Type::getVoidTy(*m_context), argTys, false);
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, funcName, m_module);
@@ -3684,9 +3684,9 @@ unsigned PatchInOutImportExport::combineBufferStore(const std::vector<Value *> &
 
   Type *storeTys[4] = {
       Type::getInt32Ty(*m_context),
-      VectorType::get(Type::getInt32Ty(*m_context), 2),
-      VectorType::get(Type::getInt32Ty(*m_context), 3),
-      VectorType::get(Type::getInt32Ty(*m_context), 4),
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 2),
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 3),
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 4),
   };
 
   std::string funcName = "llvm.amdgcn.raw.tbuffer.store.";
@@ -3702,7 +3702,7 @@ unsigned PatchInOutImportExport::combineBufferStore(const std::vector<Value *> &
       funcName += getTypeName(storeTys[compCount - 1]);
       Value *storeValue = nullptr;
       if (compCount > 1) {
-        auto storeTy = VectorType::get(Type::getInt32Ty(*m_context), compCount);
+        auto storeTy = FixedVectorType::get(Type::getInt32Ty(*m_context), compCount);
         storeValue = UndefValue::get(storeTy);
 
         for (unsigned i = 0; i < compCount; ++i) {
@@ -3760,9 +3760,9 @@ unsigned PatchInOutImportExport::combineBufferLoad(std::vector<Value *> &loadVal
 
   Type *loadTyps[4] = {
       Type::getInt32Ty(*m_context),
-      VectorType::get(Type::getInt32Ty(*m_context), 2),
-      VectorType::get(Type::getInt32Ty(*m_context), 3),
-      VectorType::get(Type::getInt32Ty(*m_context), 4),
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 2),
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 3),
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 4),
   };
 
   std::string funcName = "llvm.amdgcn.raw.tbuffer.load.";
@@ -3828,7 +3828,7 @@ void PatchInOutImportExport::storeValueToStreamOutBuffer(Value *storeValue, unsi
   if (storeTy->isIntOrIntVectorTy()) {
     Type *bitCastTy = bitWidth == 32 ? Type::getFloatTy(*m_context) : Type::getHalfTy(*m_context);
     if (compCount > 1)
-      bitCastTy = VectorType::get(bitCastTy, compCount);
+      bitCastTy = FixedVectorType::get(bitCastTy, compCount);
     storeValue = new BitCastInst(storeValue, bitCastTy, "", insertPos);
   }
 
@@ -4403,7 +4403,7 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
     auto intTy = bitWidth == 32 || bitWidth == 64
                      ? Type::getInt32Ty(*m_context)
                      : (bitWidth == 16 ? Type::getInt16Ty(*m_context) : Type::getInt8Ty(*m_context));
-    auto castTy = VectorType::get(intTy, numChannels);
+    auto castTy = FixedVectorType::get(intTy, numChannels);
     castValue = UndefValue::get(castTy);
 
     for (unsigned i = 0; i < numChannels; ++i) {
@@ -4438,7 +4438,7 @@ void PatchInOutImportExport::writeValueToLds(Value *writeValue, Value *ldsOffset
   Type *intTy = bitWidth == 32 || bitWidth == 64
                     ? Type::getInt32Ty(*m_context)
                     : (bitWidth == 16 ? Type::getInt16Ty(*m_context) : Type::getInt8Ty(*m_context));
-  Type *castTy = numChannels > 1 ? cast<Type>(VectorType::get(intTy, numChannels)) : intTy;
+  Type *castTy = numChannels > 1 ? cast<Type>(FixedVectorType::get(intTy, numChannels)) : intTy;
   Value *castValue = new BitCastInst(writeValue, castTy, "", insertPos);
 
   // Extract store values (dwords) from <n x i8>, <n x i16> or <n x i32> vector
@@ -4687,12 +4687,12 @@ void PatchInOutImportExport::createTessBufferStoreFunction() {
   //     ret void
   // }
   Type *argTys[] = {
-      VectorType::get(Type::getInt32Ty(*m_context), 4), // TF buffer descriptor
-      Type::getInt32Ty(*m_context),                     // TF buffer base
-      Type::getInt32Ty(*m_context),                     // Relative patch ID
-      Type::getInt32Ty(*m_context),                     // TF stride
-      Type::getInt32Ty(*m_context),                     // TF offset
-      Type::getFloatTy(*m_context)                      // TF value
+      FixedVectorType::get(Type::getInt32Ty(*m_context), 4), // TF buffer descriptor
+      Type::getInt32Ty(*m_context),                          // TF buffer base
+      Type::getInt32Ty(*m_context),                          // Relative patch ID
+      Type::getInt32Ty(*m_context),                          // TF stride
+      Type::getInt32Ty(*m_context),                          // TF offset
+      Type::getFloatTy(*m_context)                           // TF value
   };
   auto funcTy = FunctionType::get(Type::getVoidTy(*m_context), argTys, false);
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::TfBufferStore, m_module);
@@ -5122,21 +5122,21 @@ void PatchInOutImportExport::addExportInstForGenericOutput(Value *output, unsign
   const unsigned numChannels = bitWidth == 64 ? compCount * 2 : compCount;
   unsigned startChannel = bitWidth == 64 ? compIdx * 2 : compIdx;
   Type *exportTy =
-      numChannels > 1 ? VectorType::get(Type::getFloatTy(*m_context), numChannels) : Type::getFloatTy(*m_context);
+      numChannels > 1 ? FixedVectorType::get(Type::getFloatTy(*m_context), numChannels) : Type::getFloatTy(*m_context);
 
   if (outputTy != exportTy) {
     if (bitWidth == 8) {
       // NOTE: For 16-bit output export, we have to cast the 8-bit value to 32-bit floating-point value.
       assert(outputTy->isIntOrIntVectorTy());
       Type *zExtTy = Type::getInt32Ty(*m_context);
-      zExtTy = outputTy->isVectorTy() ? cast<Type>(VectorType::get(zExtTy, compCount)) : zExtTy;
+      zExtTy = outputTy->isVectorTy() ? cast<Type>(FixedVectorType::get(zExtTy, compCount)) : zExtTy;
       exportInst = new ZExtInst(output, zExtTy, "", insertPos);
       exportInst = new BitCastInst(exportInst, exportTy, "", insertPos);
     } else if (bitWidth == 16) {
       // NOTE: For 16-bit output export, we have to cast the 16-bit value to 32-bit floating-point value.
       if (outputTy->isFPOrFPVectorTy()) {
         Type *bitCastTy = Type::getInt16Ty(*m_context);
-        bitCastTy = outputTy->isVectorTy() ? cast<Type>(VectorType::get(bitCastTy, compCount)) : bitCastTy;
+        bitCastTy = outputTy->isVectorTy() ? cast<Type>(FixedVectorType::get(bitCastTy, compCount)) : bitCastTy;
         exportInst = new BitCastInst(output, bitCastTy, "", insertPos);
       } else {
         assert(outputTy->isIntOrIntVectorTy());
@@ -5144,7 +5144,7 @@ void PatchInOutImportExport::addExportInstForGenericOutput(Value *output, unsign
       }
 
       Type *zExtTy = Type::getInt32Ty(*m_context);
-      zExtTy = outputTy->isVectorTy() ? cast<Type>(VectorType::get(zExtTy, compCount)) : zExtTy;
+      zExtTy = outputTy->isVectorTy() ? cast<Type>(FixedVectorType::get(zExtTy, compCount)) : zExtTy;
       exportInst = new ZExtInst(exportInst, zExtTy, "", insertPos);
       exportInst = new BitCastInst(exportInst, exportTy, "", insertPos);
     } else {

--- a/lgc/patch/PatchPeepholeOpt.cpp
+++ b/lgc/patch/PatchPeepholeOpt.cpp
@@ -173,16 +173,16 @@ void PatchPeepholeOpt::visitBitCast(BitCastInst &bitCast) {
 
     // Bit cast the LHS of the original shuffle.
     Value *const shuffleVectorLhs = shuffleVector->getOperand(0);
-    Type *const bitCastLhsType = VectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
-                                                 cast<VectorType>(shuffleVectorLhs->getType())->getNumElements());
+    Type *const bitCastLhsType = FixedVectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
+                                                      cast<VectorType>(shuffleVectorLhs->getType())->getNumElements());
     BitCastInst *const bitCastLhs =
         new BitCastInst(shuffleVectorLhs, bitCastLhsType, shuffleVectorLhs->getName() + ".bitcast");
     insertAfter(*bitCastLhs, *shuffleVector);
 
     // Bit cast the RHS of the original shuffle.
     Value *const shuffleVectorRhs = shuffleVector->getOperand(1);
-    Type *const bitCastRhsType = VectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
-                                                 cast<VectorType>(shuffleVectorRhs->getType())->getNumElements());
+    Type *const bitCastRhsType = FixedVectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
+                                                      cast<VectorType>(shuffleVectorRhs->getType())->getNumElements());
     BitCastInst *const bitCastRhs =
         new BitCastInst(shuffleVectorRhs, bitCastRhsType, shuffleVectorRhs->getName() + ".bitcast");
     insertAfter(*bitCastRhs, *bitCastLhs);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2665,7 +2665,7 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
         outValue = builder.CreateBitCast(outValue, builder.getFloatTy());
       }
     } else {
-      outValue = UndefValue::get(VectorType::get(builder.getFloatTy(), compCount));
+      outValue = UndefValue::get(FixedVectorType::get(builder.getFloatTy(), compCount));
       if (elementsInfo.is16Bit) {
         // Pack two elements for a component
         unsigned compIdx = 0;
@@ -2769,7 +2769,7 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
     assert(resultTy->getPrimitiveSizeInBits() == 64);
     std::string callName = isInterpolant ? lgcName::InputImportInterpolant : lgcName::InputImportGeneric;
     addTypeMangling(builder.getInt32Ty(), args, callName);
-    Value *result = UndefValue::get(VectorType::get(builder.getInt32Ty(), 2));
+    Value *result = UndefValue::get(FixedVectorType::get(builder.getInt32Ty(), 2));
     for (unsigned i = 0; i != 2; ++i) {
       args[elemIdxArgIdx] = builder.getInt32(elemIdx * 2 + i);
       result = builder.CreateInsertElement(
@@ -2885,7 +2885,7 @@ void PatchResourceCollect::scalarizeGenericOutput(CallInst *call) {
   }
 
   // Bitcast the original value to the vector type if necessary.
-  outputVal = builder.CreateBitCast(outputVal, VectorType::get(elementTy, scalarizeBy));
+  outputVal = builder.CreateBitCast(outputVal, FixedVectorType::get(elementTy, scalarizeBy));
 
   // Extract and store the individual elements.
   std::string callName;

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -138,7 +138,7 @@ Type *ShaderInputs::getInputType(ShaderInput inputKind, LLVMContext &context) {
   switch (inputKind) {
   case ShaderInput::WorkgroupId:
   case ShaderInput::LocalInvocationId:
-    return VectorType::get(Type::getInt32Ty(context), 3);
+    return FixedVectorType::get(Type::getInt32Ty(context), 3);
 
   case ShaderInput::TessCoordX:
   case ShaderInput::TessCoordY:
@@ -150,7 +150,7 @@ Type *ShaderInputs::getInputType(ShaderInput inputKind, LLVMContext &context) {
     return Type::getFloatTy(context);
 
   case ShaderInput::PerspInterpPullMode:
-    return VectorType::get(Type::getFloatTy(context), 3);
+    return FixedVectorType::get(Type::getFloatTy(context), 3);
 
   case ShaderInput::PerspInterpSample:
   case ShaderInput::PerspInterpCenter:
@@ -158,7 +158,7 @@ Type *ShaderInputs::getInputType(ShaderInput inputKind, LLVMContext &context) {
   case ShaderInput::LinearInterpSample:
   case ShaderInput::LinearInterpCenter:
   case ShaderInput::LinearInterpCentroid:
-    return VectorType::get(Type::getFloatTy(context), 2);
+    return FixedVectorType::get(Type::getFloatTy(context), 2);
 
   default:
     return Type::getInt32Ty(context);

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -110,7 +110,7 @@ FunctionType *ShaderMerger::generateLsHsEntryPointType(uint64_t *inRegMask) cons
   }
 
   assert(userDataCount > 0);
-  argTys.push_back(VectorType::get(Type::getInt32Ty(*m_context), userDataCount));
+  argTys.push_back(FixedVectorType::get(Type::getInt32Ty(*m_context), userDataCount));
   *inRegMask |= (1ull << LsHsSpecialSysValueCount);
 
   // Other system values (VGPRs)
@@ -507,7 +507,7 @@ FunctionType *ShaderMerger::generateEsGsEntryPointType(uint64_t *inRegMask) cons
   }
 
   assert(userDataCount > 0);
-  argTys.push_back(VectorType::get(Type::getInt32Ty(*m_context), userDataCount));
+  argTys.push_back(FixedVectorType::get(Type::getInt32Ty(*m_context), userDataCount));
   *inRegMask |= (1ull << EsGsSpecialSysValueCount);
 
   // Other system values (VGPRs)

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -175,7 +175,7 @@ Value *ShaderSystemValues::getTessCoord() {
     tessCoordZ =
         primitiveMode == PrimitiveMode::Triangles ? tessCoordZ : ConstantFP::get(Type::getFloatTy(*m_context), 0.0f);
 
-    m_tessCoord = UndefValue::get(VectorType::get(Type::getFloatTy(*m_context), 3));
+    m_tessCoord = UndefValue::get(FixedVectorType::get(Type::getFloatTy(*m_context), 3));
     m_tessCoord = InsertElementInst::Create(m_tessCoord, tessCoordX, ConstantInt::get(Type::getInt32Ty(*m_context), 0),
                                             "", insertPos);
     m_tessCoord = InsertElementInst::Create(m_tessCoord, tessCoordY, ConstantInt::get(Type::getInt32Ty(*m_context), 1),
@@ -194,7 +194,7 @@ Value *ShaderSystemValues::getEsGsOffsets() {
     auto insertPos = &*m_entryPoint->front().getFirstInsertionPt();
     auto intfData = m_pipelineState->getShaderInterfaceData(m_shaderStage);
 
-    m_esGsOffsets = UndefValue::get(VectorType::get(Type::getInt32Ty(*m_context), 6));
+    m_esGsOffsets = UndefValue::get(FixedVectorType::get(Type::getInt32Ty(*m_context), 6));
     for (unsigned i = 0; i < InterfaceData::MaxEsGsOffsetCount; ++i) {
       auto esGsOffset =
           getFunctionArgument(m_entryPoint, intfData->entryArgIdxs.gs.esGsOffsets[i], Twine("esGsOffset") + Twine(i));
@@ -387,9 +387,9 @@ Instruction *ShaderSystemValues::getStreamOutTablePtr() {
 
     // Get the 64-bit extended node value.
     auto streamOutTablePtrLow = getFunctionArgument(m_entryPoint, entryArgIdx, "streamOutTable");
-    auto streamOutTablePtrTy =
-        PointerType::get(ArrayType::get(VectorType::get(Type::getInt32Ty(*m_context), 4), MaxTransformFeedbackBuffers),
-                         ADDR_SPACE_CONST);
+    auto streamOutTablePtrTy = PointerType::get(
+        ArrayType::get(FixedVectorType::get(Type::getInt32Ty(*m_context), 4), MaxTransformFeedbackBuffers),
+        ADDR_SPACE_CONST);
     m_streamOutTablePtr = makePointer(streamOutTablePtrLow, streamOutTablePtrTy, InvalidValue);
   }
   return m_streamOutTablePtr;
@@ -423,7 +423,7 @@ Instruction *ShaderSystemValues::makePointer(Value *lowValue, Type *ptrTy, unsig
       // reuse this PC if its pLowValue is an arg rather than an instruction.
       auto pcInsertPos = &*m_entryPoint->front().getFirstInsertionPt();
       Value *pc = emitCall("llvm.amdgcn.s.getpc", Type::getInt64Ty(*m_context), ArrayRef<Value *>(), {}, pcInsertPos);
-      m_pc = new BitCastInst(pc, VectorType::get(Type::getInt32Ty(*m_context), 2), "", insertPos);
+      m_pc = new BitCastInst(pc, FixedVectorType::get(Type::getInt32Ty(*m_context), 2), "", insertPos);
     } else
       insertPos = m_pc->getNextNode();
     extendedPtrValue = m_pc;
@@ -449,7 +449,7 @@ Instruction *ShaderSystemValues::makePointer(Value *lowValue, Type *ptrTy, unsig
 // @param builder : Builder to use for insertion
 Instruction *ShaderSystemValues::loadDescFromDriverTable(unsigned tableOffset, BuilderBase &builder) {
   auto globalTable = getInternalGlobalTablePtr();
-  Type *descTy = VectorType::get(builder.getInt32Ty(), 4);
+  Type *descTy = FixedVectorType::get(builder.getInt32Ty(), 4);
   globalTable = cast<Instruction>(builder.CreateBitCast(globalTable, descTy->getPointerTo(ADDR_SPACE_CONST)));
   Value *descPtr = builder.CreateGEP(descTy, globalTable, builder.getInt32(tableOffset));
   LoadInst *desc = builder.CreateLoad(descTy, descPtr);

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -541,7 +541,7 @@ void PalMetadata::getVertexFetchInfo(SmallVectorImpl<VertexFetchInfo> &fetches) 
     else if (tyName == "f64")
       ty = Type::getDoubleTy(m_pipelineState->getContext());
     if (vecLength != 0)
-      ty = VectorType::get(ty, vecLength);
+      ty = FixedVectorType::get(ty, vecLength);
     fetches.push_back({location, component, ty});
   }
   m_pipelineNode.erase(m_document->getNode(PipelineMetadataKey::VertexInputs));

--- a/lgc/util/AddressExtender.cpp
+++ b/lgc/util/AddressExtender.cpp
@@ -61,7 +61,8 @@ Instruction *AddressExtender::extend(Value *addr32, unsigned highHalf, Type *ptr
     ptr = builder.CreateInsertElement(getPc(), addr32, uint64_t(0));
   } else {
     // Extend with given value
-    ptr = builder.CreateInsertElement(UndefValue::get(VectorType::get(builder.getInt32Ty(), 2)), addr32, uint64_t(0));
+    ptr = builder.CreateInsertElement(UndefValue::get(FixedVectorType::get(builder.getInt32Ty(), 2)), addr32,
+                                      uint64_t(0));
     ptr = builder.CreateInsertElement(ptr, builder.getInt32(highHalf), 1);
   }
   ptr = builder.CreateBitCast(ptr, builder.getInt64Ty());
@@ -78,7 +79,7 @@ Instruction *AddressExtender::getPc() {
     IRBuilder<> builder(m_func->getContext());
     builder.SetInsertPoint(&*m_func->front().getFirstInsertionPt());
     Value *pc = builder.CreateIntrinsic(llvm::Intrinsic::amdgcn_s_getpc, {}, {});
-    pc = cast<Instruction>(builder.CreateBitCast(pc, VectorType::get(builder.getInt32Ty(), 2)));
+    pc = cast<Instruction>(builder.CreateBitCast(pc, FixedVectorType::get(builder.getInt32Ty(), 2)));
     m_pc = cast<Instruction>(pc);
   }
   return m_pc;


### PR DESCRIPTION
Same as David just did in LLPC to avoid an LLVM deprecation, but now in
LGC. (LGC didn't fail to build with the new LLVM that deprecates that
VectorType::get overload, because we accidentally don't build LGC with
warnings-as-errors because it is built as an LLVM external project.)

Change-Id: I27eca91d4bfd1030c55c25e9e8c6648f49efff74