### PR TITLE
Return export value for unlinked frag shaders

### DIFF
--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -237,7 +237,7 @@ Function *FetchShader::createFetchFunc() {
   types.append(m_vsEntryRegInfo.sgprCount, Type::getInt32Ty(getContext()));
   types.append(m_vsEntryRegInfo.vgprCount, Type::getFloatTy(getContext()));
   for (const auto &fetch : m_fetches)
-    types.push_back(VertexFetch::getVgprTy(fetch.ty));
+    types.push_back(getVgprTy(fetch.ty));
   Type *retTy = StructType::get(getContext(), types);
   auto entryTys = ArrayRef<Type *>(types).slice(0, m_vsEntryRegInfo.sgprCount + m_vsEntryRegInfo.vgprCount);
   auto funcTy = FunctionType::get(retTy, entryTys, false);

--- a/lgc/include/lgc/patch/VertexFetch.h
+++ b/lgc/include/lgc/patch/VertexFetch.h
@@ -45,10 +45,6 @@ public:
   // Create a VertexFetch
   static VertexFetch *create(LgcContext *lgcContext);
 
-  // Given a non-aggregate type, get a float type at least as big that can be used to pass a value of that
-  // type in a return value struct, ensuring it gets into VGPRs.
-  static llvm::Type *getVgprTy(llvm::Type *ty);
-
   // Generate code to fetch a vertex value
   virtual llvm::Value *fetchVertex(llvm::Type *inputTy, const VertexInputDescription *description, unsigned location,
                                    unsigned compIdx, BuilderBase &builder) = 0;

--- a/lgc/include/lgc/util/Internal.h
+++ b/lgc/include/lgc/util/Internal.h
@@ -91,4 +91,8 @@ bool canBitCast(const llvm::Type *ty1, const llvm::Type *ty2);
 // Checks if the specified value actually represents a don't-care value (0xFFFFFFFF).
 bool isDontCareValue(llvm::Value *value);
 
+// Given a non-aggregate type, get a float type at least as big that can be used to pass a value of that
+// type in a return value struct, ensuring it gets into VGPRs.
+llvm::Type *getVgprTy(llvm::Type *ty);
+
 } // namespace lgc

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1705,13 +1705,16 @@ void PatchResourceCollect::matchGenericInOut() {
 
     nextMapLoc = 0;
     assert(inOutUsage.outputMapLocCount == 0);
+    bool generatingColorExportShader = m_shaderStage == ShaderStageFragment;
+    generatingColorExportShader &= m_pipelineState->isUnlinked() && !m_pipelineState->hasColorExportFormats();
     for (auto locMapIt = outLocMap.begin(); locMapIt != outLocMap.end();) {
       auto &locMap = *locMapIt;
       if (m_shaderStage == ShaderStageFragment) {
         unsigned location = locMap.first;
         if (m_pipelineState->getColorExportState().dualSourceBlendEnable && location == 1)
           location = 0;
-        if (m_pipelineState->getColorExportFormat(location).dfmt == BufDataFormatInvalid) {
+        if (!generatingColorExportShader &&
+            m_pipelineState->getColorExportFormat(location).dfmt == BufDataFormatInvalid) {
           locMapIt = outLocMap.erase(locMapIt);
           continue;
         }

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -425,7 +425,7 @@ bool LowerVertexFetch::runOnModule(Module &module) {
     // The return value from the fetch shader needs to use all floats, as the back-end maps an int in the
     // return value as an SGPR rather than a VGPR. For symmetry, we also use all floats here, in the input
     // args to the fetchless vertex shader.
-    ty = VertexFetch::getVgprTy(ty);
+    ty = getVgprTy(ty);
     argTys.push_back(ty);
   }
 
@@ -463,23 +463,6 @@ bool LowerVertexFetch::runOnModule(Module &module) {
   }
 
   return true;
-}
-
-// =====================================================================================================================
-// Given a non-aggregate type, get a float type at least as big that can be used to pass a value of that
-// type in a return value struct, ensuring it gets into VGPRs.
-Type *VertexFetch::getVgprTy(Type *ty) {
-  // The return value from the fetch shader needs to use all floats, as the back-end maps an int in the
-  // return value as an SGPR rather than a VGPR. For symmetry, we also use all floats in the input
-  // args to the fetchless vertex shader. We use a vector of float, even if the integer element type is
-  // not i32.
-  if (ty->isIntOrIntVectorTy()) {
-    unsigned numElements = (ty->getPrimitiveSizeInBits() + 31) / 32;
-    ty = Type::getFloatTy(ty->getContext());
-    if (numElements > 1)
-      ty = FixedVectorType::get(ty, numElements);
-  }
-  return ty;
 }
 
 // =====================================================================================================================

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -216,4 +216,23 @@ bool isDontCareValue(Value *value) {
   return isDontCare;
 }
 
+// =====================================================================================================================
+// Given a non-aggregate type, get a float type at least as big that can be used to pass a value of that
+// type in a return value struct, ensuring it gets into VGPRs.
+//
+// @param ty : A type
+Type *getVgprTy(Type *ty) {
+  // The return value from the fetch shader needs to use all floats, as the back-end maps an int in the
+  // return value as an SGPR rather than a VGPR. For symmetry, we also use all floats in the input
+  // args to the fetchless vertex shader. We use a vector of float, even if the integer element type is
+  // not i32.
+  if (ty->isIntOrIntVectorTy()) {
+    unsigned numElements = (ty->getPrimitiveSizeInBits() + 31) / 32;
+    ty = Type::getFloatTy(ty->getContext());
+    if (numElements > 1)
+      ty = FixedVectorType::get(ty, numElements);
+  }
+  return ty;
+}
+
 } // namespace lgc


### PR DESCRIPTION
For unlinked shaders, we want to return the color export values, so
they are in registers for the color export shader.  This is preparing
this case for the generation of the color export shader.

Built on top of #774