### PR TITLE
Move functions from llpcShaderModuleHelper to vkgcUtil

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -484,7 +484,7 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
                               TimerProfiler::ShaderModuleTimerEnableMask);
 
   // Check the type of input shader binary
-  if (ShaderModuleHelper::isSpirvBinary(&shaderInfo->shaderBin)) {
+  if (Vkgc::isSpirvBinary(&shaderInfo->shaderBin)) {
     unsigned debugInfoSize = 0;
 
     moduleDataEx.common.binType = BinaryType::Spirv;

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -1297,7 +1297,7 @@ static Result processPipeline(ICompiler *compiler, ArrayRef<std::string> inFiles
       if (result == Result::Success) {
         // NOTE: If the entry target is not specified, we set it to the one gotten from SPIR-V binary.
         if (EntryTarget.empty())
-          EntryTarget.setValue(ShaderModuleHelper::getEntryPointNameFromSpirvBinary(&spvBin));
+          EntryTarget.setValue(Vkgc::getEntryPointNameFromSpirvBinary(&spvBin));
 
         unsigned stageMask = ShaderModuleHelper::getStageMaskFromSpirvBinary(&spvBin, EntryTarget.c_str());
 

--- a/llpc/util/llpcShaderModuleHelper.h
+++ b/llpc/util/llpcShaderModuleHelper.h
@@ -35,15 +35,6 @@
 
 namespace Llpc {
 
-// Represents the special header of SPIR-V token stream (the first dword).
-struct SpirvHeader {
-  unsigned magicNumber;    // Magic number of SPIR-V module
-  unsigned spvVersion;     // SPIR-V version number
-  unsigned genMagicNumber; // Generator's magic number
-  unsigned idBound;        // Upbound (X) of all IDs used in SPIR-V (0 < ID < X)
-  unsigned reserved;       // Reserved word
-};
-
 // Represents the information of one shader entry in ShaderModuleData
 struct ShaderModuleEntry {
   unsigned entryNameHash[4]; // Hash code of entry name
@@ -73,11 +64,7 @@ public:
 
   static unsigned getStageMaskFromSpirvBinary(const BinaryData *spvBin, const char *entryName);
 
-  static const char *getEntryPointNameFromSpirvBinary(const BinaryData *spvBin);
-
   static Result verifySpirvBinary(const BinaryData *spvBin);
-
-  static bool isSpirvBinary(const BinaryData *shaderBin);
 
   static bool isLlvmBitcode(const BinaryData *shaderBin);
 };

--- a/util/vkgcUtil.h
+++ b/util/vkgcUtil.h
@@ -34,6 +34,15 @@
 
 namespace Vkgc {
 
+// Represents the special header of SPIR-V token stream (the first dword).
+struct SpirvHeader {
+  unsigned magicNumber;    // Magic number of SPIR-V module
+  unsigned spvVersion;     // SPIR-V version number
+  unsigned genMagicNumber; // Generator's magic number
+  unsigned idBound;        // Upbound (X) of all IDs used in SPIR-V (0 < ID < X)
+  unsigned reserved;       // Reserved word
+};
+
 // Invalid value
 static const unsigned InvalidValue = ~0u;
 
@@ -45,6 +54,12 @@ bool createDirectory(const char *dir);
 
 // Translate enum "ResourceMappingNodeType" to string
 const char *getResourceMappingNodeTypeName(ResourceMappingNodeType type);
+
+// Checks whether input binary data is SPIR-V binary
+bool isSpirvBinary(const BinaryData *shaderBin);
+
+// Gets the entry-point name from the SPIR-V binary
+const char *getEntryPointNameFromSpirvBinary(const BinaryData *spvBin);
 
 // =====================================================================================================================
 // Increments a pointer by nBytes by first casting it to a uint8_t*.


### PR DESCRIPTION
Move isSpirvBinary() and getEntryPointNameFromSpirvBinary() from llpcShaderModuleHelper to vkgcUtil to make them compiler independent components.