### PR TITLE
Fix ShaderOptions initialization

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -128,63 +128,63 @@ struct Options {
 // Middle-end per-shader options to pass to SetShaderOptions.
 // The front-end should zero-initialize it with "= {}" in case future changes add new fields.
 struct ShaderOptions {
-  uint64_t hash[2];     // Shader hash to set in ELF PAL metadata
-  unsigned trapPresent; // Indicates a trap handler will be present when this pipeline is executed,
-                        //  and any trap conditions encountered in this shader should call the trap
-                        //  handler. This could include an arithmetic exception, an explicit trap
-                        //  request from the host, or a trap after every instruction when in debug
-                        //  mode.
-  unsigned debugMode;   // When set, this shader should cause the trap handler to be executed after
-                        //  every instruction.  Only valid if trapPresent is set.
-  unsigned allowReZ;    // Allow the DB ReZ feature to be enabled.  This will cause an early-Z test
-                        //  to potentially kill PS waves before launch, and also issues a late-Z test
-                        //  in case the PS kills pixels.  Only valid for pixel shaders.
+  uint64_t hash[2] = {};    // Shader hash to set in ELF PAL metadata
+  unsigned trapPresent = 0; // Indicates a trap handler will be present when this pipeline is executed,
+                            //  and any trap conditions encountered in this shader should call the trap
+                            //  handler. This could include an arithmetic exception, an explicit trap
+                            //  request from the host, or a trap after every instruction when in debug
+                            //  mode.
+  unsigned debugMode = 0;   // When set, this shader should cause the trap handler to be executed after
+                            //  every instruction.  Only valid if trapPresent is set.
+  unsigned allowReZ = 0;    // Allow the DB ReZ feature to be enabled.  This will cause an early-Z test
+                            //  to potentially kill PS waves before launch, and also issues a late-Z test
+                            //  in case the PS kills pixels.  Only valid for pixel shaders.
 
   // Maximum VGPR limit for this shader. The actual limit used by back-end for shader compilation is the smaller
   // of this value and whatever the target GPU supports. To effectively disable this limit, set this to 0.
-  unsigned vgprLimit;
+  unsigned vgprLimit = 0;
 
   // Maximum SGPR limit for this shader. The actual limit used by back-end for shader compilation is the smaller
   // of this value and whatever the target GPU supports. To effectively disable this limit, set this to 0.
-  unsigned sgprLimit;
+  unsigned sgprLimit = 0;
 
   /// Overrides the number of CS thread-groups which the GPU will launch per compute-unit. This throttles the
   /// shader, which can sometimes enable more graphics shader work to complete in parallel. A value of zero
   /// disables limiting the number of thread-groups to launch. This field is ignored for graphics shaders.
-  unsigned maxThreadGroupsPerComputeUnit;
+  unsigned maxThreadGroupsPerComputeUnit = 0;
 
-  unsigned waveSize;       // Control the number of threads per wavefront (GFX10+)
-  unsigned subgroupSize;   // Override for the wave size when the shader uses gl_SubgroupSize, 0 for no override
-  unsigned wgpMode;        // Whether to choose WGP mode or CU mode (GFX10+)
-  WaveBreak waveBreakSize; // Size of region to force the end of a wavefront (GFX10+).
-                           // Only valid for fragment shaders.
+  unsigned waveSize = 0;     // Control the number of threads per wavefront (GFX10+)
+  unsigned subgroupSize = 0; // Override for the wave size when the shader uses gl_SubgroupSize, 0 for no override
+  unsigned wgpMode = 0;      // Whether to choose WGP mode or CU mode (GFX10+)
+  WaveBreak waveBreakSize = WaveBreak::None; // Size of region to force the end of a wavefront (GFX10+).
+                                             // Only valid for fragment shaders.
 
   // Vector size threshold for load scalarizer. 0 means do not scalarize loads at all.
-  unsigned loadScalarizerThreshold;
+  unsigned loadScalarizerThreshold = 0;
 
   // Use the LLVM backend's SI scheduler instead of the default scheduler.
-  bool useSiScheduler;
+  bool useSiScheduler = false;
 
   // Whether update descriptor root offset in ELF
-  bool updateDescInElf;
+  bool updateDescInElf = false;
 
   // Default unroll threshold for LLVM.
-  unsigned unrollThreshold;
+  unsigned unrollThreshold = 0;
 
   /// Override FP32 denormal handling.
-  DenormalMode fp32DenormalMode;
+  DenormalMode fp32DenormalMode = DenormalMode::Auto;
 
   /// Whether enable adjustment of the fragment shader depth import for the variable shading rate
-  bool adjustDepthImportVrs;
+  bool adjustDepthImportVrs = false;
 
   // Unroll loops by specified amount. 0 is default, 1 is no unroll.
-  unsigned forceLoopUnrollCount;
+  unsigned forceLoopUnrollCount = 0;
 
   // Disable loop unrolling.
-  bool disableLoopUnroll;
+  bool disableLoopUnroll = false;
 
   // Disable LICM pass.
-  bool disableLicm;
+  bool disableLicm = false;
 };
 
 // =====================================================================================================================


### PR DESCRIPTION
The PipelineState relies on ShaderOptions being zero if unused.
This was a problem when doing `m_shaderOptions.resize(stage + 1);` in
PipelineState, which leaves all newly added ShaderOptions in an
uninitialized state.

valgrind+gcc showed this.