### PR TITLE
Bump new interface version to 42 to remove unused flag tileOptimal

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -74,6 +74,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
 //* |     41.0 | Moved resource mapping from ShaderPipeline-level to Pipeline-level                                    |
 //* |     40.4 | Added fp32DenormalMode in PipelineShaderOptions to allow overriding SPIR-V denormal settings          |
 //* |     40.3 | Added ICache interface                                                                                |
@@ -600,8 +601,12 @@ struct SamplerYCbCrConversionMetaData {
       unsigned xChromaOffset : 1; ///< COSITED_EVEN(0) or MIDPOINT(1)
       unsigned yChromaOffset : 1; ///< COSITED_EVEN(0) or MIDPOINT(1)
       unsigned xSubSampled : 1;   ///< true(1) or false(0)
-      unsigned ySubSampled : 1;   ///< true(1) or false(0)
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 42
+      unsigned : 1; ///< Unused
+#else
       unsigned tileOptimal : 1;   ///< true(1) or false(0)
+#endif
+      unsigned ySubSampled : 1;   ///< true(1) or false(0)
       unsigned dstSelXYZW : 12;   ///< dst selection Swizzle
       unsigned undefined : 11;
     };

--- a/lgc/builder/YCbCrAddressHandler.h
+++ b/lgc/builder/YCbCrAddressHandler.h
@@ -51,7 +51,7 @@ public:
   void genBaseAddress(unsigned planeCount);
 
   // Generate height and pitch
-  void genHeightAndPitch(unsigned bits, unsigned bpp, unsigned xBitCount, bool isTileOptimal, unsigned planeNum);
+  void genHeightAndPitch(unsigned bits, unsigned bpp, unsigned xBitCount, unsigned planeNum);
 
   // Power2Align operation
   llvm::Value *power2Align(llvm::Value *x, unsigned align);
@@ -83,7 +83,6 @@ private:
   llvm::Value *m_pitchCb = nullptr;
   llvm::Value *m_heightCb = nullptr;
   llvm::Value *m_swizzleMode = nullptr;
-  llvm::Value *m_isTileOpt = nullptr;
   llvm::Value *m_one;
   GfxIpVersion *m_gfxIp;
 };

--- a/lgc/builder/YCbCrConverter.cpp
+++ b/lgc/builder/YCbCrConverter.cpp
@@ -371,7 +371,7 @@ void YCbCrConverter::genImgDescChroma() {
 
     YCbCrAddressHandler addrHelper(m_builder, &proxySqRsrcRegHelper, m_gfxIp);
     addrHelper.genHeightAndPitch(m_metaData.word0.bitDepth.channelBitsR, 32, m_metaData.word2.bitCounts.xBitCount,
-                                 m_metaData.word1.tileOptimal, m_metaData.word1.planes);
+                                 m_metaData.word1.planes);
     proxySqRsrcRegHelper.setReg(SqRsrcRegs::Width,
                                 m_builder->CreateLShr(width, ConstantInt::get(m_builder->getInt32Ty(), 1)));
     proxySqRsrcRegHelper.setReg(SqRsrcRegs::DstSelXYZW, dstSelXYZW);

--- a/lgc/builder/YCbCrConverter.h
+++ b/lgc/builder/YCbCrConverter.h
@@ -73,9 +73,8 @@ struct SamplerYCbCrConversionMetaData {
       unsigned yChromaOffset : 1; // COSITED_EVEN(0) or MIDPOINT(1)
       unsigned xSubSampled : 1;   // true(1) or false(0)
       unsigned ySubSampled : 1;   // true(1) or false(0)
-      unsigned tileOptimal : 1;   // true(1) or false(0)
       unsigned dstSelXYZW : 12;   // dst selection Swizzle
-      unsigned undefined : 11;
+      unsigned undefined : 12;
     };
     unsigned u32All;
   } word1;


### PR DESCRIPTION
This flag is supposed to be initialized in VLK XGL
frontend. However, in new code, there is no initialization.

The flag is unused and this is why should  be removed