### PR TITLE
Explicitly include "llvm/Support/MemoryBuffer.h" for MemoryBufferRef

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -33,6 +33,7 @@
 #include "CommonDefs.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {


### PR DESCRIPTION
Without this, this upstream LLVM commit b9a15c245f2 will break the
build.