### PR TITLE
Update compute shader hash

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -907,8 +907,12 @@ MetroHash::Hash PipelineDumper::generateHashForComputePipeline(const ComputePipe
   hasher.Update(pipeline->options.scalarBlockLayout);
   hasher.Update(pipeline->options.includeIr);
   hasher.Update(pipeline->options.robustBufferAccess);
-  hasher.Update(pipeline->options.shadowDescriptorTableUsage);
-  hasher.Update(pipeline->options.shadowDescriptorTablePtrHigh);
+
+  if (!isRelocatableShader) {
+    hasher.Update(pipeline->options.shadowDescriptorTableUsage);
+    hasher.Update(pipeline->options.shadowDescriptorTablePtrHigh);
+  }
+
   hasher.Update(pipeline->options.extendedRobustness.robustBufferAccess);
   hasher.Update(pipeline->options.extendedRobustness.robustImageAccess);
   hasher.Update(pipeline->options.extendedRobustness.nullDescriptor);


### PR DESCRIPTION
Relocatable shaders do not need to include the shadow descriptor data in
the hash because they are handled with relocataions.  They have already
been removed from the graphics shader hash, so now we remove it from the
compute pipeline.