### PR TITLE
Add Image resource type workaround

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -70,6 +70,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |
 //* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
 //* |     41.0 | Moved resource mapping from ShaderPipeline-level to Pipeline-level                                    |
@@ -325,7 +326,8 @@ struct PipelineOptions {
                                    ///  the out of bounds accesses will be skipped with this setting.
   bool enableRelocatableShaderElf; ///< If set, the pipeline will be compiled by compiling each shader separately, and
                                    ///  then linking them, when possible.  When not possible this option is ignored.
-
+  bool disableImageResourceCheck;  ///< If set, the pipeline shader will not contain code to check and fix invalid image
+                                   ///  descriptors.
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
   ExtendedRobustness extendedRobustness;                 ///< ExtendedRobustness is intended to correspond to the

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -412,6 +412,9 @@ private:
   // Patch descriptor with cube dimension for image call
   llvm::Value *patchCubeDescriptor(llvm::Value *desc, unsigned dim);
 
+  // Patch invalid resource descriptor for image call
+  llvm::Value *patchInvalidImageDescriptor(llvm::Value *desc);
+
   // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
   llvm::Value *handleFragCoordViewIndex(llvm::Value *coord, unsigned flags, unsigned &dim);
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -123,6 +123,7 @@ struct Options {
   unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
                                        //   ShadowDescriptorTableDisable to disable shadow descriptor tables
   unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
+  unsigned disableImageResourceCheck;  // Don't do image resource type check
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -311,6 +311,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
   }
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;
+  options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
   pipeline->setOptions(options);
 
   // Give the shader options (including the hash) to the middle-end.


### PR DESCRIPTION
GFX10 hardware cannot handle invalid image resource type [1, 7], so we
change such kind of value to 0 (buffer) to let hardware ignore the request.
Add an option to disable it for possible performance loss.