### PR TITLE
Elf linking: use float mode from shader body

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -253,7 +253,9 @@ union SPI_SHADER_PGM_RSRC1 {
   struct {
     unsigned int VGPRS : 6;
     unsigned int SGPRS : 4;
-    unsigned int : 22;
+    unsigned int : 2;
+    unsigned int FLOAT_MODE : 8;
+    unsigned int : 12;
   } bits, bitfields;
   unsigned int u32All;
 };

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -195,6 +195,10 @@ void PalMetadata::mergeFromBlob(llvm::StringRef blob, bool isGlueCode) {
             destRsrc1.u32All = origRsrc1.u32All | srcRsrc1.u32All;
             destRsrc1.bits.VGPRS = std::max(origRsrc1.bits.VGPRS, srcRsrc1.bits.VGPRS);
             destRsrc1.bits.SGPRS = std::max(origRsrc1.bits.SGPRS, srcRsrc1.bits.SGPRS);
+            if (isGlueCode) {
+              // The float mode should come from the body of the shader and not the glue code.
+              destRsrc1.bits.FLOAT_MODE = origRsrc1.bits.FLOAT_MODE;
+            }
             *destNode = srcNode.getDocument()->getNode(destRsrc1.u32All);
             return 0;
           }

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_CheckFloatModeFlushToZero.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_CheckFloatModeFlushToZero.pipe
@@ -1,0 +1,50 @@
+// This test case checks that the denormal mode is correctly set in the pal metadata.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: PalMetadata
+; SHADERTEST: SPI_SHADER_PGM_RSRC1_PS 0x00000000002C
+; END_SHADERTEST
+
+[Version]
+version = 41
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %9
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %9 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %9 = OpVariable %_ptr_Output_v4float Output
+         %23 = OpUndef %v4float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %9 %23
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+options.fp32DenormalMode = FlushToZero

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_CheckFloatModePreserve.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_CheckFloatModePreserve.pipe
@@ -1,0 +1,50 @@
+// This test case checks that the denormal mode is correctly set in the pal metadata.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: PalMetadata
+; SHADERTEST: SPI_SHADER_PGM_RSRC1_PS 0x00000000002F
+; END_SHADERTEST
+
+[Version]
+version = 41
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %9
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %9 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %9 = OpVariable %_ptr_Output_v4float Output
+         %23 = OpUndef %v4float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %9 %23
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+options.fp32DenormalMode = Preserve


### PR DESCRIPTION
When merging the pal metadata, we currently do an xor of the float
modes.  This can cause problems when the fetch or color export shader
have a different float mode than the body of the shader.  The solution
is to use the float mode from the body of the function.

Fixes https://github.com/GPUOpen-Drivers/llpc/issues/1047.