### PR TITLE
Add parentheses to improve readability (NFC)

### DIFF
--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -3050,7 +3050,7 @@ void InOutLocationMapManager::buildLocationMap(bool checkCompatibility) {
     m_locationMap[origLocation] = newLocation;
 
     // Update component index
-    if (spanIt->compatibilityInfo.is16Bit && isHighHalf || !spanIt->compatibilityInfo.is16Bit)
+    if ((spanIt->compatibilityInfo.is16Bit && isHighHalf) || !spanIt->compatibilityInfo.is16Bit)
       ++compIdx;
     assert(compIdx <= 4);
   }


### PR DESCRIPTION
Our internal builds complain with:

```
error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
```

This is a warning, but we treat warnings as errors.  It also help make
the code more readable.