### PR TITLE
Move builtin export generation to the color export shader.

### DIFF
--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -33,6 +33,7 @@
 #include "lgc/BuilderBase.h"
 #include "lgc/Pipeline.h"
 #include "lgc/state/IntrinsDefs.h"
+#include "lgc/state/PalMetadata.h"
 #include "lgc/util/Internal.h"
 
 namespace lgc {
@@ -59,6 +60,8 @@ public:
   llvm::Value *run(llvm::Value *output, unsigned int hwColorTarget, llvm::Instruction *insertPos, ExportFormat expFmt,
                    const bool signedness);
 
+  void generateExportInstructions(llvm::ArrayRef<lgc::ColorExportInfo> info, llvm::ArrayRef<llvm::Value *> values,
+                                  llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);
   static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
   static llvm::CallInst *addDummyExport(BuilderBase &builder);
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -405,7 +405,6 @@ struct ResourceUsage {
       std::vector<FsInterpInfo> interpInfo;   // Array of interpolation info
       BasicType outputTypes[MaxColorTargets]; // Array of basic types of fragment outputs
       unsigned cbShaderMask;                  // CB shader channel mask (correspond to register CB_SHADER_MASK)
-      bool dummyExport;                       // Control to generate fragment shader dummy export
       bool isNullFs;                          // Is null FS, so should set final cbShaderMask to 0
     } fs;
   } inOutUsage;

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -148,7 +148,6 @@ bool PatchNullFragShader::runOnModule(Module &module) {
 
   // Add usage info for dummy output
   resUsage->inOutUsage.fs.cbShaderMask = 0;
-  resUsage->inOutUsage.fs.dummyExport = true;
   resUsage->inOutUsage.fs.isNullFs = true;
   resUsage->inOutUsage.outputLocMap[0] = InvalidValue;
 

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -762,6 +762,8 @@ llvm::Type *PalMetadata::getLlvmType(StringRef tyName) const {
 void PalMetadata::updateSpiShaderColFormat(ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled) {
   unsigned spiShaderColFormat = 0;
   for (auto &exp : exps) {
+    if (exp.hwColorTarget == MaxColorTargets)
+      continue;
     unsigned expFormat = m_pipelineState->computeExportFormat(exp.ty, exp.location);
     spiShaderColFormat |= (expFormat << (4 * exp.hwColorTarget));
   }

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -63,7 +63,6 @@ ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
     }
 
     inOutUsage.fs.cbShaderMask = 0;
-    inOutUsage.fs.dummyExport = true;
     inOutUsage.fs.isNullFs = false;
   }
 }

--- a/llpc/test/shaderdb/ObjOutput_TestFsBuiltIn_lit.frag
+++ b/llpc/test/shaderdb/ObjOutput_TestFsBuiltIn_lit.frag
@@ -19,7 +19,7 @@ void main()
 ; SHADERTEST: call void @lgc.output.export.builtin.SampleMask.i32.a1i32
 ; SHADERTEST: call void @lgc.output.export.builtin.FragStencilRef
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32
+; SHADERTEST: ret { <4 x float> }
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_BuiltinExportInPrologue.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_BuiltinExportInPrologue.pipe
@@ -1,0 +1,36 @@
+// Test that when building relocatable shaders, that the color export shader contains exactly one export, which is for
+// the depth, and that the done flag is set.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: <color_export_shader>:
+; SHADERTEST-NEXT: exp mrtz v0, off, off, off done vm
+; SHADERTEST-NEXT: s_endpgm
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+
+[VsGlsl]
+#version 450
+
+void main() {
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+layout(location = 0) out vec4 outputColor;
+
+void main() {
+	gl_FragDepth = 0;
+	outputColor = vec4(1.0, 1.0, 1.0, 0.0);
+}
+
+[FsInfo]
+entryPoint = main
+


### PR DESCRIPTION
In the initial design, I did not realize that it is possible that the
color export shader could be empty.  This happens when the pipeline
state does not have any color buffer information for the export
instructions that were in the shader.

This causes a problem because we cannot know if the "done" flag should
be set on the builtin export instruction until generating the color
export shader.  This means that the export instruction for the builtin
exports must be generated when building the color export shader.