### PR TITLE
Hide scratch bounds checks behind LLVM_HAVE_BRANCH_AMD_GFX.

### DIFF
--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -136,8 +136,13 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       }
 
       auto gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
+
+#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
+#warning[!amd-gfx] Scratch bounds checks not supported
+#else
       if (gfxIp.major >= 9)
         targetFeatures += ",+enable-scratch-bounds-checks";
+#endif
 
       if (gfxIp.major >= 10) {
         // Setup wavefront size per shader stage


### PR DESCRIPTION
Scratch bounds checks are currently only supported in amd-gfx LLVM.