### PR TITLE
Fixes to waterfall multi-begin support

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -285,18 +285,12 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
       nonUniformVal = CreateTrunc(nonUniformVal, getInt32Ty());
   }
 
-  bool first = true;
-  Value *waterfallBegin = nullptr;
+  // The first begin contains a null token for the previous token argument
+  Value *waterfallBegin = ConstantInt::get(getInt32Ty(), 0);
   for (auto nonUniformVal : nonUniformIndices) {
     // Start the waterfall loop using the waterfall index.
-    if (first) {
-      waterfallBegin = CreateIntrinsic(Intrinsic::amdgcn_waterfall_begin, nonUniformVal->getType(), nonUniformVal,
-                                       nullptr, instName);
-      first = false;
-    } else {
-      waterfallBegin = CreateIntrinsic(Intrinsic::amdgcn_waterfall_begin_cont, nonUniformVal->getType(),
-                                       {waterfallBegin, nonUniformVal}, nullptr, instName);
-    }
+    waterfallBegin = CreateIntrinsic(Intrinsic::amdgcn_waterfall_begin, nonUniformVal->getType(),
+                                     {waterfallBegin, nonUniformVal}, nullptr, instName);
   }
 
   // Scalarize each non-uniform operand of the instruction.

--- a/llpc/test/shaderdb/OpTypeSampledImage_TestWaterfallInsertion.frag
+++ b/llpc/test/shaderdb/OpTypeSampledImage_TestWaterfallInsertion.frag
@@ -25,7 +25,7 @@ void main()
 ; Make sure that there's a waterfall.readfirstlane for both the image resource desc and sample desc
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-DAG: call i32 @llvm.amdgcn.waterfall.begin.i32
-; SHADERTEST-DAG: call i32 @llvm.amdgcn.waterfall.begin.cont.i32
+; SHADERTEST-DAG: call i32 @llvm.amdgcn.waterfall.begin.i32
 ; SHADERTEST-DAG: call <8 x i32> @llvm.amdgcn.waterfall.readfirstlane.v8i32.v8i32
 ; SHADERTEST-DAG: call <4 x i32> @llvm.amdgcn.waterfall.readfirstlane.v4i32.v4i32
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
Changing policy from begin..begin.cont to allowing multiple begin intrinsics,
all of which take an input token:

%tok = llvm.amdgcn.waterfall.begin(i32 undef, i32 %idx)
%tok1 = llvm.amdgcn.waterfall.begin(i32 %tok, i32 %idx2)

This makes it easier to remove and handle begin intrinsics when the index is
shown to be uniform.