### PR TITLE
Removed descriptor sizes from GpuProperty

### DIFF
--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -29,10 +29,10 @@
  ***********************************************************************************************************************
  */
 #include "RelocHandler.h"
+#include "lgc/LgcContext.h"
 #include "lgc/state/AbiUnlinked.h"
 #include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineState.h"
-#include "lgc/state/TargetInfo.h"
 
 #define DEBUG_TYPE "lgc-elf-reloc-handler"
 
@@ -98,7 +98,7 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
 
       value = node->offsetInDwords * 4;
       if (type == ResourceNodeType::DescriptorSampler && node->type == ResourceNodeType::DescriptorCombinedTexture)
-        value += getPipelineState()->getTargetInfo().getGpuProperty().descriptorSizeResource;
+        value += DescriptorSizeResource;
       return true;
     }
   }
@@ -114,16 +114,15 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
       std::tie(outerNode, node) = getPipelineState()->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
       if (!node)
         report_fatal_error("No resource node for " + name);
-      const GpuProperty &gpuProperty = m_pipelineState->getTargetInfo().getGpuProperty();
       switch (node->type) {
       case ResourceNodeType::DescriptorResource:
-        value = gpuProperty.descriptorSizeResource;
+        value = DescriptorSizeResource;
         return true;
       case ResourceNodeType::DescriptorSampler:
-        value = gpuProperty.descriptorSizeSampler;
+        value = DescriptorSizeSampler;
         return true;
       case ResourceNodeType::DescriptorCombinedTexture:
-        value = gpuProperty.descriptorSizeResource + gpuProperty.descriptorSizeSampler;
+        value = DescriptorSizeResource + DescriptorSizeSampler;
         return true;
       default:
         break;

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -63,11 +63,6 @@ struct GpuProperty {
   unsigned tessFactorBufferSizePerSe; // Size of the tessellation-factor buffer per SE, in dwords.
   bool supportShaderPowerProfiling;   // Hardware supports Shader Profiling for Power
   bool supportSpiPrefPriority;        // Hardware supports SPI shader preference priority
-
-  // Descriptor sizes.
-  unsigned descriptorSizeResource; // Size in bytes of resource (image) descriptor
-  unsigned descriptorSizeSampler;  // Size in bytes of sampler descriptor
-  unsigned descriptorSizeBuffer;   // Size in bytes of buffer descriptor
 };
 
 // Contains flags for all of the hardware workarounds which affect pipeline compilation.

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -56,6 +56,13 @@ class PassManagerCache;
 class Pipeline;
 class TargetInfo;
 
+// Size in bytes of resource (image) descriptor
+static constexpr unsigned DescriptorSizeResource = 8 * sizeof(uint32_t);
+// Size in bytes of sampler descriptor
+static constexpr unsigned DescriptorSizeSampler = 4 * sizeof(uint32_t);
+// Size in bytes of buffer descriptor
+static constexpr unsigned DescriptorSizeBuffer = 4 * sizeof(uint32_t);
+
 // =====================================================================================================================
 // LgcContext class, used to create Pipeline and Builder objects. State shared between multiple compiles
 // is kept here.

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -70,11 +70,6 @@ static void setGfx6BaseInfo(TargetInfo *targetInfo) {
 
   // TODO: Accept gsOnChipDefaultLdsSizePerSubgroup from panel option
   targetInfo->getGpuProperty().gsOnChipDefaultLdsSizePerSubgroup = 8192; // GFX6-8 value
-
-  // Descriptor sizes. Always the same for GFX6+.
-  targetInfo->getGpuProperty().descriptorSizeResource = 8 * sizeof(uint32_t);
-  targetInfo->getGpuProperty().descriptorSizeSampler = 4 * sizeof(uint32_t);
-  targetInfo->getGpuProperty().descriptorSizeBuffer = 4 * sizeof(uint32_t);
 }
 
 // gfx6


### PR DESCRIPTION
Further to Nicolai's comment on #782, this removes the descriptor sizes
from GpuProperty, and makes them constants in IntrinsDefs.h instead. As
Nicolai says, if the sizes change in some future hardware, there is
likely to be more changes needed than just changing the value in
GpuProperty, and using constants allows better optimization when
building the compiler.

Change-Id: I51c217ae04986853ccdfdcdffd5014b58c4ced5b