### PR TITLE
Remove SPIR_FUNC from lgc

### DIFF
--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -185,10 +185,11 @@ void PatchPreparePipelineAbi::setCallingConvs(Module &module) {
 // @param module : LLVM module
 void PatchPreparePipelineAbi::setRemainingCallingConvs(Module &module) {
   for (Function &func : module) {
-    if (func.isDeclaration())
+    if (func.isDeclaration() || func.getIntrinsicID() != Intrinsic::not_intrinsic ||
+        func.getName().startswith(lgcName::InternalCallPrefix) ||
+        func.getDLLStorageClass() == GlobalValue::DLLExportStorageClass)
       continue;
-    if (func.getCallingConv() == CallingConv::SPIR_FUNC)
-      func.setCallingConv(CallingConv::AMDGPU_Gfx);
+    func.setCallingConv(CallingConv::AMDGPU_Gfx);
   }
 }
 

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -2,17 +2,17 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
+; CHECK: define spir_func void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
 ; CHECK: !7 = !{i32 5}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) local_unnamed_addr #1 !lgc.shaderstage !7 {
+; CHECK: define amdgpu_gfx void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) local_unnamed_addr #1 !lgc.shaderstage !7 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
 target triple = "amdgcn--amdpal"
 
 ; Function Attrs: nounwind
-define spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+define spir_func void @func() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
 .entry:
   %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
   %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)

--- a/lgc/test/FsComputeLibrary.lgc
+++ b/lgc/test/FsComputeLibrary.lgc
@@ -2,17 +2,17 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define spir_func void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
+; CHECK: define spir_func void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
 ; CHECK: !5 = !{i32 4}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx void @lgc.shader.FS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) local_unnamed_addr #0 !lgc.shaderstage !5 {
+; CHECK: define amdgpu_gfx void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) local_unnamed_addr #0 !lgc.shaderstage !5 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
 target triple = "amdgcn--amdpal"
 
 ; Function Attrs: nounwind
-define spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+define spir_func void @func() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
 .entry:
   ret void
 }

--- a/lgc/test/VsComputeLibrary.lgc
+++ b/lgc/test/VsComputeLibrary.lgc
@@ -2,17 +2,17 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define spir_func <4 x float> @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #2 !lgc.shaderstage !4 {
+; CHECK: define spir_func <4 x float> @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #2 !lgc.shaderstage !4 {
 ; CHECK: !4 = !{i32 0}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx <4 x float> @lgc.shader.VS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #0 !lgc.shaderstage !4 {
+; CHECK: define amdgpu_gfx <4 x float> @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #0 !lgc.shaderstage !4 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
 target triple = "amdgcn--amdpal"
 
 ; Function Attrs: nounwind
-define spir_func <4 x float> @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
+define spir_func <4 x float> @func() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !5 {
 .entry:
   %0 = call <4 x i32> (...) @lgc.create.read.generic.input.v4i32(i32 5, i32 0, i32 0, i32 0, i32 0, i32 undef)
   %bc = bitcast <4 x i32> %0 to <4 x float>


### PR DESCRIPTION
lgc should be agnostic about the frontend and not know about SPIR-V.
With this patch, the calling convention of all non-entry-point functions
is set to amdgpu_gfx.