### PR TITLE
Update llpc changes to anticipate upstream revert of old change

### DIFF
--- a/llpc/test/shaderdb/ObjStorageBlock_TestAlign_lit.frag
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestAlign_lit.frag
@@ -42,9 +42,9 @@ void main()
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 16, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
-; SHADERTEST: call <2 x i32> @llvm.amdgcn.s.buffer.load.v2i32(<4 x i32> {{%[^,]+}}, i32 24, i32 0)
+; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 24, i32 0)
+; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 28, i32 0)
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2i32(<2 x i32> {{%[^,]+}}, <4 x i32> {{%[^,]+}}, i32 256, i32 0, i32 0)
-; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> {{%[^,]+}}, i32 64, i32 0, i32 0)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/ObjStorageBlock_TestOffset_lit.frag
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestOffset_lit.frag
@@ -42,7 +42,6 @@ void main()
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> %{{.*}}, <4 x i32> %{{[0-9]*}}, i32 128
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}, <4 x i32> %{{[0-9]*}}, i32 256
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v2i32(<2 x i32> %{{.*}}, <4 x i32> %{{[0-9]*}}, i32 512
-; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 256
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/ObjStorageBlock_TestVectorComponentStore_lit.comp
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestVectorComponentStore_lit.comp
@@ -17,9 +17,9 @@ void main()
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{[0-9]*}} = call i8 addrspace(7)* {{.*}} @lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 0, i32 0, i1 false,
-; SHADERTEST: %{{[0-9]*}} = load i32, i32 addrspace(7)* %{{[0-9]*}}, align 4
+; SHADERTEST: %{{[0-9]*}} = load float, float addrspace(7)* %{{[0-9]*}}, align 4
 ; SHADERTEST: %{{[0-9]*}} = getelementptr inbounds i8, i8 addrspace(7)* %{{[0-9]*}}, i64 4
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(7)* %{{[0-9]*}}, align 4
+; SHADERTEST: store float %{{[0-9]*}}, float addrspace(7)* %{{[0-9]*}}, align 4
 
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/OpAccessChain_TestInOutVectorExtract_lit.frag
+++ b/llpc/test/shaderdb/OpAccessChain_TestInOutVectorExtract_lit.frag
@@ -29,7 +29,7 @@ void main()
 ; SHADERTEST: select i1 %{{[0-9]*}}, float addrspace({{.*}})* %{{.*}}, float addrspace({{.*}})* %{{[0-9]*}}
 ; SHADERTEST: icmp eq i32 %{{[0-9]*}}, 3
 ; SHADERTEST: select i1 %{{[0-9]*}}, float addrspace({{.*}})* %{{.*}}, float addrspace({{.*}})* %{{[0-9]*}}
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace({{.*}})* %{{[0-9]*}}
+; SHADERTEST: store float %{{[0-9]*}}, float addrspace({{.*}})* %{{[0-9]*}}
 ; SHADERTEST: store float 0x3FD99999A0000000, float addrspace({{.*}})* %{{.*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
Upstream change:
[InstCombine] Revert rL226781 "Teach InstCombine to canonicalize loads which are
only ever stored to always use a legal integer type if one is available."
(PR47592)

This changes some behaviour that needs fixing in llpc test.
Interestingly, the resultant ISA from these tests is better than before since
there is one fewer buffer_load - even though the IR looks slightly worse in some
cases. However, the later stages in the backend to optimise loads and stores by
combining where possible seems to fix up the issues.