### PR TITLE
Fix visitPHINode for PatchBufferOp

### DIFF
--- a/lgc/patch/PatchBufferOp.h
+++ b/lgc/patch/PatchBufferOp.h
@@ -87,9 +87,12 @@ private:
                               llvm::Instruction *const insertPos);
   void postVisitMemCpyInst(llvm::MemCpyInst &memCpyInst);
   void postVisitMemSetInst(llvm::MemSetInst &memSetInst);
+  void fixIncompletePhis();
 
   using Replacement = std::pair<llvm::Value *, llvm::Value *>;
+  using PhiIncoming = std::pair<llvm::PHINode *, llvm::BasicBlock *>;
   llvm::DenseMap<llvm::Value *, Replacement> m_replacementMap; // The replacement map.
+  llvm::DenseMap<PhiIncoming, llvm::Value *> m_incompletePhis; // The incomplete phi map.
   llvm::DenseSet<llvm::Value *> m_invariantSet;                // The invariant set.
   llvm::DenseSet<llvm::Value *> m_divergenceSet;               // The divergence set.
   llvm::LegacyDivergenceAnalysis *m_divergenceAnalysis;        // The divergence analysis.

--- a/llpc/test/shaderdb/TestPatchBufferOp.comp
+++ b/llpc/test/shaderdb/TestPatchBufferOp.comp
@@ -1,0 +1,45 @@
+// This test case checks whether a phi is well-handed in PatchBufferOp pass. This shader will result in a phi in IR that
+// one of the incoming value comes from downstream of the control flow.
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct s
+{
+    int n;
+};
+
+layout(binding = 0) buffer _1
+{
+    s a[];
+} buffer1;
+
+layout(binding = 1) buffer _2
+{
+    int b[];
+} buffer2;
+
+void main()
+{
+    int i = buffer2.b[0];
+
+    for (;;)
+    {
+        s struct0 = buffer1.a[i];
+
+        if (i == 0)
+        {
+            break;
+        }
+
+        i = struct0.n;
+    }
+}


### PR DESCRIPTION
When visiting a phi node in PatchBufferOp, an incoming value may be unvisited and result in null when getting it from m_replacementMap. A shader to reproduce this issue is included in the commit.

This commit fixes the issue by calling the visit method when a value cannot be gotten from m_replacementMap, so there will be a valid value in the map.