### PR TITLE
Allow exp instruction for xfb output of copyshader

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -950,11 +950,10 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
     return;
 
   const auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
-  const bool enableXfb = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.enableXfb;
 
   // Whether this shader stage has to use "exp" instructions to export outputs
   const bool useExpInst = ((m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval ||
-                            (m_shaderStage == ShaderStageCopyShader && !enableXfb)) &&
+                            m_shaderStage == ShaderStageCopyShader) &&
                            (nextStage == ShaderStageInvalid || nextStage == ShaderStageFragment));
 
   auto zero = ConstantFP::get(Type::getFloatTy(*m_context), 0.0);


### PR DESCRIPTION
In current PathInOutImportExport pass, "exp" instruction will not be
generated in copyshader for generic outputs if transform feedback is
enabled. This restriction is enforced to fix a dxvk issue in early year.
The fragment shader is allowed its input receiving xfb output of the
copyshader. To fix it, we will immediadely generate "exp" instruction
for generic output in `patchCopyShaderGenericOutputExport` if xfb is
enabled.