### PR TITLE
Drop support for client interface versions < 40

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -56,12 +56,8 @@
 #endif
 #endif
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 32
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 40
 #error LLPC client version is too old
-#endif
-
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 39
-#define Vkgc Llpc
 #endif
 
 #ifndef LLPC_ENABLE_SHADER_CACHE
@@ -211,10 +207,7 @@ enum class ResourceMappingNodeType : unsigned {
   PushConst,                 ///< Push constant
   DescriptorBufferCompact,   ///< Compact buffer descriptor, only contains the buffer address
   StreamOutTableVaPtr,       ///< Stream-out buffer table VA pointer
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 40
   DescriptorReserved12,
-#elif LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 29
-#endif
   DescriptorYCbCrSampler, ///< Generic descriptor: YCbCr sampler
   Count,                  ///< Count of resource mapping node types.
 };
@@ -486,24 +479,18 @@ struct NggState {
   unsigned vertsPerSubgroup; ///< Preferred number of vertices consumed by a primitive shader sub-group
 };
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
 /// ShaderHash represents a 128-bit client-specified hash key which uniquely identifies a shader program.
 struct ShaderHash {
   uint64_t lower; ///< Lower 64 bits of hash key.
   uint64_t upper; ///< Upper 64 bits of hash key.
 };
-#else
-typedef uint64_t ShaderHash;
-#endif
 
 /// Represents per shader stage options.
 struct PipelineShaderOptions {
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
   ShaderHash clientHash; ///< Client-supplied unique shader hash. A value of zero indicates that LLPC should
                          ///  calculate its own hash. This hash is used for dumping, shader replacement, SPP, etc.
                          ///  If the client provides this hash, they are responsible for ensuring it is as stable
                          ///  as possible.
-#endif
   bool trapPresent;           ///< Indicates a trap handler will be present when this pipeline is executed,
                               ///  and any trap conditions encountered in this shader should call the trap
                               ///  handler. This could include an arithmetic exception, an explicit trap
@@ -537,21 +524,19 @@ struct PipelineShaderOptions {
   /// Force loop unroll count. "0" means using default value; "1" means disabling loop unroll.
   unsigned forceLoopUnrollCount;
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
   /// Enable LLPC load scalarizer optimization.
   bool enableLoadScalarizer;
-#endif
-  bool allowVaryWaveSize; ///< If set, lets the pipeline vary the wave sizes.
+  /// If set, lets the pipeline vary the wave sizes.
+  bool allowVaryWaveSize;
   /// Use the LLVM backend's SI scheduler instead of the default scheduler.
   bool useSiScheduler;
 
   // Whether update descriptor root offset in ELF
   bool updateDescInElf;
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
   /// Disable the the LLVM backend's LICM pass.
   bool disableLicm;
-#endif
+
   /// Default unroll threshold for LLVM.
   unsigned unrollThreshold;
 
@@ -664,7 +649,7 @@ struct GraphicsPipelineBuildInfo {
   void *pUserData;                ///< User data
   OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
   ICache *cache;                  ///< ICache, used to search for the compiled shader data
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   IShaderCache *pShaderCache; ///< Shader cache, used to search for the compiled shader data
 #endif
   PipelineShaderInfo vs;  ///< Vertex shader
@@ -729,7 +714,7 @@ struct ComputePipelineBuildInfo {
   void *pUserData;                ///< User data
   OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
   ICache *cache;                  ///< ICache, used to search for the compiled shader data
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   IShaderCache *pShaderCache; ///< Shader cache, used to search for the compiled shader data
 #endif
   unsigned deviceIndex;  ///< Device index for device group

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -146,12 +146,6 @@ static opt<std::string> ExecutableName("executable-name", desc("Executable file 
 // -enable-spirv-opt: enable optimization for SPIR-V binary
 opt<bool> EnableSpirvOpt("enable-spirv-opt", desc("Enable optimization for SPIR-V binary"), init(false));
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 37
-// -enable-dynamic-loop-unroll: Enable dynamic loop unroll. (Deprecated)
-opt<bool> EnableDynamicLoopUnroll("enable-dynamic-loop-unroll", desc("Enable dynamic loop unroll (deprecated)"),
-                                  init(false));
-#endif
-
 // -enable-shader-module-opt: Enable translate & lower phase in shader module build.
 opt<bool> EnableShaderModuleOpt("enable-shader-module-opt",
                                 cl::desc("Enable translate & lower phase in shader module build."), init(false));
@@ -810,14 +804,14 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
     if (context->isGraphics()) {
       auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
       cacheHash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo, true, true, stage);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
       userShaderCache = reinterpret_cast<IShaderCache *>(pipelineInfo->pShaderCache);
 #endif
       userCache = pipelineInfo->cache;
     } else {
       auto pipelineInfo = reinterpret_cast<const ComputePipelineBuildInfo *>(context->getPipelineBuildInfo());
       cacheHash = PipelineDumper::generateHashForComputePipeline(pipelineInfo, true, true);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
       userShaderCache = reinterpret_cast<IShaderCache *>(pipelineInfo->pShaderCache);
 #endif
       userCache = pipelineInfo->cache;
@@ -1225,7 +1219,7 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, unsigned stageM
 
   IShaderCache *appCache = nullptr;
   auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(m_context->getPipelineBuildInfo());
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   appCache = reinterpret_cast<IShaderCache *>(pipelineInfo->pShaderCache);
 #endif
   ICache *userCache = nullptr;
@@ -1456,7 +1450,7 @@ Result Compiler::BuildGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline
 
   ShaderEntryState cacheEntryState = ShaderEntryState::New;
   IShaderCache *appCache = nullptr;
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   appCache = reinterpret_cast<IShaderCache *>(pipelineInfo->pShaderCache);
 #endif
   ICache *userCache = nullptr;
@@ -1585,7 +1579,7 @@ Result Compiler::BuildComputePipeline(const ComputePipelineBuildInfo *pipelineIn
 
   ShaderEntryState cacheEntryState = ShaderEntryState::New;
   IShaderCache *appCache = nullptr;
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   appCache = reinterpret_cast<IShaderCache *>(pipelineInfo->pShaderCache);
 #endif
   ICache *userCache = nullptr;
@@ -1735,7 +1729,7 @@ Result Compiler::validatePipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   return result;
 }
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
 // =====================================================================================================================
 // Creates shader cache object with the requested properties.
 // @param : Shader cache create info.

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -141,7 +141,7 @@ public:
 
   static MetroHash::Hash generateHashForCompileOptions(unsigned optionCount, const char *const *options);
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   virtual Result CreateShaderCache(const ShaderCacheCreateInfo *pCreateInfo, IShaderCache **ppShaderCache);
 #endif
 

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -229,7 +229,7 @@ public:
   virtual Result BuildComputePipeline(const ComputePipelineBuildInfo *pPipelineInfo,
                                       ComputePipelineBuildOut *pPipelineOut, void *pPipelineDumpFile = nullptr) = 0;
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 38 || LLPC_ENABLE_SHADER_CACHE
+#if LLPC_ENABLE_SHADER_CACHE
   /// Creates a shader cache object with the requested properties.
   ///
   /// @param [in]  pCreateInfo    Create info of the shader cache.

--- a/llpc/translator/include/LLVMSPIRVLib.h
+++ b/llpc/translator/include/LLVMSPIRVLib.h
@@ -45,10 +45,6 @@
 #include <iostream>
 #include "spirvExt.h"
 
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 39
-#define Vkgc Llpc
-#endif
-
 namespace llvm {
 // llvm::Pass initialization functions need to be declared before inclusion of
 // PassSupport.h.

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -508,12 +508,8 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.useSiScheduler = " << shaderInfo->options.useSiScheduler << "\n";
   dumpFile << "options.updateDescInElf = " << shaderInfo->options.updateDescInElf << "\n";
   dumpFile << "options.allowVaryWaveSize = " << shaderInfo->options.allowVaryWaveSize << "\n";
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
   dumpFile << "options.enableLoadScalarizer = " << shaderInfo->options.enableLoadScalarizer << "\n";
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
   dumpFile << "options.disableLicm = " << shaderInfo->options.disableLicm << "\n";
-#endif
   dumpFile << "options.unrollThreshold = " << shaderInfo->options.unrollThreshold << "\n";
   dumpFile << "options.scalarThreshold = " << shaderInfo->options.scalarThreshold << "\n";
   dumpFile << "options.disableLoopUnroll = " << shaderInfo->options.disableLoopUnroll << "\n";
@@ -1056,12 +1052,8 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.useSiScheduler);
       hasher->Update(options.updateDescInElf);
       hasher->Update(options.allowVaryWaveSize);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
       hasher->Update(options.enableLoadScalarizer);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
       hasher->Update(options.disableLicm);
-#endif
       hasher->Update(options.unrollThreshold);
       hasher->Update(options.scalarThreshold);
       hasher->Update(options.disableLoopUnroll);

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -128,12 +128,8 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 33
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);
-#endif
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 35
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
-#endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);

--- a/util/vkgcMetroHash.h
+++ b/util/vkgcMetroHash.h
@@ -62,16 +62,6 @@ inline unsigned compact32(const Hash *hash) {
   return hash->dwords[3] ^ hash->dwords[2] ^ hash->dwords[1] ^ hash->dwords[0];
 }
 
-// Compacts a 64-bit hash checksum into a 32-bit one by XOR'ing each 32-bit chunk together.
-//
-// Takes input parameter hash, which is 64-bit hash to be compacted.
-//
-// Returns 32-bit hash value based on the inputted 64-bit hash.
-inline unsigned compact32(uint64_t hash) {
-  return static_cast<unsigned>(hash) ^ static_cast<unsigned>(hash >> 32);
-}
-
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 36
 // Compacts a 128-bit hash into a 32-bit one by XOR'ing each 32-bit chunk together.
 //
 // Takes input parameter ShaderHash, which is a struct consisting of 2 quad words to be compacted.
@@ -81,6 +71,5 @@ inline unsigned compact32(Vkgc::ShaderHash hash) {
   return (static_cast<unsigned>(hash.lower) ^ static_cast<unsigned>(hash.lower >> 32) ^
           static_cast<unsigned>(hash.upper) ^ static_cast<unsigned>(hash.upper >> 32));
 }
-#endif
 
 } // namespace MetroHash


### PR DESCRIPTION
Clean up preprocessor code for old LLPC_CLIENT_INTERFACE_MAJOR_VERSION.