### PR TITLE
Add a boolean flag to represent misc. export

### DIFF
--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -484,7 +484,8 @@ void ConfigBuilder::buildVsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   useLayer = useLayer || m_pipelineState->getInputAssemblyState().enableMultiView;
 
-  if (usePointSize || useLayer || useViewportIndex) {
+  bool miscExport = usePointSize || useLayer || useViewportIndex;
+  if (miscExport) {
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
@@ -509,7 +510,7 @@ void ConfigBuilder::buildVsRegConfig(ShaderStage shaderStage, T *pConfig) {
   }
 
   unsigned posCount = 1; // gl_Position is always exported
-  if (usePointSize || useLayer || useViewportIndex)
+  if (miscExport)
     ++posCount;
 
   if (clipDistanceCount + cullDistanceCount > 0) {

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -999,8 +999,8 @@ void ConfigBuilder::buildVsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   useLayer = useLayer || m_pipelineState->getInputAssemblyState().enableMultiView;
 
-  if (usePointSize || useLayer || useViewportIndex)
-  {
+  bool miscExport = usePointSize || useLayer || useViewportIndex;
+  if (miscExport) {
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
     SET_REG_FIELD(&pConfig->vsRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
@@ -1030,7 +1030,7 @@ void ConfigBuilder::buildVsRegConfig(ShaderStage shaderStage, T *pConfig) {
   }
 
   unsigned posCount = 1; // gl_Position is always exported
-  if (usePointSize || useLayer || useViewportIndex)
+  if (miscExport)
     ++posCount;
 
   if (clipDistanceCount + cullDistanceCount > 0) {
@@ -1678,8 +1678,8 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
 
   useLayer = useLayer || m_pipelineState->getInputAssemblyState().enableMultiView;
 
-  if (usePointSize || useLayer || useViewportIndex)
-  {
+  bool miscExport = usePointSize || useLayer || useViewportIndex;
+  if (miscExport) {
     SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_POINT_SIZE, usePointSize);
     SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_RENDER_TARGET_INDX, useLayer);
     SET_REG_FIELD(&pConfig->primShaderRegs, PA_CL_VS_OUT_CNTL, USE_VTX_VIEWPORT_INDX, useViewportIndex);
@@ -1704,7 +1704,7 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
   }
 
   unsigned posCount = 1; // gl_Position is always exported
-  if (usePointSize || useLayer || useViewportIndex)
+  if (miscExport)
     ++posCount;
 
   if (clipDistanceCount + cullDistanceCount > 0) {

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -1144,9 +1144,9 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
           cullDistanceCount = builtInUsage.cullDistance;
         }
 
-        // NOTE: When gl_PointSize, gl_Layer, or gl_ViewportIndex is used, gl_ClipDistance[] or
-        // gl_CullDistance[] should start from pos2.
-        clipCullPos = (usePointSize || useLayer || useViewportIndex) ? EXP_TARGET_POS_2 : EXP_TARGET_POS_1;
+        bool miscExport = usePointSize || useLayer || useViewportIndex;
+        // NOTE: When misc. export is present, gl_ClipDistance[] or gl_CullDistance[] should start from pos2.
+        clipCullPos = miscExport ? EXP_TARGET_POS_2 : EXP_TARGET_POS_1;
 
         // Collect clip/cull distance from exported value
         for (const auto &expData : expDataSet) {

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -966,9 +966,9 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           clipCullDistance.push_back(undef);
       }
 
-      // NOTE: When gl_PointSize, gl_Layer, or gl_ViewportIndex is used, gl_ClipDistance[] or gl_CullDistance[]
-      // should start from pos2.
-      unsigned pos = (usePointSize || useLayer || useViewportIndex) ? EXP_TARGET_POS_2 : EXP_TARGET_POS_1;
+      bool miscExport = usePointSize || useLayer || useViewportIndex;
+      // NOTE: When misc. export is present, gl_ClipDistance[] or gl_CullDistance[] should start from pos2.
+      unsigned pos = miscExport ? EXP_TARGET_POS_2 : EXP_TARGET_POS_1;
       Value *args[] = {
           ConstantInt::get(Type::getInt32Ty(*m_context), pos),  // tgt
           ConstantInt::get(Type::getInt32Ty(*m_context), 0xF),  // en


### PR DESCRIPTION
We use this style "usePointSize || useLayer || useViewportIndex" in
the codes to check if misc. export is present. It is better to define
a boolean flag locally. The motivation is more categories of misc.
export might be needed. It is more clear to do this.

Change-Id: I413a417c573a17712ac3575bfb39f0115b6a1692