### PR TITLE
add ICache interface

### DIFF
--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -175,10 +175,11 @@ public:
   /// @param [in]  optionCount    Count of compilation-option strings
   /// @param [in]  options        An array of compilation-option strings
   /// @param [out] ppCompiler     Pointer to the created pipeline compiler object
+  /// @param [in]  pCache         Pointer to the ICache object
   ///
   /// @returns Result::Success if successful. Other return codes indicate failure.
   static Result VKAPI_CALL Create(GfxIpVersion gfxIp, unsigned optionCount, const char *const *options,
-                                  ICompiler **ppCompiler);
+                                  ICompiler **ppCompiler, Vkgc::ICache *pCache = nullptr);
 
   /// Checks whether a vertex attribute format is supported by fetch shader.
   ///


### PR DESCRIPTION
    Pick up Nicolai's idea.

    Now on the interface design between compiler and client driver, there are a couple of constraints on the design that should be taken into account:
    1. Potential desire to store the shaders in the VkPipelineCache. Since the VkPipelineCache can be specified per vkCreateGraphicsPipeline call, we have
    to keep the ability to specify it as such even if the first version of this looks different.
    2. Lockout of redundant parallel compilation: the internal shader cache of LLPC (and SCPC) are currently able to detect when two threads attempt to
    compile the same shader which is not in the cache yet. In this case, only one thread will do the compilation while the other thread waits for it to complete.

    To these ends, I would like the cache interface to look more like what's currently in the ShaderCache class. This is largely the same interface as that
    provided by ShaderCache, but cleaned up and refined in several ways:
    1. Explicit PutEntry allows the underlying cache implementation to shrink its memory use (current Llpc::ShaderCache cannot do this).
    2. Explicit WaitForEntry allows more concurrency between compiling shaders of a pipeline. This also allows asynchronous loading of data from disk.
    3. Allow zero-copy value retrieval for implementations that can support it.
    4. Use 128-bit hashes instead of 64-bit ones, to align better with PAL and to further reduce the risk of hash collisions.

    The details of how the interface is realized mechanically in C++ basically is:
    An ICache interface class which is implemented by the client driver, an additional wrapper cache EntryHandle class that provides more automatic safety
    guarantees against accidental programmer error.

    The ICache interface is implemented in terms of Get/Store functions or in terms of pipeline binary cache.

Signed-off-by: Chunming Zhou <david1.zhou@amd.com>