### PR TITLE
NGG: Set PAL metadata .nggSubgroupSize

### DIFF
--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -282,6 +282,15 @@ void ConfigBuilderBase::setEsGsLdsSize(unsigned value) {
 }
 
 // =====================================================================================================================
+// Set NGG sub-group size
+//
+// @param value : Value to set
+void ConfigBuilderBase::setNggSubgroupSize(unsigned value) {
+  assert(value != 0);
+  m_pipelineNode[Util::Abi::PipelineMetadataKey::NggSubgroupSize] = value;
+}
+
+// =====================================================================================================================
 /// Append a single entry to the PAL register metadata.
 ///
 /// @param [in] key : The metadata key (usually a register address).

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -81,6 +81,7 @@ protected:
   void setPipelineType(Util::Abi::PipelineType value);
   void setLdsSizeByteSize(Util::Abi::HardwareStage hwStage, unsigned value);
   void setEsGsLdsSize(unsigned value);
+  void setNggSubgroupSize(unsigned value);
   unsigned setupFloatingPointMode(ShaderStage shaderStage);
 
   void appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1476,6 +1476,7 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
 
   SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_ONCHIP_CNTL, ES_VERTS_PER_SUBGRP, calcFactor.esVertsPerSubgroup);
   SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_ONCHIP_CNTL, GS_PRIMS_PER_SUBGRP, calcFactor.gsPrimsPerSubgroup);
+  setNggSubgroupSize(std::max(calcFactor.esVertsPerSubgroup, calcFactor.gsPrimsPerSubgroup));
 
   const unsigned gsInstPrimsInSubgrp = geometryMode.invocations > 1
                                            ? (calcFactor.gsPrimsPerSubgroup * geometryMode.invocations)


### PR DESCRIPTION
Originally, we don't set this metadata and NGG doesn't expose any
problem because we always allocate LDS regions based on max subgroup
size (256). Now, this latent problem occurs because LDS regions will
be changed to dynamic sizing based on vertex count per subgroup.

PAL uses this metadata to contrl the register GE_CNTL.

Change-Id: Ic7252ded810e87a7e364f95b5a87af5d6e2c9aee