### PR TITLE
[CI] Resolve Ubuntu version and GCloud SDK warnings

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host-os:        ["ubuntu-18.04"]
+        host-os:        ["ubuntu-20.04"]
         image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
         branch:         [dev]
         config:         [Release]
@@ -25,12 +25,13 @@ jobs:
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git checkout ${GITHUB_SHA}
-      - name: Setup Google Cloud CLI
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
         with:
-          version: '270.0.0'
+          version: '290.0.1'
           service_account_email: ${{ secrets.GCR_USER }}
           service_account_key: ${{ secrets.GCR_KEY }}
+          export_default_credentials: true
       - name: Setup Docker to use the GCR
         run: |
           gcloud auth configure-docker

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host-os:             ["ubuntu-18.04"]
+        host-os:             ["ubuntu-20.04"]
         base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
         config:              [Release]
         assertions:          ["OFF", "ON"]

--- a/.github/workflows/check-cppcheck-llpc.yml
+++ b/.github/workflows/check-cppcheck-llpc.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cppcheck:
     name: cppcheck
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
       - name: Setup environment
         run: |

--- a/.github/workflows/check-formatting-llpc.yml
+++ b/.github/workflows/check-formatting-llpc.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   clang-format-check:
     name: clang-format
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
       - name: Setup environment
         run: |

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -234,6 +234,7 @@ Value *DescBuilder::getStride(ResourceNodeType descType, unsigned descSet, unsig
     return CreateRelocationConstant(reloc::DescriptorStride + Twine(descSet) + "_" + Twine(binding));
   }
   // Pipeline compilation: Get the stride from the node.
+  assert(node);
   return getInt32(node->stride * sizeof(uint32_t));
 }
 


### PR DESCRIPTION
Resolve the Ubuntu version warning by using 20.04 explicitly. See
https://github.com/actions/virtual-environments/issues/1816.

Resolve the GCloud SDK warning by switching to the new repo and pinning to a newwer version.
See https://github.com/google-github-actions/setup-gcloud.