### PR TITLE
Clean up logging and function comments

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -828,6 +828,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
       elf[stage].assign(data, data + elfBin.codeSize);
       // Release Entry
       ReleaseCacheEntry(false, nullptr, &cacheEntry);
+      LLPC_OUTS("Cache hit for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
       continue;
     }
 
@@ -838,10 +839,10 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
     if (cacheEntryState == ShaderEntryState::Ready) {
       auto data = reinterpret_cast<const char *>(elfBin.pCode);
       elf[stage].assign(data, data + elfBin.codeSize);
-      LLPC_OUTS("Cache hit for shader stage " << stage << "\n");
+      LLPC_OUTS("Cache hit for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
       continue;
     }
-    LLPC_OUTS("Cache miss for shader stage " << stage << "\n");
+    LLPC_OUTS("Cache miss for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
 
     // There was a cache miss, so we need to build the relocatable shader for
     // this stage.

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -879,6 +879,7 @@ MetroHash::Hash PipelineDumper::generateHashForGraphicsPipeline(const GraphicsPi
 //
 // @param pipeline : Info to build a compute pipeline
 // @param isCacheHash : TRUE if the hash is used by shader cache
+// @param isRelocatableShader : TRUE if we are building relocatable shader
 MetroHash::Hash PipelineDumper::generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline,
                                                                bool isCacheHash, bool isRelocatableShader) {
   MetroHash64 hasher;
@@ -1037,6 +1038,7 @@ void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo 
 // @param shaderInfo : Shader info in specified shader stage
 // @param isCacheHash : TRUE if the hash is used by shader cache
 // @param [in/out] hasher : Haher to generate hash code
+// @param isRelocatableShader : TRUE if we are building relocatable shader
 void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const PipelineShaderInfo *shaderInfo,
                                                      bool isCacheHash, MetroHash64 *hasher, bool isRelocatableShader) {
   if (shaderInfo->pModuleData) {
@@ -1175,6 +1177,7 @@ void PipelineDumper::updateHashForResourceMappingInfo(const ResourceMappingData 
 // @param userDataNode : Resource mapping node
 // @param isRootNode : TRUE if the node is in root level
 // @param [in/out] hasher : Haher to generate hash code
+// @param isRelocatableShader : TRUE if we are building relocatable shader
 void PipelineDumper::updateHashForResourceMappingNode(const ResourceMappingNode *userDataNode, bool isRootNode,
                                                       MetroHash64 *hasher, bool isRelocatableShader) {
   hasher->Update(userDataNode->type);


### PR DESCRIPTION
- Output the name of the shader stage instead of its number when logging
cache hits and misses.

- Add logging for a cache hit in the binary cache.

- Fixup some places where comments where missing for function
parameters.