### PR TITLE
Formally add the workaround waGeNggMaxVertOutWithGsInstancing

### DIFF
--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -121,7 +121,8 @@ struct WorkaroundFlags {
       unsigned waWarFpAtomicDenormHazard : 1;
       unsigned waNggDisabled : 1;
       unsigned waLimitedMaxOutputVertexCount : 1;
-      unsigned reserved : 14;
+      unsigned waGeNggMaxVertOutWithGsInstancing : 1;
+      unsigned reserved : 13;
     };
     unsigned u32All;
   } gfx10;

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -276,8 +276,10 @@ bool PatchResourceCollect::canUseNgg(Module *module) {
 
     // NOTE: On GFX10, the bit VGT_GS_INSTANCE_CNT.EN_MAX_VERT_OUT_PER_GS_INSTANCE provided by HW allows each GS
     // instance to emit maximum vertices (256). But this mode is not supported when tessellation is enabled.
-    if (geometryMode.invocations * geometryMode.outputVertices > Gfx9::NggMaxThreadsPerSubgroup)
-      return false;
+    if (m_pipelineState->getTargetInfo().getGpuWorkarounds().gfx10.waGeNggMaxVertOutWithGsInstancing) {
+      if (geometryMode.invocations * geometryMode.outputVertices > Gfx9::NggMaxThreadsPerSubgroup)
+        return false;
+    }
   }
 
   // We can safely enable NGG here if NGG flag allows us to do so

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -281,6 +281,7 @@ static void setGfx10Info(TargetInfo *targetInfo) {
   // Hardware workarounds for GFX10 based GPU's:
   targetInfo->getGpuWorkarounds().gfx10.disableI32ModToI16Mod = 1;
   targetInfo->getGpuWorkarounds().gfx10.waLimitedMaxOutputVertexCount = 1;
+  targetInfo->getGpuWorkarounds().gfx10.waGeNggMaxVertOutWithGsInstancing = 1;
 }
 
 // gfx1010 (including gfx101E and gfx101F)


### PR DESCRIPTION
Previously, we disable NGG by calculating the total max output
vertices from GS and comparing it with supported HW max value. This
is treated as a workaround and is expected to be fixed by future HW.

Change-Id: I4329039c10b7e5da546e46c1d109436121ea1362