### PR TITLE
Reimplement dynamic indexed inOut in interpolate functions

### DIFF
--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -80,6 +80,10 @@ private:
                                   llvm::Value *elemIdx, llvm::Value *vertexIdx, unsigned emitStreamId,
                                   llvm::Instruction *insertPos);
 
+  Value *loadDynamicIndexedMembers(Type *inOutTy, unsigned addrSpace, const std::vector<Value *> &indexOperands,
+                                   unsigned operandIdx, Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc,
+                                   Value *auxInterpValue, Instruction *insertPos);
+
   llvm::Value *loadInOutMember(llvm::Type *inOutTy, unsigned addrSpace, const std::vector<llvm::Value *> &indexOperands,
                                unsigned operandIdx, unsigned maxLocOffset, llvm::Constant *inOutMeta,
                                llvm::Value *locOffset, llvm::Value *vertexIdx, unsigned interpLoc,

--- a/llpc/test/shaderdb/OpExtInst_TestInterpolateDynIdxVector.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestInterpolateDynIdxVector.frag
@@ -1,0 +1,35 @@
+#version 450 core
+
+layout(location = 0) out vec4 frag_color;
+layout(location = 0) centroid in vec2 interp;
+layout(location = 1) centroid in vec2 interp2[2];
+layout(push_constant) uniform PushConstants {
+  uint component;
+};
+
+void main()
+{
+    frag_color.x = interpolateAtSample(interp[component], gl_SampleID);
+    frag_color.y = interpolateAtSample(interp2[component][0], gl_SampleID);
+}
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-COUNT-2: %{{[0-9]*}} = call {{.*}} float @interpolateAtSample.p64f32.i32(float addrspace(64)* %{{.*}}, i32 %{{.*}})
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST-DAG: = call <2 x float> @lgc.input.import.builtin.SamplePosOffset.v2f32.i32.i32(
+; SHADERTEST-DAG: = call <3 x float> @lgc.input.import.builtin.InterpPullMode.v3f32.i32(
+; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32
+; SHADERTEST-DAG: = call <2 x float> @lgc.input.import.interpolant.v2f32.i32.i32.i32.i32.v2f32(i32 0, i32 0, i32 0, i32 0,
+; SHADERTEST-DAG: = call <2 x float> @lgc.input.import.builtin.SamplePosOffset.v2f32.i32.i32(
+; SHADERTEST-DAG: = call <3 x float> @lgc.input.import.builtin.InterpPullMode.v3f32.i32(
+; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32
+; SHADERTEST-DAG: = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 1, i32 0, i32 0, i32 0, <2 x float>
+; SHADERTEST-DAG: = call <2 x float> @lgc.input.import.builtin.SamplePosOffset.v2f32.i32.i32(
+; SHADERTEST-DAG: = call <3 x float> @lgc.input.import.builtin.InterpPullMode.v3f32.i32(
+; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32
+; SHADERTEST-DAG: = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 2, i32 0, i32 0, i32 0, <2 x float>
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST


### PR DESCRIPTION
This PR mainly add support for dynamic indexed vector inOut in interpolateXXX() functions. As the existing solution is hard to extend, I choose to re-implement it.