### PR TITLE
Disable packing input/output for dynamic component index

### DIFF
--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -101,6 +101,7 @@ bool BuilderReplayer::runOnModule(Module &module) {
   // Set up the pipeline state from the specified linked IR module.
   PipelineState *pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
   pipelineState->readState(&module);
+  pipelineState->initializePackInOut();
 
   // Create the BuilderImpl to replay into, passing it the PipelineState
   LgcContext *builderContext = pipelineState->getLgcContext();

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -257,8 +257,14 @@ public:
   // ring is on-chip.
   bool isGsOnChip() const { return m_gsOnChip; }
 
-  // Determine whether to use input/output packing
-  bool isPackInOut();
+  // Initialize the state of input/output packing
+  void initializePackInOut();
+
+  // Set the state of input/output packing
+  void setPackInOut(bool isPack) { m_packInOut = isPack; }
+
+  // Check whether input/output packing can be used
+  bool canPackInOut() const { return m_packInOut; }
 
   // Gets wave size for the specified shader stage
   unsigned getShaderWaveSize(ShaderStage stage);
@@ -419,6 +425,7 @@ private:
   // Cached MDString for each resource node type
 
   bool m_gsOnChip = false;                                                     // Whether to use GS on-chip mode
+  bool m_packInOut = false;                                                    // Whether to use packing on input/output
   NggControl m_nggControl = {};                                                // NGG control settings
   ShaderModes m_shaderModes;                                                   // Shader modes for this pipeline
   unsigned m_deviceIndex = 0;                                                  // Device index

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -446,7 +446,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
             loc = resUsage->inOutUsage.perPatchInputLocMap[value];
           }
         } else {
-          if (m_pipelineState->isPackInOut() &&
+          if (m_pipelineState->canPackInOut() &&
               (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl)) {
             // The new InOutLocationInfo is used to map scalarized FS and TCS input import as compact as possible
             InOutLocationInfo origLocInfo = {};
@@ -734,7 +734,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           loc = resUsage->inOutUsage.outputLocMap[outLocInfo.u32All];
         }
       } else {
-        if (m_pipelineState->isPackInOut() && m_shaderStage == ShaderStageVertex &&
+        if (m_pipelineState->canPackInOut() && m_shaderStage == ShaderStageVertex &&
             m_pipelineState->hasShaderStage(ShaderStageTessControl)) {
           // The new InOutLocationInfo is used to map scalarized VS output export in a VS-TCS-TES-FS to lds as compact
           // as possible

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -994,19 +994,15 @@ bool PipelineState::isTessOffChip() {
 }
 
 // =====================================================================================================================
-// Determine whether to use input/output packing
-bool PipelineState::isPackInOut() {
+// Initialize the state of input/output packing
+void PipelineState::initializePackInOut() {
   // Pack input/output requirements:
   // 1) -pack-in-out option is on
   // 2) It supports VS-FS, VS-TCS-TES-(FS)
-  if (!PackInOut)
-    return false;
-
-  if (hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
+  if (PackInOut && hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
     const unsigned nextStage = getNextShaderStage(ShaderStageVertex);
-    return nextStage == ShaderStageFragment || nextStage == ShaderStageTessControl;
+    m_packInOut = nextStage == ShaderStageFragment || nextStage == ShaderStageTessControl;
   }
-  return false;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Commit 8cd0205 caused a regression in tessellation in the Sascha WIllems
tesselation example. The root cause is not taking dynamic component
index into consideration. This change is a wordround for this case by
totaly disabling input/output packing. A proper fix should be a partial
packing scheme that is non-packable locations (with dynamic location
offset or component index) should be skipped and placed at the back of
packable locations with consecitve location index.
Considering a future required change of refactoring the location maps, I
think it' better to integrate the partial packing in that change.