### PR TITLE
Revert "Fix-ups for now deprecated getNumElements on VectorType"

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -230,7 +230,7 @@ Value *ArithBuilder::CreateSMod(Value *dividend, Value *divisor, const Twine &in
         Value *pc = CreateIntrinsic(Intrinsic::amdgcn_s_getpc, {}, {});
         Value *pcHi = CreateExtractElement(CreateBitCast(pc, FixedVectorType::get(getInt32Ty(), 2)), 1);
         Value *nonConstantZero = CreateLShr(pcHi, getInt32(15));
-        if (auto vecTy = dyn_cast<FixedVectorType>(divisor->getType()))
+        if (auto vecTy = dyn_cast<VectorType>(divisor->getType()))
           nonConstantZero = CreateVectorSplat(vecTy->getNumElements(), nonConstantZero);
         // Add the non-constant 0 to the denominator to disable the optimization.
         divisor = CreateAdd(divisor, nonConstantZero);
@@ -830,7 +830,7 @@ Value *ArithBuilder::CreateExtractExponent(Value *value, const Twine &instName) 
 // @param y : Input value Y
 // @param instName : Name to give instruction(s)
 Value *ArithBuilder::CreateCrossProduct(Value *x, Value *y, const Twine &instName) {
-  assert(x->getType() == y->getType() && cast<FixedVectorType>(x->getType())->getNumElements() == 3);
+  assert(x->getType() == y->getType() && cast<VectorType>(x->getType())->getNumElements() == 3);
 
   Value *left = UndefValue::get(x->getType());
   Value *right = UndefValue::get(x->getType());
@@ -896,7 +896,7 @@ Value *ArithBuilder::CreateFaceForward(Value *n, Value *i, Value *nref, const Tw
 Value *ArithBuilder::CreateReflect(Value *i, Value *n, const Twine &instName) {
   Value *dot = CreateDotProduct(n, i);
   dot = CreateFMul(dot, ConstantFP::get(dot->getType(), 2.0));
-  if (auto vecTy = dyn_cast<FixedVectorType>(n->getType()))
+  if (auto vecTy = dyn_cast<VectorType>(n->getType()))
     dot = CreateVectorSplat(vecTy->getNumElements(), dot);
   return CreateFSub(i, CreateFMul(dot, n), instName);
 }
@@ -924,7 +924,7 @@ Value *ArithBuilder::CreateRefract(Value *i, Value *n, Value *eta, const Twine &
   Value *etaDot = CreateFMul(eta, dot);
   Value *innt = CreateFAdd(etaDot, kSqrt);
 
-  if (auto vecTy = dyn_cast<FixedVectorType>(n->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(n->getType())) {
     eta = CreateVectorSplat(vecTy->getNumElements(), eta);
     innt = CreateVectorSplat(vecTy->getNumElements(), innt);
   }
@@ -1177,7 +1177,7 @@ Value *ArithBuilder::createCallAmdgcnClass(Value *value, unsigned flags, const T
 Value *ArithBuilder::CreateInsertBitField(Value *base, Value *insert, Value *offset, Value *count,
                                           const Twine &instName) {
   // Make pOffset and pCount vectors of the right integer type if necessary.
-  if (auto vecTy = dyn_cast<FixedVectorType>(base->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(base->getType())) {
     if (!isa<VectorType>(offset->getType()))
       offset = CreateVectorSplat(vecTy->getNumElements(), offset);
     if (!isa<VectorType>(count->getType()))
@@ -1211,7 +1211,7 @@ Value *ArithBuilder::CreateInsertBitField(Value *base, Value *insert, Value *off
 Value *ArithBuilder::CreateExtractBitField(Value *base, Value *offset, Value *count, bool isSigned,
                                            const Twine &instName) {
   // Make pOffset and pCount vectors of the right integer type if necessary.
-  if (auto vecTy = dyn_cast<FixedVectorType>(base->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(base->getType())) {
     if (!isa<VectorType>(offset->getType()))
       offset = CreateVectorSplat(vecTy->getNumElements(), offset);
     if (!isa<VectorType>(count->getType()))
@@ -1280,7 +1280,7 @@ Value *ArithBuilder::CreateFindSMsb(Value *value, const Twine &instName) {
 // @param instName : Name to give instruction(s)
 Value *ArithBuilder::createFMix(Value *x, Value *y, Value *a, const Twine &instName) {
   Value *ySubX = CreateFSub(y, x);
-  if (auto vectorResultTy = dyn_cast<FixedVectorType>(ySubX->getType())) {
+  if (auto vectorResultTy = dyn_cast<VectorType>(ySubX->getType())) {
     // pX, pY => vector, but pA => scalar
     if (!isa<VectorType>(a->getType()))
       a = CreateVectorSplat(vectorResultTy->getNumElements(), a);

--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -133,7 +133,7 @@ const ComputeShaderMode &Builder::getComputeShaderMode() {
 // @param elementTy : Element type
 // @param maybeVecTy : Possible vector type to get number of elements from
 Type *Builder::getConditionallyVectorizedTy(Type *elementTy, Type *maybeVecTy) {
-  if (auto vecTy = dyn_cast<FixedVectorType>(maybeVecTy))
+  if (auto vecTy = dyn_cast<VectorType>(maybeVecTy))
     return FixedVectorType::get(elementTy, vecTy->getNumElements());
   return elementTy;
 }
@@ -160,7 +160,7 @@ Value *Builder::CreateMapToInt32(PFN_MapToInt32Func mapFunc, ArrayRef<Value *> m
 
   if (mappedArgs[0]->getType()->isVectorTy()) {
     // For vectors we extract each vector component and map them individually.
-    const unsigned compCount = cast<FixedVectorType>(type)->getNumElements();
+    const unsigned compCount = cast<VectorType>(type)->getNumElements();
 
     SmallVector<Value *, 4> results;
 
@@ -247,7 +247,7 @@ Type *Builder::getTransposedMatrixTy(Type *const matrixType) const {
   assert(columnVectorType->isVectorTy());
 
   const unsigned columnCount = matrixType->getArrayNumElements();
-  const unsigned rowCount = cast<FixedVectorType>(columnVectorType)->getNumElements();
+  const unsigned rowCount = cast<VectorType>(columnVectorType)->getNumElements();
 
   return ArrayType::get(FixedVectorType::get(cast<VectorType>(columnVectorType)->getElementType(), columnCount),
                         rowCount);

--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -65,7 +65,7 @@ Value *BuilderImplBase::CreateDotProduct(Value *const vector1, Value *const vect
   if (!isa<VectorType>(product->getType()))
     return product;
 
-  const unsigned compCount = cast<FixedVectorType>(product->getType())->getNumElements();
+  const unsigned compCount = cast<VectorType>(product->getType())->getNumElements();
   Value *scalar = CreateExtractElement(product, uint64_t(0));
 
   for (unsigned i = 1; i < compCount; ++i)
@@ -276,7 +276,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
 
     Use *useOfNonUniformInst = nullptr;
     Type *waterfallEndTy = resultValue->getType();
-    if (auto vecTy = dyn_cast<FixedVectorType>(waterfallEndTy)) {
+    if (auto vecTy = dyn_cast<VectorType>(waterfallEndTy)) {
       if (vecTy->getElementType()->isIntegerTy(8)) {
         // ISel does not like waterfall.end with vector of i8 type, so cast if necessary.
         assert((vecTy->getNumElements() % 4) == 0);
@@ -312,7 +312,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
 // @param value : Input value
 // @param callback : Callback function
 Value *BuilderImplBase::scalarize(Value *value, std::function<Value *(Value *)> callback) {
-  if (auto vecTy = dyn_cast<FixedVectorType>(value->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(value->getType())) {
     Value *result0 = callback(CreateExtractElement(value, uint64_t(0)));
     Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
     result = CreateInsertElement(result, result0, uint64_t(0));
@@ -331,7 +331,7 @@ Value *BuilderImplBase::scalarize(Value *value, std::function<Value *(Value *)> 
 // @param value : Input value
 // @param callback : Callback function
 Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Value *)> callback) {
-  if (auto vecTy = dyn_cast<FixedVectorType>(value->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(value->getType())) {
     Value *inComps = CreateShuffleVector(value, value, ArrayRef<int>{0, 1});
     Value *resultComps = callback(inComps);
     Value *result =
@@ -366,7 +366,7 @@ Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Val
 // @param value1 : Input value 1
 // @param callback : Callback function
 Value *BuilderImplBase::scalarize(Value *value0, Value *value1, std::function<Value *(Value *, Value *)> callback) {
-  if (auto vecTy = dyn_cast<FixedVectorType>(value0->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(value0->getType())) {
     Value *result0 = callback(CreateExtractElement(value0, uint64_t(0)), CreateExtractElement(value1, uint64_t(0)));
     Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
     result = CreateInsertElement(result, result0, uint64_t(0));
@@ -389,7 +389,7 @@ Value *BuilderImplBase::scalarize(Value *value0, Value *value1, std::function<Va
 // @param callback : Callback function
 Value *BuilderImplBase::scalarize(Value *value0, Value *value1, Value *value2,
                                   std::function<Value *(Value *, Value *, Value *)> callback) {
-  if (auto vecTy = dyn_cast<FixedVectorType>(value0->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(value0->getType())) {
     Value *result0 = callback(CreateExtractElement(value0, uint64_t(0)), CreateExtractElement(value1, uint64_t(0)),
                               CreateExtractElement(value2, uint64_t(0)));
     Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -416,7 +416,7 @@ Value *BuilderRecorder::CreateVectorTimesMatrix(Value *const vector, Value *cons
 Value *BuilderRecorder::CreateMatrixTimesVector(Value *const matrix, Value *const vector, const Twine &instName) {
   Type *const columnType = matrix->getType()->getArrayElementType();
   Type *const compType = cast<VectorType>(columnType)->getElementType();
-  const unsigned rowCount = cast<FixedVectorType>(columnType)->getNumElements();
+  const unsigned rowCount = cast<VectorType>(columnType)->getNumElements();
   Type *const vectorType = FixedVectorType::get(compType, rowCount);
   return record(Opcode::MatrixTimesVector, vectorType, {matrix, vector}, instName);
 }
@@ -441,7 +441,7 @@ Value *BuilderRecorder::CreateMatrixTimesMatrix(Value *const matrix1, Value *con
 // @param vector2 : The vector 2
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateOuterProduct(Value *const vector1, Value *const vector2, const Twine &instName) {
-  const unsigned colCount = cast<FixedVectorType>(vector2->getType())->getNumElements();
+  const unsigned colCount = cast<VectorType>(vector2->getType())->getNumElements();
   Type *const resultTy = ArrayType::get(vector1->getType(), colCount);
   return record(Opcode::OuterProduct, resultTy, {vector1, vector2}, instName);
 }

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -405,7 +405,7 @@ static Type *convertToFloatingPointType(Type *origTy) {
     llvm_unreachable("Should never be called!");
   }
   if (isa<VectorType>(origTy))
-    newTy = FixedVectorType::get(newTy, cast<FixedVectorType>(origTy)->getNumElements());
+    newTy = FixedVectorType::get(newTy, cast<VectorType>(origTy)->getNumElements());
   return newTy;
 }
 
@@ -437,7 +437,7 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
     texelTy = FixedVectorType::get(getInt32Ty(), 2);
   }
 
-  if (auto vectorResultTy = dyn_cast<FixedVectorType>(texelTy))
+  if (auto vectorResultTy = dyn_cast<VectorType>(texelTy))
     dmask = (1U << vectorResultTy->getNumElements()) - 1;
 
   // Prepare the coordinate, which might also change the dimension.
@@ -510,7 +510,7 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
         Value *isNullDesc = CreateICmpEQ(descWord3, getInt32(0));
         defaults[2] = CreateSelect(isNullDesc, getInt64(0), getInt64(1));
       }
-      for (unsigned i = 1; i < cast<FixedVectorType>(origTexelTy)->getNumElements(); ++i)
+      for (unsigned i = 1; i < cast<VectorType>(origTexelTy)->getNumElements(); ++i)
         texel = CreateInsertElement(texel, defaults[i - 1], i);
     }
 
@@ -631,7 +631,7 @@ Value *ImageBuilder::CreateImageStore(Value *texel, unsigned dim, unsigned flags
     // Not texel buffer; use image store instruction.
     // Build the intrinsic arguments.
     unsigned dmask = 1;
-    if (auto vectorTexelTy = dyn_cast<FixedVectorType>(texelTy))
+    if (auto vectorTexelTy = dyn_cast<VectorType>(texelTy))
       dmask = (1U << vectorTexelTy->getNumElements()) - 1;
 
     // Build the intrinsic arguments.
@@ -657,7 +657,7 @@ Value *ImageBuilder::CreateImageStore(Value *texel, unsigned dim, unsigned flags
   } else {
     // Texel buffer descriptor. Use the buffer instruction.
     // First widen texel to vec4 if necessary.
-    if (auto vectorTexelTy = dyn_cast<FixedVectorType>(texelTy)) {
+    if (auto vectorTexelTy = dyn_cast<VectorType>(texelTy)) {
       if (vectorTexelTy->getNumElements() != 4) {
         texel = CreateShuffleVector(texel, Constant::getNullValue(texelTy), ArrayRef<int>{0, 1, 2, 3});
       }
@@ -928,7 +928,7 @@ Value *ImageBuilder::preprocessIntegerImageGather(unsigned dim, Value *&imageDes
   Value *widthHeight = CreateShuffleVector(resInfo, resInfo, ArrayRef<int>{0, 1});
   widthHeight = CreateSIToFP(widthHeight, FixedVectorType::get(getFloatTy(), 2));
   Value *valueToAdd = CreateFDiv(ConstantFP::get(widthHeight->getType(), -0.5), widthHeight);
-  unsigned coordCount = cast<FixedVectorType>(coord->getType())->getNumElements();
+  unsigned coordCount = cast<VectorType>(coord->getType())->getNumElements();
   if (coordCount > 2) {
     valueToAdd = CreateShuffleVector(valueToAdd, Constant::getNullValue(valueToAdd->getType()),
                                      ArrayRef<int>({0, 1, 2, 3}).slice(0, coordCount));
@@ -1052,10 +1052,10 @@ Value *ImageBuilder::CreateImageSampleGather(Type *resultTy, unsigned dim, unsig
     Value *singleOffsetVal = nullptr;
     if (isa<VectorType>((offsetVal)->getType())) {
       singleOffsetVal = CreateAnd(CreateExtractElement(offsetVal, uint64_t(0)), getInt32(0x3F));
-      if (cast<FixedVectorType>(offsetVal->getType())->getNumElements() >= 2) {
+      if (cast<VectorType>(offsetVal->getType())->getNumElements() >= 2) {
         singleOffsetVal = CreateOr(
             singleOffsetVal, CreateShl(CreateAnd(CreateExtractElement(offsetVal, 1), getInt32(0x3F)), getInt32(8)));
-        if (cast<FixedVectorType>(offsetVal->getType())->getNumElements() >= 3) {
+        if (cast<VectorType>(offsetVal->getType())->getNumElements() >= 3) {
           singleOffsetVal = CreateOr(
               singleOffsetVal, CreateShl(CreateAnd(CreateExtractElement(offsetVal, 2), getInt32(0x3F)), getInt32(16)));
         }
@@ -1464,7 +1464,7 @@ unsigned ImageBuilder::prepareCoordinate(unsigned dim, Value *coord, Value *proj
     assert(getImageNumCoords(dim) == 1);
     outCoords.push_back(coord);
   } else {
-    assert(getImageNumCoords(dim) == cast<FixedVectorType>(coordTy)->getNumElements());
+    assert(getImageNumCoords(dim) == cast<VectorType>(coordTy)->getNumElements());
 
     // Push the components.
     for (unsigned i = 0; i != getImageNumCoords(dim); ++i)
@@ -1555,7 +1555,7 @@ unsigned ImageBuilder::prepareCoordinate(unsigned dim, Value *coord, Value *proj
   // Push the derivative components.
   if (derivativeX) {
     // Derivatives by X
-    if (auto vectorDerivativeXTy = dyn_cast<FixedVectorType>(derivativeX->getType())) {
+    if (auto vectorDerivativeXTy = dyn_cast<VectorType>(derivativeX->getType())) {
       for (unsigned i = 0; i != vectorDerivativeXTy->getNumElements(); ++i)
         outDerivatives.push_back(CreateExtractElement(derivativeX, i));
     } else
@@ -1567,7 +1567,7 @@ unsigned ImageBuilder::prepareCoordinate(unsigned dim, Value *coord, Value *proj
     }
 
     // Derivatives by Y
-    if (auto vectorDerivativeYTy = dyn_cast<FixedVectorType>(derivativeY->getType())) {
+    if (auto vectorDerivativeYTy = dyn_cast<VectorType>(derivativeY->getType())) {
       for (unsigned i = 0; i != vectorDerivativeYTy->getNumElements(); ++i)
         outDerivatives.push_back(CreateExtractElement(derivativeY, i));
     } else
@@ -1780,7 +1780,7 @@ Value *ImageBuilder::handleFragCoordViewIndex(Value *coord, unsigned flags, unsi
     if (getPipelineState()->getInputAssemblyState().enableMultiView) {
       useViewIndex = true;
       dim = Dim2DArray;
-      unsigned coordCount = cast<FixedVectorType>(coord->getType())->getNumElements();
+      unsigned coordCount = cast<VectorType>(coord->getType())->getNumElements();
       if (coordCount < 3) {
         const static int Indexes[] = {0, 1, 1};
         coord = CreateShuffleVector(coord, Constant::getNullValue(coord->getType()), Indexes);
@@ -1802,7 +1802,7 @@ Value *ImageBuilder::handleFragCoordViewIndex(Value *coord, unsigned flags, unsi
     fragCoord->setName("FragCoord");
     fragCoord = CreateShuffleVector(fragCoord, fragCoord, ArrayRef<int>{0, 1});
     fragCoord = CreateFPToSI(fragCoord, FixedVectorType::get(getInt32Ty(), 2));
-    unsigned coordCount = cast<FixedVectorType>(coord->getType())->getNumElements();
+    unsigned coordCount = cast<VectorType>(coord->getType())->getNumElements();
     if (coordCount > 2) {
       const static int Indexes[] = {0, 1, 2, 3};
       fragCoord = CreateShuffleVector(fragCoord, Constant::getNullValue(fragCoord->getType()),

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -498,7 +498,7 @@ Value *InOutBuilder::adjustIj(Value *value, Value *offset) {
   offset = CreateFPExt(offset, FixedVectorType::get(getFloatTy(), 2));
   Value *offsetX = CreateExtractElement(offset, uint64_t(0));
   Value *offsetY = CreateExtractElement(offset, 1);
-  if (auto vecTy = dyn_cast<FixedVectorType>(value->getType())) {
+  if (auto vecTy = dyn_cast<VectorType>(value->getType())) {
     offsetX = CreateVectorSplat(vecTy->getNumElements(), offsetX);
     offsetY = CreateVectorSplat(vecTy->getNumElements(), offsetY);
   }

--- a/lgc/builder/MatrixBuilder.cpp
+++ b/lgc/builder/MatrixBuilder.cpp
@@ -50,7 +50,7 @@ Value *MatrixBuilder::CreateTransposeMatrix(Value *const matrix, const Twine &in
   assert(columnVectorType->isVectorTy());
 
   const unsigned columnCount = matrixType->getArrayNumElements();
-  const unsigned rowCount = cast<FixedVectorType>(columnVectorType)->getNumElements();
+  const unsigned rowCount = cast<VectorType>(columnVectorType)->getNumElements();
 
   Type *const elementType = cast<VectorType>(columnVectorType)->getElementType();
 
@@ -92,7 +92,7 @@ Value *MatrixBuilder::CreateTransposeMatrix(Value *const matrix, const Twine &in
 Value *MatrixBuilder::CreateMatrixTimesScalar(Value *const matrix, Value *const scalar, const Twine &instName) {
   Type *const matrixTy = matrix->getType();
   Type *const columnTy = matrixTy->getArrayElementType();
-  const unsigned rowCount = cast<FixedVectorType>(columnTy)->getNumElements();
+  const unsigned rowCount = cast<VectorType>(columnTy)->getNumElements();
   unsigned columnCount = matrixTy->getArrayNumElements();
   auto smearScalar = CreateVectorSplat(rowCount, scalar);
 
@@ -137,7 +137,7 @@ Value *MatrixBuilder::CreateVectorTimesMatrix(Value *const vector, Value *const 
 // @param instName : Name to give instruction(s)
 Value *MatrixBuilder::CreateMatrixTimesVector(Value *const matrix, Value *const vector, const Twine &instName) {
   Type *const columnTy = matrix->getType()->getArrayElementType();
-  const unsigned rowCount = cast<FixedVectorType>(columnTy)->getNumElements();
+  const unsigned rowCount = cast<VectorType>(columnTy)->getNumElements();
   Value *result = nullptr;
 
   for (unsigned i = 0; i < matrix->getType()->getArrayNumElements(); ++i) {
@@ -182,8 +182,8 @@ Value *MatrixBuilder::CreateMatrixTimesMatrix(Value *const matrix1, Value *const
 // @param vector2 : The float vector 2
 // @param instName : Name to give instruction(s)
 Value *MatrixBuilder::CreateOuterProduct(Value *const vector1, Value *const vector2, const Twine &instName) {
-  const unsigned rowCount = cast<FixedVectorType>(vector1->getType())->getNumElements();
-  const unsigned colCount = cast<FixedVectorType>(vector2->getType())->getNumElements();
+  const unsigned rowCount = cast<VectorType>(vector1->getType())->getNumElements();
+  const unsigned colCount = cast<VectorType>(vector2->getType())->getNumElements();
   Type *const resultTy = ArrayType::get(vector1->getType(), colCount);
   Value *result = UndefValue::get(resultTy);
 
@@ -204,7 +204,7 @@ Value *MatrixBuilder::CreateOuterProduct(Value *const vector1, Value *const vect
 // @param instName : Name to give instruction(s)
 Value *MatrixBuilder::CreateDeterminant(Value *const matrix, const Twine &instName) {
   unsigned order = matrix->getType()->getArrayNumElements();
-  assert(cast<FixedVectorType>(cast<ArrayType>(matrix->getType())->getElementType())->getNumElements() == order);
+  assert(cast<VectorType>(cast<ArrayType>(matrix->getType())->getElementType())->getNumElements() == order);
   assert(order >= 2);
 
   // Extract matrix elements.
@@ -287,7 +287,7 @@ void MatrixBuilder::getSubmatrix(ArrayRef<Value *> matrix, MutableArrayRef<Value
 // @param instName : Name to give instruction(s)
 Value *MatrixBuilder::CreateMatrixInverse(Value *const matrix, const Twine &instName) {
   unsigned order = matrix->getType()->getArrayNumElements();
-  assert(cast<FixedVectorType>(cast<ArrayType>(matrix->getType())->getElementType())->getNumElements() == order);
+  assert(cast<VectorType>(cast<ArrayType>(matrix->getType())->getElementType())->getNumElements() == order);
   assert(order >= 2);
 
   // Extract matrix elements.

--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -121,7 +121,7 @@ Value *SubgroupBuilder::CreateSubgroupAllEqual(Value *const value, bool wqm, con
   if (type->isVectorTy()) {
     Value *result = CreateExtractElement(compare, getInt32(0));
 
-    for (unsigned i = 1, compCount = cast<FixedVectorType>(type)->getNumElements(); i < compCount; i++)
+    for (unsigned i = 1, compCount = cast<VectorType>(type)->getNumElements(); i < compCount; i++)
       result = CreateAnd(result, CreateExtractElement(compare, i));
 
     return CreateSubgroupAll(result, wqm, instName);

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -112,7 +112,7 @@ Value *FragColorExport::run(Value *output, unsigned hwColorTarget, Instruction *
   Type *outputTy = output->getType();
   const unsigned bitWidth = outputTy->getScalarSizeInBits();
   auto compTy = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getElementType() : outputTy;
-  unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
+  unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
 
   Value *comps[4] = {nullptr};
   if (compCount == 1)
@@ -569,7 +569,7 @@ void LowerFragColorExport::updateFragColors(CallInst *callInst, ColorExportValue
   (void(bitWidth)); // unused
 
   auto compTy = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getElementType() : outputTy;
-  unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
+  unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
 
   std::vector<Value *> outputComps;
   for (unsigned i = 0; i < compCount; ++i) {

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -2348,7 +2348,7 @@ void NggPrimShader::runEs(Module *module, Argument *sysValueStart) {
     if (esArgTy->isVectorTy()) {
       assert(cast<VectorType>(esArgTy)->getElementType()->isIntegerTy());
 
-      const unsigned userDataSize = cast<FixedVectorType>(esArgTy)->getNumElements();
+      const unsigned userDataSize = cast<VectorType>(esArgTy)->getNumElements();
 
       std::vector<int> shuffleMask;
       for (unsigned i = 0; i < userDataSize; ++i)
@@ -2519,7 +2519,7 @@ Value *NggPrimShader::runEsPartial(Module *module, Argument *sysValueStart, Valu
     if (esPartialArgTy->isVectorTy()) {
       assert(cast<VectorType>(esPartialArgTy)->getElementType()->isIntegerTy());
 
-      const unsigned userDataSize = cast<FixedVectorType>(esPartialArgTy)->getNumElements();
+      const unsigned userDataSize = cast<VectorType>(esPartialArgTy)->getNumElements();
 
       std::vector<int> shuffleMask;
       for (unsigned i = 0; i < userDataSize; ++i)
@@ -2809,7 +2809,7 @@ void NggPrimShader::runGs(Module *module, Argument *sysValueStart) {
     if (gsArgTy->isVectorTy()) {
       assert(cast<VectorType>(gsArgTy)->getElementType()->isIntegerTy());
 
-      const unsigned userDataSize = cast<FixedVectorType>(gsArgTy)->getNumElements();
+      const unsigned userDataSize = cast<VectorType>(gsArgTy)->getNumElements();
 
       std::vector<int> shuffleMask;
       for (unsigned i = 0; i < userDataSize; ++i)
@@ -3151,13 +3151,13 @@ void NggPrimShader::exportGsOutput(Value *output, unsigned location, unsigned co
       assert(bitWidth == 16);
       Type *castTy = m_builder->getInt16Ty();
       if (outputTy->isVectorTy())
-        castTy = FixedVectorType::get(m_builder->getInt16Ty(), cast<FixedVectorType>(outputTy)->getNumElements());
+        castTy = FixedVectorType::get(m_builder->getInt16Ty(), cast<VectorType>(outputTy)->getNumElements());
       output = m_builder->CreateBitCast(output, castTy);
     }
 
     Type *extTy = m_builder->getInt32Ty();
     if (outputTy->isVectorTy())
-      extTy = FixedVectorType::get(m_builder->getInt32Ty(), cast<FixedVectorType>(outputTy)->getNumElements());
+      extTy = FixedVectorType::get(m_builder->getInt32Ty(), cast<VectorType>(outputTy)->getNumElements());
     output = m_builder->CreateZExt(output, extTy);
   } else
     assert(bitWidth == 32 || bitWidth == 64);
@@ -3211,7 +3211,7 @@ Value *NggPrimShader::importGsOutput(Type *outputTy, unsigned location, unsigned
 
   if (origOutputTy != outputTy) {
     assert(origOutputTy->isArrayTy() && outputTy->isVectorTy() &&
-           origOutputTy->getArrayNumElements() == cast<FixedVectorType>(outputTy)->getNumElements());
+           origOutputTy->getArrayNumElements() == cast<VectorType>(outputTy)->getNumElements());
 
     // <n x Ty> -> [n x Ty]
     const unsigned elemCount = origOutputTy->getArrayNumElements();

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -530,8 +530,7 @@ void PatchBufferOp::visitInsertElementInst(InsertElementInst &insertElementInst)
   Value *indexVector = nullptr;
 
   if (isa<UndefValue>(insertElementInst.getOperand(0)))
-    indexVector =
-        UndefValue::get(FixedVectorType::get(index->getType(), cast<FixedVectorType>(type)->getNumElements()));
+    indexVector = UndefValue::get(FixedVectorType::get(index->getType(), cast<VectorType>(type)->getNumElements()));
   else
     indexVector = m_replacementMap[getPointerOperandAsInst(insertElementInst.getOperand(0))].second;
 
@@ -1154,8 +1153,8 @@ void PatchBufferOp::postVisitMemSetInst(MemSetInst &memSetInst) {
       Value *const castMemoryPointer = m_builder->CreateBitCast(memoryPointer, int8PtrTy);
       copyMetadata(castMemoryPointer, &memSetInst);
 
-      Value *const memSet = m_builder->CreateMemSet(castMemoryPointer, value,
-                                                    cast<FixedVectorType>(memoryType)->getNumElements(), Align());
+      Value *const memSet =
+          m_builder->CreateMemSet(castMemoryPointer, value, cast<VectorType>(memoryType)->getNumElements(), Align());
       copyMetadata(memSet, &memSetInst);
 
       newValue = m_builder->CreateLoad(memoryPointer);
@@ -1216,7 +1215,7 @@ Value *PatchBufferOp::getBaseAddressFromBufferDesc(Value *const bufferDesc) cons
   Type *const descType = bufferDesc->getType();
 
   assert(descType->isVectorTy());
-  assert(cast<FixedVectorType>(descType)->getNumElements() == 4);
+  assert(cast<VectorType>(descType)->getNumElements() == 4);
   assert(cast<VectorType>(descType)->getElementType()->isIntegerTy(32));
 
   // Get the base address of our buffer by extracting the two components with the 48-bit address, and masking.
@@ -1542,7 +1541,7 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
         const unsigned byteSize = static_cast<unsigned>(dataLayout.getTypeStoreSize(part->getType()));
 
         // Bitcast it to a vector of the smallest load type.
-        FixedVectorType *const castType = FixedVectorType::get(smallestType, byteSize / smallestByteSize);
+        VectorType *const castType = FixedVectorType::get(smallestType, byteSize / smallestByteSize);
         part = m_builder->CreateBitCast(part, castType);
         copyMetadata(part, &inst);
 
@@ -1599,7 +1598,7 @@ Value *PatchBufferOp::replaceICmp(ICmpInst *const iCmpInst) {
   Type *const bufferDescTy = bufferDescs[0]->getType();
 
   assert(bufferDescTy->isVectorTy());
-  assert(cast<FixedVectorType>(bufferDescTy)->getNumElements() == 4);
+  assert(cast<VectorType>(bufferDescTy)->getNumElements() == 4);
   assert(cast<VectorType>(bufferDescTy)->getElementType()->isIntegerTy(32));
   (void(bufferDescTy)); // unused
   assert(iCmpInst->getPredicate() == ICmpInst::ICMP_EQ || iCmpInst->getPredicate() == ICmpInst::ICMP_NE);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -316,7 +316,7 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
 
         unsigned compCount = 1;
         auto compTy = outputTy;
-        auto outputVecTy = dyn_cast<FixedVectorType>(outputTy);
+        auto outputVecTy = dyn_cast<VectorType>(outputTy);
         if (outputVecTy) {
           compCount = outputVecTy->getNumElements();
           compTy = outputVecTy->getElementType();
@@ -463,7 +463,7 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
     elemCount = cast<ArrayType>(loadTy)->getNumElements();
     elemTy = cast<ArrayType>(loadTy)->getElementType();
   } else if (loadTy->isVectorTy()) {
-    elemCount = cast<FixedVectorType>(loadTy)->getNumElements();
+    elemCount = cast<VectorType>(loadTy)->getNumElements();
     elemTy = cast<VectorType>(loadTy)->getElementType();
   }
   assert(elemTy->isIntegerTy(32) || elemTy->isFloatTy()); // Must be 32-bit type
@@ -581,7 +581,7 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
         auto outputTy = outputValue->getType();
         assert(outputTy->isFPOrFPVectorTy() && outputTy->getScalarSizeInBits() == 32);
 
-        const unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
+        const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
         if (compCount > 1) {
           outputValue = builder.CreateBitCast(outputValue, FixedVectorType::get(builder.getInt32Ty(), compCount));
           outputValue = builder.CreateTrunc(outputValue, FixedVectorType::get(builder.getInt16Ty(), compCount));

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1342,7 +1342,7 @@ Value *PatchInOutImportExport::patchGsGenericInputImport(Type *inputTy, unsigned
                                                          Value *vertexIdx, Instruction *insertPos) {
   assert(vertexIdx);
 
-  const unsigned compCount = inputTy->isVectorTy() ? cast<FixedVectorType>(inputTy)->getNumElements() : 1;
+  const unsigned compCount = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getNumElements() : 1;
   const unsigned bitWidth = inputTy->getScalarSizeInBits();
 
   Type *origInputTy = inputTy;
@@ -1458,7 +1458,7 @@ Value *PatchInOutImportExport::patchFsGenericInputImport(Type *inputTy, unsigned
 
   Type *basicTy = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getElementType() : inputTy;
 
-  const unsigned compCout = inputTy->isVectorTy() ? cast<FixedVectorType>(inputTy)->getNumElements() : 1;
+  const unsigned compCout = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getNumElements() : 1;
   const unsigned bitWidth = inputTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
 
@@ -1638,7 +1638,7 @@ void PatchInOutImportExport::patchVsGenericOutputExport(Value *output, unsigned 
         // For 64-bit data type, the component indexing must multiply by 2
         compIdx *= 2;
 
-        unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() * 2 : 2;
+        unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() * 2 : 2;
 
         outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), compCount);
         output = new BitCastInst(output, outputTy, "", insertPos);
@@ -1687,7 +1687,7 @@ void PatchInOutImportExport::patchTesGenericOutputExport(Value *output, unsigned
       // For 64-bit data type, the component indexing must multiply by 2
       compIdx *= 2;
 
-      unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() * 2 : 2;
+      unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() * 2 : 2;
       outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), compCount);
 
       output = new BitCastInst(output, outputTy, "", insertPos);
@@ -1718,8 +1718,7 @@ void PatchInOutImportExport::patchGsGenericOutputExport(Value *output, unsigned 
     compIdx *= 2;
 
     if (outputTy->isVectorTy())
-      outputTy =
-          FixedVectorType::get(Type::getFloatTy(*m_context), cast<FixedVectorType>(outputTy)->getNumElements() * 2);
+      outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(outputTy)->getNumElements() * 2);
     else
       outputTy = FixedVectorType::get(Type::getFloatTy(*m_context), 2);
 
@@ -1727,7 +1726,7 @@ void PatchInOutImportExport::patchGsGenericOutputExport(Value *output, unsigned 
   } else
     assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32);
 
-  const unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
+  const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
   // NOTE: Currently, to simplify the design of load/store data from GS-VS ring, we always extend byte/word to dword and
   // store dword to GS-VS ring. So for 8-bit/16-bit data type, the actual byte size is based on number of dwords.
   unsigned byteSize = (outputTy->getScalarSizeInBits() / 8) * compCount;
@@ -3297,7 +3296,7 @@ void PatchInOutImportExport::patchXfbOutputExport(Value *output, unsigned xfbBuf
   unsigned xfbStride = xfbStrides[xfbBuffer];
 
   auto outputTy = output->getType();
-  unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
+  unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
   unsigned bitWidth = outputTy->getScalarSizeInBits();
 
   xfbOffset = xfbOffset + xfbExtraOffset;
@@ -3451,7 +3450,7 @@ void PatchInOutImportExport::createStreamOutBufferStoreFunction(Value *storeValu
 
   auto storeTy = storeValue->getType();
 
-  unsigned compCount = storeTy->isVectorTy() ? cast<FixedVectorType>(storeTy)->getNumElements() : 1;
+  unsigned compCount = storeTy->isVectorTy() ? cast<VectorType>(storeTy)->getNumElements() : 1;
   assert(compCount <= 4);
 
   const uint64_t bitWidth = storeTy->getScalarSizeInBits();
@@ -3682,7 +3681,7 @@ void PatchInOutImportExport::storeValueToStreamOutBuffer(Value *storeValue, unsi
                                                          Instruction *insertPos) {
   auto storeTy = storeValue->getType();
 
-  unsigned compCount = storeTy->isVectorTy() ? cast<FixedVectorType>(storeTy)->getNumElements() : 1;
+  unsigned compCount = storeTy->isVectorTy() ? cast<VectorType>(storeTy)->getNumElements() : 1;
   assert(compCount <= 4);
 
   const uint64_t bitWidth = storeTy->getScalarSizeInBits();
@@ -3774,8 +3773,8 @@ void PatchInOutImportExport::storeValueToEsGsRing(Value *storeValue, unsigned lo
   assert((elemTy->isFloatingPointTy() || elemTy->isIntegerTy()) && (bitWidth == 8 || bitWidth == 16 || bitWidth == 32));
 
   if (storeTy->isArrayTy() || storeTy->isVectorTy()) {
-    const unsigned elemCount = storeTy->isArrayTy() ? cast<ArrayType>(storeTy)->getNumElements()
-                                                    : cast<FixedVectorType>(storeTy)->getNumElements();
+    const unsigned elemCount =
+        storeTy->isArrayTy() ? cast<ArrayType>(storeTy)->getNumElements() : cast<VectorType>(storeTy)->getNumElements();
 
     for (unsigned i = 0; i < elemCount; ++i) {
       Value *storeElem = nullptr;
@@ -3866,8 +3865,8 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
   Value *loadValue = UndefValue::get(loadTy);
 
   if (loadTy->isArrayTy() || loadTy->isVectorTy()) {
-    const unsigned elemCount = loadTy->isArrayTy() ? cast<ArrayType>(loadTy)->getNumElements()
-                                                   : cast<FixedVectorType>(loadTy)->getNumElements();
+    const unsigned elemCount =
+        loadTy->isArrayTy() ? cast<ArrayType>(loadTy)->getNumElements() : cast<VectorType>(loadTy)->getNumElements();
 
     for (unsigned i = 0; i < elemCount; ++i) {
       auto loadElem =
@@ -3965,8 +3964,8 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
   }
 
   if (storeTy->isArrayTy() || storeTy->isVectorTy()) {
-    const unsigned elemCount = storeTy->isArrayTy() ? cast<ArrayType>(storeTy)->getNumElements()
-                                                    : cast<FixedVectorType>(storeTy)->getNumElements();
+    const unsigned elemCount =
+        storeTy->isArrayTy() ? cast<ArrayType>(storeTy)->getNumElements() : cast<VectorType>(storeTy)->getNumElements();
 
     for (unsigned i = 0; i < elemCount; ++i) {
       Value *storeElem = nullptr;
@@ -4198,7 +4197,7 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
   assert(readTy->isSingleValueType());
 
   // Read dwords from LDS
-  const unsigned compCount = readTy->isVectorTy() ? cast<FixedVectorType>(readTy)->getNumElements() : 1;
+  const unsigned compCount = readTy->isVectorTy() ? cast<VectorType>(readTy)->getNumElements() : 1;
   const unsigned bitWidth = readTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
   const unsigned numChannels = compCount * (bitWidth == 64 ? 2 : 1);
@@ -4292,7 +4291,7 @@ void PatchInOutImportExport::writeValueToLds(Value *writeValue, Value *ldsOffset
   auto writeTy = writeValue->getType();
   assert(writeTy->isSingleValueType());
 
-  const unsigned compCout = writeTy->isVectorTy() ? cast<FixedVectorType>(writeTy)->getNumElements() : 1;
+  const unsigned compCout = writeTy->isVectorTy() ? cast<VectorType>(writeTy)->getNumElements() : 1;
   const unsigned bitWidth = writeTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
   const unsigned numChannels = compCout * (bitWidth == 64 ? 2 : 1);
@@ -4976,7 +4975,7 @@ void PatchInOutImportExport::addExportInstForGenericOutput(Value *output, unsign
 
   auto &inOutUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage;
 
-  const unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
+  const unsigned compCount = outputTy->isVectorTy() ? cast<VectorType>(outputTy)->getNumElements() : 1;
   const unsigned bitWidth = outputTy->getScalarSizeInBits();
   assert(bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64);
 

--- a/lgc/patch/PatchLoadScalarizer.cpp
+++ b/lgc/patch/PatchLoadScalarizer.cpp
@@ -107,7 +107,7 @@ bool PatchLoadScalarizer::runOnFunction(Function &function) {
 // @param loadInst : The instruction
 void PatchLoadScalarizer::visitLoadInst(LoadInst &loadInst) {
   const unsigned addrSpace = loadInst.getPointerAddressSpace();
-  auto loadTy = dyn_cast<FixedVectorType>(loadInst.getType());
+  auto loadTy = dyn_cast<VectorType>(loadInst.getType());
 
   if (loadTy) {
     // This optimization will try to scalarize the load inst. The pattern is like:

--- a/lgc/patch/PatchPeepholeOpt.cpp
+++ b/lgc/patch/PatchPeepholeOpt.cpp
@@ -170,18 +170,16 @@ void PatchPeepholeOpt::visitBitCast(BitCastInst &bitCast) {
 
     // Bit cast the LHS of the original shuffle.
     Value *const shuffleVectorLhs = shuffleVector->getOperand(0);
-    Type *const bitCastLhsType =
-        FixedVectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
-                             cast<FixedVectorType>(shuffleVectorLhs->getType())->getNumElements());
+    Type *const bitCastLhsType = FixedVectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
+                                                      cast<VectorType>(shuffleVectorLhs->getType())->getNumElements());
     BitCastInst *const bitCastLhs =
         new BitCastInst(shuffleVectorLhs, bitCastLhsType, shuffleVectorLhs->getName() + ".bitcast");
     insertAfter(*bitCastLhs, *shuffleVector);
 
     // Bit cast the RHS of the original shuffle.
     Value *const shuffleVectorRhs = shuffleVector->getOperand(1);
-    Type *const bitCastRhsType =
-        FixedVectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
-                             cast<FixedVectorType>(shuffleVectorRhs->getType())->getNumElements());
+    Type *const bitCastRhsType = FixedVectorType::get(cast<VectorType>(bitCast.getDestTy())->getElementType(),
+                                                      cast<VectorType>(shuffleVectorRhs->getType())->getNumElements());
     BitCastInst *const bitCastRhs =
         new BitCastInst(shuffleVectorRhs, bitCastRhsType, shuffleVectorRhs->getName() + ".bitcast");
     insertAfter(*bitCastRhs, *bitCastLhs);
@@ -462,7 +460,7 @@ void PatchPeepholeOpt::visitPHINode(PHINode &phiNode) {
     Type *const type = phiNode.getType();
 
     // The number of elements in the vector type (which will result in N new scalar PHI nodes).
-    const unsigned numElements = cast<FixedVectorType>(type)->getNumElements();
+    const unsigned numElements = cast<VectorType>(type)->getNumElements();
 
     // The element type of the vector.
     Type *const elementType = cast<VectorType>(type)->getElementType();

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2821,7 +2821,7 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
 
   // Now we know we're reading a vector.
   Type *elementTy = cast<VectorType>(resultTy)->getElementType();
-  unsigned scalarizeBy = cast<FixedVectorType>(resultTy)->getNumElements();
+  unsigned scalarizeBy = cast<VectorType>(resultTy)->getNumElements();
 
   // Find trivially unused elements.
   // This is not quite as good as the previous version of this code that scalarized in the
@@ -2910,7 +2910,7 @@ void PatchResourceCollect::scalarizeGenericOutput(CallInst *call) {
   Value *outputVal = call->getArgOperand(valArgIdx);
   Type *elementTy = outputVal->getType();
   unsigned scalarizeBy = 1;
-  if (auto vectorTy = dyn_cast<FixedVectorType>(elementTy)) {
+  if (auto vectorTy = dyn_cast<VectorType>(elementTy)) {
     scalarizeBy = vectorTy->getNumElements();
     elementTy = vectorTy->getElementType();
   }

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -311,7 +311,7 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
       if (lsArgTy->isVectorTy()) {
         assert(cast<VectorType>(lsArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = cast<FixedVectorType>(lsArgTy)->getNumElements();
+        const unsigned userDataSize = cast<VectorType>(lsArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)
@@ -394,7 +394,7 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
       if (hsArgTy->isVectorTy()) {
         assert(cast<VectorType>(hsArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = cast<FixedVectorType>(hsArgTy)->getNumElements();
+        const unsigned userDataSize = cast<VectorType>(hsArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)
@@ -745,7 +745,7 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
       if (esArgTy->isVectorTy()) {
         assert(cast<VectorType>(esArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = cast<FixedVectorType>(esArgTy)->getNumElements();
+        const unsigned userDataSize = cast<VectorType>(esArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)
@@ -904,7 +904,7 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
       if (gsArgTy->isVectorTy()) {
         assert(cast<VectorType>(gsArgTy)->getElementType()->isIntegerTy());
 
-        const unsigned userDataSize = cast<FixedVectorType>(gsArgTy)->getNumElements();
+        const unsigned userDataSize = cast<VectorType>(gsArgTy)->getNumElements();
 
         std::vector<Constant *> shuffleMask;
         for (unsigned i = 0; i < userDataSize; ++i)

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -446,7 +446,7 @@ bool LowerVertexFetch::runOnModule(Module &module) {
       if (call->getType() != vertex->getType()) {
         // The types are now vectors of the same element type but different element counts, or call->getType()
         // is scalar.
-        if (auto vecTy = dyn_cast<FixedVectorType>(call->getType())) {
+        if (auto vecTy = dyn_cast<VectorType>(call->getType())) {
           int indices[] = {0, 1, 2, 3};
           vertex =
               builder.CreateShuffleVector(vertex, vertex, ArrayRef<int>(indices).slice(0, vecTy->getNumElements()));
@@ -587,7 +587,7 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
     }
 
     if (patchA2S) {
-      assert(cast<FixedVectorType>(vertexFetches[0]->getType())->getNumElements() == 4);
+      assert(cast<VectorType>(vertexFetches[0]->getType())->getNumElements() == 4);
 
       // Extract alpha channel: %a = extractelement %vf0, 3
       Value *alpha = ExtractElementInst::Create(vertexFetches[0], ConstantInt::get(Type::getInt32Ty(*m_context), 3), "",
@@ -674,9 +674,9 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
     // NOTE: If we performs vertex fetch operations twice, we have to coalesce result values of the two
     // fetch operations and generate a combined one.
     assert(vertexFetches[0] && vertexFetches[1]);
-    assert(cast<FixedVectorType>(vertexFetches[0]->getType())->getNumElements() == 4);
+    assert(cast<VectorType>(vertexFetches[0]->getType())->getNumElements() == 4);
 
-    unsigned compCount = cast<FixedVectorType>(vertexFetches[1]->getType())->getNumElements();
+    unsigned compCount = cast<VectorType>(vertexFetches[1]->getType())->getNumElements();
     assert(compCount == 2 || compCount == 4); // Should be <2 x i32> or <4 x i32>
 
     if (compCount == 2) {
@@ -732,7 +732,7 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
   } else
     llvm_unreachable("Should never be called!");
 
-  const unsigned defaultCompCount = cast<FixedVectorType>(defaults->getType())->getNumElements();
+  const unsigned defaultCompCount = cast<VectorType>(defaults->getType())->getNumElements();
   std::vector<Value *> defaultValues(defaultCompCount);
 
   for (unsigned i = 0; i < defaultValues.size(); ++i) {
@@ -742,7 +742,7 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
 
   // Get vertex fetch values
   const unsigned fetchCompCount =
-      vertexFetch->getType()->isVectorTy() ? cast<FixedVectorType>(vertexFetch->getType())->getNumElements() : 1;
+      vertexFetch->getType()->isVectorTy() ? cast<VectorType>(vertexFetch->getType())->getNumElements() : 1;
   std::vector<Value *> fetchValues(fetchCompCount);
 
   if (fetchCompCount == 1)
@@ -755,7 +755,7 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
   }
 
   // Construct vertex fetch results
-  const unsigned inputCompCount = inputTy->isVectorTy() ? cast<FixedVectorType>(inputTy)->getNumElements() : 1;
+  const unsigned inputCompCount = inputTy->isVectorTy() ? cast<VectorType>(inputTy)->getNumElements() : 1;
   const unsigned vertexCompCount = inputCompCount * (bitWidth == 64 ? 2 : 1);
 
   std::vector<Value *> vertexValues(vertexCompCount);
@@ -795,7 +795,7 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
     Type *vertexTy = vertex->getType();
     Type *truncTy = Type::getInt8Ty(*m_context);
     truncTy = vertexTy->isVectorTy()
-                  ? cast<Type>(FixedVectorType::get(truncTy, cast<FixedVectorType>(vertexTy)->getNumElements()))
+                  ? cast<Type>(FixedVectorType::get(truncTy, cast<VectorType>(vertexTy)->getNumElements()))
                   : truncTy;
     vertex = new TruncInst(vertex, truncTy, "", insertPos);
   } else if (is16bitFetch) {
@@ -804,7 +804,7 @@ Value *VertexFetchImpl::fetchVertex(Type *inputTy, const VertexInputDescription 
     Type *vertexTy = vertex->getType();
     Type *truncTy = Type::getInt16Ty(*m_context);
     truncTy = vertexTy->isVectorTy()
-                  ? cast<Type>(FixedVectorType::get(truncTy, cast<FixedVectorType>(vertexTy)->getNumElements()))
+                  ? cast<Type>(FixedVectorType::get(truncTy, cast<VectorType>(vertexTy)->getNumElements()))
                   : truncTy;
     vertex = new TruncInst(vertex, truncTy, "", insertPos);
   }

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1087,7 +1087,7 @@ unsigned PipelineState::computeExportFormat(Type *outputTy, unsigned location) {
   const ColorExportFormat *colorExportFormat = &getColorExportFormat(location);
   GfxIpVersion gfxIp = getTargetInfo().getGfxIpVersion();
   auto gpuWorkarounds = &getTargetInfo().getGpuWorkarounds();
-  unsigned outputMask = outputTy->isVectorTy() ? (1 << cast<FixedVectorType>(outputTy)->getNumElements()) - 1 : 1;
+  unsigned outputMask = outputTy->isVectorTy() ? (1 << cast<VectorType>(outputTy)->getNumElements()) - 1 : 1;
   const auto cbState = &getColorExportState();
   // NOTE: Alpha-to-coverage only takes effect for outputs from color target 0.
   const bool enableAlphaToCoverage = (cbState->alphaToCoverageEnable && location == 0);

--- a/lgc/util/GfxRegHandlerBase.cpp
+++ b/lgc/util/GfxRegHandlerBase.cpp
@@ -44,7 +44,7 @@ using namespace llvm;
 void GfxRegHandlerBase::setRegister(Value *newRegister) {
   assert(newRegister->getType()->isIntOrIntVectorTy());
 
-  if (auto vectorTy = dyn_cast<FixedVectorType>(newRegister->getType())) {
+  if (auto vectorTy = dyn_cast<VectorType>(newRegister->getType())) {
     unsigned count = vectorTy->getNumElements();
 
     // Clear previously stored dwords

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -113,7 +113,7 @@ void getTypeName(Type *ty, raw_ostream &nameStream) {
     return;
   }
 
-  if (auto vectorTy = dyn_cast<FixedVectorType>(ty)) {
+  if (auto vectorTy = dyn_cast<VectorType>(ty)) {
     nameStream << "v" << vectorTy->getNumElements();
     ty = vectorTy->getElementType();
   }
@@ -193,8 +193,8 @@ bool canBitCast(const Type *ty1, const Type *ty2) {
     const Type *compTy2 = ty2->isVectorTy() ? cast<VectorType>(ty2)->getElementType() : ty2;
     if ((compTy1->isFloatingPointTy() || compTy1->isIntegerTy()) &&
         (compTy2->isFloatingPointTy() || compTy2->isIntegerTy())) {
-      const unsigned compCount1 = ty1->isVectorTy() ? cast<FixedVectorType>(ty1)->getNumElements() : 1;
-      const unsigned compCount2 = ty2->isVectorTy() ? cast<FixedVectorType>(ty2)->getNumElements() : 1;
+      const unsigned compCount1 = ty1->isVectorTy() ? cast<VectorType>(ty1)->getNumElements() : 1;
+      const unsigned compCount2 = ty2->isVectorTy() ? cast<VectorType>(ty2)->getNumElements() : 1;
 
       valid = compCount1 * compTy1->getScalarSizeInBits() == compCount2 * compTy2->getScalarSizeInBits();
     }

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -444,9 +444,9 @@ void SpirvLowerMathFloatOp::visitFPTruncInst(FPTruncInst &fptruncInst) {
     if (srcTy->getScalarType()->isDoubleTy() && destTy->getScalarType()->isHalfTy()) {
       // NOTE: doubel -> float16 conversion is done in backend compiler with RTE rounding. Thus, we have to split
       // it with two phases to disable such lowering if we need RTZ rounding.
-      auto floatTy = srcTy->isVectorTy() ? FixedVectorType::get(Type::getFloatTy(*m_context),
-                                                                cast<FixedVectorType>(srcTy)->getNumElements())
-                                         : Type::getFloatTy(*m_context);
+      auto floatTy = srcTy->isVectorTy()
+                         ? FixedVectorType::get(Type::getFloatTy(*m_context), cast<VectorType>(srcTy)->getNumElements())
+                         : Type::getFloatTy(*m_context);
       auto floatValue = new FPTruncInst(src, floatTy, "", &fptruncInst);
       auto dest = new FPTruncInst(floatValue, destTy, "", &fptruncInst);
 

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -116,7 +116,7 @@ void SpirvLowerMemoryOp::visitExtractElementInst(ExtractElementInst &extractElem
     auto addrSpace = loadPtr->getType()->getPointerAddressSpace();
 
     if (addrSpace == SPIRAS_Local || addrSpace == SPIRAS_Uniform) {
-      auto srcTy = cast<FixedVectorType>(src->getType());
+      auto srcTy = cast<VectorType>(src->getType());
       auto castTy = ArrayType::get(srcTy->getElementType(), srcTy->getNumElements());
       auto castPtrTy = castTy->getPointerTo(addrSpace);
       auto castPtr = new BitCastInst(loadPtr, castPtrTy, "", &extractElementInst);
@@ -219,7 +219,7 @@ bool SpirvLowerMemoryOp::needExpandDynamicIndex(GetElementPtrInst *getElemPtr, u
               *dynIndexBound = arrayTy->getNumElements();
           } else if (isa<VectorType>(indexedTy)) {
             // Always expand for vector
-            auto vectorTy = dyn_cast<FixedVectorType>(indexedTy);
+            auto vectorTy = dyn_cast<VectorType>(indexedTy);
             *dynIndexBound = vectorTy->getNumElements();
           } else {
             llvm_unreachable("Should never be called!");

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -236,7 +236,7 @@ bool SpirvLowerResourceCollect::runOnModule(Module &module) {
 
       fsOutInfo.location = location;
       fsOutInfo.location = index;
-      fsOutInfo.componentCount = globalTy->isVectorTy() ? cast<FixedVectorType>(globalTy)->getNumElements() : 1;
+      fsOutInfo.componentCount = globalTy->isVectorTy() ? cast<VectorType>(globalTy)->getNumElements() : 1;
       ;
       fsOutInfo.basicType = basicTy;
       m_fsOutInfos.push_back(fsOutInfo);

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1150,7 +1150,7 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix() {
 
             Value *newLoad = UndefValue::get(load->getType());
 
-            for (unsigned i = 0; i < cast<FixedVectorType>(pointerType)->getNumElements(); i++) {
+            for (unsigned i = 0; i < cast<VectorType>(pointerType)->getNumElements(); i++) {
               Value *const pointerElem = getBuilder()->CreateExtractElement(pointer, i);
               Type *const newLoadElemType = pointerElem->getType()->getPointerElementType();
 
@@ -1222,7 +1222,7 @@ bool SPIRVToLLVM::postProcessRowMajorMatrix() {
             Type *const pointerType = pointer->getType();
             assert(pointerType->isVectorTy());
 
-            for (unsigned i = 0; i < cast<FixedVectorType>(pointerType)->getNumElements(); i++) {
+            for (unsigned i = 0; i < cast<VectorType>(pointerType)->getNumElements(); i++) {
               Value *storeValueElem = store->getValueOperand();
 
               if (storeValueElem->getType()->isArrayTy())
@@ -4204,7 +4204,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     auto scalar = transValue(vts->getScalar(), f, bb);
     auto vector = transValue(vts->getVector(), f, bb);
     assert(vector->getType()->isVectorTy() && "Invalid type");
-    unsigned vecSize = cast<FixedVectorType>(vector->getType())->getNumElements();
+    unsigned vecSize = cast<VectorType>(vector->getType())->getNumElements();
     auto newVec = getBuilder()->CreateVectorSplat(vecSize, scalar, scalar->getName());
     newVec->takeName(scalar);
     auto scale = getBuilder()->CreateFMul(vector, newVec, "scale");
@@ -4252,7 +4252,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
           // NOTE: It is allowed to construct a vector from several "smaller"
           // scalars or vectors, such as vec4 = (vec2, vec2) or vec4 = (float,
           // vec3).
-          auto compCount = cast<FixedVectorType>(constituents[i]->getType())->getNumElements();
+          auto compCount = cast<VectorType>(constituents[i]->getType())->getNumElements();
           for (unsigned j = 0; j < compCount; ++j) {
             auto comp = ExtractElementInst::Create(constituents[i], ConstantInt::get(*m_context, APInt(32, j)), "", bb);
             v = InsertElementInst::Create(v, comp, ConstantInt::get(*m_context, APInt(32, idx)), "", bb);
@@ -4533,7 +4533,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     if (!isa<VectorType>(val->getType()))
       return val;
     Value *result = getBuilder()->CreateExtractElement(val, uint64_t(0));
-    for (unsigned i = 1, e = cast<FixedVectorType>(val->getType())->getNumElements(); i != e; ++i) {
+    for (unsigned i = 1, e = cast<VectorType>(val->getType())->getNumElements(); i != e; ++i) {
       Value *elem = getBuilder()->CreateExtractElement(val, i);
       if (oc == OpAny)
         result = getBuilder()->CreateOr(result, elem);
@@ -5079,7 +5079,7 @@ static void printTypeName(Type *ty, raw_ostream &nameStream) {
     nameStream << "]";
     return;
   }
-  if (auto vecTy = dyn_cast<FixedVectorType>(ty)) {
+  if (auto vecTy = dyn_cast<VectorType>(ty)) {
     nameStream << "v" << vecTy->getNumElements();
     ty = vecTy->getElementType();
   }
@@ -5312,7 +5312,7 @@ void SPIRVToLLVM::setupImageAddressOperands(SPIRVInstruction *bi, unsigned maskI
   // SPIR-V allows the coordinate vector to be too wide; chop it down here.
   // Also handle the extra projective component if any.
   Value *coord = addr[lgc::Builder::ImageAddressIdxCoordinate];
-  if (auto coordVecTy = dyn_cast<FixedVectorType>(coord->getType())) {
+  if (auto coordVecTy = dyn_cast<VectorType>(coord->getType())) {
     unsigned numCoords = getBuilder()->getImageNumCoords(imageInfo->dim);
     if (hasProj) {
       addr[lgc::Builder::ImageAddressIdxProjective] = getBuilder()->CreateExtractElement(coord, numCoords);
@@ -5451,11 +5451,11 @@ void SPIRVToLLVM::handleImageFetchReadWriteCoord(SPIRVInstruction *bi, Extracted
     if (isa<VectorType>(coord->getType())) {
       if (!isa<VectorType>(offset->getType())) {
         offset = getBuilder()->CreateInsertElement(Constant::getNullValue(coord->getType()), offset, uint64_t(0));
-      } else if (cast<FixedVectorType>(coord->getType())->getNumElements() !=
-                 cast<FixedVectorType>(offset->getType())->getNumElements()) {
+      } else if (cast<VectorType>(coord->getType())->getNumElements() !=
+                 cast<VectorType>(offset->getType())->getNumElements()) {
         offset = getBuilder()->CreateShuffleVector(
             offset, Constant::getNullValue(offset->getType()),
-            ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<FixedVectorType>(coord->getType())->getNumElements()));
+            ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements()));
       }
     }
     coord = getBuilder()->CreateAdd(coord, offset);
@@ -5600,7 +5600,7 @@ Value *SPIRVToLLVM::transSPIRVImageAtomicOpFromInst(SPIRVInstruction *bi, BasicB
     idxs.push_back(1);
     if (imageInfo.desc->Arrayed)
       idxs.push_back(2);
-    idxs.push_back(cast<FixedVectorType>(coord->getType())->getNumElements());
+    idxs.push_back(cast<VectorType>(coord->getType())->getNumElements());
     coord = getBuilder()->CreateShuffleVector(coord, sampleNum, idxs);
   }
 
@@ -5966,7 +5966,7 @@ Value *SPIRVToLLVM::transSPIRVImageFetchReadFromInst(SPIRVInstruction *bi, Basic
       sampleNum = getBuilder()->CreateInsertElement(UndefValue::get(coord->getType()), sampleNum, uint64_t(0));
       coord = getBuilder()->CreateShuffleVector(
           coord, sampleNum,
-          ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<FixedVectorType>(coord->getType())->getNumElements() + 1));
+          ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements() + 1));
     }
   }
 
@@ -6014,7 +6014,7 @@ Value *SPIRVToLLVM::transSPIRVImageWriteFromInst(SPIRVInstruction *bi, BasicBloc
     sampleNum = getBuilder()->CreateInsertElement(UndefValue::get(coord->getType()), sampleNum, uint64_t(0));
     coord = getBuilder()->CreateShuffleVector(
         coord, sampleNum,
-        ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<FixedVectorType>(coord->getType())->getNumElements() + 1));
+        ArrayRef<int>({0, 1, 2, 3}).slice(0, cast<VectorType>(coord->getType())->getNumElements() + 1));
   }
 
   // Do the image store.


### PR DESCRIPTION
That change appeared to be causing CTS failures in internal testing.

This reverts commit 6107115c6a63e291a1b84bc175914d65efb96715.