### PR TITLE
NGG: Remove the member 'enableFastLaunch' of NGG state

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -43,7 +43,7 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 44
+#define LLPC_INTERFACE_MAJOR_VERSION 45
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -70,7 +70,8 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
-//* |     44.0 | Rename the member 'forceNonPassthrough' of NGG state to 'forceCullingMode'
+//* |     45.0 | Remove the member 'enableFastLaunch' of NGG state                                                     |
+//* |     44.0 | Rename the member 'forceNonPassthrough' of NGG state to 'forceCullingMode'                            |
 //* |     43.1 | Add disableImageResourceCheck in PipelineOptions                                                      |
 //* |     43.0 | Removed the enumerant WaveBreakSize::DrawTime                                                         |
 //* |     42.0 | Removed tileOptimal flag from SamplerYcbcrConversion metadata struct                                  |
@@ -466,7 +467,9 @@ struct NggState {
   bool alwaysUsePrimShaderTable; ///< Always use primitive shader table to fetch culling-control registers
   NggCompactMode compactMode;    ///< Compaction mode after culling operations
 
-  bool enableFastLaunch;          ///< Enable the hardware to launch subgroups of work at a faster rate
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 45
+  bool enableFastLaunch; ///< Enable the hardware to launch subgroups of work at a faster rate
+#endif
   bool enableVertexReuse;         ///< Enable optimization to cull duplicate vertices
   bool enableBackfaceCulling;     ///< Enable culling of primitives that don't meet facing criteria
   bool enableFrustumCulling;      ///< Enable discarding of primitives outside of view frustum

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -59,14 +59,13 @@ enum NggFlag : unsigned {
   NggFlagDontAlwaysUsePrimShaderTable = 0x0008, // Don't always use primitive shader table to fetch culling-control
                                                 //   registers
   NggFlagCompactDisable = 0x0010,               // Vertex compaction is disabled
-  NggFlagEnableFastLaunch = 0x0020,             // Enable the hardware to launch subgroups of work at a faster rate
-  NggFlagEnableVertexReuse = 0x0040,            // Enable optimization to cull duplicate vertices
-  NggFlagEnableBackfaceCulling = 0x0080,        // Enable culling of primitives that don't meet facing criteria
-  NggFlagEnableFrustumCulling = 0x0100,         // Enable discarding of primitives outside of view frustum
-  NggFlagEnableBoxFilterCulling = 0x0200,       // Enable simpler frustum culler that is less accurate
-  NggFlagEnableSphereCulling = 0x0400,          // Enable frustum culling based on a sphere
-  NggFlagEnableSmallPrimFilter = 0x0800,        // Enable trivial sub-sample primitive culling
-  NggFlagEnableCullDistanceCulling = 0x1000,    // Enable culling when "cull distance" exports are present
+  NggFlagEnableVertexReuse = 0x0020,            // Enable optimization to cull duplicate vertices
+  NggFlagEnableBackfaceCulling = 0x0040,        // Enable culling of primitives that don't meet facing criteria
+  NggFlagEnableFrustumCulling = 0x0080,         // Enable discarding of primitives outside of view frustum
+  NggFlagEnableBoxFilterCulling = 0x0100,       // Enable simpler frustum culler that is less accurate
+  NggFlagEnableSphereCulling = 0x0200,          // Enable frustum culling based on a sphere
+  NggFlagEnableSmallPrimFilter = 0x0400,        // Enable trivial sub-sample primitive culling
+  NggFlagEnableCullDistanceCulling = 0x0800,    // Enable culling when "cull distance" exports are present
 };
 
 // Enumerates various sizing options of sub-group size for NGG primitive shader.

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -147,7 +147,7 @@ void PatchResourceCollect::setNggControl(Module *module) {
   nggControl.alwaysUsePrimShaderTable = (options.nggFlags & NggFlagDontAlwaysUsePrimShaderTable) == 0;
   nggControl.compactMode = (options.nggFlags & NggFlagCompactDisable) ? NggCompactDisable : NggCompactVertices;
 
-  nggControl.enableFastLaunch = (options.nggFlags & NggFlagEnableFastLaunch);
+  nggControl.enableFastLaunch = false; // Currently, always false
   nggControl.enableVertexReuse = (options.nggFlags & NggFlagEnableVertexReuse);
   nggControl.enableBackfaceCulling = (options.nggFlags & NggFlagEnableBackfaceCulling);
   nggControl.enableFrustumCulling = (options.nggFlags & NggFlagEnableFrustumCulling);

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -283,7 +283,6 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
 #endif
                          (nggState.alwaysUsePrimShaderTable ? 0 : NggFlagDontAlwaysUsePrimShaderTable) |
                          (nggState.compactMode == NggCompactDisable ? NggFlagCompactDisable : 0) |
-                         (nggState.enableFastLaunch ? NggFlagEnableFastLaunch : 0) |
                          (nggState.enableVertexReuse ? NggFlagEnableVertexReuse : 0) |
                          (nggState.enableBackfaceCulling ? NggFlagEnableBackfaceCulling : 0) |
                          (nggState.enableFrustumCulling ? NggFlagEnableFrustumCulling : 0) |

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -156,12 +156,6 @@ static cl::opt<unsigned> NggCompactionMode("ngg-compaction-mode",
                                                     "1: Compaction is based on vertices"),
                                            cl::value_desc("mode"), cl::init(static_cast<unsigned>(NggCompactVertices)));
 
-// -ngg-enable-fast-launch-rate: enable the hardware to launch subgroups of work at a faster rate (NGG)
-static cl::opt<bool>
-    NggEnableFastLaunchRate("ngg-enable-fast-launch-rate",
-                            cl::desc("Enable the hardware to launch subgroups of work at a faster rate (NGG)"),
-                            cl::init(false));
-
 // -ngg-enable-vertex-reuse: enable optimization to cull duplicate vertices (NGG)
 static cl::opt<bool> NggEnableVertexReuse("ngg-enable-vertex-reuse",
                                           cl::desc("Enable optimization to cull duplicate vertices (NGG)"),
@@ -479,7 +473,9 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
 #endif
     nggState.alwaysUsePrimShaderTable = NggAlwaysUsePrimShaderTable;
     nggState.compactMode = static_cast<NggCompactMode>(NggCompactionMode.getValue());
-    nggState.enableFastLaunch = NggEnableFastLaunchRate;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 45
+    nggState.enableFastLaunch = false;
+#endif
     nggState.enableVertexReuse = NggEnableVertexReuse;
     nggState.enableBackfaceCulling = NggEnableBackfaceCulling;
     nggState.enableFrustumCulling = NggEnableFrustumCulling;

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -749,7 +749,9 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
 #endif
   dumpFile << "nggState.alwaysUsePrimShaderTable = " << pipelineInfo->nggState.alwaysUsePrimShaderTable << "\n";
   dumpFile << "nggState.compactMode = " << pipelineInfo->nggState.compactMode << "\n";
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 45
   dumpFile << "nggState.enableFastLaunch = " << pipelineInfo->nggState.enableFastLaunch << "\n";
+#endif
   dumpFile << "nggState.enableVertexReuse = " << pipelineInfo->nggState.enableVertexReuse << "\n";
   dumpFile << "nggState.enableBackfaceCulling = " << pipelineInfo->nggState.enableBackfaceCulling << "\n";
   dumpFile << "nggState.enableFrustumCulling = " << pipelineInfo->nggState.enableFrustumCulling << "\n";
@@ -1011,7 +1013,9 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
 #endif
       hasher->Update(nggState->alwaysUsePrimShaderTable);
       hasher->Update(nggState->compactMode);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 45
       hasher->Update(nggState->enableFastLaunch);
+#endif
       hasher->Update(nggState->enableVertexReuse);
       hasher->Update(nggState->enableBackfaceCulling);
       hasher->Update(nggState->enableFrustumCulling);

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -400,7 +400,9 @@ public:
 #endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, alwaysUsePrimShaderTable, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 45
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFastLaunch, MemberTypeBool, false);
+#endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableVertexReuse, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBackfaceCulling, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFrustumCulling, MemberTypeBool, false);


### PR DESCRIPTION
Fast launch is not exposed as an option. It will be used within LGC only.

Change-Id: I0dbe99e46e544ce4fd856a44261b54ac9d02d206