### PR TITLE
Remove WaveBreak::DrawTime and add interface version 43

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -70,6 +70,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
 //* |     41.0 | Moved resource mapping from ShaderPipeline-level to Pipeline-level                                    |
 //* |     40.4 | Added fp32DenormalMode in PipelineShaderOptions to allow overriding SPIR-V denormal settings          |
@@ -423,11 +424,13 @@ enum class DenormalMode : unsigned {
 /// If next available quad falls outside tile aligned region of size defined by this enumeration the SC will force end
 /// of vector in the SC to shader wavefront.
 enum class WaveBreakSize : unsigned {
-  None = 0x0,     ///< No wave break by region
-  _8x8 = 0x1,     ///< Outside a 8x8 pixel region
-  _16x16 = 0x2,   ///< Outside a 16x16 pixel region
-  _32x32 = 0x3,   ///< Outside a 32x32 pixel region
+  None = 0x0,   ///< No wave break by region
+  _8x8 = 0x1,   ///< Outside a 8x8 pixel region
+  _16x16 = 0x2, ///< Outside a 16x16 pixel region
+  _32x32 = 0x3, ///< Outside a 32x32 pixel region
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 43
   DrawTime = 0xF, ///< Choose wave break size per draw
+#endif
 };
 
 /// Enumerates various sizing options of sub-group size for NGG primitive shader.

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -105,7 +105,6 @@ static constexpr char StreamOutTableAddress[] = ".stream_out_table_address";
 static constexpr char IndirectUserDataTableAddresses[] = ".indirect_user_data_table_addresses";
 static constexpr char NggSubgroupSize[] = ".nggSubgroupSize";
 static constexpr char NumInterpolants[] = ".num_interpolants";
-static constexpr char CalcWaveBreakSizeAtDrawTime[] = ".calc_wave_break_size_at_draw_time";
 static constexpr char Api[] = ".api";
 static constexpr char ApiCreateInfo[] = ".api_create_info";
 }; // namespace PipelineMetadataKey

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -90,13 +90,12 @@ enum class DenormalMode : unsigned {
 
 // If next available quad falls outside tile aligned region of size defined by this enumeration, the compiler
 // will force end of vector in the compiler to shader wavefront.
-// All of these values except DrawTime correspond to settings of WAVE_BREAK_REGION_SIZE in PA_SC_SHADER_CONTROL.
+// All of these values correspond to settings of WAVE_BREAK_REGION_SIZE in PA_SC_SHADER_CONTROL.
 enum class WaveBreak : unsigned {
   None = 0x0,     ///< No wave break by region
   _8x8 = 0x1,     ///< Outside a 8x8 pixel region
   _16x16 = 0x2,   ///< Outside a 16x16 pixel region
   _32x32 = 0x3,   ///< Outside a 32x32 pixel region
-  DrawTime = 0xF, ///< Choose wave break size per draw
 };
 
 // Value for shadowDescriptorTable pipeline option.

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -196,14 +196,6 @@ void ConfigBuilderBase::setEsGsLdsByteSize(unsigned value) {
 }
 
 // =====================================================================================================================
-// Set CALC_WAVE_BREAK_SIZE_AT_DRAW_TIME
-//
-// @param value : Value to set
-void ConfigBuilderBase::setCalcWaveBreakSizeAtDrawTime(bool value) {
-  m_pipelineNode[Util::Abi::PipelineMetadataKey::CalcWaveBreakSizeAtDrawTime] = value;
-}
-
-// =====================================================================================================================
 // Set hardware stage wavefront
 //
 // @param hwStage : Hardware shader stage

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -75,7 +75,6 @@ protected:
   void setPsWritesUavs(bool value);
   void setPsWritesDepth(bool value);
   void setEsGsLdsByteSize(unsigned value);
-  void setCalcWaveBreakSizeAtDrawTime(bool value);
   void setWaveFrontSize(Util::Abi::HardwareStage hwStage, unsigned value);
   void setApiName(const char *value);
   void setPipelineType(Util::Abi::PipelineType value);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1773,14 +1773,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   if (gfxIp.major == 10) {
     SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, MEM_ORDERED, true);
-
-    if (shaderOptions.waveBreakSize == lgc::WaveBreak::DrawTime)
-      setCalcWaveBreakSizeAtDrawTime(true);
-    else {
-      SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_SC_SHADER_CONTROL, WAVE_BREAK_REGION_SIZE,
-                          static_cast<unsigned>(shaderOptions.waveBreakSize));
-    }
-
+    SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_SC_SHADER_CONTROL, WAVE_BREAK_REGION_SIZE,
+                        static_cast<unsigned>(shaderOptions.waveBreakSize));
     SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_STEREO_CNTL, STEREO_MODE, STATE_STEREO_X);
     SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
   } else {

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -352,7 +352,6 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
       static_assert(static_cast<WaveBreak>(WaveBreakSize::_8x8) == WaveBreak::_8x8, "Mismatch");
       static_assert(static_cast<WaveBreak>(WaveBreakSize::_16x16) == WaveBreak::_16x16, "Mismatch");
       static_assert(static_cast<WaveBreak>(WaveBreakSize::_32x32) == WaveBreak::_32x32, "Mismatch");
-      static_assert(static_cast<WaveBreak>(WaveBreakSize::DrawTime) == WaveBreak::DrawTime, "Mismatch");
       shaderOptions.waveBreakSize = static_cast<WaveBreak>(shaderInfo->options.waveBreakSize);
 
       shaderOptions.loadScalarizerThreshold = 0;

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1579,7 +1579,9 @@ std::ostream &operator<<(std::ostream &out, WaveBreakSize waveBreakSize) {
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, _8x8)
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, _16x16)
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, _32x32)
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 43
     CASE_CLASSENUM_TO_STRING(WaveBreakSize, DrawTime)
+#endif
     break;
   default:
     llvm_unreachable("Should never be called!");

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -75,7 +75,9 @@ public:
     ADD_CLASS_ENUM_MAP(WaveBreakSize, _8x8)
     ADD_CLASS_ENUM_MAP(WaveBreakSize, _16x16)
     ADD_CLASS_ENUM_MAP(WaveBreakSize, _32x32)
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 43
     ADD_CLASS_ENUM_MAP(WaveBreakSize, DrawTime)
+#endif
 
     ADD_CLASS_ENUM_MAP(DenormalMode, Auto)
     ADD_CLASS_ENUM_MAP(DenormalMode, FlushToZero)


### PR DESCRIPTION
This mode is unsupported by PAL any more. We remove the PAL metadata
.calc_wave_break_size_at_draw_time as well.

Change-Id: Ie15133be87c99ea82489d7e870f42af319fdff21