### PR TITLE
Report cache access information

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -46,7 +46,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 45
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -70,6 +70,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     45.1 | Add pipelineCacheAccess, stageCacheAccess(es) to GraphicsPipelineBuildOut/ComputePipelineBuildOut     |
 //* |     45.0 | Remove the member 'enableFastLaunch' of NGG state                                                     |
 //* |     44.0 | Rename the member 'forceNonPassthrough' of NGG state to 'forceCullingMode'                            |
 //* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -122,13 +122,16 @@ public:
                                       ComputePipelineBuildOut *pipelineOut, void *pipelineDumpFile = nullptr);
   Result buildGraphicsPipelineInternal(GraphicsContext *graphicsContext,
                                        llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
-                                       bool buildingRelocatableElf, ElfPackage *pipelineElf);
+                                       bool buildingRelocatableElf, ElfPackage *pipelineElf,
+                                       llvm::MutableArrayRef<CacheAccessInfo> stageCacheAccesses);
 
   Result buildComputePipelineInternal(ComputeContext *computeContext, const ComputePipelineBuildInfo *pipelineInfo,
-                                      bool buildingRelocatableElf, ElfPackage *pipelineElf);
+                                      bool buildingRelocatableElf, ElfPackage *pipelineElf,
+                                      CacheAccessInfo *stageCacheAccess);
 
   Result buildPipelineWithRelocatableElf(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
-                                         ElfPackage *pipelineElf);
+                                         ElfPackage *pipelineElf,
+                                         llvm::MutableArrayRef<CacheAccessInfo> stageCacheAccesses);
 
   Result buildPipelineInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo, bool unlinked,
                                ElfPackage *pipelineElf);

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -109,14 +109,24 @@ struct ShaderModuleBuildOut {
   ShaderModuleData *pModuleData; ///< Output shader module data (opaque)
 };
 
+enum CacheAccessInfo : uint8_t {
+  CacheNotChecked = 0, ///< Stage cache is not checked.
+  CacheMiss,           ///< Stage cache miss.
+  CacheHit,            ///< Stage cache hit.
+};
+
 /// Represents output of building a graphics pipeline.
 struct GraphicsPipelineBuildOut {
   BinaryData pipelineBin; ///< Output pipeline binary data
+  CacheAccessInfo pipelineCacheAccess; ///< Pipeline cache access status i.e., hit, miss, or not checked
+  CacheAccessInfo stageCacheAccesses[ShaderStageCount]; ///< Shader cache access status i.e., hit, miss, or not checked
 };
 
 /// Represents output of building a compute pipeline.
 struct ComputePipelineBuildOut {
   BinaryData pipelineBin; ///< Output pipeline binary data
+  CacheAccessInfo pipelineCacheAccess; ///< Pipeline cache access status i.e., hit, miss, or not checked
+  CacheAccessInfo stageCacheAccess;    ///< Shader cache access status i.e., hit, miss, or not checked
 };
 
 /// Defines callback function used to lookup shader cache info in an external cache


### PR DESCRIPTION
Based on the Vulkan spec, Vulkan application can get the cache hit/miss
information for the pipeline and all shader stages using
[Pipeline Creation Feedback](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/chap11.html#pipelines-creation-feedback).

Since LLPC uses/maintains the pipeline and the shader caches, the ICD
needs the help from LLPC to get the cache hit/miss information.
This commit lets LLPC report the information to the ICD i.e., XGL.

[This XGL PR](https://github.com/GPUOpen-Drivers/xgl/pull/68) reports
the cache hit/miss information through `VkPipelineCreationFeedbackCreateInfoEXT`
data structure based on the information given by LLPC.