### PR TITLE
Use unnamed fields in builtInUsage and add missing MVG stage mask

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1283,6 +1283,7 @@ unsigned InOutBuilder::getBuiltInValidMask(BuiltInKind builtIn, bool isOutput) {
            (1 << ShaderStageFragment),
     HG = (1 << ShaderStageTessControl) | (1 << ShaderStageGeometry),
     MG = (1 << ShaderStageGeometry),
+    MVG = (1 << ShaderStageVertex) | (1 << ShaderStageGeometry),
     MVDG = (1 << ShaderStageVertex) | (1 << ShaderStageTessEval) | (1 << ShaderStageGeometry),
     MVHDG = (1 << ShaderStageVertex) | (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) |
             (1 << ShaderStageGeometry),

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -153,7 +153,8 @@ struct ResourceUsage {
         unsigned cullDistance : 4;  // Array size of gl_CullDistance[] (0 means unused)
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
-        unsigned reserved19 : 1;
+        unsigned : 1;               // Reserved
+        unsigned : 1;               // Reserved
       } vs;
 
       // Tessellation control shader
@@ -195,7 +196,7 @@ struct ResourceUsage {
         unsigned cullDistance : 4;  // Array size gl_CullDistance[] (0 means unused)
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
-        unsigned reserved28 : 1;
+        unsigned : 1;               // Reserved
       } tes;
 
       // Geometry shader
@@ -216,7 +217,8 @@ struct ResourceUsage {
         unsigned primitiveId : 1;   // Whether gl_PrimitiveID is used
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
-        unsigned reserved26 : 1;
+        unsigned : 1;               // Reserved
+        unsigned : 1;               // Reserved
       } gs;
 
       // Fragment shader
@@ -244,6 +246,7 @@ struct ResourceUsage {
         unsigned viewportIndex : 1;            // Whether gl_ViewportIndex is used
         unsigned helperInvocation : 1;         // Whether gl_HelperInvocation is used
         unsigned viewIndex : 1;                // Whether gl_ViewIndex is used
+        unsigned : 1;                          // Reserved
         unsigned baryCoordNoPersp : 1;         // Whether gl_BaryCoordNoPersp is used (AMD extension)
         unsigned baryCoordNoPerspCentroid : 1; // Whether gl_BaryCoordNoPerspCentroid is used (AMD extension)
         unsigned baryCoordNoPerspSample : 1;   // Whether gl_BaryCoordNoPerspSample is used (AMD extension)


### PR DESCRIPTION
It is convenient for us to add new reserved fields if we use unnamed
ones and we don't have to give them "meaningful" names any more.
This change also reserves some fields for future uses.

Also, add missing MVG stage mask to represent a built-in usage that
is valid in vertex shader or geometry shader.

Change-Id: I3203fd1cbb980d6cb4777a14a3e6fdc00681e747