### PR TITLE
Don't access the color export state with unlinked shaders

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -310,7 +310,11 @@ union DB_SHADER_CONTROL {
   struct {
     unsigned int : 6;
     unsigned int KILL_ENABLE : 1;
-    unsigned int : 25;
+    unsigned int : 1;
+    unsigned int MASK_EXPORT_ENABLE : 1;
+    unsigned int : 2;
+    unsigned int ALPHA_TO_MASK_DISABLE : 1;
+    unsigned int : 20;
   } bitfields, bits;
   unsigned int u32All;
 };

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1832,8 +1832,7 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, Z_EXPORT_ENABLE, builtInUsage.fragDepth);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
-  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE,
-                (builtInUsage.sampleMask || m_pipelineState->getColorExportState().alphaToCoverageEnable == false));
+  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE, 0); // Set during pipeline finalization.
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                 (fragmentMode.earlyFragmentTests && resUsage->resourceWrite));

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1711,8 +1711,6 @@ void PatchResourceCollect::matchGenericInOut() {
       auto &locMap = *locMapIt;
       if (m_shaderStage == ShaderStageFragment) {
         unsigned location = locMap.first;
-        if (m_pipelineState->getColorExportState().dualSourceBlendEnable && location == 1)
-          location = 0;
         if (!generatingColorExportShader &&
             m_pipelineState->getColorExportFormat(location).dfmt == BufDataFormatInvalid) {
           locMapIt = outLocMap.erase(locMapIt);

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -458,6 +458,15 @@ void PalMetadata::finalizePipeline() {
     paClClipCntl.bits.ZCLIP_FAR_DISABLE = depthClipDisable;
     paClClipCntl.bits.DX_RASTERIZATION_KILL = rasterizerDiscardEnable;
     setRegister(mmPA_CL_CLIP_CNTL, paClClipCntl.u32All);
+
+    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9) {
+      DB_SHADER_CONTROL dbShaderControl = {};
+      dbShaderControl.u32All = getRegister(mmDB_SHADER_CONTROL);
+      dbShaderControl.bitfields.ALPHA_TO_MASK_DISABLE =
+          dbShaderControl.bitfields.MASK_EXPORT_ENABLE ||
+          m_pipelineState->getColorExportState().alphaToCoverageEnable == false;
+      setRegister(mmDB_SHADER_CONTROL, dbShaderControl.u32All);
+    }
   }
 
   // If there are root user data nodes but none of them are used, adjust userDataLimit accordingly.

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -872,7 +872,7 @@ void PipelineState::setColorExportState(ArrayRef<ColorExportFormat> formats, con
 //
 // @param location : Export location
 const ColorExportFormat &PipelineState::getColorExportFormat(unsigned location) {
-  if (m_colorExportState.dualSourceBlendEnable)
+  if (getColorExportState().dualSourceBlendEnable)
     location = 0;
 
   if (location >= m_colorExportFormats.size()) {
@@ -1085,7 +1085,7 @@ unsigned PipelineState::computeExportFormat(Type *outputTy, unsigned location) {
   GfxIpVersion gfxIp = getTargetInfo().getGfxIpVersion();
   auto gpuWorkarounds = &getTargetInfo().getGpuWorkarounds();
   unsigned outputMask = outputTy->isVectorTy() ? (1 << cast<VectorType>(outputTy)->getNumElements()) - 1 : 1;
-  const auto cbState = &m_colorExportState;
+  const auto cbState = &getColorExportState();
   // NOTE: Alpha-to-coverage only takes effect for outputs from color target 0.
   const bool enableAlphaToCoverage = (cbState->alphaToCoverageEnable && location == 0);
 


### PR DESCRIPTION
When building a fragment shader that will have a color export shader, we
do not set the color export state in the pipeline state, so we better
not reference it.  Not many changes are needed.  The
"dualSourceBlendEnabled" is was only used when getting the color format
for a location, which is not called when generating a color export
shader.

The "alphaToCoverageEnable" field is only used when generating the pal
metadata for gfx9.  That has been moved to when the pal metadata is
finalized.