### PR TITLE
Remove elements from the hash for reloc ps shaders

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -240,9 +240,11 @@ constexpr unsigned mmDB_SHADER_CONTROL = 0xA203;
 constexpr unsigned mmSPI_SHADER_Z_FORMAT = 0xA1C4;
 constexpr unsigned mmCB_SHADER_MASK = 0xA08F;
 
-// PS Input register numbers in PAL metadata
-constexpr unsigned int mmSPI_PS_INPUT_ENA = 0xA1B3;
-constexpr unsigned int mmSPI_PS_INPUT_ADDR = 0xA1B4;
+// PS register numbers in PAL metadata
+constexpr unsigned mmSPI_PS_INPUT_ENA = 0xA1B3;
+constexpr unsigned mmSPI_PS_INPUT_ADDR = 0xA1B4;
+constexpr unsigned mmPA_SC_SHADER_CONTROL = 0xA310;
+constexpr unsigned mmPA_SC_AA_CONFIG = 0xA2F8;
 
 // Register bitfield layout.
 
@@ -320,6 +322,33 @@ union DB_SHADER_CONTROL {
     unsigned int : 20;
   } bitfields, bits;
   unsigned int u32All;
+};
+
+union PA_SC_SHADER_CONTROL {
+  struct {
+    unsigned : 5;
+    unsigned WAVE_BREAK_REGION_SIZE : 2;
+    unsigned : 25;
+  } gfx10;
+
+  unsigned u32All;
+};
+
+enum CovToShaderSel {
+  INPUT_COVERAGE = 0x00000000,
+  INPUT_INNER_COVERAGE = 0x00000001,
+  INPUT_DEPTH_COVERAGE = 0x00000002,
+  RAW = 0x00000003,
+};
+
+union PA_SC_AA_CONFIG {
+  struct {
+    unsigned : 26;
+    unsigned COVERAGE_TO_SHADER_SELECT : 2;
+    unsigned : 4;
+  } bits, bitfields;
+
+  unsigned u32All;
 };
 
 } // namespace lgc

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1774,8 +1774,6 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   if (gfxIp.major == 10) {
     SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC1_PS, MEM_ORDERED, true);
-    SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_SC_SHADER_CONTROL, WAVE_BREAK_REGION_SIZE,
-                        static_cast<unsigned>(shaderOptions.waveBreakSize));
     SET_REG_GFX10_FIELD(&pConfig->psRegs, PA_STEREO_CNTL, STEREO_MODE, STATE_STEREO_X);
     SET_REG_GFX10_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
   } else {
@@ -1937,12 +1935,6 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
     setPsWritesDepth(builtInUsage.fragDepth);
   } else
     setPsUsesUavs(static_cast<unsigned>(resUsage->resourceWrite));
-
-  if (m_pipelineState->getRasterizerState().innerCoverage) {
-    SET_REG_FIELD(&pConfig->psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_INNER_COVERAGE);
-  } else {
-    SET_REG_FIELD(&pConfig->psRegs, PA_SC_AA_CONFIG, COVERAGE_TO_SHADER_SELECT, INPUT_COVERAGE);
-  }
 
   const unsigned loadCollisionWaveId = GET_REG_FIELD(&pConfig->psRegs, SPI_SHADER_PGM_RSRC2_PS, LOAD_COLLISION_WAVEID);
   const unsigned loadIntrawaveCollision =

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -483,6 +483,23 @@ void PalMetadata::finalizePipeline() {
           m_pipelineState->getColorExportState().alphaToCoverageEnable == false;
       setRegister(mmDB_SHADER_CONTROL, dbShaderControl.u32All);
     }
+
+    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major == 10) {
+      auto waveBreakSize = m_pipelineState->getShaderOptions(ShaderStageFragment).waveBreakSize;
+      PA_SC_SHADER_CONTROL paScShaderControl = {};
+      paScShaderControl.gfx10.WAVE_BREAK_REGION_SIZE = static_cast<unsigned int>(waveBreakSize);
+      setRegister(mmPA_SC_SHADER_CONTROL, paScShaderControl.u32All);
+    }
+
+    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9) {
+      PA_SC_AA_CONFIG paScAaConfig = {};
+      if (m_pipelineState->getRasterizerState().innerCoverage) {
+        paScAaConfig.bitfields.COVERAGE_TO_SHADER_SELECT = INPUT_INNER_COVERAGE;
+      } else {
+        paScAaConfig.bitfields.COVERAGE_TO_SHADER_SELECT = INPUT_COVERAGE;
+      }
+      setRegister(mmPA_SC_AA_CONFIG, paScAaConfig.u32All);
+    }
   }
 
   // If there are root user data nodes but none of them are used, adjust userDataLimit accordingly.

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2072,7 +2072,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
     fragmentHasher.Update(pipelineOptions->extendedRobustness.robustBufferAccess);
     fragmentHasher.Update(pipelineOptions->extendedRobustness.robustImageAccess);
     fragmentHasher.Update(pipelineOptions->extendedRobustness.nullDescriptor);
-    PipelineDumper::updateHashForFragmentState(pipelineInfo, &fragmentHasher);
+    PipelineDumper::updateHashForFragmentState(pipelineInfo, &fragmentHasher, false);
     fragmentHasher.Finalize(fragmentHash->bytes);
   }
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -869,7 +869,7 @@ MetroHash::Hash PipelineDumper::generateHashForGraphicsPipeline(const GraphicsPi
   }
 
   if (stage == ShaderStageFragment || stage == ShaderStageInvalid)
-    updateHashForFragmentState(pipeline, &hasher);
+    updateHashForFragmentState(pipeline, &hasher, isRelocatableShader);
 
   MetroHash::Hash hash = {};
   hasher.Finalize(hash.bytes);
@@ -1014,22 +1014,27 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
 //
 // @param pipeline : Info to build a graphics pipeline
 // @param [in/out] hasher : Hasher to generate hash code
-void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher) {
+// @param isRelocatableShader : TRUE if we are building relocatable shader
+void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher,
+                                                bool isRelocatableShader) {
   auto rsState = &pipeline->rsState;
-  hasher->Update(rsState->innerCoverage);
   hasher->Update(rsState->perSampleShading);
-  hasher->Update(rsState->numSamples);
-  hasher->Update(rsState->samplePatternIdx);
 
-  auto cbState = &pipeline->cbState;
-  hasher->Update(cbState->alphaToCoverageEnable);
-  hasher->Update(cbState->dualSourceBlendEnable);
-  for (unsigned i = 0; i < MaxColorTargets; ++i) {
-    if (cbState->target[i].format != VK_FORMAT_UNDEFINED) {
-      hasher->Update(cbState->target[i].channelWriteMask);
-      hasher->Update(cbState->target[i].blendEnable);
-      hasher->Update(cbState->target[i].blendSrcAlphaToColor);
-      hasher->Update(cbState->target[i].format);
+  if (!isRelocatableShader) {
+    hasher->Update(rsState->innerCoverage);
+    hasher->Update(rsState->numSamples);
+    hasher->Update(rsState->samplePatternIdx);
+
+    auto cbState = &pipeline->cbState;
+    hasher->Update(cbState->alphaToCoverageEnable);
+    hasher->Update(cbState->dualSourceBlendEnable);
+    for (unsigned i = 0; i < MaxColorTargets; ++i) {
+      if (cbState->target[i].format != VK_FORMAT_UNDEFINED) {
+        hasher->Update(cbState->target[i].channelWriteMask);
+        hasher->Update(cbState->target[i].blendEnable);
+        hasher->Update(cbState->target[i].blendSrcAlphaToColor);
+        hasher->Update(cbState->target[i].format);
+      }
     }
   }
 }
@@ -1114,7 +1119,10 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.maxThreadGroupsPerComputeUnit);
       hasher->Update(options.waveSize);
       hasher->Update(options.wgpMode);
-      hasher->Update(options.waveBreakSize);
+
+      if (!isRelocatableShader)
+        hasher->Update(options.waveBreakSize);
+
       hasher->Update(options.forceLoopUnrollCount);
       hasher->Update(options.useSiScheduler);
       hasher->Update(options.updateDescInElf);

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -107,7 +107,8 @@ public:
   static void updateHashForNonFragmentState(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
                                             MetroHash64 *hasher);
 
-  static void updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher);
+  static void updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher,
+                                         bool isRelocatableShader);
 
   // Get name of register, or "" if not known
   static const char *getRegisterNameString(unsigned regNumber);


### PR DESCRIPTION
Some element that we hash are not needed for relocatable shaders because
the are handled during the link step.

- Set the wavebrake size during metadata finalization and not include it
in the hash

- Set the inner coveration during metadata finalization and not include
it in the hash

- The cbstate is only used when generating the color export shader, so
not needed in the hash.

- Relocation are added for numSamples and samplePatternIdx, so they are not
needed in the hash.