### PR TITLE
[CI] Preload asan libraries for build too

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build and Test with Docker
         run: docker build . --file docker/llpc.Dockerfile
                             --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
+                            --build-arg FEATURES="${{ matrix.feature-set }}"
                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"

--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -75,7 +75,9 @@ RUN EXTRA_FLAGS="" \
          EXTRA_FLAGS="$EXTRA_FLAGS -DLLPC_ENABLE_SHADER_CACHE=1"; \
        fi \
     && if echo "$FEATURES" | grep -q "+sanitizers" ; then \
-         EXTRA_FLAGS="$EXTRA_FLAGS -DXGL_USE_SANITIZER=Address;Undefined"; \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DXGL_USE_SANITIZER=Address;Undefined" \
+         && export ASAN_OPTIONS=detect_leaks=0 \
+         && export LD_PRELOAD=/usr/lib/llvm-9/lib/clang/9.0.0/lib/linux/libclang_rt.asan-x86_64.so; \
        fi \
     && echo "Extra CMake flags: $EXTRA_FLAGS" \
     && cmake "/vulkandriver/drivers/xgl" \
@@ -95,8 +97,8 @@ RUN EXTRA_FLAGS="" \
 
 # Run the lit test suite.
 RUN if echo "$FEATURES" | grep -q "+sanitizers" ; then \
-        export ASAN_OPTIONS=detect_leaks=0 \
-        && export LD_PRELOAD=/usr/lib/llvm-9/lib/clang/9.0.0/lib/linux/libclang_rt.asan-x86_64.so; \
+      export ASAN_OPTIONS=detect_leaks=0 \
+      && export LD_PRELOAD=/usr/lib/llvm-9/lib/clang/9.0.0/lib/linux/libclang_rt.asan-x86_64.so; \
     fi \
     && cmake --build . --target check-amdllpc -- -v \
     && cmake --build . --target check-lgc -- -v \


### PR DESCRIPTION
Tablegen is built with sanitizers enabled when assertions are off,
so we need to provide the sanitizer binary for the build too.

Fixes the build as @kuhar noticed in #805.
This time I tested with assertions off and on.

Sidenote: @kuhar, do you manually trigger the nightly builds? If so, how?