### PR TITLE
NGG: Correct defaults of NGG options according to GFX IP

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -32,6 +32,7 @@
 
 #include "vulkan.h"
 #include <cassert>
+#include <tuple>
 
 // Confliction of Xlib and LLVM headers
 #if defined(__unix__)
@@ -46,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 45
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -70,6 +71,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     45.2 | Add GFX IP plus checker to GfxIpVersion                                                               |
 //* |     45.1 | Add pipelineCacheAccess, stageCacheAccess(es) to GraphicsPipelineBuildOut/ComputePipelineBuildOut     |
 //* |     45.0 | Remove the member 'enableFastLaunch' of NGG state                                                     |
 //* |     44.0 | Rename the member 'forceNonPassthrough' of NGG state to 'forceCullingMode'                            |
@@ -291,6 +293,11 @@ struct GfxIpVersion {
   unsigned major;    ///< Major version
   unsigned minor;    ///< Minor version
   unsigned stepping; ///< Stepping info
+
+  // GFX+ checker
+  bool operator>=(const GfxIpVersion &rhs) const {
+    return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
+  }
 };
 
 /// Represents shader binary data.

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -40,6 +40,11 @@ struct GfxIpVersion {
   unsigned major;    // Major version
   unsigned minor;    // Minor version
   unsigned stepping; // Stepping info
+
+  // GFX+ checker
+  bool operator>=(const GfxIpVersion &rhs) const {
+    return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
+  }
 };
 
 // Represents the properties of GPU device.

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -830,6 +830,8 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
   assert(m_ldsManager->getLdsRegionStart(LdsRegionVertPosData) % SizeOfVec4 == 0);
 
   const bool disableCompact = m_nggControl->compactMode == NggCompactDisable;
+  if (disableCompact)
+    assert(m_gfxIp >= GfxIpVersion({10, 3})); // Must be GFX10.3+
 
   // Define basic blocks
   auto entryBlock = createBlock(entryPoint, ".entry");
@@ -1503,6 +1505,8 @@ void NggPrimShader::constructPrimShaderWithGs(Module *module) {
   assert(waveSize == 32 || waveSize == 64);
 
   const bool disableCompact = m_nggControl->compactMode == NggCompactDisable;
+  if (disableCompact)
+    assert(m_gfxIp >= GfxIpVersion({10, 3})); // Must be GFX10.3+
 
   const unsigned waveCountInSubgroup = Gfx9::NggMaxThreadsPerSubgroup / waveSize;
   const bool cullingMode = !m_nggControl->passthroughMode;

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -402,6 +402,16 @@ static Result init(int argc, char *argv[], ICompiler **ppCompiler) {
       break;
     }
 
+    // Change defaults of NGG options according to GFX IP
+    if (ParsedGfxIp >= GfxIpVersion({10, 3})) {
+      // For GFX10.3+, we always prefer to enable NGG. Backface culling and small primitive filter are enabled as
+      // well. Also, the compaction mode is set to compactionless.
+      EnableNgg.setValue(true);
+      NggCompactionMode.setValue(static_cast<unsigned>(NggCompactDisable));
+      NggEnableBackfaceCulling.setValue(true);
+      NggEnableSmallPrimFilter.setValue(true);
+    }
+
     // Provide a default for -shader-cache-file-dir, as long as the environment variables below are
     // not set.
     // TODO: Was this code intended to set the default of -shader-cache-file-dir in the case that it


### PR DESCRIPTION
The following defaults are changed to align the values with preferred
settings:

Change-Id: Ia53ae3e02d1cda5dfc7a01bce54cc9fe6bd857c4
EnableNgg: false -> true
NggCompactionMode: Vertices -> Disable
NggEnableBackfaceCulling: false -> true
NggEnableSmallPrimFilter: false -> true