### PR TITLE
Fix descriptor set user data in compute libraries

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -924,7 +924,7 @@ void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
   AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);
   entryPoint->addAttributes(attribIdx, builder);
 
-  // NOTE: Remove "readnone" attribute for entry-point. If GS is emtry, this attribute will allow
+  // NOTE: Remove "readnone" attribute for entry-point. If GS is empty, this attribute will allow
   // LLVM optimization to remove sendmsg(GS_DONE). It is unexpected.
   if (entryPoint->hasFnAttribute(Attribute::ReadNone))
     entryPoint->removeFnAttr(Attribute::ReadNone);
@@ -1246,12 +1246,10 @@ void PatchEntryPointMutate::addUserDataArgs(SmallVectorImpl<UserDataArg> &userDa
     case ResourceNodeType::DescriptorTableVaPtr: {
       // Check if the descriptor set is in use. For compute with calls, enable it anyway.
       UserDataNodeUsage *descSetUsage = nullptr;
-      if (!isComputeWithCalls()) {
-        if (userDataUsage->descriptorTables.size() > userDataNodeIdx)
-          descSetUsage = &userDataUsage->descriptorTables[userDataNodeIdx];
-        if (!descSetUsage || descSetUsage->users.empty())
-          break;
-      }
+      if (userDataUsage->descriptorTables.size() > userDataNodeIdx)
+        descSetUsage = &userDataUsage->descriptorTables[userDataNodeIdx];
+      if (!isComputeWithCalls() && (!descSetUsage || descSetUsage->users.empty()))
+        break;
 
       unsigned userDataValue = node.offsetInDwords;
       if (m_pipelineState->getShaderOptions(m_shaderStage).updateDescInElf && m_shaderStage == ShaderStageFragment) {

--- a/lgc/test/CallLibFromCs-indirect.lgc
+++ b/lgc/test/CallLibFromCs-indirect.lgc
@@ -2,8 +2,8 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
-; CHECK: %[[#]] = call amdgpu_gfx i32 %[[#]](i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16)
+; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %descTable2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %spillTable, <3 x i32> inreg %13, i32 inreg %14, <3 x i32> %15) #1 !lgc.shaderstage !7 {
+; CHECK: %[[#]] = call amdgpu_gfx i32 %[[#]](i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %descTable2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %spillTable, <3 x i32> inreg %13, i32 inreg %14, <3 x i32> %15)
 ; CHECK: !7 = !{i32 5}
 
 ; ModuleID = 'lgcPipeline'

--- a/lgc/test/CallLibFromCs.lgc
+++ b/lgc/test/CallLibFromCs.lgc
@@ -3,8 +3,8 @@
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
 ; CHECK: declare amdgpu_gfx i32 @compute_library_func() #0
-; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #2 !lgc.shaderstage !7 {
-; CHECK: %[[#]] = call amdgpu_gfx i32 bitcast (i32 ()* @compute_library_func to i32 (i32, i32, <3 x i32> addrspace(4)*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <3 x i32>, i32, <3 x i32>)*)(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16)
+; CHECK: define dllexport spir_func void @lgc.shader.CS.main(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %descTable2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %spillTable, <3 x i32> inreg %13, i32 inreg %14, <3 x i32> %15) #2 !lgc.shaderstage !7 {
+; CHECK: %[[#]] = call amdgpu_gfx i32 bitcast (i32 ()* @compute_library_func to i32 (i32, i32, <3 x i32> addrspace(4)*, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, <3 x i32>, i32, <3 x i32>)*)(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %descTable2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %spillTable, <3 x i32> inreg %13, i32 inreg %14, <3 x i32> %15)
 ; CHECK: !7 = !{i32 5}
 
 ; ModuleID = 'lgcPipeline'

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -2,10 +2,10 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define spir_func void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) #1 !lgc.shaderstage !7 {
+; CHECK: define spir_func void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %descTable2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %spillTable, <3 x i32> inreg %13, i32 inreg %14, <3 x i32> %15) #1 !lgc.shaderstage !7 {
 ; CHECK: !7 = !{i32 5}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %spillTable, <3 x i32> inreg %14, i32 inreg %15, <3 x i32> %16) local_unnamed_addr #1 !lgc.shaderstage !7 {
+; CHECK: define amdgpu_gfx void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %descTable2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %spillTable, <3 x i32> inreg %13, i32 inreg %14, <3 x i32> %15) #1 !lgc.shaderstage !7 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"


### PR DESCRIPTION
There was a mismatch about spilled or unspilled descriptors for compute
libraries. The emitted PAL metadata put pointers to the descriptor sets
into sgprs, but the emitted code loaded the sets from the spill table.

@trenouf Do you know by chance a good way to assert if the emitted code does not match the emitted metadata?