### PR TITLE
Revert "[PR909]Add Image resource type workaround"

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -70,7 +70,6 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
-//* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |
 //* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
 //* |     41.0 | Moved resource mapping from ShaderPipeline-level to Pipeline-level                                    |
@@ -326,8 +325,7 @@ struct PipelineOptions {
                                    ///  the out of bounds accesses will be skipped with this setting.
   bool enableRelocatableShaderElf; ///< If set, the pipeline will be compiled by compiling each shader separately, and
                                    ///  then linking them, when possible.  When not possible this option is ignored.
-  bool disableImageResourceCheck;  ///< If set, the pipeline shader will not contain code to check and fix invalid image
-                                   ///  descriptors.
+
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
   ExtendedRobustness extendedRobustness;                 ///< ExtendedRobustness is intended to correspond to the

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -412,9 +412,6 @@ private:
   // Patch descriptor with cube dimension for image call
   llvm::Value *patchCubeDescriptor(llvm::Value *desc, unsigned dim);
 
-  // Patch invalid resource descriptor for image call
-  llvm::Value *patchInvalidImageDescriptor(llvm::Value *desc);
-
   // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
   llvm::Value *handleFragCoordViewIndex(llvm::Value *coord, unsigned flags, unsigned &dim);
 

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -424,7 +424,6 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
   getPipelineState()->getShaderResourceUsage(m_shaderStage)->resourceRead = true;
   assert(coord->getType()->getScalarType()->isIntegerTy(32));
   imageDesc = patchCubeDescriptor(imageDesc, dim);
-  imageDesc = patchInvalidImageDescriptor(imageDesc);
   coord = handleFragCoordViewIndex(coord, flags, dim);
 
   unsigned dmask = 1;
@@ -603,7 +602,6 @@ Value *ImageBuilder::CreateImageStore(Value *texel, unsigned dim, unsigned flags
   getPipelineState()->getShaderResourceUsage(m_shaderStage)->resourceWrite = true;
   assert(coord->getType()->getScalarType()->isIntegerTy(32));
   imageDesc = patchCubeDescriptor(imageDesc, dim);
-  imageDesc = patchInvalidImageDescriptor(imageDesc);
   coord = handleFragCoordViewIndex(coord, flags, dim);
 
   // For 64-bit texel, only the first component is stored
@@ -1200,7 +1198,6 @@ Value *ImageBuilder::CreateImageAtomicCommon(unsigned atomicOp, unsigned dim, un
   if (imageDesc->getType() == getDescTy(ResourceNodeType::DescriptorResource)) {
     // Resource descriptor. Use the image atomic instruction.
     imageDesc = patchCubeDescriptor(imageDesc, dim);
-    imageDesc = patchInvalidImageDescriptor(imageDesc);
     args.push_back(inputValue);
     if (atomicOp == AtomicOpCompareSwap)
       args.push_back(comparatorValue);
@@ -1723,28 +1720,6 @@ void ImageBuilder::combineCubeArrayFaceAndSlice(Value *coord, SmallVectorImpl<Va
   }
   coords[2] = combined;
   coords.pop_back();
-}
-
-// =====================================================================================================================
-// A buffer descriptor may be incorrectly given when it should be an image descriptor, we need to fix it to valid buffer
-// type (0) to make hardware happily ignore it. This is to check and fix against buggy applications which declares a
-// image descriptor in shader but provide a buffer descriptor in driver. Note this only applies to gfx10.
-//
-// @param desc : Descriptor before patching
-Value *ImageBuilder::patchInvalidImageDescriptor(Value *desc) {
-  if (getPipelineState()->getOptions().disableImageResourceCheck ||
-      getPipelineState()->getTargetInfo().getGfxIpVersion().major != 10)
-    return desc;
-
-  // Extract the dword3. force the 'type' to 0 if [0, 7]
-  Value *elem3 = CreateExtractElement(desc, 3);
-  Value *resourceType = CreateLShr(elem3, getInt32(28));
-  Value *isInvalid = CreateICmpSLE(resourceType, getInt32(7));
-  Value *masked = CreateAnd(elem3, getInt32(0x0FFFFFFF));
-  elem3 = CreateSelect(isInvalid, masked, elem3);
-
-  // Reassemble descriptor.
-  return CreateInsertElement(desc, elem3, 3);
 }
 
 // =====================================================================================================================

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -123,7 +123,6 @@ struct Options {
   unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
                                        //   ShadowDescriptorTableDisable to disable shadow descriptor tables
   unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
-  unsigned disableImageResourceCheck;  // Don't do image resource type check
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -311,7 +311,6 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
   }
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;
-  options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
   pipeline->setOptions(options);
 
   // Give the shader options (including the hash) to the middle-end.


### PR DESCRIPTION
This reverts commit f5863d8832a8dd9d2786021d6f077702dcd44207.
This commit cause cts regression for Navi:
dEQP-VK.descriptor_indexing.storage_texel_buffer_after_bind_in_loop
dEQP-VK.descriptor_indexing.storage_texel_buffer_in_loop
dEQP-VK.descriptor_indexing.uniform_texel_buffer_after_bind_in_loop
dEQP-VK.descriptor_indexing.uniform_texel_buffer_in_loop