### PR TITLE
Amend PatchLoopMetadata pass

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 45
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 3
+#define LLPC_INTERFACE_MINOR_VERSION 4
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -71,6 +71,7 @@
 //* %Version History
 //* | %Version | Change Description                                                                                    |
 //* | -------- | ----------------------------------------------------------------------------------------------------- |
+//* |     45.4 | Added disableLicmThreshold, unrollHintThreshold, and dontUnrollHintThreshold to PipelineShaderOptions |
 //* |     45.2 | Add GFX IP plus checker to GfxIpVersion                                                               |
 //* |     45.1 | Add pipelineCacheAccess, stageCacheAccess(es) to GraphicsPipelineBuildOut/ComputePipelineBuildOut     |
 //* |     45.0 | Remove the member 'enableFastLaunch' of NGG state                                                     |
@@ -556,7 +557,7 @@ struct PipelineShaderOptions {
   // Whether update descriptor root offset in ELF
   bool updateDescInElf;
 
-  /// Disable the the LLVM backend's LICM pass.
+  /// Disable the the LLVM backend's LICM pass (equivalent to disableLicmThreshold=1).
   bool disableLicm;
 
   /// Default unroll threshold for LLVM.
@@ -573,6 +574,15 @@ struct PipelineShaderOptions {
 
   /// Override FP32 denormal handling.
   DenormalMode fp32DenormalMode;
+
+  /// Threshold number of blocks in a loop for LICM pass to be disabled.
+  unsigned disableLicmThreshold;
+
+  /// Threshold to use for loops with "Unroll" hint (0 = use llvm.llop.unroll.full).
+  unsigned unrollHintThreshold;
+
+  /// Threshold to use for loops with "DontUnroll" hint (0 = use llvm.llop.unroll.disable).
+  unsigned dontUnrollHintThreshold;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -183,8 +183,14 @@ struct ShaderOptions {
   // Disable loop unrolling.
   bool disableLoopUnroll = false;
 
-  // Disable LICM pass.
-  bool disableLicm = false;
+  // Threshold for minimum number of blocks in a loop to disable the LICM pass.
+  unsigned disableLicmThreshold = 0;
+
+  // Threshold to use for loops with Unroll hint. 0 to use llvm.loop.unroll.full metadata.
+  unsigned unrollHintThreshold = 0;
+
+  // Threshold to use for loops with DontUnroll hint. 0 to use llvm.loop.unroll.disable metadata.
+  unsigned dontUnrollHintThreshold = 0;
 };
 
 // =====================================================================================================================

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -559,6 +559,9 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.disableLoopUnroll = " << shaderInfo->options.disableLoopUnroll << "\n";
   dumpFile << "options.fp32DenormalMode = " << shaderInfo->options.fp32DenormalMode << "\n";
   dumpFile << "options.adjustDepthImportVrs = " << shaderInfo->options.adjustDepthImportVrs << "\n";
+  dumpFile << "options.disableLicmThreshold = " << shaderInfo->options.disableLicmThreshold << "\n";
+  dumpFile << "options.unrollHintThreshold = " << shaderInfo->options.unrollHintThreshold << "\n";
+  dumpFile << "options.dontUnrollHintThreshold = " << shaderInfo->options.dontUnrollHintThreshold << "\n";
   dumpFile << "\n";
 }
 
@@ -1214,6 +1217,9 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.disableLoopUnroll);
       hasher->Update(options.fp32DenormalMode);
       hasher->Update(options.adjustDepthImportVrs);
+      hasher->Update(options.disableLicmThreshold);
+      hasher->Update(options.unrollHintThreshold);
+      hasher->Update(options.dontUnrollHintThreshold);
     }
   }
 }

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -157,6 +157,9 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, adjustDepthImportVrs, MemberTypeBool, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicmThreshold, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollHintThreshold, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -165,7 +168,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 21;
+  static const unsigned MemberCount = 24;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Several changes to the loop metadata:

Replaced the -strict-unroll-hints and -strict-dont-unroll-hints boolean options with -unroll-hint-threshold and -dontunroll-hint-threshold respectively.
The new options take an integer threshold value. A value of 0 (default) will use the llvm.loop.unroll.full or llvm.loop.unroll.disable metadata as previously.
When non-zero the amdgpu.loop.unroll.threshold metadata with the specified value is attached to loops wih the SPIR-V "Unroll" and "DontUnroll" hints.

Added option -disable-licm-threshold which takes an integer value - a non-zero value will disable the LICM pass for any loops with at least the specified number of blocks. 
The -disable-licm option is retained for backwards compatibility, but is now equivalent to -disable-licm-threshold=1.
A default value of 20 is used - which disables LICM for loops with 20 blocks or more. This allows LICM to operate in most cases where it is beneficial, but significantly reduces register pressure resulting from LICM on larger loops (and thereby increases occupancy).