### PR TITLE
Support packing input and output on tessellation

### DIFF
--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -142,8 +142,8 @@ class InOutLocationMapManager {
 public:
   InOutLocationMapManager() {}
 
-  void addSpan(llvm::CallInst *call);
-  void buildLocationMap();
+  void addSpan(llvm::CallInst *call, ShaderStage shaderStage);
+  void buildLocationMap(bool checkCompatibility);
 
   bool findMap(const InOutLocation &originalLocation, const InOutLocation *&newLocation);
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -988,8 +988,15 @@ bool PipelineState::isTessOffChip() {
 bool PipelineState::isPackInOut() {
   // Pack input/output requirements:
   // 1) -pack-in-out option is on
-  // 2) It is a VS-FS pipeline
-  return PackInOut && (m_stageMask == (shaderStageToMask(ShaderStageVertex) | shaderStageToMask(ShaderStageFragment)));
+  // 2) It supports VS-FS, VS-TCS-TES-(FS)
+  if (!PackInOut)
+    return false;
+
+  if (hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
+    const unsigned nextStage = getNextShaderStage(ShaderStageVertex);
+    return nextStage == ShaderStageFragment || nextStage == ShaderStageTessControl;
+  }
+  return false;
 }
 
 // =====================================================================================================================

--- a/llpc/test/shaderdb/PipelineGsTess_TestInOutPacking.pipe.avoid
+++ b/llpc/test/shaderdb/PipelineGsTess_TestInOutPacking.pipe.avoid
@@ -1,0 +1,182 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: shl i32 %3, 3
+; SHADERTEST: or i32 %{{[0-9]*}}, 4
+; SHADERTEST: getelementptr [16384 x i32], [16384 x i32] addrspace(3)* @lds, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: shl nuw nsw i32 %{{[0-9]*}}, 3
+; SHADERTEST: or i32 %{{[0-9]*}}, 2
+; SHADERTEST: getelementptr [16384 x i32], [16384 x i32] addrspace(3)* @lds, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: add nuw nsw i32 %{{[0-9]*}}, 384
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 inV0;
+layout(location = 1) in vec2 inV1;
+layout(location = 2) in vec2 inV2;
+
+layout(location = 0) out vec2 out1;
+layout(location = 1) out vec2 out2;
+
+void main(void)
+{
+    gl_Position = inV0;
+    out1 = inV1;
+    out2 = inV2;
+}
+
+[VsInfo]
+entryPoint = main
+
+
+[TcsGlsl]
+#version 450 core
+layout(vertices=3) out;
+layout(location = 0) in vec2 inArray1[];
+layout(location = 1) in vec2 inArray2[];
+
+layout(location = 0) out vec4 outArray[];
+
+void main(void)
+{
+    gl_TessLevelOuter[0] = 2.0;
+    gl_TessLevelOuter[1] = 2.0;
+    gl_TessLevelOuter[2] = 2.0;
+    gl_TessLevelInner[0] = 4.0;
+
+    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+    outArray[gl_InvocationID] = vec4(inArray2[gl_InvocationID].xy, inArray1[gl_InvocationID].xy);
+}
+[TcsInfo]
+entryPoint = main
+
+[TesGlsl]
+#version 450 core
+
+layout(triangles,fractional_even_spacing,ccw) in;
+
+layout(location = 0) in vec4 inArray[];
+
+layout(location = 0) out vec4 color;
+
+void main(void)
+{
+    float u = gl_TessCoord[0];
+    float v = gl_TessCoord[1];
+    float w = gl_TessCoord[2];
+
+    gl_Position = inArray[0] * u + inArray[1] * v + inArray[2] * w;
+    color = (inArray[0] + inArray[1] + inArray[2]) / 3.0;
+}
+
+[TesInfo]
+entryPoint = main
+
+[GsGlsl]
+#version 450 core
+layout(triangles) in;
+layout(triangle_strip, max_vertices = 16) out;
+layout(location = 0) in vec4 in_vtxColor[];
+layout(location = 0) out vec4 vtxColor;
+out gl_PerVertex { vec4 gl_Position; float gl_PointSize; };
+in gl_PerVertex { vec4 gl_Position; float gl_PointSize; } gl_in[];
+void main()
+{
+    for (uint i = 0; i < gl_in.length(); ++i)
+    {
+        gl_Position = gl_in[i].gl_Position;
+        vtxColor = in_vtxColor[i];
+        EmitVertex();
+    }
+    EndPrimitive();
+}
+
+
+[GsInfo]
+entryPoint = main
+
+
+[FsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 inColor;
+
+layout(location = 0) out vec4 fragColor;
+
+void main(void)
+{
+    fragColor =  inColor;
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+patchControlPoints = 3
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 0
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 0
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactDisable
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 1
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.reconfigWorkgroupLayout = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 0
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32_SFLOAT
+attribute[2].offset = 0

--- a/llpc/test/shaderdb/PipelineTess_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/PipelineTess_TestInOutPacking.pipe
@@ -1,0 +1,177 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: shl i32 %3, 3
+; SHADERTEST: or i32 %{{[0-9]*}}, 4
+; SHADERTEST: getelementptr [16384 x i32], [16384 x i32] addrspace(3)* @lds, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: shl nuw nsw i32 %{{[0-9]*}}, 3
+; SHADERTEST: or i32 %{{[0-9]*}}, 2
+; SHADERTEST: getelementptr [16384 x i32], [16384 x i32] addrspace(3)* @lds, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: add nuw nsw i32 %{{[0-9]*}}, 384
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 32, i32 immarg 15, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, i1 immarg false, i1 immarg false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 33, i32 immarg 3, float %{{[0-9]*}}, float %{{[0-9]*}}, float undef, float undef, i1 immarg false, i1 immarg false)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 1, i32 immarg 1, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 2, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 3, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 0, i32 immarg 1, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 0, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 1, i32 immarg 0, i32 %2)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 inV0;
+layout(location = 1) in vec2 inV1;
+layout(location = 2) in vec2 inV2;
+
+layout(location = 0) out vec2 out1;
+layout(location = 1) out vec2 out2;
+
+void main(void)
+{
+    gl_Position = inV0;
+    out1 = inV1;
+    out2 = inV2;
+}
+
+[VsInfo]
+entryPoint = main
+
+
+[TcsGlsl]
+#version 450 core
+layout(vertices=3) out;
+layout(location = 0) in vec2 inArray1[];
+layout(location = 1) in vec2 inArray2[];
+
+layout(location = 0) out vec4 outArray[];
+
+void main(void)
+{
+    gl_TessLevelOuter[0] = 2.0;
+    gl_TessLevelOuter[1] = 2.0;
+    gl_TessLevelOuter[2] = 2.0;
+    gl_TessLevelInner[0] = 4.0;
+
+    gl_out[gl_InvocationID].gl_Position = gl_in[gl_InvocationID].gl_Position;
+    outArray[gl_InvocationID] = vec4(inArray2[gl_InvocationID].xy, inArray1[gl_InvocationID].xy);
+}
+[TcsInfo]
+entryPoint = main
+
+[TesGlsl]
+#version 450 core
+
+layout(triangles,fractional_even_spacing,ccw) in;
+
+layout(location = 0) in vec4 inArray[];
+
+layout(location = 0) out vec2 oVf2;
+layout(location = 1) out vec3 oVf3;
+layout(location = 2) out float of;
+void main(void)
+{
+    float u = gl_TessCoord[0];
+    float v = gl_TessCoord[1];
+    float w = gl_TessCoord[2];
+
+    gl_Position = inArray[0] * u + inArray[1] * v + inArray[2] * w;
+    oVf2 = inArray[0].xy;
+    oVf3 = inArray[1].xyz;
+    of = inArray[2].w;
+}
+
+[TesInfo]
+entryPoint = main
+
+
+[FsGlsl]
+#version 450 core
+
+layout(location = 0) in vec2 inVf2;
+layout(location = 1) in vec3 inVf3;
+layout(location = 2) in float inf;
+
+layout(location = 0) out vec4 fragColor;
+
+void main(void)
+{
+    fragColor =  vec4(inVf2.xy + inVf3.xy, inVf3.z, inf);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+patchControlPoints = 3
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 0
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 0
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactDisable
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 1
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.reconfigWorkgroupLayout = 0
+options.shadowDescriptorTableUsage = Enable
+options.shadowDescriptorTablePtrHigh = 2
+options.extendedRobustness.robustBufferAccess = 0
+options.extendedRobustness.robustImageAccess = 0
+options.extendedRobustness.nullDescriptor = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 0
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32_SFLOAT
+attribute[2].offset = 0


### PR DESCRIPTION
In the current framework of packing input and output on VS-FS, we add the support to pack input and ouput between VS-TCS and TES-FS, respectively.
- The packing for VS-TCS is to reduce lds fragmentations by mapping all scalarized input calls to lds locations as continuious as possible. We execute addSpan and then fillInOutLocMap for TCS inputs as same as FS inputs. In PatchInOutImportExport, we use packed InOutLocationInfo to do patchVsGenericOutputExport and patchTcsGenericInputImport for VS-TCS.
- The packing for TES-FS is similar to VS-FS by re-assembling scalarized output calls in order to reduce the count of time-consuming exp instcutions.

Fixes: #523