### PR TITLE
Clean up amdllpc options.

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -867,6 +867,9 @@ MetroHash::Hash PipelineDumper::generateHashForGraphicsPipeline(const GraphicsPi
 
   hasher.Update(pipeline->iaState.deviceIndex);
 
+  // Relocatable shaders force an unlinked compilation.
+  hasher.Update(pipeline->unlinked || isRelocatableShader);
+
   if (stage != ShaderStageFragment) {
     if (!isRelocatableShader)
       updateHashForVertexInputState(pipeline->pVertexInput, &hasher);


### PR DESCRIPTION
This change does a few misc changes to make amdllpc better at compiling
shaders that will be used in the xgl cache creator.

- We can remove the "build-shader-cache" options.  The unlinked option
can provide the functionality that is needed.

- Don't link relocatable shader if the pipeline build info says it
should be unlinked.

- If not linking the relocatable shaders, output one of the relocatable
elf files as the pipeline elf.  Only outputting one should not be a
problem because I expect most cases should only have 1 input shader for
unlinked pipelines.

- Allow a relocatable shader compilation that is missing the vertex or
fragment shader when not linking.

- Don't include the "unlinked" option in the compiler options shader.
The compiler does not look at that option.  It is passed as a flag in
the pipeline info.

- Include the "unlinked" flag in the pipeline info in the cache hash.

- When multiple spv or glsl files are given to amdllpc with the unlinked
flag, amdllpc should not try to combine them into a single pipeline.
Compile each shader individaully.