### PR TITLE
PatchEntryPointMutate: Adjust calling convention

### DIFF
--- a/lgc/test/CallLibFromCs-indirect.lgc
+++ b/lgc/test/CallLibFromCs-indirect.lgc
@@ -1,0 +1,63 @@
+; Call an extern compute library function from a compute shader.
+
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
+; CHECK: %[[#]] = call amdgpu_gfx i32 %[[#]](i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16)
+; CHECK: !7 = !{i32 5}
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  %func_ptr_ptr = bitcast i8 addrspace(7)* %1 to i32()* addrspace(7)*
+  %func_ptr = load i32()*, i32()* addrspace(7)* %func_ptr_ptr, align 16
+  %v = call spir_func i32 %func_ptr()
+  %v2 = insertelement <4 x i32> %19, i32 %v, i32 0
+  store <4 x i32> %v2, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/CallLibFromCs.lgc
+++ b/lgc/test/CallLibFromCs.lgc
@@ -2,6 +2,7 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: declare amdgpu_gfx i32 @compute_library_func() #0
 ; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #2 !lgc.shaderstage !7 {
 ; CHECK: %[[#]] = call amdgpu_gfx i32 bitcast (i32 ()* @compute_library_func to i32 (i32, i32, <3 x i32> addrspace(4)*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <3 x i32>, i32, <3 x i32>)*)(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16)
 ; CHECK: !7 = !{i32 5}
@@ -10,7 +11,7 @@
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
 target triple = "amdgcn--amdpal"
 
-declare i32 @compute_library_func() #0
+declare spir_func i32 @compute_library_func() #0
 
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
@@ -36,7 +37,7 @@ define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spi
   %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
   %19 = add <4 x i32> %16, %18
   %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
-  %v = call amdgpu_gfx i32 @compute_library_func()
+  %v = call spir_func i32 @compute_library_func()
   %v2 = insertelement <4 x i32> %19, i32 %v, i32 0
   store <4 x i32> %v2, <4 x i32> addrspace(7)* %20, align 16
   ret void

--- a/lgc/test/CallLibFromFs.lgc
+++ b/lgc/test/CallLibFromFs.lgc
@@ -2,6 +2,7 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: declare amdgpu_gfx <4 x float> @compute_library_func() #0
 ; CHECK: define dllexport spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 inreg %15, <2 x float> %16, <2 x float> %17, <2 x float> %18, <3 x float> %19, <2 x float> %20, <2 x float> %21, <2 x float> %22, float %23, float %24, float %25, float %26, float %27, i32 %28, i32 %29, i32 %30, i32 %31) #2 !lgc.shaderstage !5 {
 ; CHECK: %[[#]] = call amdgpu_gfx <4 x float> bitcast (<4 x float> ()* @compute_library_func to <4 x float> (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <2 x float>, <2 x float>, <2 x float>, <3 x float>, <2 x float>, <2 x float>, <2 x float>, float, float, float, float, float, i32, i32, i32, i32)*)(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 inreg %15, <2 x float> %16, <2 x float> %17, <2 x float> %18, <3 x float> %19, <2 x float> %20, <2 x float> %21, <2 x float> %22, float %23, float %24, float %25, float %26, float %27, i32 %28, i32 %29, i32 %30, i32 %31)
 ; CHECK: !5 = !{i32 4}
@@ -10,12 +11,12 @@
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
 target triple = "amdgcn--amdpal"
 
-declare <4 x float> @compute_library_func() #0
+declare spir_func <4 x float> @compute_library_func() #0
 
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
 .entry:
-  %res = call amdgpu_gfx <4 x float> @compute_library_func()
+  %res = call spir_func <4 x float> @compute_library_func()
   call void (...) @lgc.create.write.generic.output(<4 x float> %res, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
   ret void
 }

--- a/lgc/test/CallLibFromVs.lgc
+++ b/lgc/test/CallLibFromVs.lgc
@@ -2,6 +2,7 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
+; CHECK: declare amdgpu_gfx <4 x float> @compute_library_func() #0
 ; CHECK: define dllexport spir_func void @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 %15, i32 %16, i32 %17, i32 %18) #1 !lgc.shaderstage !4 {
 ; CHECK: %[[#]] = call amdgpu_gfx <4 x float> bitcast (<4 x float> ()* @compute_library_func to <4 x float> (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32)*)(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %spillTable, i32 %15, i32 %16, i32 %17, i32 %18)
 ; CHECK: !4 = !{i32 0}
@@ -10,12 +11,12 @@
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
 target triple = "amdgcn--amdpal"
 
-declare <4 x float> @compute_library_func() #0
+declare spir_func <4 x float> @compute_library_func() #0
 
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
 .entry:
-  %res = call amdgpu_gfx <4 x float> @compute_library_func()
+  %res = call spir_func <4 x float> @compute_library_func()
   call void (...) @lgc.create.write.generic.output(<4 x float> %res, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
   ret void
 }

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -1,9 +1,11 @@
 ; Define a compute library that can be called from a compute shader.
 
-; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
 ; CHECK: define spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
 ; CHECK: !7 = !{i32 5}
+; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
+; CHECK: define amdgpu_gfx void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) local_unnamed_addr #1 !lgc.shaderstage !7 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"

--- a/lgc/test/FsComputeLibrary.lgc
+++ b/lgc/test/FsComputeLibrary.lgc
@@ -1,9 +1,11 @@
 ; Define a compute library that can be called from a compute shader.
 
-; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
 ; CHECK: define spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
 ; CHECK: !5 = !{i32 4}
+; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
+; CHECK: define amdgpu_gfx void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) local_unnamed_addr #0 !lgc.shaderstage !5 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"

--- a/lgc/test/VsComputeLibrary.lgc
+++ b/lgc/test/VsComputeLibrary.lgc
@@ -1,9 +1,11 @@
 ; Define a compute library that can be called from a compute shader.
 
-; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
 ; CHECK: define spir_func <4 x float> @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #2 !lgc.shaderstage !4 {
 ; CHECK: !4 = !{i32 0}
+; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
+; CHECK: define amdgpu_gfx <4 x float> @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #0 !lgc.shaderstage !4 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"


### PR DESCRIPTION
Change the calling convention to amdgpu_gfx if it was spir_func
previously.

This allows creating and calling compute libraries with the spir_func
calling convention.

Only the two topmost commits “PatchEntryPointMutate: Adjust calling convention” and “Add test for indirect call from cs” are part of this pr.