### PR TITLE
Use memset to initialize builtInUsage and clear inappropriate fields

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -154,8 +154,6 @@ struct ResourceUsage {
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
         unsigned reserved19 : 1;
-
-        uint64_t unused : 45;
       } vs;
 
       // Tessellation control shader
@@ -175,8 +173,6 @@ struct ResourceUsage {
         unsigned cullDistance : 4;   // Array size of gl_out[].gl_CullDistance[] (0 means unused)
         unsigned tessLevelOuter : 1; // Whether gl_TessLevelOuter[] is used
         unsigned tessLevelInner : 1; // Whether gl_TessLevelInner[] is used
-
-        uint64_t unused : 39;
       } tcs;
 
       // Tessellation evaluation shader
@@ -200,8 +196,6 @@ struct ResourceUsage {
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
         unsigned reserved28 : 1;
-
-        uint64_t unused : 35;
       } tes;
 
       // Geometry shader
@@ -223,8 +217,6 @@ struct ResourceUsage {
         unsigned viewportIndex : 1; // Whether gl_ViewportIndex is used
         unsigned layer : 1;         // Whether gl_Layer is used
         unsigned reserved26 : 1;
-
-        uint64_t unused : 37;
       } gs;
 
       // Fragment shader
@@ -266,8 +258,6 @@ struct ResourceUsage {
         // Statements
         unsigned discard : 1;         // Whether "discard" statement is used
         unsigned runAtSampleRate : 1; // Whether fragment shader run at sample rate
-
-        uint64_t unused : 32;
       } fs;
 
       // Compute shader
@@ -280,36 +270,22 @@ struct ResourceUsage {
         unsigned workgroupId : 1;       // Whether gl_WorkGroupID is used
         unsigned numSubgroups : 1;      // Whether gl_NumSubgroups is used
         unsigned subgroupId : 1;        // Whether gl_SubgroupID is used
-
-        uint64_t unused : 57;
       } cs;
-
-      struct {
-        uint64_t u64All;
-      } perStage;
     };
 
     // Common built-in usage
-    union {
-      struct {
-        unsigned subgroupSize : 1;              // Whether gl_SubGroupSize is used
-        unsigned subgroupLocalInvocationId : 1; // Whether gl_SubGroupInvocation is used
-        unsigned subgroupEqMask : 1;            // Whether gl_SubGroupEqMask is used
-        unsigned subgroupGeMask : 1;            // Whether gl_SubGroupGeMask is used
-        unsigned subgroupGtMask : 1;            // Whether gl_SubGroupGtMask is used
-        unsigned subgroupLeMask : 1;            // Whether gl_SubGroupLeMask is used
-        unsigned subgroupLtMask : 1;            // Whether gl_SubGroupLtMask is used
-        unsigned deviceIndex : 1;               // Whether gl_DeviceIndex is used
+    struct {
+      unsigned subgroupSize : 1;              // Whether gl_SubGroupSize is used
+      unsigned subgroupLocalInvocationId : 1; // Whether gl_SubGroupInvocation is used
+      unsigned subgroupEqMask : 1;            // Whether gl_SubGroupEqMask is used
+      unsigned subgroupGeMask : 1;            // Whether gl_SubGroupGeMask is used
+      unsigned subgroupGtMask : 1;            // Whether gl_SubGroupGtMask is used
+      unsigned subgroupLeMask : 1;            // Whether gl_SubGroupLeMask is used
+      unsigned subgroupLtMask : 1;            // Whether gl_SubGroupLtMask is used
+      unsigned deviceIndex : 1;               // Whether gl_DeviceIndex is used
+    } common;
 
-        uint64_t unused : 56;
-      } common;
-
-      struct {
-        uint64_t u64All;
-      } allStage;
-    };
-
-  } builtInUsage = {};
+  } builtInUsage;
 
   // Usage of generic input/output
   struct {

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -34,6 +34,9 @@ using namespace lgc;
 
 // =====================================================================================================================
 ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
+  // NOTE: We use memset to explicitly zero builtInUsage since it has unions inside.
+  memset(&builtInUsage, 0, sizeof(builtInUsage));
+
   if (shaderStage == ShaderStageVertex) {
     // NOTE: For vertex shader, PAL expects base vertex and base instance in user data,
     // even if they are not used in shader.


### PR DESCRIPTION
The structure builtInUsage has unions inside and only memset could
always work correctly to zero the contents, independent of compilers.

Also, some fields, such as "unused", "allStage", and "perStage",
don't make sense any more. They are ununsed now.

Change-Id: I247e19e1f64d094e13586df7d77e14d3dddc6755