### PR TITLE
Allow multi-table desc sets

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -244,7 +244,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
         if (auto call = dyn_cast<CallInst>(base)) {
           if (index) {
             if (auto calledFunc = call->getCalledFunction()) {
-              if (calledFunc->getName().startswith(lgcName::DescriptorSet) ||
+              if (calledFunc->getName().startswith(lgcName::DescriptorTableAddr) ||
                   calledFunc->getName().startswith("llvm.amdgcn.reloc.constant")) {
                 if (worklist.size()) {
                   base = worklist.pop_back_val();

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -74,9 +74,9 @@ const static char PushConst[] = "lgc.push.const";
 // Get a descriptor that is in the root user data (as descriptor type indicated by the return type).
 // The arg is the dword offset of the node in the root user data layout.
 const static char RootDescriptor[] = "lgc.root.descriptor";
-// Get pointer to a descriptor set table. First arg is the descriptor set number; second arg is the value to use
-// for the high half of the address, or HighAddrPc to use PC.
-const static char DescriptorSet[] = "lgc.descriptor.set";
+// Get pointer to the descriptor table for the given resource. First arg is the descriptor set number; second arg
+// is the binding number; third arg is the value to use for the high half of the address, or HighAddrPc to use PC.
+const static char DescriptorTableAddr[] = "lgc.descriptor.table.addr";
 // Get special user data input. Arg is UserDataMapping enum value. The optional second arg causes the 32-bit
 // value to be extended to 64-bit pointer and specifies the value to use for the high half, or
 // ShadowDescriptorTable::Disable to use PC.

--- a/llpc/test/shaderdb/PipelineCs_TestMultiEntryPoint_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestMultiEntryPoint_lit.pipe
@@ -6,7 +6,7 @@
 ; SHADERTEST: !llpc.compute.mode = !{![[COMPUTEMODE:[0-9]+]]}
 ; SHADERTEST: ![[COMPUTEMODE]] = !{i32 1, i32 1, i32 1}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg %0, i32 inreg %1, i32 inreg{{[^,]*}} %descSet0, <3 x i32> inreg %WorkgroupId, i32 inreg %2, <3 x i32> %LocalInvocationId)
+; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg %0, i32 inreg %1, i32 inreg{{[^,]*}} %descTable0, <3 x i32> inreg %WorkgroupId, i32 inreg %2, <3 x i32> %LocalInvocationId)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/PipelineVsFs_MultiTableDescSet.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_MultiTableDescSet.pipe
@@ -1,0 +1,233 @@
+// This test has three resources in descriptor set 0, but each is in a
+// different descriptor table.  The test checks that all three are loaded correctly.
+
+// This first part checks that the PAL metadata is as expected.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; First check that the buffer load in the vertex shader loads the correct
+; descriptor.  The high half of the descriptor load should come from the PC.
+; The low half should come from the user data node at offet 0. The 0 offset if
+; found in the PAL metadata.
+; SHADERTEST-LABEL: _amdgpu_vs_main:
+; SHADERTEST: s_getpc_b64 s{{\[}}[[VS_PC:[0-9]*]]:{{[0-9]*}}]
+; SHADERTEST: s_mov_b64 s{{\[}}[[T0_ADDR:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[VS_PC]]:{{[0-9]*}}]
+; SHADERTEST: s_mov_b32 s[[T0_ADDR]], s[[table0:[0-9]*]]
+; SHADERTEST: s_load_dwordx4 s{{\[}}[[T0_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T0_ADDR]]:{{[0-9]*}}], 0x0
+; SHADERTEST: s_buffer_load_dwordx16 s[0:15], s{{\[}}[[T0_DESC]]:{{[0-9]*}}], 0x0
+; Now check that the image sample in the pixel shader uses the correct
+; descriptors.  The high half of the descriptor load should come from the PC.
+; The low half should come from the user data node at offet 1 and 2.
+; SHADERTEST-LABEL: _amdgpu_ps_main:
+; SHADERTEST: s_getpc_b64 s{{\[}}[[T1_ADDR:[0-9]*]]:{{[0-9]*}}]
+; SHADERTEST: s_mov_b64 s{{\[}}[[T2_ADDR:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T1_ADDR]]:{{[0-9]*}}]
+; SHADERTEST: s_mov_b32 s[[T2_ADDR]], s[[table2:[0-9]*]]
+; SHADERTEST: s_mov_b32 s[[T1_ADDR]], s[[table1:[0-9]*]]
+; SHADERTEST: s_load_dwordx8 s{{\[}}[[T1_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T1_ADDR]]:{{[0-9]*}}], 0x0
+; SHADERTEST: s_load_dwordx4 s{{\[}}[[T2_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T2_ADDR]]:{{[0-9]*}}], 0x0
+; SHADERTEST: image_sample v[{{[0-9]*:[0-9]*}}], v[{{[0-9]*:[0-9]*}}], s{{\[}}[[T1_DESC]]:{{[0-9]*}}], s{{\[}}[[T2_DESC]]:{{[0-9]*}}]
+; SHADERTEST-LABEL: PalMetadata
+; SHADERTEST-LABEL: .registers:
+; SHADERTEST: SPI_SHADER_USER_DATA_PS_[[table1]]                     0x0000000000000002
+; SHADERTEST: SPI_SHADER_USER_DATA_PS_[[table2]]                     0x0000000000000003
+; SHADERTEST: SPI_SHADER_USER_DATA_VS_[[table0]]                     0x0000000000000001
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsSpirv]
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %vsmain "vsmain" %in_var_POSITION %in_var_TEXCOORD0 %gl_Position %out_var_TEXCOORD
+               OpSource HLSL 600
+               OpName %type_ConstantBuffer_TransformData "type.ConstantBuffer.TransformData"
+               OpMemberName %type_ConstantBuffer_TransformData 0 "M"
+               OpName %Transform "Transform"
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %in_var_TEXCOORD0 "in.var.TEXCOORD0"
+               OpName %out_var_TEXCOORD "out.var.TEXCOORD"
+               OpName %vsmain "vsmain"
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorate %in_var_POSITION Location 0
+               OpDecorate %in_var_TEXCOORD0 Location 1
+               OpDecorate %out_var_TEXCOORD Location 0
+               OpDecorate %Transform DescriptorSet 0
+               OpDecorate %Transform Binding 0
+               OpMemberDecorate %type_ConstantBuffer_TransformData 0 Offset 0
+               OpMemberDecorate %type_ConstantBuffer_TransformData 0 MatrixStride 16
+               OpMemberDecorate %type_ConstantBuffer_TransformData 0 RowMajor
+               OpDecorate %type_ConstantBuffer_TransformData Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+%type_ConstantBuffer_TransformData = OpTypeStruct %mat4v4float
+%_ptr_Uniform_type_ConstantBuffer_TransformData = OpTypePointer Uniform %type_ConstantBuffer_TransformData
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_ptr_Output_v2float = OpTypePointer Output %v2float
+       %void = OpTypeVoid
+         %20 = OpTypeFunction %void
+%_ptr_Uniform_mat4v4float = OpTypePointer Uniform %mat4v4float
+  %Transform = OpVariable %_ptr_Uniform_type_ConstantBuffer_TransformData Uniform
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%in_var_TEXCOORD0 = OpVariable %_ptr_Input_v2float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+%out_var_TEXCOORD = OpVariable %_ptr_Output_v2float Output
+     %vsmain = OpFunction %void None %20
+         %22 = OpLabel
+         %23 = OpLoad %v4float %in_var_POSITION
+         %24 = OpLoad %v2float %in_var_TEXCOORD0
+         %25 = OpAccessChain %_ptr_Uniform_mat4v4float %Transform %int_0
+         %26 = OpLoad %mat4v4float %25
+         %27 = OpVectorTimesMatrix %v4float %23 %26
+               OpStore %gl_Position %27
+               OpStore %out_var_TEXCOORD %24
+               OpReturn
+               OpFunctionEnd
+
+
+[VsInfo]
+entryPoint = vsmain
+userDataNode[0].visibility = 1
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 4
+userDataNode[1].next[0].set = 0
+userDataNode[1].next[0].binding = 0
+userDataNode[2].type = DescriptorTableVaPtr
+userDataNode[2].offsetInDwords = 2
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].next[0].type = DescriptorResource
+userDataNode[2].next[0].offsetInDwords = 0
+userDataNode[2].next[0].sizeInDwords = 8
+userDataNode[2].next[0].set = 0
+userDataNode[2].next[0].binding = 1
+userDataNode[3].type = DescriptorTableVaPtr
+userDataNode[3].offsetInDwords = 3
+userDataNode[3].sizeInDwords = 1
+userDataNode[3].next[0].type = DescriptorSampler
+userDataNode[3].next[0].offsetInDwords = 0
+userDataNode[3].next[0].sizeInDwords = 4
+userDataNode[3].next[0].set = 0
+userDataNode[3].next[0].binding = 2
+userDataNode[4].type = IndirectUserDataVaPtr
+userDataNode[4].offsetInDwords = 4
+userDataNode[4].sizeInDwords = 1
+userDataNode[4].indirectUserDataCount = 4
+
+[FsSpirv]
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %psmain "psmain" %gl_FragCoord %in_var_TEXCOORD %out_var_SV_TARGET
+               OpExecutionMode %psmain OriginUpperLeft
+               OpSource HLSL 600
+               OpName %type_2d_image "type.2d.image"
+               OpName %Tex0 "Tex0"
+               OpName %type_sampler "type.sampler"
+               OpName %Sampler0 "Sampler0"
+               OpName %in_var_TEXCOORD "in.var.TEXCOORD"
+               OpName %out_var_SV_TARGET "out.var.SV_TARGET"
+               OpName %psmain "psmain"
+               OpName %type_sampled_image "type.sampled.image"
+               OpDecorate %gl_FragCoord BuiltIn FragCoord
+               OpDecorate %in_var_TEXCOORD Location 0
+               OpDecorate %out_var_SV_TARGET Location 0
+               OpDecorate %Tex0 DescriptorSet 0
+               OpDecorate %Tex0 Binding 1
+               OpDecorate %Sampler0 DescriptorSet 0
+               OpDecorate %Sampler0 Binding 2
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+    %v2float = OpTypeVector %float 2
+%_ptr_Input_v2float = OpTypePointer Input %v2float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+       %Tex0 = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+   %Sampler0 = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+%gl_FragCoord = OpVariable %_ptr_Input_v4float Input
+%in_var_TEXCOORD = OpVariable %_ptr_Input_v2float Input
+%out_var_SV_TARGET = OpVariable %_ptr_Output_v4float Output
+     %psmain = OpFunction %void None %19
+         %20 = OpLabel
+         %21 = OpLoad %v2float %in_var_TEXCOORD
+         %22 = OpLoad %type_2d_image %Tex0
+         %23 = OpLoad %type_sampler %Sampler0
+         %24 = OpSampledImage %type_sampled_image %22 %23
+         %25 = OpImageSampleImplicitLod %v4float %24 %21 None
+               OpStore %out_var_SV_TARGET %25
+               OpReturn
+               OpFunctionEnd
+
+
+[FsInfo]
+entryPoint = psmain
+userDataNode[0].visibility = 1
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 4
+userDataNode[1].next[0].set = 0
+userDataNode[1].next[0].binding = 0
+userDataNode[2].type = DescriptorTableVaPtr
+userDataNode[2].offsetInDwords = 2
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].next[0].type = DescriptorResource
+userDataNode[2].next[0].offsetInDwords = 0
+userDataNode[2].next[0].sizeInDwords = 8
+userDataNode[2].next[0].set = 0
+userDataNode[2].next[0].binding = 1
+userDataNode[3].type = DescriptorTableVaPtr
+userDataNode[3].offsetInDwords = 3
+userDataNode[3].sizeInDwords = 1
+userDataNode[3].next[0].type = DescriptorSampler
+userDataNode[3].next[0].offsetInDwords = 0
+userDataNode[3].next[0].sizeInDwords = 4
+userDataNode[3].next[0].set = 0
+userDataNode[3].next[0].binding = 2
+userDataNode[4].type = IndirectUserDataVaPtr
+userDataNode[4].offsetInDwords = 4
+userDataNode[4].sizeInDwords = 1
+userDataNode[4].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 20
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 12
+

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -5,7 +5,7 @@
 ; Skip to the patching results for the fetch shader
 ; SHADERTEST-LABEL: LLPC pipeline patching results
 ; Check the inputs to the vertex shader.  This should be all of the regular inputs.  There is one vertex attribute being passed in: The vector at the end.
-; SHADERTEST: define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %0, i32 inreg %1, i32 inreg %descSet0, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %spillTable, i32 %VertexId, i32 %5, i32 %6, i32 %InstanceId, <4 x float> %vertex0.0)
+; SHADERTEST: define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %0, i32 inreg %1, i32 inreg %descTable0, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %spillTable, i32 %VertexId, i32 %5, i32 %6, i32 %InstanceId, <4 x float> %vertex0.0)
 ; SHADERTEST-LABEL: LGC glue shader results
 ; Check the inputs to the fetch shader.  This should match the vertex shader except:
 ; - there are extra inreg inputs because its determination of how many SGPR inputs


### PR DESCRIPTION
The Vulkan API guarentees that all resources in the same descriptor set
will be in the same descriptor table.  Dynamic buffers are an exception.
However, some people would like to experiment with less restrictive
binding models that are more compatible with other APIs.

Note that relocatable shaders will not work if descriptor sets are split
across multiple tables, so LLPC will fall back to whole pipeline
compilation if it observes a multi-table descriptor set.

Fixes https://github.com/GPUOpen-Drivers/llpc/issues/1073