### PR TITLE
Refactor PatchLoopMetadata Pass

### DIFF
--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "lgc/Pipeline.h"
+#include "llvm/Analysis/LoopPass.h"
 #include "llvm/Pass.h"
 
 namespace llvm {
@@ -97,7 +98,7 @@ llvm::ModulePass *createPatchEntryPointMutate();
 llvm::ModulePass *createPatchInOutImportExport();
 llvm::ModulePass *createPatchLlvmIrInclusion();
 llvm::FunctionPass *createPatchLoadScalarizer();
-llvm::ModulePass *createPatchLoopMetadata();
+llvm::LoopPass *createPatchLoopMetadata();
 llvm::ModulePass *createPatchNullFragShader();
 llvm::FunctionPass *createPatchPeepholeOpt();
 llvm::ModulePass *createPatchPreparePipelineAbi(bool onlySetCallingConvs);


### PR DESCRIPTION
Refactor the PatchLoopMetadata pass to change it from a module pass to a
loop pass. This will make it easier for future changes to make use of
loop analysis information.
This change is a refactor only, and behavior is unchanged.