### PR TITLE
NGG: Fix a regression of Navi14

### DIFF
--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -317,7 +317,7 @@ static void setGfx1012Info(TargetInfo *targetInfo) {
   targetInfo->getGpuWorkarounds().gfx10.waNggCullingNoEmptySubgroups = 1;
   targetInfo->getGpuWorkarounds().gfx10.waShaderInstPrefetchFwd64 = 1;
   targetInfo->getGpuWorkarounds().gfx10.waWarFpAtomicDenormHazard = 1;
-  targetInfo->getGpuWorkarounds().gfx10.waNggDisabled = 0;
+  targetInfo->getGpuWorkarounds().gfx10.waNggDisabled = 1;
   targetInfo->getGpuWorkarounds().gfx10.waFixBadImageDescriptor = 1;
 }
 


### PR DESCRIPTION
NGG is mistakenly enabled on Navi14 by a coding error. Should be
disabled because of HW limitation.

Change-Id: Ic1ba9ae3e5953ba1ffa67dfef31dadb7f0a7987f