### PR TITLE
Update PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2872,7 +2872,7 @@ void PatchInOutImportExport::patchTcsBuiltInOutputExport(Value *output, unsigned
     storeTessFactorToBuffer(tessFactors, tessFactorOffset, insertPos);
 
     if (perPatchBuiltInOutLocMap.count(builtInId) == 0)
-      return; // Avoid writing unused tessellation factor to Lds
+      return; // Avoid writing unused tessellation factor to LDS
 
     unsigned loc = perPatchBuiltInOutLocMap[builtInId];
 
@@ -4406,6 +4406,7 @@ void PatchInOutImportExport::storeTessFactorToBuffer(const SmallVectorImpl<Value
 // =====================================================================================================================
 // Creates the LLPC intrinsic "llpc.tfbuffer.store.%tfValueType" to store tessellation factor.
 //
+// param@ funcName : The internal function name
 // param@ compCount : The component count of the store value
 void PatchInOutImportExport::createTessBufferStoreFunction(StringRef funcName, unsigned compCount) {
   // %tfValueType could be one of {i32, v2i32, v3i32, v4i32}

--- a/llpc/test/shaderdb/PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe
+++ b/llpc/test/shaderdb/PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe
@@ -2,6 +2,13 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST-LABEL: {{^// LLPC}} tessellation calculation factor results
+; SHADERTEST: Patch constant count: 0
+; SHADERTEST: Patch constant size: 0
+; SHADERTEST: Patch constant total size: 0
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call void @llvm.amdgcn.raw.tbuffer.store.i32
+; SHADERTEST-NEXT: ret void
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
Add patterns to verify that no TFs is written to LDS if they are not
read by TES or TCS.
Modify two place with coding style issue.