### PR TITLE
Use two local variables to express NGG enablement

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -288,10 +288,12 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
     // Only set NGG options for a GFX10+ graphics pipeline.
     auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo());
     const auto &nggState = pipelineInfo->nggState;
-    if (!nggState.enableNgg)
+    bool enableNgg = nggState.enableNgg;
+    bool enableGsUse = nggState.enableGsUse;
+    if (!enableNgg)
       options.nggFlags |= NggFlagDisable;
     else {
-      options.nggFlags = (nggState.enableGsUse ? NggFlagEnableGsUse : 0) |
+      options.nggFlags = (enableGsUse ? NggFlagEnableGsUse : 0) |
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
                          (nggState.forceNonPassthrough ? NggFlagForceCullingMode : 0) |
 #else


### PR DESCRIPTION
We can update them for future HW if more NGG enablement controls
are involved.

Change-Id: I84ce78fd56e05d75647a322b02dbd53980fe38bb