### PR TITLE
Fix tests to cope with upstream change to relocs

### DIFF
--- a/llpc/test/shaderdb/PipelineVsFs_FsWithData.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_FsWithData.pipe
@@ -4,7 +4,7 @@
 ; SHADERTEST-LABEL: <_amdgpu_ps_main>:
 ; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[fs_data_sym:[.a-z]*]]
-; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, {{4|12}}
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[fs_data_sym]]
 ; SHADERTEST: 0000000000000000 <[[fs_data_sym]]>:
 ; SHADERTEST-NEXT: 000000000000: 3F800000
@@ -24,9 +24,9 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2-LABEL: <_amdgpu_ps_main>:
-; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[fsdata_offset:[0-9]*]]
+; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[fsdata_offset:[0-9A-F]*]]
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .text
-; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[fsdata_offset]]
+; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_HI    .text
 ; SHADERTEST2-LABEL: <__llpc_global_proxy_>:
 ; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000

--- a/llpc/test/shaderdb/PipelineVsFs_VsAndFsWithData.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_VsAndFsWithData.pipe
@@ -4,12 +4,12 @@
 ; SHADERTEST-LABEL: <_amdgpu_vs_main>:
 ; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[vs_data_sym:[.a-z]*]]
-; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, {{4|12}}
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[vs_data_sym]]
 ; SHADERTEST-LABEL: <_amdgpu_ps_main>:
 ; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[fs_data_sym:[.a-z]*]]
-; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, {{4|12}}
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[fs_data_sym]]
 ; SHADERTEST: 0000000000000000 <[[vs_data_sym]]>:
 ; SHADERTEST-NEXT: 000000000000: 3F800000
@@ -42,9 +42,9 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2-LABEL: <_amdgpu_vs_main>:
-; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset:[0-9]*]]
+; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset:[0-9A-F]*]]
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .text
-; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset]]
+; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_HI    .text
 ; SHADERTEST2-LABEL: <__llpc_global_proxy_>:
 ; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000

--- a/llpc/test/shaderdb/PipelineVsFs_VsWithData.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_VsWithData.pipe
@@ -4,7 +4,7 @@
 ; SHADERTEST-LABEL: <_amdgpu_vs_main>:
 ; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[vs_data_sym:[.a-z]*]]
-; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
+; SHADERTEST-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, {{4|12}}
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_HI    [[vs_data_sym]]
 ; SHADERTEST: 0000000000000000 <[[vs_data_sym]]>:
 ; SHADERTEST-NEXT: 000000000000: 3F800000
@@ -24,9 +24,9 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2-LABEL: <_amdgpu_vs_main>:
-; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset:[0-9]*]]
+; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset:[0-9A-F]*]]
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .text
-; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x[[vsdata_offset]]
+; SHADERTEST2-NEXT: s_addc_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0x
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_HI    .text
 ; SHADERTEST2-LABEL: <__llpc_global_proxy_>:
 ; SHADERTEST2-NEXT: {{[0-9]*}}: 3F800000


### PR DESCRIPTION
Fix some tests to cope with this upstream LLVM patch which changes the
offsets used in REL32_HI relocs:
https://reviews.llvm.org/D86938 [AMDGPU] Fix offset for REL32_HI relocs

The tests now accept either the old or the new offsets, so we don't need
to synchronize this change with the LLVM upgrade.