### PR TITLE
 Add LowerFragColorExport pass

### DIFF
--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -43,6 +43,7 @@ class PassManager;
 
 } // namespace legacy
 
+void initializeLowerFragColorExportPass(PassRegistry &);
 void initializeLowerVertexFetchPass(PassRegistry &);
 void initializePatchBufferOpPass(PassRegistry &);
 void initializePatchCheckShaderCachePass(PassRegistry &);
@@ -69,6 +70,7 @@ class PatchCheckShaderCache;
 //
 // @param passRegistry : Pass registry
 inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
+  initializeLowerFragColorExportPass(passRegistry);
   initializeLowerVertexFetchPass(passRegistry);
   initializePatchBufferOpPass(passRegistry);
   initializePatchCheckShaderCachePass(passRegistry);
@@ -86,6 +88,7 @@ inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializePatchSetupTargetFeaturesPass(passRegistry);
 }
 
+llvm::ModulePass *createLowerFragColorExport();
 llvm::ModulePass *createLowerVertexFetch();
 llvm::FunctionPass *createPatchBufferOp();
 PatchCheckShaderCache *createPatchCheckShaderCache();

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -236,6 +236,7 @@ public:
 
   // Accessors for color export state
   const ColorExportFormat &getColorExportFormat(unsigned location);
+  const bool hasColorExportFormats() { return !m_colorExportFormats.empty(); }
   const ColorExportState &getColorExportState() { return m_colorExportState; }
 
   // Accessors for pipeline state

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -109,6 +109,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Lower vertex fetch operations.
   passMgr.add(createLowerVertexFetch());
 
+  // Lower fragment export operations.
+  passMgr.add(createLowerFragColorExport());
+
   // Patch entry-point mutation (should be done before external library link)
   passMgr.add(createPatchEntryPointMutate());
 

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -90,8 +90,6 @@ private:
                                    llvm::Instruction *insertPos);
   void patchGsGenericOutputExport(llvm::Value *output, unsigned location, unsigned compIdx, unsigned streamId,
                                   llvm::Instruction *insertPos);
-  void patchFsGenericOutputExport(llvm::Value *output, unsigned location, unsigned compIdx,
-                                  llvm::Instruction *insertPos);
 
   llvm::Value *patchVsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Instruction *insertPos);
   llvm::Value *patchTcsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,


### PR DESCRIPTION
We want to move the code that adds the export to a fragment shader from the
PatchInOutImportExport pass into it own pass.  This should make the code more
readable and make it easier to generate the unlinked shader that will
patched with a color export shader.

This is built on top of PR #842.