### PR TITLE
Add pass that inserts stack bounds checks

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -70,6 +70,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     43.2 | Add enableScratchBoundsCheck in PipelineOptions                                                       |
 //* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |
 //* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
@@ -328,6 +329,8 @@ struct PipelineOptions {
                                    ///  then linking them, when possible.  When not possible this option is ignored.
   bool disableImageResourceCheck;  ///< If set, the pipeline shader will not contain code to check and fix invalid image
                                    ///  descriptors.
+  bool enableScratchBoundsCheck;   ///< If set, accessing a stack object out of bounds will be skipped for stores and
+                                   ///  return zero for loads.
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
   ExtendedRobustness extendedRobustness;                 ///< ExtendedRobustness is intended to correspond to the

--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -108,6 +108,7 @@ target_sources(LLVMlgc PRIVATE
     patch/NggLdsManager.cpp
     patch/NggPrimShader.cpp
     patch/Patch.cpp
+    patch/PatchBoundsCheckMemory.cpp
     patch/PatchBufferOp.cpp
     patch/PatchCheckShaderCache.cpp
     patch/PatchCopyShader.cpp

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -45,6 +45,7 @@ class PassManager;
 
 void initializeLowerFragColorExportPass(PassRegistry &);
 void initializeLowerVertexFetchPass(PassRegistry &);
+void initializePatchBoundsCheckMemoryPass(PassRegistry &);
 void initializePatchBufferOpPass(PassRegistry &);
 void initializePatchCheckShaderCachePass(PassRegistry &);
 void initializePatchCopyShaderPass(PassRegistry &);
@@ -71,6 +72,7 @@ class PatchCheckShaderCache;
 inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializeLowerFragColorExportPass(passRegistry);
   initializeLowerVertexFetchPass(passRegistry);
+  initializePatchBoundsCheckMemoryPass(passRegistry);
   initializePatchBufferOpPass(passRegistry);
   initializePatchCheckShaderCachePass(passRegistry);
   initializePatchCopyShaderPass(passRegistry);
@@ -88,6 +90,7 @@ inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
 
 llvm::ModulePass *createLowerFragColorExport();
 llvm::ModulePass *createLowerVertexFetch();
+llvm::ModulePass *createPatchBoundsCheckMemory();
 llvm::FunctionPass *createPatchBufferOp();
 PatchCheckShaderCache *createPatchCheckShaderCache();
 llvm::ModulePass *createPatchCopyShader();

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -124,6 +124,8 @@ struct Options {
                                        //   ShadowDescriptorTableDisable to disable shadow descriptor tables
   unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
   unsigned disableImageResourceCheck;  // Don't do image resource type check
+  unsigned enableScratchBoundsCheck;   // If set, accessing a stack object out of bounds will be skipped for stores and
+                                       // return zero for loads.
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -130,6 +130,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Patch input import and output export operations
   passMgr.add(createPatchInOutImportExport());
 
+  // Add bounds checks to stack accesses
+  passMgr.add(createPatchBoundsCheckMemory());
+
   // Prior to general optimization, do function inlining and dead function removal once again
   passMgr.add(createAlwaysInlinerLegacyPass());
   passMgr.add(createGlobalDCEPass());

--- a/lgc/patch/PatchBoundsCheckMemory.cpp
+++ b/lgc/patch/PatchBoundsCheckMemory.cpp
@@ -1,0 +1,226 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchBoundsCheckMemory.cpp
+ * @brief LLPC source file: contains implementation of class lgc::PatchBoundsCheckMemory.
+ *
+ * This pass adds bounds checks to all stack/scratch accesses with dynamic indices. The pass looks at every
+ * getelementptr instruction, checking which of the used indices are not constants. For non-constant indices, it checks
+ * if they index into either a FixedVectorType or an ArrayType and gets their element count, which is the upper bound of
+ * the index.
+ *
+ * Example:
+ * We have a getelementptr, followed by a load.
+ *
+ * %elemPtr = getelementptr [16 x float], [16 x float] addrspace(5)* %array, i32 0, i32 %index
+ * %value = load float, float addrspace(5)* %elemPtr, align 4
+ *
+ * Behind the getelementptr, we will compute the condition if all dynamic indices are in-bounds:
+ *
+ * %elemPtr = getelementptr [16 x float], [16 x float] addrspace(5)* %array, i32 0, i32 %index
+ * %inBounds = icmp ult i32 %index, 16
+ *
+ * %value = load float, float addrspace(5)* %elemPtr, align 4
+ *
+ * We look at all users of the getelementptr and guard loads and stores with the in-bounds condition. Stores are skipped
+ * if out-of-bounds, loads will return zero.
+ *
+ * %elemPtr = getelementptr [16 x float], [16 x float] addrspace(5)* %array, i32 0, i32 %index
+ * %inBounds = icmp ult i32 %index, 16
+ *
+ * br i1 %inBounds, label %inBoundsBB, label %continueBB
+ *
+ * inBoundsBB:
+ * %loadValue = load float, float addrspace(5)* %elemPtr, align 4
+ * br label %continueBB
+ *
+ * continueBB:
+ * %value = phi float [ %loadValue, %inBoundsBB ], [ 0.000000e+00, %.entry ]
+ *
+ ***********************************************************************************************************************
+ */
+#include "PatchBoundsCheckMemory.h"
+#include "lgc/state/IntrinsDefs.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+#define DEBUG_TYPE "lgc-bounds-check-memory"
+
+using namespace lgc;
+using namespace llvm;
+
+namespace lgc {
+
+// =====================================================================================================================
+// Initializes static members.
+char PatchBoundsCheckMemory::ID = 0;
+
+// =====================================================================================================================
+// Pass creator, creates the pass of bounds check memory operations.
+ModulePass *createPatchBoundsCheckMemory() {
+  return new PatchBoundsCheckMemory();
+}
+
+static Value *getZeroConstant(Type *ty) {
+  if (ty->isIntegerTy()) {
+    return ConstantInt::get(ty, 0);
+  }
+  if (ty->isFloatingPointTy()) {
+    return ConstantFP::get(ty, 0.0);
+  }
+  return ConstantAggregateZero::get(ty);
+}
+
+// =====================================================================================================================
+PatchBoundsCheckMemory::PatchBoundsCheckMemory() : Patch(ID) {
+}
+
+// =====================================================================================================================
+// Executes this pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+bool PatchBoundsCheckMemory::runOnModule(Module &module) {
+  LLVM_DEBUG(dbgs() << "Run the pass llpc-bounds-check-memory\n");
+
+  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+
+  if (!m_pipelineState->getOptions().enableScratchBoundsCheck)
+    return false;
+
+  m_context = &module.getContext();
+  m_builder = std::make_unique<IRBuilder<>>(*m_context);
+
+  visit(module);
+
+  bool changed = false;
+  for (auto &inst : m_getElementPtrInsts)
+    changed |= addBoundsCheck(inst);
+  m_getElementPtrInsts.clear();
+
+  return changed;
+}
+
+// =====================================================================================================================
+// Visits "getelementptr" instruction.
+//
+// @param getElemPtr : "GetElementPtr" instruction
+void PatchBoundsCheckMemory::visitGetElementPtrInst(GetElementPtrInst &getElemPtr) {
+  auto pointerTy = getElemPtr.getPointerOperand()->getType();
+  if (pointerTy->getPointerAddressSpace() != ADDR_SPACE_PRIVATE)
+    return;
+
+  // Search for dynamic indices in the instruction and collect them in a GetElemPtrInfo struct
+  llvm::SmallVector<std::pair<Value *, uint64_t>, 1> dynIndices;
+  std::vector<Value *> indices;
+  for (const auto &index : getElemPtr.indices()) {
+    if (!isa<Constant>(index)) {
+      auto indexedTy = GetElementPtrInst::getIndexedType(pointerTy->getPointerElementType(), indices);
+      // Save the index value its the upper bound
+      if (auto vectorTy = dyn_cast<FixedVectorType>(indexedTy)) {
+        dynIndices.push_back({index, vectorTy->getNumElements()});
+      } else if (auto arrayTy = dyn_cast<ArrayType>(indexedTy)) {
+        dynIndices.push_back({index, arrayTy->getNumElements()});
+      } else {
+        llvm_unreachable("Unsupported indexed type for bounds checking");
+      }
+    }
+    indices.push_back(index);
+  }
+  if (dynIndices.empty())
+    return;
+  m_getElementPtrInsts.push_back({&getElemPtr, dynIndices});
+}
+
+// =====================================================================================================================
+// Checks whether each dynamic index in the specified "getelementptr" instruction is lower than its allowed upper bound.
+//
+// @param info : "GetElementPtr" instruction and its dynamic indices
+// @returns : True if the code was changed or false if unmodified
+bool PatchBoundsCheckMemory::addBoundsCheck(GetElemPtrInfo &info) {
+  auto &getElemPtr = *info.getElemPtr;
+
+  // Copy users
+  std::vector<Instruction *> users;
+  for (auto user : getElemPtr.users()) {
+    Instruction *inst = dyn_cast<Instruction>(user);
+    if (!inst)
+      continue;
+    // Look through bitcasts
+    if (isa<BitCastInst>(user)) {
+      for (auto user : inst->users()) {
+        if (Instruction *inst = dyn_cast<Instruction>(user))
+          users.push_back(inst);
+      }
+    } else {
+      users.push_back(inst);
+    }
+  }
+
+  if (users.empty())
+    return false;
+
+  // Insert after getElemPtr
+  m_builder->SetInsertPoint(getElemPtr.getParent(), ++getElemPtr.getIterator());
+
+  // Get condition for in-bounds pointer
+  Value *inBounds = nullptr;
+  // Iterate through all dynamic indices and check that each one is in bounds
+  for (auto indexBoundPair : info.dynIndices) {
+    auto indexTy = cast<IntegerType>(indexBoundPair.first->getType());
+    auto curInBounds = m_builder->CreateCmp(CmpInst::ICMP_ULT, indexBoundPair.first,
+                                            m_builder->getIntN(indexTy->getScalarSizeInBits(), indexBoundPair.second));
+    inBounds = inBounds ? m_builder->CreateAnd(inBounds, curInBounds) : curInBounds;
+  }
+
+  // Only execute loads and stores if in-bounds
+  for (auto user : users) {
+    BasicBlock *instBB = user->getParent();
+    Instruction *inBoundsTerminator = SplitBlockAndInsertIfThen(inBounds, user, false);
+    user->moveBefore(inBoundsTerminator);
+    BasicBlock *inBoundsBB = inBoundsTerminator->getParent();
+    BasicBlock *continueBB = cast<BranchInst>(inBoundsTerminator)->getSuccessor(0);
+
+    if (auto loadInst = dyn_cast<LoadInst>(user)) {
+      // Load returns zero if out-of-bounds
+      auto loadTy = loadInst->getType();
+      m_builder->SetInsertPoint(&continueBB->front());
+      auto *phi = m_builder->CreatePHI(loadTy, 2);
+      loadInst->replaceAllUsesWith(phi);
+      phi->addIncoming(loadInst, inBoundsBB);
+      phi->addIncoming(getZeroConstant(loadTy), instBB);
+    } else if (!isa<StoreInst>(user)) {
+      llvm_unreachable("Expected a load or store instruction");
+    }
+  }
+  return true;
+}
+
+} // namespace lgc
+
+// =====================================================================================================================
+// Initializes the pass of bounds check memory operations.
+INITIALIZE_PASS(PatchBoundsCheckMemory, DEBUG_TYPE, "Patch LLVM for memory operation bounds checks", false, false)

--- a/lgc/patch/PatchBoundsCheckMemory.h
+++ b/lgc/patch/PatchBoundsCheckMemory.h
@@ -1,0 +1,82 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchBoundsCheckMemory.h
+ * @brief LLPC header file: contains declaration of class lgc::PatchBoundsCheckMemory.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/patch/Patch.h"
+#include "lgc/state/PipelineState.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstVisitor.h"
+#include <utility>
+#include <vector>
+
+namespace llvm {
+class GetElementPtrInst;
+class StoreInst;
+} // namespace llvm
+
+namespace lgc {
+
+// =====================================================================================================================
+// The structure for getelementptr instruction which need to be checked.
+struct GetElemPtrInfo {
+  llvm::GetElementPtrInst *getElemPtr;
+  // Dynamic index value and maximum for each index.
+  llvm::SmallVector<std::pair<llvm::Value *, uint64_t>, 1> dynIndices;
+};
+
+// =====================================================================================================================
+// Represents the pass of bounds check memory operations.
+class PatchBoundsCheckMemory final : public Patch, public llvm::InstVisitor<PatchBoundsCheckMemory> {
+public:
+  PatchBoundsCheckMemory();
+
+  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
+    analysisUsage.addRequired<PipelineStateWrapper>();
+  }
+
+  bool runOnModule(llvm::Module &module) override;
+  void visitGetElementPtrInst(llvm::GetElementPtrInst &getElementPtrInst);
+
+  static char ID; // ID of this pass
+
+private:
+  PatchBoundsCheckMemory(const PatchBoundsCheckMemory &) = delete;
+  PatchBoundsCheckMemory &operator=(const PatchBoundsCheckMemory &) = delete;
+
+  bool addBoundsCheck(GetElemPtrInfo &info);
+
+  std::vector<GetElemPtrInfo> m_getElementPtrInsts; // The memory accesses to patch.
+  std::unique_ptr<llvm::IRBuilder<>> m_builder;
+  llvm::LLVMContext *m_context;
+  PipelineState *m_pipelineState;
+};
+
+} // namespace lgc

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -137,13 +137,6 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
 
       auto gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
 
-#if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
-#warning[!amd-gfx] Scratch bounds checks not supported
-#else
-      if (gfxIp.major >= 9)
-        targetFeatures += ",+enable-scratch-bounds-checks";
-#endif
-
       if (gfxIp.major >= 10) {
         // Setup wavefront size per shader stage
         unsigned waveSize = m_pipelineState->getShaderWaveSize(shaderStage);

--- a/lgc/test/StackBoundsCheck.lgc
+++ b/lgc/test/StackBoundsCheck.lgc
@@ -1,0 +1,133 @@
+; RUN: lgc -mcpu=gfx900 -stop-after=lgc-bounds-check-memory - <%s | FileCheck %s
+
+; lgc code generated with amdllpc llpc/test/shaderdb/OpLoad_StackBoundsCheck_struct.pipe -emit-lgc
+
+; ModuleID = 'lgcPipeline'
+source_filename = "lgcPipeline"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !10 !lgc.shaderstage !10 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  call void (...) @lgc.create.write.builtin.output(<4 x float> %0, i32 0, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output(float undef, i32 1, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output([1 x float] undef, i32 3, i32 4096, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output([1 x float] undef, i32 4, i32 4096, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.builtin.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+define spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !11 !lgc.shaderstage !11 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 16, i32 undef)
+  %1 = alloca [16 x [16 x { <3 x float>, float, <3 x float> }]], align 16, addrspace(5)
+  br label %2
+
+2:                                                ; preds = %18, %.entry
+  %.0 = phi i32 [ 0, %.entry ], [ %19, %18 ]
+  %3 = icmp slt i32 %.0, 16
+  br i1 %3, label %4, label %20
+
+4:                                                ; preds = %2, %6
+  %.013 = phi i32 [ %17, %6 ], [ 0, %2 ]
+  %5 = icmp slt i32 %.013, 16
+  br i1 %5, label %6, label %18
+
+6:                                                ; preds = %4
+  %__llpc_input_proxy_.0.vec.extract = extractelement <4 x float> %0, i32 0
+  %7 = sitofp i32 %.0 to float
+  %8 = fadd reassoc nnan nsz arcp contract afn float %__llpc_input_proxy_.0.vec.extract, %7
+  %9 = fadd reassoc nnan nsz arcp contract afn float %8, 5.000000e+00
+  %10 = insertelement <3 x float> undef, float %9, i32 0
+  %11 = shufflevector <3 x float> %10, <3 x float> undef, <3 x i32> zeroinitializer
+  %__llpc_input_proxy_.4.vec.extract = extractelement <4 x float> %0, i32 1
+  %12 = fadd reassoc nnan nsz arcp contract afn float %__llpc_input_proxy_.4.vec.extract, %7
+  %13 = fadd reassoc nnan nsz arcp contract afn float %12, 2.000000e+00
+  %14 = getelementptr [16 x [16 x { <3 x float>, float, <3 x float> }]], [16 x [16 x { <3 x float>, float, <3 x float> }]] addrspace(5)* %1, i32 0, i32 %.0, i32 %.013, i32 0
+  store <3 x float> %11, <3 x float> addrspace(5)* %14, align 16
+  %15 = getelementptr [16 x [16 x { <3 x float>, float, <3 x float> }]], [16 x [16 x { <3 x float>, float, <3 x float> }]] addrspace(5)* %1, i32 0, i32 %.0, i32 %.013, i32 1
+  store float %13, float addrspace(5)* %15, align 16
+  %16 = getelementptr [16 x [16 x { <3 x float>, float, <3 x float> }]], [16 x [16 x { <3 x float>, float, <3 x float> }]] addrspace(5)* %1, i32 0, i32 %.0, i32 %.013, i32 2
+  store <3 x float> %11, <3 x float> addrspace(5)* %16, align 16
+  %17 = add i32 %.013, 1
+  br label %4, !llvm.loop !12
+
+18:                                               ; preds = %4
+  %19 = add i32 %.0, 1
+  br label %2, !llvm.loop !13
+
+20:                                               ; preds = %2
+  %__llpc_input_proxy_.4.vec.extract12 = extractelement <4 x float> %0, i32 1
+
+; CHECK:      %[[MUL:[0-9]+]] = fmul reassoc nnan nsz arcp contract afn float %[[#]], 2.550000e+02
+; CHECK-NEXT: %[[TSI:[0-9]+]] = fptosi float %[[MUL]] to i32
+; CHECK-NEXT: %[[CMP:[0-9]+]] = icmp ult i32 %[[TSI]], -16
+; CHECK-NEXT: %.inv = xor i1 %[[CMP]], true
+; CHECK-NEXT: %[[IFC:[0-9]+]] = call { i1, i64 } @llvm.amdgcn.if.i64(i1 %.inv)
+; CHECK-NEXT: %[[IF0:[0-9]+]] = extractvalue { i1, i64 } %[[IFC]], 0
+; CHECK-NEXT: %[[IF1:[0-9]+]] = extractvalue { i1, i64 } %[[IFC]], 1
+; CHECK-NEXT: br i1 %[[IF0]], label %[[LB0:[0-9]+]], label %[[LB1:[0-9]+]]
+
+  %21 = fmul reassoc nnan nsz arcp contract afn float %__llpc_input_proxy_.4.vec.extract12, 2.550000e+02
+  %22 = fptosi float %21 to i32
+
+; CHECK:      [[LB0]]:
+; CHECK-NEXT: %[[ADD:[0-9]+]] = add nsw i32 %[[TSI]], 16
+; CHECK-NEXT: %[[PTR:[0-9]+]] = getelementptr [16 x [16 x { <3 x float>, float, <3 x float> }]], [16 x [16 x { <3 x float>, float, <3 x float> }]] addrspace(5)* %[[#]], i32 0, i32 %[[ADD]], i32 1, i32 2, i32 1
+; CHECK-NEXT: %[[VAL:[0-9]+]] = load float, float addrspace(5)* %[[PTR]], align 4
+; CHECK-NEXT: br label %[[LB1]]
+
+  %23 = add i32 %22, 16
+  %24 = getelementptr [16 x [16 x { <3 x float>, float, <3 x float> }]], [16 x [16 x { <3 x float>, float, <3 x float> }]] addrspace(5)* %1, i32 0, i32 %23, i32 1, i32 2, i32 1
+  %25 = load float, float addrspace(5)* %24, align 4
+
+; CHECK:      [[LB1]]:
+; CHECK-NEXT: %[[PHI:[0-9]+]] = phi float [ 0.000000e+00, %.entry ], [ %[[VAL]], %[[LB0]] ]
+; CHECK-NEXT: call void @llvm.amdgcn.end.cf.i64(i64 %[[IF1]])
+; CHECK-NEXT: %[[CVT:[0-9]+]] = call <2 x half> @llvm.amdgcn.cvt.pkrtz(float %[[PHI]], float 0.000000e+00) #1
+; CHECK-NEXT: call void @llvm.amdgcn.exp.compr.v2f16(i32 immarg 0, i32 immarg 15, <2 x half> %[[CVT]], <2 x half> <half 0xH0000, half 0xH3C00>, i1 immarg true, i1 immarg true) #2
+; CHECK-NEXT: ret void
+
+  %26 = insertelement <4 x float> <float undef, float 0.000000e+00, float 0.000000e+00, float 1.000000e+00>, float %25, i32 0
+  call void (...) @lgc.create.write.generic.output(<4 x float> %26, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!lgc.options = !{!0}
+!lgc.options.VS = !{!1}
+!lgc.options.FS = !{!2}
+!lgc.vertex.inputs = !{!3, !4, !5}
+!lgc.color.export.formats = !{!6}
+!lgc.input.assembly.state = !{!7}
+!lgc.viewport.state = !{!8}
+!lgc.rasterizer.state = !{!9}
+
+!0 = !{i32 1472734038, i32 951774412, i32 -1164039144, i32 -357869313, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2, i32 0, i32 0, i32 1}
+!1 = !{i32 2059820324, i32 -2055480947, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!2 = !{i32 272488772, i32 -330177307, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 0, i32 0, i32 0, i32 16, i32 14, i32 7, i32 -1}
+!4 = !{i32 1, i32 0, i32 0, i32 16, i32 11, i32 7, i32 -1}
+!5 = !{i32 2, i32 0, i32 0, i32 16, i32 11, i32 7, i32 -1}
+!6 = !{i32 10, i32 0, i32 0, i32 1}
+!7 = !{i32 10, i32 3}
+!8 = !{i32 1}
+!9 = !{i32 0, i32 0, i32 0, i32 1}
+!10 = !{i32 0}
+!11 = !{i32 4}
+!12 = distinct !{!12}
+!13 = distinct !{!13}

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -312,6 +312,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;
   options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
+  options.enableScratchBoundsCheck = getPipelineOptions()->enableScratchBoundsCheck;
   pipeline->setOptions(options);
 
   // Give the shader options (including the hash) to the middle-end.

--- a/llpc/test/shaderdb/OpLoad_StackBoundsCheck.pipe
+++ b/llpc/test/shaderdb/OpLoad_StackBoundsCheck.pipe
@@ -1,0 +1,129 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 inV0;
+
+layout(location = 0) out vec4 out1;
+
+void main(void)
+{
+    gl_Position = inV0;
+    out1 = inV0;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+void main() {
+  vec2 localData[16];
+  // Bounds checks for the loop get optimized away
+  for (int i = 0; i < 16; i++)
+    localData[i] = vec2(color_in.x + i + 5);
+
+/*
+; SHADERTEST: = icmp ult i32 %[[#]], 16
+; SHADERTEST: br i1 %
+
+; SHADERTEST: = getelementptr [16 x <2 x float>], [16 x <2 x float>] addrspace(5)* %
+; SHADERTEST: = load float, float addrspace(5)* %
+; SHADERTEST: br label %
+
+; SHADERTEST: = phi float [ %[[#]], %[[#]] ], [ 0.000000e+00, %.entry ]
+
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+*/
+
+  // Read out-of-bounds of the stack array
+  float v = localData[int(color_in.x * 255) + 5024].x;
+
+  color_out = vec4(v, 0.0, 0.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+patchControlPoints = 3
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 0
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 0
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactDisable
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 1
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.enableScratchBoundsCheck = 1
+options.reconfigWorkgroupLayout = 0
+options.shadowDescriptorTableUsage = Enable
+options.shadowDescriptorTablePtrHigh = 2
+options.extendedRobustness.robustBufferAccess = 0
+options.extendedRobustness.robustImageAccess = 0
+options.extendedRobustness.nullDescriptor = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 0
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32_SFLOAT
+attribute[2].offset = 0

--- a/llpc/test/shaderdb/OpLoad_StackBoundsCheck_struct.pipe
+++ b/llpc/test/shaderdb/OpLoad_StackBoundsCheck_struct.pipe
@@ -1,0 +1,141 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 inV0;
+
+layout(location = 0) out vec4 out1;
+
+void main(void)
+{
+    gl_Position = inV0;
+    out1 = inV0;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+struct Str {
+  vec3 v1;
+  float f;
+  vec3 v2;
+};
+
+void main() {
+  Str localStructs[16][16];
+  for (int i = 0; i < 16; i++) {
+    for (int j = 0; j < 16; j++) {
+      Str s;
+      s.v1 = vec3(color_in.x + i + 5);
+      s.f = color_in.y + i + 2;
+      s.v2 = vec3(color_in.x + i + 5);
+      localStructs[i][j] = s;
+    }
+  }
+
+/*
+  Skip load if int(color_in.y * 255) < -16
+
+; SHADERTEST: = icmp ult i32 %[[#]], -16
+; SHADERTEST: br i1 %
+
+; SHADERTEST: = getelementptr [16 x [16 x { <3 x float>, float, <3 x float> }]], [16 x [16 x { <3 x float>, float, <3 x float> }]] addrspace(5)* %
+; SHADERTEST: = load float, float addrspace(5)* %
+; SHADERTEST: br label %
+
+; SHADERTEST: = phi float [ %[[#]], %[[#]] ], [ 0.000000e+00, %.entry ]
+
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+*/
+
+  // Read out-of-bounds of the stack array
+  float v = localStructs[int(color_in.y * 255) + 16][1].v2.y;
+  color_out = vec4(v, 0.0, 0.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+patchControlPoints = 3
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 0
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 0
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactDisable
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 1
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.enableScratchBoundsCheck = 1
+options.reconfigWorkgroupLayout = 0
+options.shadowDescriptorTableUsage = Enable
+options.shadowDescriptorTablePtrHigh = 2
+options.extendedRobustness.robustBufferAccess = 0
+options.extendedRobustness.robustImageAccess = 0
+options.extendedRobustness.nullDescriptor = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 0
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32_SFLOAT
+attribute[2].offset = 0

--- a/llpc/test/shaderdb/OpLoad_StackBoundsCheck_write.pipe
+++ b/llpc/test/shaderdb/OpLoad_StackBoundsCheck_write.pipe
@@ -1,0 +1,135 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+
+; SHADERTEST: = icmp ult i32 %[[#]], 16
+; SHADERTEST: br i1 %
+
+; SHADERTEST: = getelementptr [16 x [16 x <2 x float>]], [16 x [16 x <2 x float>]] addrspace(5)* %
+; SHADERTEST: store float 4.000000e+00, float addrspace(5)* %
+; SHADERTEST: br label %
+
+; SHADERTEST: = icmp ult i32 %[[#]], 16
+; SHADERTEST: br i1 %
+
+; SHADERTEST: = getelementptr [16 x [16 x <2 x float>]], [16 x [16 x <2 x float>]] addrspace(5)* %
+; SHADERTEST: = load float, float addrspace(5)* %
+; SHADERTEST: br label %
+
+; SHADERTEST: = phi float [ %[[#]], %[[#]] ], [ 0.000000e+00, %[[#]] ]
+
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 inV0;
+
+layout(location = 0) out vec4 out1;
+
+void main(void)
+{
+    gl_Position = inV0;
+    out1 = inV0;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450 core
+
+layout(location = 0) in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+void main() {
+  vec2 localData[16][16];
+  for (int i = 0; i < 17; i++)
+    for (int j = 0; j < 17; j++)
+      localData[i][j] = vec2(color_in.x + i + 5);
+
+  // Write out-of-bounds of the stack array
+  localData[int(color_in.x * 255) + 5025][int(color_in.x * 255) + 5005].x = 4;
+
+  // Read out-of-bounds of the stack array
+  float v = localData[int(color_in.x * 255) + 5024][int(color_in.x * 255) + 5004].x;
+  color_out = vec4(v, 0.0, 0.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+patchControlPoints = 3
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 0
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 0
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactDisable
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 1
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.enableScratchBoundsCheck = 1
+options.reconfigWorkgroupLayout = 0
+options.shadowDescriptorTableUsage = Enable
+options.shadowDescriptorTablePtrHigh = 2
+options.extendedRobustness.robustBufferAccess = 0
+options.extendedRobustness.robustImageAccess = 0
+options.extendedRobustness.nullDescriptor = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 0
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32_SFLOAT
+attribute[2].offset = 0

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -665,6 +665,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
   dumpFile << "options.scalarBlockLayout = " << options->scalarBlockLayout << "\n";
   dumpFile << "options.includeIr = " << options->includeIr << "\n";
   dumpFile << "options.robustBufferAccess = " << options->robustBufferAccess << "\n";
+  dumpFile << "options.enableScratchBoundsCheck = " << options->enableScratchBoundsCheck << "\n";
   dumpFile << "options.reconfigWorkgroupLayout = " << options->reconfigWorkgroupLayout << "\n";
   dumpFile << "options.shadowDescriptorTableUsage = " << options->shadowDescriptorTableUsage << "\n";
   dumpFile << "options.shadowDescriptorTablePtrHigh = " << options->shadowDescriptorTablePtrHigh << "\n";
@@ -906,6 +907,7 @@ MetroHash::Hash PipelineDumper::generateHashForComputePipeline(const ComputePipe
   hasher.Update(pipeline->options.scalarBlockLayout);
   hasher.Update(pipeline->options.includeIr);
   hasher.Update(pipeline->options.robustBufferAccess);
+  hasher.Update(pipeline->options.enableScratchBoundsCheck);
   hasher.Update(pipeline->options.shadowDescriptorTableUsage);
   hasher.Update(pipeline->options.shadowDescriptorTablePtrHigh);
   hasher.Update(pipeline->options.extendedRobustness.robustBufferAccess);
@@ -1015,6 +1017,7 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     hasher->Update(pipeline->options.scalarBlockLayout);
     hasher->Update(pipeline->options.includeIr);
     hasher->Update(pipeline->options.robustBufferAccess);
+    hasher->Update(pipeline->options.enableScratchBoundsCheck);
     hasher->Update(pipeline->options.reconfigWorkgroupLayout);
 
     if (!isRelocatableShader) {

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -357,6 +357,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, enableScratchBoundsCheck, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
@@ -371,7 +372,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 8;
+  static const unsigned MemberCount = 9;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Some applications access stack objects out of bounds, leading to
segfaults and hangs.

The pass checks the upper bound of dynamic array indices. Out of bounds
stores will be omitted, loads return zero.

This pass replaces the `enable-scratch-bounds-checks` option of llvm.

Open question:
When should this option be activated? `enable-scratch-bounds-checks` is currently always enabled, though probably it should only be enabled for pipelines or apps that need it. For what it’s worth, I cannot reproduce the original issue anymore that lead to the implementation of `enable-scratch-bounds-checks` (it runs fine with disabled bounds checks).

Should this option also have a corresponding command line option for amdllpc?