### PR TITLE
Fixes for compute libraries

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -32,7 +32,6 @@
 #include "lgc/Builder.h"
 #include "lgc/LgcContext.h"
 #include "lgc/state/IntrinsDefs.h"
-#include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -73,8 +72,6 @@ PatchBufferOp::PatchBufferOp() : FunctionPass(ID) {
 void PatchBufferOp::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
   analysisUsage.addRequired<LegacyDivergenceAnalysis>();
   analysisUsage.addRequired<PipelineStateWrapper>();
-  analysisUsage.addRequired<PipelineShaders>();
-  analysisUsage.addPreserved<PipelineShaders>();
   analysisUsage.addRequired<TargetTransformInfoWrapperPass>();
   analysisUsage.addPreserved<TargetTransformInfoWrapperPass>();
 }
@@ -91,11 +88,11 @@ bool PatchBufferOp::runOnFunction(Function &function) {
   m_builder = std::make_unique<IRBuilder<>>(*m_context);
 
   // Invoke visitation of the target instructions.
-  auto pipelineShaders = &getAnalysis<PipelineShaders>();
 
   // If the function is not a valid shader stage, bail.
-  if (pipelineShaders->getShaderStage(&function) == ShaderStageInvalid)
+  if (lgc::getShaderStage(&function) == ShaderStageInvalid) {
     return false;
+  }
 
   m_divergenceAnalysis = &getAnalysis<LegacyDivergenceAnalysis>();
 
@@ -1700,6 +1697,5 @@ void PatchBufferOp::fixIncompletePhis() {
 // Initializes the pass of LLVM patch operations for buffer operations.
 INITIALIZE_PASS_BEGIN(PatchBufferOp, DEBUG_TYPE, "Patch LLVM for buffer operations", false, false)
 INITIALIZE_PASS_DEPENDENCY(LegacyDivergenceAnalysis)
-INITIALIZE_PASS_DEPENDENCY(PipelineShaders)
 INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)
 INITIALIZE_PASS_END(PatchBufferOp, DEBUG_TYPE, "Patch LLVM for buffer operations", false, false)

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -65,6 +65,9 @@ private:
   PatchInOutImportExport(const PatchInOutImportExport &) = delete;
   PatchInOutImportExport &operator=(const PatchInOutImportExport &) = delete;
 
+  void processFunction(llvm::Function &func, ShaderStage shaderStage,
+                       llvm::SmallVectorImpl<llvm::Function *> &inputCallees,
+                       llvm::SmallVectorImpl<llvm::Function *> &otherCallees);
   void initPerShader();
 
   void markExportDone(llvm::Function *func, llvm::PostDominatorTree &postDomTree);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -94,6 +94,17 @@ bool PatchResourceCollect::runOnModule(Module &module) {
     }
   }
 
+  // Process non-entry-point shaders
+  for (Function &func : module) {
+    if (func.isDeclaration())
+      continue;
+    m_shaderStage = getShaderStage(&func);
+    if (m_shaderStage == ShaderStage::ShaderStageInvalid || &func == m_pipelineShaders->getEntryPoint(m_shaderStage))
+      continue;
+    m_entryPoint = &func;
+    processShader();
+  }
+
   if (m_pipelineState->isGraphics()) {
     // Set NGG control settings
     setNggControl(&module);

--- a/lgc/test/CallLibFromCs.lgc
+++ b/lgc/test/CallLibFromCs.lgc
@@ -1,0 +1,63 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #2 !lgc.shaderstage !7 {
+; CHECK: %[[#]] = call amdgpu_gfx i32 bitcast (i32 ()* @compute_library_func to i32 (i32, i32, <3 x i32> addrspace(4)*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <3 x i32>, i32, <3 x i32>)*)(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16)
+; CHECK: !7 = !{i32 5}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare i32 @compute_library_func() #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  %v = call amdgpu_gfx i32 @compute_library_func()
+  %v2 = insertelement <4 x i32> %19, i32 %v, i32 0
+  store <4 x i32> %v2, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/CallLibFromFs.lgc
+++ b/lgc/test/CallLibFromFs.lgc
@@ -1,0 +1,39 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 inreg %15, <2 x float> %16, <2 x float> %17, <2 x float> %18, <3 x float> %19, <2 x float> %20, <2 x float> %21, <2 x float> %22, float %23, float %24, float %25, float %26, float %27, i32 %28, i32 %29, i32 %30, i32 %31) #2 !lgc.shaderstage !5 {
+; CHECK: %[[#]] = call amdgpu_gfx <4 x float> bitcast (<4 x float> ()* @compute_library_func to <4 x float> (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <2 x float>, <2 x float>, <2 x float>, <3 x float>, <2 x float>, <2 x float>, <2 x float>, float, float, float, float, float, i32, i32, i32, i32)*)(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 inreg %15, <2 x float> %16, <2 x float> %17, <2 x float> %18, <3 x float> %19, <2 x float> %20, <2 x float> %21, <2 x float> %22, float %23, float %24, float %25, float %26, float %27, i32 %28, i32 %29, i32 %30, i32 %31)
+; CHECK: !5 = !{i32 4}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare <4 x float> @compute_library_func() #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %res = call amdgpu_gfx <4 x float> @compute_library_func()
+  call void (...) @lgc.create.write.generic.output(<4 x float> %res, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+attributes #0 = { nounwind }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.FS = !{!2}
+!lgc.color.export.formats = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 -794913950, i32 -27741903, i32 1278784547, i32 441582842, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1072849668, i32 -352651751, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 14, i32 7}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 4}

--- a/lgc/test/CallLibFromVs.lgc
+++ b/lgc/test/CallLibFromVs.lgc
@@ -1,0 +1,37 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 %15, i32 %16, i32 %17, i32 %18) #1 !lgc.shaderstage !4 {
+; CHECK: %[[#]] = call amdgpu_gfx <4 x float> bitcast (<4 x float> ()* @compute_library_func to <4 x float> (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)*)(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 %15, i32 %16, i32 %17, i32 %18)
+; CHECK: !4 = !{i32 0}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare <4 x float> @compute_library_func() #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %res = call amdgpu_gfx <4 x float> @compute_library_func()
+  call void (...) @lgc.create.write.generic.output(<4 x float> %res, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+attributes #0 = { nounwind }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.VS = !{!2}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 628083063, i32 1661573491, i32 -2141117829, i32 766255606, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1951548461, i32 273960056, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 3, i32 3}
+!5 = !{i32 0}

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -1,0 +1,58 @@
+; Define a compute library that can be called from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
+; CHECK: !7 = !{i32 5}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  store <4 x i32> %19, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/FsComputeLibrary.lgc
+++ b/lgc/test/FsComputeLibrary.lgc
@@ -1,0 +1,35 @@
+; Define a compute library that can be called from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
+; CHECK: !5 = !{i32 4}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.FS = !{!2}
+!lgc.color.export.formats = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 -794913950, i32 -27741903, i32 1278784547, i32 441582842, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1072849668, i32 -352651751, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 14, i32 7}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 4}

--- a/lgc/test/VsComputeLibrary.lgc
+++ b/lgc/test/VsComputeLibrary.lgc
@@ -1,0 +1,35 @@
+; Define a compute library that can be called from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define spir_func <4 x float> @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #2 !lgc.shaderstage !4 {
+; CHECK: !4 = !{i32 0}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func <4 x float> @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %0 = call <4 x i32> (...) @lgc.create.read.generic.input.v4i32(i32 5, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  %bc = bitcast <4 x i32> %0 to <4 x float>
+  ret <4 x float> %bc
+}
+
+; Function Attrs: nounwind readonly
+declare <4 x i32> @lgc.create.read.generic.input.v4i32(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.VS = !{!2}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 628083063, i32 1661573491, i32 -2141117829, i32 766255606, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1951548461, i32 273960056, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 3, i32 3}
+!5 = !{i32 0}


### PR DESCRIPTION
- Use amdgpu_gfx calling convention for libraries
- Allow library calls in more shader types
- Fix patching non-entrypoints
- Add tests

The large diff for `PatchEntryPointMutate::processCalls` is just a change in indentation as it does not iterate over all functions in a module. The content of the loop does not change.

This patch also spills root descriptors for compute libraries as unspilling them definitely does not work. With spilling, it probably does not work either (see https://github.com/GPUOpen-Drivers/llpc/pull/986#issuecomment-730633961) but at least the compiler does not crash anymore.
