### PR TITLE
Reapply "PR777 "Refactor FragColorExport to not use the pipeline state"

### DIFF
--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -53,28 +53,19 @@ enum class CompSetting : unsigned {
 // Represents the manager of fragment color export operations.
 class FragColorExport {
 public:
-  FragColorExport(PipelineState *pipelineState, llvm::Module *module);
+  FragColorExport(llvm::LLVMContext *context);
 
-  llvm::Value *run(llvm::Value *output, unsigned location, llvm::Instruction *insertPos);
-
-  ExportFormat computeExportFormat(llvm::Type *outputTy, unsigned location) const;
+  llvm::Value *run(llvm::Value *output, unsigned int hwColorTarget, llvm::Instruction *insertPos, ExportFormat expFmt,
+                   const bool signedness);
 
 private:
   FragColorExport() = delete;
   FragColorExport(const FragColorExport &) = delete;
   FragColorExport &operator=(const FragColorExport &) = delete;
 
-  static CompSetting computeCompSetting(BufDataFormat dfmt);
-  static unsigned getNumChannels(BufDataFormat dfmt);
-
-  static bool hasAlpha(BufDataFormat dfmt);
-
-  static unsigned getMaxComponentBitCount(BufDataFormat dfmt);
-
   llvm::Value *convertToFloat(llvm::Value *value, bool signedness, llvm::Instruction *insertPos) const;
   llvm::Value *convertToInt(llvm::Value *value, bool signedness, llvm::Instruction *insertPos) const;
 
-  PipelineState *m_pipelineState; // Pipeline state
   llvm::LLVMContext *m_context;   // LLVM context
 };
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -149,7 +149,7 @@ bool PatchInOutImportExport::runOnModule(Module &module) {
 void PatchInOutImportExport::processShader() {
   if (m_shaderStage == ShaderStageFragment) {
     // Create fragment color export manager
-    m_fragColorExport = new FragColorExport(m_pipelineState, m_module);
+    m_fragColorExport = new FragColorExport(m_context);
   }
 
   // Initialize the output value for gl_PrimitiveID
@@ -1322,8 +1322,8 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
     }
 
     // Export fragment colors
-    for (unsigned location = 0; location < MaxColorTargets; ++location) {
-      auto &expFragColor = m_expFragColors[location];
+    for (unsigned hwColorTarget = 0; hwColorTarget < MaxColorTargets; ++hwColorTarget) {
+      auto &expFragColor = m_expFragColors[hwColorTarget];
       if (expFragColor.size() > 0) {
         Value *output = nullptr;
         unsigned compCount = expFragColor.size();
@@ -1332,11 +1332,11 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
         // Set CB shader mask
         auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment);
         const unsigned channelMask = ((1 << compCount) - 1);
-        const unsigned origLoc = resUsage->inOutUsage.fs.outputOrigLocs[location];
-        if (origLoc == InvalidValue)
+        unsigned location = resUsage->inOutUsage.fs.outputOrigLocs[hwColorTarget];
+        if (location == InvalidValue)
           continue;
 
-        resUsage->inOutUsage.fs.cbShaderMask |= (channelMask << (4 * origLoc));
+        resUsage->inOutUsage.fs.cbShaderMask |= (channelMask << (4 * location));
 
         // Construct exported fragment colors
         if (compCount == 1)
@@ -1352,8 +1352,22 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           }
         }
 
+        // Update the pipeline state with new information about the export.
+        Type *outputTy = output->getType();
+        ExportFormat expFmt = static_cast<ExportFormat>(m_pipelineState->computeExportFormat(outputTy, location));
+        if (expFmt == EXP_FORMAT_ZERO) {
+          // Clear channel mask if shader export format is ZERO
+          resUsage->inOutUsage.fs.cbShaderMask &= ~(0xF << (4 * location));
+        }
+
+        BasicType outputType = resUsage->inOutUsage.fs.outputTypes[location];
+        const bool signedness =
+            (outputType == BasicType::Int8 || outputType == BasicType::Int16 || outputType == BasicType::Int);
+
+        resUsage->inOutUsage.fs.expFmts[hwColorTarget] = expFmt;
+
         // Do fragment color exporting
-        auto exportInst = m_fragColorExport->run(output, location, insertPos);
+        auto exportInst = m_fragColorExport->run(output, hwColorTarget, insertPos, expFmt, signedness);
         if (exportInst)
           m_lastExport = cast<CallInst>(exportInst);
       }

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -63,6 +63,152 @@ static const char RsStateMetadataName[] = "lgc.rasterizer.state";
 static const char ColorExportFormatsMetadataName[] = "lgc.color.export.formats";
 static const char ColorExportStateMetadataName[] = "lgc.color.export.state";
 
+namespace {
+
+// =====================================================================================================================
+// Gets the maximum bit-count of any component in specified color attachment format.
+//
+// @param dfmt : Color attachment data format
+static unsigned getMaxComponentBitCount(BufDataFormat dfmt) {
+  switch (dfmt) {
+  case BufDataFormatInvalid:
+  case BufDataFormatReserved:
+    return 0;
+  case BufDataFormat4_4:
+  case BufDataFormat4_4_4_4:
+  case BufDataFormat4_4_4_4_Bgra:
+    return 4;
+  case BufDataFormat5_6_5:
+  case BufDataFormat5_6_5_Bgr:
+  case BufDataFormat5_6_5_1:
+  case BufDataFormat5_6_5_1_Bgra:
+  case BufDataFormat1_5_6_5:
+    return 6;
+  case BufDataFormat8:
+  case BufDataFormat8_8:
+  case BufDataFormat8_8_8:
+  case BufDataFormat8_8_8_Bgr:
+  case BufDataFormat8_8_8_8:
+  case BufDataFormat8_8_8_8_Bgra:
+    return 8;
+  case BufDataFormat5_9_9_9:
+    return 9;
+  case BufDataFormat10_10_10_2:
+  case BufDataFormat2_10_10_10:
+  case BufDataFormat2_10_10_10_Bgra:
+    return 10;
+  case BufDataFormat10_11_11:
+  case BufDataFormat11_11_10:
+    return 11;
+  case BufDataFormat16:
+  case BufDataFormat16_16:
+  case BufDataFormat16_16_16_16:
+    return 16;
+  case BufDataFormat32:
+  case BufDataFormat32_32:
+  case BufDataFormat32_32_32:
+  case BufDataFormat32_32_32_32:
+    return 32;
+  case BufDataFormat64:
+  case BufDataFormat64_64:
+  case BufDataFormat64_64_64:
+  case BufDataFormat64_64_64_64:
+    return 64;
+  }
+  return 0;
+}
+
+// =====================================================================================================================
+// Checks whether the alpha channel is present in the specified color attachment format.
+//
+// @param dfmt : Color attachment data format
+static bool hasAlpha(BufDataFormat dfmt) {
+  switch (dfmt) {
+  case BufDataFormat10_10_10_2:
+  case BufDataFormat2_10_10_10:
+  case BufDataFormat8_8_8_8:
+  case BufDataFormat16_16_16_16:
+  case BufDataFormat32_32_32_32:
+  case BufDataFormat8_8_8_8_Bgra:
+  case BufDataFormat2_10_10_10_Bgra:
+  case BufDataFormat64_64_64_64:
+  case BufDataFormat4_4_4_4:
+  case BufDataFormat4_4_4_4_Bgra:
+  case BufDataFormat5_6_5_1:
+  case BufDataFormat5_6_5_1_Bgra:
+  case BufDataFormat1_5_6_5:
+  case BufDataFormat5_9_9_9:
+    return true;
+  default:
+    return false;
+  }
+}
+
+// =====================================================================================================================
+// Get the number of channels
+//
+// @param dfmt : Color attachment data format
+static unsigned getNumChannels(BufDataFormat dfmt) {
+  switch (dfmt) {
+  case BufDataFormatInvalid:
+  case BufDataFormatReserved:
+  case BufDataFormat8:
+  case BufDataFormat16:
+  case BufDataFormat32:
+  case BufDataFormat64:
+    return 1;
+  case BufDataFormat4_4:
+  case BufDataFormat8_8:
+  case BufDataFormat16_16:
+  case BufDataFormat32_32:
+  case BufDataFormat64_64:
+    return 2;
+  case BufDataFormat8_8_8:
+  case BufDataFormat8_8_8_Bgr:
+  case BufDataFormat10_11_11:
+  case BufDataFormat11_11_10:
+  case BufDataFormat32_32_32:
+  case BufDataFormat64_64_64:
+  case BufDataFormat5_6_5:
+  case BufDataFormat5_6_5_Bgr:
+    return 3;
+  case BufDataFormat10_10_10_2:
+  case BufDataFormat2_10_10_10:
+  case BufDataFormat8_8_8_8:
+  case BufDataFormat16_16_16_16:
+  case BufDataFormat32_32_32_32:
+  case BufDataFormat8_8_8_8_Bgra:
+  case BufDataFormat2_10_10_10_Bgra:
+  case BufDataFormat64_64_64_64:
+  case BufDataFormat4_4_4_4:
+  case BufDataFormat4_4_4_4_Bgra:
+  case BufDataFormat5_6_5_1:
+  case BufDataFormat5_6_5_1_Bgra:
+  case BufDataFormat1_5_6_5:
+  case BufDataFormat5_9_9_9:
+    return 4;
+  }
+  return 0;
+}
+
+// =====================================================================================================================
+// This is the helper function for the algorithm to determine the shader export format.
+//
+// @param dfmt : Color attachment data format
+static CompSetting computeCompSetting(BufDataFormat dfmt) {
+  CompSetting compSetting = CompSetting::Invalid;
+  switch (getNumChannels(dfmt)) {
+  case 1:
+    compSetting = CompSetting::OneCompRed;
+    break;
+  case 2:
+    compSetting = CompSetting::TwoCompGreenRed;
+    break;
+  }
+  return compSetting;
+}
+} // namespace
+
 namespace lgc {
 // Create BuilderReplayer pass
 ModulePass *createBuilderReplayer(Pipeline *pipeline);
@@ -726,6 +872,9 @@ void PipelineState::setColorExportState(ArrayRef<ColorExportFormat> formats, con
 //
 // @param location : Export location
 const ColorExportFormat &PipelineState::getColorExportFormat(unsigned location) {
+  if (m_colorExportState.dualSourceBlendEnable)
+    location = 0;
+
   if (location >= m_colorExportFormats.size()) {
     static const ColorExportFormat EmptyFormat = {};
     return EmptyFormat;
@@ -928,13 +1077,93 @@ InterfaceData *PipelineState::getShaderInterfaceData(ShaderStage shaderStage) {
 // =====================================================================================================================
 // Compute the ExportFormat (as an opaque int) of the specified color export location with the specified output
 // type. Only the number of elements of the type is significant.
-// This is not used in a normal compile; it is only used by amdllpc's -check-auto-layout-compatible option.
 //
 // @param outputTy : Color output type
 // @param location : Location
 unsigned PipelineState::computeExportFormat(Type *outputTy, unsigned location) {
-  std::unique_ptr<FragColorExport> fragColorExport(new FragColorExport(this, nullptr));
-  return fragColorExport->computeExportFormat(outputTy, location);
+  const ColorExportFormat *colorExportFormat = &getColorExportFormat(location);
+  GfxIpVersion gfxIp = getTargetInfo().getGfxIpVersion();
+  auto gpuWorkarounds = &getTargetInfo().getGpuWorkarounds();
+  unsigned outputMask = outputTy->isVectorTy() ? (1 << cast<VectorType>(outputTy)->getNumElements()) - 1 : 1;
+  const auto cbState = &m_colorExportState;
+  // NOTE: Alpha-to-coverage only takes effect for outputs from color target 0.
+  const bool enableAlphaToCoverage = (cbState->alphaToCoverageEnable && location == 0);
+
+  const bool blendEnabled = colorExportFormat->blendEnable;
+
+  const bool isUnormFormat = (colorExportFormat->nfmt == BufNumFormatUnorm);
+  const bool isSnormFormat = (colorExportFormat->nfmt == BufNumFormatSnorm);
+  bool isFloatFormat = (colorExportFormat->nfmt == BufNumFormatFloat);
+  const bool isUintFormat = (colorExportFormat->nfmt == BufNumFormatUint);
+  const bool isSintFormat = (colorExportFormat->nfmt == BufNumFormatSint);
+  const bool isSrgbFormat = (colorExportFormat->nfmt == BufNumFormatSrgb);
+
+  if (colorExportFormat->dfmt == BufDataFormat8_8_8 || colorExportFormat->dfmt == BufDataFormat8_8_8_Bgr) {
+    // These three-byte formats are handled by pretending they are float.
+    isFloatFormat = true;
+  }
+
+  const unsigned maxCompBitCount = getMaxComponentBitCount(colorExportFormat->dfmt);
+
+  const bool formatHasAlpha = hasAlpha(colorExportFormat->dfmt);
+  const bool alphaExport =
+      (outputMask == 0xF && (formatHasAlpha || colorExportFormat->blendSrcAlphaToColor || enableAlphaToCoverage));
+
+  const CompSetting compSetting = computeCompSetting(colorExportFormat->dfmt);
+
+  // Start by assuming EXP_FORMAT_ZERO (no exports)
+  ExportFormat expFmt = EXP_FORMAT_ZERO;
+
+  bool gfx8RbPlusEnable = false;
+  if (gfxIp.major == 8 && gfxIp.minor == 1)
+    gfx8RbPlusEnable = true;
+
+  if (colorExportFormat->dfmt == BufDataFormatInvalid)
+    expFmt = EXP_FORMAT_ZERO;
+  else if (compSetting == CompSetting::OneCompRed && !alphaExport && !isSrgbFormat &&
+           (!gfx8RbPlusEnable || maxCompBitCount == 32)) {
+    // NOTE: When Rb+ is enabled, "R8 UNORM" and "R16 UNORM" shouldn't use "EXP_FORMAT_32_R", instead
+    // "EXP_FORMAT_FP16_ABGR" and "EXP_FORMAT_UNORM16_ABGR" should be used for 2X exporting performance.
+    expFmt = EXP_FORMAT_32_R;
+  } else if (((isUnormFormat || isSnormFormat) && maxCompBitCount <= 10) || (isFloatFormat && maxCompBitCount <= 16) ||
+             (isSrgbFormat && maxCompBitCount == 8))
+    expFmt = EXP_FORMAT_FP16_ABGR;
+  else if (isSintFormat &&
+           (maxCompBitCount == 16 ||
+            (!static_cast<bool>(gpuWorkarounds->gfx6.cbNoLt16BitIntClamp) && maxCompBitCount < 16)) &&
+           !enableAlphaToCoverage) {
+    // NOTE: On some hardware, the CB will not properly clamp its input if the shader export format is "UINT16"
+    // "SINT16" and the CB format is less than 16 bits per channel. On such hardware, the workaround is picking
+    // an appropriate 32-bit export format. If this workaround isn't necessary, then we can choose this higher
+    // performance 16-bit export format in this case.
+    expFmt = EXP_FORMAT_SINT16_ABGR;
+  } else if (isSnormFormat && maxCompBitCount == 16 && !blendEnabled)
+    expFmt = EXP_FORMAT_SNORM16_ABGR;
+  else if (isUintFormat &&
+           (maxCompBitCount == 16 ||
+            (!static_cast<bool>(gpuWorkarounds->gfx6.cbNoLt16BitIntClamp) && maxCompBitCount < 16)) &&
+           !enableAlphaToCoverage) {
+    // NOTE: On some hardware, the CB will not properly clamp its input if the shader export format is "UINT16"
+    // "SINT16" and the CB format is less than 16 bits per channel. On such hardware, the workaround is picking
+    // an appropriate 32-bit export format. If this workaround isn't necessary, then we can choose this higher
+    // performance 16-bit export format in this case.
+    expFmt = EXP_FORMAT_UINT16_ABGR;
+  } else if (isUnormFormat && maxCompBitCount == 16 && !blendEnabled)
+    expFmt = EXP_FORMAT_UNORM16_ABGR;
+  else if (((isUintFormat || isSintFormat) || (isFloatFormat && maxCompBitCount > 16) ||
+            ((isUnormFormat || isSnormFormat) && maxCompBitCount == 16)) &&
+           (compSetting == CompSetting::OneCompRed || compSetting == CompSetting::OneCompAlpha ||
+            compSetting == CompSetting::TwoCompAlphaRed))
+    expFmt = EXP_FORMAT_32_AR;
+  else if (((isUintFormat || isSintFormat) || (isFloatFormat && maxCompBitCount > 16) ||
+            ((isUnormFormat || isSnormFormat) && maxCompBitCount == 16)) &&
+           compSetting == CompSetting::TwoCompGreenRed && !alphaExport)
+    expFmt = EXP_FORMAT_32_GR;
+  else if (((isUnormFormat || isSnormFormat) && maxCompBitCount == 16) || (isUintFormat || isSintFormat) ||
+           (isFloatFormat && maxCompBitCount > 16))
+    expFmt = EXP_FORMAT_32_ABGR;
+
+  return expFmt;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
This reapplies commit 1354393fcd8eb248e30e687e57ac1e699b0e48ce from PR #777 by Steven.

Dual source color blending handling is fixed and passes CTS `dEQP-VK.pipeline.blend.dual_source.*`.
This fix makes `getColorExportFormat` aware of dual source blending such that its callers don't have to
be concerned with it.