### PR TITLE
Don't add EsGsLdsSize ABI metadata to TCS

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -866,8 +866,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       wantEsGsLdsSize = enableNgg;
       break;
     case ShaderStageTessControl:
-      wantEsGsLdsSize = m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 &&
-                        m_pipelineState->isGsOnChip() && cl::InRegEsGsLdsSize;
+      wantEsGsLdsSize = false;
       break;
     case ShaderStageTessEval:
       wantEsGsLdsSize = enableNgg;


### PR DESCRIPTION
EsGsLdsSize is used by NGG or GS-present. For TCS, it shouldn't be
added. This will cause a PAL assert SetupSignatureForStageFromElf()
when handling HS ABI metadata.

Change-Id: I53cd7c90f30d5aa2af5509a236c9de56ca3f5ded