### PR TITLE
Add color export info to the pal metadata.

### DIFF
--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -43,6 +43,7 @@ class PassManager;
 
 } // namespace legacy
 
+void initializeLowerFragColorExportPass(PassRegistry &);
 void initializeLowerVertexFetchPass(PassRegistry &);
 void initializePatchBufferOpPass(PassRegistry &);
 void initializePatchCheckShaderCachePass(PassRegistry &);
@@ -69,6 +70,7 @@ class PatchCheckShaderCache;
 //
 // @param passRegistry : Pass registry
 inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
+  initializeLowerFragColorExportPass(passRegistry);
   initializeLowerVertexFetchPass(passRegistry);
   initializePatchBufferOpPass(passRegistry);
   initializePatchCheckShaderCachePass(passRegistry);
@@ -86,6 +88,7 @@ inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializePatchSetupTargetFeaturesPass(passRegistry);
 }
 
+llvm::ModulePass *createLowerFragColorExport();
 llvm::ModulePass *createLowerVertexFetch();
 llvm::FunctionPass *createPatchBufferOp();
 PatchCheckShaderCache *createPatchCheckShaderCache();

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -177,6 +177,20 @@ enum class UserDataMapping : unsigned {
   Invalid = ~0U // Invalid value used internally in LGC.
 };
 
+// An enumeration of shader export formats.
+typedef enum SPI_SHADER_EX_FORMAT {
+  SPI_SHADER_ZERO = 0x00000000,
+  SPI_SHADER_32_R = 0x00000001,
+  SPI_SHADER_32_GR = 0x00000002,
+  SPI_SHADER_32_AR = 0x00000003,
+  SPI_SHADER_FP16_ABGR = 0x00000004,
+  SPI_SHADER_UNORM16_ABGR = 0x00000005,
+  SPI_SHADER_SNORM16_ABGR = 0x00000006,
+  SPI_SHADER_UINT16_ABGR = 0x00000007,
+  SPI_SHADER_SINT16_ABGR = 0x00000008,
+  SPI_SHADER_32_ABGR = 0x00000009,
+} SPI_SHADER_EX_FORMAT;
+
 // The names of API shader stages used in PAL metadata, in ShaderStage order.
 static const char *const ApiStageNames[] = {".vertex", ".hull", ".domain", ".geometry", ".pixel", ".compute"};
 
@@ -222,6 +236,10 @@ constexpr unsigned mmSPI_SHADER_PGM_RSRC2_VS = 0x2C4B;
 // Other SPI register numbers in PAL metadata
 constexpr unsigned int mmPA_CL_CLIP_CNTL = 0xA204;
 constexpr unsigned mmVGT_SHADER_STAGES_EN = 0xA2D5;
+constexpr unsigned mmSPI_SHADER_COL_FORMAT = 0xA1C5;
+constexpr unsigned mmDB_SHADER_CONTROL = 0xA203;
+constexpr unsigned mmSPI_SHADER_Z_FORMAT = 0xA1C4;
+constexpr unsigned mmCB_SHADER_MASK = 0xA08F;
 
 // Register bitfield layout.
 
@@ -284,6 +302,16 @@ union VGT_SHADER_STAGES_EN {
     unsigned int VS_W32_EN : 1;
     unsigned int : 8;
   } gfx10;
+  unsigned int u32All;
+};
+
+// The DB_SHADER_CONTROL register.
+union DB_SHADER_CONTROL {
+  struct {
+    unsigned int : 6;
+    unsigned int KILL_ENABLE : 1;
+    unsigned int : 25;
+  } bitfields, bits;
   unsigned int u32All;
 };
 

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -111,6 +111,7 @@ static constexpr char FetchlessLsEntryName[] = "_amdgpu_ls_main_fetchless";
 namespace PipelineMetadataKey {
 
 static const char VertexInputs[] = ".vertexInputs";
+static const char ColorExports[] = ".colorExports";
 
 } // namespace PipelineMetadataKey
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -236,6 +236,7 @@ public:
 
   // Accessors for color export state
   const ColorExportFormat &getColorExportFormat(unsigned location);
+  const bool hasColorExportFormats() { return !m_colorExportFormats.empty(); }
   const ColorExportState &getColorExportState() { return m_colorExportState; }
 
   // Accessors for pipeline state

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -403,7 +403,6 @@ struct ResourceUsage {
       unsigned outputOrigLocs[MaxColorTargets];
 
       std::vector<FsInterpInfo> interpInfo;   // Array of interpolation info
-      ExportFormat expFmts[MaxColorTargets];  // Shader export formats
       BasicType outputTypes[MaxColorTargets]; // Array of basic types of fragment outputs
       unsigned cbShaderMask;                  // CB shader channel mask (correspond to register CB_SHADER_MASK)
       bool dummyExport;                       // Control to generate fragment shader dummy export

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -922,25 +922,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
     depthExpFmt = EXP_FORMAT_32_R;
   SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
 
-  unsigned spiShaderColFormat = 0;
   unsigned cbShaderMask = resUsage->inOutUsage.fs.cbShaderMask;
   cbShaderMask = resUsage->inOutUsage.fs.isNullFs ? 0 : cbShaderMask;
-  const auto &expFmts = resUsage->inOutUsage.fs.expFmts;
-  for (unsigned i = 0; i < MaxColorTargets; ++i) {
-    // Set fields COL0_EXPORT_FORMAT ~ COL7_EXPORT_FORMAT
-    spiShaderColFormat |= (expFmts[i] << (4 * i));
-  }
-
-  if (spiShaderColFormat == 0 && depthExpFmt == EXP_FORMAT_ZERO) {
-    // NOTE: Hardware requires that fragment shader always exports "something" (color or depth) to the SX.
-    // If both SPI_SHADER_Z_FORMAT and SPI_SHADER_COL_FORMAT are zero, we need to override
-    // SPI_SHADER_COL_FORMAT to export one channel to MRT0. This dummy export format will be masked
-    // off by CB_SHADER_MASK.
-    spiShaderColFormat = SPI_SHADER_32_R;
-  }
-
-  SET_REG(&pConfig->psRegs, SPI_SHADER_COL_FORMAT, spiShaderColFormat);
-
   SET_REG(&pConfig->psRegs, CB_SHADER_MASK, cbShaderMask);
   SET_REG_FIELD(&pConfig->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, resUsage->inOutUsage.fs.interpInfo.size());
 

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1854,25 +1854,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
     depthExpFmt = EXP_FORMAT_32_R;
   SET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
 
-  unsigned spiShaderColFormat = 0;
   unsigned cbShaderMask = resUsage->inOutUsage.fs.cbShaderMask;
   cbShaderMask = resUsage->inOutUsage.fs.isNullFs ? 0 : cbShaderMask;
-  const auto &expFmts = resUsage->inOutUsage.fs.expFmts;
-  for (unsigned i = 0; i < MaxColorTargets; ++i) {
-    // Set fields COL0_EXPORT_FORMAT ~ COL7_EXPORT_FORMAT
-    spiShaderColFormat |= (expFmts[i] << (4 * i));
-  }
-
-  if (spiShaderColFormat == 0 && depthExpFmt == EXP_FORMAT_ZERO && resUsage->inOutUsage.fs.dummyExport) {
-    // NOTE: Hardware requires that fragment shader always exports "something" (color or depth) to the SX.
-    // If both SPI_SHADER_Z_FORMAT and SPI_SHADER_COL_FORMAT are zero, we need to override
-    // SPI_SHADER_COL_FORMAT to export one channel to MRT0. This dummy export format will be masked
-    // off by CB_SHADER_MASK.
-    spiShaderColFormat = SPI_SHADER_32_R;
-  }
-
-  SET_REG(&pConfig->psRegs, SPI_SHADER_COL_FORMAT, spiShaderColFormat);
-
   SET_REG(&pConfig->psRegs, CB_SHADER_MASK, cbShaderMask);
   SET_REG_FIELD(&pConfig->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, resUsage->inOutUsage.fs.interpInfo.size());
 

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -109,6 +109,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Lower vertex fetch operations.
   passMgr.add(createLowerVertexFetch());
 
+  // Lower fragment export operations.
+  passMgr.add(createLowerFragColorExport());
+
   // Patch entry-point mutation (should be done before external library link)
   passMgr.add(createPatchEntryPointMutate());
 

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -90,8 +90,6 @@ private:
                                    llvm::Instruction *insertPos);
   void patchGsGenericOutputExport(llvm::Value *output, unsigned location, unsigned compIdx, unsigned streamId,
                                   llvm::Instruction *insertPos);
-  void patchFsGenericOutputExport(llvm::Value *output, unsigned location, unsigned compIdx,
-                                  llvm::Instruction *insertPos);
 
   llvm::Value *patchVsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Instruction *insertPos);
   llvm::Value *patchTcsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -59,7 +59,6 @@ ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
     inOutUsage.gs.calcFactor = {};
   } else if (shaderStage == ShaderStageFragment) {
     for (uint32_t i = 0; i < MaxColorTargets; ++i) {
-      inOutUsage.fs.expFmts[i] = EXP_FORMAT_ZERO;
       inOutUsage.fs.outputTypes[i] = BasicType::Unknown;
     }
 


### PR DESCRIPTION
- Define pal metadata info for the color export information, and generate it.
- Use it to compute the SPI_SHADER_COL_FORMAT during pal metadata finalization.

This is now based on #777 and #786.  Only the latest commit is part of this change.