### PR TITLE
Fix a mistake in shader merger that adds primitive shader as a member

### DIFF
--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -49,7 +49,7 @@ using namespace lgc;
 // @param pipelineShaders : API shaders in the pipeline
 ShaderMerger::ShaderMerger(PipelineState *pipelineState, PipelineShaders *pipelineShaders)
     : m_pipelineState(pipelineState), m_context(&pipelineState->getContext()),
-      m_gfxIp(pipelineState->getTargetInfo().getGfxIpVersion()), m_primShader(pipelineState) {
+      m_gfxIp(pipelineState->getTargetInfo().getGfxIpVersion()) {
   assert(m_gfxIp.major >= 9);
   assert(m_pipelineState->isGraphics());
 

--- a/lgc/patch/ShaderMerger.h
+++ b/lgc/patch/ShaderMerger.h
@@ -96,8 +96,6 @@ private:
   llvm::LLVMContext *m_context;   // LLVM context
   GfxIpVersion m_gfxIp;           // Graphics IP version info
 
-  NggPrimShader m_primShader; // Manager of NGG primitive shader
-
   bool m_hasVs;  // Whether the pipeline has vertex shader
   bool m_hasTcs; // Whether the pipeline has tessellation control shader
   bool m_hasTes; // Whether the pipeline has tessellation evaluation shader


### PR DESCRIPTION
We don't need this because primitive shader is created by
buildPrimShader(). This is a coding mistake.

Change-Id: I6875608be010e35ac659cd32b0dd769c17343ce7