### PR TITLE
Remove all instructions in a block after OpKill.

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -171,6 +171,7 @@ if(ICD_BUILD_LLPC)
         lower/llpcSpirvLowerMath.cpp
         lower/llpcSpirvLowerMemoryOp.cpp
         lower/llpcSpirvLowerResourceCollect.cpp
+        lower/llpcSpirvLowerTerminator.cpp
         lower/llpcSpirvLowerTranslator.cpp
         lower/llpcSpirvLowerUtil.cpp
     )

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -166,6 +166,9 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassMana
   // Lower SPIR-V access chain
   passMgr.add(createSpirvLowerAccessChain());
 
+  // Lower SPIR-V terminators
+  passMgr.add(createSpirvLowerTerminator());
+
   // Lower SPIR-V global variables, inputs, and outputs
   passMgr.add(createSpirvLowerGlobal());
 

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -55,6 +55,7 @@ void initializeSpirvLowerMemoryOpPass(PassRegistry &);
 void initializeSpirvLowerGlobalPass(PassRegistry &);
 void initializeSpirvLowerInstMetaRemovePass(PassRegistry &);
 void initializeSpirvLowerResourceCollectPass(PassRegistry &);
+void initializeSpirvLowerTerminatorPass(PassRegistry &);
 void initializeSpirvLowerTranslatorPass(PassRegistry &);
 } // namespace llvm
 
@@ -78,6 +79,7 @@ inline static void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
   initializeSpirvLowerGlobalPass(passRegistry);
   initializeSpirvLowerInstMetaRemovePass(passRegistry);
   initializeSpirvLowerResourceCollectPass(passRegistry);
+  initializeSpirvLowerTerminatorPass(passRegistry);
   initializeSpirvLowerTranslatorPass(passRegistry);
 }
 
@@ -91,6 +93,7 @@ llvm::ModulePass *createSpirvLowerMemoryOp();
 llvm::ModulePass *createSpirvLowerGlobal();
 llvm::ModulePass *createSpirvLowerInstMetaRemove();
 llvm::ModulePass *createSpirvLowerResourceCollect(bool collectDetailUsage);
+llvm::ModulePass *createSpirvLowerTerminator();
 llvm::ModulePass *createSpirvLowerTranslator(ShaderStage stage, const PipelineShaderInfo *shaderInfo);
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerTerminator.cpp
+++ b/llpc/lower/llpcSpirvLowerTerminator.cpp
@@ -1,0 +1,176 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcSpirvLowerTerminator.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::SpirvLowerTerminator.
+ * @details This pass removes trailing instructions after known terminators.
+ *          These dead instructions can occur when functions calling terminators, such as OpKill, are inlined.
+ ***********************************************************************************************************************
+ */
+#include "SPIRVInternal.h"
+#include "llpcContext.h"
+#include "llpcDebug.h"
+#include "llpcSpirvLower.h"
+#include "llpcSpirvLowerUtil.h"
+#include "lgc/Builder.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "llpc-spirv-lower-terminator"
+
+using namespace llvm;
+using namespace SPIRV;
+using namespace Llpc;
+
+namespace Llpc {
+
+// =====================================================================================================================
+// Represents the pass of SPIR-V lowering terminators.
+class SpirvLowerTerminator : public SpirvLower, public llvm::InstVisitor<SpirvLowerTerminator> {
+public:
+  SpirvLowerTerminator();
+
+  virtual bool runOnModule(llvm::Module &module);
+  virtual void visitCallInst(llvm::CallInst &callInst);
+
+  static char ID; // ID of this pass
+
+private:
+  SpirvLowerTerminator(const SpirvLowerTerminator &) = delete;
+  SpirvLowerTerminator &operator=(const SpirvLowerTerminator &) = delete;
+
+  // Instructions to be removed; set for tests, vector for order
+  SmallPtrSet<llvm::Instruction *, 8> m_instsForRemoval;
+  SmallVector<llvm::Instruction *, 8> m_removalStack;
+};
+
+// =====================================================================================================================
+// Initializes static members.
+char SpirvLowerTerminator::ID = 0;
+
+// =====================================================================================================================
+// Pass creator, creates the pass of SPIR-V lowering terminator operations
+ModulePass *createSpirvLowerTerminator() {
+  return new SpirvLowerTerminator();
+}
+
+// =====================================================================================================================
+SpirvLowerTerminator::SpirvLowerTerminator() : SpirvLower(ID) {
+}
+
+// =====================================================================================================================
+// Executes this SPIR-V lowering pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+bool SpirvLowerTerminator::runOnModule(Module &module) {
+  LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Terminator\n");
+
+  SpirvLower::init(&module);
+
+  // Kills are only valid in fragment shader model.
+  if (m_shaderStage != ShaderStageFragment)
+    return false;
+
+  // Invoke handling of "kill" instructions.
+  visit(m_module);
+
+  // Remove any dead instructions.
+  bool changed = !m_removalStack.empty();
+  while (!m_removalStack.empty()) {
+    auto deadInst = m_removalStack.pop_back_val();
+    LLVM_DEBUG(dbgs() << "remove: " << *deadInst << "\n");
+    deadInst->dropAllReferences();
+    deadInst->eraseFromParent();
+  }
+  m_instsForRemoval.clear();
+
+  return changed;
+}
+
+// =====================================================================================================================
+// Visits "call" instruction.
+//
+// Look for kills followed by instructions other than a return.
+// If found, mark dead instructions for removal and add a return immediately following the kill.
+//
+// @param callInst : "Call" instruction
+void SpirvLowerTerminator::visitCallInst(CallInst &callInst) {
+  auto callee = callInst.getCalledFunction();
+  if (!callee)
+    return;
+
+  auto mangledName = callee->getName();
+  if (mangledName != "lgc.create.kill")
+    return;
+
+  // Already marked for removal?
+  if (m_instsForRemoval.count(&callInst))
+    return;
+
+  BasicBlock *parentBlock = callInst.getParent();
+  auto instIter = std::next(callInst.getIterator());
+  assert(instIter != parentBlock->end() && "Should not be at end of block; illegal IR?");
+
+  // Already has a return?
+  if (isa<ReturnInst>(*instIter))
+    return;
+
+  // If terminator branches to block containing a PHI node which references
+  // this block then instructions following kill may be part of a return
+  // value sequence. In which case we cannot safely modify the instructions.
+  auto blockTerm = parentBlock->getTerminator();
+  if (!blockTerm)
+    return;
+  if (BranchInst *branch = dyn_cast<BranchInst>(blockTerm)) {
+    assert(branch->isUnconditional());
+    BasicBlock *targetBlock = branch->getSuccessor(0);
+    for (PHINode &phiNode : targetBlock->phis()) {
+      for (BasicBlock *incomingBlock : phiNode.blocks()) {
+        if (incomingBlock == parentBlock)
+          return;
+      }
+    }
+  }
+
+  // Add return
+  ReturnInst::Create(*m_context, nullptr, &*instIter);
+
+  // Mark all other instructions for removal
+  while (instIter != parentBlock->end()) {
+    if (m_instsForRemoval.insert(&*instIter).second)
+      m_removalStack.emplace_back(&*instIter);
+    ++instIter;
+  }
+}
+
+} // namespace Llpc
+
+// =====================================================================================================================
+// Initializes the pass of SPIR-V lowering terminator operations..
+INITIALIZE_PASS(SpirvLowerTerminator, DEBUG_TYPE, "Lower SPIR-V terminator", false, false)

--- a/llpc/make/Makefile.llpc
+++ b/llpc/make/Makefile.llpc
@@ -58,6 +58,7 @@ ifeq ($(ICD_BUILD_LLPC), 1)
         llpcSpirvLowerMath.cpp                  \
         llpcSpirvLowerMemoryOp.cpp              \
         llpcSpirvLowerResourceCollect.cpp       \
+        llpcSpirvLowerTerminator.cpp            \
         llpcSpirvLowerTranslator.cpp            \
         llpcSpirvLowerUtil.cpp
 

--- a/llpc/test/shaderdb/OpKill_TestFunctionInlineReturn_lit.frag
+++ b/llpc/test/shaderdb/OpKill_TestFunctionInlineReturn_lit.frag
@@ -1,0 +1,60 @@
+#version 450
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; Test that after SPIR-V lowering all operations after second kill
+; have been replaced with a branch to the return block; however,
+; the operations after first kill should not be touched as these
+; are part of return .
+
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
+; SHADERTEST: call void{{.*}} @lgc.create.kill
+; SHADERTEST-NEXT: br label %[[EXIT:.exit[0-9]*]]
+; SHADERTEST: call void{{.*}} @lgc.create.kill
+; SHADERTEST-NEXT: br label %[[LABEL:[0-9]*]]
+; SHADERTEST-NOT: call void{{.*}} @lgc.create.kill
+; SHADERTEST: [[LABEL]]:
+; SHADERTEST: call void{{.*}} @lgc.create.write.generic.output
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+layout(location = 0) in mediump vec4 v_color1;
+layout(location = 2) in mediump vec4 v_coords;
+layout(location = 0) out mediump vec4 o_color;
+
+layout(set = 0, binding = 0, std140) uniform buf0
+{
+    float zero;
+} param;
+
+void myfunc0 (void)
+{
+    discard;
+}
+
+highp float myfunc1(int b)
+{
+    if (b == 0)
+    {
+      discard;
+    }
+    if (b > 2)
+    {
+      return 3.0;
+    }
+    return 5.0;
+}
+
+void main (void)
+{
+    o_color = v_color1;
+    o_color.x = myfunc1(int(param.zero));
+    if (v_coords.x+v_coords.y > 0.0) {
+      myfunc0();
+      myfunc0();
+    }
+}

--- a/llpc/test/shaderdb/OpKill_TestFunctionInline_lit.frag
+++ b/llpc/test/shaderdb/OpKill_TestFunctionInline_lit.frag
@@ -1,0 +1,44 @@
+#version 450
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; Test that after SPIR-V lowering all operations after first kill have been
+; replaced with a branch to the return block.
+
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
+; SHADERTEST: call void{{.*}} @lgc.create.kill
+; SHADERTEST-NEXT: br label %[[LABEL:[0-9]*]]
+; SHADERTEST-NOT: call void{{.*}} @lgc.create.kill
+; SHADERTEST: [[LABEL]]:
+; SHADERTEST-NEXT: call void{{.*}} @lgc.create.write.generic.output
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+layout(location = 0) in mediump vec4 v_color1;
+layout(location = 1) in mediump vec4 v_color2;
+layout(location = 2) in mediump vec4 v_coords;
+layout(location = 0) out mediump vec4 o_color;
+
+void myfunc0 (void)
+{
+    discard;
+}
+
+void myfunc1 (void)
+{
+    o_color = v_color2;
+}
+
+void main (void)
+{
+    o_color = v_color1;
+    if (v_coords.x+v_coords.y > 0.0) {
+      myfunc0();
+      myfunc1();
+      myfunc0();
+    }
+}

--- a/llpc/test/shaderdb/OpKill_TestFunctionUnreachable_lit.spvasm
+++ b/llpc/test/shaderdb/OpKill_TestFunctionUnreachable_lit.spvasm
@@ -1,0 +1,91 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; Test that unreachable after a kill is correct replaced with branch to
+; return block.
+
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIRV-to-LLVM translation results
+; SHADERTEST: unreachable
+
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
+; SHADERTEST: call void{{.*}} @lgc.create.kill
+; SHADERTEST-NEXT: br label %[[LABEL:[0-9]*]]
+; SHADERTEST: [[LABEL]]:
+; SHADERTEST-NEXT: call void{{.*}} @lgc.create.write.generic.output
+
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 33
+; Schema: 0
+               OpCapability Shader
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %o_color %v_color %v_coords
+               OpExecutionMode %main OriginUpperLeft
+          %1 = OpString "OpKill_TestFunctionInline_lit.frag"
+               OpSource GLSL 450 %1 ""
+               OpName %main "main"
+               OpName %myfunc_ "myfunc("
+               OpName %o_color "o_color"
+               OpName %v_color "v_color"
+               OpName %v_coords "v_coords"
+               OpModuleProcessed "client vulkan100"
+               OpModuleProcessed "target-env spirv1.5"
+               OpModuleProcessed "target-env vulkan1.1"
+               OpModuleProcessed "entry-point main"
+               OpModuleProcessed "use-storage-buffer"
+               OpDecorate %o_color RelaxedPrecision
+               OpDecorate %o_color Location 0
+               OpDecorate %v_color RelaxedPrecision
+               OpDecorate %v_color Location 0
+               OpDecorate %16 RelaxedPrecision
+               OpDecorate %v_coords RelaxedPrecision
+               OpDecorate %v_coords Location 1
+               OpDecorate %22 RelaxedPrecision
+               OpDecorate %25 RelaxedPrecision
+               OpDecorate %26 RelaxedPrecision
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+    %o_color = OpVariable %_ptr_Output_v4float Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+    %v_color = OpVariable %_ptr_Input_v4float Input
+   %v_coords = OpVariable %_ptr_Input_v4float Input
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_float = OpTypePointer Input %float
+     %uint_1 = OpConstant %uint 1
+    %float_0 = OpConstant %float 0
+       %bool = OpTypeBool
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpLine %1 14 0
+         %16 = OpLoad %v4float %v_color
+               OpStore %o_color %16
+               OpLine %1 15 0
+         %21 = OpAccessChain %_ptr_Input_float %v_coords %uint_0
+         %22 = OpLoad %float %21
+         %24 = OpAccessChain %_ptr_Input_float %v_coords %uint_1
+         %25 = OpLoad %float %24
+         %26 = OpFAdd %float %22 %25
+         %29 = OpFOrdGreaterThan %bool %26 %float_0
+               OpSelectionMerge %31 None
+               OpBranchConditional %29 %30 %31
+         %30 = OpLabel
+               OpLine %1 16 0
+         %32 = OpFunctionCall %void %myfunc_
+               OpUnreachable
+         %31 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    %myfunc_ = OpFunction %void None %4
+          %8 = OpLabel
+               OpLine %1 9 0
+               OpKill
+               OpFunctionEnd


### PR DESCRIPTION
During inlining it is possible to construct a block which has trailing instructions after a kill.
This can prevent return block unification and cause exports to be skipped.
In particular some SPIRV generators terminate a block with a function calling OpKill with OpUnreachable, this also fixes these by replacing unreachable with ret void, which is then unified.