### PR TITLE
Add options for overriding SPIRV denorm settings.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -74,6 +74,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     40.4 | Added fp32DenormalMode in PipelineShaderOptions to allow overriding SPIR-V denormal settings          |
 //* |     40.3 | Added ICache interface                                                                                |
 //* |     40.2 | Added extendedRobustness in PipelineOptions to support VK_EXT_robustness2                             |
 //* |     40.1 | Added disableLoopUnroll to PipelineShaderOptions                                                      |
@@ -374,6 +375,13 @@ struct PipelineDumpOptions {
                                      ///  numeric suffix attached
 };
 
+/// Enumerate denormal override modes.
+enum class DenormalMode : unsigned {
+  Auto = 0x0,        ///< No denormal override (default behaviour)
+  FlushToZero = 0x1, ///< Denormals flushed to zero
+  Preserve = 0x2,    ///< Denormals preserved
+};
+
 /// If next available quad falls outside tile aligned region of size defined by this enumeration the SC will force end
 /// of vector in the SC to shader wavefront.
 enum class WaveBreakSize : unsigned {
@@ -508,6 +516,9 @@ struct PipelineShaderOptions {
 
   /// Forcibly disable loop unrolling - overrides any explicit unroll directives
   bool disableLoopUnroll;
+
+  /// Override FP32 denormal handling.
+  DenormalMode fp32DenormalMode;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -81,6 +81,13 @@ enum class NggSubgroupSizing : unsigned {
                     ///  primsPerSubgroup
 };
 
+/// Enumerate denormal override modes.
+enum class DenormalMode : unsigned {
+  Auto = 0x0,        ///< No denormal override (default behaviour)
+  FlushToZero = 0x1, ///< Denormals flushed to zero
+  Preserve = 0x2,    ///< Denormals preserved
+};
+
 // If next available quad falls outside tile aligned region of size defined by this enumeration, the compiler
 // will force end of vector in the compiler to shader wavefront.
 // All of these values except DrawTime correspond to settings of WAVE_BREAK_REGION_SIZE in PA_SC_SHADER_CONTROL.
@@ -164,6 +171,9 @@ struct ShaderOptions {
 
   /// Default unroll threshold for LLVM.
   unsigned unrollThreshold;
+
+  /// Override FP32 denormal handling.
+  DenormalMode fp32DenormalMode;
 };
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -377,6 +377,13 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
       shaderOptions.updateDescInElf = shaderInfo->options.updateDescInElf;
       shaderOptions.unrollThreshold = shaderInfo->options.unrollThreshold;
 
+      static_assert(static_cast<lgc::DenormalMode>(Vkgc::DenormalMode::Auto) == lgc::DenormalMode::Auto, "mismatch");
+      static_assert(static_cast<lgc::DenormalMode>(Vkgc::DenormalMode::FlushToZero) == lgc::DenormalMode::FlushToZero,
+                    "mismatch");
+      static_assert(static_cast<lgc::DenormalMode>(Vkgc::DenormalMode::Preserve) == lgc::DenormalMode::Preserve,
+                    "mismatch");
+      shaderOptions.fp32DenormalMode = static_cast<lgc::DenormalMode>(shaderInfo->options.fp32DenormalMode);
+
       pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);
     }
   }

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -49,6 +49,7 @@ using Vkgc::NggSubgroupSizingType;
 using Vkgc::OutputAllocFunc;
 using Vkgc::PipelineOptions;
 using Vkgc::PipelineShaderInfo;
+using Vkgc::PipelineShaderOptions;
 using Vkgc::ResourceMappingNode;
 using Vkgc::ResourceMappingNodeType;
 using Vkgc::ResourceNodeData;

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -39,6 +39,7 @@ using Vkgc::BinaryData;
 using Vkgc::BinaryType;
 using Vkgc::ColorTarget;
 using Vkgc::ComputePipelineBuildInfo;
+using Vkgc::DenormalMode;
 using Vkgc::DescriptorRangeValue;
 using Vkgc::FsOutInfo;
 using Vkgc::GfxIpVersion;

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -114,8 +114,9 @@ void SpirvLowerTranslator::translateSpirvToLlvm(const PipelineShaderInfo *shader
 
   Context *context = static_cast<Context *>(&module->getContext());
 
-  if (!readSpirv(context->getBuilder(), &(moduleData->usage), spirvStream, convertToExecModel(entryStage),
-                 shaderInfo->pEntryTarget, specConstMap, convertingSamplers, module, errMsg)) {
+  if (!readSpirv(context->getBuilder(), &(moduleData->usage), &(shaderInfo->options), spirvStream,
+                 convertToExecModel(entryStage), shaderInfo->pEntryTarget, specConstMap, convertingSamplers, module,
+                 errMsg)) {
     report_fatal_error(Twine("Failed to translate SPIR-V to LLVM (") +
                            getShaderStageName(static_cast<ShaderStage>(entryStage)) + " shader): " + errMsg,
                        false);

--- a/llpc/translator/include/LLVMSPIRVLib.h
+++ b/llpc/translator/include/LLVMSPIRVLib.h
@@ -105,6 +105,7 @@ class Builder;
 
 namespace Vkgc {
 struct ShaderModuleUsage;
+struct PipelineShaderOptions;
 } // End namespace Vkgc
 
 namespace llvm {
@@ -116,8 +117,9 @@ bool writeSpirv(llvm::Module *M, llvm::raw_ostream &OS, std::string &ErrMsg);
 
 /// \brief Load SPIRV from istream and translate to LLVM module.
 /// \returns true if succeeds.
-bool readSpirv(lgc::Builder *Builder, const Vkgc::ShaderModuleUsage *ModuleData, std::istream &IS,
-               spv::ExecutionModel EntryExecModel, const char *EntryName, const SPIRV::SPIRVSpecConstMap &SpecConstMap,
+bool readSpirv(lgc::Builder *Builder, const Vkgc::ShaderModuleUsage *ModuleData,
+               const Vkgc::PipelineShaderOptions *ShaderOptions, std::istream &IS, spv::ExecutionModel EntryExecModel,
+               const char *EntryName, const SPIRV::SPIRVSpecConstMap &SpecConstMap,
                llvm::ArrayRef<SPIRV::ConvertingSampler> ConvertingSamplers, llvm::Module *M, std::string &ErrMsg);
 
 /// \brief Regularize LLVM module by removing entities not representable by

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -126,10 +126,11 @@ static void dumpLLVM(Module *m, const std::string &fName) {
 
 SPIRVToLLVM::SPIRVToLLVM(Module *llvmModule, SPIRVModule *theSpirvModule, const SPIRVSpecConstMap &theSpecConstMap,
                          ArrayRef<ConvertingSampler> convertingSamplers, lgc::Builder *builder,
-                         const Vkgc::ShaderModuleUsage *moduleUsage)
+                         const Vkgc::ShaderModuleUsage *moduleUsage, const Vkgc::PipelineShaderOptions *shaderOptions)
     : m_m(llvmModule), m_builder(builder), m_bm(theSpirvModule), m_enableXfb(false), m_entryTarget(nullptr),
       m_specConstMap(theSpecConstMap), m_convertingSamplers(convertingSamplers), m_dbgTran(m_bm, m_m, this),
-      m_moduleUsage(reinterpret_cast<const Vkgc::ShaderModuleUsage *>(moduleUsage)) {
+      m_moduleUsage(reinterpret_cast<const Vkgc::ShaderModuleUsage *>(moduleUsage)),
+      m_shaderOptions(reinterpret_cast<const Vkgc::PipelineShaderOptions *>(shaderOptions)) {
   assert(m_m);
   m_context = &m_m->getContext();
   m_spirvOpMetaKindId = m_context->getMDKindID(MetaNameSpirvOp);
@@ -8043,16 +8044,17 @@ llvm::GlobalValue::LinkageTypes SPIRVToLLVM::transLinkageType(const SPIRVValue *
 
 } // namespace SPIRV
 
-bool llvm::readSpirv(Builder *builder, const ShaderModuleUsage *shaderInfo, std::istream &is,
-                     spv::ExecutionModel entryExecModel, const char *entryName, const SPIRVSpecConstMap &specConstMap,
-                     ArrayRef<ConvertingSampler> convertingSamplers, Module *m, std::string &errMsg) {
+bool llvm::readSpirv(Builder *builder, const ShaderModuleUsage *shaderInfo, const PipelineShaderOptions *shaderOptions,
+                     std::istream &is, spv::ExecutionModel entryExecModel, const char *entryName,
+                     const SPIRVSpecConstMap &specConstMap, ArrayRef<ConvertingSampler> convertingSamplers, Module *m,
+                     std::string &errMsg) {
   assert(entryExecModel != ExecutionModelKernel && "Not support ExecutionModelKernel");
 
   std::unique_ptr<SPIRVModule> bm(SPIRVModule::createSPIRVModule());
 
   is >> *bm;
 
-  SPIRVToLLVM btl(m, bm.get(), specConstMap, convertingSamplers, builder, shaderInfo);
+  SPIRVToLLVM btl(m, bm.get(), specConstMap, convertingSamplers, builder, shaderInfo, shaderOptions);
   bool succeed = true;
   if (!btl.translate(entryExecModel, entryName)) {
     bm->getError(errMsg);

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -70,7 +70,7 @@ class SPIRVToLLVM {
 public:
   SPIRVToLLVM(Module *llvmModule, SPIRVModule *theSpirvModule, const SPIRVSpecConstMap &theSpecConstMap,
               llvm::ArrayRef<ConvertingSampler> convertingSamplers, lgc::Builder *builder,
-              const Vkgc::ShaderModuleUsage *moduleUsage);
+              const Vkgc::ShaderModuleUsage *moduleUsage, const Vkgc::PipelineShaderOptions *shaderOptions);
 
   DebugLoc getDebugLoc(SPIRVInstruction *bi, Function *f);
 
@@ -217,6 +217,7 @@ private:
   DenseMap<std::pair<SPIRVType *, unsigned>, Type *> m_overlappingStructTypeWorkaroundMap;
   DenseMap<std::pair<BasicBlock *, BasicBlock *>, unsigned> m_blockPredecessorToCount;
   const Vkgc::ShaderModuleUsage *m_moduleUsage;
+  const Vkgc::PipelineShaderOptions *m_shaderOptions;
   unsigned m_spirvOpMetaKindId;
 
   lgc::Builder *getBuilder() const { return m_builder; }

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -60,6 +60,7 @@ std::ostream &operator<<(std::ostream &out, VkFrontFace frontFace);
 std::ostream &operator<<(std::ostream &out, ResourceMappingNodeType type);
 std::ostream &operator<<(std::ostream &out, NggSubgroupSizingType subgroupSizing);
 std::ostream &operator<<(std::ostream &out, NggCompactMode compactMode);
+std::ostream &operator<<(std::ostream &out, DenormalMode denormalMode);
 std::ostream &operator<<(std::ostream &out, WaveBreakSize waveBreakSize);
 std::ostream &operator<<(std::ostream &out, ShadowDescriptorTableUsage shadowDescriptorTableUsage);
 
@@ -517,6 +518,7 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.unrollThreshold = " << shaderInfo->options.unrollThreshold << "\n";
   dumpFile << "options.scalarThreshold = " << shaderInfo->options.scalarThreshold << "\n";
   dumpFile << "options.disableLoopUnroll = " << shaderInfo->options.disableLoopUnroll << "\n";
+  dumpFile << "options.fp32DenormalMode = " << shaderInfo->options.fp32DenormalMode << "\n";
 
   dumpFile << "\n";
 }
@@ -1064,6 +1066,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.unrollThreshold);
       hasher->Update(options.scalarThreshold);
       hasher->Update(options.disableLoopUnroll);
+      hasher->Update(options.fp32DenormalMode);
     }
   }
 }
@@ -1545,6 +1548,26 @@ std::ostream &operator<<(std::ostream &out, NggCompactMode compactMode) {
   switch (compactMode) {
     CASE_ENUM_TO_STRING(NggCompactDisable)
     CASE_ENUM_TO_STRING(NggCompactVertices)
+    break;
+  default:
+    llvm_unreachable("Should never be called!");
+    break;
+  }
+
+  return out << string;
+}
+
+// =====================================================================================================================
+// Translates enum "DenormalMode" to string and output to ostream.
+//
+// @param [out] out : Output stream
+// @param denormalMode : Denormal mode
+std::ostream &operator<<(std::ostream &out, DenormalMode denormalMode) {
+  const char *string = nullptr;
+  switch (denormalMode) {
+    CASE_CLASSENUM_TO_STRING(DenormalMode, Auto)
+    CASE_CLASSENUM_TO_STRING(DenormalMode, FlushToZero)
+    CASE_CLASSENUM_TO_STRING(DenormalMode, Preserve)
     break;
   default:
     llvm_unreachable("Should never be called!");

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -76,6 +76,10 @@ public:
     ADD_CLASS_ENUM_MAP(WaveBreakSize, _16x16)
     ADD_CLASS_ENUM_MAP(WaveBreakSize, _32x32)
     ADD_CLASS_ENUM_MAP(WaveBreakSize, DrawTime)
+
+    ADD_CLASS_ENUM_MAP(DenormalMode, Auto)
+    ADD_CLASS_ENUM_MAP(DenormalMode, FlushToZero)
+    ADD_CLASS_ENUM_MAP(DenormalMode, Preserve)
   }
 };
 

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -136,6 +136,7 @@ public:
 #endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -144,7 +145,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 18;
+  static const unsigned MemberCount = 19;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Add fp32DenormalMode option to pipeline shader options.
Add command line override -fp32-denormal-mode, which can be auto, ftz or preserve.