### PR TITLE
NGG: Add runtime passthrough support

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1540,7 +1540,9 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
   // TODO: Multiple output streams are not supported.
   SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GS_OUT_PRIM_TYPE, OUTPRIM_TYPE, gsOutputPrimitiveType);
   SET_REG_FIELD(&pConfig->primShaderRegs, VGT_GSVS_RING_ITEMSIZE, ITEMSIZE, calcFactor.gsVsRingItemSize);
-  SET_REG_FIELD(&pConfig->primShaderRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, calcFactor.esGsRingItemSize);
+  // NOTE: When GS is absent, always set ES-GS ring item size to 1. Thus, we can easily get vertex ID in subgroup
+  // without any additional calculations.
+  SET_REG_FIELD(&pConfig->primShaderRegs, VGT_ESGS_RING_ITEMSIZE, ITEMSIZE, hasGs ? calcFactor.esGsRingItemSize : 1);
 
   const unsigned maxVertsPerSubgroup = std::min(gsInstPrimsInSubgrp * maxVertOut, NggMaxThreadsPerSubgroup);
   SET_REG_FIELD(&pConfig->primShaderRegs, GE_MAX_OUTPUT_PER_SUBGROUP, MAX_VERTS_PER_SUBGROUP, maxVertsPerSubgroup);

--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -57,29 +57,13 @@ const unsigned NggLdsManager::LdsRegionSizes[LdsRegionCount] = {
     // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionDistribPrimId
     // 4 dwords (vec4) per thread
-    SizeOfVec4 * Gfx9::NggMaxThreadsPerSubgroup,              // LdsRegionPosData
-    // 1 byte (uint8) per thread
-    Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionDrawFlag
+    SizeOfVec4 * Gfx9::NggMaxThreadsPerSubgroup,              // LdsRegionVertPosData
+    // Vertex cull info size is dynamically calculated (don't use it)
+    InvalidValue,                                             // LdsRegionVertCullInfo
     // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
     SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionVertCountInWaves
     // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCullDistance
-    // 1 byte (uint8) per thread
-    Gfx9::NggMaxThreadsPerSubgroup,                           // LdsRegionVertThreadIdMap
-    // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactVertexId
-    // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactInstanceId
-    // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactPrimId
-    // 1 dword (float) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactTessCoordX
-    // 1 dword (float) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactTessCoordY
-    // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactPatchId
-    // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionCompactRelPatchId
+    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionVertThreadIdMap
 
     //
     // LDS region size for ES-GS
@@ -105,18 +89,10 @@ const char *NggLdsManager::m_ldsRegionNames[LdsRegionCount] = {
     // LDS region name for ES-only
     //
     "Distributed primitive ID",             // LdsRegionDistribPrimId
-    "Vertex position data",                 // LdsRegionPosData
-    "Draw flag",                            // LdsRegionDrawFlag
+    "Vertex position data",                 // LdsRegionVertPosData
+    "Vertex cull info",                     // LdsRegionVertCullInfo
     "Vertex count in waves",                // LdsRegionVertCountInWaves
-    "Cull distance",                        // LdsRegionCullDistance
     "Vertex thread ID map",                 // LdsRegionVertThreadIdMap
-    "Compacted vertex ID (VS)",             // LdsRegionCompactVertexId
-    "Compacted instance ID (VS)",           // LdsRegionCompactInstanceId
-    "Compacted primitive ID (VS)",          // LdsRegionCompactPrimId
-    "Compacted tesscoord X (TES)",          // LdsRegionCompactTessCoordX
-    "Compacted tesscoord Y (TES)",          // LdsRegionCompactTessCoordY
-    "Compacted patch ID (TES)",             // LdsRegionCompactPatchId
-    "Compacted relative patch ID (TES)",    // LdsRegionCompactRelPatchId
 
     //
     // LDS region name for ES-GS
@@ -135,19 +111,13 @@ const char *NggLdsManager::m_ldsRegionNames[LdsRegionCount] = {
 // @param pipelineState : Pipeline state
 // @param builder : LLVM IR builder
 NggLdsManager::NggLdsManager(Module *module, PipelineState *pipelineState, IRBuilder<> *builder)
-    : m_pipelineState(pipelineState), m_context(&pipelineState->getContext()),
-      m_waveCountInSubgroup(Gfx9::NggMaxThreadsPerSubgroup /
-                            m_pipelineState->getTargetInfo().getGpuProperty().waveSize),
-      m_builder(builder) {
+    : m_pipelineState(pipelineState), m_context(&pipelineState->getContext()), m_builder(builder) {
   assert(builder);
 
   const auto nggControl = m_pipelineState->getNggControl();
   assert(nggControl->enableNgg);
 
-  const unsigned stageMask = m_pipelineState->getShaderStageMask();
-  const bool hasGs = (stageMask & shaderStageToMask(ShaderStageGeometry));
-  const bool hasTs =
-      ((stageMask & (shaderStageToMask(ShaderStageTessControl) | shaderStageToMask(ShaderStageTessEval))) != 0);
+  const bool hasGs = m_pipelineState->hasShaderStage(ShaderStageGeometry);
 
   //
   // Create global variable modeling LDS
@@ -212,46 +182,33 @@ NggLdsManager::NggLdsManager(Module *module, PipelineState *pipelineState, IRBui
       //
       // The LDS layout is something like this:
       //
-      // +--------------------------+-----------+----------------------------+---------------+
-      // | Vertex position data     | Draw flag | Vertex count (in waves)    | Cull distance | >>>
-      // +--------------------------+-----------+----------------------------+---------------+
-      // | Distributed primitive ID |           | Primitive count (in waves) |
-      // +--------------------------+           +----------------------------+
+      // +--------------------------+
+      // | Distributed primitive ID |
+      // +--------------------------+
       //
-      //                            | ====== Compacted data region (for vertex compaction) ====== |
-      //     +----------------------+-------------+-------------+-------------+
-      // >>> | Vertex thread ID map | Vertex ID   | Instance ID | Primtive ID |                     (VS)
-      //     +----------------------+-------------+-------------+-------------+-------------------+
-      //                            | Tesscoord X | Tesscoord Y | Patch ID    | Relative patch ID | (TES)
-      //                            +-------------+-------------+-------------+-------------------+
+      // +----------------------+-------------------------------+-------------------------+----------------------+
+      // | Vertex position data | Vertex cull info (ES-GS ring) | Vertex count (in waves) | Vertex thread ID map |
+      // +----------------------+-------------------------------+-------------------------+----------------------+
       //
       unsigned ldsRegionStart = 0;
       for (unsigned region = LdsRegionEsBeginRange; region <= LdsRegionEsEndRange; ++region) {
-        // NOTE: For NGG non pass-through mode, primitive ID region is overlapped with position data.
+        // NOTE: For NGG culling mode, distributed primitive ID region is partially overlapped with vertex cull info
+        // region.
         if (region == LdsRegionDistribPrimId)
           continue;
 
-        // NOTE: If cull distance culling is disabled, skip this region
-        if (region == LdsRegionCullDistance && !nggControl->enableCullDistanceCulling)
-          continue;
+        unsigned ldsRegionSize = LdsRegionSizes[region];
 
-        if (hasTs) {
-          // Skip those regions that are for VS only
-          if (region == LdsRegionCompactVertexId || region == LdsRegionCompactInstanceId ||
-              region == LdsRegionCompactPrimId)
-            continue;
-        } else {
-          // Skip those regions that are for TES only
-          if (region == LdsRegionCompactTessCoordX || region == LdsRegionCompactTessCoordY ||
-              region == LdsRegionCompactRelPatchId || region == LdsRegionCompactPatchId)
-            continue;
-        }
+        // NOTE: LDS size of vertex cull info (ES-GS ring) is calculated
+        if (region == LdsRegionVertCullInfo)
+          ldsRegionSize = calcFactor.esGsRingItemSize * calcFactor.esVertsPerSubgroup * SizeOfDword;
 
         m_ldsRegionStart[region] = ldsRegionStart;
-        ldsRegionStart += LdsRegionSizes[region];
+        assert(ldsRegionSize != InvalidValue);
+        ldsRegionStart += ldsRegionSize;
 
         LLPC_OUTS(format("%-40s : offset = 0x%04" PRIX32 ", size = 0x%04" PRIX32, m_ldsRegionNames[region],
-                         m_ldsRegionStart[region], LdsRegionSizes[region])
+                         m_ldsRegionStart[region], ldsRegionSize)
                   << "\n");
       }
     }
@@ -271,55 +228,27 @@ unsigned NggLdsManager::calcEsExtraLdsSize(PipelineState *pipelineState) {
   if (!nggControl->enableNgg)
     return 0;
 
-  const unsigned stageMask = pipelineState->getShaderStageMask();
-  const bool hasGs = ((stageMask & shaderStageToMask(ShaderStageGeometry)) != 0);
-
+  const bool hasGs = pipelineState->hasShaderStage(ShaderStageGeometry);
   if (hasGs) {
     // NOTE: Not need ES extra LDS when GS is present.
     return 0;
   }
 
-  const bool hasTs =
-      ((stageMask & (shaderStageToMask(ShaderStageTessControl) | shaderStageToMask(ShaderStageTessEval))) != 0);
-
-  unsigned esExtraLdsSize = 0;
-
   if (nggControl->passthroughMode) {
-    // NOTE: For NGG pass-through mode, only primitive ID region is valid.
-    bool distributePrimId = false;
+    // NOTE: For NGG pass-through mode, only distributed primitive ID region is valid.
+    bool distributePrimitiveId = false;
+    const bool hasTs =
+        pipelineState->hasShaderStage(ShaderStageTessControl) || pipelineState->hasShaderStage(ShaderStageTessEval);
     if (!hasTs) {
       const auto &builtInUsage = pipelineState->getShaderResourceUsage(ShaderStageVertex)->builtInUsage.vs;
-      distributePrimId = builtInUsage.primitiveId;
+      distributePrimitiveId = builtInUsage.primitiveId;
     }
 
-    esExtraLdsSize = distributePrimId ? LdsRegionSizes[LdsRegionDistribPrimId] : 0;
-  } else {
-    for (unsigned region = LdsRegionEsBeginRange; region <= LdsRegionEsEndRange; ++region) {
-      // NOTE: For NGG non pass-through mode, primitive ID region is overlapped with position data.
-      if (region == LdsRegionDistribPrimId)
-        continue;
-
-      // NOTE: If cull distance culling is disabled, skip this region
-      if (region == LdsRegionCullDistance && !nggControl->enableCullDistanceCulling)
-        continue;
-
-      if (hasTs) {
-        // Skip those regions that are for VS only
-        if (region == LdsRegionCompactVertexId || region == LdsRegionCompactInstanceId ||
-            region == LdsRegionCompactPrimId)
-          continue;
-      } else {
-        // Skip those regions that are for TES only
-        if (region == LdsRegionCompactTessCoordX || region == LdsRegionCompactTessCoordY ||
-            region == LdsRegionCompactRelPatchId || region == LdsRegionCompactPatchId)
-          continue;
-      }
-
-      esExtraLdsSize += LdsRegionSizes[region];
-    }
+    return distributePrimitiveId ? LdsRegionSizes[LdsRegionDistribPrimId] : 0;
   }
 
-  return esExtraLdsSize;
+  return LdsRegionSizes[LdsRegionVertPosData] + LdsRegionSizes[LdsRegionVertCountInWaves] +
+         LdsRegionSizes[LdsRegionVertThreadIdMap];
 }
 
 // =====================================================================================================================
@@ -388,7 +317,7 @@ void NggLdsManager::writeValueToLds(Value *writeValue, Value *ldsOffset, bool us
   auto lds = ConstantExpr::getBitCast(
       m_lds, PointerType::get(Type::getInt8Ty(*m_context), m_lds->getType()->getPointerAddressSpace()));
 
-  Value* writePtr = m_builder->CreateGEP(lds, ldsOffset);
+  Value *writePtr = m_builder->CreateGEP(lds, ldsOffset);
   writePtr = m_builder->CreateBitCast(writePtr, PointerType::get(writeTy, ADDR_SPACE_LOCAL));
 
   m_builder->CreateAlignedStore(writeValue, writePtr, Align(alignment));

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -45,28 +45,14 @@ enum NggLdsRegionType {
   //
   // LDS region for ES only (no GS)
   //
-  LdsRegionDistribPrimId = 0, // Distributed primitive ID (a special region, overlapped with the region of
-                              //   position data in NGG non pass-through mode)
-  LdsRegionPosData,           // Position data to export
-  LdsRegionDrawFlag,          // Draw flag indicating whether the vertex survives
+  LdsRegionDistribPrimId,     // Distributed primitive ID (VS only, for both pass-through and culling modes)
+  LdsRegionVertPosData,       // Vertex position data
+  LdsRegionVertCullInfo,      // Vertex cull info
   LdsRegionVertCountInWaves,  // Vertex count accumulated per wave (8 potential waves) and per sub-group
-  LdsRegionCullDistance,      // Aggregated sign value of cull distance (bitmask)
-
-  // Below regions are for vertex compaction
-  LdsRegionVertThreadIdMap,   // Vertex thread ID map (uncompacted -> compacted)
-  LdsRegionCompactVertexId,   // Vertex ID (VS only)
-  LdsRegionCompactInstanceId, // Instance ID (VS only)
-  LdsRegionCompactPrimId,     // Primitive ID (VS only)
-  LdsRegionCompactTessCoordX, // X of tessCoord (U) (TES only)
-  LdsRegionCompactTessCoordY, // Y of tessCoord (V) (TES only)
-  LdsRegionCompactPatchId,    // Patch ID (TES only)
-  LdsRegionCompactRelPatchId, // Relative patch ID (TES only)
-
-  LdsRegionCompactBeginRange = LdsRegionVertThreadIdMap,
-  LdsRegionCompactEndRange = LdsRegionCompactRelPatchId,
+  LdsRegionVertThreadIdMap,   // Vertex thread ID map (compacted -> uncompacted)
 
   LdsRegionEsBeginRange = LdsRegionDistribPrimId,
-  LdsRegionEsEndRange = LdsRegionCompactRelPatchId,
+  LdsRegionEsEndRange = LdsRegionVertThreadIdMap,
 
   //
   // LDS region for ES-GS
@@ -123,8 +109,6 @@ private:
   llvm::GlobalValue *m_lds; // Global variable to model NGG LDS
 
   unsigned m_ldsRegionStart[LdsRegionCount]; // Start LDS offsets for all available LDS region types (in bytes)
-
-  unsigned m_waveCountInSubgroup; // Wave count in sub-group
 
   llvm::IRBuilder<> *m_builder; // LLVM IR builder
 };

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -52,14 +52,14 @@ NggPrimShader::NggPrimShader(PipelineState *pipelineState)
     : m_pipelineState(pipelineState), m_context(&pipelineState->getContext()),
       m_gfxIp(pipelineState->getTargetInfo().getGfxIpVersion()), m_nggControl(m_pipelineState->getNggControl()),
       m_ldsManager(nullptr), m_builder(new IRBuilder<>(*m_context)) {
+  assert(m_nggControl->enableNgg);
+
   // Always allow approximation, to change fdiv(1.0, x) to rcp(x)
   FastMathFlags fastMathFlags;
   fastMathFlags.setApproxFunc();
   m_builder->setFastMathFlags(fastMathFlags);
 
   assert(m_pipelineState->isGraphics());
-
-  buildPrimShaderCbLayoutLookupTable();
 
   memset(&m_nggFactor, 0, sizeof(m_nggFactor));
 
@@ -91,12 +91,44 @@ NggPrimShader::NggPrimShader(PipelineState *pipelineState)
     }
   } else
     memset(m_gsStreamBases, 0, sizeof(m_gsStreamBases));
+
+  buildPrimShaderCbLayoutLookupTable();
+  calcVertexCullInfoSizeAndOffsets(m_pipelineState, m_vertCullInfoOffsets);
 }
 
 // =====================================================================================================================
 NggPrimShader::~NggPrimShader() {
   if (m_ldsManager)
     delete m_ldsManager;
+}
+
+// =====================================================================================================================
+// Calculates the dword size of ES-GS ring item.
+//
+// @param pipelineState : Pipeline state
+unsigned NggPrimShader::calcEsGsRingItemSize(PipelineState *pipelineState) {
+  assert(pipelineState->getNggControl()->enableNgg);
+
+  const bool hasGs = pipelineState->hasShaderStage(ShaderStageGeometry);
+  if (hasGs) {
+    auto resUsage = pipelineState->getShaderResourceUsage(ShaderStageGeometry);
+    // NOTE: Make esGsRingItemSize odd by "| 1", to optimize ES -> GS ring layout for LDS bank conflicts.
+    return (4 * std::max(1u, resUsage->inOutUsage.inputMapLocCount)) | 1;
+  }
+
+  if (pipelineState->getNggControl()->passthroughMode)
+    return 1; // Always 1 for NGG pass-through mode
+
+  VertexCullInfoOffsets vertCullInfoOffsets = {}; // Dummy offsets (don't care)
+  // For non-GS NGG, in the culling mode, the ES-GS ring item is vertex cull info.
+  unsigned esGsRingItemSize = calcVertexCullInfoSizeAndOffsets(pipelineState, vertCullInfoOffsets);
+
+  // Change it back to dword size
+  assert(esGsRingItemSize % SizeOfDword == 0);
+  esGsRingItemSize /= SizeOfDword;
+
+  // NOTE: Make esGsRingItemSize odd by "| 1", to optimize ES -> GS ring layout for LDS bank conflicts.
+  return esGsRingItemSize | 1;
 }
 
 // =====================================================================================================================
@@ -140,6 +172,90 @@ Function *NggPrimShader::generate(Function *esEntryPoint, Function *gsEntryPoint
   m_ldsManager = new NggLdsManager(module, m_pipelineState, m_builder.get());
 
   return generatePrimShaderEntryPoint(module);
+}
+
+// =====================================================================================================================
+// Calculates the byte size of vertex cull info. Meanwhile, builds the collection of LDS offsets within an item of
+// vertex cull info region.
+//
+// @param pipelineState : Pipeline state
+// @param [out] vertCullInfoOffsets : The collection of LDS offsets to build
+unsigned NggPrimShader::calcVertexCullInfoSizeAndOffsets(PipelineState *pipelineState,
+                                                         VertexCullInfoOffsets &vertCullInfoOffsets) {
+  auto nggControl = pipelineState->getNggControl();
+  assert(nggControl->enableNgg);
+
+  vertCullInfoOffsets = {};
+
+  // Only for non-GS NGG with culling mode enabled
+  const bool hasGs = pipelineState->hasShaderStage(ShaderStageGeometry);
+  if (hasGs || nggControl->passthroughMode)
+    return 0;
+
+  unsigned cullInfoSize = 0;
+  unsigned cullInfoOffset = 0;
+
+  if (nggControl->enableCullDistanceCulling) {
+    cullInfoSize += sizeof(VertexCullInfo::cullDistanceSignMask);
+    vertCullInfoOffsets.cullDistanceSignMask = cullInfoOffset;
+    cullInfoOffset += sizeof(VertexCullInfo::cullDistanceSignMask);
+  }
+
+  cullInfoSize += sizeof(VertexCullInfo::drawFlag);
+  vertCullInfoOffsets.drawFlag = cullInfoOffset;
+  cullInfoOffset += sizeof(VertexCullInfo::drawFlag);
+
+  if (nggControl->compactMode != NggCompactDisable) {
+    cullInfoSize += sizeof(VertexCullInfo::compactThreadId);
+    vertCullInfoOffsets.compactThreadId = cullInfoOffset;
+    cullInfoOffset += sizeof(VertexCullInfo::compactThreadId);
+
+    const bool hasTs = pipelineState->getShaderResourceUsage(ShaderStageTessControl) ||
+                       pipelineState->getShaderResourceUsage(ShaderStageTessEval);
+    if (hasTs) {
+      auto builtInUsage = pipelineState->getShaderResourceUsage(ShaderStageTessEval)->builtInUsage.tes;
+      if (builtInUsage.tessCoord) {
+        cullInfoSize += sizeof(VertexCullInfo::tes.tessCoordX);
+        vertCullInfoOffsets.tessCoordX = cullInfoOffset;
+        cullInfoOffset += sizeof(VertexCullInfo::tes.tessCoordX);
+
+        cullInfoSize += sizeof(VertexCullInfo::tes.tessCoordY);
+        vertCullInfoOffsets.tessCoordY = cullInfoOffset;
+        cullInfoOffset += sizeof(VertexCullInfo::tes.tessCoordY);
+      }
+
+      cullInfoSize += sizeof(VertexCullInfo::tes.relPatchId);
+      vertCullInfoOffsets.relPatchId = cullInfoOffset;
+      cullInfoOffset += sizeof(VertexCullInfo::tes.relPatchId);
+
+      if (builtInUsage.primitiveId) {
+        cullInfoSize += sizeof(VertexCullInfo::tes.patchId);
+        vertCullInfoOffsets.patchId = cullInfoOffset;
+        cullInfoOffset += sizeof(VertexCullInfo::tes.patchId);
+      }
+    } else {
+      auto builtInUsage = pipelineState->getShaderResourceUsage(ShaderStageVertex)->builtInUsage.vs;
+      if (builtInUsage.vertexIndex) {
+        cullInfoSize += sizeof(VertexCullInfo::vs.vertexId);
+        vertCullInfoOffsets.vertexId = cullInfoOffset;
+        cullInfoOffset += sizeof(VertexCullInfo::vs.vertexId);
+      }
+
+      if (builtInUsage.instanceIndex) {
+        cullInfoSize += sizeof(VertexCullInfo::vs.instanceId);
+        vertCullInfoOffsets.instanceId = cullInfoOffset;
+        cullInfoOffset += sizeof(VertexCullInfo::vs.instanceId);
+      }
+
+      if (builtInUsage.primitiveId) {
+        cullInfoSize += sizeof(VertexCullInfo::vs.primitiveId);
+        vertCullInfoOffsets.primitiveId = cullInfoOffset;
+        cullInfoOffset += sizeof(VertexCullInfo::vs.primitiveId);
+      }
+    }
+  }
+
+  return cullInfoSize;
 }
 
 // =====================================================================================================================
@@ -416,101 +532,50 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
 
   const auto resUsage = m_pipelineState->getShaderResourceUsage(hasTs ? ShaderStageTessEval : ShaderStageVertex);
 
+  //
   // NOTE: If primitive ID is used in VS, we have to insert several basic blocks to distribute the value across
   // LDS because the primitive ID is provided as per-primitive instead of per-vertex. The algorithm is something
   // like this:
   //
-  //   if (threadIdInWave < primCountInWave)
-  //   {
-  //      ldsOffset = vindex0 * 4
-  //      ds_write ldsOffset, primId
+  // if (distribPrimitiveId) {
+  //     if (threadIdInWave < primCountInWave)
+  //       Distribute primitive ID to provoking vertex (vertex0)
+  //     Barrier
+  //
+  //     if (threadIdInWave < vertCountInWave)
+  //       Get primitive ID
+  //     Barrier
   //   }
   //
-  //   s_barrier
-  //
-  //   if (threadIdInWave < vertCountInWave)
-  //   {
-  //      ldsOffset = threadIdInSubgroup * 4
-  //      ds_read primId, ldsOffset
-  //   }
-  //
-  //   s_barrier
-  //
-  const bool distributePrimId = hasTs ? false : resUsage->builtInUsage.vs.primitiveId;
+  const bool distributePrimitiveId = hasTs ? false : resUsage->builtInUsage.vs.primitiveId;
 
-  // No GS in primitive shader (ES only)
   if (m_nggControl->passthroughMode) {
-    // Pass-through mode
-
-    // define dllexport amdgpu_gs @_amdgpu_gs_main(
-    //     inreg i32 %sgpr0..7, inreg <n x i32> %userData, i32 %vgpr0..8)
-    // {
-    // .entry:
-    //     ; Initialize EXEC mask: exec = 0xFFFFFFFF'FFFFFFFF
-    //     call void @llvm.amdgcn.init.exec(i64 -1)
     //
-    //     ; Get thread ID in a wave:
-    //     ;   bitCount  = ((1 << threadPosition) - 1) & 0xFFFFFFFF
-    //     ;   bitCount += (((1 << threadPosition) - 1) >> 32) & 0xFFFFFFFF
-    //     ;   threadIdInWave = bitCount
-    //     %threadIdInWave = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
-    //     %threadIdInWave = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %threadIdInWave)
+    // For pass-through mode, the processing is something like this:
     //
-    //     %waveIdInSubgroup = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr3, i32 24, i32 4)
-    //     %threadIdInSubgroup = mul i32 %waveIdInSubgroup, %waveSize
-    //     %threadIdInSubgroup = add i32 %threadIdInSubgroup, %threadIdInWave
+    // NGG() {
+    //   Initialize thread/wave info
     //
-    //     %primCountInSubgroup = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr2, i32 22, i32 9)
-    //     %vertCountInSubgroup = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr2, i32 12, i32 9)
+    //   if (distribPrimitiveId) {
+    //     if (threadIdInWave < primCountInWave)
+    //       Distribute primitive ID to provoking vertex (vertex0)
+    //     Barrier
     //
-    //     %primCountInWave = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr3, i32 8, i32 8)
-    //     %vertCountInWave = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr3, i32 0, i32 8)
+    //     if (threadIdInWave < vertCountInWave)
+    //       Get primitive ID
+    //   }
+    //   Barrier
     //
-    //     %primValid = icmp ult i32 %threadIdInWave , %primCountInWave
-    //     br i1 %primValid, label %.writePrimId, label %.endWritePrimId
-    // [
-    // .writePrimId:
-    //     ; Write LDS region (primitive ID)
-    //     br label %.endWritePrimId
+    //   if (waveId == 0)
+    //     GS allocation request (GS_ALLOC_REQ)
     //
-    // .endWritePrimId:
-    //     call void @llvm.amdgcn.s.barrier()
-    //     %vertValid = icmp ult i32 %threadIdInWave , %vertCountInWave
-    //     br i1 %vertValid, label %.readPrimId, label %.endReadPrimId
+    //   if (threadIdInSubgroup < primCountInSubgroup)
+    //     Do primitive connectivity data export
     //
-    // .readPrimId:
-    //     ; Read LDS region (primitive ID)
-    //     br label %.endReadPrimId
-    //
-    // .endReadPrimId:
-    // ]
-    //     call void @llvm.amdgcn.s.barrier()
-    //     %firstWaveInSubgroup = icmp eq i32 %waveIdInSubgroup, 0
-    //     br i1 %firstWaveInSubgroup, label %.allocreq, label %.endAllocReq
-    //
-    // .allocReq:
-    //     ; Do parameter cache (PC) alloc request: s_sendmsg(GS_ALLOC_REQ, ...)
-    //     br label %.endAllocReq
-    //
-    // .endAllocReq:
-    //     %primExp = icmp ult i32 %threadIdInSubgroup, %primCountInSubgroup
-    //     br i1 %primExp, label %.expPrim, label %.endExpPrim
-    //
-    // .expPrim:
-    //     ; Do primitive export: exp prim, ...
-    //     br label %.endExpPrim
-    //
-    // .endExpPrim:
-    //     %vertExp = icmp ult i32 %threadIdInSubgroup, %vertCountInSubgroup
-    //     br i1 %vertExp, label %.expVert, label %.endExpVert
-    //
-    // .expVert:
-    //     call void @llpc.ngg.ES.main(%sgpr..., %userData..., %vgpr...)
-    //     br label %.endExpVert
-    //
-    // .endExpVert:
-    //     ret void
+    //   if (threadIdInSubgroup < vertCountInSubgroup)
+    //     Run ES
     // }
+    //
 
     // Define basic blocks
     auto entryBlock = createBlock(entryPoint, ".entry");
@@ -521,7 +586,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
     BasicBlock *readPrimIdBlock = nullptr;
     BasicBlock *endReadPrimIdBlock = nullptr;
 
-    if (distributePrimId) {
+    if (distributePrimitiveId) {
       writePrimIdBlock = createBlock(entryPoint, ".writePrimId");
       endWritePrimIdBlock = createBlock(entryPoint, ".endWritePrimId");
 
@@ -547,7 +612,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       // Record primitive connectivity data
       m_nggFactor.primData = esGsOffsets01;
 
-      if (distributePrimId) {
+      if (distributePrimitiveId) {
         auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.primCountInWave);
         m_builder->CreateCondBr(primValid, writePrimIdBlock, endWritePrimIdBlock);
       } else {
@@ -558,7 +623,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       }
     }
 
-    if (distributePrimId) {
+    if (distributePrimitiveId) {
       // Construct ".writePrimId" block
       {
         m_builder->SetInsertPoint(writePrimIdBlock);
@@ -570,17 +635,8 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
         //   ES_GS_OFFSET01[8:0]   = vertexId0 (in bytes)
 
         // Distribute primitive ID
-        auto vertexId0 =
-            m_builder->CreateIntrinsic(Intrinsic::amdgcn_ubfe, m_builder->getInt32Ty(),
-                                       {m_nggFactor.primData, m_builder->getInt32(0), m_builder->getInt32(9)});
-
-        unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDistribPrimId);
-
-        auto ldsOffset = m_builder->CreateShl(vertexId0, 2);
-        ldsOffset = m_builder->CreateAdd(m_builder->getInt32(regionStart), ldsOffset);
-
-        auto primIdWriteValue = gsPrimitiveId;
-        m_ldsManager->writeValueToLds(primIdWriteValue, ldsOffset);
+        auto vertexId0 = CreateUBfe(m_nggFactor.primData, 0, 9);
+        writePerThreadDataToLds(gsPrimitiveId, vertexId0, LdsRegionDistribPrimId);
 
         BranchInst::Create(endWritePrimIdBlock, writePrimIdBlock);
       }
@@ -596,16 +652,12 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       }
 
       // Construct ".readPrimId" block
-      Value *primIdReadValue = nullptr;
+      Value *primitiveId = nullptr;
       {
         m_builder->SetInsertPoint(readPrimIdBlock);
 
-        unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDistribPrimId);
-
-        auto ldsOffset = m_builder->CreateShl(m_nggFactor.threadIdInSubgroup, 2);
-        ldsOffset = m_builder->CreateAdd(m_builder->getInt32(regionStart), ldsOffset);
-
-        primIdReadValue = m_ldsManager->readValueFromLds(m_builder->getInt32Ty(), ldsOffset);
+        primitiveId =
+            readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionDistribPrimId);
 
         m_builder->CreateBr(endReadPrimIdBlock);
       }
@@ -614,13 +666,13 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       {
         m_builder->SetInsertPoint(endReadPrimIdBlock);
 
-        auto primitiveId = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+        auto primitiveIdPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
 
-        primitiveId->addIncoming(primIdReadValue, readPrimIdBlock);
-        primitiveId->addIncoming(m_builder->getInt32(0), endWritePrimIdBlock);
+        primitiveIdPhi->addIncoming(primitiveId, readPrimIdBlock);
+        primitiveIdPhi->addIncoming(m_builder->getInt32(0), endWritePrimIdBlock);
 
         // Record primitive ID
-        m_nggFactor.primitiveId = primitiveId;
+        m_nggFactor.primitiveId = primitiveIdPhi;
 
         m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
@@ -641,8 +693,8 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
     {
       m_builder->SetInsertPoint(endAllocReqBlock);
 
-      auto primExp = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
-      m_builder->CreateCondBr(primExp, expPrimBlock, endExpPrimBlock);
+      auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
+      m_builder->CreateCondBr(primValid, expPrimBlock, endExpPrimBlock);
     }
 
     // Construct ".expPrim" block
@@ -657,8 +709,8 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
     {
       m_builder->SetInsertPoint(endExpPrimBlock);
 
-      auto vertExp = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
-      m_builder->CreateCondBr(vertExp, expVertBlock, endExpVertBlock);
+      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+      m_builder->CreateCondBr(vertValid, expVertBlock, endExpVertBlock);
     }
 
     // Construct ".expVert" block
@@ -676,744 +728,578 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
 
       m_builder->CreateRetVoid();
     }
-  } else {
-    // Non pass-through mode
 
-    // define dllexport amdgpu_gs @_amdgpu_gs_main(
-    //     inreg i32 %sgpr0..7, inreg <n x i32> %userData, i32 %vgpr0..8])
-    // {
-    // .entry:
-    //     ; Initialize EXEC mask: exec = 0xFFFFFFFF'FFFFFFFF
-    //     call void @llvm.amdgcn.init.exec(i64 -1)
-    //
-    //     ; Get thread ID in a wave:
-    //     ;   bitCount  = ((1 << threadPosition) - 1) & 0xFFFFFFFF
-    //     ;   bitCount += (((1 << threadPosition) - 1) >> 32) & 0xFFFFFFFF
-    //     ;   threadIdInWave = bitCount
-    //     %threadIdInWave = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
-    //     %threadIdInWave = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %threadIdInWave)
-    //
-    //     %waveIdInSubgroup = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr3, i32 24, i32 4)
-    //
-    //     %threadIdInSubgroup = mul i32 %waveIdInSubgroup, %waveSize
-    //     %threadIdInSubgroup = add i32 %threadIdInSubgroup, %threadIdInWave
-    //
-    //     %primCountInSubgroup = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr2, i32 22, i32 9)
-    //     %vertCountInSubgroup = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr2, i32 12, i32 9)
-    //
-    //     %primCountInWave = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr3, i32 8, i32 8)
-    //     %vertCountInWave = call i32 @llvm.amdgcn.ubfe.i32(i32 %sgpr3, i32 0, i32 8)
-    //
-    // <if (distributePrimId)>
-    // [
-    // .writePrimId:
-    //     ; Write LDS region (primitive ID)
-    //     br label %.endWritePrimId
-    //
-    // .endWritePrimId:
-    //     call void @llvm.amdgcn.s.barrier()
-    //     %vertValid = icmp ult i32 %threadIdInWave , %vertCountInWave
-    //     br i1 %vertValid, label %.readPrimId, label %.endReadPrimId
-    //
-    // .readPrimId:
-    //     ; Read LDS region (primitive ID)
-    //     br label %.endReadPrimId
-    //
-    // .endReadPrimId:
-    //     call void @llvm.amdgcn.s.barrier()
-    // ]
-    //     %firstThreadInSubgroup = icmp eq i32 %threadIdInSubgroup, 0
-    //     br i1 %firstThreadInSubgroup, label %.zeroPrimWaveCount, label %.endZeroPrimWaveCount
-    //
-    // .zeroThreadCount:
-    //     ; Zero LDS region (primitive/vertex count in waves), do it for the first thread
-    //     br label %.endZeroThreadCount
-    //
-    // .endZeroThreadCount:
-    //     %firstWaveInSubgroup = icmp eq i32 %waveIdInSubgroup, 0
-    //     br i1 %firstWaveInSubgroup, label %.zeroDrawFlag, label %.endZeroDrawFlag
-    //
-    // .zeroDrawFlag:
-    //     ; Zero LDS regision (draw flag), do it for the first wave
-    //     br label %.endZeroDrawFlag
-    //
-    // .endZeroDrawFlag:
-    //     %vertValid = icmp ult i32 %threadIdInWave , %vertCountInWave
-    //     br i1 %vertValid, label %.writePosData, label %.endWritePosData
-    //
-    // .writePosData:
-    //     ; Write LDS region (position data)
-    //     %cullData = call [ position: <4 x float>, cull-distance: [8 x float] ]
-    //                     @lgc.ngg.ES.cull.data.fetch(%sgpr..., %userData..., %vgpr...)
-    //     br label %.endWritePosData
-    //
-    // .endWritePosData:
-    //     call void @llvm.amdgcn.s.barrier()
-    //
-    //     %primValidInWave = icmp ult i32 %threadIdInWave, %primCountInWave
-    //     %primValidInSubgroup = icmp ult i32 %threadIdInSubgroup, %primCountInSubgroup
-    //     %primValid = and i1 %primValidInWave, %primValidInSubgroup
-    //     br i1 %primValid, label %.culling, label %.endCulling
-    //
-    // .culling:
-    //     ; Do culling
-    //     %doCull = call i32 @llpc.ngg.culling.XXX(...)
-    //     br label %.endCulling
-    //
-    // .endCulling:
-    //     %cullFlag = phi i1 [ true, %.endWritePosData ], [ %doCull, %.culling ]
-    //     %drawFlag = xor i1 1, %cullFlag
-    //     br i1 %drawFlag, label %.writeDrawFlag, label %.endWriteDrawFlag
-    //
-    // .writeDrawFlag:
-    //     ; Write LDS region (draw flag)
-    //     br label %.endWriteDrawFlag
-    //
-    // .endWriteDrawFlag:
-    //     call void @llvm.amdgcn.s.barrier()
-    //
-    //     %drawMask = call i64 @llpc.subgroup.ballot(i1 %drawFlag)
-    //     %drawCount = call i64 @llvm.ctpop.i64(i64 %drawMask)
-    //     %hasSurviveDraw = icmp ne i64 %drawCount, 0
-    //
-    //     %theadIdUpbound = sub i32 %waveCountInSubgroup, %waveIdInSubgroup
-    //     %threadValid = icmp ult i32 %threadIdInWave, %theadIdUpbound
-    //     %primCountAcc = and i1 %hasSurviveDraw, %threadValid
-    //     br i1 %primCountAcc, label %.accThreadCount, label %.endAccThreadCount
-    //
-    // .accThreadCount:
-    //     ; Write LDS region (primitive/vertex count in waves)
-    //     br label %.endAccThreadCount
-    //
-    // .endAccThreadCount:
-    //     call void @llvm.amdgcn.s.barrier()
-    //     br lable %.readThreadCount
-    //
-    // .readThreadCount:
-    //     %vertCountInWaves = ... (read LDS region, vertex count in waves)
-    //     %threadCountInWaves = %vertCountInWaves
-    //
-    //     %vertValid = icmp ult i32 %threadIdInWave , %vertCountInWave
-    //     %compactDataWrite = and i1 %vertValid, %drawFlag
-    //     br i1 %compactDataWrite, label %.writeCompactData, label %.endReadThreadCount
-    //
-    // .writeCompactData:
-    //     ; Write LDS region (compaction data: compacted thread ID, vertex position data,
-    //     ; vertex ID/tessCoordX, instance ID/tessCoordY, primitive ID/relative patch ID, patch ID)
-    //     br label %.endReadThreadCount
-    //
-    // .endReadThreadCount:
-    //     %hasSurviveVert = icmp ne i32 %vertCountInWaves, 0
-    //     %primCountInSubgroup =
-    //         select i1 %hasSurviveVert, i32 %primCountInSubgroup, i32 %fullyCulledThreadCount
-    //     %vertCountInSubgroup =
-    //         select i1 %hasSurviveVert, i32 %vertCountInWaves, i32 %fullyCulledThreadCount
-    //
-    //     %firstWaveInSubgroup = icmp eq i32 %waveIdInSubgroup, 0
-    //     br i1 %firstWaveInSubgroup, label %.allocreq, label %.endAllocReq
-    //
-    // .allocReq:
-    //     ; Do parameter cache (PC) alloc request: s_sendmsg(GS_ALLOC_REQ, ...)
-    //     br label %.endAllocReq
-    //
-    // .endAlloReq:
-    //     call void @llvm.amdgcn.s.barrier()
-    //
-    //     %noSurviveThread = icmp eq %threadCountInWaves, 0
-    //     br i1 %noSurviveThread, label %.earlyExit, label %.noEarlyExit
-    //
-    // .earlyExit:
-    //     %firstThreadInSubgroup = icmp eq i32 %threadIdInSubgroup, 0
-    //     br i1 %firstThreadInSubgroup, label %.dummyExp, label %.endDummyExp
-    //
-    // .dummyExp:
-    //     ; Do position export: exp pos, ... (off, off, off, off)
-    //     ; Do primitive export: exp prim, ... (0, off, off, off)
-    //     br label %.endDummyExp
-    //
-    // .endDummyExp:
-    //     ret void
-    //
-    // .noEarlyExit:
-    //     %primExp = icmp ult i32 %threadIdInSubgroup, %primCountInSubgroup
-    //     br i1 %primExp, label %.expPrim, label %.endExpPrim
-    //
-    // .expPrim:
-    //     ; Do primitive export: exp prim, ...
-    //     br label %.endExpPrim
-    //
-    // .endExpPrim:
-    //     %vertExp = icmp ult i32 %threadIdInSubgroup, %vertCountInSubgroup
-    //     br i1 %vertExp, label %.expVert, label %.endExpVert
-    //
-    // .expVert:
-    //     ; Do deferred vertex export: exp posN, ...; exp paramN, ...
-    //     call void @lgc.ngg.ES.deferred.vertex.export(%position, %sgpr..., %userData..., %vgpr...)
-    //     br label %.endExpVert
-    //
-    // .endExpVert:
-    //     ret void
-    // }
+    return;
+  }
 
-    // Thread count when the entire sub-group is fully culled
-    const unsigned fullyCulledThreadCount =
-        m_pipelineState->getTargetInfo().getGpuWorkarounds().gfx10.waNggCullingNoEmptySubgroups ? 1 : 0;
+  //
+  // For culling mode, the processing is something like this:
+  //
+  // NGG() {
+  //   Initialize thread/wave info
+  //
+  //   if (distribPrimitiveId) {
+  //     if (threadIdInWave < primCountInWave)
+  //       Distribute primitive ID to provoking vertex (vertex0)
+  //     Barrier
+  //
+  //     if (threadIdInWave < vertCountInWave)
+  //       Get primitive ID
+  //     Barrier
+  //   }
+  //
+  //   if (threadIdInSubgroup < vertCountInSubgroup)
+  //     Initialize vertex draw flag
+  //   if (threadIdInSubgroup < waveCount + 1)
+  //     Initialize per-wave and per-subgroup count of output vertices
+  //
+  //   if (threadIdInWave < vertCountInWave)
+  //     Write vertex cull data
+  //   Barrier
+  //
+  //   if (threadIdInSubgroup < primCountInSubgroup) {
+  //     Do culling (run culling algorithms)
+  //     if (primitive not culled)
+  //       Write draw flags of forming vertices
+  //   }
+  //   Barrier
+  //
+  //   if (threadIdInSubgroup < vertCountInSubgroup)
+  //     Check draw flags of vertices and compute draw mask
+  //
+  //   if (threadIdInWave < waveCount - waveId)
+  //     Accumulate per-wave and per-subgroup count of output vertices
+  //   Barrier
+  //
+  //   if (vertex compacted && vertex drawed) {
+  //     Compact vertex thread ID (map: compacted -> uncompacted)
+  //     Write vertex compaction info
+  //   }
+  //   Update vertCountInSubgroup and primCountInSubgroup
+  //
+  //   if (waveId == 0)
+  //     GS allocation request (GS_ALLOC_REQ)
+  //   Barrier
+  //
+  //   if (fullyCulled) {
+  //     Do dummy export
+  //     return (early exit)
+  //   }
+  //
+  //   if (threadIdInSubgroup < primCountInSubgroup)
+  //     Do primitive connectivity data export
+  //
+  //   if (threadIdInSubgroup < vertCountInSubgroup)
+  //     Run ES-partial to do deferred vertex export
+  // }
+  //
 
-    // Define basic blocks
-    auto entryBlock = createBlock(entryPoint, ".entry");
+  // Export count when the entire sub-group is fully culled
+  const unsigned fullyCulledExportCount =
+      m_pipelineState->getTargetInfo().getGpuWorkarounds().gfx10.waNggCullingNoEmptySubgroups ? 1 : 0;
 
-    // NOTE: Those basic blocks are conditionally created on the basis of actual use of primitive ID.
-    BasicBlock *writePrimIdBlock = nullptr;
-    BasicBlock *endWritePrimIdBlock = nullptr;
-    BasicBlock *readPrimIdBlock = nullptr;
-    BasicBlock *endReadPrimIdBlock = nullptr;
+  const unsigned esGsRingItemSize =
+      m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
 
-    if (distributePrimId) {
-      writePrimIdBlock = createBlock(entryPoint, ".writePrimId");
-      endWritePrimIdBlock = createBlock(entryPoint, ".endWritePrimId");
+  // NOTE: Make sure vertex position data is 16-byte alignment because we will use 128-bit LDS read/write for it.
+  assert(m_ldsManager->getLdsRegionStart(LdsRegionVertPosData) % SizeOfVec4 == 0);
 
-      readPrimIdBlock = createBlock(entryPoint, ".readPrimId");
-      endReadPrimIdBlock = createBlock(entryPoint, ".endReadPrimId");
+  // Define basic blocks
+  auto entryBlock = createBlock(entryPoint, ".entry");
+
+  // NOTE: Those basic blocks are conditionally created on the basis of actual use of primitive ID.
+  BasicBlock *writePrimIdBlock = nullptr;
+  BasicBlock *endWritePrimIdBlock = nullptr;
+  BasicBlock *readPrimIdBlock = nullptr;
+  BasicBlock *endReadPrimIdBlock = nullptr;
+
+  if (distributePrimitiveId) {
+    writePrimIdBlock = createBlock(entryPoint, ".writePrimId");
+    endWritePrimIdBlock = createBlock(entryPoint, ".endWritePrimId");
+
+    readPrimIdBlock = createBlock(entryPoint, ".readPrimId");
+    endReadPrimIdBlock = createBlock(entryPoint, ".endReadPrimId");
+  }
+
+  auto initVertDrawFlagBlock = createBlock(entryPoint, ".initVertDrawFlag");
+  auto endInitVertDrawFlagBlock = createBlock(entryPoint, ".endInitVertDrawFlag");
+
+  auto initVertCountBlock = createBlock(entryPoint, ".initVertCount");
+  auto endInitVertCountBlock = createBlock(entryPoint, ".endInitVertCount");
+
+  auto writeVertCullDataBlock = createBlock(entryPoint, ".writeVertCullData");
+  auto endWriteVertCullDataBlock = createBlock(entryPoint, ".endWriteVertCullData");
+
+  auto cullingBlock = createBlock(entryPoint, ".culling");
+  auto writeVertDrawFlagBlock = createBlock(entryPoint, ".writeVertDrawFlag");
+  auto endCullingBlock = createBlock(entryPoint, ".endCulling");
+
+  auto checkVertDrawFlagBlock = createBlock(entryPoint, ".checkVertDrawFlag");
+  auto endCheckVertDrawFlagBlock = createBlock(entryPoint, ".endCheckVertDrawFlag");
+
+  auto accumVertCountBlock = createBlock(entryPoint, ".accumVertCount");
+  auto endAccumVertCountBlock = createBlock(entryPoint, ".endAccumVertCount");
+
+  auto compactVertBlock = createBlock(entryPoint, ".compactVert");
+  auto endCompactVertBlock = createBlock(entryPoint, ".endCompactVert");
+
+  auto allocReqBlock = createBlock(entryPoint, ".allocReq");
+  auto endAllocReqBlock = createBlock(entryPoint, ".endAllocReq");
+
+  auto earlyExitBlock = createBlock(entryPoint, ".earlyExit");
+  auto noEarlyExitBlock = createBlock(entryPoint, ".noEarlyExit");
+
+  auto expPrimBlock = createBlock(entryPoint, ".expPrim");
+  auto endExpPrimBlock = createBlock(entryPoint, ".endExpPrim");
+
+  auto expVertBlock = createBlock(entryPoint, ".expVert");
+  auto endExpVertBlock = createBlock(entryPoint, ".endExpVert");
+
+  // Construct ".entry" block
+  Value *vertexItemOffset = nullptr;
+  {
+    m_builder->SetInsertPoint(entryBlock);
+
+    initWaveThreadInfo(mergedGroupInfo, mergedWaveInfo);
+
+    m_nggFactor.primShaderTableAddrLow = primShaderTableAddrLow;
+    m_nggFactor.primShaderTableAddrHigh = primShaderTableAddrHigh;
+
+    // Record ES-GS vertex offsets info
+    m_nggFactor.esGsOffset0 = CreateUBfe(esGsOffsets01, 0, 16);
+    m_nggFactor.esGsOffset1 = CreateUBfe(esGsOffsets01, 16, 16);
+    m_nggFactor.esGsOffset2 = CreateUBfe(esGsOffsets23, 0, 16);
+
+    vertexItemOffset =
+        m_builder->CreateMul(m_nggFactor.threadIdInSubgroup, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+
+    if (distributePrimitiveId) {
+      auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.primCountInWave);
+      m_builder->CreateCondBr(primValid, writePrimIdBlock, endWritePrimIdBlock);
+    } else {
+      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+      m_builder->CreateCondBr(vertValid, initVertDrawFlagBlock, endInitVertDrawFlagBlock);
     }
+  }
 
-    auto zeroThreadCountBlock = createBlock(entryPoint, ".zeroThreadCount");
-    auto endZeroThreadCountBlock = createBlock(entryPoint, ".endZeroThreadCount");
-
-    auto zeroDrawFlagBlock = createBlock(entryPoint, ".zeroDrawFlag");
-    auto endZeroDrawFlagBlock = createBlock(entryPoint, ".endZeroDrawFlag");
-
-    auto writePosDataBlock = createBlock(entryPoint, ".writePosData");
-    auto endWritePosDataBlock = createBlock(entryPoint, ".endWritePosData");
-
-    auto cullingBlock = createBlock(entryPoint, ".culling");
-    auto endCullingBlock = createBlock(entryPoint, ".endCulling");
-
-    auto writeDrawFlagBlock = createBlock(entryPoint, ".writeDrawFlag");
-    auto endWriteDrawFlagBlock = createBlock(entryPoint, ".endWriteDrawFlag");
-
-    auto accThreadCountBlock = createBlock(entryPoint, ".accThreadCount");
-    auto endAccThreadCountBlock = createBlock(entryPoint, ".endAccThreadCount");
-
-    auto readThreadCountBlock = createBlock(entryPoint, ".readThreadCount");
-    auto writeCompactDataBlock = createBlock(entryPoint, ".writeCompactData");
-    auto endReadThreadCountBlock = createBlock(entryPoint, ".endReadThreadCount");
-
-    auto allocReqBlock = createBlock(entryPoint, ".allocReq");
-    auto endAllocReqBlock = createBlock(entryPoint, ".endAllocReq");
-
-    auto earlyExitBlock = createBlock(entryPoint, ".earlyExit");
-    auto noEarlyExitBlock = createBlock(entryPoint, ".noEarlyExit");
-
-    auto expPrimBlock = createBlock(entryPoint, ".expPrim");
-    auto endExpPrimBlock = createBlock(entryPoint, ".endExpPrim");
-
-    auto expVertBlock = createBlock(entryPoint, ".expVert");
-    auto endExpVertBlock = createBlock(entryPoint, ".endExpVert");
-
-    // Construct ".entry" block
+  if (distributePrimitiveId) {
+    // Construct ".writePrimId" block
     {
-      m_builder->SetInsertPoint(entryBlock);
+      m_builder->SetInsertPoint(writePrimIdBlock);
 
-      initWaveThreadInfo(mergedGroupInfo, mergedWaveInfo);
+      // Primitive data layout
+      //   ES_GS_OFFSET23[15:0]  = vertexId2 (in dwords)
+      //   ES_GS_OFFSET01[31:16] = vertexId1 (in dwords)
+      //   ES_GS_OFFSET01[15:0]  = vertexId0 (in dwords)
 
-      // Record primitive shader table address info
-      m_nggFactor.primShaderTableAddrLow = primShaderTableAddrLow;
-      m_nggFactor.primShaderTableAddrHigh = primShaderTableAddrHigh;
+      // Use vertex0 as provoking vertex to distribute primitive ID
+      auto vertexId0 = m_nggFactor.esGsOffset0;
+      writePerThreadDataToLds(gsPrimitiveId, vertexId0, LdsRegionDistribPrimId);
 
-      // Record ES-GS vertex offsets info
-      m_nggFactor.esGsOffset0 = CreateUBfe(esGsOffsets01, 0, 16);
-      m_nggFactor.esGsOffset1 = CreateUBfe(esGsOffsets01, 16, 16);
-      m_nggFactor.esGsOffset2 = CreateUBfe(esGsOffsets23, 0, 16);
-
-      if (distributePrimId) {
-        auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.primCountInWave);
-        m_builder->CreateCondBr(primValid, writePrimIdBlock, endWritePrimIdBlock);
-      } else {
-        auto firstThreadInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.threadIdInSubgroup, m_builder->getInt32(0));
-        m_builder->CreateCondBr(firstThreadInSubgroup, zeroThreadCountBlock, endZeroThreadCountBlock);
-      }
+      m_builder->CreateBr(endWritePrimIdBlock);
     }
 
-    if (distributePrimId) {
-      // Construct ".writePrimId" block
-      {
-        m_builder->SetInsertPoint(writePrimIdBlock);
-
-        // Primitive data layout
-        //   ES_GS_OFFSET23[15:0]  = vertexId2 (in dwords)
-        //   ES_GS_OFFSET01[31:16] = vertexId1 (in dwords)
-        //   ES_GS_OFFSET01[15:0]  = vertexId0 (in dwords)
-
-        const unsigned esGsRingItemSize =
-            m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
-        assert(isPowerOf2_32(esGsRingItemSize));
-
-        // Use vertex0 as provoking vertex to distribute primitive ID
-        auto vertexId0 = m_builder->CreateLShr(m_nggFactor.esGsOffset0, Log2_32(esGsRingItemSize));
-
-        unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDistribPrimId);
-
-        auto ldsOffset = m_builder->CreateShl(vertexId0, 2);
-        ldsOffset = m_builder->CreateAdd(m_builder->getInt32(regionStart), ldsOffset);
-
-        auto primIdWriteValue = gsPrimitiveId;
-        m_ldsManager->writeValueToLds(primIdWriteValue, ldsOffset);
-
-        m_builder->CreateBr(endWritePrimIdBlock);
-      }
-
-      // Construct ".endWritePrimId" block
-      {
-        m_builder->SetInsertPoint(endWritePrimIdBlock);
-
-        m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
-
-        auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.vertCountInWave);
-        m_builder->CreateCondBr(vertValid, readPrimIdBlock, endReadPrimIdBlock);
-      }
-
-      // Construct ".readPrimId" block
-      Value *primIdReadValue = nullptr;
-      {
-        m_builder->SetInsertPoint(readPrimIdBlock);
-
-        unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDistribPrimId);
-
-        auto ldsOffset = m_builder->CreateShl(m_nggFactor.threadIdInSubgroup, 2);
-        ldsOffset = m_builder->CreateAdd(m_builder->getInt32(regionStart), ldsOffset);
-
-        primIdReadValue = m_ldsManager->readValueFromLds(m_builder->getInt32Ty(), ldsOffset);
-
-        m_builder->CreateBr(endReadPrimIdBlock);
-      }
-
-      // Construct ".endReadPrimId" block
-      {
-        m_builder->SetInsertPoint(endReadPrimIdBlock);
-
-        auto primitiveId = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
-
-        primitiveId->addIncoming(primIdReadValue, readPrimIdBlock);
-        primitiveId->addIncoming(m_builder->getInt32(0), endWritePrimIdBlock);
-
-        // Record primitive ID
-        m_nggFactor.primitiveId = primitiveId;
-
-        m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
-
-        auto firstThreadInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.threadIdInSubgroup, m_builder->getInt32(0));
-        m_builder->CreateCondBr(firstThreadInSubgroup, zeroThreadCountBlock, endZeroThreadCountBlock);
-      }
-    }
-
-    // Construct ".zeroThreadCount" block
+    // Construct ".endWritePrimId" block
     {
-      m_builder->SetInsertPoint(zeroThreadCountBlock);
+      m_builder->SetInsertPoint(endWritePrimIdBlock);
 
-      unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionVertCountInWaves);
-
-      auto zero = m_builder->getInt32(0);
-
-      // Zero per-wave primitive/vertex count
-      auto zeros = ConstantVector::getSplat(ElementCount::get(Gfx9::NggMaxWavesPerSubgroup, false), zero);
-
-      auto ldsOffset = m_builder->getInt32(regionStart);
-      m_ldsManager->writeValueToLds(zeros, ldsOffset);
-
-      // Zero sub-group primitive/vertex count
-      ldsOffset = m_builder->getInt32(regionStart + SizeOfDword * Gfx9::NggMaxWavesPerSubgroup);
-      m_ldsManager->writeValueToLds(zero, ldsOffset);
-
-      m_builder->CreateBr(endZeroThreadCountBlock);
-    }
-
-    // Construct ".endZeroThreadCount" block
-    {
-      m_builder->SetInsertPoint(endZeroThreadCountBlock);
-
-      auto firstWaveInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.waveIdInSubgroup, m_builder->getInt32(0));
-      m_builder->CreateCondBr(firstWaveInSubgroup, zeroDrawFlagBlock, endZeroDrawFlagBlock);
-    }
-
-    // Construct ".zeroDrawFlag" block
-    {
-      m_builder->SetInsertPoint(zeroDrawFlagBlock);
-
-      Value *ldsOffset = m_builder->CreateShl(m_nggFactor.threadIdInWave, 2);
-
-      unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDrawFlag);
-
-      ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(regionStart));
-
-      auto zero = m_builder->getInt32(0);
-      m_ldsManager->writeValueToLds(zero, ldsOffset);
-
-      if (waveCountInSubgroup == 8) {
-        assert(waveSize == 32);
-        ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(32 * SizeOfDword));
-        m_ldsManager->writeValueToLds(zero, ldsOffset);
-      }
-
-      m_builder->CreateBr(endZeroDrawFlagBlock);
-    }
-
-    // Construct ".endZeroDrawFlag" block
-    {
-      m_builder->SetInsertPoint(endZeroDrawFlagBlock);
+      m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
       auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.vertCountInWave);
-      m_builder->CreateCondBr(vertValid, writePosDataBlock, endWritePosDataBlock);
+      m_builder->CreateCondBr(vertValid, readPrimIdBlock, endReadPrimIdBlock);
     }
 
-    // Construct ".writePosData" block
-    Value *posData = nullptr;
+    // Construct ".readPrimId" block
+    Value *primitiveId = nullptr;
     {
-      m_builder->SetInsertPoint(writePosDataBlock);
+      m_builder->SetInsertPoint(readPrimIdBlock);
 
-      // Split ES to two parts: fetch cull data before NGG culling; do deferred vertex export after NGG culling
-      splitEs(module);
+      primitiveId =
+          readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionDistribPrimId);
 
-      // Run ES-partial to fetch cull data
-      auto cullData = runEsPartial(module, entryPoint->arg_begin());
-      posData = m_nggControl->enableCullDistanceCulling ? m_builder->CreateExtractValue(cullData, 0) : cullData;
-
-      // Write vertex position data to LDS
-      writePerThreadDataToLds(posData, m_nggFactor.threadIdInSubgroup, LdsRegionPosData);
-
-      // Write cull distance sign mask to LDS
-      if (m_nggControl->enableCullDistanceCulling) {
-        auto cullDistance = m_builder->CreateExtractValue(cullData, 1);
-
-        // Calculate the sign mask for cull distance
-        Value *signMask = m_builder->getInt32(0);
-        for (unsigned i = 0; i < cullDistance->getType()->getArrayNumElements(); ++i) {
-          auto cullDistanceVal = m_builder->CreateExtractValue(cullDistance, i);
-          cullDistanceVal = m_builder->CreateBitCast(cullDistanceVal, m_builder->getInt32Ty());
-
-          Value *signBit =
-              m_builder->CreateIntrinsic(Intrinsic::amdgcn_ubfe, m_builder->getInt32Ty(),
-                                         {cullDistanceVal, m_builder->getInt32(31), m_builder->getInt32(1)});
-          signBit = m_builder->CreateShl(signBit, i);
-
-          signMask = m_builder->CreateOr(signMask, signBit);
-        }
-
-        writePerThreadDataToLds(signMask, m_nggFactor.threadIdInSubgroup, LdsRegionCullDistance);
-      }
-
-      m_builder->CreateBr(endWritePosDataBlock);
+      m_builder->CreateBr(endReadPrimIdBlock);
     }
 
-    // Construct ".endWritePosData" block
+    // Construct ".endReadPrimId" block
     {
-      m_builder->SetInsertPoint(endWritePosDataBlock);
+      m_builder->SetInsertPoint(endReadPrimIdBlock);
 
-      PHINode *posDataPhi = m_builder->CreatePHI(FixedVectorType::get(m_builder->getFloatTy(), 4), 2);
-      posDataPhi->addIncoming(posData, writePosDataBlock);
-      posDataPhi->addIncoming(UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 4)), endZeroDrawFlagBlock);
-      posData = posDataPhi; // Update vertex position data
+      auto primitiveIdPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+      primitiveIdPhi->addIncoming(primitiveId, readPrimIdBlock);
+      primitiveIdPhi->addIncoming(m_builder->getInt32(0), endWritePrimIdBlock);
+
+      // Record primitive ID
+      m_nggFactor.primitiveId = primitiveId;
 
       m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
-      auto primValidInWave = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.primCountInWave);
-      auto primValidInSubgroup =
-          m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
-
-      auto primValid = m_builder->CreateAnd(primValidInWave, primValidInSubgroup);
-      m_builder->CreateCondBr(primValid, cullingBlock, endCullingBlock);
+      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+      m_builder->CreateCondBr(vertValid, initVertDrawFlagBlock, endInitVertDrawFlagBlock);
     }
+  }
 
-    // Construct ".culling" block
-    Value *doCull = nullptr;
-    {
-      m_builder->SetInsertPoint(cullingBlock);
+  // Construct ".initVertDrawFlag" block
+  {
+    m_builder->SetInsertPoint(initVertDrawFlagBlock);
 
-      const unsigned esGsRingItemSize =
-          m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
-      assert(isPowerOf2_32(esGsRingItemSize));
+    writeVertexCullInfoToLds(m_builder->getInt32(0), vertexItemOffset, m_vertCullInfoOffsets.drawFlag);
 
-      auto vertexId0 = m_builder->CreateLShr(m_nggFactor.esGsOffset0, Log2_32(esGsRingItemSize));
-      auto vertexId1 = m_builder->CreateLShr(m_nggFactor.esGsOffset1, Log2_32(esGsRingItemSize));
-      auto vertexId2 = m_builder->CreateLShr(m_nggFactor.esGsOffset2, Log2_32(esGsRingItemSize));
+    m_builder->CreateBr(endInitVertDrawFlagBlock);
+  }
 
-      doCull = doCulling(module, vertexId0, vertexId1, vertexId2);
-      m_builder->CreateBr(endCullingBlock);
-    }
+  // Construct ".endInitVertDrawFlag" block
+  {
+    m_builder->SetInsertPoint(endInitVertDrawFlagBlock);
 
-    // Construct ".endCulling" block
-    Value *drawFlag = nullptr;
-    PHINode *cullFlag = nullptr;
-    {
-      m_builder->SetInsertPoint(endCullingBlock);
+    auto waveValid =
+        m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_builder->getInt32(waveCountInSubgroup + 1));
+    m_builder->CreateCondBr(waveValid, initVertCountBlock, endInitVertCountBlock);
+  }
 
-      cullFlag = m_builder->CreatePHI(m_builder->getInt1Ty(), 2);
+  // Construct ".initVertCount" block
+  {
+    m_builder->SetInsertPoint(initVertCountBlock);
 
-      cullFlag->addIncoming(m_builder->getTrue(), endWritePosDataBlock);
-      cullFlag->addIncoming(doCull, cullingBlock);
+    writePerThreadDataToLds(m_builder->getInt32(0), m_nggFactor.threadIdInSubgroup, LdsRegionVertCountInWaves);
 
-      drawFlag = m_builder->CreateNot(cullFlag);
-      m_builder->CreateCondBr(drawFlag, writeDrawFlagBlock, endWriteDrawFlagBlock);
-    }
+    m_builder->CreateBr(endInitVertCountBlock);
+  }
 
-    // Construct ".writeDrawFlag" block
-    {
-      m_builder->SetInsertPoint(writeDrawFlagBlock);
+  // Construct ".endInitVertCount" block
+  {
+    m_builder->SetInsertPoint(endInitVertCountBlock);
 
-      auto vertexId0 = m_builder->CreateLShr(m_nggFactor.esGsOffset0, 2);
-      auto vertexId1 = m_builder->CreateLShr(m_nggFactor.esGsOffset1, 2);
-      auto vertexId2 = m_builder->CreateLShr(m_nggFactor.esGsOffset2, 2);
+    auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.vertCountInWave);
+    m_builder->CreateCondBr(vertValid, writeVertCullDataBlock, endWriteVertCullDataBlock);
+  }
 
-      Value *vertexId[3] = {vertexId0, vertexId1, vertexId2};
+  // Construct ".writeVertexCullData" block
+  Value *position = nullptr;
+  {
+    m_builder->SetInsertPoint(writeVertCullDataBlock);
 
-      unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDrawFlag);
-      auto regionStartVal = m_builder->getInt32(regionStart);
+    // Split ES to two parts: fetch cull data before NGG culling; do deferred vertex export after NGG culling
+    splitEs(module);
 
-      auto one = m_builder->getInt8(1);
+    // Run ES-partial to fetch cull data
+    auto cullData = runEsPartial(module, entryPoint->arg_begin());
+    position = m_nggControl->enableCullDistanceCulling ? m_builder->CreateExtractValue(cullData, 0) : cullData;
 
-      for (unsigned i = 0; i < 3; ++i) {
-        auto ldsOffset = m_builder->CreateAdd(regionStartVal, vertexId[i]);
-        m_ldsManager->writeValueToLds(one, ldsOffset);
+    // Write vertex position data
+    writePerThreadDataToLds(position, m_nggFactor.threadIdInSubgroup, LdsRegionVertPosData, true);
+
+    // Write cull distance sign mask
+    if (m_nggControl->enableCullDistanceCulling) {
+      auto cullDistance = m_builder->CreateExtractValue(cullData, 1);
+
+      // Calculate the sign mask for cull distance
+      Value *signMask = m_builder->getInt32(0);
+      for (unsigned i = 0; i < cullDistance->getType()->getArrayNumElements(); ++i) {
+        auto cullDistanceVal = m_builder->CreateExtractValue(cullDistance, i);
+        cullDistanceVal = m_builder->CreateBitCast(cullDistanceVal, m_builder->getInt32Ty());
+
+        Value *signBit = m_builder->CreateIntrinsic(Intrinsic::amdgcn_ubfe, m_builder->getInt32Ty(),
+                                                    {cullDistanceVal, m_builder->getInt32(31), m_builder->getInt32(1)});
+        signBit = m_builder->CreateShl(signBit, i);
+
+        signMask = m_builder->CreateOr(signMask, signBit);
       }
 
-      m_builder->CreateBr(endWriteDrawFlagBlock);
+      writeVertexCullInfoToLds(signMask, vertexItemOffset, m_vertCullInfoOffsets.cullDistanceSignMask);
     }
 
-    // Construct ".endWriteDrawFlag" block
-    Value *drawCount = nullptr;
-    {
-      m_builder->SetInsertPoint(endWriteDrawFlagBlock);
+    m_builder->CreateBr(endWriteVertCullDataBlock);
+  }
 
-      m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+  // Construct ".endWriteVertCullData" block
+  {
+    m_builder->SetInsertPoint(endWriteVertCullDataBlock);
 
-      unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionDrawFlag);
+    PHINode *positionPhi = m_builder->CreatePHI(FixedVectorType::get(m_builder->getFloatTy(), 4), 2);
+    positionPhi->addIncoming(position, writeVertCullDataBlock);
+    positionPhi->addIncoming(UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 4)), endInitVertCountBlock);
+    position = positionPhi; // Update vertex position data
+    position->setName("position");
 
-      auto ldsOffset = m_builder->CreateAdd(m_nggFactor.threadIdInSubgroup, m_builder->getInt32(regionStart));
+    m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
-      drawFlag = m_ldsManager->readValueFromLds(m_builder->getInt8Ty(), ldsOffset);
-      drawFlag = m_builder->CreateTrunc(drawFlag, m_builder->getInt1Ty());
+    auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
+    m_builder->CreateCondBr(primValid, cullingBlock, endCullingBlock);
+  }
 
-      auto drawMask = doSubgroupBallot(drawFlag);
+  // Construct ".culling" block
+  Value *cullFlag = nullptr;
+  {
+    m_builder->SetInsertPoint(cullingBlock);
 
-      drawCount = m_builder->CreateIntrinsic(Intrinsic::ctpop, m_builder->getInt64Ty(), drawMask);
-      drawCount = m_builder->CreateTrunc(drawCount, m_builder->getInt32Ty());
+    auto vertexId0 = m_nggFactor.esGsOffset0;
+    auto vertexId1 = m_nggFactor.esGsOffset1;
+    auto vertexId2 = m_nggFactor.esGsOffset2;
 
-      auto threadIdUpbound =
-          m_builder->CreateSub(m_builder->getInt32(waveCountInSubgroup), m_nggFactor.waveIdInSubgroup);
-      auto threadValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, threadIdUpbound);
+    cullFlag = doCulling(module, vertexId0, vertexId1, vertexId2);
+    m_builder->CreateCondBr(cullFlag, endCullingBlock, writeVertDrawFlagBlock);
+  }
 
-      m_builder->CreateCondBr(threadValid, accThreadCountBlock, endAccThreadCountBlock);
+  // Construct ".writeVertDrawFlag" block
+  {
+    m_builder->SetInsertPoint(writeVertDrawFlagBlock);
+
+    auto vertexItemOffset0 =
+        m_builder->CreateMul(m_nggFactor.esGsOffset0, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+    auto vertexItemOffset1 =
+        m_builder->CreateMul(m_nggFactor.esGsOffset1, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+    auto vertexItemOffset2 =
+        m_builder->CreateMul(m_nggFactor.esGsOffset2, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+
+    writeVertexCullInfoToLds(m_builder->getInt32(1), vertexItemOffset0, m_vertCullInfoOffsets.drawFlag);
+    writeVertexCullInfoToLds(m_builder->getInt32(1), vertexItemOffset1, m_vertCullInfoOffsets.drawFlag);
+    writeVertexCullInfoToLds(m_builder->getInt32(1), vertexItemOffset2, m_vertCullInfoOffsets.drawFlag);
+
+    m_builder->CreateBr(endCullingBlock);
+  }
+
+  // Construct ".endCulling" block
+  {
+    m_builder->SetInsertPoint(endCullingBlock);
+
+    auto cullFlagPhi = m_builder->CreatePHI(m_builder->getInt1Ty(), 3);
+    cullFlagPhi->addIncoming(m_builder->getTrue(), cullingBlock);
+    cullFlagPhi->addIncoming(m_builder->getFalse(), writeVertDrawFlagBlock);
+    cullFlagPhi->addIncoming(m_builder->getTrue(), endWriteVertCullDataBlock);
+    cullFlag = cullFlagPhi;
+
+    m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+
+    auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+    m_builder->CreateCondBr(vertValid, checkVertDrawFlagBlock, endCheckVertDrawFlagBlock);
+  }
+
+  // Construct ".checkVertDrawFlag"
+  Value *drawFlag = nullptr;
+  {
+    m_builder->SetInsertPoint(checkVertDrawFlagBlock);
+
+    drawFlag = readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset, m_vertCullInfoOffsets.drawFlag);
+    drawFlag = m_builder->CreateICmpNE(drawFlag, m_builder->getInt32(0));
+
+    m_builder->CreateBr(endCheckVertDrawFlagBlock);
+  }
+
+  // Construct ".endCheckVertDrawFlag"
+  Value *drawMask = nullptr;
+  Value *vertCountInWave = nullptr;
+  {
+    m_builder->SetInsertPoint(endCheckVertDrawFlagBlock);
+
+    auto drawFlagPhi = m_builder->CreatePHI(m_builder->getInt1Ty(), 2);
+    drawFlagPhi->addIncoming(drawFlag, checkVertDrawFlagBlock);
+    drawFlagPhi->addIncoming(m_builder->getFalse(), endCullingBlock);
+    drawFlag = drawFlagPhi; // Update vertex draw flag
+
+    drawMask = doSubgroupBallot(drawFlagPhi);
+
+    vertCountInWave = m_builder->CreateIntrinsic(Intrinsic::ctpop, m_builder->getInt64Ty(), drawMask);
+    vertCountInWave = m_builder->CreateTrunc(vertCountInWave, m_builder->getInt32Ty());
+
+    auto threadIdUpbound = m_builder->CreateSub(m_builder->getInt32(waveCountInSubgroup), m_nggFactor.waveIdInSubgroup);
+    auto threadValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, threadIdUpbound);
+
+    m_builder->CreateCondBr(threadValid, accumVertCountBlock, endAccumVertCountBlock);
+  }
+
+  // Construct ".accumVertCount" block
+  {
+    m_builder->SetInsertPoint(accumVertCountBlock);
+
+    auto ldsOffset = m_builder->CreateAdd(m_nggFactor.waveIdInSubgroup, m_nggFactor.threadIdInWave);
+    ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(1));
+    ldsOffset = m_builder->CreateShl(ldsOffset, 2);
+
+    unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionVertCountInWaves);
+
+    ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(regionStart));
+    m_ldsManager->atomicOpWithLds(AtomicRMWInst::Add, vertCountInWave, ldsOffset);
+
+    m_builder->CreateBr(endAccumVertCountBlock);
+  }
+
+  // Construct ".endAccumVertCount" block
+  Value *vertCountInPrevWaves = nullptr;
+  Value *vertCountInSubgroup = nullptr;
+  {
+    m_builder->SetInsertPoint(endAccumVertCountBlock);
+
+    m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+
+    auto vertCountInWaves =
+        readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInWave, LdsRegionVertCountInWaves);
+
+    // The last dword following dwords for all waves (each wave has one dword) stores vertex count of the
+    // entire sub-group
+    vertCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readlane, {},
+                                                     {vertCountInWaves, m_builder->getInt32(waveCountInSubgroup)});
+
+    // Get vertex count for all waves prior to this wave
+    vertCountInPrevWaves =
+        m_builder->CreateIntrinsic(Intrinsic::amdgcn_readlane, {}, {vertCountInWaves, m_nggFactor.waveIdInSubgroup});
+
+    auto vertCompacted = m_builder->CreateICmpULT(vertCountInSubgroup, m_nggFactor.vertCountInSubgroup);
+
+    // Record vertex compaction flag
+    m_nggFactor.vertCompacted = vertCompacted;
+
+    m_builder->CreateCondBr(m_builder->CreateAnd(drawFlag, vertCompacted), compactVertBlock, endCompactVertBlock);
+  }
+
+  // Construct ".compactVert" block
+  {
+    m_builder->SetInsertPoint(compactVertBlock);
+
+    auto drawMaskVec = m_builder->CreateBitCast(drawMask, FixedVectorType::get(Type::getInt32Ty(*m_context), 2));
+
+    auto drawMaskLow = m_builder->CreateExtractElement(drawMaskVec, static_cast<uint64_t>(0));
+    Value *compactVertexId =
+        m_builder->CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {drawMaskLow, m_builder->getInt32(0)});
+
+    if (waveSize == 64) {
+      auto drawMaskHigh = m_builder->CreateExtractElement(drawMaskVec, 1);
+      compactVertexId = m_builder->CreateIntrinsic(Intrinsic::amdgcn_mbcnt_hi, {}, {drawMaskHigh, compactVertexId});
     }
 
-    // Construct ".accThreadCount" block
-    {
-      m_builder->SetInsertPoint(accThreadCountBlock);
+    // Setup the map: compacted -> uncompacted
+    compactVertexId = m_builder->CreateAdd(vertCountInPrevWaves, compactVertexId);
+    writePerThreadDataToLds(m_nggFactor.threadIdInSubgroup, compactVertexId, LdsRegionVertThreadIdMap);
 
-      auto ldsOffset = m_builder->CreateAdd(m_nggFactor.waveIdInSubgroup, m_nggFactor.threadIdInWave);
-      ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(1));
-      ldsOffset = m_builder->CreateShl(ldsOffset, 2);
+    // Write compacted thread ID
+    writeVertexCullInfoToLds(compactVertexId, vertexItemOffset, m_vertCullInfoOffsets.compactThreadId);
 
-      unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionVertCountInWaves);
-
-      ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(regionStart));
-      m_ldsManager->atomicOpWithLds(AtomicRMWInst::Add, drawCount, ldsOffset);
-
-      m_builder->CreateBr(endAccThreadCountBlock);
-    }
-
-    // Construct ".endAccThreadCount" block
-    {
-      m_builder->SetInsertPoint(endAccThreadCountBlock);
-
-      m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
-      m_builder->CreateBr(readThreadCountBlock);
-    }
-
-    // Construct ".readThreadCount" block
-    Value *threadCountInWaves = nullptr;
-    Value *vertCountInWaves = nullptr;
-    Value *vertCountInPrevWaves = nullptr;
-    {
-      m_builder->SetInsertPoint(readThreadCountBlock);
-
-      unsigned regionStart = m_ldsManager->getLdsRegionStart(LdsRegionVertCountInWaves);
-
-      // The dword following dwords for all waves stores the vertex count of the entire sub-group
-      Value *ldsOffset = m_builder->getInt32(regionStart + waveCountInSubgroup * SizeOfDword);
-      vertCountInWaves = m_ldsManager->readValueFromLds(m_builder->getInt32Ty(), ldsOffset);
-
-      // NOTE: We promote vertex count in waves to SGPR since it is treated as an uniform value.
-      vertCountInWaves = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, vertCountInWaves);
-      threadCountInWaves = vertCountInWaves;
-
-      // Get vertex count for all waves prior to this wave
-      ldsOffset = m_builder->CreateShl(m_nggFactor.waveIdInSubgroup, 2);
-      ldsOffset = m_builder->CreateAdd(m_builder->getInt32(regionStart), ldsOffset);
-
-      vertCountInPrevWaves = m_ldsManager->readValueFromLds(m_builder->getInt32Ty(), ldsOffset);
-
-      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.vertCountInWave);
-
-      auto compactDataWrite = m_builder->CreateAnd(drawFlag, vertValid);
-
-      m_builder->CreateCondBr(compactDataWrite, writeCompactDataBlock, endReadThreadCountBlock);
-    }
-
-    // Construct ".writeCompactData" block
-    {
-      m_builder->SetInsertPoint(writeCompactDataBlock);
-
-      Value *drawMask = doSubgroupBallot(drawFlag);
-      drawMask = m_builder->CreateBitCast(drawMask, FixedVectorType::get(Type::getInt32Ty(*m_context), 2));
-
-      auto drawMaskLow = m_builder->CreateExtractElement(drawMask, static_cast<uint64_t>(0));
-
-      Value *compactThreadIdInSubrgoup =
-          m_builder->CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {drawMaskLow, m_builder->getInt32(0)});
-
-      if (waveSize == 64) {
-        auto drawMaskHigh = m_builder->CreateExtractElement(drawMask, 1);
-
-        compactThreadIdInSubrgoup =
-            m_builder->CreateIntrinsic(Intrinsic::amdgcn_mbcnt_hi, {}, {drawMaskHigh, compactThreadIdInSubrgoup});
+    if (hasTs) {
+      // Write X/Y of tessCoord (U/V)
+      if (resUsage->builtInUsage.tes.tessCoord) {
+        writeVertexCullInfoToLds(tessCoordX, vertexItemOffset, m_vertCullInfoOffsets.tessCoordX);
+        writeVertexCullInfoToLds(tessCoordY, vertexItemOffset, m_vertCullInfoOffsets.tessCoordY);
       }
 
-      compactThreadIdInSubrgoup = m_builder->CreateAdd(vertCountInPrevWaves, compactThreadIdInSubrgoup);
+      // Write relative patch ID
+      writeVertexCullInfoToLds(relPatchId, vertexItemOffset, m_vertCullInfoOffsets.relPatchId);
 
-      // Write vertex position data to LDS
-      writePerThreadDataToLds(posData, compactThreadIdInSubrgoup, LdsRegionPosData);
+      // Write patch ID
+      if (resUsage->builtInUsage.tes.primitiveId)
+        writeVertexCullInfoToLds(patchId, vertexItemOffset, m_vertCullInfoOffsets.patchId);
+    } else {
+      // Write vertex ID
+      if (resUsage->builtInUsage.vs.vertexIndex)
+        writeVertexCullInfoToLds(vertexId, vertexItemOffset, m_vertCullInfoOffsets.vertexId);
 
-      // Write thread ID in sub-group to LDS
-      Value *compactThreadId = m_builder->CreateTrunc(compactThreadIdInSubrgoup, m_builder->getInt8Ty());
-      writePerThreadDataToLds(compactThreadId, m_nggFactor.threadIdInSubgroup, LdsRegionVertThreadIdMap);
+      // Write instance ID
+      if (resUsage->builtInUsage.vs.instanceIndex)
+        writeVertexCullInfoToLds(instanceId, vertexItemOffset, m_vertCullInfoOffsets.instanceId);
 
-      if (hasTs) {
-        // Write X/Y of tessCoord (U/V) to LDS
-        if (resUsage->builtInUsage.tes.tessCoord) {
-          writePerThreadDataToLds(tessCoordX, compactThreadIdInSubrgoup, LdsRegionCompactTessCoordX);
-          writePerThreadDataToLds(tessCoordY, compactThreadIdInSubrgoup, LdsRegionCompactTessCoordY);
-        }
-
-        // Write relative patch ID to LDS
-        writePerThreadDataToLds(relPatchId, compactThreadIdInSubrgoup, LdsRegionCompactRelPatchId);
-
-        // Write patch ID to LDS
-        if (resUsage->builtInUsage.tes.primitiveId)
-          writePerThreadDataToLds(patchId, compactThreadIdInSubrgoup, LdsRegionCompactPatchId);
-      } else {
-        // Write vertex ID to LDS
-        if (resUsage->builtInUsage.vs.vertexIndex)
-          writePerThreadDataToLds(vertexId, compactThreadIdInSubrgoup, LdsRegionCompactVertexId);
-
-        // Write instance ID to LDS
-        if (resUsage->builtInUsage.vs.instanceIndex)
-          writePerThreadDataToLds(instanceId, compactThreadIdInSubrgoup, LdsRegionCompactInstanceId);
-
-        // Write primitive ID to LDS
-        if (resUsage->builtInUsage.vs.primitiveId) {
-          assert(m_nggFactor.primitiveId);
-          writePerThreadDataToLds(m_nggFactor.primitiveId, compactThreadIdInSubrgoup, LdsRegionCompactPrimId);
-        }
+      // Write primitive ID
+      if (resUsage->builtInUsage.vs.primitiveId) {
+        assert(m_nggFactor.primitiveId);
+        writeVertexCullInfoToLds(m_nggFactor.primitiveId, vertexItemOffset, m_vertCullInfoOffsets.primitiveId);
       }
-
-      m_builder->CreateBr(endReadThreadCountBlock);
     }
 
-    // Construct ".endReadThreadCount" block
-    {
-      m_builder->SetInsertPoint(endReadThreadCountBlock);
+    m_builder->CreateBr(endCompactVertBlock);
+  }
 
-      Value *hasSurviveVert = m_builder->CreateICmpNE(vertCountInWaves, m_builder->getInt32(0));
+  // Construct ".endCompactVert" block
+  Value *fullyCulled = nullptr;
+  {
+    m_builder->SetInsertPoint(endCompactVertBlock);
 
-      Value *primCountInSubgroup = m_builder->CreateSelect(hasSurviveVert, m_nggFactor.primCountInSubgroup,
-                                                           m_builder->getInt32(fullyCulledThreadCount));
+    fullyCulled = m_builder->CreateICmpEQ(vertCountInSubgroup, m_builder->getInt32(0));
 
-      // NOTE: Here, we have to promote revised primitive count in sub-group to SGPR since it is treated
-      // as an uniform value later. This is similar to the provided primitive count in sub-group that is
-      // a system value.
-      primCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, primCountInSubgroup);
+    Value *primCountInSubgroup = m_builder->CreateSelect(fullyCulled, m_builder->getInt32(fullyCulledExportCount),
+                                                         m_nggFactor.primCountInSubgroup);
 
-      Value *vertCountInSubgroup =
-          m_builder->CreateSelect(hasSurviveVert, vertCountInWaves, m_builder->getInt32(fullyCulledThreadCount));
+    // NOTE: Here, we have to promote revised primitive count in sub-group to SGPR since it is treated
+    // as an uniform value later. This is similar to the provided primitive count in sub-group that is
+    // a system value.
+    primCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, primCountInSubgroup);
 
-      // NOTE: Here, we have to promote revised vertex count in sub-group to SGPR since it is treated as
-      // an uniform value later, similar to what we have done for the revised primitive count in
-      // sub-group.
-      vertCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, vertCountInSubgroup);
+    vertCountInSubgroup =
+        m_builder->CreateSelect(fullyCulled, m_builder->getInt32(fullyCulledExportCount), vertCountInSubgroup);
 
-      m_nggFactor.primCountInSubgroup = primCountInSubgroup;
-      m_nggFactor.vertCountInSubgroup = vertCountInSubgroup;
+    // NOTE: Here, we have to promote revised vertex count in sub-group to SGPR since it is treated as
+    // an uniform value later, similar to what we have done for the revised primitive count in
+    // sub-group.
+    vertCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, vertCountInSubgroup);
 
-      auto firstWaveInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.waveIdInSubgroup, m_builder->getInt32(0));
+    // Update primitive/vertex count in sub-group
+    m_nggFactor.primCountInSubgroup = primCountInSubgroup;
+    m_nggFactor.vertCountInSubgroup = vertCountInSubgroup;
 
-      m_builder->CreateCondBr(firstWaveInSubgroup, allocReqBlock, endAllocReqBlock);
-    }
+    auto firstWaveInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.waveIdInSubgroup, m_builder->getInt32(0));
+    m_builder->CreateCondBr(firstWaveInSubgroup, allocReqBlock, endAllocReqBlock);
+  }
 
-    // Construct ".allocReq" block
-    {
-      m_builder->SetInsertPoint(allocReqBlock);
+  // Construct ".allocReq" block
+  {
+    m_builder->SetInsertPoint(allocReqBlock);
 
-      doParamCacheAllocRequest();
-      m_builder->CreateBr(endAllocReqBlock);
-    }
+    doParamCacheAllocRequest();
+    m_builder->CreateBr(endAllocReqBlock);
+  }
 
-    // Construct ".endAllocReq" block
-    {
-      m_builder->SetInsertPoint(endAllocReqBlock);
+  // Construct ".endAllocReq" block
+  {
+    m_builder->SetInsertPoint(endAllocReqBlock);
 
-      m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+    m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
-      auto noSurviveThread = m_builder->CreateICmpEQ(threadCountInWaves, m_builder->getInt32(0));
-      m_builder->CreateCondBr(noSurviveThread, earlyExitBlock, noEarlyExitBlock);
-    }
+    m_builder->CreateCondBr(fullyCulled, earlyExitBlock, noEarlyExitBlock);
+  }
 
-    // Construct ".earlyExit" block
-    {
-      m_builder->SetInsertPoint(earlyExitBlock);
+  // Construct ".earlyExit" block
+  {
+    m_builder->SetInsertPoint(earlyExitBlock);
 
-      doEarlyExit(fullyCulledThreadCount);
-    }
+    doEarlyExit(fullyCulledExportCount);
+  }
 
-    // Construct ".noEarlyExit" block
-    {
-      m_builder->SetInsertPoint(noEarlyExitBlock);
+  // Construct ".noEarlyExit" block
+  {
+    m_builder->SetInsertPoint(noEarlyExitBlock);
 
-      auto primExp = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
-      m_builder->CreateCondBr(primExp, expPrimBlock, endExpPrimBlock);
-    }
+    auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
+    m_builder->CreateCondBr(primValid, expPrimBlock, endExpPrimBlock);
+  }
 
-    // Construct ".expPrim" block
-    {
-      m_builder->SetInsertPoint(expPrimBlock);
+  // Construct ".expPrim" block
+  {
+    m_builder->SetInsertPoint(expPrimBlock);
 
-      doPrimitiveExportWithoutGs(cullFlag);
-      m_builder->CreateBr(endExpPrimBlock);
-    }
+    doPrimitiveExportWithoutGs(cullFlag);
 
-    // Construct ".endExpPrim" block
-    Value *vertExp = nullptr;
-    {
-      m_builder->SetInsertPoint(endExpPrimBlock);
+    m_builder->CreateBr(endExpPrimBlock);
+  }
 
-      vertExp = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
-      m_builder->CreateCondBr(vertExp, expVertBlock, endExpVertBlock);
-    }
+  // Construct ".endExpPrim" block
+  {
+    m_builder->SetInsertPoint(endExpPrimBlock);
 
-    // Construct ".expVert" block
-    {
-      m_builder->SetInsertPoint(expVertBlock);
+    auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+    m_builder->CreateCondBr(vertValid, expVertBlock, endExpVertBlock);
+  }
 
-      // Run ES-partial to do deferred vertex export
-      runEsPartial(module, entryPoint->arg_begin(), posData);
+  // Construct ".expVert" block
+  {
+    m_builder->SetInsertPoint(expVertBlock);
 
-      m_builder->CreateBr(endExpVertBlock);
-    }
+    // Run ES-partial to do deferred vertex export
+    runEsPartial(module, entryPoint->arg_begin(), position);
 
-    // Construct ".endExpVert" block
-    {
-      m_builder->SetInsertPoint(endExpVertBlock);
+    m_builder->CreateBr(endExpVertBlock);
+  }
 
-      m_builder->CreateRetVoid();
-    }
+  // Construct ".endExpVert" block
+  {
+    m_builder->SetInsertPoint(endExpVertBlock);
+
+    m_builder->CreateRetVoid();
   }
 }
 
@@ -1843,8 +1729,8 @@ void NggPrimShader::constructPrimShaderWithGs(Module *module) {
 
     m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
-    auto primExp = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
-    m_builder->CreateCondBr(primExp, expPrimBlock, endExpPrimBlock);
+    auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.primCountInSubgroup);
+    m_builder->CreateCondBr(primValid, expPrimBlock, endExpPrimBlock);
   }
 
   // Construct ".expPrim" block
@@ -1859,8 +1745,8 @@ void NggPrimShader::constructPrimShaderWithGs(Module *module) {
   {
     m_builder->SetInsertPoint(endExpPrimBlock);
 
-    auto pVertExp = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
-    m_builder->CreateCondBr(pVertExp, expVertBlock, endExpVertBlock);
+    auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+    m_builder->CreateCondBr(vertValid, expVertBlock, endExpVertBlock);
   }
 
   // Construct ".expVert" block
@@ -1936,8 +1822,6 @@ void NggPrimShader::initWaveThreadInfo(Value *mergedGroupInfo, Value *mergedWave
   m_nggFactor.threadIdInWave = threadIdInWave;
   m_nggFactor.threadIdInSubgroup = threadIdInSubgroup;
   m_nggFactor.waveIdInSubgroup = waveIdInSubgroup;
-
-  m_nggFactor.mergedGroupInfo = mergedGroupInfo;
 }
 
 // =====================================================================================================================
@@ -2016,73 +1900,78 @@ void NggPrimShader::doPrimitiveExportWithoutGs(Value *cullFlag) {
     // Pass-through mode (primitive data has been constructed)
     primData = m_nggFactor.primData;
   } else {
-    // Non pass-through mode (primitive data has to be constructed)
-    const unsigned esGsRingItemSize =
-        m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
-    assert(isPowerOf2_32(esGsRingItemSize));
+    // Culling mode (primitive data has to be constructed)
+    Value *vertexId0 = m_nggFactor.esGsOffset0;
+    Value *vertexId1 = m_nggFactor.esGsOffset1;
+    Value *vertexId2 = m_nggFactor.esGsOffset2;
 
-    Value *vertexId0 = m_builder->CreateLShr(m_nggFactor.esGsOffset0, Log2_32(esGsRingItemSize));
-    Value *vertexId1 = m_builder->CreateLShr(m_nggFactor.esGsOffset1, Log2_32(esGsRingItemSize));
-    Value *vertexId2 = m_builder->CreateLShr(m_nggFactor.esGsOffset2, Log2_32(esGsRingItemSize));
-
-    // NOTE: If the current vertex count in sub-group is less than the original value, then there must be
-    // vertex culling. When vertex culling occurs, the vertex IDs should be fetched from LDS (compacted).
-    auto vertCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_ubfe, m_builder->getInt32Ty(),
-                                                          {
-                                                              m_nggFactor.mergedGroupInfo,
-                                                              m_builder->getInt32(12),
-                                                              m_builder->getInt32(9),
-                                                          });
-    auto vertCulled = m_builder->CreateICmpULT(m_nggFactor.vertCountInSubgroup, vertCountInSubgroup);
+    //
+    // The processing is something like this:
+    //
+    //   compactVertexId = IDs from froming vertices
+    //   if (vertCompacted)
+    //     Get compacted vertex IDs
+    //   Export primitive
+    //
 
     auto expPrimBlock = m_builder->GetInsertBlock();
 
-    auto readCompactIdBlock = createBlock(expPrimBlock->getParent(), "readCompactId");
-    readCompactIdBlock->moveAfter(expPrimBlock);
+    if (m_nggFactor.vertCompacted) {
+      auto compactVertIdBlock = createBlock(expPrimBlock->getParent(), ".compactVertId");
+      compactVertIdBlock->moveAfter(expPrimBlock);
 
-    auto expPrimContBlock = createBlock(expPrimBlock->getParent(), "expPrimCont");
-    expPrimContBlock->moveAfter(readCompactIdBlock);
+      auto endCompactVertIdBlock = createBlock(expPrimBlock->getParent(), ".endCompactVertId");
+      endCompactVertIdBlock->moveAfter(compactVertIdBlock);
 
-    m_builder->CreateCondBr(vertCulled, readCompactIdBlock, expPrimContBlock);
+      m_builder->CreateCondBr(m_nggFactor.vertCompacted, compactVertIdBlock, endCompactVertIdBlock);
 
-    // Construct ".readCompactId" block
-    Value *compactVertexId0 = nullptr;
-    Value *compactVertexId1 = nullptr;
-    Value *compactVertexId2 = nullptr;
-    {
-      m_builder->SetInsertPoint(readCompactIdBlock);
+      // Construct ".compactVertId" block
+      Value *compactVertexId0 = nullptr;
+      Value *compactVertexId1 = nullptr;
+      Value *compactVertexId2 = nullptr;
+      {
+        m_builder->SetInsertPoint(compactVertIdBlock);
 
-      compactVertexId0 = readPerThreadDataFromLds(m_builder->getInt8Ty(), vertexId0, LdsRegionVertThreadIdMap);
-      compactVertexId0 = m_builder->CreateZExt(compactVertexId0, m_builder->getInt32Ty());
+        const unsigned esGsRingItemSize =
+            m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
 
-      compactVertexId1 = readPerThreadDataFromLds(m_builder->getInt8Ty(), vertexId1, LdsRegionVertThreadIdMap);
-      compactVertexId1 = m_builder->CreateZExt(compactVertexId1, m_builder->getInt32Ty());
+        auto vertexItemOffset0 =
+            m_builder->CreateMul(m_nggFactor.esGsOffset0, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+        auto vertexItemOffset1 =
+            m_builder->CreateMul(m_nggFactor.esGsOffset1, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+        auto vertexItemOffset2 =
+            m_builder->CreateMul(m_nggFactor.esGsOffset2, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
 
-      compactVertexId2 = readPerThreadDataFromLds(m_builder->getInt8Ty(), vertexId2, LdsRegionVertThreadIdMap);
-      compactVertexId2 = m_builder->CreateZExt(compactVertexId2, m_builder->getInt32Ty());
+        compactVertexId0 = readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset0,
+                                                     m_vertCullInfoOffsets.compactThreadId);
+        compactVertexId1 = readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset1,
+                                                     m_vertCullInfoOffsets.compactThreadId);
+        compactVertexId2 = readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset2,
+                                                     m_vertCullInfoOffsets.compactThreadId);
 
-      m_builder->CreateBr(expPrimContBlock);
-    }
+        m_builder->CreateBr(endCompactVertIdBlock);
+      }
 
-    // Construct part of ".expPrimCont" block (phi nodes)
-    {
-      m_builder->SetInsertPoint(expPrimContBlock);
+      // Construct ".endCompactVertId" block
+      {
+        m_builder->SetInsertPoint(endCompactVertIdBlock);
 
-      auto vertexId0Phi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
-      vertexId0Phi->addIncoming(compactVertexId0, readCompactIdBlock);
-      vertexId0Phi->addIncoming(vertexId0, expPrimBlock);
+        auto vertexId0Phi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+        vertexId0Phi->addIncoming(compactVertexId0, compactVertIdBlock);
+        vertexId0Phi->addIncoming(vertexId0, expPrimBlock);
 
-      auto vertexId1Phi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
-      vertexId1Phi->addIncoming(compactVertexId1, readCompactIdBlock);
-      vertexId1Phi->addIncoming(vertexId1, expPrimBlock);
+        auto vertexId1Phi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+        vertexId1Phi->addIncoming(compactVertexId1, compactVertIdBlock);
+        vertexId1Phi->addIncoming(vertexId1, expPrimBlock);
 
-      auto vertexId2Phi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
-      vertexId2Phi->addIncoming(compactVertexId2, readCompactIdBlock);
-      vertexId2Phi->addIncoming(vertexId2, expPrimBlock);
+        auto vertexId2Phi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+        vertexId2Phi->addIncoming(compactVertexId2, compactVertIdBlock);
+        vertexId2Phi->addIncoming(vertexId2, expPrimBlock);
 
-      vertexId0 = vertexId0Phi;
-      vertexId1 = vertexId1Phi;
-      vertexId2 = vertexId2Phi;
+        vertexId0 = vertexId0Phi;
+        vertexId1 = vertexId1Phi;
+        vertexId2 = vertexId2Phi;
+      }
     }
 
     primData = m_builder->CreateShl(vertexId2, 10);
@@ -2091,9 +1980,9 @@ void NggPrimShader::doPrimitiveExportWithoutGs(Value *cullFlag) {
     primData = m_builder->CreateShl(primData, 10);
     primData = m_builder->CreateOr(primData, vertexId0);
 
-    assert(cullFlag); // Must not be null
-    const auto nullPrimVal = m_builder->getInt32(NullPrim);
-    primData = m_builder->CreateSelect(cullFlag, nullPrimVal, primData);
+    // Check cull flag to determine whether this primitive is culled if the cull flag is specified.
+    if (cullFlag)
+      primData = m_builder->CreateSelect(cullFlag, m_builder->getInt32(NullPrim), primData);
   }
 
   auto undef = UndefValue::get(m_builder->getInt32Ty());
@@ -2193,10 +2082,10 @@ void NggPrimShader::doPrimitiveExportWithGs(Value *vertexId) {
 // Early exit NGG primitive shader when we detect that the entire sub-group is fully culled, doing dummy
 // primitive/vertex export if necessary.
 //
-// @param fullyCulledThreadCount : Thread count left when the entire sub-group is fully culled
-void NggPrimShader::doEarlyExit(unsigned fullyCulledThreadCount) {
-  if (fullyCulledThreadCount > 0) {
-    assert(fullyCulledThreadCount == 1); // Currently, if workarounded, this is set to 1
+// @param fullyCulledExportCount : Primitive/vertex count for dummy export when the entire sub-group is fully culled
+void NggPrimShader::doEarlyExit(unsigned fullyCulledExportCount) {
+  if (fullyCulledExportCount > 0) {
+    assert(fullyCulledExportCount == 1); // Currently, if workarounded, this is set to 1
 
     auto earlyExitBlock = m_builder->GetInsertBlock();
 
@@ -2206,7 +2095,7 @@ void NggPrimShader::doEarlyExit(unsigned fullyCulledThreadCount) {
     auto endDummyExpBlock = createBlock(earlyExitBlock->getParent(), ".endDummyExp");
     endDummyExpBlock->moveAfter(dummyExpBlock);
 
-    // Continue to construct ".earlyExit" block
+    // Construct ".earlyExit" block
     {
       auto firstThreadInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.threadIdInSubgroup, m_builder->getInt32(0));
       m_builder->CreateCondBr(firstThreadInSubgroup, dummyExpBlock, endDummyExpBlock);
@@ -2452,44 +2341,135 @@ Value *NggPrimShader::runEsPartial(Module *module, Argument *sysValueStart, Valu
   Value *vsPrimitiveId = m_nggFactor.primitiveId ? m_nggFactor.primitiveId : UndefValue::get(m_builder->getInt32Ty());
   Value *instanceId = (arg + 8);
 
-  if (deferredVertexExport) {
-    position = readPerThreadDataFromLds(FixedVectorType::get(m_builder->getFloatTy(), 4),
-                                        m_nggFactor.threadIdInSubgroup, LdsRegionPosData);
+  if (deferredVertexExport && m_nggFactor.vertCompacted) {
+    auto expVertBlock = m_builder->GetInsertBlock();
 
-    // NOTE: For deferred vertex export, the system values are from LDS compaction data region rather than from VGPRs
-    // (caused by NGG culling and vertex compaction)
-    const auto resUsage = m_pipelineState->getShaderResourceUsage(hasTs ? ShaderStageTessEval : ShaderStageVertex);
-    if (hasTs) {
-      if (resUsage->builtInUsage.tes.tessCoord) {
-        tessCoordX = readPerThreadDataFromLds(m_builder->getFloatTy(), m_nggFactor.threadIdInSubgroup,
-                                              LdsRegionCompactTessCoordX);
+    auto uncompactVertBlock = createBlock(expVertBlock->getParent(), ".uncompactVert");
+    uncompactVertBlock->moveAfter(expVertBlock);
 
-        tessCoordY = readPerThreadDataFromLds(m_builder->getFloatTy(), m_nggFactor.threadIdInSubgroup,
-                                              LdsRegionCompactTessCoordY);
+    auto endUncompactVertBlock = createBlock(expVertBlock->getParent(), ".endUncompactVert");
+    endUncompactVertBlock->moveAfter(uncompactVertBlock);
+
+    m_builder->CreateCondBr(m_nggFactor.vertCompacted, uncompactVertBlock, endUncompactVertBlock);
+
+    // Construct ".uncompactVert" block
+    Value *newPosition = nullptr;
+    Value *newTessCoordX = nullptr;
+    Value *newTessCoordY = nullptr;
+    Value *newRelPatchId = nullptr;
+    Value *newPatchId = nullptr;
+    Value *newVertexId = nullptr;
+    Value *newVsPrimitiveId = nullptr;
+    Value *newInstanceId = nullptr;
+    {
+      m_builder->SetInsertPoint(uncompactVertBlock);
+
+      const unsigned esGsRingItemSize =
+          m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
+
+      auto uncompactVertexId =
+          readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionVertThreadIdMap);
+      auto vertexItemOffset =
+          m_builder->CreateMul(uncompactVertexId, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+
+      newPosition = readPerThreadDataFromLds(FixedVectorType::get(m_builder->getFloatTy(), 4), uncompactVertexId,
+                                             LdsRegionVertPosData, true);
+
+      // NOTE: For deferred vertex export, some system values could be from vertex compaction info rather than from
+      // VGPRs (caused by NGG culling and vertex compaction)
+      const auto resUsage = m_pipelineState->getShaderResourceUsage(hasTs ? ShaderStageTessEval : ShaderStageVertex);
+      if (hasTs) {
+        if (resUsage->builtInUsage.tes.tessCoord) {
+          newTessCoordX =
+              readVertexCullInfoFromLds(m_builder->getFloatTy(), vertexItemOffset, m_vertCullInfoOffsets.tessCoordX);
+          newTessCoordY =
+              readVertexCullInfoFromLds(m_builder->getFloatTy(), vertexItemOffset, m_vertCullInfoOffsets.tessCoordY);
+        }
+
+        newRelPatchId =
+            readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset, m_vertCullInfoOffsets.relPatchId);
+
+        if (resUsage->builtInUsage.tes.primitiveId) {
+          newPatchId =
+              readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset, m_vertCullInfoOffsets.patchId);
+        }
+      } else {
+        if (resUsage->builtInUsage.vs.vertexIndex) {
+          newVertexId =
+              readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset, m_vertCullInfoOffsets.vertexId);
+        }
+
+        // NOTE: Relative vertex ID is not used when VS is merged to GS.
+        if (resUsage->builtInUsage.vs.primitiveId) {
+          newVsPrimitiveId =
+              readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset, m_vertCullInfoOffsets.primitiveId);
+        }
+
+        if (resUsage->builtInUsage.vs.instanceIndex) {
+          newInstanceId =
+              readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset, m_vertCullInfoOffsets.instanceId);
+        }
       }
+      m_builder->CreateBr(endUncompactVertBlock);
+    }
 
-      relPatchId =
-          readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionCompactRelPatchId);
+    // Construct ".endUncompactVert" block
+    {
+      m_builder->SetInsertPoint(endUncompactVertBlock);
 
-      if (resUsage->builtInUsage.tes.primitiveId) {
-        patchId =
-            readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionCompactPatchId);
-      }
-    } else {
-      if (resUsage->builtInUsage.vs.vertexIndex) {
-        vertexId =
-            readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionCompactVertexId);
-      }
+      auto positionPhi = m_builder->CreatePHI(FixedVectorType::get(m_builder->getFloatTy(), 4), 2);
+      positionPhi->addIncoming(newPosition, uncompactVertBlock);
+      positionPhi->addIncoming(position, expVertBlock);
+      position = positionPhi;
 
-      // NOTE: Relative vertex ID is used when VS is merged to GS.
-      if (resUsage->builtInUsage.vs.primitiveId) {
-        vsPrimitiveId =
-            readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup, LdsRegionCompactPrimId);
-      }
+      if (hasTs) {
+        if (newTessCoordX) {
+          auto tessCoordXPhi = m_builder->CreatePHI(m_builder->getFloatTy(), 2);
+          tessCoordXPhi->addIncoming(newTessCoordX, uncompactVertBlock);
+          tessCoordXPhi->addIncoming(tessCoordX, expVertBlock);
+          tessCoordX = tessCoordXPhi;
+        }
 
-      if (resUsage->builtInUsage.vs.instanceIndex) {
-        instanceId = readPerThreadDataFromLds(m_builder->getInt32Ty(), m_nggFactor.threadIdInSubgroup,
-                                              LdsRegionCompactInstanceId);
+        if (newTessCoordY) {
+          auto tessCoordYPhi = m_builder->CreatePHI(m_builder->getFloatTy(), 2);
+          tessCoordYPhi->addIncoming(newTessCoordY, uncompactVertBlock);
+          tessCoordYPhi->addIncoming(tessCoordY, expVertBlock);
+          tessCoordY = tessCoordYPhi;
+        }
+
+        assert(newRelPatchId);
+        auto relPatchPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+        relPatchPhi->addIncoming(newRelPatchId, uncompactVertBlock);
+        relPatchPhi->addIncoming(relPatchId, expVertBlock);
+        relPatchId = relPatchPhi;
+
+        if (newPatchId) {
+          auto patchIdPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+          patchIdPhi->addIncoming(newPatchId, uncompactVertBlock);
+          patchIdPhi->addIncoming(patchId, expVertBlock);
+          patchId = patchIdPhi;
+        }
+      } else {
+        if (newVertexId) {
+          auto vertexIdPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+          vertexIdPhi->addIncoming(newVertexId, uncompactVertBlock);
+          vertexIdPhi->addIncoming(vertexId, expVertBlock);
+          vertexId = vertexIdPhi;
+        }
+
+        if (newVsPrimitiveId) {
+          auto vsPrimitiveIdPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+          vsPrimitiveIdPhi->addIncoming(newVsPrimitiveId, uncompactVertBlock);
+          vsPrimitiveIdPhi->addIncoming(vsPrimitiveId, expVertBlock);
+          vsPrimitiveId = vsPrimitiveIdPhi;
+        }
+
+        if (newInstanceId) {
+          auto instanceIdPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+          instanceIdPhi->addIncoming(newInstanceId, uncompactVertBlock);
+          instanceIdPhi->addIncoming(instanceId, expVertBlock);
+          instanceId = instanceIdPhi;
+        }
       }
     }
   }
@@ -3416,10 +3396,13 @@ Function *NggPrimShader::createGsCutHandler(Module *module, unsigned streamId) {
 // =====================================================================================================================
 // Reads per-thread data from the specified NGG region in LDS.
 //
-// @param readDataTy : Data written to LDS
+// @param readDataTy : Data read from LDS
 // @param threadId : Thread ID in sub-group to calculate LDS offset
 // @param region : NGG LDS region
-Value *NggPrimShader::readPerThreadDataFromLds(Type *readDataTy, Value *threadId, NggLdsRegionType region) {
+// @param useDs128 : Whether to use 128-bit LDS read, 16-byte alignment is guaranteed by caller
+Value *NggPrimShader::readPerThreadDataFromLds(Type *readDataTy, Value *threadId, NggLdsRegionType region,
+                                               bool useDs128) {
+  assert(region != LdsRegionVertCullInfo); // Vertex cull info region is an aggregate-typed one, not applicable
   auto sizeInBytes = readDataTy->getPrimitiveSizeInBits() / 8;
 
   const auto regionStart = m_ldsManager->getLdsRegionStart(region);
@@ -3431,7 +3414,7 @@ Value *NggPrimShader::readPerThreadDataFromLds(Type *readDataTy, Value *threadId
     ldsOffset = threadId;
   ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(regionStart));
 
-  return m_ldsManager->readValueFromLds(readDataTy, ldsOffset);
+  return m_ldsManager->readValueFromLds(readDataTy, ldsOffset, useDs128);
 }
 
 // =====================================================================================================================
@@ -3440,7 +3423,9 @@ Value *NggPrimShader::readPerThreadDataFromLds(Type *readDataTy, Value *threadId
 // @param writeData : Data written to LDS
 // @param threadId : Thread ID in sub-group to calculate LDS offset
 // @param region : NGG LDS region
-void NggPrimShader::writePerThreadDataToLds(Value *writeData, Value *threadId, NggLdsRegionType region) {
+// @param useDs128 : Whether to use 128-bit LDS write, 16-byte alignment is guaranteed by caller
+void NggPrimShader::writePerThreadDataToLds(Value *writeData, Value *threadId, NggLdsRegionType region, bool useDs128) {
+  assert(region != LdsRegionVertCullInfo); // Vertex cull info region is an aggregate-typed one, not applicable
   auto writeDataTy = writeData->getType();
   auto sizeInBytes = writeDataTy->getPrimitiveSizeInBits() / 8;
 
@@ -3453,7 +3438,43 @@ void NggPrimShader::writePerThreadDataToLds(Value *writeData, Value *threadId, N
     ldsOffset = threadId;
   ldsOffset = m_builder->CreateAdd(ldsOffset, m_builder->getInt32(regionStart));
 
-  m_ldsManager->writeValueToLds(writeData, ldsOffset);
+  m_ldsManager->writeValueToLds(writeData, ldsOffset, useDs128);
+}
+
+// =====================================================================================================================
+// Reads vertex cull info from LDS (the region of vertex cull info).
+//
+// @param readDataTy : Data read from LDS
+// @param vertexItemOffset : Per-vertex item offset (in bytes) in sub-group of the entire vertex cull info
+// @param dataOffset : Data offset (in bytes) within an item of vertex cull info
+// @param useDs128 : Whether to use 128-bit LDS read, 16-byte alignment is guaranteed by caller
+Value *NggPrimShader::readVertexCullInfoFromLds(Type *readDataTy, Value *vertexItemOffset, unsigned dataOffset,
+                                                bool useDs128) {
+  // Only applied to culling mode of non-GS NGG
+  assert(!m_hasGs && !m_nggControl->passthroughMode);
+  assert(dataOffset != InvalidValue);
+
+  const auto regionStart = m_ldsManager->getLdsRegionStart(LdsRegionVertCullInfo);
+  Value *ldsOffset = m_builder->CreateAdd(vertexItemOffset, m_builder->getInt32(regionStart + dataOffset));
+  return m_ldsManager->readValueFromLds(readDataTy, ldsOffset, useDs128);
+}
+
+// =====================================================================================================================
+// Writes vertex cull info to LDS (the region of vertex cull info).
+//
+// @param writeData : Data written to LDS
+// @param vertexItemOffset : Per-vertex item offset (in bytes) in sub-group of the entire vertex cull info
+// @param dataOffset : Data offset (in bytes) within an item of vertex cull info
+// @param useDs128 : Whether to use 128-bit LDS write, 16-byte alignment is guaranteed by caller
+void NggPrimShader::writeVertexCullInfoToLds(Value *writeData, Value *vertexItemOffset, unsigned dataOffset,
+                                             bool useDs128) {
+  // Only applied to culling mode of non-GS NGG
+  assert(!m_hasGs && !m_nggControl->passthroughMode);
+  assert(dataOffset != InvalidValue);
+
+  const auto regionStart = m_ldsManager->getLdsRegionStart(LdsRegionVertCullInfo);
+  Value *ldsOffset = m_builder->CreateAdd(vertexItemOffset, m_builder->getInt32(regionStart + dataOffset));
+  m_ldsManager->writeValueToLds(writeData, ldsOffset, useDs128);
 }
 
 // =====================================================================================================================
@@ -5254,7 +5275,8 @@ unsigned NggPrimShader::getOutputVerticesPerPrimitive() const {
 Value *NggPrimShader::fetchVertexPositionData(Value *vertexId) {
   if (!m_hasGs) {
     // ES-only
-    return readPerThreadDataFromLds(FixedVectorType::get(m_builder->getFloatTy(), 4), vertexId, LdsRegionPosData);
+    return readPerThreadDataFromLds(FixedVectorType::get(m_builder->getFloatTy(), 4), vertexId, LdsRegionVertPosData,
+                                    true);
   }
 
   // ES-GS
@@ -5276,7 +5298,11 @@ Value *NggPrimShader::fetchCullDistanceSignMask(Value *vertexId) {
 
   if (!m_hasGs) {
     // ES-only
-    return readPerThreadDataFromLds(m_builder->getInt32Ty(), vertexId, LdsRegionCullDistance);
+    const unsigned esGsRingItemSize =
+        m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.esGsRingItemSize;
+    auto vertexItemOffset = m_builder->CreateMul(vertexId, m_builder->getInt32(esGsRingItemSize * SizeOfDword));
+    return readVertexCullInfoFromLds(m_builder->getInt32Ty(), vertexItemOffset,
+                                     m_vertCullInfoOffsets.cullDistanceSignMask);
   }
 
   // ES-GS

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -37,11 +37,19 @@
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 
 #define DEBUG_TYPE "lgc-ngg-prim-shader"
 
 using namespace llvm;
+
+// -ngg-small-subgroup-threshold: threshold of vertex count to determine a small subgroup (NGG)
+static cl::opt<unsigned> NggSmallSubgroupThreshold(
+    "ngg-small-subgroup-threshold",
+    cl::desc(
+        "Threshold of vertex count to determine a small subgroup and such small subgroup won't perform NGG culling"),
+    cl::value_desc("threshold"), cl::init(16));
 
 namespace lgc {
 
@@ -748,34 +756,39 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
   //     Barrier
   //   }
   //
-  //   if (threadIdInSubgroup < vertCountInSubgroup)
-  //     Initialize vertex draw flag
-  //   if (threadIdInSubgroup < waveCount + 1)
-  //     Initialize per-wave and per-subgroup count of output vertices
-  //
   //   if (threadIdInWave < vertCountInWave)
-  //     Write vertex cull data
-  //   Barrier
+  //     Run ES-partial to fetch vertex cull data
   //
-  //   if (threadIdInSubgroup < primCountInSubgroup) {
-  //     Do culling (run culling algorithms)
-  //     if (primitive not culled)
-  //       Write draw flags of forming vertices
+  //   if (!runtimePassthrough) {
+  //     if (threadIdInSubgroup < vertCountInSubgroup)
+  //       Initialize vertex draw flag
+  //     if (threadIdInSubgroup < waveCount + 1)
+  //       Initialize per-wave and per-subgroup count of output vertices
+  //
+  //     if (threadIdInWave < vertCountInWave)
+  //       Write vertex cull data
+  //     Barrier
+  //
+  //     if (threadIdInSubgroup < primCountInSubgroup) {
+  //       Do culling (run culling algorithms)
+  //       if (primitive not culled)
+  //         Write draw flags of forming vertices
+  //     }
+  //     Barrier
+  //
+  //     if (threadIdInSubgroup < vertCountInSubgroup)
+  //       Check draw flags of vertices and compute draw mask
+  //
+  //     if (threadIdInWave < waveCount - waveId)
+  //       Accumulate per-wave and per-subgroup count of output vertices
+  //     Barrier
+  //
+  //     if (vertex compacted && vertex drawed) {
+  //       Compact vertex thread ID (map: compacted -> uncompacted)
+  //       Write vertex compaction info
+  //     }
+  //     Update vertCountInSubgroup and primCountInSubgroup
   //   }
-  //   Barrier
-  //
-  //   if (threadIdInSubgroup < vertCountInSubgroup)
-  //     Check draw flags of vertices and compute draw mask
-  //
-  //   if (threadIdInWave < waveCount - waveId)
-  //     Accumulate per-wave and per-subgroup count of output vertices
-  //   Barrier
-  //
-  //   if (vertex compacted && vertex drawed) {
-  //     Compact vertex thread ID (map: compacted -> uncompacted)
-  //     Write vertex compaction info
-  //   }
-  //   Update vertCountInSubgroup and primCountInSubgroup
   //
   //   if (waveId == 0)
   //     GS allocation request (GS_ALLOC_REQ)
@@ -821,6 +834,12 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
     endReadPrimIdBlock = createBlock(entryPoint, ".endReadPrimId");
   }
 
+  auto fetchVertCullDataBlock = createBlock(entryPoint, ".fetchVertCullData");
+  auto endFetchVertCullDataBlock = createBlock(entryPoint, ".endFetchVertCullData");
+
+  auto runtimePassthroughBlock = createBlock(entryPoint, ".runtimePassthrough");
+  auto noRuntimePassthroughBlock = createBlock(entryPoint, ".noRuntimePassthrough");
+
   auto initVertDrawFlagBlock = createBlock(entryPoint, ".initVertDrawFlag");
   auto endInitVertDrawFlagBlock = createBlock(entryPoint, ".endInitVertDrawFlag");
 
@@ -843,6 +862,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
   auto compactVertBlock = createBlock(entryPoint, ".compactVert");
   auto endCompactVertBlock = createBlock(entryPoint, ".endCompactVert");
 
+  auto checkAllocReqBlock = createBlock(entryPoint, ".checkAllocReq");
   auto allocReqBlock = createBlock(entryPoint, ".allocReq");
   auto endAllocReqBlock = createBlock(entryPoint, ".endAllocReq");
 
@@ -877,8 +897,8 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       auto primValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.primCountInWave);
       m_builder->CreateCondBr(primValid, writePrimIdBlock, endWritePrimIdBlock);
     } else {
-      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
-      m_builder->CreateCondBr(vertValid, initVertDrawFlagBlock, endInitVertDrawFlagBlock);
+      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.vertCountInWave);
+      m_builder->CreateCondBr(vertValid, fetchVertCullDataBlock, endFetchVertCullDataBlock);
     }
   }
 
@@ -933,9 +953,59 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
 
       m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
-      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
-      m_builder->CreateCondBr(vertValid, initVertDrawFlagBlock, endInitVertDrawFlagBlock);
+      auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInWave, m_nggFactor.vertCountInWave);
+      m_builder->CreateCondBr(vertValid, fetchVertCullDataBlock, endFetchVertCullDataBlock);
     }
+  }
+
+  // Construct ".fetchVertCullData" block
+  Value *cullData = nullptr;
+  Value *position = nullptr;
+  {
+    m_builder->SetInsertPoint(fetchVertCullDataBlock);
+
+    // Split ES to two parts: fetch cull data before NGG culling; do deferred vertex export after NGG culling
+    splitEs(module);
+
+    // Run ES-partial to fetch cull data
+    auto cullData = runEsPartial(module, entryPoint->arg_begin());
+    position = m_nggControl->enableCullDistanceCulling ? m_builder->CreateExtractValue(cullData, 0) : cullData;
+
+    m_builder->CreateBr(endFetchVertCullDataBlock);
+  }
+
+  // Construct ".endFetchVertCullData" block
+  {
+    m_builder->SetInsertPoint(endFetchVertCullDataBlock);
+
+    PHINode *positionPhi = m_builder->CreatePHI(FixedVectorType::get(m_builder->getFloatTy(), 4), 2, "position");
+    positionPhi->addIncoming(position, fetchVertCullDataBlock);
+    positionPhi->addIncoming(UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 4)),
+                             distributePrimitiveId ? endReadPrimIdBlock : entryBlock);
+    position = positionPhi; // Update vertex position data
+
+    auto runtimePassthrough =
+        m_builder->CreateICmpULT(m_nggFactor.vertCountInSubgroup, m_builder->getInt32(NggSmallSubgroupThreshold));
+    m_builder->CreateCondBr(runtimePassthrough, runtimePassthroughBlock, noRuntimePassthroughBlock);
+  }
+
+  // Construct ".runtimePassthrough" block
+  {
+    m_builder->SetInsertPoint(runtimePassthroughBlock);
+
+    if (!distributePrimitiveId) {
+      m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+    }
+
+    m_builder->CreateBr(checkAllocReqBlock);
+  }
+
+  // Construct ".noRuntimePassthrough" block
+  {
+    m_builder->SetInsertPoint(noRuntimePassthroughBlock);
+
+    auto vertValid = m_builder->CreateICmpULT(m_nggFactor.threadIdInSubgroup, m_nggFactor.vertCountInSubgroup);
+    m_builder->CreateCondBr(vertValid, initVertDrawFlagBlock, endInitVertDrawFlagBlock);
   }
 
   // Construct ".initVertDrawFlag" block
@@ -974,16 +1044,8 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
   }
 
   // Construct ".writeVertexCullData" block
-  Value *position = nullptr;
   {
     m_builder->SetInsertPoint(writeVertCullDataBlock);
-
-    // Split ES to two parts: fetch cull data before NGG culling; do deferred vertex export after NGG culling
-    splitEs(module);
-
-    // Run ES-partial to fetch cull data
-    auto cullData = runEsPartial(module, entryPoint->arg_begin());
-    position = m_nggControl->enableCullDistanceCulling ? m_builder->CreateExtractValue(cullData, 0) : cullData;
 
     // Write vertex position data
     writePerThreadDataToLds(position, m_nggFactor.threadIdInSubgroup, LdsRegionVertPosData, true);
@@ -1014,12 +1076,6 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
   // Construct ".endWriteVertCullData" block
   {
     m_builder->SetInsertPoint(endWriteVertCullDataBlock);
-
-    PHINode *positionPhi = m_builder->CreatePHI(FixedVectorType::get(m_builder->getFloatTy(), 4), 2);
-    positionPhi->addIncoming(position, writeVertCullDataBlock);
-    positionPhi->addIncoming(UndefValue::get(FixedVectorType::get(m_builder->getFloatTy(), 4)), endInitVertCountBlock);
-    position = positionPhi; // Update vertex position data
-    position->setName("position");
 
     m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
 
@@ -1126,6 +1182,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
   // Construct ".endAccumVertCount" block
   Value *vertCountInPrevWaves = nullptr;
   Value *vertCountInSubgroup = nullptr;
+  Value *vertCompacted = nullptr;
   {
     m_builder->SetInsertPoint(endAccumVertCountBlock);
 
@@ -1143,10 +1200,7 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
     vertCountInPrevWaves =
         m_builder->CreateIntrinsic(Intrinsic::amdgcn_readlane, {}, {vertCountInWaves, m_nggFactor.waveIdInSubgroup});
 
-    auto vertCompacted = m_builder->CreateICmpULT(vertCountInSubgroup, m_nggFactor.vertCountInSubgroup);
-
-    // Record vertex compaction flag
-    m_nggFactor.vertCompacted = vertCompacted;
+    vertCompacted = m_builder->CreateICmpULT(vertCountInSubgroup, m_nggFactor.vertCountInSubgroup);
 
     m_builder->CreateCondBr(m_builder->CreateAnd(drawFlag, vertCompacted), compactVertBlock, endCompactVertBlock);
   }
@@ -1207,13 +1261,16 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
 
   // Construct ".endCompactVert" block
   Value *fullyCulled = nullptr;
+  Value *primCountInSubgroup = nullptr;
   {
     m_builder->SetInsertPoint(endCompactVertBlock);
 
+    // m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+
     fullyCulled = m_builder->CreateICmpEQ(vertCountInSubgroup, m_builder->getInt32(0));
 
-    Value *primCountInSubgroup = m_builder->CreateSelect(fullyCulled, m_builder->getInt32(fullyCulledExportCount),
-                                                         m_nggFactor.primCountInSubgroup);
+    primCountInSubgroup = m_builder->CreateSelect(fullyCulled, m_builder->getInt32(fullyCulledExportCount),
+                                                  m_nggFactor.primCountInSubgroup);
 
     // NOTE: Here, we have to promote revised primitive count in sub-group to SGPR since it is treated
     // as an uniform value later. This is similar to the provided primitive count in sub-group that is
@@ -1228,9 +1285,45 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
     // sub-group.
     vertCountInSubgroup = m_builder->CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, vertCountInSubgroup);
 
-    // Update primitive/vertex count in sub-group
-    m_nggFactor.primCountInSubgroup = primCountInSubgroup;
-    m_nggFactor.vertCountInSubgroup = vertCountInSubgroup;
+    m_builder->CreateBr(checkAllocReqBlock);
+  }
+
+  // Construct ".checkAllocReq" block
+  {
+    m_builder->SetInsertPoint(checkAllocReqBlock);
+
+    // NOTE: Here, we make several phi nodes to update some values that are different in runtime passthrough path
+    // and no runtime passthrough path (normal culling path).
+
+    // Update vertex compaction flag
+    auto vertCompactedPhi = m_builder->CreatePHI(m_builder->getInt1Ty(), 2, "vertCompacted");
+    vertCompactedPhi->addIncoming(vertCompacted, endCompactVertBlock);
+    vertCompactedPhi->addIncoming(m_builder->getFalse(), runtimePassthroughBlock);
+    m_nggFactor.vertCompacted = vertCompactedPhi; // Record vertex compaction flag
+
+    // Update cull flag
+    auto cullFlagPhi = m_builder->CreatePHI(m_builder->getInt1Ty(), 2, "cullFlag");
+    cullFlagPhi->addIncoming(cullFlag, endCompactVertBlock);
+    cullFlagPhi->addIncoming(m_builder->getFalse(), runtimePassthroughBlock);
+    cullFlag = cullFlagPhi;
+
+    // Update fully-culled flag
+    auto fullyCulledPhi = m_builder->CreatePHI(m_builder->getInt1Ty(), 2, "fullyCulled");
+    fullyCulledPhi->addIncoming(fullyCulled, endCompactVertBlock);
+    fullyCulledPhi->addIncoming(m_builder->getFalse(), runtimePassthroughBlock);
+    fullyCulled = fullyCulledPhi;
+
+    // Update primitive count in sub-group
+    auto primCountInSubgroupPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+    primCountInSubgroupPhi->addIncoming(primCountInSubgroup, endCompactVertBlock);
+    primCountInSubgroupPhi->addIncoming(m_nggFactor.primCountInSubgroup, runtimePassthroughBlock);
+    m_nggFactor.primCountInSubgroup = primCountInSubgroupPhi; // Record primitive count in subgroup
+
+    // Update vertex count in sub-group
+    auto vertCountInSubgroupPhi = m_builder->CreatePHI(m_builder->getInt32Ty(), 2);
+    vertCountInSubgroupPhi->addIncoming(vertCountInSubgroup, endCompactVertBlock);
+    vertCountInSubgroupPhi->addIncoming(m_nggFactor.vertCountInSubgroup, runtimePassthroughBlock);
+    m_nggFactor.vertCountInSubgroup = vertCountInSubgroupPhi; // Record vertex count in subgroup
 
     auto firstWaveInSubgroup = m_builder->CreateICmpEQ(m_nggFactor.waveIdInSubgroup, m_builder->getInt32(0));
     m_builder->CreateCondBr(firstWaveInSubgroup, allocReqBlock, endAllocReqBlock);

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -86,12 +86,68 @@ struct PrimShaderCbLayoutLookupTable {
   PrimShaderVportCbLookupTable vportControls[Util::Abi::MaxViewports];
 };
 
+// Represents the layout structure of an item of vertex cull info (this acts as ES-GS ring item from HW's perspective)
+struct VertexCullInfo {
+  //
+  // Vertex cull data
+  //
+  unsigned cullDistanceSignMask;
+  //
+  // Vertex cull result
+  //
+  unsigned drawFlag;
+  //
+  // Vertex compaction info (vertex compaction only, must in the end of this structure)
+  //
+  unsigned compactThreadId;
+  union {
+    struct {
+      unsigned vertexId;
+      unsigned instanceId;
+      unsigned primitiveId;
+    } vs;
+    struct {
+      float tessCoordX;
+      float tessCoordY;
+      unsigned patchId;
+      unsigned relPatchId;
+    } tes;
+  };
+};
+
+// Represents a collection of LDS offsets (in bytes) within an item of vertex cull info.
+struct VertexCullInfoOffsets {
+  //
+  // Vertex cull data
+  //
+  unsigned cullDistanceSignMask;
+  //
+  // Vertex cull result
+  //
+  unsigned drawFlag;
+  //
+  // Vertex compaction info
+  //
+  unsigned compactThreadId;
+  // VS
+  unsigned vertexId;
+  unsigned instanceId;
+  unsigned primitiveId;
+  // TES
+  unsigned tessCoordX;
+  unsigned tessCoordY;
+  unsigned patchId;
+  unsigned relPatchId;
+};
+
 // =====================================================================================================================
 // Represents the manager of NGG primitive shader.
 class NggPrimShader {
 public:
   NggPrimShader(PipelineState *pipelineState);
   ~NggPrimShader();
+
+  static unsigned calcEsGsRingItemSize(PipelineState *pipelineState);
 
   llvm::Function *generate(llvm::Function *esEntryPoint, llvm::Function *gsEntryPoint,
                            llvm::Function *copyShaderEntryPoint);
@@ -100,6 +156,9 @@ private:
   NggPrimShader() = delete;
   NggPrimShader(const NggPrimShader &) = delete;
   NggPrimShader &operator=(const NggPrimShader &) = delete;
+
+  static unsigned calcVertexCullInfoSizeAndOffsets(PipelineState *pipelineState,
+                                                   VertexCullInfoOffsets &vertCullInfoOffsets);
 
   llvm::FunctionType *generatePrimShaderEntryPointType(llvm::Module *module, uint64_t *inRegMask) const;
   llvm::Function *generatePrimShaderEntryPoint(llvm::Module *module);
@@ -116,7 +175,7 @@ private:
   void doPrimitiveExportWithoutGs(llvm::Value *cullFlag = nullptr);
   void doPrimitiveExportWithGs(llvm::Value *vertexId);
 
-  void doEarlyExit(unsigned fullyCullThreadCount);
+  void doEarlyExit(unsigned fullyCulledExportCount);
 
   void runEs(llvm::Module *module, llvm::Argument *sysValueStart);
   llvm::Value *runEsPartial(llvm::Module *module, llvm::Argument *sysValueStart, llvm::Value *position = nullptr);
@@ -145,9 +204,15 @@ private:
   llvm::Function *createGsEmitHandler(llvm::Module *module, unsigned streamId);
   llvm::Function *createGsCutHandler(llvm::Module *module, unsigned streamId);
 
-  llvm::Value *readPerThreadDataFromLds(llvm::Type *readDataTy, llvm::Value *threadId, NggLdsRegionType region);
+  llvm::Value *readPerThreadDataFromLds(llvm::Type *readDataTy, llvm::Value *threadId, NggLdsRegionType region,
+                                        bool useDs128 = false);
+  void writePerThreadDataToLds(llvm::Value *writeData, llvm::Value *threadId, NggLdsRegionType region,
+                               bool useDs128 = false);
 
-  void writePerThreadDataToLds(llvm::Value *writeData, llvm::Value *threadId, NggLdsRegionType region);
+  llvm::Value *readVertexCullInfoFromLds(llvm::Type *readDataTy, llvm::Value *vertexItemOffset, unsigned dataOffset,
+                                         bool useDs128 = false);
+  void writeVertexCullInfoToLds(llvm::Value *writeData, llvm::Value *vertexItemOffset, unsigned dataOffset,
+                                bool useDs128 = false);
 
   llvm::Value *doBackfaceCulling(llvm::Module *module, llvm::Value *cullFlag, llvm::Value *vertex0,
                                  llvm::Value *vertex1, llvm::Value *vertex2);
@@ -205,8 +270,6 @@ private:
 
   const NggControl *m_nggControl; // NGG control settings
 
-  PrimShaderCbLayoutLookupTable m_cbLayoutTable; // Layout lookup table of primitive shader constant buffer
-
   NggLdsManager *m_ldsManager; // NGG LDS manager
 
   // NGG factors used for calculation (different modes use different factors)
@@ -221,10 +284,10 @@ private:
 
     llvm::Value *waveIdInSubgroup; // Wave ID in sub-group
 
-    llvm::Value *primitiveId; // Primitive ID (for VS)
+    llvm::Value *primitiveId;   // Primitive ID (for VS)
+    llvm::Value *vertCompacted; // Whether vertex compaction is performed (for culling mode)
 
     // System values, not used in pass-through mode (SGPRs)
-    llvm::Value *mergedGroupInfo;         // Merged group info
     llvm::Value *primShaderTableAddrLow;  // Primitive shader table address low
     llvm::Value *primShaderTableAddrHigh; // Primitive shader table address high
 
@@ -247,6 +310,9 @@ private:
 
   // Base offsets (in dwords) of GS output vertex streams in GS-VS ring
   unsigned m_gsStreamBases[MaxGsStreams];
+
+  PrimShaderCbLayoutLookupTable m_cbLayoutTable; // Layout lookup table of primitive shader constant buffer
+  VertexCullInfoOffsets m_vertCullInfoOffsets;   // A collection of offsets within an item of vertex cull info
 
   std::unique_ptr<llvm::IRBuilder<>> m_builder; // LLVM IR builder
 };

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -32,6 +32,7 @@
 #include "Gfx6Chip.h"
 #include "Gfx9Chip.h"
 #include "NggLdsManager.h"
+#include "NggPrimShader.h"
 #include "lgc/Builder.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PipelineShaders.h"
@@ -613,11 +614,7 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
     const auto nggControl = m_pipelineState->getNggControl();
 
     if (nggControl->enableNgg) {
-      // NOTE: Make esGsRingItemSize odd by "| 1", to optimize ES -> GS ring layout for LDS bank conflicts.
-      const unsigned esGsRingItemSize = hasGs ? ((4 * std::max(1u,
-                                                               gsResUsage->inOutUsage.inputMapLocCount)) |
-                                                 1)
-                                              : 4; // Always 4 components for NGG when GS is not present
+      unsigned esGsRingItemSize = NggPrimShader::calcEsGsRingItemSize(m_pipelineState); // In dwords
 
       const unsigned gsVsRingItemSize =
           hasGs ? std::max(1u, 4 * gsResUsage->inOutUsage.outputMapLocCount * geometryMode.outputVertices) : 0;
@@ -952,11 +949,11 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
   LLPC_OUTS("ES vertices per sub-group: " << gsResUsage->inOutUsage.gs.calcFactor.esVertsPerSubgroup << "\n");
   LLPC_OUTS("GS primitives per sub-group: " << gsResUsage->inOutUsage.gs.calcFactor.gsPrimsPerSubgroup << "\n");
   LLPC_OUTS("\n");
-  LLPC_OUTS("ES-GS LDS size: " << gsResUsage->inOutUsage.gs.calcFactor.esGsLdsSize << "\n");
-  LLPC_OUTS("On-chip GS LDS size: " << gsResUsage->inOutUsage.gs.calcFactor.gsOnChipLdsSize << "\n");
+  LLPC_OUTS("ES-GS LDS size (in dwords): " << gsResUsage->inOutUsage.gs.calcFactor.esGsLdsSize << "\n");
+  LLPC_OUTS("On-chip GS LDS size (in dwords): " << gsResUsage->inOutUsage.gs.calcFactor.gsOnChipLdsSize << "\n");
   LLPC_OUTS("\n");
-  LLPC_OUTS("ES-GS ring item size: " << gsResUsage->inOutUsage.gs.calcFactor.esGsRingItemSize << "\n");
-  LLPC_OUTS("GS-VS ring item size: " << gsResUsage->inOutUsage.gs.calcFactor.gsVsRingItemSize << "\n");
+  LLPC_OUTS("ES-GS ring item size (in dwords): " << gsResUsage->inOutUsage.gs.calcFactor.esGsRingItemSize << "\n");
+  LLPC_OUTS("GS-VS ring item size (in dwords): " << gsResUsage->inOutUsage.gs.calcFactor.gsVsRingItemSize << "\n");
   LLPC_OUTS("\n");
 
   LLPC_OUTS("GS stream item size:\n");


### PR DESCRIPTION
Sometimes, we couldn't determine if NGG culling mode should be disabled
at compilation time. For example, if total vertex count in a subgroup
is below 16, such small subgroup shouldn't perform culling. In the
future, certain graphics states are dynamically set. We rely on part
of them to determine the feasibility of NGG culling. Therefore, a
runtime passthrough path is imperative.

This change adds such support. We define small subgroup as a compilation
option exposed to tuning: -ngg-small-subgroup-threshold. 