### PR TITLE
Fix incorrect value of SPI_SHADER_COL_FORMAT

### DIFF
--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -668,7 +668,7 @@ CallInst *LowerFragColorExport::addExportForGenericOutputs(Function *fragEntryPo
 
   if (info.empty()) {
     const auto &builtInUsage = m_resUsage->builtInUsage.fs;
-    bool hasDepthExpFmtZero = builtInUsage.sampleMask || builtInUsage.fragStencilRef || builtInUsage.fragDepth;
+    bool hasDepthExpFmtZero = !(builtInUsage.sampleMask || builtInUsage.fragStencilRef || builtInUsage.fragDepth);
     m_pipelineState->getPalMetadata()->updateSpiShaderColFormat(info, hasDepthExpFmtZero, builtInUsage.discard);
     return nullptr;
   }
@@ -685,7 +685,7 @@ CallInst *LowerFragColorExport::addExportForGenericOutputs(Function *fragEntryPo
           output, colorExportInfo.hwColorTarget, &*builder.GetInsertPoint(), expFmt, colorExportInfo.isSigned));
     }
     const auto &builtInUsage = m_resUsage->builtInUsage.fs;
-    bool hasDepthExpFmtZero = builtInUsage.sampleMask || builtInUsage.fragStencilRef || builtInUsage.fragDepth;
+    bool hasDepthExpFmtZero = !(builtInUsage.sampleMask || builtInUsage.fragStencilRef || builtInUsage.fragDepth);
     m_pipelineState->getPalMetadata()->updateSpiShaderColFormat(info, hasDepthExpFmtZero, builtInUsage.discard);
     return lastExport;
   }


### PR DESCRIPTION
The recent refactoring of export info in PAL metadata (#774)
changed the value of SPI_SHADER_COL_FORMAT for shaders
where depthExpFmt equalled EXP_FORMAT_ZERO, leading to visual
regression on GFX10.

This commit restores the original value for those shaders.