### PR TITLE
Clean up logging and variable name.

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -828,6 +828,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
       elf[stage].assign(data, data + elfBin.codeSize);
       // Release Entry
       ReleaseCacheEntry(false, nullptr, &cacheEntry);
+      LLPC_OUTS("Cache hit for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
       continue;
     }
 
@@ -838,10 +839,10 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
     if (cacheEntryState == ShaderEntryState::Ready) {
       auto data = reinterpret_cast<const char *>(elfBin.pCode);
       elf[stage].assign(data, data + elfBin.codeSize);
-      LLPC_OUTS("Cache hit for shader stage " << stage << "\n");
+      LLPC_OUTS("Cache hit for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
       continue;
     }
-    LLPC_OUTS("Cache miss for shader stage " << stage << "\n");
+    LLPC_OUTS("Cache miss for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
 
     // There was a cache miss, so we need to build the relocatable shader for
     // this stage.

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -77,19 +77,19 @@ public:
   static void DumpPipelineExtraInfo(PipelineDumpFile *binaryFile, const std::string *str);
 
   static MetroHash::Hash generateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
-                                                         bool isRelocatableShader, unsigned stage = ShaderStageInvalid);
+                                                         bool isUnlinked, unsigned stage = ShaderStageInvalid);
 
   static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline, bool isCacheHash,
-                                                        bool isRelocatableShader);
+                                                        bool isUnlinked);
 
   static std::string getPipelineInfoFileName(PipelineBuildInfo pipelineInfo, const MetroHash::Hash *hash);
 
   static void updateHashForPipelineShaderInfo(ShaderStage stage, const PipelineShaderInfo *shaderInfo, bool isCacheHash,
-                                              MetroHash64 *hasher, bool isRelocatableShader);
+                                              MetroHash64 *hasher, bool isUnlinked);
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 41
   static void updateHashForResourceMappingInfo(const ResourceMappingData *pResourceMapping, MetroHash64 *hasher,
-                                               bool isRelocatableShader);
+                                               bool isUnlinked);
 #endif
 
   static void updateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo *vertexInput,
@@ -134,7 +134,7 @@ private:
   static void dumpPipelineOptions(const PipelineOptions *options, std::ostream &dumpFile);
 
   static void updateHashForResourceMappingNode(const ResourceMappingNode *userDataNode, bool isRootNode,
-                                               MetroHash64 *hasher, bool isRelocatableShader);
+                                               MetroHash64 *hasher, bool isUnlinked);
 };
 
 } // namespace Vkgc


### PR DESCRIPTION
- Rename the variable `isRelocatableShader` in the hash code.  The term
"unlinked" is a better description.

- Output the name of the shader stage instead of its number when logging
cache hits and misses.

- Add logging for a cache hit in the binary cache.