### PR TITLE
Use SimplifyCFGOptions structure for createCFGSimplificationPass.

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -264,7 +264,12 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
     passMgr.add(createInstSimplifyLegacyPass());
     passMgr.add(createFloat2IntPass());
     passMgr.add(createLoopRotatePass());
-    passMgr.add(createCFGSimplificationPass(1, true, true, true, true));
+    passMgr.add(createCFGSimplificationPass(SimplifyCFGOptions()
+                                                .bonusInstThreshold(1)
+                                                .forwardSwitchCondToPhi(true)
+                                                .convertSwitchToLookupTable(true)
+                                                .needCanonicalLoops(true)
+                                                .sinkCommonInsts(true)));
     passMgr.add(createPatchPeepholeOpt());
     passMgr.add(createInstSimplifyLegacyPass());
     passMgr.add(createLoopUnrollPass(optLevel));


### PR DESCRIPTION
Upstream LLVM has replaced explicit parameters with options structure.