### PR TITLE
Fix findResourceNode for newer gcc versions

### DIFF
--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -760,6 +760,13 @@ PipelineState::findResourceNode(ResourceNodeType nodeType, unsigned descSet, uns
 
   if (nodeType == ResourceNodeType::DescriptorFmask &&
       getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
+#if defined(__GNUC__) && !defined(__clang__)
+    // FIXME Newer gcc versions optimize out this if statement. The reason is either undefined behavior in lgc or a bug
+    // in gcc. The following inline assembly prevents the gcc optimization.
+    // See https://github.com/GPUOpen-Drivers/llpc/issues/1096 for more information.
+    asm volatile("" : "+m,r"(nodeType) : : "memory");
+#endif
+
     // For fmask with -enable-shadow-descriptor-table, if no fmask descriptor is found, look for a resource
     // (image) one instead.
     return findResourceNode(ResourceNodeType::DescriptorResource, descSet, binding);


### PR DESCRIPTION
Hopefully temporary fix for #1096.
As referenced by @kuhar, use inline assembly to prevent gcc from removing the if statement.