### PR TITLE
Optimization for image_get_resinfo (PR #845)

### DIFF
--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1250,12 +1250,28 @@ Value *ImageBuilder::CreateImageAtomicCommon(unsigned atomicOp, unsigned dim, un
 // @param instName : Name to give instruction(s)
 Value *ImageBuilder::CreateImageQueryLevels(unsigned dim, unsigned flags, Value *imageDesc, const Twine &instName) {
   dim = dim == DimCubeArray ? DimCube : dim;
-  Value *zero = getInt32(0);
-  Instruction *resInfo = CreateIntrinsic(ImageGetResInfoIntrinsicTable[dim], {getFloatTy(), getInt32Ty()},
-                                         {getInt32(8), UndefValue::get(getInt32Ty()), imageDesc, zero, zero});
-  if (flags & ImageFlagNonUniformImage)
-    resInfo = createWaterfallLoop(resInfo, 2);
-  return CreateBitCast(resInfo, getInt32Ty(), instName);
+
+  Value *numMipLevel = nullptr;
+  if (dim == Dim2DMsaa || dim == Dim2DArrayMsaa)
+    numMipLevel = getInt32(1);
+  else {
+    GfxIpVersion gfxIp = getPipelineState()->getTargetInfo().getGfxIpVersion();
+    SqImgRsrcRegHandler proxySqRsrcRegHelper(this, imageDesc, &gfxIp);
+    Value *lastLevel = proxySqRsrcRegHelper.getReg(SqRsrcRegs::LastLevel);
+    Value *baseLevel = proxySqRsrcRegHelper.getReg(SqRsrcRegs::BaseLevel);
+    numMipLevel = CreateSub(lastLevel, baseLevel);
+    numMipLevel = CreateAdd(numMipLevel, getInt32(1));
+  }
+
+  // Set to 0 if allowNullDescriptor is on and image descriptor is a null descriptor
+  if (m_pipelineState->getOptions().allowNullDescriptor) {
+    // Check dword3 against 0 for a null descriptor
+    Value *descWord3 = CreateExtractElement(imageDesc, 3);
+    Value *isNullDesc = CreateICmpEQ(descWord3, getInt32(0));
+    numMipLevel = CreateSelect(isNullDesc, getInt32(0), numMipLevel);
+  }
+
+  return numMipLevel;
 }
 
 // =====================================================================================================================
@@ -1319,30 +1335,72 @@ Value *ImageBuilder::CreateImageQuerySize(unsigned dim, unsigned flags, Value *i
 
   // Proper image.
   unsigned modifiedDim = dim == DimCubeArray ? DimCube : change1DTo2DIfNeeded(dim);
-  Value *zero = getInt32(0);
-  Instruction *resInfo =
-      CreateIntrinsic(ImageGetResInfoIntrinsicTable[modifiedDim], {FixedVectorType::get(getFloatTy(), 4), getInt32Ty()},
-                      {getInt32(15), lod, imageDesc, zero, zero});
-  if (flags & ImageFlagNonUniformImage)
-    resInfo = createWaterfallLoop(resInfo, 2);
-  Value *intResInfo = CreateBitCast(resInfo, FixedVectorType::get(getInt32Ty(), 4));
+  Value *resInfo = nullptr;
+
+  GfxIpVersion gfxIp = getPipelineState()->getTargetInfo().getGfxIpVersion();
+  SqImgRsrcRegHandler proxySqRsrcRegHelper(this, imageDesc, &gfxIp);
+  Value *width = proxySqRsrcRegHelper.getReg(SqRsrcRegs::Width);
+  Value *height = proxySqRsrcRegHelper.getReg(SqRsrcRegs::Height);
+  Value *depth = proxySqRsrcRegHelper.getReg(SqRsrcRegs::Depth);
+  Value *baseLevel = proxySqRsrcRegHelper.getReg(SqRsrcRegs::BaseLevel);
+
+  if (dim == Dim2DMsaa || dim == Dim2DArrayMsaa)
+    baseLevel = getInt32(0);
+
+  Value *curLevel = CreateAdd(baseLevel, lod);
+
+  // Size of the level
+  width = CreateLShr(width, curLevel);
+  width = CreateSelect(CreateICmpEQ(width, getInt32(0)), getInt32(1), width);
+  height = CreateLShr(height, curLevel);
+  height = CreateSelect(CreateICmpEQ(height, getInt32(0)), getInt32(1), height);
+
+  if (dim == Dim3D) {
+    depth = CreateLShr(depth, curLevel);
+    depth = CreateSelect(CreateICmpEQ(depth, getInt32(0)), getInt32(1), depth);
+  } else {
+    if (getPipelineState()->getTargetInfo().getGfxIpVersion().major < 9) {
+      Value *baseArray = proxySqRsrcRegHelper.getReg(SqRsrcRegs::BaseArray);
+      Value *lastArray = proxySqRsrcRegHelper.getReg(SqRsrcRegs::LastArray);
+      depth = CreateSub(lastArray, baseArray);
+      depth = CreateAdd(depth, getInt32(1));
+    }
+  }
+
+  // Set to 0 if allowNullDescriptor is on and image descriptor is a null descriptor
+  if (m_pipelineState->getOptions().allowNullDescriptor) {
+    // Check dword3 against 0 for a null descriptor
+    Value *descWord3 = CreateExtractElement(imageDesc, 3);
+    Value *isNullDesc = CreateICmpEQ(descWord3, getInt32(0));
+    width = CreateSelect(isNullDesc, getInt32(0), width);
+    height = CreateSelect(isNullDesc, getInt32(0), height);
+    depth = CreateSelect(isNullDesc, getInt32(0), depth);
+  }
+
+  resInfo = CreateInsertElement(UndefValue::get(FixedVectorType::get(getInt32Ty(), 4)), width, uint64_t(0));
+  if (dim == Dim1DArray)
+    resInfo = CreateInsertElement(resInfo, depth, 1);
+  else
+    resInfo = CreateInsertElement(resInfo, height, 1);
+
+  resInfo = CreateInsertElement(resInfo, depth, 2);
 
   unsigned sizeComponentCount = getImageQuerySizeComponentCount(dim);
 
   if (sizeComponentCount == 1)
-    return CreateExtractElement(intResInfo, uint64_t(0), instName);
+    return CreateExtractElement(resInfo, uint64_t(0), instName);
 
   if (dim == DimCubeArray) {
-    Value *slices = CreateExtractElement(intResInfo, 2);
+    Value *slices = CreateExtractElement(resInfo, 2);
     slices = CreateSDiv(slices, getInt32(6));
-    intResInfo = CreateInsertElement(intResInfo, slices, 2);
+    resInfo = CreateInsertElement(resInfo, slices, 2);
   }
 
   if (dim == Dim1DArray && modifiedDim == Dim2DArray) {
     // For a 1D array on gfx9+ that we treated as a 2D array, we want components 0 and 2.
-    return CreateShuffleVector(intResInfo, intResInfo, ArrayRef<int>{0, 2}, instName);
+    return CreateShuffleVector(resInfo, resInfo, ArrayRef<int>{0, 2}, instName);
   }
-  return CreateShuffleVector(intResInfo, intResInfo, ArrayRef<int>({0, 1, 2}).slice(0, sizeComponentCount), instName);
+  return CreateShuffleVector(resInfo, resInfo, ArrayRef<int>({0, 1, 2}).slice(0, sizeComponentCount), instName);
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/util/GfxRegHandler.h
+++ b/lgc/include/lgc/util/GfxRegHandler.h
@@ -145,6 +145,10 @@ enum class SqRsrcRegs {
   Depth,
   Pitch,
   BcSwizzle,
+  BaseLevel,
+  LastLevel,
+  BaseArray,
+  LastArray, // only gfx6, gfx7 and gfx8
 
   // The following are introduced in gfx10.
   WidthLo,

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -28,12 +28,6 @@
 ; GFX900: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 ; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
-; GFX900: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
-
-; GFX900: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
-
 ; ModuleID = 'lgcPipeline'
 source_filename = "lgcPipeline"
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"

--- a/lgc/util/GfxRegHandler.cpp
+++ b/lgc/util/GfxRegHandler.cpp
@@ -177,6 +177,10 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx6[static_cast<unsigned>(SqRsrcRegs:
     {4, 0, 13},  // Depth
     {4, 13, 14}, // Pitch
     {},          // BcSwizzle
+    {3, 12, 4},  // BaseLevel
+    {3, 16, 4},  // LastLevel
+    {5, 0, 13},  // BaseArray
+    {5, 13, 13}, // LastArray
     {},          // WidthLo
     {},          // WidthHi
 };
@@ -195,6 +199,10 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx9[static_cast<unsigned>(SqRsrcRegs:
     {4, 0, 13},  // Depth
     {4, 13, 12}, // Pitch
     {4, 29, 3},  // BcSwizzle
+    {3, 12, 4},  // BaseLevel
+    {3, 16, 4},  // LastLevel
+    {5, 0, 13},  // BaseArray
+    {},          // LastArray
     {},          // WidthLo
     {},          // WidthHi
 };
@@ -213,6 +221,10 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx10[static_cast<unsigned>(SqRsrcRegs
     {4, 0, 16},  // Depth
     {},          // Pitch
     {3, 25, 3},  // BcSwizzle
+    {3, 12, 4},  // BaseLevel
+    {3, 16, 4},  // LastLevel
+    {4, 16, 16}, // BaseArray
+    {},          // LastArray
     {1, 30, 2},  // WidthLo
     {2, 0, 14},  // WidthHi
 };
@@ -256,9 +268,12 @@ Value *SqImgRsrcRegHandler::getReg(SqRsrcRegs regId) {
   case SqRsrcRegs::Format:
   case SqRsrcRegs::DstSelXYZW:
   case SqRsrcRegs::SwizzleMode:
-  case SqRsrcRegs::Depth:
   case SqRsrcRegs::BcSwizzle:
+  case SqRsrcRegs::BaseLevel:
+  case SqRsrcRegs::LastLevel:
+  case SqRsrcRegs::BaseArray:
     return getRegCommon(static_cast<unsigned>(regId));
+  case SqRsrcRegs::Depth:
   case SqRsrcRegs::Height:
   case SqRsrcRegs::Pitch:
     return m_builder->CreateAdd(getRegCommon(static_cast<unsigned>(regId)), m_one);
@@ -272,6 +287,16 @@ Value *SqImgRsrcRegHandler::getReg(SqRsrcRegs regId) {
     case 10:
       return m_builder->CreateAdd(
           getRegCombine(static_cast<unsigned>(SqRsrcRegs::WidthLo), static_cast<unsigned>(SqRsrcRegs::WidthHi)), m_one);
+    default:
+      llvm_unreachable("GFX IP is not supported!");
+      break;
+    }
+  case SqRsrcRegs::LastArray:
+    switch (m_gfxIpVersion->major) {
+    case 6:
+    case 7:
+    case 8:
+      return getRegCommon(static_cast<unsigned>(regId));
     default:
       llvm_unreachable("GFX IP is not supported!");
       break;

--- a/llpc/test/shaderdb/OpImageQueryLevels_TestBasic_lit.comp
+++ b/llpc/test/shaderdb/OpImageQueryLevels_TestBasic_lit.comp
@@ -76,20 +76,6 @@ void main()
 ; SHADERTEST: call i32 (...) @lgc.create.image.query.levels.i32(i32 8, i32 0, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.3d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQueryLevels_TestTextureQueryLevels_lit.frag
+++ b/llpc/test/shaderdb/OpImageQueryLevels_TestTextureQueryLevels_lit.frag
@@ -36,10 +36,6 @@ void main()
 ; SHADERTEST: call i32 (...) @lgc.create.image.query.levels.i32(i32 8, i32 0, <8 x {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQuerySizeLod_TestTextureSize_lit.frag
+++ b/llpc/test/shaderdb/OpImageQuerySizeLod_TestTextureSize_lit.frag
@@ -31,9 +31,6 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 2, i32 0, {{.*}}, i32 5)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 3,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 4,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.3d.v3f32.i32(i32 7, i32 5,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQuerySize_TestBasic_lit.frag
+++ b/llpc/test/shaderdb/OpImageQuerySize_TestBasic_lit.frag
@@ -111,21 +111,6 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 7, i32 0, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.3d.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.1darray.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darray.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQuerySize_TestImageSize_lit.frag
+++ b/llpc/test/shaderdb/OpImageQuerySize_TestImageSize_lit.frag
@@ -40,10 +40,6 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 8, i32 0, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2dmsaa.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQuerySize_TestImage_lit.comp
+++ b/llpc/test/shaderdb/OpImageQuerySize_TestImage_lit.comp
@@ -63,16 +63,6 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.i32(i32 0, i32 0, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.3d.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.1darray.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darray.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQuerySize_TestSeparated_lit.frag
+++ b/llpc/test/shaderdb/OpImageQuerySize_TestSeparated_lit.frag
@@ -19,7 +19,6 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v2i32(i32 1, i32 0, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpImageQuerySize_TestTextureSize_lit.frag
+++ b/llpc/test/shaderdb/OpImageQuerySize_TestTextureSize_lit.frag
@@ -34,9 +34,6 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 7, i32 0, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
-; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Optimization for image_get_resinfo. Implement its functionality by bit
manipulation.
image_get_resinfo does not actually access memory, so invoking an image
instruction for its purpose is quite expensive.
Avoid calling "ImageGetResInfoIntrinsic" functions and replace them with
some SALU operations to grab resource info from image srd directly. #845 