### PR TITLE
[CI] Don't invalidate cmake cache for llpc in CI builds

### DIFF
--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -29,8 +29,7 @@ SHELL ["/bin/bash", "-c"]
 # Sync the repos. Replace the base LLPC with a freshly checked-out one.
 RUN cat /vulkandriver/build_info.txt \
     && (cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc)) \
-    && rm -rf /vulkandriver/drivers/llpc \
-    && git clone https://github.com/"$LLPC_REPO_NAME".git /vulkandriver/drivers/llpc \
+    && git -C /vulkandriver/drivers/llpc remote add origin https://github.com/"$LLPC_REPO_NAME".git \
     && git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" --update-head-ok \
     && git -C /vulkandriver/drivers/llpc checkout "$LLPC_REPO_SHA"
 


### PR DESCRIPTION
Don't remove and clone all source files during 'Check LLPC' CI builds.
This improved build times by decreasing the number of needless recompilations
for source files that haven't changed since the last nightly build.

The biggest improvement should be visible on Pull Requests that only touch
docummentation or other not compiled files.