### PR TITLE
Allow creating exp instruction for tranform feedback output in copysh…

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -950,11 +950,10 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
     return;
 
   const auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
-  const bool enableXfb = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.enableXfb;
 
   // Whether this shader stage has to use "exp" instructions to export outputs
   const bool useExpInst = ((m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval ||
-                            (m_shaderStage == ShaderStageCopyShader && !enableXfb)) &&
+                            m_shaderStage == ShaderStageCopyShader) &&
                            (nextStage == ShaderStageInvalid || nextStage == ShaderStageFragment));
 
   auto zero = ConstantFP::get(Type::getFloatTy(*m_context), 0.0);


### PR DESCRIPTION
…ader

In current visitReturnInst of PathInOutImportExport pass, tranform feedback output of copyshader will not create "exp" instruction for generic output. This condition is added two years ago to fix a dxvk issue to support xfb extension. We want to remove the restriction to verify if the condition is really required. If it is required, we will make a change to avoid useless "lgc.output.export.generic" generated in PatchCopyShader pass for xfb output.