### PR TITLE
Amend loop unroll threshold metadata

### DIFF
--- a/lgc/patch/PatchLoopMetadata.cpp
+++ b/lgc/patch/PatchLoopMetadata.cpp
@@ -188,7 +188,7 @@ bool PatchLoopMetadata::runOnModule(Module &module) {
                 // We will use a threshold of 250 to replace the disable hint.
                 const int UnrollThreshold = 250;
                 Metadata *thresholdMeta[] = {
-                    MDString::get(*m_context, "llvm.loop.unroll.threshold"),
+                    MDString::get(*m_context, "amdgpu.loop.unroll.threshold"),
                     ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(*m_context), UnrollThreshold))};
                 MDNode *thresholdMetaNode = MDNode::get(*m_context, thresholdMeta);
                 loopMetaNode = updateMetadata(loopMetaNode, {"llvm.loop.unroll.disable", "llvm.loop.disable_nonforced"},


### PR DESCRIPTION
Change the use of llvm.loop.unroll.threshold to amdgpu.loop.unroll.threshold
to match the change in the metadata name following the related LLVM code
review.