### PR TITLE
Fix dangling else warning (-Wdangling-else)

### DIFF
--- a/lgc/patch/PatchWorkarounds.cpp
+++ b/lgc/patch/PatchWorkarounds.cpp
@@ -106,11 +106,13 @@ void PatchWorkarounds::applyImageDescWorkaround(void) {
       if (isImage || isLastUse) {
         for (auto &use : func.uses()) {
           if (auto *callInst = dyn_cast<CallInst>(use.getUser())) {
-            if (callInst->isCallee(&use))
-              if (isLastUse)
+            if (callInst->isCallee(&use)) {
+              if (isLastUse) {
                 useWorkListLastUse.push_back(callInst);
-              else
+              } else {
                 useWorkListImage.push_back(callInst);
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
TIL: [dangling else](https://en.wikipedia.org/wiki/Dangling_else) is when it's not clear which `if` statement an `else` statement corresponds to. This fixes a build warning (hence build error).