### PR TITLE
[CI] Remove unused packaged in github workflows

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -20,6 +20,18 @@ jobs:
         feature-set:    ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
         generator:      [Ninja]
     steps:
+      - name: Free up disk space
+        if: matrix.feature-set == '+clang+sanitizers'
+        run: |
+          sudo apt-get purge "ghc-*" "adoptopenjdk-*" "openjdk-*" hhvm \
+                       google-chrome-stable firefox \
+                       "llvm-*" "clang-*" "libclang*" \
+                       "g++-*" "r-*" "mongodb-*" \
+                       "dotnet-*" powershell azure-cli \
+                       snapd
+          sudo apt-get autoremove
+          sudo apt-get clean
+          df -h
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -20,6 +20,18 @@ jobs:
         assertions:          ["OFF", "ON"]
         feature-set:         ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
     steps:
+      - name: Free up disk space
+        if: matrix.feature-set == '+clang+sanitizers'
+        run: |
+          sudo apt-get purge "ghc-*" "adoptopenjdk-*" "openjdk-*" hhvm \
+                       google-chrome-stable firefox \
+                       "llvm-*" "clang-*" "libclang*" \
+                       "g++-*" "r-*" "mongodb-*" \
+                       "dotnet-*" powershell azure-cli \
+                       snapd
+          sudo apt-get autoremove
+          sudo apt-get clean
+          df -h
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .


### PR DESCRIPTION
Reclaim ~7GiB of disk space.
The workflow runner needs to only launch docker and interact with gcr;
other packages are not necessary.

Tested by running this step in the check-llpc workflow on my fork: https://github.com/kuhar/llpc/actions/runs/202851199.

Bug: https://github.com/GPUOpen-Drivers/llpc/issues/879