### PR TITLE
Reset reference to the stream in pass manager cache

### DIFF
--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -62,6 +62,7 @@ void GlueShader::compile(raw_pwrite_stream &outStream) {
   // Get the pass manager and run it on the module, generating ELF.
   PassManager &passManager = m_lgcContext->getPassManagerCache()->getGlueShaderPassManager(outStream);
   passManager.run(*module);
+  m_lgcContext->getPassManagerCache()->resetStream();
 }
 
 namespace {

--- a/lgc/include/lgc/state/PassManagerCache.h
+++ b/lgc/include/lgc/state/PassManagerCache.h
@@ -83,6 +83,8 @@ public:
   // Get pass manager for glue shader compilation
   PassManager &getGlueShaderPassManager(llvm::raw_pwrite_stream &outStream);
 
+  void resetStream();
+
 private:
   PassManager &getPassManager(const PassManagerInfo &info, llvm::raw_pwrite_stream &outStream);
 

--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -102,3 +102,10 @@ lgc::PassManager &PassManagerCache::getPassManager(const PassManagerInfo &info, 
 
   return *passManager;
 }
+
+// =====================================================================================================================
+// Removes references to the cached stream.  This must be called before the cached stream has been destroyed.
+//
+void PassManagerCache::resetStream() {
+  m_proxyStream.setUnderlyingStream(nullptr);
+}


### PR DESCRIPTION
The pass manager cache hold a possibly invalid pointer.  This will
remove reset the point in the cache before the object is deleted.

Fixes #864