### PR TITLE
NGG: Rename the member 'forceNonPassthrough' of NGG state

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -70,6 +70,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     44.0 | Rename the member 'forceNonPassthrough' of NGG state to 'forceCullingMode'
 //* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |
 //* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
@@ -455,9 +456,13 @@ enum NggCompactMode : unsigned {
 
 /// Represents NGG tuning options
 struct NggState {
-  bool enableNgg;                ///< Enable NGG mode, use an implicit primitive shader
-  bool enableGsUse;              ///< Enable NGG use on geometry shader
-  bool forceNonPassthrough;      ///< Force NGG to run in non pass-through mode
+  bool enableNgg;   ///< Enable NGG mode, use an implicit primitive shader
+  bool enableGsUse; ///< Enable NGG use on geometry shader
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
+  bool forceNonPassthrough; ///< Force NGG to run in non pass-through mode
+#else
+  bool forceCullingMode;          ///< Force NGG to run in culling mode
+#endif
   bool alwaysUsePrimShaderTable; ///< Always use primitive shader table to fetch culling-control registers
   NggCompactMode compactMode;    ///< Compaction mode after culling operations
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -86,7 +86,6 @@ enum NggCompactMode : unsigned {
 struct NggControl {
   bool enableNgg;                // Enable NGG mode, use an implicit primitive shader
   bool enableGsUse;              // Enable NGG use on geometry shader
-  bool forceNonPassthrough;      // Force NGG to run in non pass-through mode
   bool alwaysUsePrimShaderTable; // Always use primitive shader table to fetch culling-control registers
   NggCompactMode compactMode;    // Compaction mode after culling operations
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -55,7 +55,7 @@ class LgcContext;
 enum NggFlag : unsigned {
   NggFlagDisable = 0x0001,                      // Disable NGG
   NggFlagEnableGsUse = 0x0002,                  // Enable NGG when pipeline has GS
-  NggFlagForceNonPassthrough = 0x0004,          // Force NGG to run in non-passthrough mode
+  NggFlagForceCullingMode = 0x0004,             // Force NGG to run in culling mode
   NggFlagDontAlwaysUsePrimShaderTable = 0x0008, // Don't always use primitive shader table to fetch culling-control
                                                 //   registers
   NggFlagCompactDisable = 0x0010,               // Vertex compaction is disabled

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -162,7 +162,7 @@ void PatchResourceCollect::setNggControl(Module *module) {
   nggControl.vertsPerSubgroup = std::min(options.nggVertsPerSubgroup, Gfx9::NggMaxThreadsPerSubgroup);
 
   if (nggControl.enableNgg) {
-    if (options.nggFlags & NggFlagForceNonPassthrough)
+    if (options.nggFlags & NggFlagForceCullingMode)
       nggControl.passthroughMode = false;
     else {
       nggControl.passthroughMode = !nggControl.enableVertexReuse && !nggControl.enableBackfaceCulling &&

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -276,7 +276,11 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
       options.nggFlags |= NggFlagDisable;
     else {
       options.nggFlags = (nggState.enableGsUse ? NggFlagEnableGsUse : 0) |
-                         (nggState.forceNonPassthrough ? NggFlagForceNonPassthrough : 0) |
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
+                         (nggState.forceNonPassthrough ? NggFlagForceCullingMode : 0) |
+#else
+                         (nggState.forceCullingMode ? NggFlagForceCullingMode : 0) |
+#endif
                          (nggState.alwaysUsePrimShaderTable ? 0 : NggFlagDontAlwaysUsePrimShaderTable) |
                          (nggState.compactMode == NggCompactDisable ? NggFlagCompactDisable : 0) |
                          (nggState.enableFastLaunch ? NggFlagEnableFastLaunch : 0) |

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -139,9 +139,9 @@ static cl::opt<bool> EnableNgg("enable-ngg", cl::desc("Enable implicit primitive
 static cl::opt<bool> NggEnableGsUse("ngg-enable-gs-use", cl::desc("Enable NGG use on geometry shader"),
                                     cl::init(false));
 
-// -ngg-force-non-passthrough: force NGG to run in non pass-through mode
-static cl::opt<bool> NggForceNonPassThrough("ngg-force-non-passthrough",
-                                            cl::desc("Force NGG to run in non pass-through mode"), cl::init(false));
+// -ngg-force-culling-mode: force NGG to run in culling mode
+static cl::opt<bool> NggForceCullingMode("ngg-force-culling-mode", cl::desc("Force NGG to run in culling mode"),
+                                         cl::init(false));
 
 // -ngg-always-use-prim-shader-table: always use primitive shader table to fetch culling-control registers
 static cl::opt<bool>
@@ -472,7 +472,11 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
 
     nggState.enableNgg = EnableNgg;
     nggState.enableGsUse = NggEnableGsUse;
-    nggState.forceNonPassthrough = NggForceNonPassThrough;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
+    nggState.forceNonPassthrough = NggForceCullingMode;
+#else
+    nggState.forceCullingMode = NggForceCullingMode;
+#endif
     nggState.alwaysUsePrimShaderTable = NggAlwaysUsePrimShaderTable;
     nggState.compactMode = static_cast<NggCompactMode>(NggCompactionMode.getValue());
     nggState.enableFastLaunch = NggEnableFastLaunchRate;

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -742,7 +742,11 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
 
   dumpFile << "nggState.enableNgg = " << pipelineInfo->nggState.enableNgg << "\n";
   dumpFile << "nggState.enableGsUse = " << pipelineInfo->nggState.enableGsUse << "\n";
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
   dumpFile << "nggState.forceNonPassthrough = " << pipelineInfo->nggState.forceNonPassthrough << "\n";
+#else
+  dumpFile << "nggState.forceCullingMode = " << pipelineInfo->nggState.forceCullingMode << "\n";
+#endif
   dumpFile << "nggState.alwaysUsePrimShaderTable = " << pipelineInfo->nggState.alwaysUsePrimShaderTable << "\n";
   dumpFile << "nggState.compactMode = " << pipelineInfo->nggState.compactMode << "\n";
   dumpFile << "nggState.enableFastLaunch = " << pipelineInfo->nggState.enableFastLaunch << "\n";
@@ -996,7 +1000,11 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     hasher->Update(nggState->enableNgg);
     if (nggState->enableNgg) {
       hasher->Update(nggState->enableGsUse);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
       hasher->Update(nggState->forceNonPassthrough);
+#else
+      hasher->Update(nggState->forceCullingMode);
+#endif
       hasher->Update(nggState->alwaysUsePrimShaderTable);
       hasher->Update(nggState->compactMode);
       hasher->Update(nggState->enableFastLaunch);

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -393,7 +393,11 @@ public:
     StrToMemberAddr *tableItem = m_addrTable;
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableNgg, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableGsUse, MemberTypeBool, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceNonPassthrough, MemberTypeBool, false);
+#else
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceCullingMode, MemberTypeBool, false);
+#endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, alwaysUsePrimShaderTable, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFastLaunch, MemberTypeBool, false);


### PR DESCRIPTION
Rename it to 'forceCullingMode'. This is more clear.

Change-Id: I7f46af04357e656c3cdb4b8abd11d07a56e6394e