### PR TITLE
Fix VFX issues when parsing pipeline file dumped from driver

### DIFF
--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -77,6 +77,10 @@ public:
     ADD_CLASS_ENUM_MAP(WaveBreakSize, _32x32)
     ADD_CLASS_ENUM_MAP(WaveBreakSize, DrawTime)
 
+    ADD_CLASS_ENUM_MAP(ShadowDescriptorTableUsage, Auto)
+    ADD_CLASS_ENUM_MAP(ShadowDescriptorTableUsage, Enable)
+    ADD_CLASS_ENUM_MAP(ShadowDescriptorTableUsage, Disable)
+
     ADD_CLASS_ENUM_MAP(DenormalMode, Auto)
     ADD_CLASS_ENUM_MAP(DenormalMode, FlushToZero)
     ADD_CLASS_ENUM_MAP(DenormalMode, Preserve)

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -133,6 +133,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -141,7 +142,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 19;
+  static const unsigned MemberCount = 21;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
- disableLoopUnroll is missing in ShaderOption
- memberCount of ShaderOption is wrong. Add two. One is for
  disableLoopUnroll. The other is for internally reserved.
- ShadowDescriptorTableUsage enumerants are not mapped to strings and
  VFX is unable to recognize them.

Change-Id: I83755f14846a985ce09483afe52e872fd54217e7