### PR TITLE
Make coding style more consistent. NFC.

### DIFF
--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -140,7 +140,7 @@ Parameters should be commented in the main comment at
 the top of the function like this:
 
 ```
-// \param hatstand : [in/out] The Hatstand object to modify
+// @param [in/out] hatstand : The Hatstand object to modify
 ```
 
 A tag of `[in]` is unnecessary, and is assumed for a reference or pointer parameter
@@ -149,6 +149,11 @@ where no tag is given.
 Parameter comments should not be placed on the parameter line itself and aligned
 (as happens in PAL style), to avoid spuriously large diffs when a change or addition
 of one parameter means all the others need realigning.
+
+Return values have to be documented in a similar way:
+```
+// @returns : The return value description.
+```
 
 Similarly, a bunch of fields or variables should not have aligned inline comments.
 Instead, put each field's comment on the line above the field.

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -763,7 +763,7 @@ public:
   /// @param [in]  pDumpDir                 Directory of pipeline dump
   /// @param [in]  pipelineInfo             Info of the pipeline to be built
   ///
-  /// @returns The handle of pipeline dump file
+  /// @returns : The handle of pipeline dump file
   static void *VKAPI_CALL BeginPipelineDump(const PipelineDumpOptions *pDumpOptions, PipelineBuildInfo pipelineInfo);
 
   /// Ends to dump graphics/compute pipeline info.
@@ -788,27 +788,27 @@ public:
   ///
   /// @param [in]  pModuleData   Pointer to the shader module data.
   ///
-  /// @returns Hash code associated this shader module.
+  /// @returns : Hash code associated this shader module.
   static uint64_t VKAPI_CALL GetShaderHash(const void *pModuleData);
 
   /// Calculates graphics pipeline hash code.
   ///
   /// @param [in]  pPipelineInfo  Info to build this graphics pipeline
   ///
-  /// @returns Hash code associated this graphics pipeline.
+  /// @returns : Hash code associated this graphics pipeline.
   static uint64_t VKAPI_CALL GetPipelineHash(const GraphicsPipelineBuildInfo *pPipelineInfo);
 
   /// Calculates compute pipeline hash code.
   ///
   /// @param [in]  pPipelineInfo  Info to build this compute pipeline
   ///
-  /// @returns Hash code associated this compute pipeline.
+  /// @returns : Hash code associated this compute pipeline.
   static uint64_t VKAPI_CALL GetPipelineHash(const ComputePipelineBuildInfo *pPipelineInfo);
 
   /// Gets graphics pipeline name.
   ///
   /// @param [in]  pPipelineInfo  Info to build this graphics pipeline
-  /// @param [out] pPipeName      The full name of this graphics pipeline
+  /// @param [out] pPipeName : The full name of this graphics pipeline
   /// @param [in]  nameBufSize    Size of the buffer to store pipeline name
   static void VKAPI_CALL GetPipelineName(const GraphicsPipelineBuildInfo *pPipelineInfo, char *pPipeName,
                                          const size_t nameBufSize);
@@ -816,7 +816,7 @@ public:
   /// Gets compute pipeline name.
   ///
   /// @param [in]  pPipelineInfo  Info to build this compute pipeline
-  /// @param [out] pPipeName      The full name of this compute pipeline
+  /// @param [out] pPipeName : The full name of this compute pipeline
   /// @param [in]  nameBufSize    Size of the buffer to store pipeline name
   static void VKAPI_CALL GetPipelineName(const ComputePipelineBuildInfo *pPipelineInfo, char *pPipeName,
                                          const size_t nameBufSize);
@@ -846,10 +846,11 @@ public:
   ///
   /// Valid handles are always non-null.
   ///
-  /// \param hash the hash key for the cache entry
-  /// \param allocateOnMiss if true, a new cache entry will be allocated when none is found
-  /// \param pHandle will be filled with a handle to the cache entry on Success, NotReady and allocateOnMiss if NotFound
-  /// \return success code, possible values:
+  /// @param hash : The hash key for the cache entry
+  /// @param allocateOnMiss : If true, a new cache entry will be allocated when none is found
+  /// @param pHandle : Will be filled with a handle to the cache entry on Success, NotReady and allocateOnMiss if
+  /// NotFound
+  /// @returns : Success code, possible values:
   ///   * Success: an existing, ready entry was found
   ///   * NotReady: an existing entry was found, but it is not ready yet because another thread
   ///               is working on filling it
@@ -864,15 +865,15 @@ public:
   /// method without first calling SetValue.
   /// Put can be called multiple times if the Entry is empty.
   ///
-  /// \param rawHandle the handle to cache entry to be released
+  /// @param rawHandle : The handle to cache entry to be released
   virtual void ReleaseEntry(RawEntryHandle rawHandle) = 0;
 
   /// \brief Wait for a cache entry to become ready (populated by another thread).
   ///
   /// This block the current thread until the entry becomes ready.
   ///
-  /// \param rawHandle the handle to the cache entry to be wait.
-  /// \return success code, possible values:
+  /// @param rawHandle : The handle to the cache entry to be wait.
+  /// @returns : Success code, possible values:
   ///   * Success: the entry is now ready
   ///   * ErrorXxx: some internal error has occurred, or populating the cache was not successful
   ///               (e.g. due to a compiler error). The operation was semantically a no-op:
@@ -881,13 +882,13 @@ public:
 
   /// \brief Retrieve the value contents of a cache entry.
   ///
-  /// \param rawHandle the handle to the cache entry
-  /// \param pData if non-null, up to *pDataLen bytes of contents of the cache entry will be copied
+  /// @param rawHandle : The handle to the cache entry
+  /// @param pData : If non-null, up to *pDataLen bytes of contents of the cache entry will be copied
   ///              into the memory pointed to by pData
-  /// \param pDataLen if \p pData is non-null, the caller must set *pDataLen to the space available
+  /// @param pDataLen : If \p pData is non-null, the caller must set *pDataLen to the space available
   ///                 in the memory that it points to. The method will store the total size of the
   ///                 cache entry in *pDataLen.
-  /// \return success code, possible values:
+  /// @returns : Success code, possible values:
   ///   * Success: operation completed successfully
   ///   * NotReady: the entry is not ready yet (waiting to be populated by another thread)
   ///   * ErrorXxx: some internal error has occurred. The operation was semantically a no-op.
@@ -895,11 +896,11 @@ public:
 
   /// \brief Zero-copy retrieval of the value contents of a cache entry.
   ///
-  /// \param handle the handle to the cache entry
-  /// \param ppData will be set to a pointer to the cache value contents. The pointer remains
+  /// @param handle : The handle to the cache entry
+  /// @param ppData : Will be set to a pointer to the cache value contents. The pointer remains
   ///               valid until the handle is released via \ref PutEntry.
-  /// \param pDataLen will be set to the total size of the cache entry in *pDataLen.
-  /// \return success code, possible values:
+  /// @param pDataLen : Will be set to the total size of the cache entry in *pDataLen.
+  /// @returns : Success code, possible values:
   ///   * Success: operation completed successfully
   ///   * Unsupported: this implementation does not support zero-copy, the caller must use
   ///                  \ref GetValue instead
@@ -914,11 +915,11 @@ public:
   ///
   /// The handle must still be released using \ref PutEntry after calling this method.
   ///
-  /// \param handle the handle to be populated
-  /// \param success whether computing the value contents was successful
-  /// \param pData pointer to the value contents
-  /// \param dataLen size of the value contents in bytes
-  /// \return success code, possible values:
+  /// @param handle : The handle to be populated
+  /// @param success : Whether computing the value contents was successful
+  /// @param pData : Pointer to the value contents
+  /// @param dataLen : Size of the value contents in bytes
+  /// @returns : Success code, possible values:
   ///   * Success: operation completed successfully
   ///   * ErrorXxx: some internal error has occurred. The caller must not call SetValue again,
   ///               but it must still release the handle via \ref PutEntry.
@@ -931,7 +932,7 @@ public:
   /// implementation is trivial.
   virtual Result ReleaseWithValue(RawEntryHandle rawHandle, bool success, const void *pData, size_t dataLen) {
     Result result = Result::ErrorUnknown;
-    if (rawHandle == nullptr)
+    if (!rawHandle)
       return result;
     result = SetValue(rawHandle, success, pData, dataLen);
     ReleaseEntry(rawHandle);

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1633,9 +1633,9 @@ Value *BuilderRecorder::CreateSubgroupBallotFindMsb(Value *const value, const Tw
 // =====================================================================================================================
 // Create "fmix" operation, returning ( 1 - A ) * X + A * Y. Result would be FP scalar or vector.
 //
-// @param x : left Value
-// @param y : right Value
-// @param a : wight Value
+// @param x : Left Value
+// @param y : Right Value
+// @param a : Wight Value
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::createFMix(Value *x, Value *y, Value *a, const Twine &instName) {
   return record(Opcode::FMix, x->getType(), {x, y, a}, instName);
@@ -1987,7 +1987,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
 // This does not have to be particularly efficient, as it is only used with the lgc command-line utility.
 //
 // @param name : Name of function declaration
-// @return : Opcode
+// @returns : Opcode
 BuilderRecorder::Opcode BuilderRecorder::getOpcodeFromName(StringRef name) {
   assert(name.startswith(BuilderCallPrefix));
   name = name.drop_front(strlen(BuilderCallPrefix));

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1766,7 +1766,7 @@ Value *ImageBuilder::patchCubeDescriptor(Value *desc, unsigned dim) {
 //
 // @param coord : Coordinate, scalar or vector i32
 // @param flags : Image flags
-// @param [in,out] dim : Image dimension
+// @param [in/out] dim : Image dimension
 Value *ImageBuilder::handleFragCoordViewIndex(Value *coord, unsigned flags, unsigned &dim) {
   bool useViewIndex = false;
   if (flags & ImageFlagCheckMultiView) {

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -747,7 +747,7 @@ Value *InOutBuilder::readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo i
 //
 // @param builtIn : Built-in kind, one of the BuiltIn* constants
 // @param instName : Name to give instruction(s)
-// @return : Value of input; nullptr if not handled here
+// @returns : Value of input; nullptr if not handled here
 Value *InOutBuilder::readVsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
   switch (builtIn) {
   case BuiltInBaseVertex:

--- a/lgc/builder/YCbCrConverter.cpp
+++ b/lgc/builder/YCbCrConverter.cpp
@@ -39,7 +39,7 @@ using namespace llvm;
 // =====================================================================================================================
 // Implement wrapped YCbCr sample
 //
-// @param Wrapped YCbCr sample infomation
+// @param wrapInfo : Wrapped YCbCr sample infomation
 Value *YCbCrConverter::wrappedSample(YCbCrWrappedSampleInfo &wrapInfo) {
   SmallVector<Value *, 4> coordsChroma;
   YCbCrSampleInfo *sampleInfo = wrapInfo.ycbcrInfo;
@@ -85,7 +85,7 @@ Value *YCbCrConverter::wrappedSample(YCbCrWrappedSampleInfo &wrapInfo) {
 // =====================================================================================================================
 // Create YCbCr reconstruct linear X chroma sample
 //
-// @param Infomation for downsampled chroma channels in X dimension
+// @param xChromeInfo : Infomation for downsampled chroma channels in X dimension
 Value *YCbCrConverter::reconstructLinearXChromaSample(XChromaSampleInfo &xChromaInfo) {
   YCbCrSampleInfo *sampleInfo = xChromaInfo.ycbcrInfo;
   Value *isEvenI = m_builder->CreateICmpEQ(
@@ -131,7 +131,7 @@ Value *YCbCrConverter::reconstructLinearXChromaSample(XChromaSampleInfo &xChroma
 // =====================================================================================================================
 // Create YCbCr Reconstruct linear XY chroma sample
 //
-// @param Infomation for downsampled chroma channels in XY dimension
+// @param xyChromeInfo : Information for downsampled chroma channels in XY dimension
 Value *YCbCrConverter::reconstructLinearXYChromaSample(XYChromaSampleInfo &xyChromaInfo) {
   YCbCrSampleInfo *sampleInfo = xyChromaInfo.ycbcrInfo;
 
@@ -871,7 +871,7 @@ Value *YCbCrConverter::convertColor(Type *resultTy, SamplerYCbCrModelConversion 
 // Implement transfer form  ST coordinates to UV coordiantes operation
 //
 // @param coordST : ST coords
-// @param scale : with/height
+// @param scale : With/height
 Value *YCbCrConverter::transferSTtoUVCoords(Value *coordST, Value *scale) {
   return m_builder->CreateFMul(coordST, scale);
 }

--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -299,7 +299,7 @@ void ElfLinkerImpl::addGlue(unsigned glueIndex, StringRef blob) {
 // internally compiled. The client only needs to call this if it wants to cache the glue code's blob.
 //
 // @param glueIndex : Index into the array that was returned by getGlueInfo()
-// @return : The blob. A zero-length blob indicates that a recoverable error occurred, and link() will also return
+// @returns : The blob. A zero-length blob indicates that a recoverable error occurred, and link() will also return
 //           and empty ELF blob.
 StringRef ElfLinkerImpl::compileGlue(unsigned glueIndex) {
   return m_glueShaders[glueIndex]->getElfBlob();
@@ -318,7 +318,7 @@ StringRef ElfLinkerImpl::compileGlue(unsigned glueIndex) {
 //    made by LLVM to avoid memory leaks.
 //
 // @param [out] outStream : Stream to write linked ELF to
-// @return : True for success, false if something about the pipeline state stops linking
+// @returns : True for success, false if something about the pipeline state stops linking
 bool ElfLinkerImpl::link(raw_pwrite_stream &outStream) {
   // Insert glue shaders (if any).
   if (!insertGlueShaders())
@@ -493,7 +493,7 @@ unsigned ElfLinkerImpl::getStringIndex(StringRef string) {
 // Find symbol in output ELF
 //
 // @param nameIndex : Index of symbol name in string table
-// @return : Index in symbol table, or 0 if not found
+// @returns : Index in symbol table, or 0 if not found
 unsigned ElfLinkerImpl::findSymbol(unsigned nameIndex) {
   for (auto &sym : getSymbols()) {
     if (sym.st_name == nameIndex)
@@ -523,7 +523,7 @@ uint64_t ElfLinkerImpl::getRelocValue(object::RelocationRef reloc) {
 //
 // @param elfInput : ElfInput object for the ELF input
 // @param section : Section from that input
-// @return : {outputSectionIdx,withinIdx} pair, both elements UINT_MAX if no contribution to an output section
+// @returns : {outputSectionIdx,withinIdx} pair, both elements UINT_MAX if no contribution to an output section
 std::pair<unsigned, unsigned> ElfLinkerImpl::findInputSection(ElfInput &elfInput, object::SectionRef section) {
   unsigned idx = section.getIndex();
   if (idx >= elfInput.sectionMap.size())
@@ -585,7 +585,7 @@ void ElfLinkerImpl::writePalMetadata() {
 // =====================================================================================================================
 // Insert glue shaders (if any).
 //
-// @return : False if a recoverable error occurred and was reported with setError().
+// @returns : False if a recoverable error occurred and was reported with setError().
 bool ElfLinkerImpl::insertGlueShaders() {
   // Ensure glue code is compiled, and insert them as new input shaders.
   for (auto &glueShader : m_glueShaders) {

--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -46,7 +46,7 @@ using namespace llvm;
 // @param [out] descSet : Value of first integer
 // @param [out] binding : Value of second integer
 // @param [out] typeLetter : Value of optional type letter, 0 if none
-// @return : True if parse successful
+// @returns : True if parse successful
 static bool parseDescSetBinding(StringRef str, unsigned &descSet, unsigned &binding, int &typeLetter) {
   typeLetter = 0;
   if (str.consumeInteger(10, descSet) || str.empty() || str[0] != '_')
@@ -67,7 +67,7 @@ static bool parseDescSetBinding(StringRef str, unsigned &descSet, unsigned &bind
 //
 // @param name : Symbol name used by relocation
 // @param [out] value : Returns value of symbol if found
-// @return : True if successful, false if not handled
+// @returns : True if successful, false if not handled
 bool RelocHandler::getValue(StringRef name, uint64_t &value) {
   if (name.startswith(reloc::DescriptorOffset)) {
     // Descriptor offset in bytes in the descriptor table for its set, or in the spill table if in the root table.

--- a/lgc/include/lgc/state/ShaderStage.h
+++ b/lgc/include/lgc/state/ShaderStage.h
@@ -67,7 +67,7 @@ const char *getShaderStageAbbreviation(ShaderStage shaderStage);
 // @param retTy : New return type, nullptr to use the same as in the original function
 // @param argTys : Types of new args
 // @param inRegMask : Bitmask of which args should be marked "inreg", to be passed in SGPRs
-// @return : The new function
+// @returns : The new function
 llvm::Function *addFunctionArgs(llvm::Function *oldFunc, llvm::Type *retTy, llvm::ArrayRef<llvm::Type *> argTys,
                                 uint64_t inRegMask = 0);
 
@@ -75,7 +75,7 @@ llvm::Function *addFunctionArgs(llvm::Function *oldFunc, llvm::Type *retTy, llvm
 //
 // @param callingConv : Which hardware shader stage
 // @param isFetchlessVs : Whether it is (or contains) a fetchless vertex shader
-// @return : The entry-point name, or "" if callingConv not recognized
+// @returns : The entry-point name, or "" if callingConv not recognized
 llvm::StringRef getEntryPointName(unsigned callingConv, bool isFetchlessVs);
 
 } // namespace lgc

--- a/lgc/include/lgc/util/AddressExtender.h
+++ b/lgc/include/lgc/util/AddressExtender.h
@@ -58,7 +58,7 @@ public:
   // @param highHalf : Value to use for high half; HighAddrPc to use PC
   // @param ptrTy : Type to cast pointer to
   // @param builder : IRBuilder to use, already set to the required insert point
-  // @return : 64-bit pointer value
+  // @returns : 64-bit pointer value
   llvm::Instruction *extend(llvm::Value *addr32, unsigned highHalf, llvm::Type *ptrTy, llvm::IRBuilder<> &builder);
 
 private:

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -633,9 +633,9 @@ public:
   // Note that when doing vector calculation, it means add/sub are element-wise between vectors, and the product will
   // be Hadamard product.
   //
-  // @param x : left Value
-  // @param y : right Value
-  // @param a : wight Value
+  // @param x : Left Value
+  // @param y : Right Value
+  // @param a : Wight Value
   virtual llvm::Value *createFMix(llvm::Value *x, llvm::Value *y, llvm::Value *a, const llvm::Twine &instName = "") = 0;
 
   // -----------------------------------------------------------------------------------------------------------------
@@ -1436,7 +1436,7 @@ public:
   // Create a subgroup quad broadcast.
   //
   // @param value : The value to broadcast
-  // @param index : the index within the quad to broadcast from
+  // @param index : The index within the quad to broadcast from
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateSubgroupQuadBroadcast(llvm::Value *const value, llvm::Value *const index,
                                                    const llvm::Twine &instName = "") = 0;

--- a/lgc/interface/lgc/ElfLinker.h
+++ b/lgc/interface/lgc/ElfLinker.h
@@ -75,7 +75,7 @@ public:
   // internally compiled. The client only needs to call this if it wants to cache the glue code's blob.
   //
   // @param glueIndex : Index into the array that was returned by getGlueInfo()
-  // @return : The blob. A zero-length blob indicates that a recoverable error occurred, and link() will also return
+  // @returns : The blob. A zero-length blob indicates that a recoverable error occurred, and link() will also return
   //           and empty ELF blob.
   virtual llvm::StringRef compileGlue(unsigned glueIndex) = 0;
 
@@ -84,7 +84,7 @@ public:
   // Like other LGC and LLVM library functions, an internal compiler error could cause an assert or report_fatal_error.
   //
   // @param [out] outStream : Stream to write linked ELF to
-  // @return : True for success.
+  // @returns : True for success.
   //           False if there is some reason why the pipeline cannot be linked from unlinked shader/half-pipeline
   //           ELFs. The client typically then does a whole-pipeline compilation instead. The client can call
   //           getLastError() to get a textual representation of the error, for use in logging or in error

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -595,7 +595,7 @@ public:
   // it can be useful in avoiding an unnecessary shader compile before falling back to full-pipeline
   // compilation.
   //
-  // @return : True for success, false if some reason for failure found, in which case getLastError()
+  // @returns : True for success, false if some reason for failure found, in which case getLastError()
   //           returns a textual description
   virtual bool checkElfLinkable() = 0;
 
@@ -617,7 +617,7 @@ public:
   // @param otherElf : Optional ELF for the other half-pipeline when compiling an unlinked half-pipeline ELF.
   //                   Supplying this could allow more optimal code for writing/reading attribute values between
   //                   the two pipeline halves
-  // @return : True for success.
+  // @returns : True for success.
   //           False if irLink asked for an "unlinked" shader or half-pipeline, and there is some reason why the
   //           module cannot be compiled that way.  The client typically then does a whole-pipeline compilation
   //           instead. The client can call getLastError() to get a textual representation of the error, for
@@ -634,7 +634,7 @@ public:
   // methods finding something about the shaders or pipeline state that means that shader compilation then
   // linking cannot be done. This error message is intended only for logging or command-line error reporting.
   //
-  // @return : Error message from last such recoverable error; remains valid until next time generate() or
+  // @returns : Error message from last such recoverable error; remains valid until next time generate() or
   //           one of the ElfLinker methods is called, or the Pipeline object is destroyed
   virtual llvm::StringRef getLastError() = 0;
 

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -74,8 +74,8 @@ ConfigBuilderBase::~ConfigBuilderBase() {
 // =====================================================================================================================
 /// Adds the .shaders.$(apiStage).hardware_mapping node to the PAL metadata.
 ///
-/// @param [in] apiStage The API shader stage
-/// @param [in] hwStages The HW stage(s) that the API shader is mapped to, as a combination of
+/// @param [in] apiStage : The API shader stage
+/// @param [in] hwStages : The HW stage(s) that the API shader is mapped to, as a combination of
 ///                      @ref Util::Abi::HardwareStageFlagBits.
 void ConfigBuilderBase::addApiHwShaderMapping(ShaderStage apiStage, unsigned hwStages) {
   auto hwMappingNode = getApiShaderNode(apiStage)[Util::Abi::ShaderMetadataKey::HardwareMapping].getArray(true);
@@ -284,8 +284,8 @@ void ConfigBuilderBase::setEsGsLdsSize(unsigned value) {
 // =====================================================================================================================
 /// Append a single entry to the PAL register metadata.
 ///
-/// @param [in] key The metadata key (usually a register address).
-/// @param [in] value The metadata value.
+/// @param [in] key : The metadata key (usually a register address).
+/// @param [in] value : The metadata value.
 void ConfigBuilderBase::appendConfig(unsigned key, unsigned value) {
   assert(key != InvalidMetadataKey);
 
@@ -298,7 +298,7 @@ void ConfigBuilderBase::appendConfig(unsigned key, unsigned value) {
 // =====================================================================================================================
 /// Append an array of entries to the PAL register metadata. Invalid keys are filtered out.
 ///
-/// @param [in] config The array of register metadata entries.
+/// @param [in] config : The array of register metadata entries.
 void ConfigBuilderBase::appendConfig(ArrayRef<PalMetadataNoteEntry> config) {
   unsigned count = 0;
 

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -513,7 +513,7 @@ bool LowerFragColorExport::runOnModule(Module &module) {
       break;
     }
   }
-  if (retInst == nullptr)
+  if (!retInst)
     return false;
 
   BuilderBase builder(module.getContext());
@@ -679,7 +679,7 @@ Value *LowerFragColorExport::addExportForGenericOutputs(Function *fragEntryPoint
   SmallVector<ColorExportInfo, 8> info;
   for (unsigned hwColorTarget = 0; hwColorTarget < MaxColorTargets; ++hwColorTarget) {
     Value *output = exportValues[hwColorTarget];
-    if (output == nullptr)
+    if (!output)
       continue;
     const ColorExportValueInfo &colorExportInfo = expFragColors[hwColorTarget];
     info.push_back({hwColorTarget, colorExportInfo.location, colorExportInfo.isSigned, output->getType()});

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3367,8 +3367,8 @@ Value *NggPrimShader::importGsOutput(Type *outputTy, unsigned location, unsigned
 // @param module : LLVM module
 // @param streamId : ID of output vertex stream
 // @param threadIdInSubgroup : Thread ID in subgroup
-// @param [in,out] emitVertsPtr : Pointer to the counter of GS emitted vertices for this stream
-// @param [in,out] outVertsPtr : Pointer to the counter of GS output vertices of current primitive for this stream
+// @param [in/out] emitVertsPtr : Pointer to the counter of GS emitted vertices for this stream
+// @param [in/out] outVertsPtr : Pointer to the counter of GS output vertices of current primitive for this stream
 void NggPrimShader::processGsEmit(Module *module, unsigned streamId, Value *threadIdInSubgroup, Value *emitVertsPtr,
                                   Value *outVertsPtr) {
   auto gsEmitHandler = module->getFunction(lgcName::NggGsEmit);
@@ -3383,7 +3383,7 @@ void NggPrimShader::processGsEmit(Module *module, unsigned streamId, Value *thre
 //
 // @param module : LLVM module
 // @param streamId : ID of output vertex stream
-// @param [in,out] outVertsPtr : Pointer to the counter of GS output vertices of current primitive for this stream
+// @param [in/out] outVertsPtr : Pointer to the counter of GS output vertices of current primitive for this stream
 void NggPrimShader::processGsCut(Module *module, unsigned streamId, Value *outVertsPtr) {
   auto gsCutHandler = module->getFunction(lgcName::NggGsCut);
   if (!gsCutHandler)

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -82,7 +82,7 @@ void PatchBufferOp::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM function.
 //
-// @param [in,out] function : LLVM function to be run on
+// @param [in/out] function : LLVM function to be run on
 bool PatchBufferOp::runOnFunction(Function &function) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Buffer-Op\n");
 

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -77,7 +77,7 @@ PatchCheckShaderCache::PatchCheckShaderCache() : Patch(ID) {
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchCheckShaderCache::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Check-Shader-Cache\n");
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -109,7 +109,7 @@ ModulePass *lgc::createPatchCopyShader() {
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchCopyShader::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Copy-Shader\n");
 

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -193,7 +193,7 @@ PatchEntryPointMutate::PatchEntryPointMutate() : Patch(ID), m_hasTs(false), m_ha
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchEntryPointMutate::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Entry-Point-Mutate\n");
 
@@ -727,7 +727,7 @@ void PatchEntryPointMutate::processShader(ShaderInputs *shaderInputs) {
 // @param shaderInputs : ShaderInputs object representing hardware-provided shader inputs
 // @param [out] inRegMask : "Inreg" bit mask for the arguments, with a bit set to indicate that the corresponding
 //                          arg needs to have an "inreg" attribute to put the arg into SGPRs rather than VGPRs
-// @return : The newly-constructed function type
+// @returns : The newly-constructed function type
 //
 uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInputs, SmallVectorImpl<Type *> &argTys) {
 
@@ -1148,7 +1148,7 @@ void PatchEntryPointMutate::addUserDataArgs(SmallVectorImpl<UserDataArg> &userDa
 // @param useFixedLayout : True to insert padding before if required
 // @param userDataSize : Size so far of user data in dwords
 // @param builder : IRBuilder (just for getting types)
-// @return : Updated size so far of user data in dwords
+// @returns : Updated size so far of user data in dwords
 unsigned PatchEntryPointMutate::addUserDataArg(SmallVectorImpl<UserDataArg> &userDataArgs, unsigned userDataValue,
                                                unsigned sizeInDwords, unsigned *argIndex, bool useFixedLayout,
                                                unsigned userDataSize, IRBuilder<> &builder) {

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -87,7 +87,7 @@ void PatchInOutImportExport::initPerShader() {
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchInOutImportExport::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-In-Out-Import-Export\n");
 
@@ -4189,7 +4189,7 @@ Value *PatchInOutImportExport::calcGsVsRingOffsetForOutput(unsigned location, un
 // =====================================================================================================================
 // Reads value from LDS.
 //
-// @param isOutput : is the value from output variable
+// @param isOutput : Is the value from output variable
 // @param readTy : Type of value read from LDS
 // @param ldsOffset : Start offset to do LDS read operations
 // @param insertPos : Where to insert read instructions

--- a/lgc/patch/PatchIntrinsicSimplify.cpp
+++ b/lgc/patch/PatchIntrinsicSimplify.cpp
@@ -78,7 +78,7 @@ void PatchIntrinsicSimplify::getAnalysisUsage(AnalysisUsage &analysisUsage) cons
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM function.
 //
-// @param [in,out] func : LLVM function to be run on.
+// @param [in/out] func : LLVM function to be run on.
 bool PatchIntrinsicSimplify::runOnFunction(Function &func) {
   SmallVector<IntrinsicInst *, 32> candidateCalls;
   bool changed = false;

--- a/lgc/patch/PatchLlvmIrInclusion.cpp
+++ b/lgc/patch/PatchLlvmIrInclusion.cpp
@@ -59,7 +59,7 @@ PatchLlvmIrInclusion::PatchLlvmIrInclusion() : Patch(ID) {
 // This pass includes LLVM IR as a separate section in the ELF binary by inserting a new global variable with explicit
 // section.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchLlvmIrInclusion::runOnModule(Module &module) {
   Patch::init(&module);
 

--- a/lgc/patch/PatchLoadScalarizer.cpp
+++ b/lgc/patch/PatchLoadScalarizer.cpp
@@ -71,7 +71,7 @@ void PatchLoadScalarizer::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
 // =====================================================================================================================
 // Executes this LLVM pass on the specified LLVM function.
 //
-// @param [in,out] function : Function that will run this optimization.
+// @param [in/out] function : Function that will run this optimization.
 bool PatchLoadScalarizer::runOnFunction(Function &function) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Load-Scalarizer-Opt\n");
 

--- a/lgc/patch/PatchLoopMetadata.cpp
+++ b/lgc/patch/PatchLoopMetadata.cpp
@@ -84,7 +84,7 @@ PatchLoopMetadata::PatchLoopMetadata()
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchLoopMetadata::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass patch-loop-metadata\n");
 

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -76,7 +76,7 @@ ModulePass *lgc::createPatchNullFragShader() {
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchNullFragShader::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Null-Frag-Shader\n");
 

--- a/lgc/patch/PatchPeepholeOpt.cpp
+++ b/lgc/patch/PatchPeepholeOpt.cpp
@@ -69,7 +69,7 @@ PatchPeepholeOpt::PatchPeepholeOpt() : FunctionPass(ID) {
 // =====================================================================================================================
 // Executes this LLVM pass on the specified LLVM function.
 //
-// @param [in,out] function : Function that we will peephole optimize.
+// @param [in/out] function : Function that we will peephole optimize.
 bool PatchPeepholeOpt::runOnFunction(Function &function) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Peephole-Opt\n");
 
@@ -89,7 +89,7 @@ bool PatchPeepholeOpt::runOnFunction(Function &function) {
 // =====================================================================================================================
 // Specify what analysis passes this pass depends on.
 //
-// @param [in,out] analysisUsage : The place to record our analysis pass usage requirements.
+// @param [in/out] analysisUsage : The place to record our analysis pass usage requirements.
 void PatchPeepholeOpt::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
   analysisUsage.setPreservesCFG();
 }

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -104,7 +104,7 @@ ModulePass *lgc::createPatchPreparePipelineAbi(bool onlySetCallingConvs) {
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchPreparePipelineAbi::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Prepare-Pipeline-Abi\n");
 

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -72,7 +72,7 @@ PatchResourceCollect::PatchResourceCollect()
 // =====================================================================================================================
 // Executes this LLVM patching pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchResourceCollect::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Resource-Collect\n");
 

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -77,7 +77,7 @@ ModulePass *lgc::createPatchSetupTargetFeatures() {
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PatchSetupTargetFeatures::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Setup-Target-Features\n");
 
@@ -92,7 +92,7 @@ bool PatchSetupTargetFeatures::runOnModule(Module &module) {
 // =====================================================================================================================
 // Setup LLVM target features, target features are set per entry point function.
 //
-// @param [in, out] module : LLVM module
+// @param [in/out] module : LLVM module
 void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
   std::string globalFeatures = "";
 

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -480,7 +480,7 @@ static const ShaderInputDesc CsVgprInputs[] = {
 // @param pipelineState : Pipeline state
 // @param shaderStage : Shader stage
 // @param [in/out] argTys : Argument types vector to add to
-// @return : Bitmap with bits set for SGPR arguments so caller can set "inreg" attribute on the args
+// @returns : Bitmap with bits set for SGPR arguments so caller can set "inreg" attribute on the args
 uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage,
                                        SmallVectorImpl<Type *> &argTys) {
 

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -146,7 +146,7 @@ Module *PipelineState::irLink(ArrayRef<std::pair<Module *, ShaderStage>> modules
 // @param otherElf : Optional ELF for the other half-pipeline when compiling an unlinked half-pipeline ELF.
 //                   Supplying this could allow more optimal code for writing/reading attribute values between
 //                   the two pipeline halves
-// @return : True for success.
+// @returns : True for success.
 //           False if irLink asked for an "unlinked" shader or half-pipeline, and there is some reason why the
 //           module cannot be compiled that way.  The client typically then does a whole-pipeline compilation
 //           instead. The client can call getLastError() to get a textual representation of the error, for
@@ -224,7 +224,7 @@ ElfLinker *PipelineState::createElfLinker(llvm::ArrayRef<llvm::MemoryBufferRef> 
 // it can be useful in avoiding an unnecessary shader compile before falling back to full-pipeline
 // compilation.
 //
-// @return : True for success, false if some reason for failure found, in which case getLastError()
+// @returns : True for success, false if some reason for failure found, in which case getLastError()
 //           returns a textual description
 bool PipelineState::checkElfLinkable() {
   return true;
@@ -243,7 +243,7 @@ void PipelineState::setError(const Twine &message) {
 // methods finding something about the shaders or pipeline state that means that shader compilation then
 // linking cannot be done. This error message is intended only for logging or command-line error reporting.
 //
-// @return : Error message from last such recoverable error; remains valid until next time generate() or
+// @returns : Error message from last such recoverable error; remains valid until next time generate() or
 //           one of the ElfLinker methods is called, or the Pipeline object is destroyed
 StringRef PipelineState::getLastError() {
   return m_lastError;

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -223,7 +223,7 @@ Pipeline *LgcContext::createPipeline() {
 // because it always uses BuilderRecorder.
 //
 // @param pipeline : Pipeline object for pipeline compile, nullptr for shader compile
-// @param useBuilderRecorder : true to use BuilderRecorder, false to use BuilderImpl
+// @param useBuilderRecorder : True to use BuilderRecorder, false to use BuilderImpl
 Builder *LgcContext::createBuilder(Pipeline *pipeline, bool useBuilderRecorder) {
   if (!pipeline || useBuilderRecorder || EmitLgc)
     return Builder::createBuilderRecorder(this, pipeline, EmitLgc);
@@ -253,7 +253,7 @@ void LgcContext::preparePassManager(legacy::PassManager *passMgr) {
 // =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
 //
-// @param [in/out] passMgr : pass manager to add passes to
+// @param [in/out] passMgr : Pass manager to add passes to
 // @param codeGenTimer : Timer to time target passes with, nullptr if not timing
 // @param [out] outStream : Output stream
 void LgcContext::addTargetPasses(lgc::PassManager &passMgr, Timer *codeGenTimer, raw_pwrite_stream &outStream) {

--- a/lgc/state/PipelineShaders.cpp
+++ b/lgc/state/PipelineShaders.cpp
@@ -53,7 +53,7 @@ ModulePass *createPipelineShaders() {
 // This populates the shader array. In the pipeline module, a shader entrypoint is a non-internal function definition,
 // and it has metadata giving the SPIR-V execution model.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool PipelineShaders::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Pipeline-Shaders\n");
 

--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -109,7 +109,7 @@ const char *lgc::getShaderStageAbbreviation(ShaderStage shaderStage) {
 // @param retTy : New return type, nullptr to use the same as in the original function
 // @param argTys : Types of new args
 // @param inRegMask : Bitmask of which args should be marked "inreg", to be passed in SGPRs
-// @return : The new function
+// @returns : The new function
 Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> argTys, uint64_t inRegMask) {
   // Gather all arg types: first the new ones, then the ones from the original function.
   FunctionType *oldFuncTy = oldFunc->getFunctionType();
@@ -182,7 +182,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
 //
 // @param callingConv : Which hardware shader stage
 // @param isFetchlessVs : Whether it is (or contains) a fetchless vertex shader
-// @return : The entry-point name, or "" if callingConv not recognized
+// @returns : The entry-point name, or "" if callingConv not recognized
 StringRef lgc::getEntryPointName(unsigned callingConv, bool isFetchlessVs) {
   StringRef entryName;
   switch (callingConv) {

--- a/lgc/util/AddressExtender.cpp
+++ b/lgc/util/AddressExtender.cpp
@@ -53,7 +53,7 @@ Instruction *AddressExtender::getFirstInsertionPt() {
 // @param highHalf : Value to use for high half; HighAddrPc to use PC
 // @param ptrTy : Type to cast pointer to
 // @param builder : IRBuilder to use, already set to the required insert point
-// @return : 64-bit pointer value
+// @returns : 64-bit pointer value
 Instruction *AddressExtender::extend(Value *addr32, unsigned highHalf, Type *ptrTy, IRBuilder<> &builder) {
   Value *ptr = nullptr;
   if (highHalf == HighAddrPc) {

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -84,7 +84,7 @@ CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, Arra
 // Gets LLVM-style name for type.
 //
 // @param ty : Type to get mangle name
-// @param [in,out] nameStream : Stream to write the type name into
+// @param [in/out] nameStream : Stream to write the type name into
 void getTypeName(Type *ty, raw_ostream &nameStream) {
   for (;;) {
     if (auto pointerTy = dyn_cast<PointerType>(ty)) {

--- a/lgc/util/StartStopTimer.cpp
+++ b/lgc/util/StartStopTimer.cpp
@@ -75,7 +75,7 @@ ModulePass *LgcContext::createStartStopTimer(Timer *timer, bool starting) {
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool StartStopTimer::runOnModule(Module &module) {
   if (m_starting)
     m_timer->startTimer();

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -188,8 +188,7 @@ ShaderHash PipelineContext::getShaderHashCode(ShaderStage stage) const {
 #else
   const ShaderModuleData *pModuleData = reinterpret_cast<const ShaderModuleData *>(pShaderInfo->pModuleData);
 
-  return (pModuleData == nullptr) ? 0
-                                  : MetroHash::Compact64(reinterpret_cast<const MetroHash::Hash *>(&pModuleData->hash));
+  return (!pModuleData) ? 0 : MetroHash::Compact64(reinterpret_cast<const MetroHash::Hash *>(&pModuleData->hash));
 #endif
 }
 

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -153,7 +153,7 @@ void ShaderCache::resetRuntimeCache() {
 // NOTE: It is expected that the calling function has not used this shader cache since querying the size
 //
 // @param [out] blob : System memory pointer where the serialized data should be placed
-// @param [in,out] size : Size of the memory pointed to by pBlob. If the value stored in pSize is zero then no data will
+// @param [in/out] size : Size of the memory pointed to by pBlob. If the value stored in pSize is zero then no data will
 // be copied and instead the size required for serialization will be returned in pSize
 Result ShaderCache::Serialize(void *blob, size_t *size) {
   Result result = Result::Success;
@@ -514,7 +514,7 @@ ShaderEntryState ShaderCache::findShader(MetroHash::Hash hash, bool allocateOnMi
 //
 // @param hEntry : Handle of shader cache entry
 // @param blob : Shader data
-// @param shaderSize : size of shader data in bytes
+// @param shaderSize : Size of shader data in bytes
 void ShaderCache::insertShader(CacheEntryHandle hEntry, const void *blob, size_t shaderSize) {
   auto *const index = static_cast<ShaderIndex *>(hEntry);
   assert(m_disableCache == false);
@@ -605,7 +605,7 @@ void ShaderCache::resetShader(CacheEntryHandle hEntry) {
 //
 // @param hEntry : Handle of shader cache entry
 // @param [out] ppBlob : Shader data
-// @param [out] size : size of shader data in bytes
+// @param [out] size : Size of shader data in bytes
 Result ShaderCache::retrieveShader(CacheEntryHandle hEntry, const void **ppBlob, size_t *size) {
   const auto *const index = static_cast<ShaderIndex *>(hEntry);
 

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -145,7 +145,7 @@ public:
   ///                         data will be copied and instead the size required for serialization will be returned
   ///                         in pSize.
   ///
-  /// @returns Success if data was serialized successfully, Unknown if fail to do serialize.
+  /// @returns : Success if data was serialized successfully, Unknown if fail to do serialize.
   virtual Result Serialize(void *pBlob, size_t *pSize) = 0;
 
   /// Merges the provided source shader caches' content into this shader cache.
@@ -153,7 +153,7 @@ public:
   /// @param [in]  srcCacheCount  Count of source shader caches to be merged.
   /// @param [in]  ppSrcCaches    Pointer to an array of pointers to shader cache objects.
   ///
-  /// @returns Success if data of source shader caches was merged successfully, OutOfMemory if the internal allocator
+  /// @returns : Success if data of source shader caches was merged successfully, OutOfMemory if the internal allocator
   ///          memory cannot be allocated.
   virtual Result Merge(unsigned srcCacheCount, const IShaderCache **ppSrcCaches) = 0;
 
@@ -176,10 +176,10 @@ public:
   ///
   /// @param [in]  optionCount    Count of compilation-option strings
   /// @param [in]  options        An array of compilation-option strings
-  /// @param [out] ppCompiler     Pointer to the created pipeline compiler object
+  /// @param [out] ppCompiler : Pointer to the created pipeline compiler object
   /// @param [in]  pCache         Pointer to the ICache object
   ///
-  /// @returns Result::Success if successful. Other return codes indicate failure.
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
   static Result VKAPI_CALL Create(GfxIpVersion gfxIp, unsigned optionCount, const char *const *options,
                                   ICompiler **ppCompiler, Vkgc::ICache *pCache = nullptr);
 
@@ -187,7 +187,7 @@ public:
   ///
   /// @parame [in] format  Vertex attribute format
   ///
-  /// @return TRUE if the specified format is supported by fetch shader. Otherwise, FALSE is returned.
+  /// @returns : True if the specified format is supported by fetch shader. Otherwise, FALSE is returned.
   static bool VKAPI_CALL IsVertexFormatSupported(VkFormat format);
 
   /// Destroys the pipeline compiler.
@@ -198,34 +198,34 @@ public:
   /// param [in] pTarget                  Color target including color buffer format
   /// param [in] enableAlphaToCoverage    Whether enable AlphaToCoverage
   ///
-  /// @return unsigned type casted from fragment shader export format.
+  /// @returns : Unsigned type casted from fragment shader export format.
   virtual unsigned ConvertColorBufferFormatToExportFormat(const ColorTarget *pTarget,
                                                           const bool enableAlphaToCoverage) const = 0;
 
   /// Build shader module from the specified info.
   ///
   /// @param [in]  pShaderInfo    Info to build this shader module
-  /// @param [out] pShaderOut     Output of building this shader module
+  /// @param [out] pShaderOut : Output of building this shader module
   ///
-  /// @returns Result::Success if successful. Other return codes indicate failure.
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
   virtual Result BuildShaderModule(const ShaderModuleBuildInfo *pShaderInfo,
                                    ShaderModuleBuildOut *pShaderOut) const = 0;
 
   /// Build graphics pipeline from the specified info.
   ///
   /// @param [in]  pPipelineInfo  Info to build this graphics pipeline
-  /// @param [out] pPipelineOut   Output of building this graphics pipeline
+  /// @param [out] pPipelineOut : Output of building this graphics pipeline
   ///
-  /// @returns Result::Success if successful. Other return codes indicate failure.
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
   virtual Result BuildGraphicsPipeline(const GraphicsPipelineBuildInfo *pPipelineInfo,
                                        GraphicsPipelineBuildOut *pPipelineOut, void *pPipelineDumpFile = nullptr) = 0;
 
   /// Build compute pipeline from the specified info.
   ///
   /// @param [in]  pPipelineInfo  Info to build this compute pipeline
-  /// @param [out] pPipelineOut   Output of building this compute pipeline
+  /// @param [out] pPipelineOut : Output of building this compute pipeline
   ///
-  /// @returns Result::Success if successful. Other return codes indicate failure.
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
   virtual Result BuildComputePipeline(const ComputePipelineBuildInfo *pPipelineInfo,
                                       ComputePipelineBuildOut *pPipelineOut, void *pPipelineDumpFile = nullptr) = 0;
 
@@ -233,9 +233,9 @@ public:
   /// Creates a shader cache object with the requested properties.
   ///
   /// @param [in]  pCreateInfo    Create info of the shader cache.
-  /// @param [out] ppShaderCache  Constructed shader cache object.
+  /// @param [out] ppShaderCache : Constructed shader cache object.
   ///
-  /// @returns Success if the shader cache was successfully created. Otherwise, ErrorOutOfMemory is returned.
+  /// @returns : Success if the shader cache was successfully created. Otherwise, ErrorOutOfMemory is returned.
   virtual Result CreateShaderCache(const ShaderCacheCreateInfo *pCreateInfo, IShaderCache **ppShaderCache) = 0;
 #endif
 

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -60,7 +60,7 @@ SpirvLowerAccessChain::SpirvLowerAccessChain() : SpirvLower(ID) {
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerAccessChain::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Access-Chain\n");
 

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
@@ -60,7 +60,7 @@ SpirvLowerConstImmediateStore::SpirvLowerConstImmediateStore() : SpirvLower(ID) 
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerConstImmediateStore::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Const-Immediate-Store\n");
 

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -165,7 +165,7 @@ SpirvLowerGlobal::SpirvLowerGlobal()
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerGlobal::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Global\n");
 

--- a/llpc/lower/llpcSpirvLowerInstMetaRemove.cpp
+++ b/llpc/lower/llpcSpirvLowerInstMetaRemove.cpp
@@ -59,7 +59,7 @@ SpirvLowerInstMetaRemove::SpirvLowerInstMetaRemove() : SpirvLower(ID), m_changed
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerInstMetaRemove::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Inst-Meta-Remove\n");
 

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -126,7 +126,7 @@ char SpirvLowerMathFloatOp::ID = 0;
 // =====================================================================================================================
 // Initialise transform class.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 void SpirvLowerMath::init(Module &module) {
   SpirvLower::init(&module);
   m_changed = false;
@@ -223,7 +223,7 @@ void SpirvLowerMath::disableFastMath(Value *value) {
 // =====================================================================================================================
 // Executes constand folding SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerMathConstFolding::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Math-Const-Folding\n");
 
@@ -282,7 +282,7 @@ bool SpirvLowerMathConstFolding::runOnModule(Module &module) {
 // =====================================================================================================================
 // Executes floating point optimisation SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerMathFloatOp::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Math-Float-Op\n");
 

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -61,7 +61,7 @@ SpirvLowerMemoryOp::SpirvLowerMemoryOp() : SpirvLower(ID) {
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerMemoryOp::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Memory-Op\n");
 

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -142,7 +142,7 @@ void SpirvLowerResourceCollect::collectResourceNodeData(const GlobalVariable *gl
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on
+// @param [in/out] module : LLVM module to be run on
 bool SpirvLowerResourceCollect::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Resource-Collect\n");
 

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -55,7 +55,7 @@ ModulePass *Llpc::createSpirvLowerTranslator(ShaderStage stage, const PipelineSh
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
-// @param [in,out] module : LLVM module to be run on (empty on entry)
+// @param [in/out] module : LLVM module to be run on (empty on entry)
 bool SpirvLowerTranslator::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Translator\n");
 

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -496,7 +496,7 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
 // =====================================================================================================================
 // Performs cleanup work for LLPC standalone tool.
 //
-// @param [in,out] compileInfo : Compilation info of LLPC standalone tool
+// @param [in/out] compileInfo : Compilation info of LLPC standalone tool
 static void cleanupCompileInfo(CompileInfo *compileInfo) {
   for (unsigned i = 0; i < compileInfo->shaderModuleDatas.size(); ++i) {
     // NOTE: We do not have to free SPIR-V binary for pipeline info file.
@@ -803,7 +803,7 @@ static Result assembleSpirv(const std::string &inFilename, std::string &outFilen
 // Decodes the binary after building a pipeline and outputs the decoded info.
 //
 // @param pipelineBin : Pipeline binary
-// @param [in,out] compileInfo : Compilation info of LLPC standalone tool
+// @param [in/out] compileInfo : Compilation info of LLPC standalone tool
 // @param isGraphics : Whether it is graphics pipeline
 static Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileInfo, bool isGraphics) {
   // Ignore failure from ElfReader. It fails if pPipelineBin is not ELF, as happens with
@@ -823,7 +823,7 @@ static Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *c
 // Builds shader module based on the specified SPIR-V binary.
 //
 // @param compiler : LLPC compiler object
-// @param [in,out] compileInfo : Compilation info of LLPC standalone tool
+// @param [in/out] compileInfo : Compilation info of LLPC standalone tool
 static Result buildShaderModules(const ICompiler *compiler, CompileInfo *compileInfo) {
   Result result = Result::Success;
 
@@ -851,7 +851,7 @@ static Result buildShaderModules(const ICompiler *compiler, CompileInfo *compile
 // Check autolayout compatible.
 //
 // @param compiler : LLPC compiler object
-// @param [in,out] compileInfo : Compilation info of LLPC standalone tool
+// @param [in/out] compileInfo : Compilation info of LLPC standalone tool
 static Result checkAutoLayoutCompatibleFunc(const ICompiler *compiler, CompileInfo *compileInfo) {
   Result result = Result::Success;
 
@@ -927,7 +927,7 @@ static Result checkAutoLayoutCompatibleFunc(const ICompiler *compiler, CompileIn
 // Builds pipeline and do linking.
 //
 // @param compiler : LLPC compiler object
-// @param [in,out] compileInfo : Compilation info of LLPC standalone tool
+// @param [in/out] compileInfo : Compilation info of LLPC standalone tool
 static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
   Result result = Result::Success;
 
@@ -1472,7 +1472,7 @@ static void findAllMatchFiles(const std::string &inFile, std::vector<std::string
 // Expands all input files in a platform-specific way.
 //
 // @param [out] expandedFilenames : Returned expanded input filenames.
-// @returns Result::Success on success, Result::ErrorInvalidValue when expansion fails.
+// @returns : Result::Success on success, Result::ErrorInvalidValue when expansion fails.
 static Result expandInputFilenames(std::vector<std::string> &expandedFilenames) {
   unsigned i = 0;
   for (const auto &inFile : InFiles) {

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -113,8 +113,8 @@ static const ResourceMappingNode *findDescriptorTableVaPtr(PipelineShaderInfo *s
 //
 // @param userDataNode : ResourceMappingNode pointer
 // @param nodeCount : User data node count
-// @param set : find same set in node array
-// @param binding : find same binding in node array
+// @param set : Find same set in node array
+// @param binding : Find same binding in node array
 // @param [out] index : Return node position in node array
 static const ResourceMappingNode *findResourceNode(const ResourceMappingNode *userDataNode, unsigned nodeCount,
                                                    unsigned set, unsigned binding, unsigned *index) {
@@ -226,7 +226,7 @@ bool checkShaderInfoComptible(PipelineShaderInfo *shaderInfo, unsigned autoLayou
 //
 // @param compiler : LLPC compiler object
 // @param pipelineInfo : Graphics pipeline info
-// @param autoLayoutPipelineInfo : layout pipeline info
+// @param autoLayoutPipelineInfo : Layout pipeline info
 // @param gfxIp : Graphics IP version
 bool checkPipelineStateCompatible(const ICompiler *compiler, Llpc::GraphicsPipelineBuildInfo *pipelineInfo,
                                   Llpc::GraphicsPipelineBuildInfo *autoLayoutPipelineInfo, Llpc::GfxIpVersion gfxIp) {
@@ -272,7 +272,7 @@ bool checkPipelineStateCompatible(const ICompiler *compiler, Llpc::GraphicsPipel
 // graphics pipeline.
 // @param [in/out] shaderInfo : Shader info, will have user data nodes added to it
 // @param [in/out] topLevelOffset : User data offset; ensures that multiple shader stages use disjoint offsets
-// @param checkAutoLayoutCompatible : if check AutoLayout Compatiple
+// @param checkAutoLayoutCompatible : If check AutoLayout Compatiple
 void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipelineBuildInfo *pipelineInfo,
                       PipelineShaderInfo *shaderInfo, unsigned &topLevelOffset, bool checkAutoLayoutCompatible) {
   // Read the SPIR-V.

--- a/llpc/translator/include/LLVMSPIRVLib.h
+++ b/llpc/translator/include/LLVMSPIRVLib.h
@@ -112,11 +112,11 @@ namespace llvm {
 
 class raw_pwrite_stream;
 /// \brief Translate LLVM module to SPIRV and write to ostream.
-/// \returns true if succeeds.
+/// @returns : True if succeeds.
 bool writeSpirv(llvm::Module *M, llvm::raw_ostream &OS, std::string &ErrMsg);
 
 /// \brief Load SPIRV from istream and translate to LLVM module.
-/// \returns true if succeeds.
+/// @returns : True if succeeds.
 bool readSpirv(lgc::Builder *Builder, const Vkgc::ShaderModuleUsage *ModuleData,
                const Vkgc::PipelineShaderOptions *ShaderOptions, std::istream &IS, spv::ExecutionModel EntryExecModel,
                const char *EntryName, const SPIRV::SPIRVSpecConstMap &SpecConstMap,

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -426,7 +426,7 @@ inline bool operator<(const SPIRVImageOpInfo &L, const SPIRVImageOpInfo &R) {
   return L.U32All < R.U32All;
 }
 
-/// \returns a vector of types for a collection of values.
+/// @returns : a vector of types for a collection of values.
 template <class T> std::vector<Type *> getTypes(T V) {
   std::vector<Type *> Tys;
   for (auto &I : V)

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5292,13 +5292,13 @@ void SPIRVToLLVM::getImageDesc(SPIRVValue *bImageInst, ExtractedImageInfo *info)
 // Set up address operand array for image sample/gather/fetch/read/write
 // builder call.
 //
-// \param BI The SPIR-V instruction
-// \param MaskIdx Operand number of mask operand
-// \param HasProj Whether there is an extra projective component in coordinate
-// \param Addr [in/out] image address array
-// \param ImageInfo [in/out] Decoded image type information; flags modified by
+// @param BI : The SPIR-V instruction
+// @param MaskIdx : Operand number of mask operand
+// @param HasProj : Whether there is an extra projective component in coordinate
+// @param [in/out] Addr : Image address array
+// @param [in/out] ImageInfo : Decoded image type information; flags modified by
 //        memory model image operands
-// \param Sample [out] Where to store sample number for OpImageFetch; nullptr to
+// @param [out] Sample : Where to store sample number for OpImageFetch; nullptr to
 //        ignore it
 void SPIRVToLLVM::setupImageAddressOperands(SPIRVInstruction *bi, unsigned maskIdx, bool hasProj,
                                             MutableArrayRef<Value *> addr, ExtractedImageInfo *imageInfo,

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -229,7 +229,7 @@ public:
     if (L != ~0U)
       Lit.insert(L);
   }
-  /// \return Expected number of operands. If the instruction has variable
+  /// @returns : Expected number of operands. If the instruction has variable
   /// number of words, return the minimum.
   SPIRVWord getExpectedNumOperands() const {
     assert(WordCount > 0 && "Word count not initialized");
@@ -2451,7 +2451,7 @@ public:
     return MappedConst;
   }
   void mapToConstant(SPIRVValue *Const) {
-    assert(MappedConst == nullptr && "OpSpecConstantOp mapped twice");
+    assert(!MappedConst && "OpSpecConstantOp mapped twice");
     MappedConst = Const;
   }
 protected:

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -160,7 +160,7 @@ public:
 // =====================================================================================================================
 // Merges the map item pair from source map to destination map for llvm::msgpack::MapDocNode.
 //
-// @param [in,out] destMap : Destination map
+// @param [in/out] destMap : Destination map
 // @param srcMap : Source map
 // @param key : Key to check in source map
 template <class Elf>
@@ -183,8 +183,8 @@ void ElfWriter<Elf>::mergeMapItem(msgpack::MapDocNode &destMap, msgpack::MapDocN
 // =====================================================================================================================
 // Update descriptor offset to USER_DATA in metaNote, in place in the messagepack document.
 //
-// @param context : context related to ElfNote
-// @param document : [in, out] The parsed message pack document of the metadata note.
+// @param context : Context related to ElfNote
+// @param [in/out] document : The parsed message pack document of the metadata note.
 static void updateRootDescriptorRegisters(Context *context, msgpack::Document &document) {
   auto pipeline = document.getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0];
   auto registers = pipeline.getMap(true)[Util::Abi::PipelineMetadataKey::Registers].getMap(true);
@@ -712,9 +712,9 @@ Result ElfWriter<Elf>::getSectionDataBySectionIndex(unsigned secIdx, const Secti
 // =====================================================================================================================
 // Update descriptor offset to USER_DATA in metaNote.
 //
-// @param pContext : context related to ElfNote
+// @param pContext : Context related to ElfNote
 // @param pNote : Note section to update
-// @param [out] pNewNote : new note section
+// @param [out] pNewNote : New note section
 template <class Elf> void ElfWriter<Elf>::updateMetaNote(Context *pContext, const ElfNote *pNote, ElfNote *pNewNote) {
   msgpack::Document document;
 
@@ -737,9 +737,9 @@ template <class Elf> void ElfWriter<Elf>::updateMetaNote(Context *pContext, cons
 // =====================================================================================================================
 // Retrieves the section data for the specified section name, if it exists.
 //
-// @param pName : [in] Name of the section to look for
-// @param ppData : [out] Pointer to section data
-// @param pDataLength : [out] Size of the section data
+// @param [in] pName : Name of the section to look for
+// @param [out] ppData : Pointer to section data
+// @param [out] pDataLength : Size of the section data
 template <class Elf>
 Result ElfWriter<Elf>::getSectionData(const char *name, const void **ppData, size_t *dataLength) const {
   Result result = Result::ErrorInvalidValue;

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -371,7 +371,7 @@ void PipelineDumper::EndPipelineDump(PipelineDumpFile *dumpFile) {
 //
 // @param userDataNode : User data nodes to be dumped
 // @param prefix : Prefix string for each line
-// @param [out] dumpFile : dump file
+// @param [out] dumpFile : Dump file
 void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userDataNode, const char *prefix,
                                              std::ostream &dumpFile) {
   dumpFile << prefix << ".type = " << userDataNode->type << "\n";
@@ -423,7 +423,7 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
 // Dumps pipeline shader info to file.
 //
 // @param shaderInfo : Shader info of specified shader stage
-// @param [out] dumpFile : dump file
+// @param [out] dumpFile : Dump file
 void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo, std::ostream &dumpFile) {
   const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo->pModuleData);
   auto moduleHash = reinterpret_cast<const MetroHash::Hash *>(&moduleData->hash[0]);
@@ -589,7 +589,7 @@ void PipelineDumper::DumpPipelineExtraInfo(PipelineDumpFile *dumpFile, const std
 // =====================================================================================================================
 // Dumps LLPC version info to file
 //
-// @param [out] dumpFile : dump file
+// @param [out] dumpFile : Dump file
 void PipelineDumper::dumpVersionInfo(std::ostream &dumpFile) {
   dumpFile << "[Version]\n";
   dumpFile << "version = " << Version << "\n\n";
@@ -600,7 +600,7 @@ void PipelineDumper::dumpVersionInfo(std::ostream &dumpFile) {
 //
 // @param pipelineInfo : Info of the graphics pipeline to be built
 // @param dumpDir : Directory of pipeline dump
-// @param [out] dumpFile : dump file
+// @param [out] dumpFile : Dump file
 void PipelineDumper::dumpComputeStateInfo(const ComputePipelineBuildInfo *pipelineInfo, const char *dumpDir,
                                           std::ostream &dumpFile) {
   dumpFile << "[ComputePipelineState]\n";
@@ -614,7 +614,7 @@ void PipelineDumper::dumpComputeStateInfo(const ComputePipelineBuildInfo *pipeli
 // Dumps pipeline options to file.
 //
 // @param options : Pipeline options
-// @param [out] dumpFile : dump file
+// @param [out] dumpFile : Dump file
 void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::ostream &dumpFile) {
   dumpFile << "options.includeDisassembly = " << options->includeDisassembly << "\n";
   dumpFile << "options.scalarBlockLayout = " << options->scalarBlockLayout << "\n";
@@ -652,7 +652,7 @@ void PipelineDumper::dumpComputePipelineInfo(std::ostream *dumpFile, const char 
 //
 // @param pipelineInfo : Info of the graphics pipeline to be built
 // @param dumpDir : Directory of pipeline dump
-// @param [out] dumpFile : dump file
+// @param [out] dumpFile : Dump file
 void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipelineInfo, const char *dumpDir,
                                            std::ostream &dumpFile) {
   dumpFile << "[GraphicsPipelineState]\n";
@@ -854,7 +854,7 @@ MetroHash::Hash PipelineDumper::generateHashForComputePipeline(const ComputePipe
 // Updates hash code context for vertex input state
 //
 // @param vertexInput : Vertex input state
-// @param [in,out] hasher : Haher to generate hash code
+// @param [in/out] hasher : Haher to generate hash code
 void PipelineDumper::updateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo *vertexInput,
                                                    MetroHash64 *hasher) {
   if (vertexInput && vertexInput->vertexBindingDescriptionCount > 0) {
@@ -883,7 +883,7 @@ void PipelineDumper::updateHashForVertexInputState(const VkPipelineVertexInputSt
 //
 // @param pipeline : Info to build a graphics pipeline
 // @param isCacheHash : TRUE if the hash is used by shader cache
-// @param [in,out] hasher : Hasher to generate hash code
+// @param [in/out] hasher : Hasher to generate hash code
 void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
                                                    MetroHash64 *hasher) {
   auto iaState = &pipeline->iaState;
@@ -953,7 +953,7 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
 // Update hash code from fragment pipeline state
 //
 // @param pipeline : Info to build a graphics pipeline
-// @param [in,out] hasher : Hasher to generate hash code
+// @param [in/out] hasher : Hasher to generate hash code
 void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher) {
   auto rsState = &pipeline->rsState;
   hasher->Update(rsState->innerCoverage);
@@ -977,10 +977,10 @@ void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo 
 // =====================================================================================================================
 // Updates hash code context for pipeline shader stage.
 //
-// @param stage : shader stage
+// @param stage : Shader stage
 // @param shaderInfo : Shader info in specified shader stage
 // @param isCacheHash : TRUE if the hash is used by shader cache
-// @param [in,out] hasher : Haher to generate hash code
+// @param [in/out] hasher : Haher to generate hash code
 void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const PipelineShaderInfo *shaderInfo,
                                                      bool isCacheHash, MetroHash64 *hasher, bool isRelocatableShader) {
   if (shaderInfo->pModuleData) {
@@ -1077,7 +1077,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
 //
 // @param userDataNode : Resource mapping node
 // @param isRootNode : TRUE if the node is in root level
-// @param [in,out] hasher : Haher to generate hash code
+// @param [in/out] hasher : Haher to generate hash code
 void PipelineDumper::updateHashForResourceMappingNode(const ResourceMappingNode *userDataNode, bool isRootNode,
                                                       MetroHash64 *hasher, bool isRelocatableShader) {
   hasher->Update(userDataNode->type);

--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -597,7 +597,7 @@ Section *Document::createSection(const char *sectionName) {
 // =====================================================================================================================
 // Gets the pointer of sub section according to member name
 //
-// @param section : input section object
+// @param section : Input section object
 // @param lineNum : Line No.
 // @param memberName : Member name
 // @param memberType : Member type
@@ -924,7 +924,7 @@ bool parseDVec2(char *str, unsigned lineNum, IUFValue *output) {
 // @param str : Input string
 // @param lineNum : Current line number
 // @param isSign : True if it is signed integer
-// @param [in,out] bufMem : Buffer data
+// @param [in/out] bufMem : Buffer data
 bool parseIArray(char *str, unsigned lineNum, bool isSign, std::vector<uint8_t> &bufMem) {
   bool result = true;
 
@@ -963,7 +963,7 @@ bool parseIArray(char *str, unsigned lineNum, bool isSign, std::vector<uint8_t> 
 // @param str : Input string
 // @param lineNum : Current line number
 // @param isSign : True if it is signed integer
-// @param [in,out] bufMem : Buffer data
+// @param [in/out] bufMem : Buffer data
 bool parseI64Array(char *str, unsigned lineNum, bool isSign, std::vector<uint8_t> &bufMem) {
   bool result = true;
 
@@ -1002,7 +1002,7 @@ bool parseI64Array(char *str, unsigned lineNum, bool isSign, std::vector<uint8_t
 //
 // @param str : Input string
 // @param lineNum : Current line number
-// @param [in,out] bufMem : Buffer data
+// @param [in/out] bufMem : Buffer data
 bool parseFArray(char *str, unsigned lineNum, std::vector<uint8_t> &bufMem) {
   bool result = true;
 
@@ -1031,7 +1031,7 @@ bool parseFArray(char *str, unsigned lineNum, std::vector<uint8_t> &bufMem) {
 //
 // @param str : Input string
 // @param lineNum : Current line number
-// @param [in,out] bufMem : Buffer data
+// @param [in/out] bufMem : Buffer data
 bool parseF16Array(char *str, unsigned lineNum, std::vector<uint8_t> &bufMem) {
   bool result = true;
 
@@ -1063,7 +1063,7 @@ bool parseF16Array(char *str, unsigned lineNum, std::vector<uint8_t> &bufMem) {
 //
 // @param str : Input string
 // @param lineNum : Current line number
-// @param [in,out] bufMem : Buffer data
+// @param [in/out] bufMem : Buffer data
 bool parseDArray(char *str, unsigned lineNum, std::vector<uint8_t> &bufMem) {
   bool result = true;
 

--- a/util/vkgcUtil.cpp
+++ b/util/vkgcUtil.cpp
@@ -80,7 +80,7 @@ const char *getShaderStageAbbreviation(ShaderStage shaderStage, bool upper) {
 // =====================================================================================================================
 // Create directory.
 //
-// @param dir : the path of directory
+// @param dir : The path of directory
 bool createDirectory(const char *dir) {
   int result = mkdir(dir, S_IRWXU);
   return result == 0;


### PR DESCRIPTION
Reformat comments with inline documentation to make them consistent
with the most common practice and update the coding standards doc.
Also replace nullptr comparison with negation.

I never remember what the format of these comments is and get confused
by different files using slightly different style.
After this lands, I plan to submit a new PR that will add a github
actions CI check for making sure the @param and @returns comments
adhere to the standard and the source doesn't continue to diverge,
similarly to how the clang-format we've been using for a while. This will also
simplify future code reviews.

This was performed by running the following substitutions in order:
```
1. (\(|\s|\|\||&&)([a-zA-Z0-9]+)\s==\snullptr ==> $1!$2
2. (///?\s+)\\((param)|(returns?)) ==> $1@$2
3. @return\s ==> @returns 
4. (///?\s+@param)\s+([a-zA-Z0-9]+)\s+(\[.*\]) ==> $1 $3 $2
5. (///?\s+@param)\s+([a-zA-Z0-9]+)\s+:\s+(\[.*\]) ==> $1 $3 $2 :
6. (///?\s+@param)\s+(\[.*,.*\])\s([a-zA-Z0-9]+) ==> $1 [in/out] $3
7. (///?\s+@param)\s+((\[.*\]\s)?[a-zA-Z0-9]+)\s+([a-zA-Z0-9]+) ==> $1 $3 : \U$4
8. (///?\s+@returns)\s+([a-zA-Z0-9]+) ==> $1 : \U$2
```