### PR TITLE
More aggressive speculative execution

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -158,6 +158,7 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-atomic-optimizations", "1");
   setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
+  setOptionDefault("spec-exec-max-speculation-cost", "10");
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
 #warning[!amd-gfx] Conditional discard transformations not supported
 #else


### PR DESCRIPTION
Increase the threshold of max speculation cost from 7 to 10.

This option drives speculative-execution LLVM pass.

More aggressive threshold (together with D91633) gives measurable
improvements in one game, with no regressions found elsewhere.