### PR TITLE
Don't hash user data nodes for reloc shaders.

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -134,7 +134,7 @@ private:
   static void dumpPipelineOptions(const PipelineOptions *options, std::ostream &dumpFile);
 
   static void updateHashForResourceMappingNode(const ResourceMappingNode *userDataNode, bool isRootNode,
-                                               MetroHash64 *hasher, bool isRelocatableShader);
+                                               MetroHash64 *hasher);
 };
 
 } // namespace Vkgc


### PR DESCRIPTION
Relocatable shader do not use any of the user data nodes, so the hash
should not include any infomration in them.