### PR TITLE
Update VS input and non frag hash for reloc shaders

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2077,7 +2077,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
   }
 
   if (stageMask & ~shaderStageToMask(ShaderStageFragment)) {
-    PipelineDumper::updateHashForNonFragmentState(pipelineInfo, true, &nonFragmentHasher);
+    PipelineDumper::updateHashForNonFragmentState(pipelineInfo, true, &nonFragmentHasher, false);
     nonFragmentHasher.Finalize(nonFragmentHash->bytes);
   }
 }

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -105,7 +105,7 @@ public:
   }
 
   static void updateHashForNonFragmentState(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
-                                            MetroHash64 *hasher);
+                                            MetroHash64 *hasher, bool isRelocatableShader);
 
   static void updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher);
 


### PR DESCRIPTION
For relocatable shader, there are a few elements of the pipeline state
that do not have to be included in the hash.

- The vertex input states are used to construct the fetch shader, but
not the main body.

- The depth clip flag is handled when finalizing the metadata, which
happens when linking relocatable shader.

- Many ngg related flags are only needed if ngg is enabled.

- rasterizerDiscardEnable seems to only change the elf if ngg is enabled, so I
moved it with the rest of the rs state hashing.