### PR TITLE
[CI] Add build with sanitizers

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -17,7 +17,7 @@ jobs:
         branch:         [dev]
         config:         [Release]
         assertions:     ["OFF", "ON"]
-        feature-set:    ["+gcc", "+clang", "+clang+shadercache"]
+        feature-set:    ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
         generator:      [Ninja]
     steps:
       - name: Checkout LLPC

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -18,7 +18,7 @@ jobs:
         base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
         config:              [Release]
         assertions:          ["OFF", "ON"]
-        feature-set:         ["+gcc", "+clang", "+clang+shadercache"]
+        feature-set:         ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
     steps:
       - name: Checkout LLPC
         run: |

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -37,5 +37,9 @@ RUN cmake --build . \
     && cmake --build . --target spvgen
 
 # Run the lit test suite.
-RUN cmake --build . --target check-amdllpc -- -v \
+RUN if echo "$FEATURES" | grep -q "+sanitizers" ; then \
+        export ASAN_OPTIONS=detect_leaks=0 \
+        && export LD_PRELOAD=/usr/lib/llvm-9/lib/clang/9.0.0/lib/linux/libclang_rt.asan-x86_64.so; \
+    fi \
+    && cmake --build . --target check-amdllpc -- -v \
     && cmake --build . --target check-lgc -- -v


### PR DESCRIPTION
Add a build configuration `+clang+sanitizer` that builds and tests with asan and ubsan enabled.

The build currently applies a glslang patch to fix some undefined behavior. @JaxLinAMD can you update the glslang version that we use in spvgen?

Tested with `docker build . --file docker/amdvlk.Dockerfile --build-arg BRANCH=dev --build-arg CONFIG=Release --build-arg ASSERTIONS=ON --build-arg FEATURES=+clang+sanitizer --build-arg GENERATOR=Ninja --tag llpc-test`, which worked for me.