### PR TITLE
Fix negate opcode inconsistent type assertion

### DIFF
--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpSNegate.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpSNegate.spvasm
@@ -2,7 +2,6 @@
 ; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
 ; SHADERTEST: AMDLLPC SUCCESS
-; XFAIL: assertions
 ; END_SHADERTEST
 ;
 ; Based on https://github.com/GPUOpen-Drivers/llpc/issues/835.

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1451,7 +1451,8 @@ protected:
 
       (void)ResTy;
       (void)OpTy;
-      assert(getType() == getValueType(Op) && "Inconsistent type");
+      // NOTE: SPIR-V spec only request OpFNegate to match the type between Operand and Result.
+      assert((getType() == getValueType(Op) || static_cast<unsigned>(OpCode) != OpFNegate) && "Inconsistent type");
       assert((ResTy->isTypeInt() || ResTy->isTypeFloat()) &&
              "Invalid type for Generic Negate instruction");
       assert((ResTy->getBitWidth() == OpTy->getBitWidth()) &&


### PR DESCRIPTION
Per SPIR-V spec, among the three generic negate opcodes (OpSNegate, OpFNegate, OpNot), only OpFNegate has the requirement that:

    "The type of Operand must be the same as Result Type."

The Operand Type and Result Type of OpSNegate and OpNot being inconsistent is not against the spec, thus we should not assert in this case.

This fixes #835.