### PR TITLE
[CI] Read env vars from file in the check-llpc workflow.

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Build and Test with Docker
         run: docker build . --file docker/llpc.Dockerfile
                             --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
-                            --build-arg FEATURES="${{ matrix.feature-set }}"
                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"


### PR DESCRIPTION
The featureset of the child workflow should be determined by the parent
cron workflow. This complements PR #820.

Parent issue: https://github.com/GPUOpen-Drivers/llpc/issues/727.