### PR TITLE
Reenable relcoatable compute shader

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -990,12 +990,6 @@ bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineS
 //
 // @param shaderInfo : Shader info for the pipeline to be built
 bool Compiler::canUseRelocatableComputeShaderElf(const ComputePipelineBuildInfo *pipelineInfo) {
-  // Relocatable shader cannot get the order of the user data nodes correct.  We have to disable them for compute
-  // shaders until the restriction in PAL has been relaxed.
-  // The tests PipelineCs_StrideReloc.pipe, PipelineCs_RelocCombinedTextureSampler.pipe, PipelineCs_ShaderCache.pipe,
-  // and PipelineCs_RelocConst.pipe must be reenabled when this restriction is removed.
-  return false;
-
   const PipelineShaderInfo *shaderInfo = &pipelineInfo->cs;
   if (shaderInfo) {
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo->pModuleData);

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
@@ -1,5 +1,3 @@
-; XFAIL: *
-
 // This test case checks that two relocation entries are generated for a combined texture sampler descriptor,
 // one for the resource handle offset, and another for the sampler handle offset.
 ; BEGIN_SHADERTEST

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
@@ -1,5 +1,3 @@
-; XFAIL: *
-
 ; This test case checks that descriptor offset relocation works for buffer descriptors in a compute pipeline.
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s


### PR DESCRIPTION
The issue that was causing reloctable compute shaders to fail has been
resolved.  We can now reenable them.