### PR TITLE
Consider waterfall.last.use intrinsic in image rsrc workaround

### DIFF
--- a/lgc/patch/PatchWorkarounds.h
+++ b/lgc/patch/PatchWorkarounds.h
@@ -65,7 +65,7 @@ private:
   bool m_changed;
 
   void applyImageDescWorkaround(void);
-  void processImageDescWorkaround(llvm::CallInst &callInst);
+  void processImageDescWorkaround(llvm::CallInst &callInst, bool isLastUse);
 };
 
 } // namespace lgc

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -28,6 +28,16 @@
 ; GFX900: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %.desc, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 ; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> [[PATCHED_DESC0]], <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
+; CHECK: [[WFDESC:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.readfirstlane
+; GFX900: [[WFDESC1:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.last.use.v8i32(i32 %{{[0-9]+}}, <8 x i32> [[WFDESC]])
+; GFX900: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> [[WFDESC1]], i32 0, i32 0)
+; GFX1010: extractelement <8 x i32> [[WFDESC]], i64 3
+; GFX1010-NEXT: icmp sge i32
+; GFX1010-NEXT: and i32
+; GFX1010-NEXT: select i1
+; GFX1010-NEXT: [[PATCHED_DESC1:%[.a-zA-Z0-9]+]] = insertelement <8 x i32> [[WFDESC]]
+; GFX1010: [[WFDESC1:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.last.use.v8i32(i32 %{{[0-9]+}}, <8 x i32> [[PATCHED_DESC1]])
+; GFX1010: call void @llvm.amdgcn.image.store.1d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, <8 x i32> [[WFDESC1]], i32 0, i32 0)
 ; ModuleID = 'lgcPipeline'
 source_filename = "lgcPipeline"
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
@@ -56,6 +66,14 @@ define spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.Executi
 
   %.query.size = call <2 x i32> (...) @lgc.create.image.query.size.v2i32(i32 1, i32 0, <8 x i32> %.desc, i32 0)
   %.query.levels = call i32 (...) @lgc.create.image.query.levels.i32(i32 1, i32 0, <8 x i32> %.desc)
+
+  ; Use a waterfall loop with last.use to test that is also handled correctly
+  %.desc2.ptr2 = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 3, i32 4)
+  %.desc2.ptr1 = bitcast <8 x i32> addrspace(4)* %.desc2.ptr2 to i8 addrspace(4)*
+  %.desc2.ptr0 = getelementptr i8, i8 addrspace(4)* %.desc2.ptr1, i64 0
+  %.desc2.ptr = bitcast i8 addrspace(4)* %.desc2.ptr0 to <8 x i32> addrspace(4)*
+  %.desc2 = load <8 x i32>, <8 x i32> addrspace(4)* %.desc2.ptr, align 32
+  call void (...) @lgc.create.image.store(<4 x float> zeroinitializer, i32 0, i32 8, <8 x i32> %.desc2, i32 zeroinitializer)
 
   ret void
 }


### PR DESCRIPTION
In the case where an image resource descriptor is required to have a workaround
applied, we additionally need to consider the case where a waterfall.last.use
intrinsic is used, otherwise, the resource descriptor will be adjusted and it
will fall outside the waterfall loop (the last use becomes the first use in the
workaround code and not the image intrinsic).

We now additionally process last.use to see if that is for an image resource
descriptor, apply the workaround to the last.use. This means that the intent of
the waterfall code is preserved (the last use is the image intrinsic still).