### PR TITLE
Don't use PS_INPUT_* from glue code

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -171,7 +171,7 @@ private:
   std::pair<unsigned, unsigned> findInputSection(ElfInput &elfInput, object::SectionRef section);
 
   // Read PAL metadata from an ELF file and merge it in to the PAL metadata that we already have
-  void mergePalMetadataFromElf(object::ObjectFile &objectFile);
+  void mergePalMetadataFromElf(object::ObjectFile &objectFile, bool isGlueCode);
 
   // Write the PAL metadata out into the .note section.
   void writePalMetadata();
@@ -230,7 +230,7 @@ ElfLinkerImpl::ElfLinkerImpl(PipelineState *pipelineState, ArrayRef<MemoryBuffer
   // Gather and merge PAL metadata.
   m_pipelineState->clearPalMetadata();
   for (auto &elfInput : m_elfInputs)
-    mergePalMetadataFromElf(*elfInput.objectFile);
+    mergePalMetadataFromElf(*elfInput.objectFile, false);
 
   // Create any needed glue shaders.
   createGlueShaders();
@@ -542,7 +542,7 @@ std::pair<unsigned, unsigned> ElfLinkerImpl::findInputSection(ElfInput &elfInput
 // Read PAL metadata from an ELF file and merge it in to the PAL metadata that we already have
 //
 // @param objectFile : The ELF input
-void ElfLinkerImpl::mergePalMetadataFromElf(object::ObjectFile &objectFile) {
+void ElfLinkerImpl::mergePalMetadataFromElf(object::ObjectFile &objectFile, bool isGlueCode) {
   for (const object::SectionRef &section : objectFile.sections()) {
     object::ELFSectionRef elfSection(section);
     if (elfSection.getType() == ELF::SHT_NOTE) {
@@ -554,8 +554,8 @@ void ElfLinkerImpl::mergePalMetadataFromElf(object::ObjectFile &objectFile) {
       for (auto note : elfFile->notes(*shdr, err)) {
         if (note.getName() == Util::Abi::AmdGpuArchName && note.getType() == ELF::NT_AMDGPU_METADATA) {
           ArrayRef<uint8_t> desc = note.getDesc();
-          m_pipelineState->mergePalMetadataFromBlob(
-              StringRef(reinterpret_cast<const char *>(desc.data()), desc.size()));
+          m_pipelineState->mergePalMetadataFromBlob(StringRef(reinterpret_cast<const char *>(desc.data()), desc.size()),
+                                                    isGlueCode);
         }
       }
     }
@@ -645,7 +645,7 @@ bool ElfLinkerImpl::insertGlueShaders() {
     // Merge PAL metadata from glue ELF.
     // Note that the merger callback in PalMetadata.cpp relies on the PAL metadata for the shader/half-pipeline
     // ELFs being read first, and the glue shaders being merged in afterwards.
-    mergePalMetadataFromElf(*glueElfInput.objectFile);
+    mergePalMetadataFromElf(*glueElfInput.objectFile, true);
 
     // Insert the glue shader in the appropriate place in the list of ELFs.
     assert(insertPos != UINT_MAX && "Main shader not found for glue shader");

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -240,6 +240,10 @@ constexpr unsigned mmDB_SHADER_CONTROL = 0xA203;
 constexpr unsigned mmSPI_SHADER_Z_FORMAT = 0xA1C4;
 constexpr unsigned mmCB_SHADER_MASK = 0xA08F;
 
+// PS Input register numbers in PAL metadata
+constexpr unsigned int mmSPI_PS_INPUT_ENA = 0xA1B3;
+constexpr unsigned int mmSPI_PS_INPUT_ADDR = 0xA1B4;
+
 // Register bitfield layout.
 
 // General RSRC1 register, enough to get the VGPR and SGPR counts.

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -94,7 +94,7 @@ public:
   ~PalMetadata();
 
   // Read blob as PAL metadata and merge it into existing PAL metadata (if any).
-  void mergeFromBlob(llvm::StringRef blob);
+  void mergeFromBlob(llvm::StringRef blob, bool isGlueCode);
 
   // Record the PAL metadata into IR metadata in the specified module.
   void record(llvm::Module *module);

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -279,7 +279,7 @@ public:
   void clearPalMetadata();
 
   // Merge blob of MsgPack data into existing PAL metadata
-  void mergePalMetadataFromBlob(llvm::StringRef blob);
+  void mergePalMetadataFromBlob(llvm::StringRef blob, bool isGlueCode);
 
   // Set error message to be returned to the client by it calling getLastError
   void setError(const llvm::Twine &message);

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -255,11 +255,14 @@ void PipelineState::clearPalMetadata() {
 
 // =====================================================================================================================
 // Merge blob of MsgPack data into existing PAL metadata
-void PipelineState::mergePalMetadataFromBlob(StringRef blob) {
+//
+// @param blob : MsgPack PAL metadata to merge
+// @param isGlueCode : True if the blob is was generated for glue code.
+void PipelineState::mergePalMetadataFromBlob(llvm::StringRef blob, bool isGlueCode) {
   if (!m_palMetadata)
     m_palMetadata = new PalMetadata(this, blob);
   else
-    m_palMetadata->mergeFromBlob(blob);
+    m_palMetadata->mergeFromBlob(blob, isGlueCode);
 }
 
 // =====================================================================================================================

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_PsInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_PsInput.pipe
@@ -1,0 +1,59 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: SPI_PS_INPUT_CNTL_0                           0x0000000000000000
+; SHADERTEST: SPI_PS_INPUT_ENA                              0x0000000000000002
+; SHADERTEST: SPI_PS_INPUT_ADDR                             0x0000000000000002
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %26 %320
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %26 Location 0
+               OpDecorate %320 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+         %26 = OpVariable %_ptr_Input_v2float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+        %320 = OpVariable %_ptr_Output_v4float Output
+        %348 = OpUndef %v2float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+        %154 = OpLoad %v2float %26
+        %155 = OpVectorShuffle %v4float %154 %348 0 1 0 1
+               OpStore %320 %155
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+olorBuffer[0].format = VK_FORMAT_R16G16B16A16_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0


### PR DESCRIPTION
The color export shader will have entries for the PS_INPUT_* metadata,
but those values are completely wrong because the inputs to the color
export shader has no connection with the inputs to the pixel shader.  We
need to avoid using those values.

Fixes https://github.com/GPUOpen-Drivers/llpc/issues/861