### PR TITLE
Refactor the setting of tbuffer format

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -113,6 +113,19 @@ bool PatchInOutImportExport::runOnModule(Module &module) {
   if (m_hasTs || (m_hasGs && (m_pipelineState->isGsOnChip() || m_gfxIp.major >= 9)))
     m_lds = Patch::getLdsVariable(m_pipelineState, m_module);
 
+  // Set buffer formats based on specific GFX
+  static const std::array<std::array<unsigned, 4>, 2> BufferFormats = {
+      BUF_NUM_FORMAT_FLOAT << 4 | BUF_DATA_FORMAT_32,
+      BUF_NUM_FORMAT_FLOAT << 4 | BUF_DATA_FORMAT_32_32,
+      BUF_NUM_FORMAT_FLOAT << 4 | BUF_DATA_FORMAT_32_32_32,
+      BUF_NUM_FORMAT_FLOAT << 4 | BUF_DATA_FORMAT_32_32_32_32,
+      BUF_FORMAT_32_FLOAT,
+      BUF_FORMAT_32_32_FLOAT,
+      BUF_FORMAT_32_32_32_FLOAT,
+      BUF_FORMAT_32_32_32_32_FLOAT};
+
+  m_buffFormats = m_gfxIp.major <= 9 ? &BufferFormats[0] : &BufferFormats[1];
+
   // Process each shader in turn, in reverse order (because for example VS uses inOutUsage.tcs.calcFactor
   // set by TCS).
   auto pipelineShaders = &getAnalysis<PipelineShaders>();
@@ -3499,21 +3512,6 @@ void PatchInOutImportExport::createStreamOutBufferStoreFunction(Value *storeValu
 unsigned PatchInOutImportExport::combineBufferStore(const std::vector<Value *> &storeValues, unsigned startIdx,
                                                     unsigned valueOffset, Value *bufDesc, Value *storeOffset,
                                                     Value *bufBase, CoherentFlag coherent, Instruction *insertPos) {
-
-  std::vector<unsigned> formats;
-
-  if (m_gfxIp.major <= 9) {
-    formats = {
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32_32_32)),
-    };
-  } else if (m_gfxIp.major == 10) {
-    formats = {BUF_FORMAT_32_FLOAT, BUF_FORMAT_32_32_FLOAT, BUF_FORMAT_32_32_32_FLOAT, BUF_FORMAT_32_32_32_32_FLOAT};
-  } else
-    llvm_unreachable("Not implemented!");
-
   Type *storeTys[4] = {
       Type::getInt32Ty(*m_context),
       FixedVectorType::get(Type::getInt32Ty(*m_context), 2),
@@ -3547,12 +3545,12 @@ unsigned PatchInOutImportExport::combineBufferStore(const std::vector<Value *> &
       auto writeOffset = BinaryOperator::CreateAdd(
           storeOffset, ConstantInt::get(Type::getInt32Ty(*m_context), valueOffset * 4), "", insertPos);
       Value *args[] = {
-          storeValue,                                                             // vdata
-          bufDesc,                                                                // rsrc
-          writeOffset,                                                            // voffset
-          bufBase,                                                                // soffset
-          ConstantInt::get(Type::getInt32Ty(*m_context), formats[compCount - 1]), // format
-          ConstantInt::get(Type::getInt32Ty(*m_context), coherent.u32All)         // glc
+          storeValue,                                                                      // vdata
+          bufDesc,                                                                         // rsrc
+          writeOffset,                                                                     // voffset
+          bufBase,                                                                         // soffset
+          ConstantInt::get(Type::getInt32Ty(*m_context), (*m_buffFormats)[compCount - 1]), // format
+          ConstantInt::get(Type::getInt32Ty(*m_context), coherent.u32All)                  // glc
       };
       emitCall(funcName, Type::getVoidTy(*m_context), args, {}, insertPos);
 
@@ -3576,20 +3574,6 @@ unsigned PatchInOutImportExport::combineBufferStore(const std::vector<Value *> &
 unsigned PatchInOutImportExport::combineBufferLoad(std::vector<Value *> &loadValues, unsigned startIdx, Value *bufDesc,
                                                    Value *loadOffset, Value *bufBase, CoherentFlag coherent,
                                                    Instruction *insertPos) {
-  std::vector<unsigned> formats;
-
-  if (m_gfxIp.major <= 9) {
-    formats = {
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32_32_32)),
-    };
-  } else if (m_gfxIp.major == 10) {
-    formats = {BUF_FORMAT_32_FLOAT, BUF_FORMAT_32_32_FLOAT, BUF_FORMAT_32_32_32_FLOAT, BUF_FORMAT_32_32_32_32_FLOAT};
-  } else
-    llvm_unreachable("Not implemented!");
-
   Type *loadTyps[4] = {
       Type::getInt32Ty(*m_context),
       FixedVectorType::get(Type::getInt32Ty(*m_context), 2),
@@ -3614,11 +3598,11 @@ unsigned PatchInOutImportExport::combineBufferLoad(std::vector<Value *> &loadVal
       auto writeOffset = BinaryOperator::CreateAdd(
           loadOffset, ConstantInt::get(Type::getInt32Ty(*m_context), startIdx * 4), "", insertPos);
       Value *args[] = {
-          bufDesc,                                                                // rsrc
-          writeOffset,                                                            // voffset
-          bufBase,                                                                // soffset
-          ConstantInt::get(Type::getInt32Ty(*m_context), formats[compCount - 1]), // format
-          ConstantInt::get(Type::getInt32Ty(*m_context), coherent.u32All)         // glc
+          bufDesc,                                                                         // rsrc
+          writeOffset,                                                                     // voffset
+          bufBase,                                                                         // soffset
+          ConstantInt::get(Type::getInt32Ty(*m_context), (*m_buffFormats)[compCount - 1]), // format
+          ConstantInt::get(Type::getInt32Ty(*m_context), coherent.u32All)                  // glc
       };
       loadValue = emitCall(funcName, loadTyps[compCount - 1], args, {}, insertPos);
       assert(loadValue);
@@ -3999,7 +3983,7 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
             ConstantInt::get(Type::getInt32Ty(*m_context), coherent.u32All) // glc, slc, swz
         };
         emitCall("llvm.amdgcn.raw.tbuffer.store.i32", Type::getVoidTy(*m_context), args, {}, insertPos);
-      } else if (m_gfxIp.major == 10) {
+      } else {
         CoherentFlag coherent = {};
         coherent.bits.glc = true;
         coherent.bits.slc = true;
@@ -4013,8 +3997,7 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
             ConstantInt::get(Type::getInt32Ty(*m_context), coherent.u32All)      // glc, slc, swz
         };
         emitCall("llvm.amdgcn.raw.tbuffer.store.i32", Type::getVoidTy(*m_context), args, {}, insertPos);
-      } else
-        llvm_unreachable("Not implemented!");
+      }
     }
   }
 }
@@ -4545,30 +4528,16 @@ void PatchInOutImportExport::createTessBufferStoreFunction(StringRef funcName, u
   auto branch = BranchInst::Create(endBlock, tfStoreBlock);
 
   // Create llvm.amdgcn.raw.tbuffer.store.
-  SmallVector<unsigned> formats;
-  if (m_gfxIp.major <= 9) {
-    formats = {
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32_32)),
-        ((BUF_NUM_FORMAT_FLOAT << 4) | (BUF_DATA_FORMAT_32_32_32_32)),
-    };
-  } else if (m_gfxIp.major == 10) {
-    formats = {BUF_FORMAT_32_FLOAT, BUF_FORMAT_32_32_FLOAT, BUF_FORMAT_32_32_32_FLOAT, BUF_FORMAT_32_32_32_32_FLOAT};
-  } else {
-    llvm_unreachable("Not implemented!");
-  }
-
   CoherentFlag coherent = {};
   coherent.bits.glc = true;
 
   Value *args[] = {
-      tfValue,                                  // vdata
-      tfBufferDesc,                             // rsrc
-      tfBufferOffset,                           // voffset
-      tfBufferBase,                             // soffset
-      builder.getInt32(formats[compCount - 1]), // format
-      builder.getInt32(coherent.u32All)         // glc
+      tfValue,                                           // vdata
+      tfBufferDesc,                                      // rsrc
+      tfBufferOffset,                                    // voffset
+      tfBufferBase,                                      // soffset
+      builder.getInt32((*m_buffFormats)[compCount - 1]), // format
+      builder.getInt32(coherent.u32All)                  // glc
   };
 
   builder.SetInsertPoint(branch);

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -238,6 +238,7 @@ private:
   PipelineState *m_pipelineState = nullptr; // Pipeline state from PipelineStateWrapper pass
 
   std::set<unsigned> m_expLocs; // The locations that already have an export instruction for the vertex shader.
+  const std::array<unsigned, 4> *m_buffFormats; // The format of MTBUF instructions for specified GFX
 };
 
 } // namespace lgc


### PR DESCRIPTION
Remove the duplicate code of setting tbuffer format for creating
"llvm.amdgcn.raw.tbuffer.*" each time. Use an ArrayRef `m_buffFormat`
referring to one of two static const arrays (one for <= gfx9, one for >=
gfx10) `BufferFormats[2][4]`.