### PR TITLE
Use the original key when removing unused outputs

### DIFF
--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1637,7 +1637,7 @@ void PatchResourceCollect::matchGenericInOut() {
             assert(m_shaderStage == ShaderStageTessControl);
             locMap.second = availInMapLoc++;
           } else
-            unusedLocs.push_back(loc);
+            unusedLocs.push_back(locMap.first);
         }
       }
 


### PR DESCRIPTION
Commit 966a827 merged GsOutLocInfo into
InOutLocationInfo and made 'location' start at bit 3 instead of bit 0,
exposing a bug where the GS output location would be used as the map key
when removing unused outputs. Use the original map key instead of the raw
location when removing the unused outputs.

For example, if a GS has 12 outputs but only 0-4 are used then when
output location 8 (b1000) is removed it will actually remove output
location 1 when interpreted as an InOutLocationInfo.