### PR TITLE
Favour uniform uses

### DIFF
--- a/lgc/test/PatchReadLane.lgc
+++ b/lgc/test/PatchReadLane.lgc
@@ -1,0 +1,132 @@
+; RUN: lgc -mcpu=gfx900 -print-after=lgc-patch-read-first-lane %s -o /dev/null 2>&1 | FileCheck  %s
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-read-first-lane %s -o /dev/null 2>&1 | FileCheck %s
+
+; ModuleID = 'lgcPipeline'
+source_filename = "llpccompute6"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn--amdpal"
+
+@lds = local_unnamed_addr addrspace(3) global i32 undef, align 16
+@lds_float = local_unnamed_addr addrspace(3) global float undef, align 16
+
+; Test that %LocalInvocationId.i0 gets replaced with %scalar in BB1.
+; CHECK: @icmp_eq_true
+; CHECK: %use = add i32 %scalar, 1
+; CHECK: store i32 %use, i32 addrspace(3)* @lds, align 16
+
+; Function Attrs: nounwind
+define dllexport amdgpu_cs void @icmp_eq_true(i32 inreg %0, i32 inreg %1, <3 x i32> inreg %2, i32 inreg %3, <3 x i32> %LocalInvocationId) local_unnamed_addr #0 !lgc.shaderstage !4 {
+.entry:
+  %LocalInvocationId.i0 = extractelement <3 x i32> %LocalInvocationId, i32 0
+  %scalar = call i32 @llvm.amdgcn.readlane(i32 %LocalInvocationId.i0, i32 0)
+  %cmp = icmp eq i32 %LocalInvocationId.i0, %scalar
+  br i1 %cmp, label %BB1, label %BB2
+
+ BB1:
+  %use = add i32 %LocalInvocationId.i0, 1
+  store i32 %use, i32 addrspace(3)* @lds, align 16
+  br label %BB3
+
+ BB2:
+  br label %BB3
+
+ BB3:
+  ret void
+}
+
+; Test that %LocalInvocationId.i0 gets replaced with %scalar in BB1.
+; CHECK: @icmp_ne_false
+; CHECK: %use = add i32 %scalar, 1
+; CHECK: store i32 %use, i32 addrspace(3)* @lds, align 16
+
+; Function Attrs: nounwind
+define dllexport amdgpu_cs void @icmp_ne_false(i32 inreg %0, i32 inreg %1, <3 x i32> inreg %2, i32 inreg %3, <3 x i32> %LocalInvocationId) local_unnamed_addr #0 !lgc.shaderstage !4 {
+.entry:
+  %LocalInvocationId.i0 = extractelement <3 x i32> %LocalInvocationId, i32 0
+  %scalar = call i32 @llvm.amdgcn.readlane(i32 %LocalInvocationId.i0, i32 0)
+  %cmp = icmp ne i32 %LocalInvocationId.i0, %scalar
+  br i1 %cmp, label %BB2, label %BB1
+
+ BB1:
+  %use = add i32 %LocalInvocationId.i0, 1
+  store i32 %use, i32 addrspace(3)* @lds, align 16
+  br label %BB3
+
+ BB2:
+  br label %BB3
+
+ BB3:
+  ret void
+}
+
+; Test that %LocalInvocationId.i0 does not get replaced with %scalar in BB1.
+; CHECK: @icmp_eq_false
+; CHECK: %use = add i32 %LocalInvocationId.i01, 1
+; CHECK: store i32 %use, i32 addrspace(3)* @lds, align 16
+
+; Function Attrs: nounwind
+define dllexport amdgpu_cs void @icmp_eq_false(i32 inreg %0, i32 inreg %1, <3 x i32> inreg %2, i32 inreg %3, <3 x i32> %LocalInvocationId) local_unnamed_addr #0 !lgc.shaderstage !4 {
+.entry:
+  %LocalInvocationId.i0 = extractelement <3 x i32> %LocalInvocationId, i32 0
+  %scalar = call i32 @llvm.amdgcn.readlane(i32 %LocalInvocationId.i0, i32 0)
+  %cmp = icmp eq i32 %LocalInvocationId.i0, %scalar
+  br i1 %cmp, label %BB2, label %BB1
+
+ BB1:
+  %use = add i32 %LocalInvocationId.i0, 1
+  store i32 %use, i32 addrspace(3)* @lds, align 16
+  br label %BB3
+
+ BB2:
+  br label %BB3
+
+ BB3:
+  ret void
+}
+
+; Test that %LocalInvocationId.i0 does not get replaced with %scalar in BB1.
+; CHECK: @icmp_ne_true
+; CHECK: %use = add i32 %LocalInvocationId.i01, 1
+; CHECK: store i32 %use, i32 addrspace(3)* @lds, align 16
+
+; Function Attrs: nounwind
+define dllexport amdgpu_cs void @icmp_ne_true(i32 inreg %0, i32 inreg %1, <3 x i32> inreg %2, i32 inreg %3, <3 x i32> %LocalInvocationId) local_unnamed_addr #0 !lgc.shaderstage !4 {
+.entry:
+  %LocalInvocationId.i0 = extractelement <3 x i32> %LocalInvocationId, i32 0
+  %scalar = call i32 @llvm.amdgcn.readlane(i32 %LocalInvocationId.i0, i32 0)
+  %cmp = icmp ne i32 %LocalInvocationId.i0, %scalar
+  br i1 %cmp, label %BB1, label %BB2
+
+ BB1:
+  %use = add i32 %LocalInvocationId.i0, 1
+  store i32 %use, i32 addrspace(3)* @lds, align 16
+  br label %BB3
+
+ BB2:
+  br label %BB3
+
+ BB3:
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare <3 x i32> @lgc.shader.input.LocalInvocationId(i32) #1
+
+; Function Attrs: convergent nounwind readnone willreturn
+declare i32 @llvm.amdgcn.readlane(i32, i32) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+attributes #2 = { convergent nounwind readnone willreturn }
+
+
+!llpc.compute.mode = !{!0}
+!lgc.unlinked = !{!1}
+!lgc.options = !{!2}
+!lgc.options.CS = !{!3}
+
+!0 = !{i32 12, i32 16, i32 1}
+!1 = !{i32 1}
+!2 = !{i32 -344463852, i32 959545418, i32 1162175331, i32 709288033, i32 1, i32 0, i32 1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!3 = !{i32 -418681142, i32 -675614356, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!4 = !{i32 5}


### PR DESCRIPTION
Use the uniform (non-divergent) node instead of a divergent one
if they are equal.

Detect a case where a branch condition tests two nodes for equality
where one of them is divergent and the other uniform. In the true
block replace the divergent use with the uniform one as it helps
instruction selection decide what to put in an SGPR.