### PR TITLE
Rework implementation for OpCopyObject

### DIFF
--- a/llpc/test/shaderdb/OpCopyObject_TestVec4_lit.spvasm
+++ b/llpc/test/shaderdb/OpCopyObject_TestVec4_lit.spvasm
@@ -3,8 +3,6 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]+}} = load <4 x float>, <4 x float> addrspace({{[0-9]+}})* %{{.*}}
-; SHADERTEST: store <4 x float> %{{[0-9]+}}, <4 x float> addrspace({{[0-9]+}})* %{{[0-9]+}}
-; SHADERTEST: %{{[0-9]+}} = load <4 x float>, <4 x float> addrspace({{[0-9]+}})* %{{[0-9]+}}
 ; SHADERTEST: store <4 x float> %{{[0-9]+}}, <4 x float> addrspace({{[0-9]+}})* @{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC.*}} lowering results
 ; SHADERTEST: @lgc.output.export.generic.i32.i32.v4f32

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObject.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObject.spvasm
@@ -2,7 +2,6 @@
 ; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
 ; SHADERTEST: AMDLLPC SUCCESS
-; XFAIL: *
 ; END_SHADERTEST
 ;
 ; Based on https://github.com/GPUOpen-Drivers/llpc/issues/834.

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
@@ -2,7 +2,6 @@
 ; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
 ; SHADERTEST: AMDLLPC SUCCESS
-; XFAIL: *
 ; END_SHADERTEST
 ;
 ; Based on https://github.com/GPUOpen-Drivers/llpc/issues/834.

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectOfVoidType.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectOfVoidType.spvasm
@@ -2,7 +2,6 @@
 ; RUN: amdllpc --verify-ir -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
 ; SHADERTEST: AMDLLPC SUCCESS
-; XFAIL: *
 ; END_SHADERTEST
 ;
 ; Based on https://github.com/GPUOpen-Drivers/llpc/issues/833.

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4211,12 +4211,15 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     return mapValue(bv, scale);
   }
 
-#if SPV_VERSION >= 0x10400
-  case OpCopyObject:
-  case OpCopyLogical: {
-#else
   case OpCopyObject: {
-#endif
+    SPIRVCopyBase *copy = static_cast<SPIRVCopyBase *>(bv);
+    Value *v = transValue(copy->getOperand(), f, bb);
+    assert(v);
+    return mapValue(bv, v);
+  }
+
+#if SPV_VERSION >= 0x10400
+  case OpCopyLogical: {
     SPIRVCopyBase *copy = static_cast<SPIRVCopyBase *>(bv);
     AllocaInst *ai = nullptr;
     auto at = transType(copy->getOperand()->getType());
@@ -4232,6 +4235,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     LoadInst *li = new LoadInst(at, ai, "", bb);
     return mapValue(bv, li);
   }
+#endif
 
   case OpCompositeConstruct: {
     auto cc = static_cast<SPIRVCompositeConstruct *>(bv);


### PR DESCRIPTION
Previously OpCopyObject is handled by a store + load, it will lead to problem when copying pointer type object, for example, mentioned in #834. LLPC fails to handle the pointer-to-pointer type in some lower passes so invalid IR is generated / assertion is triggered.

Directly mapping the llvm value of the Operand to the Result should be enough for OpCopyObject, since the Operand and Result should be exactly the same for OpCopyObject.

This fixes #834.