### PR TITLE
Fix for upstream change to ELFObjectFile::getELFFile

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -630,9 +630,9 @@ void ElfLinkerImpl::mergePalMetadataFromElf(object::ObjectFile &objectFile, bool
       // This is a .note section. Find the PAL metadata note and merge it into the PalMetadata object
       // in the PipelineState.
       Error err = ErrorSuccess();
-      auto elfFile = cast<object::ELFObjectFile<object::ELF64LE>>(&objectFile)->getELFFile();
-      auto shdr = cantFail(elfFile->getSection(elfSection.getIndex()));
-      for (auto note : elfFile->notes(*shdr, err)) {
+      auto &elfFile = cast<object::ELFObjectFile<object::ELF64LE>>(&objectFile)->getELFFile();
+      auto shdr = cantFail(elfFile.getSection(elfSection.getIndex()));
+      for (auto note : elfFile.notes(*shdr, err)) {
         if (note.getName() == Util::Abi::AmdGpuArchName && note.getType() == ELF::NT_AMDGPU_METADATA) {
           ArrayRef<uint8_t> desc = note.getDesc();
           m_pipelineState->mergePalMetadataFromBlob(StringRef(reinterpret_cast<const char *>(desc.data()), desc.size()),


### PR DESCRIPTION
Upstream commit ffbce65f95ee "Make ELFObjectFile::getELFFile return reference."
needs a corresponding change in the ElfLinker.