### PR TITLE
Update test

### DIFF
--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -32,9 +32,9 @@
 ; SHADERTEST2: Disassembly of section .text:
 ; SHADERTEST2: 0000000000000000 <_amdgpu_vs_main>
 ; SHADERTEST2-DAG: v_mov_b32_e32 v7, 1.0
-; SHADERTEST2-DAG: tbuffer_load_format_x v4, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  dfmt:4, nfmt:7, 0 idxen
-; SHADERTEST2-DAG: tbuffer_load_format_x v5, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  dfmt:4, nfmt:7, 0 idxen offset:4
-; SHADERTEST2-DAG: tbuffer_load_format_x v6, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  dfmt:4, nfmt:7, 0 idxen offset:8
+; SHADERTEST2-DAG: tbuffer_load_format_x v4, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  {{dfmt:4, nfmt:7, 0|0 format:\[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT\]}} idxen
+; SHADERTEST2-DAG: tbuffer_load_format_x v5, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  {{dfmt:4, nfmt:7, 0|0 format:\[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT\]}} idxen offset:4
+; SHADERTEST2-DAG: tbuffer_load_format_x v6, v{{[0-9]*}}, s[{{[0-9]+}}:{{[0-9]+}}],  {{dfmt:4, nfmt:7, 0|0 format:\[BUF_DATA_FORMAT_32,BUF_NUM_FORMAT_FLOAT\]}} idxen offset:8
 ; Identify the start of the vertex shader
 ; SHADERTEST2: s_getpc_b64 s[0:1]
 ; Identify the start of the fragment shader, and check its alignment at the same time.


### PR DESCRIPTION
D84026 changed the way MTBUF are output by the disassmbler.
Modify the expected line of the test to match both versions.