### PR TITLE
Fix setting shader stage of shaders with ngg

### DIFF
--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -217,11 +217,11 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         auto hsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTessControl);
 
         if (hsEntryPoint) {
+          if (lsEntryPoint)
+            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
           auto lsHsEntryPoint = shaderMerger.generateLsHsEntryPoint(lsEntryPoint, hsEntryPoint);
           lsHsEntryPoint->setCallingConv(CallingConv::AMDGPU_HS);
           lgc::setShaderStage(lsHsEntryPoint, ShaderStageTessControl);
-          if (lsEntryPoint)
-            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
         }
       }
 
@@ -230,22 +230,22 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
 
       if (enableNgg) {
         if (gsEntryPoint) {
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
           auto copyShaderEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageCopyShader);
+          if (copyShaderEntryPoint)
+            lgc::setShaderStage(copyShaderEntryPoint, ShaderStageGeometry);
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, gsEntryPoint, copyShaderEntryPoint);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
           lgc::setShaderStage(primShaderEntryPoint, ShaderStageGeometry);
-          if (esEntryPoint)
-            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
-          if (copyShaderEntryPoint)
-            lgc::setShaderStage(copyShaderEntryPoint, ShaderStageGeometry);
         }
       } else {
         if (gsEntryPoint) {
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
           auto esGsEntryPoint = shaderMerger.generateEsGsEntryPoint(esEntryPoint, gsEntryPoint);
           esGsEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
           lgc::setShaderStage(esGsEntryPoint, ShaderStageGeometry);
-          if (esEntryPoint)
-            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
         }
 
         setCallingConv(ShaderStageCopyShader, CallingConv::AMDGPU_VS);
@@ -257,11 +257,11 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         auto hsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTessControl);
 
         if (hsEntryPoint) {
+          if (lsEntryPoint)
+            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
           auto lsHsEntryPoint = shaderMerger.generateLsHsEntryPoint(lsEntryPoint, hsEntryPoint);
           lsHsEntryPoint->setCallingConv(CallingConv::AMDGPU_HS);
           lgc::setShaderStage(lsHsEntryPoint, ShaderStageTessControl);
-          if (lsEntryPoint)
-            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
         }
       }
 
@@ -270,10 +270,10 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         auto esEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTessEval);
 
         if (esEntryPoint) {
+          lgc::setShaderStage(esEntryPoint, ShaderStageTessEval);
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, nullptr, nullptr);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
           lgc::setShaderStage(primShaderEntryPoint, ShaderStageTessEval);
-          lgc::setShaderStage(esEntryPoint, ShaderStageTessEval);
         }
       } else {
         setCallingConv(ShaderStageTessEval, CallingConv::AMDGPU_VS);
@@ -285,22 +285,22 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
 
       if (enableNgg) {
         if (gsEntryPoint) {
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
           auto copyShaderEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageCopyShader);
+          if (copyShaderEntryPoint)
+            lgc::setShaderStage(copyShaderEntryPoint, ShaderStageGeometry);
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, gsEntryPoint, copyShaderEntryPoint);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
           lgc::setShaderStage(primShaderEntryPoint, ShaderStageGeometry);
-          if (esEntryPoint)
-            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
-          if (copyShaderEntryPoint)
-            lgc::setShaderStage(copyShaderEntryPoint, ShaderStageGeometry);
         }
       } else {
         if (gsEntryPoint) {
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
           auto esGsEntryPoint = shaderMerger.generateEsGsEntryPoint(esEntryPoint, gsEntryPoint);
           esGsEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
           lgc::setShaderStage(esGsEntryPoint, ShaderStageGeometry);
-          if (esEntryPoint)
-            lgc::setShaderStage(esEntryPoint, ShaderStageGeometry);
         }
 
         setCallingConv(ShaderStageCopyShader, CallingConv::AMDGPU_VS);
@@ -311,11 +311,11 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
         // If NGG is enabled, ES-GS merged shader should be present even if GS is absent
         auto esEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageVertex);
         if (esEntryPoint) {
+          if (esEntryPoint)
+            lgc::setShaderStage(esEntryPoint, ShaderStageVertex);
           auto primShaderEntryPoint = shaderMerger.buildPrimShader(esEntryPoint, nullptr, nullptr);
           primShaderEntryPoint->setCallingConv(CallingConv::AMDGPU_GS);
           lgc::setShaderStage(primShaderEntryPoint, ShaderStageVertex);
-          if (esEntryPoint)
-            lgc::setShaderStage(esEntryPoint, ShaderStageVertex);
         }
       } else
         setCallingConv(ShaderStageVertex, CallingConv::AMDGPU_VS);

--- a/llpc/test/shaderdb/gfx10/PipelineVsFs_TestFetchSingleInputNgg.pipe
+++ b/llpc/test/shaderdb/gfx10/PipelineVsFs_TestFetchSingleInputNgg.pipe
@@ -1,0 +1,245 @@
+; Test that a fetch shader for 1 input is not crashing with NGG.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: =====  AMDLLPC SUCCESS  =====
+; END_SHADERTEST
+
+[Version]
+version = 40
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %pos
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %UBO "UBO"
+               OpMemberName %UBO 0 "projection"
+               OpMemberName %UBO 1 "model"
+               OpMemberName %UBO 2 "gradientPos"
+               OpName %ubo "ubo"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpName %_ ""
+               OpName %pos "pos"
+               OpMemberDecorate %UBO 0 ColMajor
+               OpMemberDecorate %UBO 0 Offset 0
+               OpMemberDecorate %UBO 0 MatrixStride 16
+               OpMemberDecorate %UBO 1 ColMajor
+               OpMemberDecorate %UBO 1 Offset 64
+               OpMemberDecorate %UBO 1 MatrixStride 16
+               OpMemberDecorate %UBO 2 Offset 128
+               OpDecorate %UBO Block
+               OpDecorate %ubo DescriptorSet 0
+               OpDecorate %ubo Binding 0
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %pos Location 0
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+        %UBO = OpTypeStruct %mat4v4float %mat4v4float %float
+%_ptr_Uniform_UBO = OpTypePointer Uniform %UBO
+        %ubo = OpVariable %_ptr_Uniform_UBO Uniform
+        %int = OpTypeInt 32 1
+%gl_PerVertex = OpTypeStruct %v4float
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+      %int_0 = OpConstant %int 0
+%_ptr_Uniform_mat4v4float = OpTypePointer Uniform %mat4v4float
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+        %pos = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+    %float_1 = OpConstant %float 1
+       %main = OpFunction %void None %9
+         %21 = OpLabel
+         %22 = OpAccessChain %_ptr_Uniform_mat4v4float %ubo %int_0
+         %23 = OpLoad %mat4v4float %22
+         %24 = OpLoad %v4float %pos
+         %25 = OpCompositeInsert %v4float %float_1 %24 3
+         %26 = OpMatrixTimesVector %v4float %23 %25
+         %27 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %27 %26
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 4
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorCombinedTexture
+userDataNode[0].next[1].offsetInDwords = 4
+userDataNode[0].next[1].sizeInDwords = 12
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 1
+userDataNode[0].next[2].type = DescriptorBuffer
+userDataNode[0].next[2].offsetInDwords = 16
+userDataNode[0].next[2].sizeInDwords = 4
+userDataNode[0].next[2].set = 0
+userDataNode[0].next[2].binding = 2
+userDataNode[1].type = IndirectUserDataVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].indirectUserDataCount = 4
+
+options.trapPresent = 0
+options.debugMode = 0
+options.enablePerformanceData = 0
+options.allowReZ = 0
+options.vgprLimit = 0
+options.sgprLimit = 0
+options.maxThreadGroupsPerComputeUnit = 0
+options.waveSize = 0
+options.wgpMode = 0
+options.waveBreakSize = DrawTime
+options.forceLoopUnrollCount = 0
+options.useSiScheduler = 0
+options.updateDescInElf = 0
+options.allowVaryWaveSize = 0
+options.enableLoadScalarizer = 0
+options.disableLicm = 0
+options.unrollThreshold = 0
+options.scalarThreshold = 0
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %outFragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %outFragColor "outFragColor"
+               OpDecorate %outFragColor Location 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%outFragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+    %float_0 = OpConstant %float 0
+         %11 = OpConstantComposite %v4float %float_0 %float_1 %float_0 %float_1
+       %main = OpFunction %void None %5
+         %12 = OpLabel
+               OpStore %outFragColor %11
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 4
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorCombinedTexture
+userDataNode[0].next[1].offsetInDwords = 4
+userDataNode[0].next[1].sizeInDwords = 12
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 1
+userDataNode[0].next[2].type = DescriptorBuffer
+userDataNode[0].next[2].offsetInDwords = 16
+userDataNode[0].next[2].sizeInDwords = 4
+userDataNode[0].next[2].set = 0
+userDataNode[0].next[2].binding = 2
+
+options.trapPresent = 0
+options.debugMode = 0
+options.enablePerformanceData = 0
+options.allowReZ = 0
+options.vgprLimit = 0
+options.sgprLimit = 0
+options.maxThreadGroupsPerComputeUnit = 0
+options.waveSize = 0
+options.wgpMode = 0
+options.waveBreakSize = DrawTime
+options.forceLoopUnrollCount = 0
+options.useSiScheduler = 0
+options.updateDescInElf = 0
+options.allowVaryWaveSize = 0
+options.enableLoadScalarizer = 0
+options.disableLicm = 0
+options.unrollThreshold = 0
+options.scalarThreshold = 0
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+patchControlPoints = 0
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 1
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+polygonMode = VK_POLYGON_MODE_FILL
+cullMode = VK_CULL_MODE_NONE
+frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE
+depthBiasEnable = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+nggState.enableNgg = 1
+nggState.enableGsUse = 0
+nggState.forceNonPassthrough = 1
+nggState.alwaysUsePrimShaderTable = 0
+nggState.compactMode = NggCompactSubgroup
+nggState.enableFastLaunch = 0
+nggState.enableVertexReuse = 1
+nggState.enableBackfaceCulling = 0
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 0
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 0
+nggState.vertsPerSubgroup = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 0
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.reconfigWorkgroupLayout = 0
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 44
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32_SFLOAT
+attribute[1].offset = 12
+attribute[2].location = 2
+attribute[2].binding = 0
+attribute[2].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[2].offset = 20
+attribute[3].location = 3
+attribute[3].binding = 0
+attribute[3].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[3].offset = 32

--- a/llpc/test/shaderdb/gfx10/lit.local.cfg
+++ b/llpc/test/shaderdb/gfx10/lit.local.cfg
@@ -1,0 +1,9 @@
+
+# overwrite %gfxip in config.substitutions
+config.gfxip = '-gfxip=10.3'
+
+index = 0;
+for substitution in config.substitutions :
+   if substitution[0] == '%gfxip' :
+       config.substitutions[index] = ('%gfxip', config.gfxip);
+   index += 1;

--- a/llpc/test/testShaders.py
+++ b/llpc/test/testShaders.py
@@ -40,7 +40,7 @@ SHADER_SRC = "shaderdb"
 COMPILER = ""
 SPVGEN  = ""
 
-GFX_DIRS = [".", "gfx9"]
+GFX_DIRS = [".", "gfx9", "gfx10"]
 GFXIP = 0
 
 fail_count = 0


### PR DESCRIPTION
When ngg is enabled and passthrough disabled, the es shader gets
deleted for vs-fs pipelines.
This caused problems when trying to set the shader stage afterwards.
This patch changes this, setting the shader stage before merging
shaders to fix the crash.