### PR TITLE
Separately report cache hit of internal cache

### DIFF
--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -110,9 +110,10 @@ struct ShaderModuleBuildOut {
 };
 
 enum CacheAccessInfo : uint8_t {
-  CacheNotChecked = 0, ///< Stage cache is not checked.
-  CacheMiss,           ///< Stage cache miss.
-  CacheHit,            ///< Stage cache hit.
+  CacheNotChecked = 0, ///< Cache is not checked.
+  CacheMiss,           ///< Cache miss.
+  CacheHit,            ///< Cache hit using VkPipelineCache.
+  InternalCacheHit,    ///< cache hit using internal cache.
 };
 
 /// Represents output of building a graphics pipeline.


### PR DESCRIPTION
`Compiler::BuildGraphicsPipeline/BuildComputePipeline()` reports cache
access results to the [Pipeline Creation Feedback](
https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/chap11.html#pipelines-creation-feedback).
Since the pipeline cache and base pipeline acceleration are only two
options to report the cache access result (see
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreationFeedbackFlagBitsEXT.html),
we have to separately report the cache hit of the internal cache.
This commit separates the cache hit of the internal cache from the
cache hit of the pipeline cache that is given by VkPipelineCache.

Related PR: #1061