### PR TITLE
Replace inOutLocMap with inputLocMap/outputLocMap

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -287,22 +287,23 @@ void InOutBuilder::markGenericInputOutputUsage(bool isOutput, unsigned location,
   auto resUsage = getPipelineState()->getShaderResourceUsage(m_shaderStage);
 
   // Mark the input or output locations as in use.
-  std::map<unsigned, unsigned> *inOutLocMap = nullptr;
+  std::map<InOutLocationInfo, InOutLocationInfo> *inOutLocInfoMap = nullptr;
+  std::map<unsigned, unsigned> *perPatchInOutLocMap = nullptr;
   if (!isOutput) {
     if (m_shaderStage != ShaderStageTessEval || vertexIndex) {
       // Normal input
-      inOutLocMap = &resUsage->inOutUsage.inputLocMap;
+      inOutLocInfoMap = &resUsage->inOutUsage.inputLocInfoMap;
     } else {
       // TES per-patch input
-      inOutLocMap = &resUsage->inOutUsage.perPatchInputLocMap;
+      perPatchInOutLocMap = &resUsage->inOutUsage.perPatchInputLocMap;
     }
   } else {
     if (m_shaderStage != ShaderStageTessControl || vertexIndex) {
       // Normal output
-      inOutLocMap = &resUsage->inOutUsage.outputLocMap;
+      inOutLocInfoMap = &resUsage->inOutUsage.outputLocInfoMap;
     } else {
       // TCS per-patch output
-      inOutLocMap = &resUsage->inOutUsage.perPatchOutputLocMap;
+      perPatchInOutLocMap = &resUsage->inOutUsage.perPatchOutputLocMap;
     }
   }
 
@@ -316,15 +317,26 @@ void InOutBuilder::markGenericInputOutputUsage(bool isOutput, unsigned location,
     }
     unsigned startLocation = (keepAllLocations ? 0 : location);
     // Non-GS-output case.
-    for (unsigned i = startLocation; i < location + locationCount; ++i)
-      (*inOutLocMap)[i] = InvalidValue;
+    if (inOutLocInfoMap) {
+      for (unsigned i = startLocation; i < location + locationCount; ++i) {
+        InOutLocationInfo origLocationInfo;
+        origLocationInfo.setLocation(i);
+        auto &newLocationInfo = (*inOutLocInfoMap)[origLocationInfo];
+        newLocationInfo.setData(InvalidValue);
+      }
+    }
+    if (perPatchInOutLocMap) {
+      for (unsigned i = startLocation; i < location + locationCount; ++i)
+        (*perPatchInOutLocMap)[i] = InvalidValue;
+    }
   } else {
     // GS output. We include the stream ID with the location in the map key.
     for (unsigned i = 0; i < locationCount; ++i) {
-      InOutLocationInfo outLocInfo = {};
-      outLocInfo.location = location + i;
-      outLocInfo.streamId = inOutInfo.getStreamId();
-      (*inOutLocMap)[outLocInfo.u16All] = InvalidValue;
+      InOutLocationInfo outLocationInfo;
+      outLocationInfo.setLocation(location + i);
+      outLocationInfo.setStreamId(inOutInfo.getStreamId());
+      auto &newLocationInfo = (*inOutLocInfoMap)[outLocationInfo];
+      newLocationInfo.setData(InvalidValue);
     }
   }
 
@@ -555,10 +567,10 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
 
   if (m_shaderStage == ShaderStageGeometry) {
     // Mark the XFB output for copy shader generation.
-    InOutLocationInfo outLocInfo = {};
-    outLocInfo.location = location;
-    outLocInfo.isBuiltIn = isBuiltIn;
-    outLocInfo.streamId = streamId;
+    InOutLocationInfo outLocationInfo;
+    outLocationInfo.setLocation(location);
+    outLocationInfo.setBuiltIn(isBuiltIn);
+    outLocationInfo.setStreamId(streamId);
 
     XfbOutInfo xfbOutInfo = {};
     xfbOutInfo.xfbBuffer = xfbBuffer;
@@ -567,11 +579,11 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
     xfbOutInfo.xfbExtraOffset = 0;
 
     auto resUsage = getPipelineState()->getShaderResourceUsage(ShaderStageGeometry);
-    resUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u16All] = xfbOutInfo.u32All;
+    resUsage->inOutUsage.gs.xfbOutsInfo[outLocationInfo] = xfbOutInfo.u32All;
     if (valueToWrite->getType()->getPrimitiveSizeInBits() > 128) {
-      ++outLocInfo.location;
+      outLocationInfo.setLocation(location + 1);
       xfbOutInfo.xfbOffset += 32;
-      resUsage->inOutUsage.gs.xfbOutsInfo[outLocInfo.u16All] = xfbOutInfo.u32All;
+      resUsage->inOutUsage.gs.xfbOutsInfo[outLocationInfo] = xfbOutInfo.u32All;
     }
   }
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -89,16 +89,45 @@ struct FsInterpInfo {
 // Invalid interpolation info
 static const FsInterpInfo InvalidFsInterpInfo = {InvalidValue, false, false, false, false, false};
 
-// Represents the location info of input/output
-union InOutLocationInfo {
-  struct {
-    uint16_t half : 1;      // High half in case of 16-bit attriburtes
-    uint16_t component : 2; // The component index
-    uint16_t location : 10; // The location
-    uint16_t isBuiltIn : 1; // Whether location is actually built-in ID
-    uint16_t streamId : 2;  // Output vertex stream ID
-  };
-  uint16_t u16All;
+// Represents the location information on an input or output
+class InOutLocationInfo {
+public:
+  InOutLocationInfo() { m_data.u16All = 0; }
+  InOutLocationInfo(unsigned data) { this->m_data.u16All = static_cast<uint16_t>(data); }
+  InOutLocationInfo(const InOutLocationInfo &inOutLocInfo) { m_data.u16All = inOutLocInfo.getData(); }
+
+  unsigned getData() const { return static_cast<uint16_t>(m_data.u16All); }
+  void setData(unsigned data) { m_data.u16All = static_cast<uint16_t>(data); }
+  bool isInvalid() const { return m_data.u16All == 0xFFFF; }
+
+  bool isHighHalf() const { return m_data.bits.isHighHalf; }
+  void setHighHalf(bool isHighHalf) { m_data.bits.isHighHalf = isHighHalf; }
+
+  unsigned getComponent() const { return m_data.bits.component; }
+  void setComponent(unsigned compIdx) { m_data.bits.component = static_cast<uint16_t>(compIdx); }
+
+  unsigned getLocation() const { return m_data.bits.location; }
+  void setLocation(unsigned loc) { m_data.bits.location = static_cast<uint16_t>(loc); }
+
+  bool isBuiltIn() const { return m_data.bits.isBuiltIn; }
+  void setBuiltIn(bool isBuiltIn) { m_data.bits.isBuiltIn = isBuiltIn; }
+
+  unsigned getStreamId() const { return m_data.bits.streamId; }
+  void setStreamId(unsigned streamId) { m_data.bits.streamId = static_cast<uint16_t>(streamId); }
+
+  bool operator<(const InOutLocationInfo &rhs) const { return this->getData() < rhs.getData(); }
+
+private:
+  union {
+    struct {
+      uint16_t isHighHalf : 1; // High half in case of 16-bit attriburtes
+      uint16_t component : 2;  // The component index
+      uint16_t location : 10;  // The location
+      uint16_t isBuiltIn : 1;  // Whether location is actually built-in ID
+      uint16_t streamId : 2;   // Output vertex stream ID
+    } bits;
+    uint16_t u16All;
+  } m_data;
 };
 
 // Enumerate the workgroup layout options.
@@ -280,12 +309,9 @@ struct ResourceUsage {
 
   // Usage of generic input/output
   struct {
-    // Map from shader specified locations to tightly packed locations
-    std::map<unsigned, unsigned> inputLocMap;
-    std::map<unsigned, unsigned> outputLocMap;
-
-    // The original and new InOutLocations for shader cache
-    std::map<unsigned, unsigned> inOutLocMap;
+    // Map from shader specified InOutLocations to tightly packed InOutLocations
+    std::map<InOutLocationInfo, InOutLocationInfo> inputLocInfoMap;
+    std::map<InOutLocationInfo, InOutLocationInfo> outputLocInfoMap;
 
     std::map<unsigned, unsigned> perPatchInputLocMap;
     std::map<unsigned, unsigned> perPatchOutputLocMap;
@@ -361,7 +387,7 @@ struct ResourceUsage {
       std::unordered_map<unsigned, std::vector<unsigned>> genericOutByteSizes[MaxGsStreams];
 
       // Map from output location to the transform feedback info
-      std::map<unsigned, unsigned> xfbOutsInfo;
+      std::map<InOutLocationInfo, unsigned> xfbOutsInfo;
 
       // ID of the vertex stream sent to rasterizor
       unsigned rasterStream = 0;

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -557,10 +557,12 @@ void LowerFragColorExport::updateFragColors(CallInst *callInst, ColorExportValue
   const unsigned compIdx = cast<ConstantInt>(callInst->getOperand(1))->getZExtValue();
   Value *output = callInst->getOperand(2);
 
-  auto it = m_resUsage->inOutUsage.outputLocMap.find(location);
-  if (it == m_resUsage->inOutUsage.outputLocMap.end())
+  InOutLocationInfo origLocInfo;
+  origLocInfo.setLocation(location);
+  auto locInfoMapIt = m_resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+  if (locInfoMapIt == m_resUsage->inOutUsage.outputLocInfoMap.end())
     return;
-  unsigned hwColorTarget = it->second;
+  unsigned hwColorTarget = locInfoMapIt->second.getLocation();
 
   Type *outputTy = output->getType();
 

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -123,9 +123,8 @@ bool PatchCheckShaderCache::runOnModule(Module &module) {
     raw_string_ostream stream(inOutUsageStreams[stage]);
 
     // Update input/output usage
-    streamMapEntries(resUsage->inOutUsage.inputLocMap, stream);
-    streamMapEntries(resUsage->inOutUsage.outputLocMap, stream);
-    streamMapEntries(resUsage->inOutUsage.inOutLocMap, stream);
+    streamMapEntries(resUsage->inOutUsage.inputLocInfoMap, stream);
+    streamMapEntries(resUsage->inOutUsage.outputLocInfoMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchInputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchOutputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.builtInInputLocMap, stream);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -502,11 +502,14 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           }
         }
 
+        InOutLocationInfo origLocInfo;
+        origLocInfo.setLocation(value);
+        auto locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
         if (m_shaderStage == ShaderStageTessEval) {
           // NOTE: For generic inputs of tessellation evaluation shader, they could be per-patch ones.
-          if (resUsage->inOutUsage.inputLocMap.find(value) != resUsage->inOutUsage.inputLocMap.end())
-            loc = resUsage->inOutUsage.inputLocMap[value];
-          else {
+          if (locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end()) {
+            loc = locInfoMapIt->second.getLocation();
+          } else {
             assert(resUsage->inOutUsage.perPatchInputLocMap.find(value) !=
                    resUsage->inOutUsage.perPatchInputLocMap.end());
             loc = resUsage->inOutUsage.perPatchInputLocMap[value];
@@ -515,21 +518,16 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           if (m_pipelineState->canPackInOut() &&
               (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl)) {
             // The new InOutLocationInfo is used to map scalarized FS and TCS input import as compact as possible
-            InOutLocationInfo origLocInfo = {};
-            origLocInfo.location = value;
             const uint32_t elemIdxArgIdx = isInterpolantInputImport || m_shaderStage != ShaderStageFragment ? 2 : 1;
-            origLocInfo.component = cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue();
-            origLocInfo.half = false;
-            assert(resUsage->inOutUsage.inOutLocMap.find(origLocInfo.u16All) != resUsage->inOutUsage.inOutLocMap.end());
-
-            InOutLocationInfo newLocInfo = {};
-            newLocInfo.u16All = resUsage->inOutUsage.inOutLocMap[origLocInfo.u16All];
-            loc = newLocInfo.location;
-            elemIdx = builder.getInt32(newLocInfo.component);
-            highHalf = newLocInfo.half;
+            origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue());
+            locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
+            assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
+            loc = locInfoMapIt->second.getLocation();
+            elemIdx = builder.getInt32(locInfoMapIt->second.getComponent());
+            highHalf = locInfoMapIt->second.isHighHalf();
           } else {
-            assert(resUsage->inOutUsage.inputLocMap.find(value) != resUsage->inOutUsage.inputLocMap.end());
-            loc = resUsage->inOutUsage.inputLocMap[value];
+            assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
+            loc = locInfoMapIt->second.getLocation();
           }
         }
       }
@@ -650,9 +648,12 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       }
 
       // NOTE: For generic outputs of tessellation control shader, they could be per-patch ones.
-      if (resUsage->inOutUsage.outputLocMap.find(value) != resUsage->inOutUsage.outputLocMap.end())
-        loc = resUsage->inOutUsage.outputLocMap[value];
-      else {
+      InOutLocationInfo origLocInfo;
+      origLocInfo.setLocation(value);
+      auto locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+      if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
+        loc = locInfoMapIt->second.getLocation();
+      } else {
         assert(resUsage->inOutUsage.perPatchOutputLocMap.find(value) !=
                resUsage->inOutUsage.perPatchOutputLocMap.end());
         loc = resUsage->inOutUsage.perPatchOutputLocMap[value];
@@ -766,6 +767,10 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       Value *locOffset = nullptr;
       unsigned elemIdx = InvalidValue;
 
+      InOutLocationInfo origLocInfo;
+      origLocInfo.setLocation(value);
+      auto locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+
       if (m_shaderStage == ShaderStageTessControl) {
         // NOTE: If location offset is a constant, we have to add it to the unmapped location before querying
         // the mapped location. Meanwhile, we have to adjust the location offset to 0 (rebase it).
@@ -776,9 +781,9 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         }
 
         // NOTE: For generic outputs of tessellation control shader, they could be per-patch ones.
-        if (resUsage->inOutUsage.outputLocMap.find(value) != resUsage->inOutUsage.outputLocMap.end()) {
+        if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[value];
+          loc = locInfoMapIt->second.getLocation();
         } else if (resUsage->inOutUsage.perPatchOutputLocMap.find(value) !=
                    resUsage->inOutUsage.perPatchOutputLocMap.end()) {
           exist = true;
@@ -790,35 +795,27 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       } else if (m_shaderStage == ShaderStageGeometry) {
         assert(callInst.getNumArgOperands() == 4);
 
-        InOutLocationInfo outLocInfo = {};
-        outLocInfo.location = value;
-        outLocInfo.isBuiltIn = false;
-        outLocInfo.streamId = cast<ConstantInt>(callInst.getOperand(2))->getZExtValue();
-
-        if (resUsage->inOutUsage.outputLocMap.find(outLocInfo.u16All) != resUsage->inOutUsage.outputLocMap.end()) {
+        origLocInfo.setStreamId(cast<ConstantInt>(callInst.getOperand(2))->getZExtValue());
+        locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+        if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[outLocInfo.u16All];
+          loc = locInfoMapIt->second.getLocation();
         }
       } else {
-        if (m_pipelineState->canPackInOut() && m_shaderStage == ShaderStageVertex &&
-            m_pipelineState->hasShaderStage(ShaderStageTessControl)) {
-          // The new InOutLocationInfo is used to map scalarized VS output export in a VS-TCS-TES-FS to lds as compact
-          // as possible
-          InOutLocationInfo origLocInfo = {};
-          origLocInfo.location = value;
-          origLocInfo.component = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
-          origLocInfo.half = false;
-          if (resUsage->inOutUsage.inOutLocMap.find(origLocInfo.u16All) != resUsage->inOutUsage.inOutLocMap.end()) {
-            InOutLocationInfo newLocInfo = {};
-            newLocInfo.u16All = resUsage->inOutUsage.inOutLocMap[origLocInfo.u16All];
-            loc = newLocInfo.location;
-            elemIdx = newLocInfo.component;
+        if (m_pipelineState->canPackInOut()) {
+          assert(m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval);
+          origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(1))->getZExtValue());
+          locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+          if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
+            loc = locInfoMapIt->second.getLocation();
+            elemIdx = locInfoMapIt->second.getComponent();
             exist = true;
-          } else
+          } else {
             exist = false;
-        } else if (resUsage->inOutUsage.outputLocMap.find(value) != resUsage->inOutUsage.outputLocMap.end()) {
+          }
+        } else if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[value];
+          loc = locInfoMapIt->second.getLocation();
         }
       }
 
@@ -1348,8 +1345,8 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
       // generic outputs that are not written to.  We need to count them in
       // the export count.
       auto resUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage);
-      for (auto locMap : resUsage->inOutUsage.outputLocMap) {
-        if (m_expLocs.count(locMap.second) != 0)
+      for (const auto &locInfoPair : resUsage->inOutUsage.outputLocInfoMap) {
+        if (m_expLocs.count(locInfoPair.second.getLocation()) != 0)
           continue;
         ++inOutUsage.expCount;
       }

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -143,13 +143,16 @@ bool PatchNullFragShader::runOnModule(Module &module) {
   // Add usage info for dummy input
   FsInterpInfo interpInfo = {0, false, false, false, false, false};
   resUsage->builtInUsage.fs.smooth = true;
-  resUsage->inOutUsage.inputLocMap[0] = InvalidValue;
+  InOutLocationInfo origLocInfo;
+  auto &newInLocInfo = resUsage->inOutUsage.inputLocInfoMap[origLocInfo];
+  newInLocInfo.setData(InvalidValue);
   resUsage->inOutUsage.fs.interpInfo.push_back(interpInfo);
 
   // Add usage info for dummy output
   resUsage->inOutUsage.fs.cbShaderMask = 0;
   resUsage->inOutUsage.fs.isNullFs = true;
-  resUsage->inOutUsage.outputLocMap[0] = InvalidValue;
+  auto &newOutLocInfo = resUsage->inOutUsage.outputLocInfoMap[origLocInfo];
+  newOutLocInfo.setData(InvalidValue);
 
   return true;
 }

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include <set>
 
 #define DEBUG_TYPE "lgc-patch-resource-collect"
 
@@ -1318,19 +1319,19 @@ void PatchResourceCollect::clearInactiveInput() {
     // is easy to cause incorrectness of location mapping.
 
     // Clear normal inputs
-    std::unordered_set<unsigned> unusedLocs;
-    for (auto locMap : m_resUsage->inOutUsage.inputLocMap) {
-      unsigned loc = locMap.first;
+    std::set<InOutLocationInfo> unusedLocInfos;
+    for (const auto &locInfoPair : m_resUsage->inOutUsage.inputLocInfoMap) {
+      unsigned loc = locInfoPair.first.getLocation();
       if (m_activeInputLocs.find(loc) == m_activeInputLocs.end())
-        unusedLocs.insert(loc);
+        unusedLocInfos.insert(locInfoPair.first);
     }
 
-    for (auto loc : unusedLocs)
-      m_resUsage->inOutUsage.inputLocMap.erase(loc);
+    for (auto locInfo : unusedLocInfos)
+      m_resUsage->inOutUsage.inputLocInfoMap.erase(locInfo);
 
     // Clear per-patch inputs
     if (m_shaderStage == ShaderStageTessEval) {
-      unusedLocs.clear();
+      std::unordered_set<unsigned> unusedLocs;
       for (auto locMap : m_resUsage->inOutUsage.perPatchInputLocMap) {
         unsigned loc = locMap.first;
         if (m_activeInputLocs.find(loc) == m_activeInputLocs.end())
@@ -1601,8 +1602,8 @@ void PatchResourceCollect::matchGenericInOut() {
   assert(m_pipelineState->isGraphics());
   auto &inOutUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage;
 
-  auto &inLocMap = inOutUsage.inputLocMap;
-  auto &outLocMap = inOutUsage.outputLocMap;
+  auto &inLocInfoMap = inOutUsage.inputLocInfoMap;
+  auto &outLocInfoMap = inOutUsage.outputLocInfoMap;
 
   auto &perPatchInLocMap = inOutUsage.perPatchInputLocMap;
   auto &perPatchOutLocMap = inOutUsage.perPatchOutputLocMap;
@@ -1614,36 +1615,35 @@ void PatchResourceCollect::matchGenericInOut() {
     // Do normal input/output matching
     if (nextStage != ShaderStageInvalid) {
       const auto nextResUsage = m_pipelineState->getShaderResourceUsage(nextStage);
-      const auto &nextInLocMap = nextResUsage->inOutUsage.inputLocMap;
+      const auto &nextInLocInfoMap = nextResUsage->inOutUsage.inputLocInfoMap;
 
       unsigned availInMapLoc = nextResUsage->inOutUsage.inputMapLocCount;
 
       // Collect locations of those outputs that are not used by next shader stage
-      std::vector<unsigned> unusedLocs;
-      for (auto &locMap : outLocMap) {
-        unsigned loc = locMap.first;
+      std::vector<InOutLocationInfo> unusedLocInfos;
+      for (auto &locInfoPair : outLocInfoMap) {
+        unsigned loc = locInfoPair.first.getLocation();
         bool outputXfb = false;
-        if (m_shaderStage == ShaderStageGeometry) {
-          unsigned outLocInfo = locMap.first;
-          loc = reinterpret_cast<InOutLocationInfo *>(&outLocInfo)->location;
-          outputXfb = inOutUsage.gs.xfbOutsInfo.find(outLocInfo) != inOutUsage.gs.xfbOutsInfo.end();
-        }
+        if (m_shaderStage == ShaderStageGeometry)
+          outputXfb = inOutUsage.gs.xfbOutsInfo.find(locInfoPair.first) != inOutUsage.gs.xfbOutsInfo.end();
 
-        if (nextInLocMap.find(loc) == nextInLocMap.end() && !outputXfb) {
+        if (nextInLocInfoMap.find(locInfoPair.first) == nextInLocInfoMap.end() && !outputXfb) {
           if (m_hasDynIndexedOutput || m_importedOutputLocs.find(loc) != m_importedOutputLocs.end()) {
             // NOTE: If either dynamic indexing of generic outputs exists or the generic output involve in
             // output import, we have to mark it as active. The assigned location must not overlap with
             // those used by inputs of next shader stage.
             assert(m_shaderStage == ShaderStageTessControl);
-            locMap.second = availInMapLoc++;
+            auto &newLocationInfo = locInfoPair.second;
+            newLocationInfo.setData(0);
+            newLocationInfo.setLocation(availInMapLoc++);
           } else
-            unusedLocs.push_back(locMap.first);
+            unusedLocInfos.push_back(locInfoPair.first);
         }
       }
 
       // Remove those collected locations
-      for (auto loc : unusedLocs)
-        outLocMap.erase(loc);
+      for (auto locInfo : unusedLocInfos)
+        outLocInfoMap.erase(locInfo);
     }
 
     // Do per-patch input/output matching
@@ -1690,20 +1690,29 @@ void PatchResourceCollect::matchGenericInOut() {
   LLPC_OUTS("// LLPC location input/output mapping results (" << getShaderStageAbbreviation(m_shaderStage)
                                                               << " shader)\n\n");
   unsigned nextMapLoc = 0;
-  if (!inLocMap.empty()) {
+  if (!inLocInfoMap.empty()) {
     assert(inOutUsage.inputMapLocCount == 0);
-    for (auto &locMap : inLocMap) {
-      assert(locMap.second == InvalidValue || m_pipelineState->isUnlinked());
-      // NOTE: For vertex shader, the input location mapping is actually trivial.
-      locMap.second = m_shaderStage == ShaderStageVertex ? locMap.first : nextMapLoc++;
-      inOutUsage.inputMapLocCount = std::max(inOutUsage.inputMapLocCount, locMap.second + 1);
-      LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Input:  loc = " << locMap.first
-                    << "  =>  Mapped = " << locMap.second << "\n");
+    for (auto &locInfoPair : inLocInfoMap) {
+
+      auto &newLocationInfo = locInfoPair.second;
+      if (m_shaderStage == ShaderStageVertex) {
+        // NOTE: For vertex shader, use the orignal location as the remapped location
+        newLocationInfo = locInfoPair.first;
+      } else if (newLocationInfo.isInvalid() || m_pipelineState->isUnlinked()) {
+        // For other shaders, map the location to continous locations if they are not mapped or in un-linked mode
+        newLocationInfo.setData(0);
+        newLocationInfo.setLocation(nextMapLoc++);
+      }
+      const unsigned newLocation = locInfoPair.second.getLocation();
+
+      inOutUsage.inputMapLocCount = std::max(inOutUsage.inputMapLocCount, newLocation + 1);
+      LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Input:  loc = "
+                    << locInfoPair.first.getLocation() << "  =>  Mapped = " << newLocation << "\n");
     }
     LLPC_OUTS("\n");
   }
 
-  if (!outLocMap.empty()) {
+  if (!outLocInfoMap.empty()) {
     auto &outOrigLocs = inOutUsage.fs.outputOrigLocs;
     if (m_shaderStage == ShaderStageFragment)
       memset(&outOrigLocs, InvalidValue, sizeof(inOutUsage.fs.outputOrigLocs));
@@ -1712,37 +1721,48 @@ void PatchResourceCollect::matchGenericInOut() {
     assert(inOutUsage.outputMapLocCount == 0);
     bool generatingColorExportShader = m_shaderStage == ShaderStageFragment;
     generatingColorExportShader &= m_pipelineState->isUnlinked() && !m_pipelineState->hasColorExportFormats();
-    for (auto locMapIt = outLocMap.begin(); locMapIt != outLocMap.end();) {
-      auto &locMap = *locMapIt;
+
+    for (auto locInfoMapIt = outLocInfoMap.begin(); locInfoMapIt != outLocInfoMap.end();) {
+      const unsigned origLocation = locInfoMapIt->first.getLocation();
+      auto &newLocationInfo = locInfoMapIt->second;
+
       if (m_shaderStage == ShaderStageFragment) {
-        unsigned location = locMap.first;
         if (!generatingColorExportShader &&
-            m_pipelineState->getColorExportFormat(location).dfmt == BufDataFormatInvalid) {
-          locMapIt = outLocMap.erase(locMapIt);
+            m_pipelineState->getColorExportFormat(origLocation).dfmt == BufDataFormatInvalid) {
+          locInfoMapIt = outLocInfoMap.erase(locInfoMapIt);
           continue;
         }
       }
 
-      if (m_shaderStage == ShaderStageGeometry) {
-        if (locMap.second == InvalidValue) {
-          unsigned outLocInfo = locMap.first;
-          mapGsGenericOutput(*(reinterpret_cast<InOutLocationInfo *>(&outLocInfo)));
-        }
+      if (m_shaderStage == ShaderStageGeometry && newLocationInfo.isInvalid()) {
+        // TODO: pack GS outputs
+        const unsigned streamId = locInfoMapIt->first.getStreamId();
+        newLocationInfo.setData(0);
+        newLocationInfo.setLocation(inOutUsage.gs.outLocCount[streamId]++);
+        newLocationInfo.setStreamId(streamId);
+
+        unsigned assignedLocCount = inOutUsage.gs.outLocCount[0] + inOutUsage.gs.outLocCount[1] +
+                                    inOutUsage.gs.outLocCount[2] + inOutUsage.gs.outLocCount[3];
+
+        inOutUsage.outputMapLocCount = std::max(inOutUsage.outputMapLocCount, assignedLocCount);
+        LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: stream = " << streamId << ", "
+                      << " loc = " << origLocation << "  =>  Mapped = " << newLocationInfo.getLocation() << "\n");
       } else {
-        if (locMap.second == InvalidValue) {
-          // Only do location mapping if the output has not been mapped
-          locMap.second = nextMapLoc++;
-        } else
-          assert(m_shaderStage == ShaderStageTessControl);
-        inOutUsage.outputMapLocCount = std::max(inOutUsage.outputMapLocCount, locMap.second + 1);
-        LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: loc = " << locMap.first
-                      << "  =>  Mapped = " << locMap.second << "\n");
+        if (newLocationInfo.isInvalid()) {
+          newLocationInfo.setData(0);
+          newLocationInfo.setLocation(nextMapLoc++);
+        }
+        const unsigned newLocation = newLocationInfo.getLocation();
+
+        inOutUsage.outputMapLocCount = std::max(inOutUsage.outputMapLocCount, newLocation + 1);
+        LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: loc = " << origLocation
+                      << "  =>  Mapped = " << newLocation << "\n");
 
         if (m_shaderStage == ShaderStageFragment)
-          outOrigLocs[locMap.second] = locMap.first;
+          outOrigLocs[newLocation] = origLocation;
       }
 
-      ++locMapIt;
+      ++locInfoMapIt;
     }
     LLPC_OUTS("\n");
   }
@@ -2389,7 +2409,7 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       }
     } else if (nextStage == ShaderStageInvalid) {
       // GS only
-      unsigned availOutMapLoc = inOutUsage.outputLocMap.size(); // Reset available location
+      unsigned availOutMapLoc = inOutUsage.outputLocInfoMap.size(); // Reset available location
 
       if (builtInUsage.gs.clipDistance > 0 || builtInUsage.gs.cullDistance > 0) {
         unsigned mapLoc = availOutMapLoc++;
@@ -2528,22 +2548,25 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
 // Map locations of generic outputs of geometry shader to tightly packed ones.
 //
 // @param outLocInfo : GS output location info
-void PatchResourceCollect::mapGsGenericOutput(InOutLocationInfo outLocInfo) {
+void PatchResourceCollect::mapGsGenericOutput(const InOutLocationInfo &outLocInfo) {
   assert(m_shaderStage == ShaderStageGeometry);
-  unsigned streamId = outLocInfo.streamId;
+  unsigned streamId = outLocInfo.getStreamId();
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageGeometry);
   auto &inOutUsage = resUsage->inOutUsage.gs;
 
-  resUsage->inOutUsage.outputLocMap[outLocInfo.u16All] = inOutUsage.outLocCount[streamId]++;
+  auto &newLocInfo = resUsage->inOutUsage.outputLocInfoMap[outLocInfo];
+  newLocInfo.setData(0);
+  const unsigned newLocation = inOutUsage.outLocCount[streamId]++;
+  newLocInfo.setLocation(newLocation);
+  newLocInfo.setStreamId(streamId);
 
   unsigned assignedLocCount =
       inOutUsage.outLocCount[0] + inOutUsage.outLocCount[1] + inOutUsage.outLocCount[2] + inOutUsage.outLocCount[3];
 
   resUsage->inOutUsage.outputMapLocCount = std::max(resUsage->inOutUsage.outputMapLocCount, assignedLocCount);
 
-  LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: stream = " << outLocInfo.streamId << ", "
-                << " loc = " << outLocInfo.location
-                << "  =>  Mapped = " << resUsage->inOutUsage.outputLocMap[outLocInfo.u16All] << "\n");
+  LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: stream = " << streamId << ", "
+                << " loc = " << outLocInfo.getLocation() << "  =>  Mapped = " << newLocation << "\n");
 }
 
 // =====================================================================================================================
@@ -2574,7 +2597,7 @@ void PatchResourceCollect::packInOutLocation() {
   if (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl) {
     // Build location map based on FS (VS-FS, TES-FS) and TCS spans
     m_locationMapManager->buildLocationMap(m_shaderStage == ShaderStageFragment);
-    fillInOutLocMap();
+    fillInOutLocInfoMap();
   } else {
     reassembleOutputExportCalls();
 
@@ -2582,8 +2605,8 @@ void PatchResourceCollect::packInOutLocation() {
     // remapped location
     auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
     if (nextStage != ShaderStageInvalid) {
-      m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.inOutLocMap =
-          m_pipelineState->getShaderResourceUsage(nextStage)->inOutUsage.inOutLocMap;
+      m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.outputLocInfoMap =
+          m_pipelineState->getShaderResourceUsage(nextStage)->inOutUsage.inputLocInfoMap;
     }
   }
   // Clear it to hold previous calls
@@ -2591,17 +2614,16 @@ void PatchResourceCollect::packInOutLocation() {
 }
 
 // =====================================================================================================================
-// Fill inOutLocMap based on FS or TCS input import calls
-void PatchResourceCollect::fillInOutLocMap() {
+// Fill inputLocInfoMap based on FS or TCS input import calls
+void PatchResourceCollect::fillInOutLocInfoMap() {
   if (m_inOutCalls.empty())
     return;
 
   assert(m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl);
 
   auto &inOutUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage;
-  auto &inputLocMap = inOutUsage.inputLocMap;
-  inputLocMap.clear();
-  inOutUsage.inOutLocMap.clear();
+  auto &inputLocInfoMap = inOutUsage.inputLocInfoMap;
+  inputLocInfoMap.clear();
 
   // TCS: @llpc.input.import.generic.%Type%(i32 location, i32 locOffset, i32 elemIdx, i32 vertexIdx)
   // FS:  @llpc.input.import.generic.%Type%(i32 location, i32 elemIdx, i32 interpMode, i32 interpLoc)
@@ -2618,20 +2640,16 @@ void PatchResourceCollect::fillInOutLocMap() {
       compIdxArgIdx = 2;
     }
 
-    // Construct original InOutLocation from the location and elemIdx operands of the FS' or TCS' input import call
-    InOutLocation origInLoc = {};
-    origInLoc.locationInfo.location = cast<ConstantInt>(call->getOperand(0))->getZExtValue() + locOffset;
-    origInLoc.locationInfo.component = cast<ConstantInt>(call->getOperand(compIdxArgIdx))->getZExtValue();
-    origInLoc.locationInfo.half = false;
+    // Construct original InOutLocationInfo from the location and elemIdx operands of the FS' or TCS' input import call
+    InOutLocationInfo origLocInfo;
+    origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue() + locOffset);
+    origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(compIdxArgIdx))->getZExtValue());
 
-    // Get the packed InOutLocation from locationMap
-    const InOutLocation *newInLoc = nullptr;
-    assert(m_locationMapManager->findMap(origInLoc, newInLoc));
-    m_locationMapManager->findMap(origInLoc, newInLoc);
-
-    // TODO: inputLocMap can be removed
-    inputLocMap[newInLoc->locationInfo.location] = InvalidValue;
-    inOutUsage.inOutLocMap[origInLoc.asIndex()] = newInLoc->asIndex();
+    // Get the packed InOutLocationInfo from locationMap
+    InOutLocationInfoMap::const_iterator mapIter;
+    assert(m_locationMapManager->findMap(origLocInfo, mapIter));
+    m_locationMapManager->findMap(origLocInfo, mapIter);
+    inputLocInfoMap.insert({origLocInfo, mapIter->second});
   }
 }
 
@@ -2644,12 +2662,12 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
   BuilderBase builder(*m_context);
   builder.SetInsertPoint(m_inOutCalls.back());
 
-  auto &inOutUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage;
-
   // ElementsInfo represents the info of composing a vector in a location
   struct ElementsInfo {
     // Elements to be packed in one location, where 32-bit element is placed at the even index
     Value *elements[8];
+    // The corresponding call of each element
+    CallInst *outCalls[8];
     // Element number of 32-bit
     unsigned elemCountOf32bit;
     // Element number of 16-bit
@@ -2657,23 +2675,23 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
   };
 
   // Collect ElementsInfo in each packed location
-  ElementsInfo elemsInfo = {{nullptr}, 0, false};
+  ElementsInfo elemsInfo = {{nullptr}, {nullptr}, 0, 0};
   std::vector<ElementsInfo> elementsInfoArray(m_inOutCalls.size(), elemsInfo);
   for (auto call : m_inOutCalls) {
-    InOutLocation origOutLoc = {};
-    origOutLoc.locationInfo.location = cast<ConstantInt>(call->getOperand(0))->getZExtValue();
-    origOutLoc.locationInfo.component = cast<ConstantInt>(call->getOperand(1))->getZExtValue();
-    origOutLoc.locationInfo.half = false;
+    InOutLocationInfo origLocInfo;
+    origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue());
+    origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(1))->getZExtValue());
 
-    const InOutLocation *newInLoc = nullptr;
-    if (!m_locationMapManager->findMap(origOutLoc, newInLoc)) {
+    InOutLocationInfoMap::const_iterator mapIter;
+    if (!m_locationMapManager->findMap(origLocInfo, mapIter)) {
       // An unused export call
       continue;
     }
 
-    const unsigned newLoc = newInLoc->locationInfo.location;
+    const unsigned newLoc = mapIter->second.getLocation();
     auto &elementsInfo = elementsInfoArray[newLoc];
-    unsigned elemIdx = newInLoc->locationInfo.component * 2 + newInLoc->locationInfo.half;
+    unsigned elemIdx = mapIter->second.getComponent() * 2 + mapIter->second.isHighHalf();
+    elementsInfo.outCalls[elemIdx] = call;
 
     // Bit cast i8/i16/f16 to i32 for packing in a 32-bit component
     Value *element = call->getOperand(2);
@@ -2697,11 +2715,7 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
   }
 
   // Re-assamble XX' output export calls for each packed location
-  auto &outputLocMap = inOutUsage.outputLocMap;
-  outputLocMap.clear();
-
   Value *args[3] = {};
-  unsigned newLoc = 0;
   for (auto &elementsInfo : elementsInfoArray) {
     if (elementsInfo.elemCountOf16bit + elementsInfo.elemCountOf32bit == 0) {
       // It's the end of the packed location
@@ -2738,16 +2752,14 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
       }
     }
 
-    // Create an output export call at new location with packed value
-    args[0] = builder.getInt32(newLoc);
-    args[1] = builder.getInt32(0);
+    // Create an output export call with the original call aurgement
+    args[0] = elementsInfo.outCalls[0]->getOperand(0);
+    args[1] = elementsInfo.outCalls[0]->getOperand(1);
     args[2] = outValue;
 
     std::string callName(lgcName::OutputExportGeneric);
     addTypeMangling(nullptr, args, callName);
     builder.CreateNamedCall(callName, builder.getVoidTy(), args, {});
-
-    outputLocMap[newLoc++] = InvalidValue;
   }
 }
 
@@ -2768,11 +2780,17 @@ void PatchResourceCollect::scalarizeForInOutPacking(Module *module) {
       for (User *user : func.users()) {
         auto call = cast<CallInst>(user);
         ShaderStage shaderStage = m_pipelineShaders->getShaderStage(call->getFunction());
-        if (shaderStage == ShaderStageFragment || shaderStage == ShaderStageTessControl) {
-          // This is a workaround to disable pack for the pipeline if there exists dynamic component index
-          // TODO: Do partial packing except calls with dynamic component index in future change
-          const unsigned elemArgIdx = (shaderStage == ShaderStageFragment && !isInterpolant) ? 1 : 2;
-          if (!isa<ConstantInt>(call->getOperand(elemArgIdx))) {
+        const bool isFs = shaderStage == ShaderStageFragment;
+        const bool isTcs = shaderStage == ShaderStageTessControl;
+        if (isFs || isTcs) {
+          // This is a workaround to disable pack for the pipeline if there exists dynamic index in TCS
+          // TODO: Do partial packing except calls with dynamic index in future change
+          // NOTE: Dynamic index (location offset or component) in FS is processed to be constant in lower pass.
+          assert(!isInterpolant ||
+                 (isInterpolant && isa<ConstantInt>(call->getOperand(1)) && isa<ConstantInt>(call->getOperand(2))));
+          const bool hasDynIdx =
+              isTcs && (!isa<ConstantInt>(call->getOperand(1)) || !isa<ConstantInt>(call->getOperand(2)));
+          if (hasDynIdx) {
             m_pipelineState->setPackInOut(false);
             break;
           }
@@ -2989,9 +3007,8 @@ void InOutLocationMapManager::addSpan(CallInst *call, ShaderStage shaderStage) {
   }
 
   LocationSpan span = {};
-  span.firstLocation.locationInfo.location = cast<ConstantInt>(call->getOperand(0))->getZExtValue() + locOffset;
-  span.firstLocation.locationInfo.component = cast<ConstantInt>(call->getOperand(compIdxArgIdx))->getZExtValue();
-  span.firstLocation.locationInfo.half = false;
+  span.firstLocation.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue() + locOffset);
+  span.firstLocation.setComponent(cast<ConstantInt>(call->getOperand(compIdxArgIdx))->getZExtValue());
 
   unsigned bitWidth = call->getType()->getScalarSizeInBits();
   if (isTcs && bitWidth < 32)
@@ -3015,18 +3032,18 @@ void InOutLocationMapManager::addSpan(CallInst *call, ShaderStage shaderStage) {
 }
 
 // =====================================================================================================================
-// Build the map between orignal InOutLocation and packed InOutLocation based on sorted locaiton spans
+// Build the map between orignal InOutLocationInfo and packed InOutLocationInfo based on sorted locaiton spans
 //
 // @param checkCompatibility : whether to check compatibilty between two spans to start a new location
 void InOutLocationMapManager::buildLocationMap(bool checkCompatibility) {
   if (m_locationSpans.empty())
     return;
-  // Sort m_locationSpans based on LocationSpan::GetCompatibilityKey() and InOutLocation::AsIndex()
+  // Sort m_locationSpans based on LocationSpan::GetCompatibilityKey() and InOutLocationInfo::AsIndex()
   std::sort(m_locationSpans.begin(), m_locationSpans.end());
 
   m_locationMap.clear();
 
-  // Map original InOutLocation to new InOutLocation
+  // Map original InOutLocationInfo to new InOutLocationInfo
   unsigned consectiveLocation = 0;
   unsigned compIdx = 0;
   bool isHighHalf = false;
@@ -3050,12 +3067,11 @@ void InOutLocationMapManager::buildLocationMap(bool checkCompatibility) {
     }
 
     // Add a location map item
-    InOutLocation newLocation = {};
-    newLocation.locationInfo.location = consectiveLocation;
-    newLocation.locationInfo.component = compIdx;
-    newLocation.locationInfo.half = isHighHalf;
-    InOutLocation &origLocation = spanIt->firstLocation;
-    m_locationMap[origLocation] = newLocation;
+    InOutLocationInfo newLocInfo;
+    newLocInfo.setLocation(consectiveLocation);
+    newLocInfo.setComponent(compIdx);
+    newLocInfo.setHighHalf(isHighHalf);
+    m_locationMap.insert({spanIt->firstLocation, newLocInfo});
 
     // Update component index
     if ((spanIt->compatibilityInfo.is16Bit && isHighHalf) || !spanIt->compatibilityInfo.is16Bit)
@@ -3068,17 +3084,14 @@ void InOutLocationMapManager::buildLocationMap(bool checkCompatibility) {
 }
 
 // =====================================================================================================================
-// Output a mapped InOutLocation from a given InOutLocation if the mapping exists
+// Output a mapped InOutLocationInfo from a given InOutLocationInfo if the mapping exists
 //
-// @param originalLocation : The original InOutLocation
-// @param [out] newLocation : The new InOutLocation
-bool InOutLocationMapManager::findMap(const InOutLocation &originalLocation, const InOutLocation *&newLocation) {
-  auto it = m_locationMap.find(originalLocation);
-  if (it == m_locationMap.end())
-    return false;
-
-  newLocation = &(it->second);
-  return true;
+// @param origLocInfo : The original InOutLocationInfo
+// @param [out] mapIt : Iterator to an element of m_locationMap with key equivalent to the given InOutLocationInfo
+bool InOutLocationMapManager::findMap(const InOutLocationInfo &origLocInfo,
+                                      InOutLocationInfoMap::const_iterator &mapIt) {
+  mapIt = m_locationMap.find(origLocInfo);
+  return mapIt != m_locationMap.end();
 }
 
 } // namespace lgc

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -999,7 +999,7 @@ void PipelineState::initializePackInOut() {
   // Pack input/output requirements:
   // 1) -pack-in-out option is on
   // 2) It supports VS-FS, VS-TCS-TES-(FS)
-  if (PackInOut && hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
+  if (PackInOut && !m_unlinked && hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
     const unsigned nextStage = getNextShaderStage(ShaderStageVertex);
     m_packInOut = nextStage == ShaderStageFragment || nextStage == ShaderStageTessControl;
   }


### PR DESCRIPTION
`InOutLocMap` is introduced to a <unsigned, unsigned> map for
input/output packing by decoding the unsigned as `InOutLocationInfo`.
However, it is a bit reduncant. Original `inputLocMap`/`outputLocMap`
also do a <unsigned, unsigned> mapping from user specified locations to
concecutive locations. We could reuse it by uniformly decoding the
unsigned as `InOutLocationInfo` for both packing and non-packing code
paths. This change will include:
- Rename `inputLocMap`/`outputLocMap` to
`inputLocInfoMap`/`outputLocInfoMap` to distinguish with pure location
maps.
- In packing code path, replace `inOutLocMap` with
`inputLocInfoMap`/`outputLocInfoMap`.
- In non-packing code path, construct a `InOutLocationInfo` for map
lookup and extract requried bit field from mapped `InOutLocationInfo`.