### PR TITLE
NGG: Clarify the use of ES-GS offsets

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -203,6 +203,8 @@ private:
 
   llvm::BasicBlock *createBlock(llvm::Function *parent, const llvm::Twine &blockName = "");
 
+  llvm::Value *CreateUBfe(llvm::Value *value, unsigned offset, unsigned count);
+
   static const unsigned NullPrim = (1u << 31); // Null primitive data (invalid)
 
   PipelineState *m_pipelineState; // Pipeline state
@@ -235,9 +237,14 @@ private:
     llvm::Value *primShaderTableAddrHigh; // Primitive shader table address high
 
     // System values (VGPRs)
-    llvm::Value *esGsOffsets01; // ES-GS offset 0 and 1
-    llvm::Value *esGsOffsets23; // ES-GS offset 2 and 3
-    llvm::Value *esGsOffsets45; // ES-GS offset 4 and 5
+    llvm::Value *primData; // Primitive connectivity data (only for non-GS NGG pass-through mode)
+
+    llvm::Value *esGsOffset0; // ES-GS offset of vertex0
+    llvm::Value *esGsOffset1; // ES-GS offset of vertex1
+    llvm::Value *esGsOffset2; // ES-GS offset of vertex2
+    llvm::Value *esGsOffset3; // ES-GS offset of vertex3
+    llvm::Value *esGsOffset4; // ES-GS offset of vertex4
+    llvm::Value *esGsOffset5; // ES-GS offset of vertex5
 
   } m_nggFactor;
 


### PR DESCRIPTION
1. For merged shader, ES-GS offsets are packed together: 0,1 -> 01,
   2,3 -> 23, 4,5 -> 45. Recode the unpacked values for later uses.
   Also, replace the unpacking operation (ubfe) with and+shift.

2. The vertex indices within NGG subgroup are calculated from
   dividing ES-GS offset by ES-GS ring item size. Originally, the
   size was always 4, so we right-shift 2. But in the future,
   ES-GS ring item could be enlarged.

3. Add a helper function CreateUBfe to do bitfield extraction.

Change-Id: Ibdaf3fd21e3399d678d5baaff83a97b306050999