### PR TITLE
Move image descriptor workaround to a later workaround patch pass

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -121,6 +121,7 @@ target_sources(LLVMlgc PRIVATE
     patch/PatchPreparePipelineAbi.cpp
     patch/PatchResourceCollect.cpp
     patch/PatchSetupTargetFeatures.cpp
+    patch/PatchWorkarounds.cpp
     patch/ShaderInputs.cpp
     patch/ShaderMerger.cpp
     patch/SystemValues.cpp

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -412,9 +412,6 @@ private:
   // Patch descriptor with cube dimension for image call
   llvm::Value *patchCubeDescriptor(llvm::Value *desc, unsigned dim);
 
-  // Patch invalid resource descriptor for image call
-  llvm::Value *patchInvalidImageDescriptor(llvm::Value *desc);
-
   // Handle cases where we need to add the FragCoord x,y to the coordinate, and use ViewIndex as the z coordinate.
   llvm::Value *handleFragCoordViewIndex(llvm::Value *coord, unsigned flags, unsigned &dim);
 

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -58,6 +58,7 @@ void initializePatchPeepholeOptPass(PassRegistry &);
 void initializePatchPreparePipelineAbiPass(PassRegistry &);
 void initializePatchResourceCollectPass(PassRegistry &);
 void initializePatchSetupTargetFeaturesPass(PassRegistry &);
+void initializePatchWorkaroundsPass(PassRegistry &);
 
 } // namespace llvm
 
@@ -84,6 +85,7 @@ inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializePatchPreparePipelineAbiPass(passRegistry);
   initializePatchResourceCollectPass(passRegistry);
   initializePatchSetupTargetFeaturesPass(passRegistry);
+  initializePatchWorkaroundsPass(passRegistry);
 }
 
 llvm::ModulePass *createLowerFragColorExport();
@@ -101,6 +103,7 @@ llvm::FunctionPass *createPatchPeepholeOpt();
 llvm::ModulePass *createPatchPreparePipelineAbi(bool onlySetCallingConvs);
 llvm::ModulePass *createPatchResourceCollect();
 llvm::ModulePass *createPatchSetupTargetFeatures();
+llvm::ModulePass *createPatchWorkarounds();
 
 class PipelineState;
 

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -111,6 +111,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Patch resource collecting, remove inactive resources (should be the first preliminary pass)
   passMgr.add(createPatchResourceCollect());
 
+  // Patch workarounds
+  passMgr.add(createPatchWorkarounds());
+
   // Generate copy shader if necessary.
   passMgr.add(createPatchCopyShader());
 

--- a/lgc/patch/PatchWorkarounds.cpp
+++ b/lgc/patch/PatchWorkarounds.cpp
@@ -1,0 +1,186 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchWorkarounds.cpp
+ * @brief LLPC source file: contains implementation of class lgc::PatchWorkarounds.
+ ***********************************************************************************************************************
+ */
+
+#include "PatchWorkarounds.h"
+#include "lgc/BuilderBase.h"
+#include "lgc/state/PipelineShaders.h"
+#include "lgc/state/PipelineState.h"
+#include "lgc/state/TargetInfo.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "lgc-patch-workarounds"
+
+using namespace lgc;
+using namespace llvm;
+
+namespace lgc {
+
+// =====================================================================================================================
+// Define static members (no initializer needed as LLVM only cares about the address of ID, never its value).
+char PatchWorkarounds::ID;
+
+// =====================================================================================================================
+// Pass creator, creates the pass of LLVM patching operations for peephole optimizations.
+ModulePass *createPatchWorkarounds() {
+  return new PatchWorkarounds();
+}
+
+PatchWorkarounds::PatchWorkarounds() : Patch(ID) {
+}
+
+// =====================================================================================================================
+// Executes this LLVM pass on the specified LLVM function.
+//
+// @param [in/out] module : Module that we will add workarounds in.
+bool PatchWorkarounds::runOnModule(Module &module) {
+  LLVM_DEBUG(dbgs() << "Run the pass Patch-Workarounds\n");
+
+  Patch::init(&module);
+
+  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  m_builder = std::make_unique<IRBuilder<>>(*m_context);
+  m_processed.clear();
+
+  m_changed = false;
+
+  // Patch image resource descriptor when app provides wrong type
+  applyImageDescWorkaround();
+
+  return m_changed;
+}
+
+// =====================================================================================================================
+// Apply resource descriptor workaround where application is erroneously providing a buffer descriptor when it should
+// be an image descriptor. We only have to apply the workaround for gfx10.1 (note: this is an application error that
+// are handling gracefully)
+//
+void PatchWorkarounds::applyImageDescWorkaround(void) {
+  if (!m_pipelineState->getOptions().disableImageResourceCheck &&
+      m_pipelineState->getTargetInfo().getGpuWorkarounds().gfx10.waFixBadImageDescriptor) {
+
+    for (const Function &func : m_module->getFunctionList()) {
+      if (func.getName().startswith("llvm.amdgcn.image")) {
+        // Build up a list of uses (since we modify we can't process them immediately)
+        SmallVector<CallInst *, 8> useWorkList;
+        for (auto &use : func.uses()) {
+          if (auto *callInst = dyn_cast<CallInst>(use.getUser())) {
+            if (callInst->isCallee(&use))
+              useWorkList.push_back(callInst);
+          }
+        }
+        // Process the uses
+        for (auto imgInst : useWorkList) {
+          processImageDescWorkaround(*imgInst);
+        }
+      }
+    }
+  }
+}
+
+// =====================================================================================================================
+// Process calls to image instrinsics and apply buffer descriptor should be image descriptor workaround
+//
+// @param callInst : The image intrinsic call instruction
+void PatchWorkarounds::processImageDescWorkaround(CallInst &callInst) {
+  Function *const calledFunc = callInst.getCalledFunction();
+  if (!calledFunc)
+    return;
+
+  // A buffer descriptor may be incorrectly given when it should be an image descriptor, we need to fix it to valid
+  // buffer type (0) to make hardware happily ignore it. This is to check and fix against buggy applications which
+  // declares a image descriptor in shader but provide a buffer descriptor in driver. Note this only applies to gfx10.1.
+  // Look for 8 dword resource descriptor argument
+  for (Value *arg : callInst.args()) {
+    if (auto vecTy = dyn_cast<FixedVectorType>(arg->getType())) {
+      if (vecTy->getNumElements() == 8 && vecTy->getElementType()->isIntegerTy(32)) {
+        if (isa<UndefValue>(arg))
+          // We don't need to worry if the value is actually undef. This situation only really occurs in unit test
+          // but either way, it is pointless to apply the workaround to an undef.
+          break;
+
+        if (m_processed.count(arg) > 0)
+          // Already processed this one
+          break;
+
+        Instruction *rsrcInstr = cast<Instruction>(arg);
+
+        m_builder->SetInsertPoint(rsrcInstr->getNextNode());
+        m_builder->SetCurrentDebugLocation(rsrcInstr->getNextNode()->getDebugLoc());
+
+        // Create a new rsrc load instruction - we apply the workaround the the new instruction and then replace
+        // all uses of the old one with the derived value. This prevents us replacing the original value with the
+        // derived one in the code to insert the new element.
+        Instruction *newInstr = rsrcInstr->clone();
+        newInstr->insertAfter(rsrcInstr);
+
+        Value *elem3 = m_builder->CreateExtractElement(newInstr, 3);
+        Value *isInvalid = m_builder->CreateICmpSGE(elem3, m_builder->getInt32(0));
+        Value *masked = m_builder->CreateAnd(elem3, m_builder->getInt32(0x0FFFFFFF));
+        elem3 = m_builder->CreateSelect(isInvalid, masked, elem3);
+
+        // Re-assemble descriptor
+        Value *newArg = m_builder->CreateInsertElement(newInstr, elem3, 3);
+
+        auto rsrcInstrName = rsrcInstr->getName();
+        newInstr->setName(rsrcInstrName); // Preserve the old name for the load
+        newArg->setName(rsrcInstrName);   // Derive a new name based on the old name for the load
+        rsrcInstr->replaceAllUsesWith(newArg);
+        rsrcInstr->eraseFromParent();
+
+        // Record the new argument as already processed. If we encounter it in
+        // another image intrinsic call we can skip
+        m_processed.insert(newArg);
+
+        m_changed = true;
+        break;
+      }
+    }
+  }
+}
+
+// =====================================================================================================================
+// Get the analysis usage of this pass.
+//
+// @param [out] analysisUsage : The analysis usage.
+void PatchWorkarounds::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
+  analysisUsage.addRequired<PipelineStateWrapper>();
+  analysisUsage.addRequired<PipelineShaders>();
+  analysisUsage.addPreserved<PipelineShaders>();
+}
+
+} // namespace lgc
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patching opertions for workarounds
+INITIALIZE_PASS(PatchWorkarounds, DEBUG_TYPE, "Patch LLVM for workarounds", false, false)

--- a/lgc/patch/PatchWorkarounds.h
+++ b/lgc/patch/PatchWorkarounds.h
@@ -1,0 +1,71 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchWorkarounds.h
+ * @brief LLPC header file: contains declaration of class lgc::PatchWorkarounds.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/patch/Patch.h"
+#include "lgc/util/Internal.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Pass.h"
+
+namespace lgc {
+
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for applying workarounds:
+//
+// - fix up issues when buffer descriptor is incorrectly given when it should be an image descriptor. Some architectures
+//   require a fix so the hardware will ignore this difference (actually an app error, but common enough to require
+//   handling)
+//
+class PatchWorkarounds final : public Patch {
+public:
+  PatchWorkarounds();
+
+  bool runOnModule(llvm::Module &module) override;
+
+  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override;
+
+  static char ID; // ID of this pass
+
+private:
+  std::unique_ptr<llvm::IRBuilder<>> m_builder; // The IRBuilder.
+  PipelineState *m_pipelineState;               // The pipeline state
+
+  llvm::SmallPtrSet<llvm::Value *, 8> m_processed; // Track rsrc-desc args already processed
+
+  bool m_changed;
+
+  void applyImageDescWorkaround(void);
+  void processImageDescWorkaround(llvm::CallInst &callInst);
+};
+
+} // namespace lgc

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -1,73 +1,38 @@
 ; Test that invalid image descriptor patching is applied where required.
 
-; RUN: lgc -mcpu=gfx900 -print-before=lgc-patch-null-frag-shader -o - - <%s 2>&1 | FileCheck --check-prefixes=CHECK,GFX900 %s
-; RUN: lgc -mcpu=gfx1010 -print-before=lgc-patch-null-frag-shader -o - - <%s 2>&1 | FileCheck --check-prefixes=CHECK,GFX1010 %s
+; RUN: lgc -mcpu=gfx900 -print-after=lgc-patch-workarounds -o - - <%s 2>&1 | FileCheck --check-prefixes=CHECK,GFX900 %s
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-workarounds -o - - <%s 2>&1 | FileCheck --check-prefixes=CHECK,GFX1010 %s
 
-; CHECK-LABEL: IR Dump Before Patch LLVM for null fragment shader generation
+; CHECK-LABEL: IR Dump After Patch LLVM for workarounds
 
 ; GFX900: %.load = call <4 x float> @llvm.amdgcn.image.load.2d.v4f32.i32(i32 15, i32 1, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
+; GFX1010: extractelement <8 x i32> %.desc1, i64 3
 ; GFX1010-NEXT: icmp sge i32
 ; GFX1010-NEXT: and i32
 ; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC0:%[0-9]+]] = insertelement <8 x i32> %.desc
+; GFX1010-NEXT: [[PATCHED_DESC0:%[.a-zA-Z0-9]+]] = insertelement <8 x i32> %.desc1
 ; GFX1010:  %.load = call <4 x float> @llvm.amdgcn.image.load.1d.v4f32.i32(i32 15, i32 1, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
 
 ; GFX900: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC1:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> [[PATCHED_DESC1]], i32 0, i32 0)
+; GFX1010: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
 
 ; GFX900: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %.sampler, i1 false, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC2:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC2]], <4 x i32> %.sampler, i1 false, i32 0, i32 0)
+; GFX1010: %.sample = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %.sampler, i1 false, i32 0, i32 0)
 
 ; GFX900: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC3:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC3]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX1010: %.gather = call <4 x float> @llvm.amdgcn.image.gather4.l.2d.v4f32.f32(i32 1, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
 ; GFX900: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.2d.i32.i32(i32 1, i32 0, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC4:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.1d.i32.i32(i32 1, i32 0, <8 x i32> [[PATCHED_DESC4]], i32 0, i32 0)
+; GFX1010: %.atomic = call i32 @llvm.amdgcn.image.atomic.add.1d.i32.i32(i32 1, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
 
 ; GFX900: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC5:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC5]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
+; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
 ; GFX900: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC6:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> [[PATCHED_DESC6]], i32 0, i32 0)
+; GFX1010: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
 
 ; GFX900: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> %.desc, i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> %.desc, i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC7:%[0-9]+]] = insertelement <8 x i32> %.desc
-; GFX1010: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> [[PATCHED_DESC7]], i32 0, i32 0)
+; GFX1010: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
 
 ; ModuleID = 'lgcPipeline'
 source_filename = "lgcPipeline"


### PR DESCRIPTION
Adding the image descriptor workaround (gfx10.1) in the builder code meant that
it introduced extra code that prevented other optimizations.

Move this to a later patching pass (that could contain future workaround
patching too).