### PR TITLE
Update memory ordering for MakePointerVisible/MakePointerAvailable

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -173,9 +173,11 @@ public:
   Value *transSPIRVImageQueryLodFromInst(SPIRVInstruction *bi, BasicBlock *bb);
 
   Value *createLaunderRowMajorMatrix(Value *const);
-  Value *addLoadInstRecursively(SPIRVType *const, Value *const, bool, bool, bool);
-  void addStoreInstRecursively(SPIRVType *const, Value *const, Value *const, bool, bool, bool);
+  Value *addLoadInstRecursively(SPIRVType *const, Value *const, bool, bool, AtomicOrdering);
+  void addStoreInstRecursively(SPIRVType *const, Value *const, Value *const, bool, bool, AtomicOrdering);
   Constant *buildConstStoreRecursively(SPIRVType *const, Type *const, Constant *const);
+
+  template <class T> AtomicOrdering getMemoryOrdering(T *const, bool);
 
   // Post-process translated LLVM module to undo row major matrices.
   bool postProcessRowMajorMatrix();


### PR DESCRIPTION
The memory ordering mapping from MakePointerVisible/MakePointerAvailable
to LLVM Unordered was too weak. MakePointerVisible/MakePointerAvailable
correspond to C++/LLVM Acquire/Release memory ordering.

Fixes: dEQP-VK.memory_model.message_passing.ext.u32.*physbuffer*