### PR TITLE
Link relocatable shaders with data in the .rodata section

### DIFF
--- a/llpc/test/shaderdb/PipelineVsFs_FsWithData.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_FsWithData.pipe
@@ -1,0 +1,81 @@
+; Test that constant data in the fragement shader is handled correctly.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: <_amdgpu_ps_main>:
+; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[fs_data_sym:[.a-z]*]]
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[fs_data_sym]]
+; SHADERTEST: 0000000000000000 <[[fs_data_sym]]>:
+; SHADERTEST-NEXT: 000000000000: 3F800000
+; SHADERTEST-NEXT: 000000000004: 00000000
+; SHADERTEST-NEXT: 000000000008: 00000000
+; SHADERTEST-NEXT: 00000000000C: 3F800000
+; SHADERTEST-NEXT: 000000000010: 00000000
+; SHADERTEST-NEXT: 000000000014: 3F800000
+; SHADERTEST-NEXT: 000000000018: 00000000
+; SHADERTEST-NEXT: 00000000001C: 3F800000
+; SHADERTEST-NEXT: 000000000020: 00000000
+; SHADERTEST-NEXT: 000000000024: 00000000
+; SHADERTEST-NEXT: 000000000028: 3F800000
+; SHADERTEST-NEXT: 00000000002C: 3F800000
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; SHADERTEST2-LABEL: <_amdgpu_ps_main>:
+; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[fsdata_offset:[0-9]*]]
+; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .text
+; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[fsdata_offset]]
+; SHADERTEST2-NEXT: R_AMDGPU_REL32_HI    .text
+; SHADERTEST2-LABEL: <__llpc_global_proxy_>:
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0]*}}[[fsdata_offset]]: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+void main() {
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) out vec4 outColor;
+
+vec4 colors[3] = vec4[](
+  vec4(1.0, 0.0, 0.0, 1.0),
+  vec4(0.0, 1.0, 0.0, 1.0),
+  vec4(0.0, 0.0, 1.0, 1.0)
+);
+
+void main() {
+  outColor = colors[gl_SampleID%3];
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0

--- a/llpc/test/shaderdb/PipelineVsFs_VsAndFsWithData.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_VsAndFsWithData.pipe
@@ -1,0 +1,106 @@
+; Test that constant data in the vertex shader is handled correctly.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: <_amdgpu_vs_main>:
+; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[vs_data_sym:[.a-z]*]]
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[vs_data_sym]]
+; SHADERTEST-LABEL: <_amdgpu_ps_main>:
+; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[fs_data_sym:[.a-z]*]]
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[fs_data_sym]]
+; SHADERTEST: 0000000000000000 <[[vs_data_sym]]>:
+; SHADERTEST-NEXT: 000000000000: 3F800000
+; SHADERTEST-NEXT: 000000000004: 00000000
+; SHADERTEST-NEXT: 000000000008: 00000000
+; SHADERTEST-NEXT: 00000000000C: 3F800000
+; SHADERTEST-NEXT: 000000000010: 00000000
+; SHADERTEST-NEXT: 000000000014: 3F800000
+; SHADERTEST-NEXT: 000000000018: 00000000
+; SHADERTEST-NEXT: 00000000001C: 3F800000
+; SHADERTEST-NEXT: 000000000020: 00000000
+; SHADERTEST-NEXT: 000000000024: 00000000
+; SHADERTEST-NEXT: 000000000028: 3F800000
+; SHADERTEST-NEXT: 00000000002C: 3F800000
+; SHADERTEST: 0000000000000030 <[[fs_data_sym]]>:
+; SHADERTEST-NEXT: 000000000030: 3F800000
+; SHADERTEST-NEXT: 000000000034: 00000000
+; SHADERTEST-NEXT: 000000000038: 00000000
+; SHADERTEST-NEXT: 00000000003C: 3F800000
+; SHADERTEST-NEXT: 000000000040: 00000000
+; SHADERTEST-NEXT: 000000000044: 3F800000
+; SHADERTEST-NEXT: 000000000048: 00000000
+; SHADERTEST-NEXT: 00000000004C: 3F800000
+; SHADERTEST-NEXT: 000000000050: 00000000
+; SHADERTEST-NEXT: 000000000054: 00000000
+; SHADERTEST-NEXT: 000000000058: 3F800000
+; SHADERTEST-NEXT: 00000000005C: 3F800000
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; SHADERTEST2-LABEL: <_amdgpu_vs_main>:
+; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset:[0-9]*]]
+; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .text
+; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset]]
+; SHADERTEST2-NEXT: R_AMDGPU_REL32_HI    .text
+; SHADERTEST2-LABEL: <__llpc_global_proxy_>:
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0]*}}[[vsdata_offset]]: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+vec4 pos[3] = vec4[](
+  vec4(1.0, 0.0, 0.0, 1.0),
+  vec4(0.0, 1.0, 0.0, 1.0),
+  vec4(0.0, 0.0, 1.0, 1.0)
+);
+
+void main() {
+  gl_Position = pos[gl_VertexIndex%3];
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) out vec4 outColor;
+
+vec4 colors[3] = vec4[](
+  vec4(1.0, 0.0, 0.0, 1.0),
+  vec4(0.0, 1.0, 0.0, 1.0),
+  vec4(0.0, 0.0, 1.0, 1.0)
+);
+
+void main() {
+  outColor = colors[gl_SampleID%3];
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0

--- a/llpc/test/shaderdb/PipelineVsFs_VsWithData.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_VsWithData.pipe
@@ -1,0 +1,82 @@
+; Test that constant data in the vertex shader is handled correctly.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: <_amdgpu_vs_main>:
+; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[vs_data_sym:[.a-z]*]]
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[vs_data_sym]]
+; SHADERTEST: 0000000000000000 <[[vs_data_sym]]>:
+; SHADERTEST-NEXT: 000000000000: 3F800000
+; SHADERTEST-NEXT: 000000000004: 00000000
+; SHADERTEST-NEXT: 000000000008: 00000000
+; SHADERTEST-NEXT: 00000000000C: 3F800000
+; SHADERTEST-NEXT: 000000000010: 00000000
+; SHADERTEST-NEXT: 000000000014: 3F800000
+; SHADERTEST-NEXT: 000000000018: 00000000
+; SHADERTEST-NEXT: 00000000001C: 3F800000
+; SHADERTEST-NEXT: 000000000020: 00000000
+; SHADERTEST-NEXT: 000000000024: 00000000
+; SHADERTEST-NEXT: 000000000028: 3F800000
+; SHADERTEST-NEXT: 00000000002C: 3F800000
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; SHADERTEST2-LABEL: <_amdgpu_vs_main>:
+; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset:[0-9]*]]
+; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .text
+; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset]]
+; SHADERTEST2-NEXT: R_AMDGPU_REL32_HI    .text
+; SHADERTEST2-LABEL: <__llpc_global_proxy_>:
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0]*}}[[vsdata_offset]]: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 00000000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+vec4 pos[3] = vec4[](
+  vec4(1.0, 0.0, 0.0, 1.0),
+  vec4(0.0, 1.0, 0.0, 1.0),
+  vec4(0.0, 0.0, 1.0, 1.0)
+);
+
+void main() {
+  gl_Position = pos[gl_VertexIndex%3];
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) out vec4 outColor;
+
+void main() {
+  outColor = vec4(1.0, 0.0, 0.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0


### PR DESCRIPTION
The current relocatabale shader linking does not work when there is read
only data.  See https://github.com/GPUOpen-Drivers/llpc/issues/896 for
an example.  So a change is going into LLVM
(https://reviews.llvm.org/D85895) to place the data in the .rodata
section instead of the .text section.  This change is to have the elf
linker handle it correclty.

Fixes #896