### PR TITLE
[CI] Allow manual trigger of amdvlk base build

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -3,6 +3,7 @@ name: Build AMDVLK for LLPC
 on:
   schedule:
     - cron:  "0 */12 * * *"
+  workflow_dispatch:
 
 jobs:
   build-and-push-amdvlk:


### PR DESCRIPTION
This adds a ‘Run workflow’ button in the GitHub ui, so we can recreate the base image on demand.
GitHub doc: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/