### PR TITLE
[CI] Remove glslang pin for sanitizer build

### DIFF
--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -62,11 +62,7 @@ RUN repo init -u https://github.com/GPUOpen-Drivers/AMDVLK.git -b "$BRANCH" \
     && repo sync -c --no-clone-bundle -j$(nproc) \
     && touch ./env.sh \
     && cd /vulkandriver/drivers/spvgen/external \
-    && python3 fetch_external_sources.py \
-    && if echo "$FEATURES" | grep -q "+sanitizers" ; then \
-         cd glslang \
-         && git checkout adacba3ee9213be19c8c238334a3a61ae4201812; \
-       fi
+    && python3 fetch_external_sources.py
 
 # Build LLPC.
 WORKDIR /vulkandriver/builds/ci-build


### PR DESCRIPTION
The pinned glslang commit in spvgen was updated to a more recent commit.
Building the commit that was pinned in docker lead to failing builds.

I did not do a docker build, but I checked locally that using the old
glslang version leads to the same build failure as in the GitHub CI
and not pinning it works fine.