### PR TITLE
Reapply: Add Image resource type workaround

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -70,6 +70,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |
 //* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
 //* |     41.0 | Moved resource mapping from ShaderPipeline-level to Pipeline-level                                    |
@@ -325,7 +326,8 @@ struct PipelineOptions {
                                    ///  the out of bounds accesses will be skipped with this setting.
   bool enableRelocatableShaderElf; ///< If set, the pipeline will be compiled by compiling each shader separately, and
                                    ///  then linking them, when possible.  When not possible this option is ignored.
-
+  bool disableImageResourceCheck;  ///< If set, the pipeline shader will not contain code to check and fix invalid image
+                                   ///  descriptors.
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
   ExtendedRobustness extendedRobustness;                 ///< ExtendedRobustness is intended to correspond to the

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -412,6 +412,9 @@ private:
   // Patch descriptor with cube dimension for image call
   llvm::Value *patchCubeDescriptor(llvm::Value *desc, unsigned dim);
 
+  // Patch invalid resource descriptor for image call
+  llvm::Value *patchInvalidImageDescriptor(llvm::Value *desc);
+
   // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
   llvm::Value *handleFragCoordViewIndex(llvm::Value *coord, unsigned flags, unsigned &dim);
 

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -424,6 +424,7 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
   getPipelineState()->getShaderResourceUsage(m_shaderStage)->resourceRead = true;
   assert(coord->getType()->getScalarType()->isIntegerTy(32));
   imageDesc = patchCubeDescriptor(imageDesc, dim);
+  imageDesc = patchInvalidImageDescriptor(imageDesc);
   coord = handleFragCoordViewIndex(coord, flags, dim);
 
   unsigned dmask = 1;
@@ -602,6 +603,7 @@ Value *ImageBuilder::CreateImageStore(Value *texel, unsigned dim, unsigned flags
   getPipelineState()->getShaderResourceUsage(m_shaderStage)->resourceWrite = true;
   assert(coord->getType()->getScalarType()->isIntegerTy(32));
   imageDesc = patchCubeDescriptor(imageDesc, dim);
+  imageDesc = patchInvalidImageDescriptor(imageDesc);
   coord = handleFragCoordViewIndex(coord, flags, dim);
 
   // For 64-bit texel, only the first component is stored
@@ -1198,6 +1200,7 @@ Value *ImageBuilder::CreateImageAtomicCommon(unsigned atomicOp, unsigned dim, un
   if (imageDesc->getType() == getDescTy(ResourceNodeType::DescriptorResource)) {
     // Resource descriptor. Use the image atomic instruction.
     imageDesc = patchCubeDescriptor(imageDesc, dim);
+    imageDesc = patchInvalidImageDescriptor(imageDesc);
     args.push_back(inputValue);
     if (atomicOp == AtomicOpCompareSwap)
       args.push_back(comparatorValue);
@@ -1720,6 +1723,27 @@ void ImageBuilder::combineCubeArrayFaceAndSlice(Value *coord, SmallVectorImpl<Va
   }
   coords[2] = combined;
   coords.pop_back();
+}
+
+// =====================================================================================================================
+// A buffer descriptor may be incorrectly given when it should be an image descriptor, we need to fix it to valid buffer
+// type (0) to make hardware happily ignore it. This is to check and fix against buggy applications which declares a
+// image descriptor in shader but provide a buffer descriptor in driver. Note this only applies to gfx10.1.
+//
+// @param desc : Descriptor before patching
+Value *ImageBuilder::patchInvalidImageDescriptor(Value *desc) {
+  if (getPipelineState()->getOptions().disableImageResourceCheck ||
+      !getPipelineState()->getTargetInfo().getGpuWorkarounds().gfx10.waFixBadImageDescriptor)
+    return desc;
+
+  // Extract the dword3. force the 'type' to 0 if [0, 7]
+  Value *elem3 = CreateExtractElement(desc, 3);
+  Value *isInvalid = CreateICmpSGE(elem3, getInt32(0));
+  Value *masked = CreateAnd(elem3, getInt32(0x0FFFFFFF));
+  elem3 = CreateSelect(isInvalid, masked, elem3);
+
+  // Reassemble descriptor.
+  return CreateInsertElement(desc, elem3, 3);
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -120,6 +120,7 @@ struct WorkaroundFlags {
       unsigned waShaderInstPrefetchFwd64 : 1;
       unsigned waWarFpAtomicDenormHazard : 1;
       unsigned waNggDisabled : 1;
+      unsigned waFixBadImageDescriptor : 1;
       unsigned waLimitedMaxOutputVertexCount : 1;
       unsigned waGeNggMaxVertOutWithGsInstancing : 1;
       unsigned : 1;

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -123,6 +123,7 @@ struct Options {
   unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
                                        //   ShadowDescriptorTableDisable to disable shadow descriptor tables
   unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
+  unsigned disableImageResourceCheck;  // Don't do image resource type check
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -298,6 +298,7 @@ static void setGfx1010Info(TargetInfo *targetInfo) {
   targetInfo->getGpuWorkarounds().gfx10.waTessIncorrectRelativeIndex = 1;
   targetInfo->getGpuWorkarounds().gfx10.waSmemFollowedByVopc = 1;
   targetInfo->getGpuWorkarounds().gfx10.waNggCullingNoEmptySubgroups = 1;
+  targetInfo->getGpuWorkarounds().gfx10.waFixBadImageDescriptor = 1;
 }
 
 // gfx1012
@@ -317,6 +318,7 @@ static void setGfx1012Info(TargetInfo *targetInfo) {
   targetInfo->getGpuWorkarounds().gfx10.waShaderInstPrefetchFwd64 = 1;
   targetInfo->getGpuWorkarounds().gfx10.waWarFpAtomicDenormHazard = 1;
   targetInfo->getGpuWorkarounds().gfx10.waNggDisabled = 0;
+  targetInfo->getGpuWorkarounds().gfx10.waFixBadImageDescriptor = 1;
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -311,6 +311,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
   }
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;
+  options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
   pipeline->setOptions(options);
 
   // Give the shader options (including the hash) to the middle-end.


### PR DESCRIPTION
GFX10 hardware cannot handle invalid image resource type [1, 7], so we
change such kind of value to 0 (buffer) to let hardware ignore the
request.  This may happen when buggy application declares an image in
shader but provide a buffer descriptor in driver. Also add a pipeline
option to disable it for possible performance loss.

This fix was originally by Ruiling Song as #909, but had to be
temporarily reverted as it showed up an unrelated problem in LLVM
waterfall loop support. It can now be reapplied.

I have made a couple of changes to Ruiling's fix:

1. Added a workaround flag, which is set only for GFX10.1. The fix is
   unnecessary for GFX10.3.
2. Saved one instruction by spotting a type field (bits 31..28 of dword
   3) with value [0,7] by just checking if dword3 is non-negative.

Change-Id: I13875268d03bd4ae41414bcee729af087db3ff47