### PR TITLE
Handle descriptor buffer relocations

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -114,10 +114,10 @@ private:
   uint64_t getAlignment(const InputSection &inputSection);
 
   ElfLinkerImpl *m_linker;
-  uint64_t m_offset;                            // File offset of this output section
-  SmallVector<InputSection, 4> m_inputSections; // Input sections contributing to this output section
   StringRef m_name;                             // Section name
   unsigned m_type;                              // Section type (SHT_* value)
+  uint64_t m_offset = 0;                        // File offset of this output section
+  SmallVector<InputSection, 4> m_inputSections; // Input sections contributing to this output section
   uint64_t m_alignment = 0;                     // Overall alignment required for the section
   unsigned m_reduceAlign = 0;                   // Bitmap of input sections to reduce alignment for
 };

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -53,6 +53,16 @@ namespace reloc {
 // It is illegal for the specified descriptor not to exist.
 const static char DescriptorOffset[] = "doff_";
 
+// Whether the descriptor pointer comes from a spill table.
+// The format is: "dusespill_X_Y" where:
+// * X is the descriptor set number
+// * Y is the binding number
+//
+// The value of the relocation is either:
+//  * 0: spill table not used and the pointer comes from descriptor table
+//  * 1: descriptor pointer should be loaded from the spill table
+const static char DescriptorUseSpillTable[] = "dusespill_";
+
 // Descriptor stride is "dstride_X_Y" where:
 // * X is the descriptor set number
 // * Y is the binding number

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1219,7 +1219,9 @@ void PatchEntryPointMutate::determineUnspilledUserDataArgs(ArrayRef<UserDataArg>
         break;
       }
     }
-    m_pipelineState->getPalMetadata()->setUserDataSpillUsage(std::min(userDataUsage->spillUsage, minByteOffset / 4));
+    // In relocatable shader compilation userDataUsage is unknown until linking.
+    if (minByteOffset != UINT_MAX && !m_pipelineState->isUnlinked())
+      m_pipelineState->getPalMetadata()->setUserDataSpillUsage(std::min(userDataUsage->spillUsage, minByteOffset / 4));
   }
 
   // Figure out how many sgprs we have available for userDataArgs.

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -365,8 +365,12 @@ void PalMetadata::fixUpRegisters() {
   const ResourceNode *pushConstNode;
   for (const auto &node : m_pipelineState->getUserDataNodes()) {
     if (node.type == ResourceNodeType::DescriptorTableVaPtr && !node.innerTable.empty()) {
-      unsigned descSet = node.innerTable[0].set;
-      descSetNodes.resize(std::max(unsigned(descSetNodes.size()), descSet + 1));
+      size_t descSet = node.innerTable[0].set;
+      descSetNodes.resize(std::max(descSetNodes.size(), descSet + 1));
+      descSetNodes[descSet] = &node;
+    } else if (node.type == ResourceNodeType::DescriptorBuffer) {
+      size_t descSet = node.set;
+      descSetNodes.resize(std::max(descSetNodes.size(), descSet + 1));
       descSetNodes[descSet] = &node;
     } else if (node.type == ResourceNodeType::PushConst) {
       pushConstNode = &node;

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -5,7 +5,7 @@
 ; Skip to the patching results for the fetch shader
 ; SHADERTEST-LABEL: LLPC pipeline patching results
 ; Check the inputs to the vertex shader.  This should be all of the regular inputs.  There is one vertex attribute being passed in: The vector at the end.
-; SHADERTEST: define amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %0, i32 inreg %1, i32 inreg %descSet0, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 %VertexId, i32 %5, i32 %6, i32 %InstanceId, <4 x float> %vertex0.0)
+; SHADERTEST: define amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %0, i32 inreg %1, i32 inreg %descSet0, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %spillTable, i32 %VertexId, i32 %5, i32 %6, i32 %InstanceId, <4 x float> %vertex0.0)
 ; SHADERTEST-LABEL: LGC glue shader results
 ; Check the inputs to the fetch shader.  This should match the vertex shader except:
 ; - there are extra inreg inputs because its determination of how many SGPR inputs

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocTopLevelDescBuffer.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocTopLevelDescBuffer.pipe
@@ -1,42 +1,20 @@
 // This test case checks that descriptor offset and descriptor buffer pointer relocation works
-// for buffer descriptors in a vs/fs pipeline.
-// Also check that the user data limit is set correctly.
+// for top-level buffer descriptors in a vs/fs pipeline.
+//
+// Based on PipelineVsFS_RelocConst.pipe.
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_vs_main>:
-; SHADERTEST: s_and_b32 s[[RELOCCOND:[0-9]+]], 0, 1 //{{.*}}
+; SHADERTEST: s_and_b32 s[[RELOCCOND:[0-9]+]], 1, 1 //{{.*}}
 ; SHADERTEST: s_cmp_eq_u32 s[[RELOCCOND]], 0 //{{.*}}
 ; SHADERTEST: s_cselect_b32 s[[RELOCCOND]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
-; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 12 //{{.*}}
+; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 0 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
 ; SHADERTEST: {{[0-9A-Za-z]+}} <_amdgpu_ps_main>:
-; SHADERTEST: s_and_b32 s[[RELOCCOND1:[0-9]+]], 0, 1 //{{.*}}
-; SHADERTEST: s_mov_b32 s[[RELOREG1:[0-9]+]], 12 //{{.*}}
+; SHADERTEST: s_and_b32 s[[RELOCCOND1:[0-9]+]], 1, 1 //{{.*}}
+; SHADERTEST: s_mov_b32 s[[RELOREG1:[0-9]+]], 0 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG1]] //{{.*}}
-; END_SHADERTEST
-
-; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST1 %s
-; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST1-LABEL: _amdgpu_vs_main_fetchless
-; SHADERTEST1: %[[SPILLCONST:.+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[SPILLNODE:[0-9]+]])
-; SHADERTEST1: %[[CONSTAND:.+]] = and i32 %[[SPILLCONST]], 1
-; SHADERTEST1: %[[CONSTICMP:.+]] = icmp eq i32 %[[CONSTAND]], 0
-; SHADERTEST1: %[[DESCPTRSELECT:.+]] = select i1 %[[CONSTICMP:[0-9]+]], {{.*}}
-; SHADERTEST1: %[[OFFCONST:.+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[OFFNODE:[0-9]+]])
-; SHADERTEST1: %[[OFFCONSTEXT:.+]] = zext i32 %[[OFFCONST]] to i64
-; SHADERTEST1: %[[BUFFFERDESCADDR:.+]] = add i64 %{{.+}}, %[[OFFCONSTEXT]]
-; SHADERTEST1: %[[BUFFERDESCPTR:.+]] = inttoptr i64 %[[BUFFFERDESCADDR]] {{.*}}
-; SHADERTEST1: %{{.+}} = load <4 x i32>, <4 x i32> addrspace(4)* %[[BUFFERDESCPTR]], align 1
-; SHADERTEST1: ![[SPILLNODE]] = !{!"dusespill_0_0"}
-; SHADERTEST1: ![[OFFNODE]] = !{!"doff_0_0_b"}
-; SHADERTEST1-LABEL: {{^// LLPC}} final pipeline module info
-; SHADERTEST1-DAG: SPI_SHADER_USER_DATA_VS_{{.}} 0x000000000000000B
-; SHADERTEST1-DAG: SPI_SHADER_USER_DATA_PS_{{.}} 0x000000000000000B
-; SHADERTEST1: .spill_threshold: 0x00000000FFFFFFFF
-; SHADERTEST1: .user_data_limit: 0x000000000000000C
-; SHADERTEST1: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
 [VsGlsl]
@@ -62,19 +40,11 @@ void main() {
 
 [VsInfo]
 entryPoint = main
-userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].type = DescriptorBuffer
 userDataNode[0].offsetInDwords = 0
-userDataNode[0].sizeInDwords = 1
-userDataNode[0].indirectUserDataCount = 0
-userDataNode[1].type = DescriptorTableVaPtr
-userDataNode[1].offsetInDwords = 11
-userDataNode[1].sizeInDwords = 1
-userDataNode[1].set = 0
-userDataNode[1].next[0].type = DescriptorBuffer
-userDataNode[1].next[0].offsetInDwords = 3
-userDataNode[1].next[0].sizeInDwords = 8
-userDataNode[1].next[0].set = 0
-userDataNode[1].next[0].binding = 0
+userDataNode[0].sizeInDwords = 8
+userDataNode[0].set = 0
+userDataNode[0].binding = 0
 
 trapPresent = 0
 debugMode = 0


### PR DESCRIPTION
This adds relocation logic for getting descriptor pointers. Descriptors
can come from either descriptor table or spill table, and we select between the
two during linking based on node types.

This is a work in progress patch.