### PR TITLE
NGG (GS): Fix a mistake when GS does output export

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3269,7 +3269,7 @@ void NggPrimShader::exportGsOutput(Value *output, unsigned location, unsigned co
     Value *outputVec = UndefValue::get(FixedVectorType::get(outputElemTy, elemCount));
     for (unsigned i = 0; i < elemCount; ++i) {
       auto outputElem = m_builder->CreateExtractValue(output, i);
-      m_builder->CreateInsertElement(outputVec, outputElem, i);
+      outputVec = m_builder->CreateInsertElement(outputVec, outputElem, i);
     }
 
     outputTy = outputVec->getType();


### PR DESCRIPTION
When handling clip/cull distance, the output values are array-typed.
We translate them to vector-typed by extracting array elements and
re-construct vectors. There is a mistake when we insert elements to
a vector. The vector is not updated.

The defect is caught by dEQP-VK.clipping.user_defined.*distance*geom*.

Change-Id: I2e0b8bf4b0e54a60c60c3245a6d2cb6661afb871