### PR TITLE
Implicitly set value for gl_ViewportIndex

### DIFF
--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -317,6 +317,15 @@ void ConfigBuilderBase::appendConfig(ArrayRef<PalMetadataNoteEntry> config) {
 }
 
 // =====================================================================================================================
+// Whether USES_VIEWPORT_ARRAY_INDEX is set
+bool ConfigBuilderBase::usesViewportArrayIndex() {
+  if (m_pipelineNode[Util::Abi::PipelineMetadataKey::UsesViewportArrayIndex].isEmpty())
+    m_pipelineNode[Util::Abi::PipelineMetadataKey::UsesViewportArrayIndex] = false;
+
+  return m_pipelineNode[Util::Abi::PipelineMetadataKey::UsesViewportArrayIndex].getBool();
+}
+
+// =====================================================================================================================
 // Finish ConfigBuilder processing by writing into the PalMetadata document
 void ConfigBuilderBase::writePalMetadata() {
   // Generating MsgPack metadata.

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -86,6 +86,8 @@ protected:
   void appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config);
   void appendConfig(unsigned key, unsigned value);
 
+  bool usesViewportArrayIndex();
+
   template <typename T> void appendConfig(const T &config) {
     static_assert(T::ContainsPalAbiMetadataOnly, "may only be used with structs that are fully metadata notes");
     static_assert(sizeof(T) % sizeof(PalMetadataNoteEntry) == 0,

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1868,10 +1868,18 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
     setWaveFrontSize(Util::Abi::HardwareStage::Ps, waveFrontSize);
 
   unsigned pointCoordLoc = InvalidValue;
-  if (resUsage->inOutUsage.builtInInputLocMap.find(BuiltInPointCoord) !=
-      resUsage->inOutUsage.builtInInputLocMap.end()) {
+  unsigned viewportIndexLoc = InvalidValue;
+
+  auto builtInInputLocMapIt = resUsage->inOutUsage.builtInInputLocMap.find(BuiltInPointCoord);
+  if (builtInInputLocMapIt != resUsage->inOutUsage.builtInInputLocMap.end()) {
     // Get generic input corresponding to gl_PointCoord (to set the field PT_SPRITE_TEX)
-    pointCoordLoc = resUsage->inOutUsage.builtInInputLocMap[BuiltInPointCoord];
+    pointCoordLoc = builtInInputLocMapIt->second;
+  }
+
+  builtInInputLocMapIt = resUsage->inOutUsage.builtInInputLocMap.find(BuiltInViewportIndex);
+  if (builtInInputLocMapIt != resUsage->inOutUsage.builtInInputLocMap.end()) {
+    // Get generic input corresponding to gl_ViewportIndex (to set the field OFFSET and FLAT_SHADE)
+    viewportIndexLoc = builtInInputLocMapIt->second;
   }
 
   // NOTE: PAL expects at least one mmSPI_PS_INPUT_CNTL_0 register set, so we always patch it at least one if none
@@ -1906,12 +1914,16 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
       spiPsInputCntl.bits.ATTR1_VALID = interpInfoElem.attr1Valid;
     }
 
+    constexpr unsigned UseDefaultVal = (1 << 5);
     if (pointCoordLoc == i) {
       spiPsInputCntl.bits.PT_SPRITE_TEX = true;
 
       // NOTE: Set the offset value to force hardware to select input defaults (no VS match).
-      static const unsigned UseDefaultVal = (1 << 5);
       spiPsInputCntl.bits.OFFSET = UseDefaultVal;
+    } else if (viewportIndexLoc == i && !usesViewportArrayIndex()) {
+      // NOTE: Use default value 0 for viewport array index if it is only used in FS (not set in other stages)
+      spiPsInputCntl.bits.OFFSET = UseDefaultVal;
+      spiPsInputCntl.bits.FLAT_SHADE = false;
     }
 
     appendConfig(mmSPI_PS_INPUT_CNTL_0 + i, spiPsInputCntl.u32All);


### PR DESCRIPTION
Per GLSLangSpec.4.60 spec, Chapter 7. Built-In Variables, 7.1.5. Fragment Shader Special Variables:

    "If the geometry stage makes no static assignment to gl_ViewportIndex, the fragment stage will read zero."

So we need to check whether gl_viewportIndex is explicitly set before PS, if not, set the register accordingly to use default 0 value.

This change fixes CTS dEQP-VK.draw.shader_viewport_index.fragment_shader_implicit.