### PR TITLE
Fix setting shader stage of new functions

### DIFF
--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -69,7 +69,6 @@ void lgc::setShaderStage(Function *func, ShaderStage stage) {
   unsigned mdKindId = func->getContext().getMDKindID(ShaderStageMetadata);
   auto stageMetaNode = MDNode::get(
       func->getContext(), {ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(func->getContext()), stage))});
-  assert(!func->isDeclaration());
   func->setMetadata(mdKindId, stageMetaNode);
 }
 


### PR DESCRIPTION
We want to be able to set the shader stage after creating a function but
before adding instructions to it. Therefore there should not be an
assert.

IIRC we agreed to just remove the assert in on of the comments in #986.