### PR TITLE
Fix a crash when non-uniformly indexing a row-major matrix member

### DIFF
--- a/llpc/test/shaderdb/ObjNonUniformIndex_TestLoadRowMajor.comp
+++ b/llpc/test/shaderdb/ObjNonUniformIndex_TestLoadRowMajor.comp
@@ -1,0 +1,21 @@
+#version 450
+
+#extension GL_EXT_nonuniform_qualifier : enable
+layout(local_size_x = 1) in;
+
+layout(row_major, binding = 1) buffer BlockB
+{
+    vec4 value;
+    mat3x4 mm;
+} blockB[];
+
+void main (void)
+{
+    blockB[nonuniformEXT(0)].value = blockB[nonuniformEXT(0)].mm[0];
+}
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1301,6 +1301,9 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix() {
             if (store->getMetadata(LLVMContext::MD_nontemporal))
               transNonTemporalMetadata(newStore);
           }
+        } else if (CallInst *const callInst = dyn_cast<CallInst>(value)) {
+          if (callInst->getCalledFunction()->getName().startswith(gSPIRVMD::NonUniform))
+            continue;
         } else
           llvm_unreachable("Should never be called!");
       }


### PR DESCRIPTION
- The problem is that row major matrix users can be a CallInst (i.e., spirv.NonUniform) for
non-uniformly indexing, which is treated as "Should never be called!" in postProcessRowMajorMatrix.
- Add one more `else if` condition for spirv.NonUniform CallInst and just skip it.
Fix: dEQP-VK.ssbo.layout.random.8bit.descriptor_indexing.12