### PR TITLE
Include offset and size of data symbols when linking

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultipleConstData.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultipleConstData.pipe
@@ -1,0 +1,123 @@
+// This test case checks that the elf linker places symbols for constant data at the correct offset with the correct size.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -t %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: SYMBOL TABLE:
+; SHADERTEST: 0000000000000000 l O .rodata.cst32 0000000000000020 __unnamed_1.vertex
+; SHADERTEST: 0000000000000020 l O .rodata.cst32 0000000000000020 __unnamed_2.vertex
+; END_SHADERTEST
+
+
+[Version]
+version = 41
+
+[VsSpirv]
+               OpCapability StorageImageExtendedFormats
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "VS_Fullscreen" %gl_VertexIndex %gl_Position %4
+               OpDecorate %gl_VertexIndex BuiltIn VertexIndex
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorate %4 Location 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+    %v2float = OpTypeVector %float 2
+     %uint_4 = OpConstant %uint 4
+%_arr_v2float_uint_4 = OpTypeArray %v2float %uint_4
+       %void = OpTypeVoid
+         %12 = OpTypeFunction %void
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+   %float_n1 = OpConstant %float -1
+%_ptr_Input_uint = OpTypePointer Input %uint
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+  %float_0_5 = OpConstant %float 0.5
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+%gl_VertexIndex = OpVariable %_ptr_Input_uint Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+          %4 = OpVariable %_ptr_Output_v2float Output
+%_ptr_Function__arr_v2float_uint_4 = OpTypePointer Function %_arr_v2float_uint_4
+         %22 = OpConstantComposite %v2float %float_0 %float_0
+         %23 = OpConstantComposite %v2float %float_1 %float_0
+         %24 = OpConstantComposite %v2float %float_0 %float_1
+         %25 = OpConstantComposite %v2float %float_1 %float_1
+         %26 = OpConstantComposite %_arr_v2float_uint_4 %22 %23 %24 %25
+         %27 = OpConstantComposite %v2float %float_n1 %float_1
+         %28 = OpConstantComposite %v2float %float_n1 %float_n1
+         %29 = OpConstantComposite %v2float %float_1 %float_n1
+         %30 = OpConstantComposite %_arr_v2float_uint_4 %27 %25 %28 %29
+         %31 = OpConstantNull %v4float
+          %1 = OpFunction %void None %12
+         %32 = OpLabel
+         %33 = OpVariable %_ptr_Function__arr_v2float_uint_4 Function
+         %34 = OpVariable %_ptr_Function__arr_v2float_uint_4 Function
+               OpStore %34 %26
+               OpStore %33 %30
+         %35 = OpLoad %uint %gl_VertexIndex
+         %36 = OpAccessChain %_ptr_Function_v2float %33 %35
+         %37 = OpLoad %v2float %36
+         %38 = OpVectorShuffle %v4float %31 %37 4 5 2 3
+         %39 = OpCompositeInsert %v4float %float_0_5 %38 2
+         %40 = OpCompositeInsert %v4float %float_1 %39 3
+         %41 = OpAccessChain %_ptr_Function_v2float %34 %35
+         %42 = OpLoad %v2float %41
+               OpStore %gl_Position %40
+               OpStore %4 %42
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = VS_Fullscreen
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 2
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 0
+
+[FsSpirv]
+               OpCapability StorageImageExtendedFormats
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "PS_Blend" %4 %5
+               OpExecutionMode %2 OriginUpperLeft
+               OpDecorate %4 Location 0
+               OpDecorate %5 Location 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+    %v2float = OpTypeVector %float 2
+        %int = OpTypeInt 32 1
+          %9 = OpTypeImage %float 2D 2 0 0 1 Unknown
+       %void = OpTypeVoid
+         %22 = OpTypeFunction %void
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+     %int_12 = OpConstant %int 12
+      %v2int = OpTypeVector %int 2
+      %int_0 = OpConstant %int 0
+      %v3int = OpTypeVector %int 3
+          %4 = OpVariable %_ptr_Input_v2float Input
+          %5 = OpVariable %_ptr_Output_v4float Output
+        %259 = OpUndef %v3int
+        %260 = OpUndef %9
+          %2 = OpFunction %void None %22
+         %63 = OpLabel
+         %64 = OpLoad %v2float %4
+        %246 = OpCompositeExtract %float %64 0
+        %248 = OpConvertFToS %int %246
+        %250 = OpCompositeConstruct %v3int %int_12 %248 %int_0
+        %251 = OpVectorShuffle %v2int %250 %259 0 1
+        %253 = OpImageFetch %v4float %260 %251 Lod %int_0
+               OpStore %5 %253
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = PS_Blend
+
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 1


### PR DESCRIPTION
The linker does not pass along the size and offset of the original
relocation symbols when linking.  This causes symbols to overlap, which
is wrong.