### PR TITLE
Enable use of color export shaders

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -87,6 +87,10 @@ static cl::opt<bool> EnableSiScheduler("enable-si-scheduler", cl::desc("Enable t
 // -disable-licm: annotate loops with metadata to disable the LLVM LICM pass
 static cl::opt<bool> DisableLicm("disable-licm", cl::desc("Disable LLVM LICM pass"), cl::init(false));
 
+// -disable-color-export-shader: disable the color export shader when doing unlinked shaders.
+static cl::opt<bool> DisableColorExportShader("disable-color-export-shader", cl::desc("Disable color export shaders"),
+                                              cl::init(false));
+
 // -subgroup-size: sub-group size exposed via Vulkan API.
 static cl::opt<int> SubgroupSize("subgroup-size", cl::desc("Sub-group size exposed via Vulkan API"), cl::init(64));
 
@@ -217,8 +221,10 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, bool unlinked) const 
       setVertexInputDescriptions(pipeline);
     }
 
-    // Give the color export state to the middle-end.
-    setColorExportState(pipeline);
+    if (!unlinked || DisableColorExportShader) {
+      // Give the color export state to the middle-end.
+      setColorExportState(pipeline);
+    }
 
     // Give the graphics pipeline state to the middle-end.
     setGraphicsStateInPipeline(pipeline);

--- a/llpc/test/shaderdb/ObjOutput_TestFsBasic_lit.frag
+++ b/llpc/test/shaderdb/ObjOutput_TestFsBasic_lit.frag
@@ -19,7 +19,9 @@ void main()
 ; SHADERTEST: call void @lgc.output.export.generic{{.*}}i32
 ; SHADERTEST: call void @lgc.output.export.generic{{.*}}f32
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32
+; SHADERTEST: [[value1:%[0-9]*]] = insertvalue { float, float } undef, float {{%[0-9]*}}, 0
+; SHADERTEST: [[value2:%[0-9]*]] = insertvalue { float, float } [[value1]], float {{%[0-9]*}}, 1
+; SHADERTEST: ret { float, float } [[value2]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/ObjOutput_TestFsCompSpecifier_lit.frag
+++ b/llpc/test/shaderdb/ObjOutput_TestFsCompSpecifier_lit.frag
@@ -19,7 +19,8 @@ void main (void)
 ; SHADERTEST: call void @lgc.output.export.generic{{.*}}v2f32(i32 0, i32 1, <2 x float> %{{[0-9]*}})
 ; SHADERTEST: call void @lgc.output.export.generic{{.*}}f32(i32 0, i32 3, float %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32
+; SHADERTEST: [[value:%[0-9]*]] = insertvalue { <4 x float> } undef, <4 x float> {{%[0-9]*}}, 0
+; SHADERTEST: ret { <4 x float> } [[value]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/ObjOutput_TestFsVector_lit.frag
+++ b/llpc/test/shaderdb/ObjOutput_TestFsVector_lit.frag
@@ -19,7 +19,9 @@ void main()
 ; SHADERTEST: call void @lgc.output.export.generic{{.*}}v3i32
 ; SHADERTEST: call void @lgc.output.export.generic{{.*}}v3f32
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32
+; SHADERTEST: [[value1:%[0-9]*]] = insertvalue { <3 x float>, <3 x float> } undef, <3 x float> {{%[0-9]*}}, 0
+; SHADERTEST: [[value2:%[0-9]*]] = insertvalue { <3 x float>, <3 x float> } [[value1]], <3 x float> {{%[0-9]*}}, 1
+; SHADERTEST: ret { <3 x float>, <3 x float> } [[value2]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpBitFieldInsert_TestIntConst_lit.frag
+++ b/llpc/test/shaderdb/OpBitFieldInsert_TestIntConst_lit.frag
@@ -16,7 +16,7 @@ void main()
 ; SHADERTEST: = call i32 (...) @lgc.create.insert.bit.field.i32(i32 3, i32 6, i32 4, i32 5)
 
 ; SHADERTEST-LABEL: {{^// LLPC.*}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, i1 immarg true, i1 immarg true)
+; SHADERTEST: ret { <4 x float> } { <4 x float> <float 9.900000e+01, float 9.900000e+01, float 9.900000e+01, float 9.900000e+01> }
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpCopyMemory_TestCopyLocalToOutput_lit.spvasm
+++ b/llpc/test/shaderdb/OpCopyMemory_TestCopyLocalToOutput_lit.spvasm
@@ -5,7 +5,7 @@
 ; SHADERTEST: %{{[0-9]+}} = load <4 x float>, <4 x float> addrspace({{[0-9]+}})* %{{.*}}
 ; SHADERTEST: store <4 x float> %{{[0-9]+}}, <4 x float> addrspace({{[0-9]+}})* @{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
-; SHADERTEST: @llvm.amdgcn.exp.f32
+; SHADERTEST: ret { <4 x float> } undef
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/OpCopyMemory_TestCopyUniformToOutput_lit.spvasm
+++ b/llpc/test/shaderdb/OpCopyMemory_TestCopyUniformToOutput_lit.spvasm
@@ -4,8 +4,10 @@
 ; SHADERTEST: %{{[0-9]+}} = load <4 x float>,
 ; SHADERTEST: store <4 x float> %{{[0-9]+}}, <4 x float> addrspace({{[0-9]+}})* @{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC.*}} patching results
-; SHADERTEST: @llvm.amdgcn.s.buffer.load
-; SHADERTEST: @llvm.amdgcn.exp.f32
+; SHADERTEST: [[ld:%[0-9]*]] = call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32
+; SHADERTEST: [[cast:%[0-9]*]] = bitcast <4 x i32> [[ld]] to <4 x float>
+; SHADERTEST: [[val:%[0-9]*]] = insertvalue { <4 x float> } undef, <4 x float> [[cast]], 0
+; SHADERTEST: ret { <4 x float> } [[val]]
 ; END_SHADERTEST
 
 ; SPIR-V

--- a/llpc/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
@@ -19,11 +19,15 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.pow.v4f32(<4 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
+; SHADERTEST: [[mul1:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
+; SHADERTEST: [[mul2:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
+; SHADERTEST: [[mul3:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
 ; SHADERTEST-NOT: = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.200000e+01, float
+; SHADERTEST: [[val1:%[.0-9a-zA-Z]*]] = insertelement <4 x float> <float 1.200000e+01, float undef, float undef, float undef>, float [[mul1]], i32 1
+; SHADERTEST: [[val2:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i32 2
+; SHADERTEST: [[val3:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i32 3
+; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } undef, <4 x float> [[val3]], 0
+; SHADERTEST: ret { <4 x float> } [[ret]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
@@ -19,10 +19,14 @@ void main()
 ; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float> %{{.*}}, <float undef, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000>
 ; SHADERTEST: = insertelement <4 x float> %{{.*}}, float 0x3F9ACEEA00000000, i32 0
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 0x3F9ACEEA00000000, float %{{.*}}, float %{{.*}}, float %{{.*}}, i1 immarg true, i1 immarg true)
+; SHADERTEST: [[mul1:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
+; SHADERTEST: [[mul2:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
+; SHADERTEST: [[mul3:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
+; SHADERTEST: [[val1:%.[0-9a-zA-Z]*]] = insertelement <4 x float> <float 0x3F9ACEEA00000000, float undef, float undef, float undef>, float [[mul1]], i32 1
+; SHADERTEST: [[val2:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i32 2
+; SHADERTEST: [[val3:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i32 3
+; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } undef, <4 x float> [[val3]], 0
+; SHADERTEST: ret { <4 x float> } [[ret]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestSinVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestSinVec4Const_lit.frag
@@ -21,7 +21,7 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sin.f32(float %{{.*}})
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.sin.f32(float %{{.*}})
 ; SHADERTEST-NOT: = call{{.*}} float @llvm.sin.f32(float %{{.*}})
-; SHADERTEST: ret void
+; SHADERTEST: ret
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpMatrixTimesScalar_TestMat4X2xConstFloat_lit.frag
+++ b/llpc/test/shaderdb/OpMatrixTimesScalar_TestMat4X2xConstFloat_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; SHADERTEST: [4 x <2 x float>] (...) @lgc.create.matrix.times.scalar.a4v2f32
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float 1.000000e+00, float 5.000000e-01, float 0.000000e+00, float 0.000000e+00, i1 immarg true, i1 immarg true)
+; SHADERTEST: ret { <4 x float> } { <4 x float> <float 1.000000e+00, float 5.000000e-01, float 0.000000e+00, float 0.000000e+00> }
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpSpecConstantOp_TestArithLogicOp_lit.frag
+++ b/llpc/test/shaderdb/OpSpecConstantOp_TestArithLogicOp_lit.frag
@@ -258,7 +258,7 @@ void main()
 
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32
+; SHADERTEST: ret { <4 x float> } { <4 x float> <float 0x4034E66680000000, float 0x4034E66680000000, float 0x4034E66680000000, float 0x4034E66680000000> }
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -542,8 +542,8 @@ void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipe
     else
       llvm_unreachable("Should never be called!");
     pipelineInfo->iaState.topology = topology;
-  } else if (shaderStage == ShaderStageFragment) {
-    // Set dummy color formats for fragment outputs
+  } else if (shaderStage == ShaderStageFragment && AutoLayoutDesc) {
+    // Set dummy color formats for fragment outputs, but only if -auto-layout-desc is on.
     for (auto varId : ArrayRef<SPIRVWord>(inOuts.first, inOuts.second)) {
       auto entry = module->getValue(varId);
       if (!entry->isVariable())


### PR DESCRIPTION
    - This will enable color export shaders when relocatable shader are
    being used.
    
    - They are also enabled when compiling a single fragment shader using
    amdllpc.
    
    - Tests are updated to reflect these changes.
