### PR TITLE
[CI] Don't checkout full repos in github workflows

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git checkout ${GITHUB_SHA}
+          find ./ -maxdepth 1 -mindepth 1 ! -name docker -exec rm -rf '{}' '+'
       - name: Setup Google Cloud CLI
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -25,6 +25,7 @@ jobs:
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
           git checkout ${GITHUB_SHA}
+          find ./ -maxdepth 1 -mindepth 1 ! -name docker -exec rm -rf '{}' '+'
       - name: Generate Docker base image tag string
         run: |
           CONFIG_LOWER=$(echo "${{ matrix.config }}" | tr "[:upper:]" "[:lower:]")


### PR DESCRIPTION
Save some disk space (34MiB) by keeping only the 'docker' subdirectory.

An alternative solution would be to do a sparse checkout, but
this requires very recent git versions and doesn't seem well
documented.

Bug: https://github.com/GPUOpen-Drivers/llpc/issues/879