### PR TITLE
Set minimum waves per eu to 1 instead of 0.

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -666,7 +666,7 @@ void PatchEntryPointMutate::processShader(ShaderInputs *shaderInputs) {
       std::min(resUsage->numSgprsAvailable, m_pipelineState->getTargetInfo().getGpuProperty().maxSgprsAvailable);
 
   if (shaderOptions->maxThreadGroupsPerComputeUnit != 0) {
-    std::string wavesPerEu = std::string("0,") + std::to_string(shaderOptions->maxThreadGroupsPerComputeUnit);
+    std::string wavesPerEu = std::string("1,") + std::to_string(shaderOptions->maxThreadGroupsPerComputeUnit);
     builder.addAttribute("amdgpu-waves-per-eu", wavesPerEu);
   }
 


### PR DESCRIPTION
The backend ignores the amdgpu-waves-per-eu attribute if the minimum
value is less than 1 or if the maximum value is greater than the limit
imposed by the hardware architecture. We set the minimum to 0, which
meant that the attribute was always ignored. Setting it to 1 means that
the attribute is not ignored, so we can use the -waves-per-eu command
line option to set a useful maximum.