### PR TITLE
 Add glue shader for color exports

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -257,6 +257,13 @@ void ElfLinkerImpl::createGlueShaders() {
     m_glueShaders.push_back(
         std::unique_ptr<GlueShader>(GlueShader::createFetchShader(m_pipelineState, fetches, vsEntryRegInfo)));
   }
+
+  // Create a color export shader if we need one.
+  SmallVector<ColorExportInfo, 8> exports;
+  m_pipelineState->getPalMetadata()->getColorExportInfo(exports);
+  if (!exports.empty()) {
+    m_glueShaders.push_back(GlueShader::createColorExportShader(m_pipelineState, exports));
+  }
 }
 
 // =====================================================================================================================

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -47,6 +47,9 @@ public:
   // Create a fetch shader
   static GlueShader *createFetchShader(PipelineState *pipelineState, llvm::ArrayRef<VertexFetchInfo> fetches,
                                        const VsEntryRegInfo &vsEntryRegInfo);
+  // Create a color export shader
+  static std::unique_ptr<GlueShader> createColorExportShader(PipelineState *pipelineState,
+                                                             llvm::ArrayRef<ColorExportInfo> exports);
 
   // Get the string for this glue shader. This is some encoding or hash of the inputs to the create*Shader function
   // that the front-end client can use as a cache key to avoid compiling the same glue shader more than once.

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "lgc/BuilderBase.h"
 #include "lgc/Pipeline.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/util/Internal.h"
@@ -57,6 +58,9 @@ public:
 
   llvm::Value *run(llvm::Value *output, unsigned int hwColorTarget, llvm::Instruction *insertPos, ExportFormat expFmt,
                    const bool signedness);
+
+  static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
+  static llvm::CallInst *addDummyExport(BuilderBase &builder);
 
 private:
   FragColorExport() = delete;

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -153,8 +153,7 @@ public:
   void finalizePipeline();
 
   // Updates the PS register information that depends on the exports.
-  void updateSpiShaderColFormat(const llvm::SmallVector<ColorExportInfo, 8> &exps, bool hasDepthExpFmtZero,
-                                bool killEnabled);
+  void updateSpiShaderColFormat(llvm::ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled);
 
 private:
   // Initialize the PalMetadata object after reading in already-existing PAL metadata if any

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -159,6 +159,12 @@ void PalMetadata::mergeFromBlob(StringRef blob) {
             *destNode = srcNode;
             return 0;
           }
+          if (srcNode.getString() == "color_export_shader")
+            return 0;
+          if (destNode->getString() == "color_export_shader") {
+            *destNode = srcNode;
+            return 0;
+          }
         }
         // Disallow merging other than uint.
         if (destNode->getKind() != msgpack::Type::UInt || srcNode.getKind() != msgpack::Type::UInt)
@@ -739,8 +745,7 @@ llvm::Type *PalMetadata::getLlvmType(StringRef tyName) const {
 // =====================================================================================================================
 // Updates the SPI_SHADER_COL_FORMAT entry.
 //
-void PalMetadata::updateSpiShaderColFormat(const SmallVector<ColorExportInfo, 8> &exps, bool hasDepthExpFmtZero,
-                                           bool killEnabled) {
+void PalMetadata::updateSpiShaderColFormat(ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled) {
   unsigned spiShaderColFormat = 0;
   for (auto &exp : exps) {
     unsigned expFormat = m_pipelineState->computeExportFormat(exp.ty, exp.location);


### PR DESCRIPTION
Generate a color export shader for fragment shaders that need one, and
append it during elf linking.

Based on #796