### PR TITLE
Complete the tes shader output variable PrimitiveId

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -225,9 +225,8 @@ void PatchInOutImportExport::processShader() {
     if (builtInUsage.vs.primitiveId)
       m_primitiveId = getFunctionArgument(m_entryPoint, entryArgIdxs.vs.primitiveId);
   } else if (m_shaderStage == ShaderStageTessEval) {
-    if (builtInUsage.tes.primitiveId) {
-      // TODO: Support tessellation shader.
-      m_primitiveId = UndefValue::get(Type::getInt32Ty(*m_context));
+    if (builtInUsage.tes.primitiveId) {      
+      m_primitiveId = getFunctionArgument(m_entryPoint, entryArgIdxs.tes.patchId);
     }
   }
 


### PR DESCRIPTION
PrimitiveId is treated as an undefined value in tes shader,if we use gl_primitiveId in frag shader, we will get an incorrect value.
Whether primitiveId is used is set in the previous code, just need to get it from entryPoint.