### PR TITLE
Use a local variable to control NGG enablement on patch passes

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -175,8 +175,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Fully prepare the pipeline ABI (must be after optimizations)
   passMgr.add(createPatchPreparePipelineAbi(/* onlySetCallingConvs = */ false));
 
-  if (pipelineState->isGraphics() && pipelineState->getTargetInfo().getGfxIpVersion().major >= 10 &&
-      (pipelineState->getOptions().nggFlags & NggFlagDisable) == 0) {
+  const bool canUseNgg = pipelineState->isGraphics() && pipelineState->getTargetInfo().getGfxIpVersion().major == 10 &&
+                         (pipelineState->getOptions().nggFlags & NggFlagDisable) == 0;
+  if (canUseNgg) {
     // Stop timer for patching passes and restart timer for optimization passes.
     if (patchTimer) {
       passMgr.add(LgcContext::createStartStopTimer(patchTimer, false));

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -288,12 +288,10 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
     // Only set NGG options for a GFX10+ graphics pipeline.
     auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo());
     const auto &nggState = pipelineInfo->nggState;
-    bool enableNgg = nggState.enableNgg;
-    bool enableGsUse = nggState.enableGsUse;
-    if (!enableNgg)
+    if (!nggState.enableNgg)
       options.nggFlags |= NggFlagDisable;
     else {
-      options.nggFlags = (enableGsUse ? NggFlagEnableGsUse : 0) |
+      options.nggFlags = (nggState.enableGsUse ? NggFlagEnableGsUse : 0) |
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 44
                          (nggState.forceNonPassthrough ? NggFlagForceCullingMode : 0) |
 #else


### PR DESCRIPTION
This is also a revert change of the PR#1111 at the same time.

Change-Id: I321dbe645bd2aa24b323efa6b1b441d409900766