### PR TITLE
Don't build LLVM tools by default

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 ### Cached Project Options #############################################################################################
 option(LLPC_BUILD_LIT        "LLPC build lit test"         OFF)
-option(LLPC_BUILD_LLVM_TOOLS "Build LLVM tools"            ON)
+option(LLPC_BUILD_LLVM_TOOLS "Build LLVM tools"            OFF)
 option(LLPC_ENABLE_WERROR    "Build LLPC with more errors" OFF)
 
 if(ICD_BUILD_LLPC)


### PR DESCRIPTION
Most llvm are not required by llpc tests but take significant time
to compile and consume a lot of disk space.

This is as follow up commit to: https://github.com/GPUOpen-Drivers/llpc/pull/889.