### PR TITLE
Make a test more permissive

### DIFF
--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -10,8 +10,8 @@
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to <4 x i32> addrspace(4)*
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, i64 0
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i64 1
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, {{i32|i64}} 0
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, {{i32|i64}} 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)
 ; SHADERTEST: bitcast <4 x i32> %{{.*}} to <2 x double>
 


### PR DESCRIPTION
This is required by the following upstream LLVM commit:
f62c8dbc99e [Scalarizer] InsertElement handling w/ constant insert index