### PR TITLE
NGG: Add vertex compactionless mode to GS

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -153,6 +153,10 @@ NggLdsManager::NggLdsManager(Module *module, PipelineState *pipelineState, IRBui
     unsigned ldsRegionStart = 0;
 
     for (unsigned region = LdsRegionGsBeginRange; region <= LdsRegionGsEndRange; ++region) {
+      // NOTE: For vertex compactionless mode, this region is unnecessary
+      if (region == LdsRegionOutVertThreadIdMap && nggControl->compactMode == NggCompactDisable)
+        continue;
+
       unsigned ldsRegionSize = LdsRegionSizes[region];
 
       // NOTE: LDS size of ES-GS ring is calculated (by rounding it up to 16-byte alignment)
@@ -271,7 +275,7 @@ unsigned NggLdsManager::calcGsExtraLdsSize(PipelineState *pipelineState) {
   }
 
   return LdsRegionSizes[LdsRegionOutPrimData] + LdsRegionSizes[LdsRegionOutVertCountInWaves] +
-         LdsRegionSizes[LdsRegionOutVertThreadIdMap];
+         (nggControl->compactMode == NggCompactDisable ? 0 : LdsRegionSizes[LdsRegionOutVertThreadIdMap]);
 }
 
 // =====================================================================================================================

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -186,7 +186,7 @@ private:
 
   llvm::Function *mutateGs(llvm::Module *module);
 
-  void runCopyShader(llvm::Module *module, llvm::Value *vertCompacted);
+  void runCopyShader(llvm::Module *module);
 
   llvm::Function *mutateCopyShader(llvm::Module *module);
 


### PR DESCRIPTION
This change is to add vertex compactionless mode to NGG GS. For non GS,
the support has already been implementation. The design is the same:
skip vertex ID compaction when compactionless mode is enabled and apply
empty wave check.

See the PR for more details: https://github.com/GPUOpen-Drivers/llpc/pull/941.

Change-Id: Ia0f0c7f4593c160e7e95a2cd9b6b02aaddf586f8