### PR TITLE
Export LLVM_BUILD_PATH to the XGL CMake scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ if(ICD_BUILD_LLPC)
     )
 
     add_subdirectory(llpc ${PROJECT_BINARY_DIR}/llpc)
+    # Export the LLVM build path so that it's available in XGL.
+    set(XGL_LLVM_BUILD_PATH ${XGL_LLVM_BUILD_PATH} PARENT_SCOPE)
 
     target_link_libraries(vkgc INTERFACE llpc)
 endif()

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -72,6 +72,8 @@ if(ICD_BUILD_LLPC)
 
     add_subdirectory(${XGL_LLVM_SRC_PATH} ${PROJECT_BINARY_DIR}/llvm)
     set(XGL_LLVM_BUILD_PATH ${PROJECT_BINARY_DIR}/llvm)
+    # Export the LLVM build path so that it's available in XGL.
+    set(XGL_LLVM_BUILD_PATH ${XGL_LLVM_BUILD_PATH} PARENT_SCOPE)
 
     llvm_map_components_to_libnames(llvm_libs
         lgc


### PR DESCRIPTION
This is to be able to use LLPC in XGL's cache creator. See the related
XGL PR: https://github.com/GPUOpen-Drivers/xgl/pull/73.