### PR TITLE
[WIP] Use CreateIntrinsicByType for creating lane intrinsics

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -500,3 +500,25 @@ CallInst *Builder::CreateIntrinsic(Intrinsic::ID id, ArrayRef<Type *> types, Arr
   return result;
 }
 
+// =====================================================================================================================
+// Create a call to the specified intrinsic with the specified arguments, mangled automatically based on the return
+// type and argument types.
+//
+// Prefer @ref CreateIntrinsic, except when an intrinsic's overload mangling is changed in LLVM. VarArg intrinsics are
+// not supported by this method.
+//
+// This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math flags from
+// the Builder if none are specified by pFmfSource.
+//
+// @param id : Intrinsic ID
+// @param retTy : Return type
+// @param args : Input values
+// @param fmfSource : Instruction to copy fast math flags from; nullptr to get from Builder
+// @param name : Name to give instruction
+CallInst *Builder::CreateIntrinsicByType(Intrinsic::ID id, Type *retTy, ArrayRef<Value *> args, Instruction *fmfSource,
+                                         const Twine &name) {
+  CallInst *result = IRBuilder<>::CreateIntrinsicByType(id, retTy, args, fmfSource, name);
+  if (!fmfSource && isa<FPMathOperator>(result))
+    result->setFastMathFlags(getFastMathFlags());
+  return result;
+}

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -356,7 +356,7 @@ Value *DescBuilder::scalarizeIfUniform(Value *value, bool isNonUniform) {
   if (!isNonUniform && !isa<Constant>(value)) {
     // NOTE: GFX6 encounters GPU hang with this optimization enabled. So we should skip it.
     if (getPipelineState()->getTargetInfo().getGfxIpVersion().major > 6)
-      value = CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, value);
+      value = CreateIntrinsicByType(Intrinsic::amdgcn_readfirstlane, getInt32Ty(), value);
   }
   return value;
 }

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -232,6 +232,16 @@ public:
                                   llvm::ArrayRef<llvm::Value *> args, llvm::Instruction *fmfSource = nullptr,
                                   const llvm::Twine &name = "");
 
+  /// Create a call to intrinsic @p ID with return type @p RetTy and arguments @p Args. Type overloads are deduced
+  /// automatically.
+  ///
+  /// If @p FMFSource is provided, copy fast-math-flags from that instruction to the intrinsic.
+  ///
+  /// @note This overload is convenient when the overload signature of an intrinsic changes in LLVM.
+  /// @ref CreateIntrinsic should be used otherwise.
+  llvm::CallInst *CreateIntrinsicByType(llvm::Intrinsic::ID id, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
+                                        llvm::Instruction *fmfSource = nullptr, const llvm::Twine &name = "");
+
   // -----------------------------------------------------------------------------------------------------------------
   // Arithmetic operations
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2728,7 +2728,7 @@ Value *SPIRVToLLVM::indexDescPtr(Type *elementTy, Value *base, Value *index, boo
   index = getBuilder()->CreateMul(index, stride);
   if (!isNonUniform && !isa<Constant>(index)) {
     // For a non-constant but uniform index, mark it uniform.
-    index = getBuilder()->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, index);
+    index = getBuilder()->CreateIntrinsicByType(Intrinsic::amdgcn_readfirstlane, getBuilder()->getInt32Ty(), index);
   }
 
   // Do the indexing operation by GEPping as a byte pointer.


### PR DESCRIPTION
The proposed upstream LLVM change https://reviews.llvm.org/D86154 adds a
type overload to lane intrinsics (readfirstlane, readlane, writelane).
This is a flag-day compatibility breaking change when CreateIntrinsic is
used, which expects a correct list of overload types.

The new method CreateIntrinsicByType, introduced by the upstream LLVM
change https://reviews.llvm.org/D86317, instead deduces the overload
types from the return type and argument types, which will allow us to
not make the change to the lane intrinsics as a flag-day change.