### PR TITLE
Allow generation of invalid waterfall loops.

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -161,7 +161,8 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
                                                   const Twine &instName) {
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
 #warning[!amd-gfx] Waterfall feature disabled
-  abort();
+  errs() << "Generating invalid waterfall loop code\n";
+  return nonUniformInst;
 #else
   assert(operandIdxs.empty() == false);
 


### PR DESCRIPTION
Instead of aborting on waterfall generation without waterfall
intrinsics simply output the non-uniform as-is (i.e. as uniform).
This will produce invalid, but generally executable code.
By making this change LLPC with stock LLVM can run (not pass) most
of VulkanCTS without crashing.