### PR TITLE
Generate readfirstlane efficiently for uniform case

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -148,6 +148,7 @@ target_sources(LLVMlgc PRIVATE
     patch/PatchNullFragShader.cpp
     patch/PatchPeepholeOpt.cpp
     patch/PatchPreparePipelineAbi.cpp
+    patch/PatchReadFirstLane.cpp
     patch/PatchResourceCollect.cpp
     patch/PatchSetupTargetFeatures.cpp
     patch/PatchWorkarounds.cpp

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -415,6 +415,9 @@ private:
   // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
   llvm::Value *handleFragCoordViewIndex(llvm::Value *coord, unsigned flags, unsigned &dim);
 
+  // Enforce readfirstlane on the image or sampler descripotrs
+  void enforceReadFirstLane(llvm::Instruction *imageInst, unsigned descIdx);
+
   enum ImgDataFormat {
     IMG_DATA_FORMAT_32 = 4,
     IMG_DATA_FORMAT_8_8_8_8 = 10,

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -59,6 +59,7 @@ void initializePatchPreparePipelineAbiPass(PassRegistry &);
 void initializePatchResourceCollectPass(PassRegistry &);
 void initializePatchSetupTargetFeaturesPass(PassRegistry &);
 void initializePatchWorkaroundsPass(PassRegistry &);
+void initializePatchReadFirstLanePass(PassRegistry &);
 
 } // namespace llvm
 
@@ -86,6 +87,7 @@ inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializePatchResourceCollectPass(passRegistry);
   initializePatchSetupTargetFeaturesPass(passRegistry);
   initializePatchWorkaroundsPass(passRegistry);
+  initializePatchReadFirstLanePass(passRegistry);
 }
 
 llvm::ModulePass *createLowerFragColorExport();
@@ -104,6 +106,7 @@ llvm::ModulePass *createPatchPreparePipelineAbi(bool onlySetCallingConvs);
 llvm::ModulePass *createPatchResourceCollect();
 llvm::ModulePass *createPatchSetupTargetFeatures();
 llvm::ModulePass *createPatchWorkarounds();
+llvm::FunctionPass *createPatchReadFirstLane();
 
 class PipelineState;
 

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -282,6 +282,8 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
     passMgr.add(createPatchPeepholeOpt());
     passMgr.add(createInstSimplifyLegacyPass());
     passMgr.add(createLoopUnrollPass(cl::OptLevel));
+    // uses DivergenceAnalysis
+    passMgr.add(createPatchReadFirstLane());
     passMgr.add(createInstructionCombiningPass(2));
     passMgr.add(createLICMPass());
     passMgr.add(createStripDeadPrototypesPass());

--- a/lgc/patch/PatchReadFirstLane.cpp
+++ b/lgc/patch/PatchReadFirstLane.cpp
@@ -1,0 +1,464 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchReadFirstLane.cpp
+ * @brief LLPC source file: contains declaration and implementation of class lgc::PatchReadFirstLane.
+ ***********************************************************************************************************************
+ */
+#include "lgc/Builder.h"
+#include "lgc/patch/Patch.h"
+#include "lgc/state/PipelineState.h"
+#include "llvm/Analysis/LegacyDivergenceAnalysis.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include <deque>
+
+#define DEBUG_TYPE "lgc-patch-read-first-lane"
+
+using namespace lgc;
+using namespace llvm;
+
+namespace {
+class PatchReadFirstLane final : public FunctionPass {
+public:
+  PatchReadFirstLane();
+
+  virtual bool runOnFunction(Function &function) override;
+  void getAnalysisUsage(AnalysisUsage &analysisUsage) const override;
+
+  static char ID; // ID of this pass
+
+private:
+  PatchReadFirstLane(const PatchReadFirstLane &) = delete;
+  PatchReadFirstLane &operator=(const PatchReadFirstLane &) = delete;
+
+  bool liftReadFirstLane(Function &function);
+  void collectAssumeUniforms(BasicBlock *block, const SmallVectorImpl<Instruction *> &initialReadFirstLanes);
+  void findBestInsertLocation(const SmallVectorImpl<Instruction *> &initialReadFirstLanes);
+  bool isAllUsersAssumedUniform(Instruction *inst);
+  void applyReadFirstLane(Instruction *inst, BuilderBase &builder);
+
+  // We only support to apply amdgcn_readfirstlane on float or int type
+  // TODO: Support various types when backend work is ready
+  bool isSupportedType(Instruction *inst) { return inst->getType()->isFloatTy() || inst->getType()->isIntegerTy(32); }
+
+  LegacyDivergenceAnalysis *m_divergenceAnalysis; // The divergence analysis
+  TargetTransformInfo *m_targetTransformInfo;     // The target tranform info to determine stop propagation
+  DenseMap<Instruction *, SmallVector<Instruction *, 2>>
+      m_uniformDivergentUsesMap; // The map key is an instruction `I` that can be assumed uniform.
+                                 // That is, we can apply readfirstlane to the result of `I` and remain
+                                 // correct. If the map value vector is non-empty, it contains a list of
+                                 // instructions that we can apply readfirstlane on to achieve the same effect
+                                 // as a readfirstlane on `I`. An empty vector means that it is not possible to
+                                 // life a readfirstlane beyond `I`.
+  DenseSet<Instruction *> m_insertLocations; // The insert locations of readfirstlane
+};
+
+} // anonymous namespace
+
+// =====================================================================================================================
+// Initializes static members.
+char PatchReadFirstLane::ID = 0;
+
+// =====================================================================================================================
+// Pass creator, creates the pass of LLVM patching operations for readfirstlane optimizations.
+FunctionPass *lgc::createPatchReadFirstLane() {
+  return new PatchReadFirstLane();
+}
+
+// =====================================================================================================================
+// Returns true if all users of the given instruction defined in the given block.
+//
+// @param inst : The given instruction
+// @param block : The given block
+static bool isAllUsersDefinedInBlock(Instruction *inst, BasicBlock *block) {
+  for (auto user : inst->users()) {
+    if (auto userInst = dyn_cast<Instruction>(user))
+      if (userInst->getParent() != block)
+        return false;
+  }
+  return true;
+}
+
+// =====================================================================================================================
+// Returns true if all users of the given instruction are already readfirstlane
+//
+// @param inst : The given instruction
+static bool areAllUserReadFirstLane(Instruction *inst) {
+  for (auto user : inst->users()) {
+    if (isa<DbgInfoIntrinsic>(user))
+      continue;
+    auto intrinsic = dyn_cast<IntrinsicInst>(user);
+    if (!intrinsic || intrinsic->getIntrinsicID() != Intrinsic::amdgcn_readfirstlane)
+      return false;
+  }
+  return true;
+}
+
+PatchReadFirstLane::PatchReadFirstLane() : FunctionPass(ID), m_targetTransformInfo(nullptr) {
+}
+
+// =====================================================================================================================
+// Executes this LLVM pass on the specified LLVM function.
+//
+// @param [in,out] function : LLVM function to be run on.
+bool PatchReadFirstLane::runOnFunction(Function &function) {
+  LLVM_DEBUG(dbgs() << "Run the pass Patch-Read-First-Lane\n");
+
+  m_divergenceAnalysis = &getAnalysis<LegacyDivergenceAnalysis>();
+  auto *targetTransformInfoWrapperPass = getAnalysisIfAvailable<TargetTransformInfoWrapperPass>();
+  if (targetTransformInfoWrapperPass)
+    m_targetTransformInfo = &targetTransformInfoWrapperPass->getTTI(function);
+  assert(m_targetTransformInfo);
+
+  const bool changed = liftReadFirstLane(function);
+
+  return changed;
+}
+
+// =====================================================================================================================
+// Specify what analysis passes this pass depends on.
+//
+// @param [in,out] analysisUsage : The place to record our analysis pass usage requirements.
+void PatchReadFirstLane::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
+  analysisUsage.addRequired<LegacyDivergenceAnalysis>();
+  analysisUsage.setPreservesCFG();
+}
+
+// =====================================================================================================================
+// Lift readfirstlanes in relevant basic blocks to transform VGPR instructions into SGPR instructions as many as
+// possible.
+//
+// @param [in,out] function : LLVM function to be run for readfirstlane optimization.
+bool PatchReadFirstLane::liftReadFirstLane(Function &function) {
+  // Collect the basic blocks with amdgcn_readfirstlane
+  // Build the map between initial readfirstlanes and their corrensponding blocks
+  DenseMap<BasicBlock *, SmallVector<Instruction *, 2>> blockInitialReadFirstLanesMap;
+  Module *module = function.getParent();
+  for (auto &func : *module) {
+    if (func.getIntrinsicID() == Intrinsic::amdgcn_readfirstlane) {
+      for (User *user : func.users()) {
+        Instruction *inst = cast<Instruction>(user);
+        if (inst->getFunction() != &function)
+          continue;
+        blockInitialReadFirstLanesMap[inst->getParent()].push_back(inst);
+      }
+      break;
+    }
+  }
+  bool changed = false;
+
+  // Lift readfirstlanes in each relevant basic block
+  for (auto blockInitialReadFirstLanes : blockInitialReadFirstLanesMap) {
+    BasicBlock *curBb = blockInitialReadFirstLanes.first;
+
+    // Step 1: Collect all instructions that "can be assumed uniform" with its divergent uses in a map
+    // (m_uniformDivergentUsesMap)
+    collectAssumeUniforms(curBb, blockInitialReadFirstLanes.second);
+
+    // Step 2: Determine the best places to insert readfirstlane according to a heuristic
+    findBestInsertLocation(blockInitialReadFirstLanes.second);
+
+    // Step 3: Apply readFirstLane on all determined locations
+    assert(m_insertLocations.size() <= blockInitialReadFirstLanes.second.size());
+    BuilderBase builder(curBb->getContext());
+    for (auto inst : m_insertLocations) {
+      // Avoid to insert reduncant readfirstlane
+      if (auto intrinsic = dyn_cast<IntrinsicInst>(inst))
+        if (intrinsic->getIntrinsicID() == Intrinsic::amdgcn_readfirstlane)
+          continue;
+      if (areAllUserReadFirstLane(inst))
+        continue;
+
+      applyReadFirstLane(inst, builder);
+      changed = true;
+    }
+
+    m_uniformDivergentUsesMap.clear();
+  }
+  return changed;
+}
+
+// =====================================================================================================================
+// The decision of whether an instruction should be added to the m_canAssumeUniformDivergentUseMap is only made once all
+// later instructions in the basic block have been processed. To avoid scanning all instructions excessively, we
+// maintain a basic-block-ordered queue of candidates. An instruction is only added as a candidate if it appears as a
+// relevant operand to an instruction that is already in the map.
+//
+// @param block : The processing basic block
+// @param initialReadFirstLanes : The initial amdgcn_readfirstlane vector
+void PatchReadFirstLane::collectAssumeUniforms(BasicBlock *block,
+                                               const SmallVectorImpl<Instruction *> &initialReadFirstLanes) {
+  auto instructionOrder = [](Instruction *lhs, Instruction *rhs) { return lhs->comesBefore(rhs); };
+  SmallVector<Instruction *, 16> candidates;
+
+  auto insertCandidate = [&](Instruction *candidate) {
+    auto insertPos = llvm::lower_bound(candidates, candidate, instructionOrder);
+    if (insertPos == candidates.end() || *insertPos != candidate)
+      candidates.insert(insertPos, candidate);
+  };
+
+  // The given instruction can be assumed to have a uniform result, i.e., replacing its uses by a use of a
+  // readfirstlane of it would be correct. This helper function:
+  //  1. Records this fact and
+  //  2. Determines whether the assumption of a uniform result could be propagated to the candidate's operands.
+  auto tryPropagate = [&](Instruction *candidate, bool isInitialReadFirstLane) {
+    bool cannotPropagate = m_targetTransformInfo->isSourceOfDivergence(candidate) || isa<PHINode>(candidate) ||
+                           (!isInitialReadFirstLane && isa<CallInst>(candidate));
+
+    SmallVector<Instruction *, 3> operandInsts;
+    if (!cannotPropagate) {
+      for (Use &use : candidate->operands()) {
+        if (!m_divergenceAnalysis->isDivergentUse(&use))
+          continue; // already known to be uniform -- no need to consider this operand
+
+        auto operandInst = dyn_cast<Instruction>(use.get());
+        if (!operandInst) {
+          // Known to be divergent, but not an instruction. Further propagation is currently not implemented.
+          assert(isa<Argument>(use.get()));
+          cannotPropagate = true;
+          break;
+        }
+
+        if (operandInst->getParent() != block || !isAllUsersDefinedInBlock(operandInst, block)) {
+          // Further propagation is currently not implemented. Theoretically, we could insert a readfirstlane
+          // instruction dedicated for users in this basic block, but it's not clear whether that would be a win.
+          cannotPropagate = true;
+          break;
+        }
+
+        operandInsts.push_back(operandInst);
+      }
+
+      if (cannotPropagate)
+        operandInsts.clear();
+    }
+
+    for (Instruction *operandInst : operandInsts)
+      insertCandidate(operandInst);
+
+    assert(m_uniformDivergentUsesMap.count(candidate) == 0);
+    m_uniformDivergentUsesMap.try_emplace(candidate, std::move(operandInsts));
+  };
+
+  for (auto readfirstlane : initialReadFirstLanes)
+    tryPropagate(readfirstlane, true);
+
+  while (!candidates.empty()) {
+    Instruction *candidate = candidates.pop_back_val();
+
+    if (isAllUsersAssumedUniform(candidate))
+      tryPropagate(candidate, false);
+  }
+}
+
+// =====================================================================================================================
+// Find the best insert locations according to the heuristic.
+// The heuristic is: if an instruction that can be assumed to be uniform has multiple divergent operands, then you take
+// the definition of the divergent operand that is earliest in basic block order (call it "the earliest divergent
+// operand") and propagate up to that instruction; if it turns out that that instruction can be assumed to be uniform,
+// then we can just insert the readfirstlane there (or propagate).
+//
+// @param readFirstLaneCount : The initial amdgcn_readfirstlane vector
+void PatchReadFirstLane::findBestInsertLocation(const SmallVectorImpl<Instruction *> &initialReadFirstLanes) {
+  // Set of instructions from m_uniformDivergentUsesMap which will be forced to become uniform by the
+  // instructions we already plan to insert so far. Allows us to break out of searches that would be redundant.
+  DenseSet<Instruction *> enforcedUniform;
+  SmallVector<Instruction *, 8> enforcedUniformTracker;
+
+  m_insertLocations.clear();
+
+  for (auto &initialReadFirstLane : initialReadFirstLanes) {
+    // Find a best insert location for a lifted readfirstlane to obsolete the existing, initial readfirstlane.
+    // Conceptually, we trace backwards through the induced data dependency graph (or "cone") of
+    // divergent-but-can-assume-uniform instructions feeding into the initialReadFirstLane.
+    // Each iteration of the middle loop jumps to the next "bottleneck" in this DAG, that is, `current` always points
+    // at a bottleneck where we could insert a single readfirstlane (depending on the type).
+    Instruction *bestInsertLocation = nullptr;
+    unsigned bestInsertLocationDepth = 0;
+
+    Instruction *current = initialReadFirstLane;
+
+    for (;;) {
+      const auto &mapIt = m_uniformDivergentUsesMap.find(current);
+      if (mapIt == m_uniformDivergentUsesMap.end())
+        break; // no futher propagation possible
+
+      const auto &divergentOperands = mapIt->second;
+      if (divergentOperands.empty())
+        break; // no further propagation possible
+
+      if (divergentOperands.size() == 1) {
+        // There is only a single operand, we can jump to it directly.
+        current = divergentOperands[0];
+      } else {
+        // There are multiple operands. Since we don't want to increase the number of readfirstlanes, try to find
+        // an earlier bottleneck in the data dependency graph.
+        //
+        // The search proceeds backwards by instruction order in the basic block, maintaining a sorted queue of
+        // instructions that remain to be explored. We use two heuristics to limit the cost of the search:
+        //  - We never explore beyond the earliest operand of `current`.
+        //  - We limit both the depth and the breadth (i.e., maximum queue size) of the search.
+        //
+        // We maintain the queue as a vector because it will always be short, and inserting into a short sorted
+        // vector is very fast.
+        constexpr unsigned MaxSearchBreadth = 4;
+        constexpr unsigned MaxSearchDepth = 10;
+        auto instructionOrder = [](Instruction *lhs, Instruction *rhs) { return lhs->comesBefore(rhs); };
+
+        if (divergentOperands.size() > MaxSearchBreadth)
+          break;
+
+        SmallVector<Instruction *, MaxSearchBreadth> queue;
+        queue.insert(queue.begin(), divergentOperands.begin(), divergentOperands.end());
+        llvm::sort(queue, instructionOrder);
+
+        bool searchAborted = false;
+        unsigned depth = 0;
+        do {
+          Instruction *candidate = queue.back();
+          if (enforcedUniform.count(candidate)) {
+            // Candidate is already enforced to be uniform by a previous decision to insert a readfirstlane.
+            // We can just skip it.
+            queue.pop_back();
+            continue;
+          }
+          const auto &mapIt = m_uniformDivergentUsesMap.find(candidate);
+          if (mapIt == m_uniformDivergentUsesMap.end())
+            break; // no further propagation possible, need to abort the search
+          const auto &candidateOperands = mapIt->second;
+          if (candidateOperands.empty())
+            break; // no further propagation possible, need to abort the search
+          queue.pop_back();
+
+          enforcedUniformTracker.push_back(candidate);
+
+          // Add the operands to the queue if they aren't already contained in it.
+          for (Instruction *operand : candidateOperands) {
+            auto insertPos = llvm::lower_bound(queue, operand, instructionOrder);
+            if (insertPos == queue.end() || *insertPos != operand) {
+              // Abort if the search becomes too "wide" or moves beyond the earliest operand of `current`.
+              if (queue.size() >= MaxSearchBreadth || insertPos == queue.begin()) {
+                searchAborted = true;
+                break;
+              }
+              queue.insert(insertPos, operand);
+            }
+          }
+
+          if (++depth > MaxSearchDepth)
+            break;
+        } while (queue.size() >= 2 && !searchAborted);
+
+        if (queue.size() >= 2)
+          break; // didn't find a next bottleneck in the data dependency graph, bail out
+
+        current = queue[0]; // move to the found bottleneck
+      }
+
+      if (enforcedUniform.count(current)) {
+        // Already enforced to be uniform, no need to continue the search or even consider inserting a new
+        // readfirstlane.
+        bestInsertLocation = nullptr;
+        break;
+      }
+
+      enforcedUniformTracker.push_back(current);
+
+      if (isSupportedType(current)) {
+        bestInsertLocation = current;
+        bestInsertLocationDepth = enforcedUniformTracker.size();
+      }
+    }
+
+    // Record the best (read: earliest) bottleneck that we were able to find in the graph/
+    if (bestInsertLocation) {
+      m_insertLocations.insert(bestInsertLocation);
+
+      for (unsigned idx = 0; idx < bestInsertLocationDepth; ++idx)
+        enforcedUniform.insert(enforcedUniformTracker[idx]);
+    }
+
+    enforcedUniformTracker.clear();
+  }
+}
+
+// =====================================================================================================================
+// Return true if all users of the given instruction are "assumed uniform"
+//
+// @param inst : The instruction to be checked
+bool PatchReadFirstLane::isAllUsersAssumedUniform(Instruction *inst) {
+  for (auto user : inst->users()) {
+    auto userInst = dyn_cast<Instruction>(user);
+    if (m_uniformDivergentUsesMap.count(userInst) == 0)
+      return false;
+  }
+  return true;
+}
+
+// =====================================================================================================================
+// Try to apply readfirstlane on the given instruction
+//
+// @param inst : The instruction to be applied readfirstlane on
+// @param builder : BuildBase to use
+void PatchReadFirstLane::applyReadFirstLane(Instruction *inst, BuilderBase &builder) {
+  // Guarantee the insert position is behind all PhiNodes
+  Instruction *insertPos = inst->getNextNonDebugInstruction();
+  while (dyn_cast<PHINode>(insertPos))
+    insertPos = insertPos->getNextNonDebugInstruction();
+  builder.SetInsertPoint(insertPos);
+
+  Type *instTy = inst->getType();
+  const bool isFloat = instTy->isFloatTy();
+  assert(isFloat || instTy->isIntegerTy(32));
+  Value *newInst = inst;
+  if (isFloat)
+    newInst = builder.CreateBitCast(inst, builder.getInt32Ty());
+
+  Value *readFirstLane = builder.CreateIntrinsic(Intrinsic::amdgcn_readfirstlane, {}, newInst);
+
+  Value *replaceInst = nullptr;
+  if (isFloat) {
+    replaceInst = builder.CreateBitCast(readFirstLane, instTy);
+  } else {
+    newInst = readFirstLane;
+    replaceInst = readFirstLane;
+  }
+  inst->replaceUsesWithIf(replaceInst, [newInst](Use &U) { return U.getUser() != newInst; });
+}
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patching operations for readfirstlane optimizations.
+INITIALIZE_PASS_BEGIN(PatchReadFirstLane, DEBUG_TYPE, "Patch LLVM for readfirstlane optimizations", false, false)
+INITIALIZE_PASS_DEPENDENCY(LegacyDivergenceAnalysis)
+INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)
+INITIALIZE_PASS_END(PatchReadFirstLane, DEBUG_TYPE, "Patch LLVM for readfirstlane optimizations", false, false)

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -5,28 +5,31 @@
 
 ; CHECK-LABEL: IR Dump After Patch LLVM for workarounds
 
-; GFX900: %.load = call <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 1, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc1, i64 3
+; GFX900: extractelement <8 x i32> %.desc, i64 7
+; GFX900: call i32 @llvm.amdgcn.readfirstlane(i32 %{{[0-9]+}})
+; GFX900: insertelement <8 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}}, i64 7
+; GFX900: %.load = call <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 1, i32 0, <8 x i32> %{{[0-9]+}}, i32 0, i32 0)
+; GFX1010: extractelement <8 x i32> %{{[0-9]+}}, i64 3
 ; GFX1010-NEXT: icmp sge i32
 ; GFX1010-NEXT: and i32
 ; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC0:%[.a-zA-Z0-9]+]] = insertelement <8 x i32> %.desc1
+; GFX1010-NEXT: [[PATCHED_DESC0:%[.a-zA-Z0-9]+]] = insertelement <8 x i32> %{{[0-9]+}}
 ; GFX1010:  %.load = call <4 x float> @llvm.amdgcn.image.load.1d.v4f32.i32(i32 15, i32 1, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
 
-; GFX900: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
+; GFX900: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> %{{[0-9]+}}, i32 0, i32 0)
+; GFX1010: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> %{{[0-9]+}}, i32 0, i32 0)
 
-; GFX900: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %.sampler, i1 false, i32 0, i32 0)
-; GFX1010: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %.sampler, i1 false, i32 0, i32 0)
+; GFX900: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX1010: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
-; GFX900: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
-; GFX1010: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX900: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX1010: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
-; GFX900: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.2d.i32.i32(i32 1, i32 0, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.1d.i32.i32(i32 1, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
+; GFX900: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.2d.i32.i32(i32 1, i32 0, i32 0, <8 x i32> %{{[0-9]+}}, i32 0, i32 0)
+; GFX1010: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.1d.i32.i32(i32 1, i32 0, <8 x i32> %{{[0-9]+}}, i32 0, i32 0)
 
-; GFX900: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
-; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX900: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
 ; CHECK: [[WFDESC:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.readfirstlane
 ; GFX900: [[WFDESC1:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.last.use.v8i32(i32 %{{[0-9]+}}, <8 x i32> [[WFDESC]])

--- a/llpc/test/shaderdb/ObjNonUniform_TestImageSample.frag
+++ b/llpc/test/shaderdb/ObjNonUniform_TestImageSample.frag
@@ -1,0 +1,25 @@
+#version 450
+#extension GL_EXT_nonuniform_qualifier : require
+layout(set=0,binding=5) uniform sampler samp;
+layout(set=0,binding=6) uniform texture2D data[];
+layout(location = 0) out vec4     FragColor;
+layout(location = 0) in flat int  index1;
+layout(location = 1) in flat int  index2;
+
+void main()
+{
+  vec4 color1 = texture(nonuniformEXT(sampler2D(data[index1], samp)), vec2(0,0));
+  vec4 color2 = texture(sampler2D(data[index2], samp), vec2(1,1));
+  FragColor = color1 + color2;
+}
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: {{%[0-9]*}} = call float @llvm.amdgcn.interp.mov
+; SHADERTEST: {{%[0-9]*}} = bitcast float {{%[0-9]*}} to i32
+; SHADERTEST: {{%[0-9]*}} = call i32 @llvm.amdgcn.readfirstlane(i32 {{%[0-9]*}})
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -95,7 +95,7 @@ public:
   Value *transImagePointer(SPIRVValue *spvImagePtr);
   Value *getDescPointerAndStride(lgc::ResourceNodeType resType, unsigned descriptorSet, unsigned binding);
   Value *transOpAccessChainForImage(SPIRVAccessChainBase *spvAccessChain);
-  Value *indexDescPtr(Type *elementTy, Value *base, Value *index, bool isNonUniform);
+  Value *indexDescPtr(Type *elementTy, Value *base, Value *index);
   Value *transGroupArithOp(lgc::Builder::GroupArithOp, SPIRVValue *);
 
   bool transDecoration(SPIRVValue *, Value *);


### PR DESCRIPTION
The Vulkan Enviroment for SPIR-V (section "Validation Rules within a
Module",  version 1.2.140) says that:
"If an instruction loads from or stores to a resource (including atomics
and image instructions)
and the resource descriptor being accessed is not dynamically uniform,
then the operand
corresponding to that resource (e.g. the pointer or sampled image
operand) must be decorated
with NonUniform."
The usage of NonUniform decoration is modified according to spec both in
CTS and glslang.
Example:
layout(set = 0, binding = 0) uniform texture2D uTex[];
layout(set = 1, binding = 0) uniform sampler uSamp;
layout(location = 0) flat in int Index;
layout(location = 0) out vec4 FragColor;
void main()
{
    // Old usage not according spec
    FragColor = texture(sampler2D(uTex[nonuniformEXT(Index)], Samp), vec2(0.5));
   // New usage according spec
   FragColor = texture(
   nonuniformEXT(sampler2D(uTex[Index], uSamp)), ec2(0.5));
}

it produces the following SPIR-V (only extract provided)
// Old usage
...
OpDecorate %18 NonUniform
OpDecorate %21 NonUniform
...
%5 = OpLabel
%17 = OpLoad %int %Index
%18 = OpCopyObject %int %17 <-- The index is NonUniform
%20 = OpAccessChain %_ptr_UniformConstant_10 %uTex %18
%21 = OpLoad %10 %20             <-- The image itself is NonUniform
%25 = OpLoad %22 %uSamp
%27 = OpSampledImage %26 %21 %25
%31 = OpImageSampleImplicitLod %v4float %27 %30 <-- The sampled image is *not* NonUniform
...
// New usage
...
OpDecorate %33 NonUniform
...
%10 = OpTypeImage %6 2D 0 0 0 1 Unknown
...
%31 = OpTypeSampledImage %10
...
%32 = OpSampledImage %31 %20 %30
%33 = OpCopyObject %31 %32
%37 = OpImageSampleImplicitLod %7 %33 %36
...

Fixes: 
- https://github.com/GPUOpen-Drivers/llpc/issues/840
- dEQP-VK.descriptor_indexing.sampled_image*.

The reason of cts failutres is that the descriptor index is mistook as uniform in indexDescPtr which it should be non-uniform.
Solution:
- Remove the non-uniform flag in indexDescPtr, which can make the test pass.
- Generate readfirstlane for operands without non-uniform decoration. 
  1) Insert readerfirstlane on the resource descriptor initially
  2) Add a otpimization pass in middle-end to push up readfirstlane to transform the use of vgpr to sgpr  as many as possible.