### PR TITLE
Merge GsOutLocInfo into InOutLocationInfo

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -321,10 +321,10 @@ void InOutBuilder::markGenericInputOutputUsage(bool isOutput, unsigned location,
   } else {
     // GS output. We include the stream ID with the location in the map key.
     for (unsigned i = 0; i < locationCount; ++i) {
-      GsOutLocInfo outLocInfo = {};
+      InOutLocationInfo outLocInfo = {};
       outLocInfo.location = location + i;
       outLocInfo.streamId = inOutInfo.getStreamId();
-      (*inOutLocMap)[outLocInfo.u32All] = InvalidValue;
+      (*inOutLocMap)[outLocInfo.u16All] = InvalidValue;
     }
   }
 
@@ -555,7 +555,7 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
 
   if (m_shaderStage == ShaderStageGeometry) {
     // Mark the XFB output for copy shader generation.
-    GsOutLocInfo outLocInfo = {};
+    InOutLocationInfo outLocInfo = {};
     outLocInfo.location = location;
     outLocInfo.isBuiltIn = isBuiltIn;
     outLocInfo.streamId = streamId;
@@ -567,11 +567,11 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
     xfbOutInfo.xfbExtraOffset = 0;
 
     auto resUsage = getPipelineState()->getShaderResourceUsage(ShaderStageGeometry);
-    resUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u32All] = xfbOutInfo.u32All;
+    resUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u16All] = xfbOutInfo.u32All;
     if (valueToWrite->getType()->getPrimitiveSizeInBits() > 128) {
       ++outLocInfo.location;
       xfbOutInfo.xfbOffset += 32;
-      resUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u32All] = xfbOutInfo.u32All;
+      resUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u16All] = xfbOutInfo.u32All;
     }
   }
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -65,20 +65,6 @@ union DescriptorPair {
   uint64_t u64All;
 };
 
-// Represents GS output location info (including location, built-in ID, and vertex stream ID)
-//
-// NOTE: Be careful to add new fields in this structure. It will be used as 32-bit hash map key in doing
-// location map for GS. The change of 32-bit value has impacts on ordering of entries. Thus, the mapping
-// result is changed accordingly.
-union GsOutLocInfo {
-  struct {
-    unsigned location : 16; // Location of the output
-    unsigned isBuiltIn : 1; // Whether location is actually built-in ID
-    unsigned streamId : 2;  // Output vertex stream ID
-  };
-  unsigned u32All;
-};
-
 // Represents transform feedback output info
 union XfbOutInfo {
   struct {
@@ -108,7 +94,9 @@ union InOutLocationInfo {
   struct {
     uint16_t half : 1;      // High half in case of 16-bit attriburtes
     uint16_t component : 2; // The component index
-    uint16_t location : 13; // The location
+    uint16_t location : 10; // The location
+    uint16_t isBuiltIn : 1; // Whether location is actually built-in ID
+    uint16_t streamId : 2;  // Output vertex stream ID
   };
   uint16_t u16All;
 };

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -302,12 +302,12 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
         unsigned value = cast<ConstantInt>(callInst->getOperand(0))->getZExtValue();
         const unsigned streamId = cast<ConstantInt>(callInst->getOperand(2))->getZExtValue();
 
-        GsOutLocInfo outLocInfo = {};
+        InOutLocationInfo outLocInfo = {};
         outLocInfo.location = value;
         outLocInfo.isBuiltIn = false;
         outLocInfo.streamId = streamId;
 
-        auto locMapIt = resUsage->inOutUsage.outputLocMap.find(outLocInfo.u32All);
+        auto locMapIt = resUsage->inOutUsage.outputLocMap.find(outLocInfo.u16All);
         if (locMapIt == resUsage->inOutUsage.outputLocMap.end())
           continue;
 
@@ -566,7 +566,7 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
     auto locIter =
         find_if(outLocMap.begin(), outLocMap.end(), [location, streamId](const std::pair<unsigned, unsigned> &outLoc) {
           unsigned outLocInfo = outLoc.first;
-          bool isStreamId = (reinterpret_cast<GsOutLocInfo *>(&outLocInfo))->streamId == streamId;
+          bool isStreamId = (reinterpret_cast<InOutLocationInfo *>(&outLocInfo))->streamId == streamId;
           return outLoc.second == location && isStreamId;
         });
 
@@ -625,13 +625,13 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
 
   if (resUsage->inOutUsage.enableXfb) {
-    GsOutLocInfo outLocInfo = {};
+    InOutLocationInfo outLocInfo = {};
     outLocInfo.location = builtInId;
     outLocInfo.isBuiltIn = true;
     outLocInfo.streamId = streamId;
 
     auto &xfbOutsInfo = resUsage->inOutUsage.gs.xfbOutsInfo;
-    auto locIter = xfbOutsInfo.find(outLocInfo.u32All);
+    auto locIter = xfbOutsInfo.find(outLocInfo.u16All);
     if (locIter != xfbOutsInfo.end()) {
       XfbOutInfo *xfbOutInfo = reinterpret_cast<XfbOutInfo *>(&xfbOutsInfo[locIter->first]);
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -724,14 +724,14 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       } else if (m_shaderStage == ShaderStageGeometry) {
         assert(callInst.getNumArgOperands() == 4);
 
-        GsOutLocInfo outLocInfo = {};
+        InOutLocationInfo outLocInfo = {};
         outLocInfo.location = value;
         outLocInfo.isBuiltIn = false;
         outLocInfo.streamId = cast<ConstantInt>(callInst.getOperand(2))->getZExtValue();
 
-        if (resUsage->inOutUsage.outputLocMap.find(outLocInfo.u32All) != resUsage->inOutUsage.outputLocMap.end()) {
+        if (resUsage->inOutUsage.outputLocMap.find(outLocInfo.u16All) != resUsage->inOutUsage.outputLocMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[outLocInfo.u32All];
+          loc = resUsage->inOutUsage.outputLocMap[outLocInfo.u16All];
         }
       } else {
         if (m_pipelineState->canPackInOut() && m_shaderStage == ShaderStageVertex &&

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1625,7 +1625,7 @@ void PatchResourceCollect::matchGenericInOut() {
         bool outputXfb = false;
         if (m_shaderStage == ShaderStageGeometry) {
           unsigned outLocInfo = locMap.first;
-          loc = reinterpret_cast<GsOutLocInfo *>(&outLocInfo)->location;
+          loc = reinterpret_cast<InOutLocationInfo *>(&outLocInfo)->location;
           outputXfb = inOutUsage.gs.xfbOutsInfo.find(outLocInfo) != inOutUsage.gs.xfbOutsInfo.end();
         }
 
@@ -1726,7 +1726,7 @@ void PatchResourceCollect::matchGenericInOut() {
       if (m_shaderStage == ShaderStageGeometry) {
         if (locMap.second == InvalidValue) {
           unsigned outLocInfo = locMap.first;
-          mapGsGenericOutput(*(reinterpret_cast<GsOutLocInfo *>(&outLocInfo)));
+          mapGsGenericOutput(*(reinterpret_cast<InOutLocationInfo *>(&outLocInfo)));
         }
       } else {
         if (locMap.second == InvalidValue) {
@@ -2528,13 +2528,13 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
 // Map locations of generic outputs of geometry shader to tightly packed ones.
 //
 // @param outLocInfo : GS output location info
-void PatchResourceCollect::mapGsGenericOutput(GsOutLocInfo outLocInfo) {
+void PatchResourceCollect::mapGsGenericOutput(InOutLocationInfo outLocInfo) {
   assert(m_shaderStage == ShaderStageGeometry);
   unsigned streamId = outLocInfo.streamId;
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageGeometry);
   auto &inOutUsage = resUsage->inOutUsage.gs;
 
-  resUsage->inOutUsage.outputLocMap[outLocInfo.u32All] = inOutUsage.outLocCount[streamId]++;
+  resUsage->inOutUsage.outputLocMap[outLocInfo.u16All] = inOutUsage.outLocCount[streamId]++;
 
   unsigned assignedLocCount =
       inOutUsage.outLocCount[0] + inOutUsage.outLocCount[1] + inOutUsage.outLocCount[2] + inOutUsage.outLocCount[3];
@@ -2543,7 +2543,7 @@ void PatchResourceCollect::mapGsGenericOutput(GsOutLocInfo outLocInfo) {
 
   LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: stream = " << outLocInfo.streamId << ", "
                 << " loc = " << outLocInfo.location
-                << "  =>  Mapped = " << resUsage->inOutUsage.outputLocMap[outLocInfo.u32All] << "\n");
+                << "  =>  Mapped = " << resUsage->inOutUsage.outputLocMap[outLocInfo.u16All] << "\n");
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -81,7 +81,7 @@ private:
   void matchGenericInOut();
   void mapBuiltInToGenericInOut();
 
-  void mapGsGenericOutput(GsOutLocInfo outLocInfo);
+  void mapGsGenericOutput(InOutLocationInfo outLocInfo);
   void mapGsBuiltInOutput(unsigned builtInId, unsigned elemCount);
 
   void packInOutLocation();


### PR DESCRIPTION
This change is to integrate all location infos into one struct
`InOutLocationInfo` to prepare for GS input/output packing. This change
will include:
- Remove `GsOutLocInfo`, and add `isBuiltIn` and `isStreamId` in
`InOutLocationInfo`.
- Replace the uses of `GsOutLocInfo` with `InOutLocationInfo`.