### PR TITLE
Add copy assignment operator for 'lgc::InOutLocationInfo'

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -95,6 +95,10 @@ public:
   InOutLocationInfo() { m_data.u16All = 0; }
   InOutLocationInfo(unsigned data) { this->m_data.u16All = static_cast<uint16_t>(data); }
   InOutLocationInfo(const InOutLocationInfo &inOutLocInfo) { m_data.u16All = inOutLocInfo.getData(); }
+  InOutLocationInfo &operator=(const InOutLocationInfo &InOutLocationInfo) {
+    m_data.u16All = InOutLocationInfo.getData();
+    return *this;
+  }
 
   unsigned getData() const { return static_cast<uint16_t>(m_data.u16All); }
   void setData(unsigned data) { m_data.u16All = static_cast<uint16_t>(data); }


### PR DESCRIPTION
Fix a clang debug build warning due to implict copy assigment operator
for `lgc::InOutLocationInfo` in 796032b.