### PR TITLE
Resolves AMDLLPC tool compilation error

### DIFF
--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -915,7 +915,7 @@ static Result checkAutoLayoutCompatibleFunc(const ICompiler *compiler, CompileIn
       buildTopLevelMapping(compileInfo->stageMask, nodeSets, pushConstSize, &resourceMappingAuto);
       if (checkResourceMappingComptible(&pipelineInfo->resourceMapping, resourceMappingAuto.userDataNodeCount,
                                         resourceMappingAuto.pUserDataNodes) &&
-          checkPipelineStateCompatible(compiler, pipelineInfo, &pipelineInfoCopy, ParsedGfxIp))
+          checkPipelineStateCompatible(compiler, pipelineInfo, &pipelineInfoAuto, ParsedGfxIp))
         outs() << "Auto Layout fragment shader in " << compileInfo->fileNames << " hit\n";
       else
         outs() << "Auto Layout fragment shader in " << compileInfo->fileNames << " failed to hit\n";


### PR DESCRIPTION
The pipelineInfoCopy variable in amdllpc.cpp was renamed to
pipelineInfoAuto. However, one spot was missed. This leads to a
compilation error when building AMDLLPC with
LLPC_CLIENT_INTERFACE_VERSION >= 41.