### PR TITLE
Fixes for glsl change for != being unordered not ordered fcmp

### DIFF
--- a/llpc/test/shaderdb/OpExtInst_TestTan_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestTan_lit.frag
@@ -27,7 +27,7 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.cos.v3f32(<3 x float>
 ; SHADERTEST: %{{[0-9]*}} = fdiv reassoc nnan nsz arcp contract afn <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>,
 ; SHADERTEST: %{{[0-9]*}} = fmul reassoc nnan nsz arcp contract afn <3 x float>
-; SHADERTEST: %{{[0-9]*}} = fcmp one float %{{.*}}, %{{.*}}
+; SHADERTEST: %{{[0-9]*}} = fcmp {{[ou]}}ne float %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpFOrdNotEqual_TestVec3_lit.frag
+++ b/llpc/test/shaderdb/OpFOrdNotEqual_TestVec3_lit.frag
@@ -16,9 +16,9 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: fcmp one <3 x float>
+; SHADERTEST: fcmp {{[ou]}}ne <3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST-COUNT-3: fcmp one float
+; SHADERTEST-COUNT-3: fcmp {{[ou]}}ne float
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestRelationalFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestRelationalFuncs_lit.frag
@@ -41,7 +41,7 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{[0-9]*}} = fcmp oeq <2 x half> %{{[0-9]*}}, %{{[0-9]*}}
-; SHADERTEST: %{{[0-9]*}} = fcmp one <2 x half> %{{[0-9]*}}, %{{[0-9]*}}
+; SHADERTEST: %{{[0-9]*}} = fcmp {{[ou]}}ne <2 x half> %{{[0-9]*}}, %{{[0-9]*}}
 ; SHADERTEST: %{{[0-9]*}} = fcmp olt <2 x half> %{{[0-9]*}}, %{{[0-9]*}}
 ; SHADERTEST: %{{[0-9]*}} = fcmp ogt <2 x half> %{{[0-9]*}}, %{{[0-9]*}}
 ; SHADERTEST: %{{[0-9]*}} = fcmp ole <2 x half> %{{[0-9]*}}, %{{[0-9]*}}


### PR DESCRIPTION
Changes in glsl (see https://github.com/KhronosGroup/glslang/issues/2259 and
https://github.com/KhronosGroup/glslang/pull/2260) mean that fcmp will now use
une (unordered) rather than one (ordered) ne.

This is in line with most high level languages and means that NaN is handled in
a more expected way.

llpc-lit tests need updating for this change. The change allows for both one and
une during the period of transition.