### PR TITLE
Add graphics fuzz tests for OpCopyObject

### DIFF
--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObject.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObject.spvasm
@@ -1,0 +1,72 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
+; SHADERTEST: AMDLLPC SUCCESS
+; XFAIL: *
+; END_SHADERTEST
+;
+; Based on https://github.com/GPUOpen-Drivers/llpc/issues/834.
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 659
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %243
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %243 BuiltIn FragCoord
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+         %22 = OpConstant %6 1
+         %37 = OpTypeInt 32 0
+        %157 = OpTypeFloat 32
+        %241 = OpTypeVector %157 4
+        %242 = OpTypePointer Input %241
+        %243 = OpVariable %242 Input
+        %244 = OpConstant %37 1
+        %245 = OpTypePointer Input %157
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+               OpSelectionMerge %182 None
+               OpSwitch %22 %182 0 %172 1 %173 2 %174 3 %175 4 %176 5 %177 6 %178 7 %179 8 %180 9 %181
+        %172 = OpLabel
+               OpBranch %182
+        %173 = OpLabel
+               OpBranch %182
+        %174 = OpLabel
+               OpBranch %182
+        %175 = OpLabel
+               OpBranch %182
+        %176 = OpLabel
+               OpBranch %182
+        %177 = OpLabel
+               OpBranch %182
+        %178 = OpLabel
+               OpBranch %182
+        %179 = OpLabel
+               OpBranch %182
+        %180 = OpLabel
+               OpBranch %182
+        %181 = OpLabel
+               OpBranch %182
+        %182 = OpLabel
+        %246 = OpAccessChain %245 %243 %244
+               OpBranch %252
+        %288 = OpLabel
+        %652 = OpCopyObject %245 %246
+               OpBranch %294
+        %294 = OpLabel
+               OpBranch %295
+        %295 = OpLabel
+               OpBranch %282
+        %282 = OpLabel
+               OpBranch %269
+        %269 = OpLabel
+               OpBranch %252
+        %252 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
@@ -1,0 +1,45 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
+; SHADERTEST: AMDLLPC SUCCESS
+; XFAIL: *
+; END_SHADERTEST
+;
+; Based on https://github.com/GPUOpen-Drivers/llpc/issues/834.
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 460
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %9 = OpTypeVector %6 4
+         %21 = OpTypeInt 32 0
+         %22 = OpConstant %21 0
+         %23 = OpTypePointer Function %6
+         %73 = OpTypeInt 32 1
+         %76 = OpConstant %73 0
+         %85 = OpConstant %21 8
+         %86 = OpTypeArray %9 %85
+        %108 = OpTypePointer Function %86
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+        %199 = OpVariable %108 Function
+               OpBranch %205
+        %205 = OpLabel
+        %279 = OpPhi %73 %76 %5 %76 %233
+               OpSwitch %22 %242
+        %242 = OpLabel
+        %217 = OpAccessChain %23 %199 %279 %22
+        %454 = OpCopyObject %23 %217
+               OpReturn
+        %233 = OpLabel
+               OpBranch %205
+               OpFunctionEnd

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectOfVoidType.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectOfVoidType.spvasm
@@ -1,0 +1,27 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
+; SHADERTEST: AMDLLPC SUCCESS
+; XFAIL: *
+; END_SHADERTEST
+;
+; Based on https://github.com/GPUOpen-Drivers/llpc/issues/833.
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 465
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main"
+               OpExecutionMode %4 OriginUpperLeft
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+        %462 = OpUndef %2
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+        %456 = OpCopyObject %2 %462
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
This adds spirv tests from #833 and #834 and marks them as expected failures.