### PR TITLE
[CI] Switch to the new method for setting env vars

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -40,10 +40,9 @@ jobs:
           FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
           ASSERTS_LOWER=$(echo "${{ matrix.assertions }}" | tr "[:upper:]" "[:lower:]")
           TAG=$(printf "${{ matrix.image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER" "$ASSERTS_LOWER")
-          echo "::set-env name=IMAGE_TAG::$TAG"
+          echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
       - name: Build and Test AMDVLK with Docker
         run: |
-          echo "IMAGE_TAG: $IMAGE_TAG"
           docker build . --file docker/amdvlk.Dockerfile \
                          --build-arg BRANCH="${{ matrix.branch }}" \
                          --build-arg CONFIG="${{ matrix.config }}" \

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -31,8 +31,7 @@ jobs:
           FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
           ASSERTS_LOWER=$(echo "${{ matrix.assertions }}" | tr "[:upper:]" "[:lower:]")
           TAG=$(printf "${{ matrix.base-image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER" "$ASSERTS_LOWER")
-          echo "IMAGE_TAG: $TAG"
-          echo "::set-env name=IMAGE_TAG::$TAG"
+          echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker


### PR DESCRIPTION
The previous syntax go deprecated and generates warnings. See
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands.