### PR TITLE
Partial fix dEQP-VK.memory_model.message_passing.ext.u32.*physbuffer*

### DIFF
--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -324,7 +324,7 @@ Value *SubgroupBuilder::CreateSubgroupShuffleXor(Value *const value, Value *cons
   // issue dpp_mov for some simple quad/row shuffle cases;
   // then issue ds_permlane_x16 if supported or ds_swizzle, if maskValue < 32
   // default to call SubgroupShuffle, which may issue waterfallloops to handle complex cases.
-  if (cast<ConstantInt>(mask)) {
+  if (dyn_cast<ConstantInt>(mask)) {
     maskValue = cast<ConstantInt>(mask)->getZExtValue();
 
     if (maskValue < 32) {

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -384,8 +384,6 @@ public:
       ++DestMaskCount;
     if (TheMemoryAccess[0] & MemoryAccessMakePointerVisibleKHRMask)
       ++DestMaskCount;
-    if (TheMemoryAccess[0] & MemoryAccessNonPrivatePointerKHRMask)
-      ++DestMaskCount;
 
     // If HasBothMasks is false, the only one mask applies to both Source and Target
     // Otherwise, the first applies to Target and the second applies to Source
@@ -411,11 +409,6 @@ public:
       if (TheMemoryAccess[MaskIdx] & MemoryAccessMakePointerVisibleKHRMask) {
         assert(TheMemoryAccess.size() > Idx && "Scope operand is missing");
         MemoryAccess[I].MakeVisibleScope = TheMemoryAccess[Idx++];
-      }
-
-      if (TheMemoryAccess[MaskIdx] & MemoryAccessNonPrivatePointerKHRMask) {
-        // Note: Scope operand is not expected.
-        MemoryAccess[I].NonPrivatePointerScope = TheMemoryAccess[Idx++];
       }
     }
   }
@@ -450,8 +443,6 @@ protected:
     SPIRVWord Alignment = 0;
     SPIRVId MakeAvailableScope = SPIRVID_INVALID;
     SPIRVId MakeVisibleScope = SPIRVID_INVALID;
-    SPIRVId NonPrivatePointerScope = SPIRVID_INVALID;
-
   } MemoryAccess[2]; // [0]:destination, [1]:source
 };
 


### PR DESCRIPTION
- Fix regression introduced from #605. The mask can be not ConstantInt, such as dEQP-VK.memory_model.message_passing.ext.u32.coherent.fence_fence.atomicwrite.subgroup.payload_nonlocal.buffer.guard_nonlocal.physbuffer.comp. For this case, we need fallback.
- Fix regression from #582. Memory Operand "NonPrivatePointer" has no following operand. 