### PR TITLE
Fix a latent issue in copy shader when multi-stream is enabled for XFB

### DIFF
--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -226,30 +226,24 @@ bool PatchCopyShader::runOnModule(Module &module) {
                                               });
 
     //
-    // .entry:
-    //      switch i32 %streamId, label %.end [ i32 0, lable %stream0
-    //                                          i32 1, label %stream1
-    //                                          i32 2, label %stream2
-    //                                          i32 3, label %stream3 ]
+    // copyShader() {
+    //   ...
+    //   switch(streamId) {
+    //   case 0:
+    //     export outputs of stream 0
+    //     break
+    //   ...
+    //   case rasterStream:
+    //     export outputs of raster stream
+    //     break
+    //   ...
+    //   case 3:
+    //     export outputs of stream 3
+    //     break
+    //   }
     //
-    // .stream0:
-    //      export(0)
-    //      br %label .end
-    //
-    // .stream1:
-    //      export(1)
-    //      br %label .end
-    //
-    // .stream2:
-    //      export(2)
-    //      br %label .end
-    //
-    // .stream3:
-    //      export(3)
-    //      br %label .end
-    //
-    // .end:
-    //      ret void
+    //   return
+    // }
     //
 
     // Add switchInst to entry block


### PR DESCRIPTION
In the pass of in/out import/export, we always assume the output export
happens in the return block. However, it is not sure for copy shader.
When multi-stream is enabled for XFB, the export stays in corresponding
handling branches for this stream. Thus, all processing in the return
block for in/out should stay in the same place.

Change-Id: I831a1b5a24dc6a63a76435ec031738ecee2a9551