### PR TITLE
Fix for effects of upstream LLVM change

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -149,6 +149,7 @@ void LgcContext::initialize() {
 
   // Initialize some command-line option defaults.
   setOptionDefault("filetype", "obj");
+  setOptionDefault("amdgpu-unroll-max-block-to-analyze", "20");
   setOptionDefault("unroll-max-percent-threshold-boost", "1000");
   setOptionDefault("pragma-unroll-threshold", "1000");
   setOptionDefault("unroll-allow-partial", "1");


### PR DESCRIPTION
An upstream LLVM change increased the default block size threshold for inner
loop analysis which resulted in a big increase in compile time, and additional
spilling for a small number of pathological cases.

As the upstream change (https://reviews.llvm.org/D86248) does not benefit any
graphics shaders, the fix is for LGC to simply override the value back to the
previous default value of 20.