### PR TITLE
Fix for removal of ElementCount constructors in upstream LLVM.

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -1015,7 +1015,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       auto zero = m_builder->getInt32(0);
 
       // Zero per-wave primitive/vertex count
-      auto zeros = ConstantVector::getSplat({Gfx9::NggMaxWavesPerSubgroup, false}, zero);
+      auto zeros = ConstantVector::getSplat(ElementCount::get(Gfx9::NggMaxWavesPerSubgroup, false), zero);
 
       auto ldsOffset = m_builder->getInt32(regionStart);
       m_ldsManager->writeValueToLds(zeros, ldsOffset);

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1085,7 +1085,7 @@ void PatchBufferOp::postVisitMemSetInst(MemSetInst &memSetInst) {
     Value *newValue = nullptr;
 
     if (Constant *const constVal = dyn_cast<Constant>(value)) {
-      newValue = ConstantVector::getSplat({stride, false}, constVal);
+      newValue = ConstantVector::getSplat(ElementCount::get(stride, false), constVal);
       newValue = m_builder->CreateBitCast(newValue, castDestType->getPointerElementType());
       copyMetadata(newValue, &memSetInst);
     } else {


### PR DESCRIPTION
Replace implicit ElementCount objects with ElementCount::get().