### PR TITLE
Refactor shadow desc table code

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -291,7 +291,7 @@ private:
 
   // Get a pointer to a descriptor, as a pointer to i8
   llvm::Value *getDescPtr(ResourceNodeType resType, unsigned descSet, unsigned binding, const ResourceNode *topNode,
-                          const ResourceNode *node, bool shadow);
+                          const ResourceNode *node);
 
   llvm::Value *scalarizeIfUniform(llvm::Value *value, bool isNonUniform);
 

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -143,13 +143,6 @@ Value *DescBuilder::CreateGetDescStride(ResourceNodeType descType, unsigned desc
   const ResourceNode *node = nullptr;
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(descType, descSet, binding);
-    if (!node && descType == ResourceNodeType::DescriptorFmask &&
-        m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
-      // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
-      // (image) one instead.
-      std::tie(topNode, node) =
-          m_pipelineState->findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);
-    }
     if (!node) {
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getInt32Ty());
@@ -179,12 +172,6 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType descType, unsigned descSet
 
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(descType, descSet, binding);
-    if (!node && descType == ResourceNodeType::DescriptorFmask && shadow) {
-      // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
-      // (image) one instead.
-      std::tie(topNode, node) =
-          m_pipelineState->findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);
-    }
     if (!node) {
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getDescPtrTy(descType));
@@ -270,6 +257,8 @@ static StringRef GetRelocTypeSuffix(ResourceNodeType type) {
     return "_b";
   case ResourceNodeType::DescriptorTexelBuffer:
     return "_t";
+  case ResourceNodeType::DescriptorFmask:
+    return "_f";
   default:
     return "_x";
   }

--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -241,7 +241,7 @@ Module *FetchShader::generate() {
         case static_cast<unsigned>(UserDataMapping::VertexBufferTable): {
           // Need to extend 32-bit vertex buffer table address to 64 bits.
           AddressExtender extender(fetchFunc);
-          unsigned highAddr = cast<ConstantInt>(call->getArgOperand(1))->getZExtValue();
+          Value *highAddr = call->getArgOperand(1);
           builder.SetInsertPoint(&*fetchFunc->front().getFirstInsertionPt());
           replacement = extender.extend(fetchFunc->getArg(m_vsEntryRegInfo.vertexBufferTable), highAddr,
                                         call->getType(), builder);

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -136,7 +136,7 @@ public:
 
   // Set and get per-pipeline options
   void setOptions(const Options &options) override final { m_options = options; }
-  const Options &getOptions() override final { return m_options; }
+  const Options &getOptions() const override final { return m_options; }
 
   // Set per-shader options
   void setShaderOptions(ShaderStage stage, const ShaderOptions &options) override final;

--- a/lgc/include/lgc/util/AddressExtender.h
+++ b/lgc/include/lgc/util/AddressExtender.h
@@ -55,11 +55,11 @@ public:
   // Extend an i32 into a 64-bit pointer
   //
   // @param addr32 : Address as 32-bit value
-  // @param highHalf : Value to use for high half; HighAddrPc to use PC
+  // @param highHalf : Value to use for high half; The constant HighAddrPc to use PC
   // @param ptrTy : Type to cast pointer to
   // @param builder : IRBuilder to use, already set to the required insert point
   // @returns : 64-bit pointer value
-  llvm::Instruction *extend(llvm::Value *addr32, unsigned highHalf, llvm::Type *ptrTy, llvm::IRBuilder<> &builder);
+  llvm::Instruction *extend(llvm::Value *addr32, llvm::Value *highHalf, llvm::Type *ptrTy, llvm::IRBuilder<> &builder);
 
 private:
   // Get PC value as v2i32.

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -519,7 +519,7 @@ public:
 
   // Set and get per-pipeline options
   virtual void setOptions(const Options &options) = 0;
-  virtual const Options &getOptions() = 0;
+  virtual const Options &getOptions() const = 0;
 
   // Set per-shader options
   virtual void setShaderOptions(ShaderStage stage, const ShaderOptions &options) = 0;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -726,6 +726,9 @@ static bool IsNodeTypeCompatible(ResourceNodeType nodeType, ResourceNodeType can
 // Returns {topNode, node} where "node" is the found user data node, and "topNode" is the top-level user data
 // node that contains it (or is equal to it).
 //
+// If the node is not found and nodeType == Fmask, then a search will be done for a DescriptorResource at the given
+// descriptor set and binding.
+//
 // @param nodeType : Type of the resource mapping node
 // @param descSet : ID of descriptor set
 // @param binding : ID of descriptor binding
@@ -748,6 +751,13 @@ PipelineState::findResourceNode(ResourceNodeType nodeType, unsigned descSet, uns
     } else if (node.set == descSet && node.binding == binding && IsNodeTypeCompatible(nodeType, node.type)) {
       return {&node, &node};
     }
+  }
+
+  if (nodeType == ResourceNodeType::DescriptorFmask &&
+      getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
+    // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
+    // (image) one instead.
+    return findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);
   }
   return {nullptr, nullptr};
 }


### PR DESCRIPTION
We want to use relocation so that unlinked shaderd do not have to access
those options.  This change will refactor a few thing to make that
easier.

- Minor refactoring so that the effects of accessing the shadow desc
option are short lived.  We don't want to set a variable that has a long
live range.  This removes the `shadow` parameter from
`DescBuilder::getDescPtr`.

- `AddressExtender::entend` is modified to accept the high half of the
addess as a value instead of an integer.  This will be useful when the
high half is obtained from a relocation.

Built on top of #962.  Look only at the last commit for this change.