### PR TITLE
Handle Fmask descriptors in relocations.

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -143,13 +143,6 @@ Value *DescBuilder::CreateGetDescStride(ResourceNodeType descType, unsigned desc
   const ResourceNode *node = nullptr;
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(descType, descSet, binding);
-    if (!node && descType == ResourceNodeType::DescriptorFmask &&
-        m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
-      // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
-      // (image) one instead.
-      std::tie(topNode, node) =
-          m_pipelineState->findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);
-    }
     if (!node) {
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getInt32Ty());
@@ -179,12 +172,6 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType descType, unsigned descSet
 
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(descType, descSet, binding);
-    if (!node && descType == ResourceNodeType::DescriptorFmask && shadow) {
-      // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
-      // (image) one instead.
-      std::tie(topNode, node) =
-          m_pipelineState->findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);
-    }
     if (!node) {
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getDescPtrTy(descType));
@@ -270,6 +257,8 @@ static StringRef GetRelocTypeSuffix(ResourceNodeType type) {
     return "_b";
   case ResourceNodeType::DescriptorTexelBuffer:
     return "_t";
+  case ResourceNodeType::DescriptorFmask:
+    return "_f";
   default:
     return "_x";
   }

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -136,7 +136,7 @@ public:
 
   // Set and get per-pipeline options
   void setOptions(const Options &options) override final { m_options = options; }
-  const Options &getOptions() override final { return m_options; }
+  const Options &getOptions() const override final { return m_options; }
 
   // Set per-shader options
   void setShaderOptions(ShaderStage stage, const ShaderOptions &options) override final;

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -519,7 +519,7 @@ public:
 
   // Set and get per-pipeline options
   virtual void setOptions(const Options &options) = 0;
-  virtual const Options &getOptions() = 0;
+  virtual const Options &getOptions() const = 0;
 
   // Set per-shader options
   virtual void setShaderOptions(ShaderStage stage, const ShaderOptions &options) = 0;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -726,6 +726,9 @@ static bool IsNodeTypeCompatible(ResourceNodeType nodeType, ResourceNodeType can
 // Returns {topNode, node} where "node" is the found user data node, and "topNode" is the top-level user data
 // node that contains it (or is equal to it).
 //
+// If the node is not found and nodeType == Fmask, then a search will be done for a DescriptorResource at the given
+// descriptor set and binding.
+//
 // @param nodeType : Type of the resource mapping node
 // @param descSet : ID of descriptor set
 // @param binding : ID of descriptor binding
@@ -748,6 +751,13 @@ PipelineState::findResourceNode(ResourceNodeType nodeType, unsigned descSet, uns
     } else if (node.set == descSet && node.binding == binding && IsNodeTypeCompatible(nodeType, node.type)) {
       return {&node, &node};
     }
+  }
+
+  if (nodeType == ResourceNodeType::DescriptorFmask &&
+      getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
+    // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
+    // (image) one instead.
+    return findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);
   }
   return {nullptr, nullptr};
 }


### PR DESCRIPTION
The descriptor offset and stride relocations do not handle Fmask
resources correctly.  We need a new suffix for them, and also fall back
to searching for a Descriptor resource if they are not used.

Tests will be added in a later PR that adds relocations for the shadow
table. (#964)