### PR TITLE
Replace inOutLocMap with inputLocMap/outputLocMap

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -89,16 +89,45 @@ struct FsInterpInfo {
 // Invalid interpolation info
 static const FsInterpInfo InvalidFsInterpInfo = {InvalidValue, false, false, false, false, false};
 
-// Represents the location info of input/output
-union InOutLocationInfo {
-  struct {
-    uint16_t half : 1;      // High half in case of 16-bit attriburtes
-    uint16_t component : 2; // The component index
-    uint16_t location : 10; // The location
-    uint16_t isBuiltIn : 1; // Whether location is actually built-in ID
-    uint16_t streamId : 2;  // Output vertex stream ID
-  };
-  uint16_t u16All;
+// Represents the location information on an input or output
+class InOutLocationInfo {
+public:
+  InOutLocationInfo() { m_data.u16All = 0; }
+  InOutLocationInfo(unsigned data) { this->m_data.u16All = static_cast<uint16_t>(data); }
+  InOutLocationInfo(const InOutLocationInfo &inOutLocInfo) { m_data.u16All = inOutLocInfo.getData(); }
+
+  unsigned getData() const { return static_cast<uint16_t>(m_data.u16All); }
+  void setData(unsigned data) { m_data.u16All = static_cast<uint16_t>(data); }
+  bool isInvalid() const { return m_data.u16All == 0xFFFF; }
+
+  bool isHighHalf() const { return m_data.bits.isHighHalf; }
+  void setHighHalf(bool isHighHalf) { m_data.bits.isHighHalf = isHighHalf; }
+
+  unsigned getComponent() const { return m_data.bits.component; }
+  void setComponent(unsigned compIdx) { m_data.bits.component = static_cast<uint16_t>(compIdx); }
+
+  unsigned getLocation() const { return m_data.bits.location; }
+  void setLocation(unsigned loc) { m_data.bits.location = static_cast<uint16_t>(loc); }
+
+  bool isBuiltIn() const { return m_data.bits.isBuiltIn; }
+  void setBuiltIn(bool isBuiltIn) { m_data.bits.isBuiltIn = isBuiltIn; }
+
+  unsigned getStreamId() const { return m_data.bits.streamId; }
+  void setStreamId(unsigned streamId) { m_data.bits.streamId = static_cast<uint16_t>(streamId); }
+
+  bool operator<(const InOutLocationInfo &rhs) const { return this->getData() < rhs.getData(); }
+
+private:
+  union {
+    struct {
+      uint16_t isHighHalf : 1; // High half in case of 16-bit attriburtes
+      uint16_t component : 2;  // The component index
+      uint16_t location : 10;  // The location
+      uint16_t isBuiltIn : 1;  // Whether location is actually built-in ID
+      uint16_t streamId : 2;   // Output vertex stream ID
+    } bits;
+    uint16_t u16All;
+  } m_data;
 };
 
 // Enumerate the workgroup layout options.
@@ -280,12 +309,9 @@ struct ResourceUsage {
 
   // Usage of generic input/output
   struct {
-    // Map from shader specified locations to tightly packed locations
-    std::map<unsigned, unsigned> inputLocMap;
-    std::map<unsigned, unsigned> outputLocMap;
-
-    // The original and new InOutLocations for shader cache
-    std::map<unsigned, unsigned> inOutLocMap;
+    // Map from shader specified InOutLocations to tightly packed InOutLocations
+    std::map<InOutLocationInfo, InOutLocationInfo> inputLocInfoMap;
+    std::map<InOutLocationInfo, InOutLocationInfo> outputLocInfoMap;
 
     std::map<unsigned, unsigned> perPatchInputLocMap;
     std::map<unsigned, unsigned> perPatchOutputLocMap;
@@ -361,7 +387,7 @@ struct ResourceUsage {
       std::unordered_map<unsigned, std::vector<unsigned>> genericOutByteSizes[MaxGsStreams];
 
       // Map from output location to the transform feedback info
-      std::map<unsigned, unsigned> xfbOutsInfo;
+      std::map<InOutLocationInfo, unsigned> xfbOutsInfo;
 
       // ID of the vertex stream sent to rasterizor
       unsigned rasterStream = 0;

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -509,10 +509,12 @@ void LowerFragColorExport::updateFragColors(CallInst *callInst, ColorExportValue
   const unsigned compIdx = cast<ConstantInt>(callInst->getOperand(1))->getZExtValue();
   Value *output = callInst->getOperand(2);
 
-  auto it = m_resUsage->inOutUsage.outputLocMap.find(location);
-  if (it == m_resUsage->inOutUsage.outputLocMap.end())
+  InOutLocationInfo origLocInfo(0);
+  origLocInfo.setLocation(location);
+  auto locInfoMapIt = m_resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+  if (locInfoMapIt == m_resUsage->inOutUsage.outputLocInfoMap.end())
     return;
-  unsigned hwColorTarget = it->second;
+  unsigned hwColorTarget = locInfoMapIt->second.getLocation();
 
   Type *outputTy = output->getType();
 

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -123,9 +123,8 @@ bool PatchCheckShaderCache::runOnModule(Module &module) {
     raw_string_ostream stream(inOutUsageStreams[stage]);
 
     // Update input/output usage
-    streamMapEntries(resUsage->inOutUsage.inputLocMap, stream);
-    streamMapEntries(resUsage->inOutUsage.outputLocMap, stream);
-    streamMapEntries(resUsage->inOutUsage.inOutLocMap, stream);
+    streamMapEntries(resUsage->inOutUsage.inputLocInfoMap, stream);
+    streamMapEntries(resUsage->inOutUsage.outputLocInfoMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchInputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchOutputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.builtInInputLocMap, stream);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -302,16 +302,15 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
         unsigned value = cast<ConstantInt>(callInst->getOperand(0))->getZExtValue();
         const unsigned streamId = cast<ConstantInt>(callInst->getOperand(2))->getZExtValue();
 
-        InOutLocationInfo outLocInfo = {};
-        outLocInfo.location = value;
-        outLocInfo.isBuiltIn = false;
-        outLocInfo.streamId = streamId;
+        InOutLocationInfo outLocInfo(0);
+        outLocInfo.setLocation(value);
+        outLocInfo.setStreamId(streamId);
 
-        auto locMapIt = resUsage->inOutUsage.outputLocMap.find(outLocInfo.u16All);
-        if (locMapIt == resUsage->inOutUsage.outputLocMap.end())
+        auto locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(outLocInfo);
+        if (locInfoMapIt == resUsage->inOutUsage.outputLocInfoMap.end())
           continue;
 
-        unsigned location = locMapIt->second;
+        unsigned location = locInfoMapIt->second.getLocation();
         const unsigned compIdx = cast<ConstantInt>(callInst->getOperand(1))->getZExtValue();
 
         unsigned compCount = 1;
@@ -562,20 +561,20 @@ void PatchCopyShader::exportGenericOutput(Value *outputValue, unsigned location,
                                           BuilderBase &builder) {
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
   if (resUsage->inOutUsage.enableXfb) {
-    auto &outLocMap = resUsage->inOutUsage.outputLocMap;
+    auto &outLocInfoMap = resUsage->inOutUsage.outputLocInfoMap;
     auto &xfbOutsInfo = resUsage->inOutUsage.gs.xfbOutsInfo;
 
-    // Find original location in outLocMap which equals used location in copy shader
-    auto locIter =
-        find_if(outLocMap.begin(), outLocMap.end(), [location, streamId](const std::pair<unsigned, unsigned> &outLoc) {
-          unsigned outLocInfo = outLoc.first;
-          bool isStreamId = (reinterpret_cast<InOutLocationInfo *>(&outLocInfo))->streamId == streamId;
-          return outLoc.second == location && isStreamId;
-        });
+    // Find original location in outLocInfoMap which equals used location in copy shader
+    auto locInfoIter =
+        find_if(outLocInfoMap.begin(), outLocInfoMap.end(),
+                [location, streamId](const std::pair<InOutLocationInfo, InOutLocationInfo> &outLocInfo) {
+                  const auto &newLocationInfo = outLocInfo.second;
+                  return newLocationInfo.getLocation() == location && newLocationInfo.getStreamId() == streamId;
+                });
 
-    assert(locIter != outLocMap.end());
-    if (xfbOutsInfo.find(locIter->first) != xfbOutsInfo.end()) {
-      XfbOutInfo *xfbOutInfo = reinterpret_cast<XfbOutInfo *>(&xfbOutsInfo[locIter->first]);
+    assert(locInfoIter != outLocInfoMap.end());
+    if (xfbOutsInfo.find(locInfoIter->first) != xfbOutsInfo.end()) {
+      XfbOutInfo *xfbOutInfo = reinterpret_cast<XfbOutInfo *>(&xfbOutsInfo[locInfoIter->first]);
 
       if (xfbOutInfo->is16bit) {
         // NOTE: For 16-bit transform feedback output, the value is 32-bit dword loaded from GS-VS ring
@@ -628,13 +627,13 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
 
   if (resUsage->inOutUsage.enableXfb) {
-    InOutLocationInfo outLocInfo = {};
-    outLocInfo.location = builtInId;
-    outLocInfo.isBuiltIn = true;
-    outLocInfo.streamId = streamId;
+    InOutLocationInfo outLocInfo(0);
+    outLocInfo.setLocation(builtInId);
+    outLocInfo.setBuiltIn(true);
+    outLocInfo.setStreamId(streamId);
 
     auto &xfbOutsInfo = resUsage->inOutUsage.gs.xfbOutsInfo;
-    auto locIter = xfbOutsInfo.find(outLocInfo.u16All);
+    auto locIter = xfbOutsInfo.find(outLocInfo);
     if (locIter != xfbOutsInfo.end()) {
       XfbOutInfo *xfbOutInfo = reinterpret_cast<XfbOutInfo *>(&xfbOutsInfo[locIter->first]);
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -502,11 +502,14 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           }
         }
 
+        InOutLocationInfo origLocInfo(0);
+        origLocInfo.setLocation(value);
+        auto locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
         if (m_shaderStage == ShaderStageTessEval) {
           // NOTE: For generic inputs of tessellation evaluation shader, they could be per-patch ones.
-          if (resUsage->inOutUsage.inputLocMap.find(value) != resUsage->inOutUsage.inputLocMap.end())
-            loc = resUsage->inOutUsage.inputLocMap[value];
-          else {
+          if (locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end()) {
+            loc = locInfoMapIt->second.getLocation();
+          } else {
             assert(resUsage->inOutUsage.perPatchInputLocMap.find(value) !=
                    resUsage->inOutUsage.perPatchInputLocMap.end());
             loc = resUsage->inOutUsage.perPatchInputLocMap[value];
@@ -515,21 +518,16 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           if (m_pipelineState->canPackInOut() &&
               (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl)) {
             // The new InOutLocationInfo is used to map scalarized FS and TCS input import as compact as possible
-            InOutLocationInfo origLocInfo = {};
-            origLocInfo.location = value;
             const uint32_t elemIdxArgIdx = isInterpolantInputImport || m_shaderStage != ShaderStageFragment ? 2 : 1;
-            origLocInfo.component = cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue();
-            origLocInfo.half = false;
-            assert(resUsage->inOutUsage.inOutLocMap.find(origLocInfo.u16All) != resUsage->inOutUsage.inOutLocMap.end());
-
-            InOutLocationInfo newLocInfo = {};
-            newLocInfo.u16All = resUsage->inOutUsage.inOutLocMap[origLocInfo.u16All];
-            loc = newLocInfo.location;
-            elemIdx = builder.getInt32(newLocInfo.component);
-            highHalf = newLocInfo.half;
+            origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue());
+            locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
+            assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
+            loc = locInfoMapIt->second.getLocation();
+            elemIdx = builder.getInt32(locInfoMapIt->second.getComponent());
+            highHalf = locInfoMapIt->second.isHighHalf();
           } else {
-            assert(resUsage->inOutUsage.inputLocMap.find(value) != resUsage->inOutUsage.inputLocMap.end());
-            loc = resUsage->inOutUsage.inputLocMap[value];
+            assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
+            loc = locInfoMapIt->second.getLocation();
           }
         }
       }
@@ -650,9 +648,12 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       }
 
       // NOTE: For generic outputs of tessellation control shader, they could be per-patch ones.
-      if (resUsage->inOutUsage.outputLocMap.find(value) != resUsage->inOutUsage.outputLocMap.end())
-        loc = resUsage->inOutUsage.outputLocMap[value];
-      else {
+      InOutLocationInfo origLocInfo(0);
+      origLocInfo.setLocation(value);
+      auto locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+      if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
+        loc = locInfoMapIt->second.getLocation();
+      } else {
         assert(resUsage->inOutUsage.perPatchOutputLocMap.find(value) !=
                resUsage->inOutUsage.perPatchOutputLocMap.end());
         loc = resUsage->inOutUsage.perPatchOutputLocMap[value];
@@ -766,6 +767,10 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       Value *locOffset = nullptr;
       unsigned elemIdx = InvalidValue;
 
+      InOutLocationInfo origLocInfo(0);
+      origLocInfo.setLocation(value);
+      auto locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+
       if (m_shaderStage == ShaderStageTessControl) {
         // NOTE: If location offset is a constant, we have to add it to the unmapped location before querying
         // the mapped location. Meanwhile, we have to adjust the location offset to 0 (rebase it).
@@ -776,9 +781,9 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         }
 
         // NOTE: For generic outputs of tessellation control shader, they could be per-patch ones.
-        if (resUsage->inOutUsage.outputLocMap.find(value) != resUsage->inOutUsage.outputLocMap.end()) {
+        if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[value];
+          loc = locInfoMapIt->second.getLocation();
         } else if (resUsage->inOutUsage.perPatchOutputLocMap.find(value) !=
                    resUsage->inOutUsage.perPatchOutputLocMap.end()) {
           exist = true;
@@ -790,35 +795,27 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       } else if (m_shaderStage == ShaderStageGeometry) {
         assert(callInst.getNumArgOperands() == 4);
 
-        InOutLocationInfo outLocInfo = {};
-        outLocInfo.location = value;
-        outLocInfo.isBuiltIn = false;
-        outLocInfo.streamId = cast<ConstantInt>(callInst.getOperand(2))->getZExtValue();
-
-        if (resUsage->inOutUsage.outputLocMap.find(outLocInfo.u16All) != resUsage->inOutUsage.outputLocMap.end()) {
+        origLocInfo.setStreamId(cast<ConstantInt>(callInst.getOperand(2))->getZExtValue());
+        locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+        if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[outLocInfo.u16All];
+          loc = locInfoMapIt->second.getLocation();
         }
       } else {
-        if (m_pipelineState->canPackInOut() && m_shaderStage == ShaderStageVertex &&
-            m_pipelineState->hasShaderStage(ShaderStageTessControl)) {
-          // The new InOutLocationInfo is used to map scalarized VS output export in a VS-TCS-TES-FS to lds as compact
-          // as possible
-          InOutLocationInfo origLocInfo = {};
-          origLocInfo.location = value;
-          origLocInfo.component = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
-          origLocInfo.half = false;
-          if (resUsage->inOutUsage.inOutLocMap.find(origLocInfo.u16All) != resUsage->inOutUsage.inOutLocMap.end()) {
-            InOutLocationInfo newLocInfo = {};
-            newLocInfo.u16All = resUsage->inOutUsage.inOutLocMap[origLocInfo.u16All];
-            loc = newLocInfo.location;
-            elemIdx = newLocInfo.component;
+        if (m_pipelineState->canPackInOut()) {
+          assert(m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval);
+          origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(1))->getZExtValue());
+          locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
+          if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
+            loc = locInfoMapIt->second.getLocation();
+            elemIdx = locInfoMapIt->second.getComponent();
             exist = true;
-          } else
+          } else {
             exist = false;
-        } else if (resUsage->inOutUsage.outputLocMap.find(value) != resUsage->inOutUsage.outputLocMap.end()) {
+          }
+        } else if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
           exist = true;
-          loc = resUsage->inOutUsage.outputLocMap[value];
+          loc = locInfoMapIt->second.getLocation();
         }
       }
 
@@ -1290,10 +1287,11 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
       // generic outputs that are not written to.  We need to count them in
       // the export count.
       auto resUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage);
-      for (auto locMap : resUsage->inOutUsage.outputLocMap) {
-        if (m_expLocs.count(locMap.second) != 0)
+      for (const auto &locInfoPair : resUsage->inOutUsage.outputLocInfoMap) {
+        const unsigned newLoc = locInfoPair.second.getLocation();
+        if (m_expLocs.count(newLoc) != 0)
           continue;
-        inOutUsage.expCount = std::max(inOutUsage.expCount, locMap.second + 1); // Update export count
+        inOutUsage.expCount = std::max(inOutUsage.expCount, newLoc + 1); // Update export count
       }
     }
   } else if (m_shaderStage == ShaderStageGeometry) {

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -143,13 +143,16 @@ bool PatchNullFragShader::runOnModule(Module &module) {
   // Add usage info for dummy input
   FsInterpInfo interpInfo = {0, false, false, false, false, false};
   resUsage->builtInUsage.fs.smooth = true;
-  resUsage->inOutUsage.inputLocMap[0] = InvalidValue;
+  InOutLocationInfo origLocInfo(0);
+  auto &newInLocInfo = resUsage->inOutUsage.inputLocInfoMap[origLocInfo];
+  newInLocInfo.setData(InvalidValue);
   resUsage->inOutUsage.fs.interpInfo.push_back(interpInfo);
 
   // Add usage info for dummy output
   resUsage->inOutUsage.fs.cbShaderMask = 0;
   resUsage->inOutUsage.fs.isNullFs = true;
-  resUsage->inOutUsage.outputLocMap[0] = InvalidValue;
+  auto &newOutLocInfo = resUsage->inOutUsage.outputLocInfoMap[origLocInfo];
+  newOutLocInfo.setData(InvalidValue);
 
   return true;
 }

--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -39,6 +39,7 @@
 namespace lgc {
 
 class InOutLocationMapManager;
+typedef std::map<InOutLocationInfo, InOutLocationInfo> InOutLocationInfoMap;
 
 // =====================================================================================================================
 // Represents the pass of LLVM patching opertions for resource collecting
@@ -81,11 +82,10 @@ private:
   void matchGenericInOut();
   void mapBuiltInToGenericInOut();
 
-  void mapGsGenericOutput(InOutLocationInfo outLocInfo);
   void mapGsBuiltInOutput(unsigned builtInId, unsigned elemCount);
 
   void packInOutLocation();
-  void fillInOutLocMap();
+  void fillInOutLocInfoMap();
   void reassembleOutputExportCalls();
 
   // Input/output scalarizing
@@ -127,15 +127,6 @@ union InOutCompatibilityInfo {
   uint16_t u16All;
 };
 
-// Represents the wrapper of input/output locatoin info, along with handlers
-struct InOutLocation {
-  uint16_t asIndex() const { return locationInfo.u16All; }
-
-  bool operator<(const InOutLocation &rhs) const { return this->asIndex() < rhs.asIndex(); }
-
-  InOutLocationInfo locationInfo; // The location info of an input or output
-};
-
 // =====================================================================================================================
 // Represents the manager of input/output locationMap generation
 class InOutLocationMapManager {
@@ -145,18 +136,18 @@ public:
   void addSpan(llvm::CallInst *call, ShaderStage shaderStage);
   void buildLocationMap(bool checkCompatibility);
 
-  bool findMap(const InOutLocation &originalLocation, const InOutLocation *&newLocation);
+  bool findMap(const InOutLocationInfo &origLocInfo, InOutLocationInfoMap::const_iterator &mapIt);
 
   struct LocationSpan {
     uint16_t getCompatibilityKey() const { return compatibilityInfo.u16All; }
 
-    unsigned asIndex() const { return ((getCompatibilityKey() << 16) | firstLocation.asIndex()); }
+    unsigned asIndex() const { return ((getCompatibilityKey() << 16) | firstLocation.getData()); }
 
     bool operator==(const LocationSpan &rhs) const { return this->asIndex() == rhs.asIndex(); }
 
     bool operator<(const LocationSpan &rhs) const { return this->asIndex() < rhs.asIndex(); }
 
-    InOutLocation firstLocation;
+    InOutLocationInfo firstLocation;
     InOutCompatibilityInfo compatibilityInfo;
   };
 
@@ -169,7 +160,7 @@ private:
   }
 
   std::vector<LocationSpan> m_locationSpans; // Tracks spans of contiguous components in the generic input space
-  std::map<InOutLocation, InOutLocation> m_locationMap; // The map between original location and new location
+  InOutLocationInfoMap m_locationMap;        // The map between original location and new location
 };
 
 } // namespace lgc

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -999,7 +999,7 @@ void PipelineState::initializePackInOut() {
   // Pack input/output requirements:
   // 1) -pack-in-out option is on
   // 2) It supports VS-FS, VS-TCS-TES-(FS)
-  if (PackInOut && hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
+  if (PackInOut && !m_unlinked && hasShaderStage(ShaderStageVertex) && !hasShaderStage(ShaderStageGeometry)) {
     const unsigned nextStage = getNextShaderStage(ShaderStageVertex);
     m_packInOut = nextStage == ShaderStageFragment || nextStage == ShaderStageTessControl;
   }


### PR DESCRIPTION
`InOutLocMap` is introduced to a <unsigned, unsigned> map for input/output
packing by decoding the unsigned as `InOutLocationInfo`. However, it is
a bit reduncant. Original `inputLocMap`/`outputLocMap` also do a
<unsigned, unsigned> mapping from user specified locations to
concecutive locations. We could reuse it for both packing and
non-packing code paths. This change will include:
-Refactor `InOutLocationInfo` by adding set/get functions and
`operator<`.
-Change the type of the key and valu of `inputLocMap`/`outputLocMap` to
`InOutLocInfo` and rename `inputLocMap`/`outputLocMap` to
`inputLocInfoMap`/`outputLocInfoMap` to distinguish with pure location
maps.
-In packing code path, replace `inOutLocMap` with
`inputLocInfoMap`/`outputLocInfoMap`.
-In non-packing code path, construct a `InOutLocationInfo` for map
lookup and extract requried bit field from mapped `InOutLocationInfo`.