### PR TITLE
Enable YCbCr sampler conversion for GFXIP=6~8 

### DIFF
--- a/lgc/builder/YCbCrAddressHandler.cpp
+++ b/lgc/builder/YCbCrAddressHandler.cpp
@@ -57,6 +57,9 @@ void YCbCrAddressHandler::genBaseAddress(unsigned planeCount) {
   Value *pipeBankXorNone = m_builder->getInt32(0);
 
   switch (m_gfxIp->major) {
+  case 6:
+  case 7:
+  case 8:
   case 9: {
     pipeBankXor1 = pipeBankXorNone;
     pipeBankXor2 = pipeBankXorNone;
@@ -134,9 +137,13 @@ Value *YCbCrAddressHandler::power2Align(Value *x, unsigned align) {
 // @param xBitCount : Effective channel bits
 // @param planeNum : Number of planes
 void YCbCrAddressHandler::genHeightAndPitch(unsigned bits, unsigned bpp, unsigned xBitCount, unsigned planeNum) {
-  m_swizzleMode = m_regHandler->getReg(SqRsrcRegs::SwizzleMode);
+  if (m_gfxIp->major > 8)
+    m_swizzleMode = m_regHandler->getReg(SqRsrcRegs::SwizzleMode);
 
   switch (m_gfxIp->major) {
+  case 6:
+  case 7:
+  case 8:
   case 9: {
     // Height = SqRsrcRegs::Height
     Value *height = m_regHandler->getReg(SqRsrcRegs::Height);

--- a/lgc/builder/YCbCrConverter.cpp
+++ b/lgc/builder/YCbCrConverter.cpp
@@ -340,6 +340,9 @@ void YCbCrConverter::genImgDescChroma() {
     Value *isBgRgFmt = nullptr;
 
     switch (m_gfxIp->major) {
+    case 6:
+    case 7:
+    case 8:
     case 9: {
       isGbGrFmt = m_builder->CreateICmpEQ(
           imgDataFmt, m_builder->getInt32(ImageBuilder::ImgDataFormat::IMG_DATA_FORMAT_BG_RG__CORE));

--- a/lgc/util/GfxRegHandler.cpp
+++ b/lgc/util/GfxRegHandler.cpp
@@ -113,6 +113,9 @@ SqImgSampRegHandler::SqImgSampRegHandler(IRBuilder<> *builder, Value *reg, GfxIp
   m_gfxIpVersion = gfxIpVersion;
 
   switch (gfxIpVersion->major) {
+  case 6:
+  case 7:
+  case 8:
   case 9:
   case 10:
     m_bitsInfo = SqImgSampRegBitsGfx9;
@@ -161,7 +164,25 @@ void SqImgSampRegHandler::setReg(SqSampRegs regId, Value *regValue) {
 }
 
 // =====================================================================================================================
-// SqImgSampReg Bits infomation look up table (Gfx9)
+// SqImgSampReg Bits information look up table (Gfx6,7,8)
+// Refer to imported/chip/gfx6/si_ci_merged_registers.h : SQ_IMG_RSRC_WORD
+static constexpr BitsInfo SqImgRsrcRegBitsGfx6[static_cast<unsigned>(SqRsrcRegs::Count)] = {
+    {0, 0, 32},  // BaseAddress
+    {1, 0, 8},   // BaseAddressHi
+    {1, 20, 6},  // Format
+    {2, 0, 14},  // Width
+    {2, 14, 14}, // Height
+    {3, 0, 12},  // DstSelXYZW
+    {},          // SwizzleMode
+    {4, 0, 13},  // Depth
+    {4, 13, 14}, // Pitch
+    {},          // BcSwizzle
+    {},          // WidthLo
+    {},          // WidthHi
+};
+
+// =====================================================================================================================
+// SqImgSampReg Bits information look up table (Gfx9)
 // Refer to imported/chip/gfx9/gfx9_plus_merged_registers.h : SQ_IMG_RSRC_WORD
 static constexpr BitsInfo SqImgRsrcRegBitsGfx9[static_cast<unsigned>(SqRsrcRegs::Count)] = {
     {0, 0, 32},  // BaseAddress
@@ -179,7 +200,7 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx9[static_cast<unsigned>(SqRsrcRegs:
 };
 
 // =====================================================================================================================
-// SqImgSampReg Bits infomation look up table (Gfx10)
+// SqImgSampReg Bits information look up table (Gfx10)
 // TODO: update comment when the registers file is available
 static constexpr BitsInfo SqImgRsrcRegBitsGfx10[static_cast<unsigned>(SqRsrcRegs::Count)] = {
     {0, 0, 32},  // BaseAddress
@@ -207,6 +228,11 @@ SqImgRsrcRegHandler::SqImgRsrcRegHandler(IRBuilder<> *builder, Value *reg, GfxIp
   m_gfxIpVersion = gfxIpVersion;
 
   switch (gfxIpVersion->major) {
+  case 6:
+  case 7:
+  case 8:
+    m_bitsInfo = SqImgRsrcRegBitsGfx6;
+    break;
   case 9:
     m_bitsInfo = SqImgRsrcRegBitsGfx9;
     break;
@@ -238,6 +264,9 @@ Value *SqImgRsrcRegHandler::getReg(SqRsrcRegs regId) {
     return m_builder->CreateAdd(getRegCommon(static_cast<unsigned>(regId)), m_one);
   case SqRsrcRegs::Width:
     switch (m_gfxIpVersion->major) {
+    case 6:
+    case 7:
+    case 8:
     case 9:
       return m_builder->CreateAdd(getRegCommon(static_cast<unsigned>(regId)), m_one);
     case 10:
@@ -276,6 +305,9 @@ void SqImgRsrcRegHandler::setReg(SqRsrcRegs regId, Value *regValue) {
     break;
   case SqRsrcRegs::Width:
     switch (m_gfxIpVersion->major) {
+    case 6:
+    case 7:
+    case 8:
     case 9:
       setRegCommon(static_cast<unsigned>(regId), m_builder->CreateSub(regValue, m_one));
       break;


### PR DESCRIPTION
This patch enables GFXIP=6,7,8 in VK_KHR_SAMPLER_YCBCR_CONVERSION extension