### PR TITLE
Fix and tidy up the -force-loop-unroll-count option

### DIFF
--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -122,18 +122,16 @@ public:
                                       ComputePipelineBuildOut *pipelineOut, void *pipelineDumpFile = nullptr);
   Result buildGraphicsPipelineInternal(GraphicsContext *graphicsContext,
                                        llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
-                                       unsigned forceLoopUnrollCount, bool buildingRelocatableElf,
-                                       ElfPackage *pipelineElf);
+                                       bool buildingRelocatableElf, ElfPackage *pipelineElf);
 
   Result buildComputePipelineInternal(ComputeContext *computeContext, const ComputePipelineBuildInfo *pipelineInfo,
-                                      unsigned forceLoopUnrollCount, bool buildingRelocatableElf,
-                                      ElfPackage *pipelineElf);
+                                      bool buildingRelocatableElf, ElfPackage *pipelineElf);
 
   Result buildPipelineWithRelocatableElf(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
-                                         unsigned forceLoopUnrollCount, ElfPackage *pipelineElf);
+                                         ElfPackage *pipelineElf);
 
-  Result buildPipelineInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
-                               unsigned forceLoopUnrollCount, bool unlinked, ElfPackage *pipelineElf);
+  Result buildPipelineInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo, bool unlinked,
+                               ElfPackage *pipelineElf);
 
   // Gets the count of compiler instance.
   static unsigned getInstanceCount() { return m_instanceCount; }

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -99,6 +99,9 @@ static cl::opt<unsigned> ShadowDescTablePtrHigh("shadow-desc-table-ptr-high",
                                                 cl::desc("High part of VA for shadow descriptor table pointer"),
                                                 cl::init(2));
 
+// -force-loop-unroll-count: Force to set the loop unroll count.
+static cl::opt<int> ForceLoopUnrollCount("force-loop-unroll-count", cl::desc("Force loop unroll count"), cl::init(0));
+
 namespace Llpc {
 
 // =====================================================================================================================
@@ -380,6 +383,9 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
       shaderOptions.disableLicm = DisableLicm || shaderInfo->options.disableLicm;
       shaderOptions.updateDescInElf = shaderInfo->options.updateDescInElf;
       shaderOptions.unrollThreshold = shaderInfo->options.unrollThreshold;
+      // A non-zero command line -force-loop-unroll-count value overrides the shaderInfo option value.
+      shaderOptions.forceLoopUnrollCount =
+          ForceLoopUnrollCount ? ForceLoopUnrollCount : shaderInfo->options.forceLoopUnrollCount;
 
       static_assert(static_cast<lgc::DenormalMode>(Vkgc::DenormalMode::Auto) == lgc::DenormalMode::Auto, "Mismatch");
       static_assert(static_cast<lgc::DenormalMode>(Vkgc::DenormalMode::FlushToZero) == lgc::DenormalMode::FlushToZero,


### PR DESCRIPTION
An earlier refactoring of the loop metadata handling accidentally broke the amdllpc -force-loop-unroll-count option.
This change tidies up the handling of this option and restoresits functionality.