### PR TITLE
Fix Tess_TestInOutPacking test operand syntax

### DIFF
--- a/llpc/test/shaderdb/PipelineTess_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/PipelineTess_TestInOutPacking.pipe
@@ -10,12 +10,12 @@
 ; SHADERTEST: add nuw nsw i32 %{{[0-9]*}}, 384
 ; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 32, i32 immarg 15, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, i1 immarg false, i1 immarg false)
 ; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 33, i32 immarg 3, float %{{[0-9]*}}, float %{{[0-9]*}}, float undef, float undef, i1 immarg false, i1 immarg false)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 1, i32 immarg 1, i32 %2)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 2, i32 immarg 0, i32 %2)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 3, i32 immarg 0, i32 %2)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 0, i32 immarg 1, i32 %2)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 0, i32 immarg 0, i32 %2)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[0-9]*}}, i32 immarg 1, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 1, i32 immarg 1, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 2, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 3, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 0, i32 immarg 1, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 0, i32 immarg 0, i32 %2)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 1, i32 immarg 0, i32 %2)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
Required for llvm upstream change - operand syntax has changed requiring extra
characters in the regex match (%123 -> %.i456)