### PR TITLE
Move CS built-ins to InOutBuilder

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -446,3 +446,13 @@ Value *BuilderImplBase::scalarize(Value *value0, Value *value1, Value *value2,
   Value *result = callback(value0, value1, value2);
   return result;
 }
+
+// =====================================================================================================================
+// Create code to get the lane number within the wave. This depends on whether the shader is wave32 or wave64,
+// and thus on the shader stage it is used from.
+Value *BuilderImplBase::CreateGetLaneNumber() {
+  Value *result = CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {getInt32(-1), getInt32(0)});
+  if (getPipelineState()->getShaderWaveSize(m_shaderStage) == 64)
+    result = CreateIntrinsic(Intrinsic::amdgcn_mbcnt_hi, {}, {getInt32(-1), result});
+  return result;
+}

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -85,6 +85,10 @@ protected:
   llvm::Value *scalarize(llvm::Value *value0, llvm::Value *value1, llvm::Value *value2,
                          std::function<llvm::Value *(llvm::Value *, llvm::Value *, llvm::Value *)> callback);
 
+  // Create code to get the lane number within the wave. This depends on whether the shader is wave32 or wave64,
+  // and thus on the shader stage it is used from.
+  llvm::Value *CreateGetLaneNumber();
+
   PipelineState *m_pipelineState = nullptr; // Pipeline state
 
 private:
@@ -501,8 +505,14 @@ private:
   llvm::Value *readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo inOutInfo, llvm::Value *vertexIndex,
                            llvm::Value *index, const llvm::Twine &instName);
 
+  // Read and directly handle certain built-ins that are common between shader stages
+  llvm::Value *readCommonBuiltIn(BuiltInKind builtIn, llvm::Type *resultTy, const llvm::Twine &instName = "");
+
+  // Read compute shader input
+  llvm::Value *readCsBuiltIn(BuiltInKind builtIn, const llvm::Twine &instName = "");
+
   // Read vertex shader input
-  llvm::Value *readVsBuiltIn(BuiltInKind builtIn, const llvm::Twine &instName);
+  llvm::Value *readVsBuiltIn(BuiltInKind builtIn, const llvm::Twine &instName = "");
 
   // Get the type of a built-in. This overrides the one in Builder to additionally recognize the internal built-ins.
   llvm::Type *getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo);

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -65,6 +65,7 @@ const static char OutputExportBuiltIn[] = "lgc.output.export.builtin.";
 const static char OutputExportXfb[] = "lgc.output.export.xfb.";
 const static char TfBufferStore[] = "lgc.tfbuffer.store.f32";
 const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
+const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
 
 // Get pointer to spill table (as pointer to i8)
 const static char SpillTable[] = "lgc.spill.table";

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -255,26 +255,8 @@ struct ResourceUsage {
       struct {
         // Workgroup layout
         unsigned workgroupLayout : 2; // The layout of the workgroup
-        // Input
-        unsigned numWorkgroups : 1;     // Whether gl_NumWorkGroups is used
-        unsigned localInvocationId : 1; // Whether gl_LocalInvocationID is used
-        unsigned workgroupId : 1;       // Whether gl_WorkGroupID is used
-        unsigned numSubgroups : 1;      // Whether gl_NumSubgroups is used
-        unsigned subgroupId : 1;        // Whether gl_SubgroupID is used
       } cs;
     };
-
-    // Common built-in usage
-    struct {
-      unsigned subgroupSize : 1;              // Whether gl_SubGroupSize is used
-      unsigned subgroupLocalInvocationId : 1; // Whether gl_SubGroupInvocation is used
-      unsigned subgroupEqMask : 1;            // Whether gl_SubGroupEqMask is used
-      unsigned subgroupGeMask : 1;            // Whether gl_SubGroupGeMask is used
-      unsigned subgroupGtMask : 1;            // Whether gl_SubGroupGtMask is used
-      unsigned subgroupLeMask : 1;            // Whether gl_SubGroupLeMask is used
-      unsigned subgroupLtMask : 1;            // Whether gl_SubGroupLtMask is used
-      unsigned deviceIndex : 1;               // Whether gl_DeviceIndex is used
-    } common;
 
   } builtInUsage;
 
@@ -517,13 +499,6 @@ struct InterfaceData {
         unsigned ancillary;      // Ancillary
         unsigned sampleCoverage; // Sample coverage
       } fs;
-
-      // Compute shader
-      struct {
-        unsigned numWorkgroupsPtr;  // Pointer of NumWorkGroups
-        unsigned localInvocationId; // LocalInvocationID
-        unsigned workgroupId;       // WorkGroupID
-      } cs;
     };
 
     bool initialized;                          // Whether entryArgIdxs has been initialized

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1000,9 +1000,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
 
   auto userDataUsage = getUserDataUsage(m_shaderStage);
   auto intfData = m_pipelineState->getShaderInterfaceData(m_shaderStage);
-  auto resUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage);
   auto &entryArgIdxs = intfData->entryArgIdxs;
-  auto &builtInUsage = resUsage->builtInUsage;
   bool enableNgg = m_pipelineState->isGraphics() ? m_pipelineState->getNggControl()->enableNgg : false;
 
   if (m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessControl ||
@@ -1100,11 +1098,9 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
     // Unlike all the special user data values above, which go after the user data node args, this goes before.
     // That is to ensure that, with a compute pipeline using a library, library code knows where to find it
     // even if it thinks that the user data layout is a prefix of what the pipeline thinks it is.
-    if (isComputeWithCalls() || builtInUsage.cs.numWorkgroups ||
-        userDataUsage->isSpecialUserDataUsed(UserDataMapping::Workgroup)) {
+    if (isComputeWithCalls() || userDataUsage->isSpecialUserDataUsed(UserDataMapping::Workgroup)) {
       auto numWorkgroupsPtrTy = PointerType::get(FixedVectorType::get(builder.getInt32Ty(), 3), ADDR_SPACE_CONST);
-      userDataArgs.push_back(
-          UserDataArg(numWorkgroupsPtrTy, UserDataMapping::Workgroup, &entryArgIdxs.cs.numWorkgroupsPtr));
+      userDataArgs.push_back(UserDataArg(numWorkgroupsPtrTy, UserDataMapping::Workgroup, nullptr));
     }
   }
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -340,6 +340,27 @@ void PatchInOutImportExport::processShader() {
       LLPC_OUTS(")\n\n");
     }
   }
+
+  if (m_shaderStage == ShaderStageCompute) {
+    // In a compute shader, process lgc.reconfigure.local.invocation.id calls.
+    // This does not particularly have to be done here; it could be done anywhere after BuilderImpl.
+    for (Function &func : *m_module) {
+      if (func.isDeclaration() && func.getName().startswith(lgcName::ReconfigureLocalInvocationId)) {
+        WorkgroupLayout workgroupLayout = calculateWorkgroupLayout();
+        while (!func.use_empty()) {
+          CallInst *reconfigCall = cast<CallInst>(*func.user_begin());
+          Value *localInvocationId = reconfigCall->getArgOperand(0);
+
+          // If we do not need to configure our workgroup in linear layout and the layout info is not specified, we
+          // do the reconfiguration for this workgroup.
+          if (workgroupLayout != WorkgroupLayout::Unknown && workgroupLayout != WorkgroupLayout::Linear)
+            localInvocationId = reconfigWorkgroup(localInvocationId, reconfigCall);
+          reconfigCall->replaceAllUsesWith(localInvocationId);
+          reconfigCall->eraseFromParent();
+        }
+      }
+    }
+  }
 }
 
 // =====================================================================================================================
@@ -467,10 +488,6 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         if (callInst.getNumArgOperands() >= 2)
           sampleId = callInst.getArgOperand(1);
         input = patchFsBuiltInInputImport(inputTy, builtInId, sampleId, &callInst);
-        break;
-      }
-      case ShaderStageCompute: {
-        input = patchCsBuiltInInputImport(inputTy, builtInId, &callInst);
         break;
       }
       default: {
@@ -1776,12 +1793,6 @@ Value *PatchInOutImportExport::patchVsBuiltInInputImport(Type *inputTy, unsigned
   // now handled in InOutBuilder.
   case BuiltInViewIndex:
     return getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
-  case BuiltInSubgroupSize:
-    return ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getShaderWaveSize(m_shaderStage));
-  case BuiltInSubgroupLocalInvocationId:
-    return getSubgroupLocalInvocationId(insertPos);
-  case BuiltInDeviceIndex:
-    return getDeviceIndex(insertPos);
   default:
     llvm_unreachable("Should never be called!");
     return UndefValue::get(inputTy);
@@ -1857,18 +1868,6 @@ Value *PatchInOutImportExport::patchTcsBuiltInInputImport(Type *inputTy, unsigne
   }
   case BuiltInInvocationId: {
     input = m_pipelineSysValues.get(m_entryPoint)->getInvocationId();
-    break;
-  }
-  case BuiltInSubgroupSize: {
-    input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getShaderWaveSize(m_shaderStage));
-    break;
-  }
-  case BuiltInSubgroupLocalInvocationId: {
-    input = getSubgroupLocalInvocationId(insertPos);
-    break;
-  }
-  case BuiltInDeviceIndex: {
-    input = getDeviceIndex(insertPos);
     break;
   }
   default: {
@@ -1994,18 +1993,6 @@ Value *PatchInOutImportExport::patchTesBuiltInInputImport(Type *inputTy, unsigne
     input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     break;
   }
-  case BuiltInSubgroupSize: {
-    input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getShaderWaveSize(m_shaderStage));
-    break;
-  }
-  case BuiltInSubgroupLocalInvocationId: {
-    input = getSubgroupLocalInvocationId(insertPos);
-    break;
-  }
-  case BuiltInDeviceIndex: {
-    input = getDeviceIndex(insertPos);
-    break;
-  }
   default: {
     llvm_unreachable("Should never be called!");
     break;
@@ -2050,18 +2037,6 @@ Value *PatchInOutImportExport::patchGsBuiltInInputImport(Type *inputTy, unsigned
   }
   case BuiltInViewIndex: {
     input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
-    break;
-  }
-  case BuiltInSubgroupSize: {
-    input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getShaderWaveSize(m_shaderStage));
-    break;
-  }
-  case BuiltInSubgroupLocalInvocationId: {
-    input = getSubgroupLocalInvocationId(insertPos);
-    break;
-  }
-  case BuiltInDeviceIndex: {
-    input = getDeviceIndex(insertPos);
     break;
   }
   // Handle internal-use built-ins
@@ -2311,18 +2286,6 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
     input = getShadingRate(insertPos);
     break;
   }
-  case BuiltInSubgroupSize: {
-    input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getShaderWaveSize(m_shaderStage));
-    break;
-  }
-  case BuiltInSubgroupLocalInvocationId: {
-    input = getSubgroupLocalInvocationId(insertPos);
-    break;
-  }
-  case BuiltInDeviceIndex: {
-    input = getDeviceIndex(insertPos);
-    break;
-  }
   // Handle internal-use built-ins for sample position emulation
   case BuiltInNumSamples: {
     if (m_pipelineState->isUnlinked()) {
@@ -2437,128 +2400,6 @@ Value *PatchInOutImportExport::getSamplePosition(Type *inputTy, Instruction *ins
   Value *sampleId = patchFsBuiltInInputImport(builder.getInt32Ty(), BuiltInSampleId, nullptr, insertPos);
   Value *input = patchFsBuiltInInputImport(inputTy, BuiltInSamplePosOffset, sampleId, insertPos);
   return builder.CreateFAdd(input, ConstantFP::get(inputTy, 0.5));
-}
-
-// =====================================================================================================================
-// Patches import calls for built-in inputs of compute shader.
-//
-// @param inputTy : Type of input value
-// @param builtInId : ID of the built-in variable
-// @param insertPos : Where to insert the patch instruction
-Value *PatchInOutImportExport::patchCsBuiltInInputImport(Type *inputTy, unsigned builtInId, Instruction *insertPos) {
-  Value *input = nullptr;
-
-  auto intfData = m_pipelineState->getShaderInterfaceData(ShaderStageCompute);
-  auto &entryArgIdxs = intfData->entryArgIdxs.cs;
-
-  switch (builtInId) {
-  case BuiltInWorkgroupSize: {
-    input = getWorkgroupSize();
-    break;
-  }
-  case BuiltInNumWorkgroups: {
-    input = m_pipelineSysValues.get(m_entryPoint)->getNumWorkgroups();
-    break;
-  }
-  case BuiltInWorkgroupId: {
-    input = getFunctionArgument(m_entryPoint, entryArgIdxs.workgroupId);
-    break;
-  }
-  case BuiltInLocalInvocationId: {
-    input = getInLocalInvocationId(insertPos);
-    break;
-  }
-  case BuiltInSubgroupSize: {
-    input = ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getShaderWaveSize(m_shaderStage));
-    break;
-  }
-  case BuiltInSubgroupLocalInvocationId: {
-    input = getSubgroupLocalInvocationId(insertPos);
-    break;
-  }
-  case BuiltInDeviceIndex: {
-    input = getDeviceIndex(insertPos);
-    break;
-  }
-  case BuiltInNumSubgroups: {
-    // workgroupSize = gl_WorkGroupSize.x * gl_WorkGroupSize.y * gl_WorkGroupSize.z
-    auto &mode = m_pipelineState->getShaderModes()->getComputeShaderMode();
-    const unsigned workgroupSize = mode.workgroupSizeX * mode.workgroupSizeY * mode.workgroupSizeZ;
-
-    // gl_NumSubgroups = (workgroupSize + gl_SubGroupSize - 1) / gl_SubgroupSize
-    const unsigned subgroupSize = m_pipelineState->getShaderWaveSize(m_shaderStage);
-    const unsigned numSubgroups = (workgroupSize + subgroupSize - 1) / subgroupSize;
-
-    input = ConstantInt::get(Type::getInt32Ty(*m_context), numSubgroups);
-    break;
-  }
-  case BuiltInGlobalInvocationId: {
-    input = getGlobalInvocationId(inputTy, insertPos);
-    break;
-  }
-  case BuiltInLocalInvocationIndex: {
-    input = getLocalInvocationIndex(inputTy, insertPos);
-    break;
-  }
-  case BuiltInSubgroupId: {
-    input = getSubgroupId(inputTy, insertPos);
-    break;
-  }
-  default: {
-    llvm_unreachable("Should never be called!");
-    break;
-  }
-  }
-
-  return input;
-}
-
-// =====================================================================================================================
-// Get GlobalInvocationId
-//
-// @param inputTy : Type of GlobalInvocationId
-// @param insertPos : Insert position
-Value *PatchInOutImportExport::getGlobalInvocationId(Type *inputTy, Instruction *insertPos) {
-  IRBuilder<> builder(*m_context);
-  builder.SetInsertPoint(insertPos);
-  Value *workgroupSize = patchCsBuiltInInputImport(inputTy, BuiltInWorkgroupSize, insertPos);
-  Value *workgroupId = patchCsBuiltInInputImport(inputTy, BuiltInWorkgroupId, insertPos);
-  Value *localInvocationId = patchCsBuiltInInputImport(inputTy, BuiltInLocalInvocationId, insertPos);
-  Value *input = builder.CreateMul(workgroupSize, workgroupId);
-  input = builder.CreateAdd(input, localInvocationId);
-  return input;
-}
-
-// =====================================================================================================================
-// Get LocalInvocationIndex
-//
-// @param inputTy : Type of LocalInvocationIndex
-// @param insertPos : Insert position
-Value *PatchInOutImportExport::getLocalInvocationIndex(Type *inputTy, Instruction *insertPos) {
-  IRBuilder<> builder(*m_context);
-  builder.SetInsertPoint(insertPos);
-  Value *workgroupSize = patchCsBuiltInInputImport(inputTy, BuiltInWorkgroupSize, insertPos);
-  Value *localInvocationId = patchCsBuiltInInputImport(inputTy, BuiltInLocalInvocationId, insertPos);
-  Value *input = builder.CreateMul(builder.CreateExtractElement(workgroupSize, 1),
-                                   builder.CreateExtractElement(localInvocationId, 2));
-  input = builder.CreateAdd(input, builder.CreateExtractElement(localInvocationId, 1));
-  input = builder.CreateMul(builder.CreateExtractElement(workgroupSize, uint64_t(0)), input);
-  input = builder.CreateAdd(input, builder.CreateExtractElement(localInvocationId, uint64_t(0)));
-  return input;
-}
-
-// =====================================================================================================================
-// Get SubgroupId
-//
-// @param inputTy : Type of LocalInvocationIndex
-// @param insertPos : Insert position
-Value *PatchInOutImportExport::getSubgroupId(Type *inputTy, Instruction *insertPos) {
-  // gl_SubgroupID = gl_LocationInvocationIndex / gl_SubgroupSize
-  IRBuilder<> builder(*m_context);
-  builder.SetInsertPoint(insertPos);
-  Value *localInvocationIndex = patchCsBuiltInInputImport(inputTy, BuiltInLocalInvocationIndex, insertPos);
-  unsigned subgroupSize = m_pipelineState->getShaderWaveSize(m_shaderStage);
-  return builder.CreateLShr(localInvocationIndex, builder.getInt32(Log2_32(subgroupSize)));
 }
 
 // =====================================================================================================================
@@ -5537,69 +5378,6 @@ Value *PatchInOutImportExport::reconfigWorkgroup(Value *localInvocationId, Instr
   remappedId = InsertElementInst::Create(remappedId, newY, ConstantInt::get(int32Ty, 1), "", insertPos);
 
   return remappedId;
-}
-
-// =====================================================================================================================
-// Get the value of compute shader built-in WorkgroupSize
-Value *PatchInOutImportExport::getWorkgroupSize() {
-  assert(m_shaderStage == ShaderStageCompute);
-
-  auto &builtInUsage = m_pipelineState->getShaderModes()->getComputeShaderMode();
-  auto workgroupSizeX = ConstantInt::get(Type::getInt32Ty(*m_context), builtInUsage.workgroupSizeX);
-  auto workgroupSizeY = ConstantInt::get(Type::getInt32Ty(*m_context), builtInUsage.workgroupSizeY);
-  auto workgroupSizeZ = ConstantInt::get(Type::getInt32Ty(*m_context), builtInUsage.workgroupSizeZ);
-
-  return ConstantVector::get({workgroupSizeX, workgroupSizeY, workgroupSizeZ});
-}
-
-// =====================================================================================================================
-// Get the value of compute shader built-in LocalInvocationId
-//
-// @param insertPos : Where to insert instructions.
-Value *PatchInOutImportExport::getInLocalInvocationId(Instruction *insertPos) {
-  assert(m_shaderStage == ShaderStageCompute);
-
-  auto &builtInUsage = m_pipelineState->getShaderModes()->getComputeShaderMode();
-  auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageCompute)->entryArgIdxs.cs;
-  Value *locaInvocatioId = getFunctionArgument(m_entryPoint, entryArgIdxs.localInvocationId);
-
-  WorkgroupLayout workgroupLayout = calculateWorkgroupLayout();
-
-  // If we do not need to configure our workgroup in linear layout and the layout info is not specified, we
-  // do the reconfiguration for this workgroup.
-  if (workgroupLayout != WorkgroupLayout::Unknown && workgroupLayout != WorkgroupLayout::Linear)
-    locaInvocatioId = reconfigWorkgroup(locaInvocatioId, insertPos);
-  else {
-    if (builtInUsage.workgroupSizeZ > 1) {
-      // XYZ, do nothing
-    } else if (builtInUsage.workgroupSizeY > 1) {
-      // XY
-      locaInvocatioId = InsertElementInst::Create(locaInvocatioId, ConstantInt::get(Type::getInt32Ty(*m_context), 0),
-                                                  ConstantInt::get(Type::getInt32Ty(*m_context), 2), "", insertPos);
-    } else {
-      // X
-      locaInvocatioId = InsertElementInst::Create(locaInvocatioId, ConstantInt::get(Type::getInt32Ty(*m_context), 0),
-                                                  ConstantInt::get(Type::getInt32Ty(*m_context), 1), "", insertPos);
-
-      locaInvocatioId = InsertElementInst::Create(locaInvocatioId, ConstantInt::get(Type::getInt32Ty(*m_context), 0),
-                                                  ConstantInt::get(Type::getInt32Ty(*m_context), 2), "", insertPos);
-    }
-  }
-  return locaInvocatioId;
-}
-
-// =====================================================================================================================
-// Get device index from pipeline state
-//
-// @param insertPos : Where to insert instructions.
-Value *PatchInOutImportExport::getDeviceIndex(Instruction *insertPos) {
-  if (m_pipelineState->isUnlinked()) {
-    BuilderBase builder(*m_context);
-    builder.SetInsertPoint(insertPos);
-    return builder.CreateRelocationConstant(reloc::DeviceIdx);
-  } else {
-    return ConstantInt::get(Type::getInt32Ty(*m_context), m_pipelineState->getDeviceIndex());
-  }
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -105,10 +105,6 @@ private:
                                          llvm::Instruction *insertPos);
   llvm::Value *getSamplePosOffset(llvm::Type *inputTy, llvm::Value *sampleId, llvm::Instruction *insertPos);
   llvm::Value *getSamplePosition(llvm::Type *inputTy, llvm::Instruction *insertPos);
-  llvm::Value *patchCsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Instruction *insertPos);
-  llvm::Value *getGlobalInvocationId(llvm::Type *inputTy, llvm::Instruction *insertPos);
-  llvm::Value *getLocalInvocationIndex(llvm::Type *inputTy, llvm::Instruction *insertPos);
-  llvm::Value *getSubgroupId(llvm::Type *inputTy, llvm::Instruction *insertPos);
 
   llvm::Value *patchTcsBuiltInOutputImport(llvm::Type *outputTy, unsigned builtInId, llvm::Value *elemIdx,
                                            llvm::Value *vertexIdx, llvm::Instruction *insertPos);
@@ -195,9 +191,6 @@ private:
 
   WorkgroupLayout calculateWorkgroupLayout();
   llvm::Value *reconfigWorkgroup(llvm::Value *localInvocationId, llvm::Instruction *insertPos);
-  llvm::Value *getWorkgroupSize();
-  llvm::Value *getInLocalInvocationId(llvm::Instruction *insertPos);
-  llvm::Value *getDeviceIndex(llvm::Instruction *insertPos);
 
   void recordVertexAttribExport(unsigned location, llvm::ArrayRef<llvm::Value *> attribValues);
   void exportVertexAttribs(llvm::Instruction *insertPos);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1505,65 +1505,7 @@ void PatchResourceCollect::clearInactiveInput() {
     if (builtInUsage.fs.baryCoordPullModel &&
         m_activeInputBuiltIns.find(BuiltInBaryCoordPullModel) == m_activeInputBuiltIns.end())
       builtInUsage.fs.baryCoordPullModel = false;
-  } else if (m_shaderStage == ShaderStageCompute) {
-    if (builtInUsage.cs.numWorkgroups &&
-        m_activeInputBuiltIns.find(BuiltInNumWorkgroups) == m_activeInputBuiltIns.end())
-      builtInUsage.cs.numWorkgroups = false;
-
-    if (builtInUsage.cs.localInvocationId &&
-        (m_activeInputBuiltIns.find(BuiltInLocalInvocationId) == m_activeInputBuiltIns.end() &&
-         m_activeInputBuiltIns.find(BuiltInGlobalInvocationId) == m_activeInputBuiltIns.end() &&
-         m_activeInputBuiltIns.find(BuiltInLocalInvocationIndex) == m_activeInputBuiltIns.end() &&
-         m_activeInputBuiltIns.find(BuiltInSubgroupId) == m_activeInputBuiltIns.end()))
-      builtInUsage.cs.localInvocationId = false;
-
-    if (builtInUsage.cs.workgroupId &&
-        (m_activeInputBuiltIns.find(BuiltInWorkgroupId) == m_activeInputBuiltIns.end() &&
-         m_activeInputBuiltIns.find(BuiltInGlobalInvocationId) == m_activeInputBuiltIns.end() &&
-         m_activeInputBuiltIns.find(BuiltInLocalInvocationIndex) == m_activeInputBuiltIns.end() &&
-         m_activeInputBuiltIns.find(BuiltInSubgroupId) == m_activeInputBuiltIns.end()))
-      builtInUsage.cs.workgroupId = false;
-
-    if (builtInUsage.cs.subgroupId && m_activeInputBuiltIns.find(BuiltInSubgroupId) == m_activeInputBuiltIns.end())
-      builtInUsage.cs.subgroupId = false;
-
-    if (builtInUsage.cs.numSubgroups && m_activeInputBuiltIns.find(BuiltInNumSubgroups) == m_activeInputBuiltIns.end())
-      builtInUsage.cs.numSubgroups = false;
   }
-
-  // Check common built-in usage
-  if (builtInUsage.common.subgroupSize &&
-      (m_activeInputBuiltIns.find(BuiltInSubgroupSize) == m_activeInputBuiltIns.end() &&
-       m_activeInputBuiltIns.find(BuiltInNumSubgroups) == m_activeInputBuiltIns.end() &&
-       m_activeInputBuiltIns.find(BuiltInSubgroupId) == m_activeInputBuiltIns.end()))
-    builtInUsage.common.subgroupSize = false;
-
-  if (builtInUsage.common.subgroupLocalInvocationId &&
-      m_activeInputBuiltIns.find(BuiltInSubgroupLocalInvocationId) == m_activeInputBuiltIns.end())
-    builtInUsage.common.subgroupLocalInvocationId = false;
-
-  if (builtInUsage.common.subgroupEqMask &&
-      m_activeInputBuiltIns.find(BuiltInSubgroupEqMask) == m_activeInputBuiltIns.end())
-    builtInUsage.common.subgroupEqMask = false;
-
-  if (builtInUsage.common.subgroupGeMask &&
-      m_activeInputBuiltIns.find(BuiltInSubgroupGeMask) == m_activeInputBuiltIns.end())
-    builtInUsage.common.subgroupGeMask = false;
-
-  if (builtInUsage.common.subgroupGtMask &&
-      m_activeInputBuiltIns.find(BuiltInSubgroupGtMask) == m_activeInputBuiltIns.end())
-    builtInUsage.common.subgroupGtMask = false;
-
-  if (builtInUsage.common.subgroupLeMask &&
-      m_activeInputBuiltIns.find(BuiltInSubgroupLeMask) == m_activeInputBuiltIns.end())
-    builtInUsage.common.subgroupLeMask = false;
-
-  if (builtInUsage.common.subgroupLtMask &&
-      m_activeInputBuiltIns.find(BuiltInSubgroupLtMask) == m_activeInputBuiltIns.end())
-    builtInUsage.common.subgroupLtMask = false;
-
-  if (builtInUsage.common.deviceIndex && m_activeInputBuiltIns.find(BuiltInDeviceIndex) == m_activeInputBuiltIns.end())
-    builtInUsage.common.deviceIndex = false;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -74,6 +74,8 @@ CallInst *ShaderInputs::getSpecialUserData(UserDataMapping kind, BuilderBase &bu
   Type *ty = builder.getInt32Ty();
   if (kind == UserDataMapping::NggCullingData)
     ty = builder.getInt64Ty();
+  else if (kind == UserDataMapping::Workgroup)
+    ty = FixedVectorType::get(builder.getInt32Ty(), 3)->getPointerTo(ADDR_SPACE_CONST);
   return builder.CreateNamedCall((Twine(lgcName::SpecialUserData) + getSpecialUserDataName(kind)).str(), ty,
                                  builder.getInt32(static_cast<unsigned>(kind)), Attribute::ReadNone);
 }
@@ -411,7 +413,7 @@ static const ShaderInputDesc FsSgprInputs[] = {
 
 // SGPRs: CS
 static const ShaderInputDesc CsSgprInputs[] = {
-    {ShaderInput::WorkgroupId, offsetof(InterfaceData, entryArgIdxs.cs.workgroupId), true},
+    {ShaderInput::WorkgroupId, 0, true},
     {ShaderInput::MultiDispatchInfo, 0, true},
 };
 
@@ -471,7 +473,7 @@ static const ShaderInputDesc FsVgprInputs[] = {
 
 // VGPRs: CS
 static const ShaderInputDesc CsVgprInputs[] = {
-    {ShaderInput::LocalInvocationId, offsetof(InterfaceData, entryArgIdxs.cs.localInvocationId), true},
+    {ShaderInput::LocalInvocationId, 0, true},
 };
 
 // =====================================================================================================================

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -314,23 +314,6 @@ Value *ShaderSystemValues::getInternalPerShaderTablePtr() {
 }
 
 // =====================================================================================================================
-// Get number of workgroups value
-Value *ShaderSystemValues::getNumWorkgroups() {
-  if (!m_numWorkgroups) {
-    Instruction *insertPos = &*m_entryPoint->front().getFirstInsertionPt();
-    auto intfData = m_pipelineState->getShaderInterfaceData(m_shaderStage);
-
-    auto numWorkgroupPtr =
-        getFunctionArgument(m_entryPoint, intfData->entryArgIdxs.cs.numWorkgroupsPtr, "numWorkgroupsPtr");
-    auto numWorkgroupTy = numWorkgroupPtr->getType()->getPointerElementType();
-    auto numWorkgroups = new LoadInst(numWorkgroupTy, numWorkgroupPtr, "", insertPos);
-    numWorkgroups->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(insertPos->getContext(), {}));
-    m_numWorkgroups = numWorkgroups;
-  }
-  return m_numWorkgroups;
-}
-
-// =====================================================================================================================
 // Get stream-out buffer descriptor
 //
 // @param xfbBuffer : Transform feedback buffer ID

--- a/lgc/patch/SystemValues.h
+++ b/lgc/patch/SystemValues.h
@@ -92,9 +92,6 @@ public:
   // Get internal per shader table pointer as pointer to i8.
   llvm::Value *getInternalPerShaderTablePtr();
 
-  // Get number of workgroups value
-  llvm::Value *getNumWorkgroups();
-
   // Get stream-out buffer descriptor
   llvm::Value *getStreamOutBufDesc(unsigned xfbBuffer);
 
@@ -132,7 +129,6 @@ private:
   llvm::Value *m_tessCoord = nullptr;                               // Tessellated coordinate (TES)
   llvm::Value *m_esGsOffsets = nullptr;                             // ES -> GS offsets (GS in)
   llvm::SmallVector<llvm::Value *, MaxGsStreams> m_emitCounterPtrs; // Pointers to emit counters (GS)
-  llvm::Value *m_numWorkgroups = nullptr;                           // NumWorkgroups
 
   llvm::SmallVector<llvm::Value *, 8> m_descTablePtrs;       // Descriptor table pointers
   llvm::SmallVector<llvm::Value *, 8> m_shadowDescTablePtrs; // Shadow descriptor table pointers

--- a/lgc/test/CsBuiltIns.lgc
+++ b/lgc/test/CsBuiltIns.lgc
@@ -102,7 +102,7 @@ attributes #0 = { nounwind }
 
 ; RUN: lgc -extract=4 -mcpu=gfx802 %s -o - | FileCheck --check-prefixes=CHECK4 %s
 ; CHECK4-LABEL: _amdgpu_cs_main:
-; CHECK4: s_load_dwordx4 s{{\[}}[[SREGNUM:[0-9]+]]:
+; CHECK4: s_load_dwordx4 s{{\[}}[[SREGNUM:[0-9]+]]:{{[0-9]+}}], s[2:3]
 ; CHECK4: v_mov_b32_e32 v0, s[[SREGNUM]]
 ; CHECK4: buffer_store_dwordx3 v[0:2],
 ; CHECK4: COMPUTE_USER_DATA_2): 0x10000006

--- a/llpc/test/shaderdb/ExtDeviceGroup_TestComputeShader_lit.comp
+++ b/llpc/test/shaderdb/ExtDeviceGroup_TestComputeShader_lit.comp
@@ -18,7 +18,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
-; SHADERTEST: call i32 @lgc.input.import.builtin.DeviceIndex.i32.i32
+; SHADERTEST: call i32 (...) @lgc.create.read.builtin.input.i32(i32 4438,
 ; SHADERTEST-LABEL: {{^// LLPC}} final ELF info
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/ExtDeviceGroup_TestGraphicsShader_lit.vert
+++ b/llpc/test/shaderdb/ExtDeviceGroup_TestGraphicsShader_lit.vert
@@ -10,7 +10,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
-; SHADERTEST: call i32 @lgc.input.import.builtin.DeviceIndex.i32.i32
+; SHADERTEST: call i32 (...) @lgc.create.read.builtin.input.i32(i32 4438,
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/ExtShaderBallot_TestGeneral_lit.frag
+++ b/llpc/test/shaderdb/ExtShaderBallot_TestGeneral_lit.frag
@@ -41,7 +41,7 @@ void main(void)
 ; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.subgroup.broadcast.f32(
 ; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.subgroup.broadcast.first.f32(
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: call i32 @lgc.input.import.builtin.SubgroupLocalInvocationId.i32.i32
+; SHADERTEST: mbcnt_lo
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/ObjInput_TestCsBuiltIn_lit.comp
+++ b/llpc/test/shaderdb/ObjInput_TestCsBuiltIn_lit.comp
@@ -22,11 +22,11 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call i32 @lgc.input.import.builtin.LocalInvocationIndex{{.*}}
-; SHADERTEST: call <3 x i32> @lgc.input.import.builtin.LocalInvocationId.v3i32{{.*}}
-; SHADERTEST: call <3 x i32> @lgc.input.import.builtin.WorkgroupId.v3i32{{.*}}
-; SHADERTEST: call <3 x i32> @lgc.input.import.builtin.GlobalInvocationId.v3i32{{.*}}
-; SHADERTEST: call <3 x i32> @lgc.input.import.builtin.NumWorkgroups.v3i32{{.*}}
+; SHADERTEST: call i32 (...) @lgc.create.read.builtin.input.i32(i32 29,
+; SHADERTEST: call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27,
+; SHADERTEST: call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 26,
+; SHADERTEST: call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 28,
+; SHADERTEST: call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 24,
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/ObjShaderBallot_TestGeneral_lit.comp
+++ b/llpc/test/shaderdb/ObjShaderBallot_TestGeneral_lit.comp
@@ -49,9 +49,6 @@ void main()
 ; SHADERTEST: call <2 x i32> (...) @lgc.create.subgroup.broadcast.first.v2i32(
 ; SHADERTEST: call <3 x i32> (...) @lgc.create.subgroup.broadcast.first.v3i32(
 
-; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: call i32 @lgc.input.import.builtin.SubgroupLocalInvocationId.i32.i32
-
 ; SHADERTEST-LABEL: {{^// LLPC.*}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.readlane(i32 %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: call i32 @llvm.amdgcn.readfirstlane(i32 %{{.*}})

--- a/llpc/test/shaderdb/PipelineCs_TestMultiEntryPoint_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestMultiEntryPoint_lit.pipe
@@ -6,7 +6,7 @@
 ; SHADERTEST: !llpc.compute.mode = !{![[COMPUTEMODE:[0-9]+]]}
 ; SHADERTEST: ![[COMPUTEMODE]] = !{i32 1, i32 1, i32 1}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg %0, i32 inreg %1, i32 inreg{{[^,]*}} %descSet0, <3 x i32> inreg %2, i32 inreg %3, <3 x i32> %4)
+; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg %0, i32 inreg %1, i32 inreg{{[^,]*}} %descSet0, <3 x i32> inreg %WorkgroupId, i32 inreg %2, <3 x i32> %LocalInvocationId)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
This removes some more persistent outside-IR state from ResourceUsage
and InterfaceData by moving the implementation of CS built-in inputs
out of PatchInOutImportExport and into InOutBuilder. The built-ins are
implemented there in terms of shader inputs and special user data
values, which are resolved in PatchEntryPointMutate.

(Just the top-most commit "Move CS built-ins to InOutBuilder)