### PR TITLE
Replace shadow desc table with relocations for unlinked shaders.

### DIFF
--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -178,6 +178,15 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
     getPipelineState()->getPalMetadata()->setUserDataSpillUsage(pushConstantNode->offsetInDwords);
     return true;
   }
+  if (name == reloc::ShadowDescriptorTableEnabled) {
+    value = m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable;
+    return true;
+  }
+
+  if (name == reloc::ShadowDescriptorTable) {
+    value = m_pipelineState->getOptions().shadowDescriptorTable;
+    return true;
+  }
 
   return false;
 }

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -89,6 +89,16 @@ const static char DeviceIdx[] = "$deviceIdx";
 // The value of the relocation is the offset of the pushconst reource node in the pipeline state.
 const static char Pushconst[] = "pushconst";
 
+// Whether the shadow descriptor is enabled or not.
+//
+// The value of the relocation is either:
+//  * 0: the shadow descriptor table is disabled.
+//  * 1: the shadow descriptor table is enabled.
+const static char ShadowDescriptorTableEnabled[] = "$shadowenabled";
+
+// The high 32-bits of the addess of the shadow descriptor table.
+const static char ShadowDescriptorTable[] = "$shadowdesctable";
+
 } // namespace reloc
 
 // =====================================================================================================================

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
@@ -1,0 +1,98 @@
+// This test case checks that descriptor offset and descriptor buffer pointer relocation works
+// for buffer descriptors in a vs/fs pipeline.
+// Also check that the user data limit is set correctly.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: _amdgpu_ps_main
+; SHADERTEST: s_mov_b32 s[[highaddr:[0-9]*]], 0xffff
+; SHADERTEST: s_load_dwordx8 s[{{[0-9]*}}:{{[0-9]*}}], s[{{[0-9]*}}:[[highaddr]]], 0x30
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1-LABEL: _amdgpu_ps_main
+; SHADERTEST1: s_getpc_b64 s[0:1]
+; SHADERTEST1: s_and_b32 [[enabled:s[0-9]*]], 1, 1
+; SHADERTEST1: s_cmp_eq_u32 [[enabled]], 0
+; SHADERTEST1: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0xffff
+; SHADERTEST1: s_mov_b32 [[offset:s[0-9]*]], 48
+; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]
+; END_SHADERTEST
+
+
+[VsGlsl]
+#version 450
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 0) out vec2 outUV;
+
+void main() {
+    outUV = inPosition;
+}
+
+
+[VsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 11
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorResource
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorFmask
+userDataNode[0].next[1].offsetInDwords = 12
+userDataNode[0].next[1].sizeInDwords = 8
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 0
+
+[FsGlsl]
+#version 450 core
+
+layout(set = 0, binding = 0) uniform sampler2DMS samp;
+layout(location = 0) in vec2 inUV;
+layout(location = 0) out vec4 oColor;
+
+void main()
+{
+    ivec2 iUV = ivec2(inUV);
+    oColor = texelFetch(samp, iUV, 2);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 1
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 11
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorResource
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorFmask
+userDataNode[0].next[1].offsetInDwords = 12
+userDataNode[0].next[1].sizeInDwords = 8
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 0
+options.shadowDescriptorTableUsage = Enable
+options.shadowDescriptorTablePtrHigh = 0xFFFF
+
+[VertexInputState]
+binding[0].binding = 1
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
@@ -1,0 +1,88 @@
+// This test case checks that descriptor offset and descriptor buffer pointer relocation works
+// for buffer descriptors in a vs/fs pipeline.
+// Also check that the user data limit is set correctly.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: _amdgpu_ps_main
+; SHADERTEST: s_mov_b32 s[[highaddr:[0-9]*]], 0xffff
+; SHADERTEST: s_load_dwordx8 s[{{[0-9]*}}:{{[0-9]*}}], s[{{[0-9]*}}:[[highaddr]]], 0x10
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST1 %s
+; SHADERTEST1-LABEL: _amdgpu_ps_main
+; SHADERTEST1: s_getpc_b64 s[0:1]
+; SHADERTEST1: s_and_b32 [[enabled:s[0-9]*]], 1, 1
+; SHADERTEST1: s_cmp_eq_u32 [[enabled]], 0
+; SHADERTEST1: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0xffff
+; SHADERTEST1: s_mov_b32 [[offset:s[0-9]*]], 16
+; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]
+; END_SHADERTEST
+
+
+[VsGlsl]
+#version 450
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 0) out vec2 outUV;
+
+void main() {
+    outUV = inPosition;
+}
+
+
+[VsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 11
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorResource
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+
+[FsGlsl]
+#version 450 core
+
+layout(set = 0, binding = 0) uniform sampler2DMS samp;
+layout(location = 0) in vec2 inUV;
+layout(location = 0) out vec4 oColor;
+
+void main()
+{
+    ivec2 iUV = ivec2(inUV);
+    oColor = texelFetch(samp, iUV, 2);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 1
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 11
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorResource
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+options.shadowDescriptorTableUsage = Enable
+options.shadowDescriptorTablePtrHigh = 0xFFFF
+
+[VertexInputState]
+binding[0].binding = 1
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0

--- a/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
+++ b/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
@@ -1,0 +1,27 @@
+#version 450 core
+
+layout(set = 0, binding = 0) uniform sampler2DMS samp;
+layout(location = 0) in vec2 inUV;
+layout(location = 0) out vec4 oColor;
+
+void main()
+{
+    ivec2 iUV = ivec2(inUV);
+    oColor = texelFetch(samp, iUV, 2);
+}
+
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: s_getpc_b64 s[0:1]
+; SHADERTEST: s_and_b32 [[enabled:s[0-9]*]], 0, 1
+; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowenabled
+; SHADERTEST: s_cmp_eq_u32 [[enabled]], 0
+; SHADERTEST: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0
+; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowdesctable
+; SHADERTEST: s_mov_b32 [[offset:s[0-9]*]], 0
+; SHADERTEST-NEXT: R_AMDGPU_ABS32 doff_0_0_f
+; SHADERTEST: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]
+*/
+// END_SHADERTEST

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1011,8 +1011,12 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     hasher->Update(pipeline->options.includeIr);
     hasher->Update(pipeline->options.robustBufferAccess);
     hasher->Update(pipeline->options.reconfigWorkgroupLayout);
-    hasher->Update(pipeline->options.shadowDescriptorTableUsage);
-    hasher->Update(pipeline->options.shadowDescriptorTablePtrHigh);
+
+    if (!isRelocatableShader) {
+      hasher->Update(pipeline->options.shadowDescriptorTableUsage);
+      hasher->Update(pipeline->options.shadowDescriptorTablePtrHigh);
+    }
+
     hasher->Update(pipeline->options.extendedRobustness.robustBufferAccess);
     hasher->Update(pipeline->options.extendedRobustness.robustImageAccess);
     hasher->Update(pipeline->options.extendedRobustness.nullDescriptor);


### PR DESCRIPTION
We want to use relocation so that unlinked shaderd do not have to access
those options.  This change will include:

- Add two new relocations.  One is used to check if shadow desc teble is
enabled, and the other is used to get the high bit for the address of
the table.

- Don't include the shadow desc options in the hash for relocatable
shaders.

Based on #962 and #963.  Only the last commit is part of this change.