### PR TITLE
Allow building against LLVM master (with some features broken)

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -159,6 +159,10 @@ BranchInst *BuilderImplBase::createIf(Value *condition, bool wantElse, const Twi
 // @param instName : Name to give instruction(s)
 Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, ArrayRef<unsigned> operandIdxs,
                                                   const Twine &instName) {
+#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
+#warning[!amd-gfx] Waterfall feature disabled
+  abort();
+#else
   assert(operandIdxs.empty() == false);
 
   // For each non-uniform input, try and trace back through a descriptor load to find the non-uniform index
@@ -298,6 +302,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
   // Restore Builder's insert point.
   restoreIP(savedInsertPoint);
   return resultValue;
+#endif
 }
 
 // =====================================================================================================================

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -99,11 +99,16 @@ Instruction *MiscBuilder::CreateKill(const Twine &instName) {
 //
 // @param instName : Name to give instruction(s)
 Instruction *MiscBuilder::CreateDemoteToHelperInvocation(const Twine &instName) {
+#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
+#warning[!amd-gfx] DemoteToHelperInvocation replaced by Kill
+  return CreateKill(instName);
+#else
   // Treat a demote as a kill for the purposes of disabling middle-end optimizations.
   auto resUsage = getPipelineState()->getShaderResourceUsage(ShaderStageFragment);
   resUsage->builtInUsage.fs.discard = true;
 
   return CreateIntrinsic(Intrinsic::amdgcn_wqm_demote, {}, getFalse(), nullptr, instName);
+#endif
 }
 
 // =====================================================================================================================
@@ -111,8 +116,14 @@ Instruction *MiscBuilder::CreateDemoteToHelperInvocation(const Twine &instName) 
 //
 // @param instName : Name to give instruction(s)
 Value *MiscBuilder::CreateIsHelperInvocation(const Twine &instName) {
+#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
+#warning[!amd-gfx] IsHelperInvocation replaced by !amdgcn.ps.live
+  Value *psLive = CreateIntrinsic(Intrinsic::amdgcn_ps_live, {}, {}, nullptr, instName);
+  return CreateNot(psLive);
+#else
   auto isNotHelper = CreateIntrinsic(Intrinsic::amdgcn_wqm_helper, {}, {}, nullptr, instName);
   return CreateNot(isNotHelper);
+#endif
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1483,8 +1483,12 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
                                           {bufferDesc, offsetVal, m_builder->getInt32(coherent.u32All)});
       } else {
         unsigned intrinsicID = Intrinsic::amdgcn_raw_buffer_load;
+#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
+#warning[!amd-gfx] Atomic load loses memory semantics
+#else
         if (ordering != AtomicOrdering::NotAtomic)
           intrinsicID = Intrinsic::amdgcn_raw_atomic_buffer_load;
+#endif
         part = m_builder->CreateIntrinsic(
             intrinsicID, intAccessType,
             {bufferDesc, offsetVal, m_builder->getInt32(0), m_builder->getInt32(coherent.u32All)});

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -146,7 +146,11 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-atomic-optimizations", "1");
   setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
+#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
+#warning[!amd-gfx] Conditional discard transformations not supported
+#else
   setOptionDefault("amdgpu-conditional-discard-transformations", "1");
+#endif
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Certain features which are not supported in LLVM master yet are keyed
off the LLVM_HAVE_BRANCH_AMD_GFX define, which is to be added to the
amd-gfx branch.

This means we will be able to build and run against LLVM master,
albeit with some known breakages.