### PR TITLE
Fix CTS ycbcr.query.lod.fragment* cases crash

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -360,7 +360,7 @@ Type *SPIRVToLLVM::transTypeWithOpcode<OpTypeMatrix>(SPIRVType *const spvType, u
     columnType = ArrayType::get(elementType, columnCount);
     columnCount = spvColumnType->getVectorComponentCount();
 
-    //with a MatrixStride Decoration, and one of the RowMajor or ColMajor Decorations
+    // with a MatrixStride Decoration, and one of the RowMajor or ColMajor Decorations
     if (!isColumnMajor && matrixStride == 0) {
       // Targeted for std430 layout
       assert(columnCount == 4);
@@ -6465,12 +6465,12 @@ bool SPIRVToLLVM::transMetadata() {
           }
         }
 
-          // Give the workgroup size to the middle-end.
-          ComputeShaderMode computeMode = {};
-          computeMode.workgroupSizeX = execModeMd.cs.LocalSizeX;
-          computeMode.workgroupSizeY = execModeMd.cs.LocalSizeY;
-          computeMode.workgroupSizeZ = execModeMd.cs.LocalSizeZ;
-          getBuilder()->setComputeShaderMode(computeMode);
+        // Give the workgroup size to the middle-end.
+        ComputeShaderMode computeMode = {};
+        computeMode.workgroupSizeX = execModeMd.cs.LocalSizeX;
+        computeMode.workgroupSizeY = execModeMd.cs.LocalSizeY;
+        computeMode.workgroupSizeZ = execModeMd.cs.LocalSizeZ;
+        getBuilder()->setComputeShaderMode(computeMode);
       } else
         llvm_unreachable("Invalid execution model");
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -305,6 +305,9 @@ private:
 
   Instruction *transMemFence(BasicBlock *bb, SPIRVWord memSema, SPIRVWord memScope);
   void truncConstantIndex(std::vector<Value *> &indices, BasicBlock *bb);
+
+  Value *ConvertingSamplerSelectLadderHelper(Value *result, Value *convertingSamplerIdx,
+                                             std::function<Value *(Value *)> createImageOp);
 }; // class SPIRVToLLVM
 
 } // namespace SPIRV


### PR DESCRIPTION
- For convering sampler, getDescPointerAndStride didn't call CreateGetDescPtr
  for handling immutable samplers which leaves sample desc ptr to be null

Signed-off-by: Jiajun Xie <jiaxie@amd.com>