### PR TITLE
Correct scope assertion for OpReadClockKHR

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2836,7 +2836,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<spv::OpReadClockKHR>(SPIRVV
   SPIRVInstruction *const spvInst = static_cast<SPIRVInstruction *>(spvValue);
   SPIRVConstant *const spvScope = static_cast<SPIRVConstant *>(spvInst->getOperands()[0]);
   const spv::Scope scope = static_cast<spv::Scope>(spvScope->getZExtIntValue());
-  assert(scope == spv::ScopeDevice || scope == spv::ScopeWorkgroup);
+  assert(scope == spv::ScopeDevice || scope == spv::ScopeSubgroup);
 
   Value *const readClock = getBuilder()->CreateReadClock(scope == spv::ScopeDevice);
 


### PR DESCRIPTION
This fix a test crash using debug driver.

according to:
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_shader_clock.html
The two valid scopes are Subgroup and Device.

Fixes: dEQP-VK.glsl.shader_clock.vertex.clockARB