### PR TITLE
Update waterfall loop syntax for multiple indices

### DIFF
--- a/llpc/test/shaderdb/OpTypeSampledImage_TestWaterfallInsertion.frag
+++ b/llpc/test/shaderdb/OpTypeSampledImage_TestWaterfallInsertion.frag
@@ -24,7 +24,8 @@ void main()
 ; Make sure that the begin indices chosen are the non-uniform offsets rather than the whole resource desc
 ; Make sure that there's a waterfall.readfirstlane for both the image resource desc and sample desc
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST-DAG: call i32 @llvm.amdgcn.waterfall.begin.sl_i32i32s
+; SHADERTEST-DAG: call i32 @llvm.amdgcn.waterfall.begin.i32
+; SHADERTEST-DAG: call i32 @llvm.amdgcn.waterfall.begin.cont.i32
 ; SHADERTEST-DAG: call <8 x i32> @llvm.amdgcn.waterfall.readfirstlane.v8i32.v8i32
 ; SHADERTEST-DAG: call <4 x i32> @llvm.amdgcn.waterfall.readfirstlane.v4i32.v4i32
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
Previously, when multiple indices were required for a waterfall loop, the
approach was to create a larger index by concatenating the individual indices
(in this case into an aggregate type). This should really have been into a
vector type of an appropriate size (2,4,8 or 16 elements).

This has been shown to not work (using an aggregate), and restricting to a
vector type is limiting, especially as the most common case for this is for an
image sample which takes a non-uniform image resource descriptor and sample
descriptor (12 elements/dwords).

In most cases the front-end can do better than this (using the GEP offsets for
each resource descriptor load), but when this fails and it falls back on full
descriptors as indices it will break.

The backend implementation has been updated to use a new multi-intrinsic begin
syntax use something like this:

  %tok1 = call i32 @llvm.amdgcn.waterfall.begin.v8i32(<8 x i32> %idx1)
  %tok2 = call i32 @llvm.amdgcn.waterfall.begin.cont.v4i32(i32 %tok1, <4 x i32> %idx2)
  %44 = call <8 x i32> @llvm.amdgcn.waterfall.readfirstlane.v8i32.v8i32(i32 %tok2, <8 x i32> %idx1)
  %45 = call <4 x i32> @llvm.amdgcn.waterfall.readfirstlane.v4i32.v4i32(i32 %tok2, <4 x i32> %idx2)
  ... and so on, using %tok2 as the waterfall token