### PR TITLE
Fix bug causing SPIRV files to be missing for a dumped pipeline.

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -571,6 +571,9 @@ void PipelineDumper::DumpSpirvBinary(const char *dumpDir, const BinaryData *spir
   pathName += "/";
   pathName += getSpirvBinaryFileName(hash);
 
+  // Make sure directory exists
+  createDirectory(dumpDir);
+
   // Open dumpfile
   std::ofstream dumpFile(pathName.c_str(), std::ios_base::binary | std::ios_base::out);
   if (!dumpFile.bad())


### PR DESCRIPTION
Address a bug where the SPIRV files would be missing for the first
pipeline dumped if the pipeline dump directory needed to be
created.  This occurs because the SPIRV output was attempted
before the BeginPipelineDump call which creates the dump directory.
Move the SPIRV file output to occur when pipeline data is written
to the .pipe file.