### PR TITLE
Refactor vertex attribute export

### DIFF
--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -199,6 +199,9 @@ private:
   llvm::Value *getInLocalInvocationId(llvm::Instruction *insertPos);
   llvm::Value *getDeviceIndex(llvm::Instruction *insertPos);
 
+  void recordVertexAttribExport(unsigned location, llvm::ArrayRef<llvm::Value *> attribValues);
+  void exportVertexAttribs(llvm::Instruction *insertPos);
+
   GfxIpVersion m_gfxIp;                     // Graphics IP version info
   PipelineSystemValues m_pipelineSysValues; // Cache of ShaderSystemValues objects, one per shader stage
 
@@ -222,9 +225,11 @@ private:
   llvm::GlobalVariable *m_lds; // Global variable to model LDS
   llvm::Value *m_threadId;     // Thread ID
 
-  std::vector<llvm::CallInst *> m_importCalls;                 // List of "call" instructions to import inputs
-  std::vector<llvm::CallInst *> m_exportCalls;                 // List of "call" instructions to export outputs
-  PipelineState *m_pipelineState = nullptr;                    // Pipeline state from PipelineStateWrapper pass
+  std::vector<llvm::CallInst *> m_importCalls; // List of "call" instructions to import inputs
+  std::vector<llvm::CallInst *> m_exportCalls; // List of "call" instructions to export outputs
+  llvm::SmallDenseMap<unsigned, std::array<llvm::Value *, 4>>
+      m_attribExports;                      // Export info of vertex attributes: <attrib loc, attrib values>
+  PipelineState *m_pipelineState = nullptr; // Pipeline state from PipelineStateWrapper pass
 
   std::set<unsigned> m_expLocs; // The locations that already have an export instruction for the vertex shader.
 };

--- a/llpc/test/shaderdb/PipelineTess_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/PipelineTess_TestInOutPacking.pipe
@@ -8,8 +8,8 @@
 ; SHADERTEST: or i32 %{{[0-9]*}}, 2
 ; SHADERTEST: getelementptr [16384 x i32], [16384 x i32] addrspace(3)* @lds, i32 0, i32 %{{[0-9]*}}
 ; SHADERTEST: add nuw nsw i32 %{{[0-9]*}}, 384
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 32, i32 immarg 15, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, i1 immarg false, i1 immarg false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 33, i32 immarg 3, float %{{[0-9]*}}, float %{{[0-9]*}}, float undef, float undef, i1 immarg false, i1 immarg false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}3, float %{{[0-9]*}}, float %{{[0-9]*}}, float undef, float undef, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 1, i32 immarg 1, i32 %2)
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 2, i32 immarg 0, i32 %2)
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[.i0-9]*}}, i32 immarg 3, i32 immarg 0, i32 %2)

--- a/llpc/test/shaderdb/PipelineVsFs_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_TestInOutPacking.pipe
@@ -2,12 +2,12 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 32, i32 immarg 15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 immarg false, i1 immarg false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 33, i32 immarg 15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 immarg false, i1 immarg false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 34, i32 immarg 15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 immarg false, i1 immarg false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 35, i32 immarg 7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 immarg false, i1 immarg false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 36, i32 immarg 15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 immarg false, i1 immarg false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 37, i32 immarg 7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 immarg false, i1 immarg false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 4, i32 %{{[0-9]*}})
 ; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 4, i32 %{{[0-9]*}})
 ; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 4, i32 %{{[0-9]*}})

--- a/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestVsInOut_lit.vert
+++ b/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestVsInOut_lit.vert
@@ -21,7 +21,7 @@ void main (void)
 ; SHADERTEST: call void @lgc.output.export.generic.i32.i32.i8(i32 0, i32 0, i8 %{{[0-9]*}})
 ; SHADERTEST: call void @lgc.output.export.generic.i32.i32.v3i8(i32 1, i32 0, <3 x i8> %{{[0-9]*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 immarg 32, i32 immarg 1, float %{{[0-9]*}}, float undef, float undef, float undef, i1 immarg false, i1 immarg false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}1, float %{{[0-9]*}}, float undef, float undef, float undef, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
We didn't collect vertex attribute exports previously. This has a latent
issue (see below GLSL of a VS):

```
  layout(location = 0, component = 0) out vec2 data1;
  layout(location = 0, component = 2) out vec2 data2;
```

We finally generate two exp instructions with this:

```
  exp param0, data1.x, data1.y, off, off
  exp param0, off, off, data2.x, data2.y
```

So this change is to collect vertex attribute exports and do exporting
with gathered operations. We introduce two functions:

  recordVertexAttribExport, exportVertexAttribs

Their functionalities are apparent. We don't explain more here. This
refactoring work is also for a future use where vertex attributes are
handled differently.

Change-Id: Ibed717a06ffd0b04ab3eaf5332e83148e795ee1d