### PR TITLE
Collect transform feedback info from struct members

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6870,12 +6870,25 @@ Constant *SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecora
     SPIRVWord blockXfbOffset = SPIRVID_INVALID;
     SPIRVWord xfbOffset = SPIRVID_INVALID;
 
-    // Do iteration to find the minimum member transform feedback offset as
-    // starting block transform feedback offset
-    for (auto memberIdx = 0; memberIdx < numMembers; ++memberIdx)
+    // Do iteration to deal with transform feedback buffer info
+    // Check if the structure member specifies transform feedback buffer ID or stride
+    // Enable transform feedback buffer if transform feedback offset is declared, and then
+    // find the minimum member transform feedback offset as starting block transform feedback offset
+    for (auto memberIdx = 0; memberIdx < numMembers; ++memberIdx) {
+      if (bt->hasMemberDecorate(memberIdx, DecorationXfbBuffer, 0, &xfbBuffer)) {
+        inOutDec.IsXfb = true;
+        inOutDec.XfbBuffer = xfbBuffer;
+      }
+
+      if (bt->hasMemberDecorate(memberIdx, DecorationXfbStride, 0, &xfbStride)) {
+        inOutDec.IsXfb = true;
+        inOutDec.XfbStride = xfbStride;
+      }
+
       if (bt->hasMemberDecorate(memberIdx, DecorationOffset, 0, &xfbOffset))
         if (xfbOffset < blockXfbOffset)
           blockXfbOffset = xfbOffset;
+    }
 
     for (auto memberIdx = 0; memberIdx < numMembers; ++memberIdx) {
       auto memberDec = inOutDec;


### PR DESCRIPTION
According to the spec, transform feedback id and stride declared by a
struct member should also be effective to the out variable. Moreover, a
declared transform feedback offset should enable transform feedback
buffer.