### PR TITLE
Detect compute shaders with only indirect calls

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -32,7 +32,6 @@
 #include "lgc/Builder.h"
 #include "lgc/LgcContext.h"
 #include "lgc/state/IntrinsDefs.h"
-#include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -73,8 +72,6 @@ PatchBufferOp::PatchBufferOp() : FunctionPass(ID) {
 void PatchBufferOp::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
   analysisUsage.addRequired<LegacyDivergenceAnalysis>();
   analysisUsage.addRequired<PipelineStateWrapper>();
-  analysisUsage.addRequired<PipelineShaders>();
-  analysisUsage.addPreserved<PipelineShaders>();
   analysisUsage.addRequired<TargetTransformInfoWrapperPass>();
   analysisUsage.addPreserved<TargetTransformInfoWrapperPass>();
 }
@@ -91,11 +88,11 @@ bool PatchBufferOp::runOnFunction(Function &function) {
   m_builder = std::make_unique<IRBuilder<>>(*m_context);
 
   // Invoke visitation of the target instructions.
-  auto pipelineShaders = &getAnalysis<PipelineShaders>();
 
   // If the function is not a valid shader stage, bail.
-  if (pipelineShaders->getShaderStage(&function) == ShaderStageInvalid)
+  if (lgc::getShaderStage(&function) == ShaderStageInvalid) {
     return false;
+  }
 
   m_divergenceAnalysis = &getAnalysis<LegacyDivergenceAnalysis>();
 
@@ -1700,6 +1697,5 @@ void PatchBufferOp::fixIncompletePhis() {
 // Initializes the pass of LLVM patch operations for buffer operations.
 INITIALIZE_PASS_BEGIN(PatchBufferOp, DEBUG_TYPE, "Patch LLVM for buffer operations", false, false)
 INITIALIZE_PASS_DEPENDENCY(LegacyDivergenceAnalysis)
-INITIALIZE_PASS_DEPENDENCY(PipelineShaders)
 INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)
 INITIALIZE_PASS_END(PatchBufferOp, DEBUG_TYPE, "Patch LLVM for buffer operations", false, false)

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -65,6 +65,9 @@ private:
   PatchInOutImportExport(const PatchInOutImportExport &) = delete;
   PatchInOutImportExport &operator=(const PatchInOutImportExport &) = delete;
 
+  void processFunction(llvm::Function &func, ShaderStage shaderStage,
+                       llvm::SmallVectorImpl<llvm::Function *> &inputCallees,
+                       llvm::SmallVectorImpl<llvm::Function *> &otherCallees);
   void initPerShader();
 
   void markExportDone(llvm::Function *func, llvm::PostDominatorTree &postDomTree);

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -219,6 +219,9 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         if (hsEntryPoint) {
           auto lsHsEntryPoint = shaderMerger.generateLsHsEntryPoint(lsEntryPoint, hsEntryPoint);
           lsHsEntryPoint->setCallingConv(CallingConv::AMDGPU_HS);
+          lgc::setShaderStage(lsHsEntryPoint, ShaderStageTessControl);
+          if (lsEntryPoint)
+            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
         }
       }
 
@@ -230,11 +233,19 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
           auto copyShaderEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageCopyShader);
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, gsEntryPoint, copyShaderEntryPoint);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
+          lgc::setShaderStage(primShaderEntryPoint, ShaderStageGeometry);
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
+          if (copyShaderEntryPoint)
+            lgc::setShaderStage(copyShaderEntryPoint, ShaderStageGeometry);
         }
       } else {
         if (gsEntryPoint) {
           auto esGsEntryPoint = shaderMerger.generateEsGsEntryPoint(esEntryPoint, gsEntryPoint);
           esGsEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
+          lgc::setShaderStage(esGsEntryPoint, ShaderStageGeometry);
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
         }
 
         setCallingConv(ShaderStageCopyShader, CallingConv::AMDGPU_VS);
@@ -248,6 +259,9 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         if (hsEntryPoint) {
           auto lsHsEntryPoint = shaderMerger.generateLsHsEntryPoint(lsEntryPoint, hsEntryPoint);
           lsHsEntryPoint->setCallingConv(CallingConv::AMDGPU_HS);
+          lgc::setShaderStage(lsHsEntryPoint, ShaderStageTessControl);
+          if (lsEntryPoint)
+            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
         }
       }
 
@@ -258,9 +272,12 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         if (esEntryPoint) {
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, nullptr, nullptr);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
+          lgc::setShaderStage(primShaderEntryPoint, ShaderStageTessEval);
+          lgc::setShaderStage(esEntryPoint, ShaderStageTessEval);
         }
-      } else
+      } else {
         setCallingConv(ShaderStageTessEval, CallingConv::AMDGPU_VS);
+      }
     } else if (m_hasGs) {
       // GS-only pipeline
       auto esEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageVertex);
@@ -271,11 +288,19 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
           auto copyShaderEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageCopyShader);
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, gsEntryPoint, copyShaderEntryPoint);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
+          lgc::setShaderStage(primShaderEntryPoint, ShaderStageGeometry);
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
+          if (copyShaderEntryPoint)
+            lgc::setShaderStage(copyShaderEntryPoint, ShaderStageGeometry);
         }
       } else {
         if (gsEntryPoint) {
           auto esGsEntryPoint = shaderMerger.generateEsGsEntryPoint(esEntryPoint, gsEntryPoint);
           esGsEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
+          lgc::setShaderStage(esGsEntryPoint, ShaderStageGeometry);
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
         }
 
         setCallingConv(ShaderStageCopyShader, CallingConv::AMDGPU_VS);
@@ -288,6 +313,9 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         if (esEntryPoint) {
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, nullptr, nullptr);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
+          lgc::setShaderStage(primShaderEntryPoint, ShaderStageVertex);
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageVertex);
         }
       } else
         setCallingConv(ShaderStageVertex, CallingConv::AMDGPU_VS);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -94,6 +94,17 @@ bool PatchResourceCollect::runOnModule(Module &module) {
     }
   }
 
+  // Process non-entry-point shaders
+  for (Function &func : module) {
+    if (func.isDeclaration())
+      continue;
+    m_shaderStage = getShaderStage(&func);
+    if (m_shaderStage == ShaderStage::ShaderStageInvalid || &func == m_pipelineShaders->getEntryPoint(m_shaderStage))
+      continue;
+    m_entryPoint = &func;
+    processShader();
+  }
+
   if (m_pipelineState->isGraphics()) {
     // Set NGG control settings
     setNggControl(&module);

--- a/lgc/test/CallLibFromCs.lgc
+++ b/lgc/test/CallLibFromCs.lgc
@@ -1,0 +1,63 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #2 !lgc.shaderstage !7 {
+; CHECK: %[[#]] = call amdgpu_gfx i32 bitcast (i32 ()* @compute_library_func to i32 (i32, i32, <3 x i32> addrspace(4)*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <3 x i32>, i32, <3 x i32>)*)(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16)
+; CHECK: !7 = !{i32 5}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare i32 @compute_library_func() #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  %v = call amdgpu_gfx i32 @compute_library_func()
+  %v2 = insertelement <4 x i32> %19, i32 %v, i32 0
+  store <4 x i32> %v2, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/CallLibFromFs.lgc
+++ b/lgc/test/CallLibFromFs.lgc
@@ -1,0 +1,39 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 inreg %15, <2 x float> %16, <2 x float> %17, <2 x float> %18, <3 x float> %19, <2 x float> %20, <2 x float> %21, <2 x float> %22, float %23, float %24, float %25, float %26, float %27, i32 %28, i32 %29, i32 %30, i32 %31) #2 !lgc.shaderstage !5 {
+; CHECK: %[[#]] = call amdgpu_gfx <4 x float> bitcast (<4 x float> ()* @compute_library_func to <4 x float> (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <2 x float>, <2 x float>, <2 x float>, <3 x float>, <2 x float>, <2 x float>, <2 x float>, float, float, float, float, float, i32, i32, i32, i32)*)(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 inreg %15, <2 x float> %16, <2 x float> %17, <2 x float> %18, <3 x float> %19, <2 x float> %20, <2 x float> %21, <2 x float> %22, float %23, float %24, float %25, float %26, float %27, i32 %28, i32 %29, i32 %30, i32 %31)
+; CHECK: !5 = !{i32 4}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare <4 x float> @compute_library_func() #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %res = call amdgpu_gfx <4 x float> @compute_library_func()
+  call void (...) @lgc.create.write.generic.output(<4 x float> %res, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+attributes #0 = { nounwind }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.FS = !{!2}
+!lgc.color.export.formats = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 -794913950, i32 -27741903, i32 1278784547, i32 441582842, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1072849668, i32 -352651751, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 14, i32 7}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 4}

--- a/lgc/test/CallLibFromVs.lgc
+++ b/lgc/test/CallLibFromVs.lgc
@@ -1,0 +1,37 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 %15, i32 %16, i32 %17, i32 %18) #1 !lgc.shaderstage !4 {
+; CHECK: %[[#]] = call amdgpu_gfx <4 x float> bitcast (<4 x float> ()* @compute_library_func to <4 x float> (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)*)(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 %15, i32 %16, i32 %17, i32 %18)
+; CHECK: !4 = !{i32 0}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare <4 x float> @compute_library_func() #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %res = call amdgpu_gfx <4 x float> @compute_library_func()
+  call void (...) @lgc.create.write.generic.output(<4 x float> %res, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+attributes #0 = { nounwind }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.VS = !{!2}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 628083063, i32 1661573491, i32 -2141117829, i32 766255606, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1951548461, i32 273960056, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 3, i32 3}
+!5 = !{i32 0}

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -1,0 +1,58 @@
+; Define a compute library that can be called from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
+; CHECK: !7 = !{i32 5}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  store <4 x i32> %19, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/FsComputeLibrary.lgc
+++ b/lgc/test/FsComputeLibrary.lgc
@@ -1,0 +1,35 @@
+; Define a compute library that can be called from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
+; CHECK: !5 = !{i32 4}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.FS = !{!2}
+!lgc.color.export.formats = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 -794913950, i32 -27741903, i32 1278784547, i32 441582842, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1072849668, i32 -352651751, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 14, i32 7}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 4}

--- a/lgc/test/ShaderStages.lgc
+++ b/lgc/test/ShaderStages.lgc
@@ -1,0 +1,530 @@
+; ----------------------------------------------------------------------
+; Extract 1: CS
+
+; RUN: lgc -extract=1 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK1,CHECK-NO-NGG1 %s
+; RUN: lgc -extract=1 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK1,CHECK-NGG1 %s
+; CHECK1: define dllexport amdgpu_cs void @_amdgpu_cs_main{{.*}} !lgc.shaderstage !3 {
+; CHECK1: !3 = !{i32 5}
+
+define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
+.entry:
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!lgc.user.data.nodes = !{!1, !2}
+!lgc.device.index = !{!3}
+
+; ShaderStageCompute
+!0 = !{i32 5}
+; type, offset, size, count
+!1 = !{!"DescriptorTableVaPtr", i32 2, i32 1, i32 1}
+; type, offset, size, set, binding, stride
+!2 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+; DeviceIndex
+!3 = !{i32 12345678}
+
+; ----------------------------------------------------------------------
+; Extract 2: VS/FS
+
+; RUN: lgc -extract=2 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK2,CHECK-NO-NGG2 %s
+; RUN: lgc -extract=2 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK2,CHECK-NGG2 %s
+; CHECK-NO-NGG2: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !3 {
+; CHECK-NO-NGG2: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !4 {
+; CHECK-NO-NGG2: !3 = !{i32 0}
+; CHECK-NO-NGG2: !4 = !{i32 4}
+
+; CHECK-NGG2: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG2: define internal void @lgc.ngg.ES.main{{.*}} !lgc.shaderstage !3 {
+; CHECK-NGG2: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !4 {
+; CHECK-NGG2: !3 = !{i32 0}
+; CHECK-NGG2: !4 = !{i32 4}
+
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
+.entry:
+  ret void
+}
+
+define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !lgc.shaderstage !4 {
+.entry:
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!lgc.user.data.nodes = !{!1, !2}
+!lgc.device.index = !{!3}
+
+; ShaderStageVertex
+!0 = !{i32 0}
+; ShaderStageFragment
+!4 = !{i32 4}
+; type, offset, size, count
+!1 = !{!"DescriptorTableVaPtr", i32 2, i32 1, i32 1}
+; type, offset, size, set, binding, stride
+!2 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+; DeviceIndex
+!3 = !{i32 12345678}
+
+; ----------------------------------------------------------------------
+; Extract 3: GS/VS
+
+; RUN: lgc -extract=3 -print-after=lgc-patch-setup-target-features -mcpu=gfx810 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK3,CHECK-NO-NGG3 %s
+; RUN: lgc -extract=3 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK3,CHECK-NGG3 %s
+; RUN: lgc -extract=3 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK3,CHECK-NGG3 %s
+; CHECK-NO-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NO-NGG3: define dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NO-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !8 {
+; CHECK-NO-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !9 {
+; CHECK-NO-NGG3: !6 = !{i32 6}
+; CHECK-NO-NGG3: !7 = !{i32 0}
+; CHECK-NO-NGG3: !8 = !{i32 3}
+; CHECK-NO-NGG3: !9 = !{i32 4}
+
+; CHECK-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NGG3: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} {
+; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !9 {
+; CHECK-NGG3: !6 = !{i32 6}
+; CHECK-NGG3: !7 = !{i32 0}
+; CHECK-NGG3: !8 = !{i32 3}
+; CHECK-NGG3: !9 = !{i32 4}
+
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !6 {
+.entry:
+  ret void
+}
+
+define dllexport spir_func void @lgc.shader.GS.main() local_unnamed_addr #0 !lgc.shaderstage !7 {
+.entry:
+  call void @lgc.output.export.builtin.Position.i32.i32.v4f32(i32 0, i32 0, <4 x float> undef) #0
+  call void @lgc.output.export.builtin.PointSize.i32.i32.f32(i32 1, i32 0, float undef) #0
+  call void @lgc.output.export.builtin.ClipDistance.i32.i32.a1f32(i32 3, i32 0, [1 x float] undef) #0
+  call void @lgc.output.export.builtin.CullDistance.i32.i32.a1f32(i32 4, i32 0, [1 x float] undef) #0
+  %0 = call i32 @lgc.input.import.builtin.GsWaveId.i32.i32(i32 268435466) #0
+  call void @llvm.amdgcn.s.sendmsg(i32 34, i32 %0)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.CullDistance.i32.i32.a1f32(i32, i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.ClipDistance.i32.i32.a1f32(i32, i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.PointSize.i32.i32.f32(i32, i32, float) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.Position.i32.i32.v4f32(i32, i32, <4 x float>) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.CullDistance.i32.a1f32(i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.ClipDistance.i32.a1f32(i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.PointSize.i32.f32(i32, float) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.Position.i32.v4f32(i32, <4 x float>) #0
+
+; Function Attrs: nounwind readonly
+declare float @lgc.input.import.generic.f32.i32.i32.i32(i32, i32, i32) #1
+
+; Function Attrs: nounwind readonly
+declare <4 x double> @lgc.input.import.generic.v4f64.i32.i32.i32(i32, i32, i32) #1
+
+; Function Attrs: nounwind
+declare i32 @lgc.input.import.builtin.GsWaveId.i32.i32(i32) #0
+
+; Function Attrs: nounwind
+declare void @llvm.amdgcn.s.sendmsg(i32 immarg, i32) #0
+
+attributes #0 = { nounwind }
+
+!llpc.geometry.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.VS = !{!2}
+!lgc.options.GS = !{!3}
+!lgc.color.export.formats = !{!4}
+!lgc.input.assembly.state = !{!5}
+
+!0 = !{i32 3, i32 2, i32 1, i32 3}
+!1 = !{i32 -457359926, i32 -978576021, i32 1254748154, i32 908319681, i32 1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 561009537, i32 1279541660, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 -2101593, i32 1179029646, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 16}
+!5 = !{i32 0, i32 3}
+; ShaderStageVertex
+!6 = !{i32 0}
+; ShaderStageGeometry
+!7 = !{i32 3}
+!8 = distinct !{!8}
+
+; ----------------------------------------------------------------------
+; Extract 4: TCS/TES
+
+; RUN: lgc -extract=4 -print-after=lgc-patch-setup-target-features -mcpu=gfx810 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK4,CHECK-NO-NGG4 %s
+; RUN: lgc -extract=4 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK4,CHECK-GFX94 %s
+; RUN: lgc -extract=4 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK4,CHECK-NGG4 %s
+; CHECK-NO-NGG4: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !5 {
+; CHECK-NO-NGG4: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NO-NGG4: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NO-NGG4: !5 = !{i32 1}
+; CHECK-NO-NGG4: !6 = !{i32 2}
+; CHECK-NO-NGG4: !7 = !{i32 4}
+
+; CHECK-GFX94: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
+; CHECK-GFX94: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !5 {
+; CHECK-GFX94: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-GFX94: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-GFX94: !5 = !{i32 1}
+; CHECK-GFX94: !6 = !{i32 2}
+; CHECK-GFX94: !7 = !{i32 4}
+
+; CHECK-NGG4: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG4: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
+; CHECK-NGG4: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !5 {
+; CHECK-NGG4: define internal void @lgc.ngg.ES.main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NGG4: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NGG4: !5 = !{i32 1}
+; CHECK-NGG4: !6 = !{i32 2}
+; CHECK-NGG4: !7 = !{i32 4}
+
+define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %0 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  %1 = call <4 x float> (...) @lgc.create.read.builtin.input.v4f32(i32 0, i32 0, i32 %0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 %0)
+  %2 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, i32 3, i32 1, i32 0, i32 0, i32 0, i32 %2)
+  %3 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> <float 3.000000e+00, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00>, i32 3, i32 3, i32 0, i32 0, i32 0, i32 %3)
+  call void (...) @lgc.create.write.builtin.output(float 1.000000e+00, i32 12, i32 8192, i32 undef, i32 1)
+  call void (...) @lgc.create.write.builtin.output(float 2.000000e+00, i32 11, i32 16384, i32 undef, i32 1)
+  ret void
+}
+
+define dllexport spir_func void @lgc.shader.TES.main() local_unnamed_addr #0 !spirv.ExecutionModel !6 !lgc.shaderstage !6 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %2 = fadd reassoc nnan nsz arcp contract afn <4 x float> %0, %1
+  %3 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 2)
+  %4 = fadd reassoc nnan nsz arcp contract afn <4 x float> %2, %3
+  %5 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 3, i32 3, i32 0, i32 0, i32 0, i32 0)
+  %6 = fadd reassoc nnan nsz arcp contract afn <4 x float> %4, %5
+  call void (...) @lgc.create.write.generic.output(<4 x float> %6, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i32 @lgc.create.read.builtin.input.i32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.builtin.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.builtin.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.tessellation.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.TCS = !{!2}
+!lgc.options.TES = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1, i32 1, i32 1, i32 0, i32 3}
+!1 = !{i32 1296810225, i32 -909790650, i32 1814881111, i32 -530888175, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 -54767410, i32 1894092071, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 1718189868, i32 -1767688178, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 1}
+!6 = !{i32 2}
+
+; ----------------------------------------------------------------------
+; Extract 5: TCS
+
+; RUN: lgc -extract=5 -print-after=lgc-patch-setup-target-features -mcpu=gfx810 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK5,CHECK-NO-NGG5 %s
+; RUN: lgc -extract=5 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK5,CHECK-NGG5 %s
+; RUN: lgc -extract=5 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK5,CHECK-NGG5 %s
+; CHECK-NO-NGG5: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !5 {
+; CHECK-NO-NGG5: !5 = !{i32 1}
+
+; CHECK-NGG5: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
+; CHECK-NGG5: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !5 {
+; CHECK-NGG5: !5 = !{i32 1}
+
+define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %0 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  %1 = call <4 x float> (...) @lgc.create.read.builtin.input.v4f32(i32 0, i32 0, i32 %0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 %0)
+  %2 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, i32 3, i32 1, i32 0, i32 0, i32 0, i32 %2)
+  %3 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> <float 3.000000e+00, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00>, i32 3, i32 3, i32 0, i32 0, i32 0, i32 %3)
+  call void (...) @lgc.create.write.builtin.output(float 1.000000e+00, i32 12, i32 8192, i32 undef, i32 1)
+  call void (...) @lgc.create.write.builtin.output(float 2.000000e+00, i32 11, i32 16384, i32 undef, i32 1)
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i32 @lgc.create.read.builtin.input.i32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.builtin.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.builtin.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.tessellation.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.TCS = !{!2}
+!lgc.options.TES = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1, i32 1, i32 1, i32 0, i32 3}
+!1 = !{i32 1296810225, i32 -909790650, i32 1814881111, i32 -530888175, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 -54767410, i32 1894092071, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 1718189868, i32 -1767688178, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 1}
+
+; ----------------------------------------------------------------------
+; Extract 6: TES
+
+; RUN: lgc -extract=6 -print-after=lgc-patch-setup-target-features -mcpu=gfx810 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK6,CHECK-NO-NGG6 %s
+; RUN: lgc -extract=6 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK6,CHECK-GFX96 %s
+; RUN: lgc -extract=6 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK6,CHECK-NGG6 %s
+; CHECK-NO-NGG6: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !5 {
+; CHECK-NO-NGG6: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NO-NGG6: !5 = !{i32 2}
+; CHECK-NO-NGG6: !6 = !{i32 4}
+
+; CHECK-GFX96: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !5 {
+; CHECK-GFX96: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-GFX96: !5 = !{i32 2}
+; CHECK-GFX96: !6 = !{i32 4}
+
+; CHECK-NGG6: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG6: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NGG6: !5 = !{i32 2}
+; CHECK-NGG6: !6 = !{i32 4}
+
+define dllexport spir_func void @lgc.shader.TES.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %2 = fadd reassoc nnan nsz arcp contract afn <4 x float> %0, %1
+  %3 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 2)
+  %4 = fadd reassoc nnan nsz arcp contract afn <4 x float> %2, %3
+  %5 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 3, i32 3, i32 0, i32 0, i32 0, i32 0)
+  %6 = fadd reassoc nnan nsz arcp contract afn <4 x float> %4, %5
+  call void (...) @lgc.create.write.generic.output(<4 x float> %6, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i32 @lgc.create.read.builtin.input.i32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.builtin.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.builtin.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.tessellation.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.TCS = !{!2}
+!lgc.options.TES = !{!3}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1, i32 1, i32 1, i32 0, i32 3}
+!1 = !{i32 1296810225, i32 -909790650, i32 1814881111, i32 -530888175, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 -54767410, i32 1894092071, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 1718189868, i32 -1767688178, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 0, i32 3}
+!5 = !{i32 2}
+
+; ----------------------------------------------------------------------
+; Extract 7: TCS/TES/GS
+
+; RUN: lgc -extract=7 -print-after=lgc-patch-setup-target-features -mcpu=gfx810 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK7,CHECK-NO-NGG7 %s
+; RUN: lgc -extract=7 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK7,CHECK-NGG7 %s
+; RUN: lgc -extract=7 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK7,CHECK-NGG7 %s
+; CHECK-NO-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NO-NGG7: define dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage !8 {
+; CHECK-NO-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !9 {
+; CHECK-NO-NGG7: define dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !10 {
+; CHECK-NO-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !11 {
+; CHECK-NO-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !12 {
+; CHECK-NO-NGG7: !7 = !{i32 6}
+; CHECK-NO-NGG7: !8 = !{i32 0}
+; CHECK-NO-NGG7: !9 = !{i32 1}
+; CHECK-NO-NGG7: !10 = !{i32 2}
+; CHECK-NO-NGG7: !11 = !{i32 3}
+; CHECK-NO-NGG7: !12 = !{i32 4}
+
+; CHECK-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NGG7: define internal dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage !8 {
+; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
+; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !9 {
+; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !10 {
+; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage !11 {
+; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !12 {
+; CHECK-NGG7: !7 = !{i32 6}
+; CHECK-NGG7: !8 = !{i32 0}
+; CHECK-NGG7: !9 = !{i32 1}
+; CHECK-NGG7: !10 = !{i32 2}
+; CHECK-NGG7: !11 = !{i32 3}
+; CHECK-NGG7: !12 = !{i32 4}
+
+define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !6 {
+.entry:
+  %0 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  %1 = call <4 x float> (...) @lgc.create.read.builtin.input.v4f32(i32 0, i32 0, i32 %0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 %0)
+  %2 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> <float 1.500000e+00, float 1.500000e+00, float 1.500000e+00, float 1.500000e+00>, i32 3, i32 1, i32 0, i32 0, i32 0, i32 %2)
+  %3 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 8, i32 0, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> <float 3.000000e+00, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00>, i32 3, i32 3, i32 0, i32 0, i32 0, i32 %3)
+  call void (...) @lgc.create.write.builtin.output(float 1.000000e+00, i32 12, i32 8192, i32 undef, i32 1)
+  call void (...) @lgc.create.write.builtin.output(float 2.000000e+00, i32 11, i32 16384, i32 undef, i32 1)
+  ret void
+}
+
+define dllexport spir_func void @lgc.shader.TES.main() local_unnamed_addr #0 !spirv.ExecutionModel !6 !lgc.shaderstage !7 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 0)
+  %1 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 1)
+  %2 = fadd reassoc nnan nsz arcp contract afn <4 x float> %0, %1
+  %3 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 2)
+  %4 = fadd reassoc nnan nsz arcp contract afn <4 x float> %2, %3
+  %5 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 3, i32 3, i32 0, i32 0, i32 0, i32 0)
+  %6 = fadd reassoc nnan nsz arcp contract afn <4 x float> %4, %5
+  call void (...) @lgc.create.write.generic.output(<4 x float> %6, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+define dllexport spir_func void @lgc.shader.GS.main() local_unnamed_addr #0 !lgc.shaderstage !8 {
+.entry:
+  call void @lgc.output.export.builtin.Position.i32.i32.v4f32(i32 0, i32 0, <4 x float> undef) #0
+  call void @lgc.output.export.builtin.PointSize.i32.i32.f32(i32 1, i32 0, float undef) #0
+  call void @lgc.output.export.builtin.ClipDistance.i32.i32.a1f32(i32 3, i32 0, [1 x float] undef) #0
+  call void @lgc.output.export.builtin.CullDistance.i32.i32.a1f32(i32 4, i32 0, [1 x float] undef) #0
+  %0 = call i32 @lgc.input.import.builtin.GsWaveId.i32.i32(i32 268435466) #0
+  call void @llvm.amdgcn.s.sendmsg(i32 34, i32 %0)
+  ret void
+}
+
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !9 {
+.entry:
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i32 @lgc.create.read.builtin.input.i32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.builtin.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.builtin.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind readonly
+declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.CullDistance.i32.i32.a1f32(i32, i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.ClipDistance.i32.i32.a1f32(i32, i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.PointSize.i32.i32.f32(i32, i32, float) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.Position.i32.i32.v4f32(i32, i32, <4 x float>) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.CullDistance.i32.a1f32(i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.ClipDistance.i32.a1f32(i32, [1 x float]) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.PointSize.i32.f32(i32, float) #0
+
+; Function Attrs: nounwind
+declare void @lgc.output.export.builtin.Position.i32.v4f32(i32, <4 x float>) #0
+
+; Function Attrs: nounwind readonly
+declare float @lgc.input.import.generic.f32.i32.i32.i32(i32, i32, i32) #1
+
+; Function Attrs: nounwind readonly
+declare <4 x double> @lgc.input.import.generic.v4f64.i32.i32.i32(i32, i32, i32) #1
+
+; Function Attrs: nounwind
+declare i32 @lgc.input.import.builtin.GsWaveId.i32.i32(i32) #0
+
+; Function Attrs: nounwind
+declare void @llvm.amdgcn.s.sendmsg(i32 immarg, i32) #0
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.tessellation.mode = !{!0}
+!llpc.geometry.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.TCS = !{!2}
+!lgc.options.TES = !{!3}
+!lgc.options.GS = !{!4}
+!lgc.options.VS = !{!10}
+!lgc.input.assembly.state = !{!5}
+
+!0 = !{i32 1, i32 1, i32 1, i32 0, i32 3}
+!1 = !{i32 1296810225, i32 -909790650, i32 1814881111, i32 -530888175, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 -54767410, i32 1894092071, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{i32 1718189868, i32 -1767688178, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 -2101593, i32 1179029646, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!5 = !{i32 0, i32 3}
+!6 = !{i32 1}
+!7 = !{i32 2}
+!8 = !{i32 3}
+!9 = !{i32 0}
+!10 = !{i32 561009537, i32 1279541660, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}

--- a/lgc/test/ShaderStages.lgc
+++ b/lgc/test/ShaderStages.lgc
@@ -35,7 +35,7 @@ attributes #0 = { nounwind }
 ; CHECK-NO-NGG2: !3 = !{i32 0}
 ; CHECK-NO-NGG2: !4 = !{i32 4}
 
-; CHECK-NGG2: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG2: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !3 {
 ; CHECK-NGG2: define internal void @lgc.ngg.ES.main{{.*}} !lgc.shaderstage !3 {
 ; CHECK-NGG2: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !4 {
 ; CHECK-NGG2: !3 = !{i32 0}
@@ -84,13 +84,12 @@ attributes #0 = { nounwind }
 
 ; CHECK-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
 ; CHECK-NGG3: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
-; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} {
-; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !9 {
+; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !7 {
+; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} !lgc.shaderstage !7 {
+; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !8 {
 ; CHECK-NGG3: !6 = !{i32 6}
-; CHECK-NGG3: !7 = !{i32 0}
-; CHECK-NGG3: !8 = !{i32 3}
-; CHECK-NGG3: !9 = !{i32 4}
+; CHECK-NGG3: !7 = !{i32 3}
+; CHECK-NGG3: !8 = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !6 {
 .entry:
@@ -178,7 +177,7 @@ attributes #0 = { nounwind }
 ; CHECK-NO-NGG4: !6 = !{i32 2}
 ; CHECK-NO-NGG4: !7 = !{i32 4}
 
-; CHECK-GFX94: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
+; CHECK-GFX94: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !5 {
 ; CHECK-GFX94: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !5 {
 ; CHECK-GFX94: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
 ; CHECK-GFX94: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !7 {
@@ -186,13 +185,13 @@ attributes #0 = { nounwind }
 ; CHECK-GFX94: !6 = !{i32 2}
 ; CHECK-GFX94: !7 = !{i32 4}
 
-; CHECK-NGG4: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
-; CHECK-NGG4: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
-; CHECK-NGG4: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !5 {
-; CHECK-NGG4: define internal void @lgc.ngg.ES.main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NGG4: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !5 {
+; CHECK-NGG4: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !6 {
+; CHECK-NGG4: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !6 {
+; CHECK-NGG4: define internal void @lgc.ngg.ES.main{{.*}} !lgc.shaderstage !5 {
 ; CHECK-NGG4: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG4: !5 = !{i32 1}
-; CHECK-NGG4: !6 = !{i32 2}
+; CHECK-NGG4: !5 = !{i32 2}
+; CHECK-NGG4: !6 = !{i32 1}
 ; CHECK-NGG4: !7 = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
@@ -263,7 +262,7 @@ attributes #1 = { nounwind readonly }
 ; CHECK-NO-NGG5: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !5 {
 ; CHECK-NO-NGG5: !5 = !{i32 1}
 
-; CHECK-NGG5: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
+; CHECK-NGG5: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !5 {
 ; CHECK-NGG5: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !5 {
 ; CHECK-NGG5: !5 = !{i32 1}
 
@@ -328,7 +327,7 @@ attributes #1 = { nounwind readonly }
 ; CHECK-GFX96: !5 = !{i32 2}
 ; CHECK-GFX96: !6 = !{i32 4}
 
-; CHECK-NGG6: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
+; CHECK-NGG6: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !5 {
 ; CHECK-NGG6: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !6 {
 ; CHECK-NGG6: !5 = !{i32 2}
 ; CHECK-NGG6: !6 = !{i32 4}
@@ -398,18 +397,16 @@ attributes #1 = { nounwind readonly }
 
 ; CHECK-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !7 {
 ; CHECK-NGG7: define internal dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} {
-; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !10 {
-; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} {
-; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage !11 {
-; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !12 {
+; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !8 {
+; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !8 {
+; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !9 {
+; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !9 {
+; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage !9 {
+; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !10 {
 ; CHECK-NGG7: !7 = !{i32 6}
-; CHECK-NGG7: !8 = !{i32 0}
-; CHECK-NGG7: !9 = !{i32 1}
-; CHECK-NGG7: !10 = !{i32 2}
-; CHECK-NGG7: !11 = !{i32 3}
-; CHECK-NGG7: !12 = !{i32 4}
+; CHECK-NGG7: !8 = !{i32 1}
+; CHECK-NGG7: !9 = !{i32 3}
+; CHECK-NGG7: !10 = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !6 {
 .entry:

--- a/lgc/test/VsComputeLibrary.lgc
+++ b/lgc/test/VsComputeLibrary.lgc
@@ -1,0 +1,35 @@
+; Define a compute library that can be called from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define spir_func <4 x float> @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #2 !lgc.shaderstage !4 {
+; CHECK: !4 = !{i32 0}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func <4 x float> @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+.entry:
+  %0 = call <4 x i32> (...) @lgc.create.read.generic.input.v4i32(i32 5, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  %bc = bitcast <4 x i32> %0 to <4 x float>
+  ret <4 x float> %bc
+}
+
+; Function Attrs: nounwind readonly
+declare <4 x i32> @lgc.create.read.generic.input.v4i32(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!lgc.unlinked = !{!0}
+!lgc.options = !{!1}
+!lgc.options.VS = !{!2}
+!lgc.input.assembly.state = !{!4}
+
+!0 = !{i32 1}
+!1 = !{i32 628083063, i32 1661573491, i32 -2141117829, i32 766255606, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1951548461, i32 273960056, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 3, i32 3}
+!5 = !{i32 0}


### PR DESCRIPTION
For an indirect call, no function is called so iterating over function
definitions only would not detect the call and lead to the wrong
pipeline layout.

Only the topmost commit “Detect compute shaders with only indirect calls” is part of this pr.