### PR TITLE
Update the size of symbol related to glue code

### DIFF
--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -82,6 +82,11 @@ public:
   // Get the symbol name of the main shader that this glue shader is prolog or epilog for.
   StringRef getMainShaderName() override;
 
+  // Get the symbol name of the glue shader.
+  StringRef getGlueShaderName() override {
+    return getEntryPointName(m_vsEntryRegInfo.callingConv, /*isFetchlessVs=*/false);
+  }
+
   // Get whether this glue shader is a prolog (rather than epilog) for its main shader.
   bool isProlog() override { return true; }
 
@@ -118,6 +123,9 @@ public:
 
   // Get the symbol name of the main shader that this glue shader is prolog or epilog for.
   StringRef getMainShaderName() override;
+
+  // Get the symbol name of the glue shader.
+  StringRef getGlueShaderName() override { return "color_export_shader"; }
 
   // Get whether this glue shader is a prolog (rather than epilog) for its main shader.
   bool isProlog() override { return false; }
@@ -288,8 +296,7 @@ Function *FetchShader::createFetchFunc() {
   auto funcTy = FunctionType::get(retTy, entryTys, false);
 
   // Create the function. Mark SGPR inputs as "inreg".
-  StringRef funcName = getEntryPointName(m_vsEntryRegInfo.callingConv, /*isFetchlessVs=*/false);
-  Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, funcName, module);
+  Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, getGlueShaderName(), module);
   func->setCallingConv(m_vsEntryRegInfo.callingConv);
   for (unsigned i = 0; i != m_vsEntryRegInfo.sgprCount; ++i)
     func->getArg(i)->addAttr(Attribute::InReg);
@@ -406,8 +413,7 @@ Function *ColorExportShader::createColorExportFunc() {
   auto funcTy = FunctionType::get(Type::getVoidTy(getContext()), entryTys, false);
 
   // Create the function. Mark SGPR inputs as "inreg".
-  StringRef funcName = "color_export_shader";
-  Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, funcName, module);
+  Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, getGlueShaderName(), module);
   func->setCallingConv(CallingConv::AMDGPU_PS);
 
   BasicBlock *block = BasicBlock::Create(func->getContext(), "", func);

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -67,6 +67,9 @@ public:
   // Get the symbol name of the main shader that this glue shader is prolog or epilog for
   virtual llvm::StringRef getMainShaderName() = 0;
 
+  // Get the symbol name of the glue shader.
+  virtual llvm::StringRef getGlueShaderName() = 0;
+
   // Get whether this glue shader is a prolog (rather than epilog) for its main shader.
   virtual bool isProlog() { return false; }
 


### PR DESCRIPTION
When we append or prepend glue code to a shader that changes the size of
the main function.  However, we currently do not update the size of the
symbols.  This add code to the elf linking code that will update the
size of the symbols related to the glue code.