### PR TITLE
Fix hashing of entire pipeline.

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1458,7 +1458,7 @@ Result Compiler::BuildGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline
 
   MetroHash::Hash cacheHash = {};
   MetroHash::Hash pipelineHash = {};
-  cacheHash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo, true, buildingRelocatableElf);
+  cacheHash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo, true, false);
   pipelineHash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo, false, false);
 
   if (result == Result::Success && EnableOuts()) {


### PR DESCRIPTION
The location that is changed is suppose to compute the hash for the
entire pipeline, and that is fed back in the pipeline elf.  We should
not be skipping parts of the pipeline because they are not used for the
relocatable shader compilation.

No test was added because I do not know how to write a stable test
checking that the hash is correct.