### PR TITLE
Update tests

### DIFF
--- a/llpc/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPowVec4Const_lit.frag
@@ -23,10 +23,10 @@ void main()
 ; SHADERTEST: [[mul2:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
 ; SHADERTEST: [[mul3:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
 ; SHADERTEST-NOT: = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
-; SHADERTEST: [[val1:%[.0-9a-zA-Z]*]] = insertelement <4 x float> <float 1.200000e+01, float undef, float undef, float undef>, float [[mul1]], i32 1
+; SHADERTEST: [[val1:%[.0-9a-zA-Z]*]] = insertelement <4 x float> <float 1.200000e+01, float {{undef|poison}}, float {{undef|poison}}, float {{undef|poison}}>, float [[mul1]], i32 1
 ; SHADERTEST: [[val2:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i32 2
 ; SHADERTEST: [[val3:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i32 3
-; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } undef, <4 x float> [[val3]], 0
+; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } {{undef|poison}}, <4 x float> [[val3]], 0
 ; SHADERTEST: ret { <4 x float> } [[ret]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestRadiansVec4Const_lit.frag
@@ -16,16 +16,16 @@ void main()
 ; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float> %{{.*}}, <float 0x3F91DF46A0000000, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000>
 ; SHADERTEST: store float 0x3F9ACEEA00000000, float addrspace(5)* %{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float> %{{.*}}, <float undef, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float> %{{.*}}, <float {{undef|poison}}, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000>
 ; SHADERTEST: = insertelement <4 x float> %{{.*}}, float 0x3F9ACEEA00000000, i32 0
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: [[mul1:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: [[mul2:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: [[mul3:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: [[val1:%.[0-9a-zA-Z]*]] = insertelement <4 x float> <float 0x3F9ACEEA00000000, float undef, float undef, float undef>, float [[mul1]], i32 1
+; SHADERTEST: [[val1:%.[0-9a-zA-Z]*]] = insertelement <4 x float> <float 0x3F9ACEEA00000000, float {{undef|poison}}, float {{undef|poison}}, float {{undef|poison}}>, float [[mul1]], i32 1
 ; SHADERTEST: [[val2:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i32 2
 ; SHADERTEST: [[val3:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i32 3
-; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } undef, <4 x float> [[val3]], 0
+; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } {{undef|poison}}, <4 x float> [[val3]], 0
 ; SHADERTEST: ret { <4 x float> } [[ret]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpSMod_TestInt_lit.frag
+++ b/llpc/test/shaderdb/OpSMod_TestInt_lit.frag
@@ -22,7 +22,7 @@ void main()
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: srem i32
-; SHADERTEST: insertelement <4 x float> <float undef, float 2.000000e+00, float 0.000000e+00, float 1.000000e+00>, float %{{.*}}, i32 0
+; SHADERTEST: insertelement <4 x float> <float {{undef|poison}}, float 2.000000e+00, float 0.000000e+00, float 1.000000e+00>, float %{{.*}}, i32 0
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpVectorShuffle_TestVec_lit.frag
+++ b/llpc/test/shaderdb/OpVectorShuffle_TestVec_lit.frag
@@ -21,12 +21,12 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{.*}} = extractelement <2 x float> %{{.*}}, i32 0
-; SHADERTEST: %{{.*}} = insertelement <4 x float> undef, float %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = insertelement <4 x float> {{undef|poison}}, float %{{.*}}, i32 0
 ; SHADERTEST: %{{.*}} = extractelement <2 x float> %{{.*}}, i32 1
 ; SHADERTEST: %{{.*}} = insertelement <4 x float> %{{.*}}, float %{{.*}}, i32 3
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: [[VEC1:%.*]] = shufflevector <3 x float> %{{.*}}, <3 x float> undef, <4 x i32> <i32 undef, i32 1, i32 2, i32 undef>
-; SHADERTEST: [[VEC2:%.*]] = shufflevector <4 x float> <float undef, float 5.000000e-01, float 5.000000e-01, float undef>, <4 x float> [[VEC1]], <4 x i32> <i32 6, i32 1, i32 2, i32 5>
+; SHADERTEST: [[VEC1:%.*]] = shufflevector <3 x float> %{{.*}}, <3 x float> {{undef|poison}}, <4 x i32> <i32 {{undef|poison}}, i32 1, i32 2, i32 {{undef|poison}}>
+; SHADERTEST: [[VEC2:%.*]] = shufflevector <4 x float> <float {{undef|poison}}, float 5.000000e-01, float 5.000000e-01, float {{undef|poison}}>, <4 x float> [[VEC1]], <4 x i32> <i32 6, i32 1, i32 2, i32 5>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpVectorTimesScalar_TestDoublexDvec4_lit.frag
+++ b/llpc/test/shaderdb/OpVectorTimesScalar_TestDoublexDvec4_lit.frag
@@ -17,8 +17,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = insertelement <4 x double> undef, double %{{.*}}, i32 0
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <4 x i32> zeroinitializer
+; SHADERTEST: %{{.*}} = insertelement <4 x double> {{undef|poison}}, double %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> {{undef|poison}}, <4 x i32> zeroinitializer
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract <4 x double> %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpVectorTimesScalar_TestDvec4xDouble_lit.frag
+++ b/llpc/test/shaderdb/OpVectorTimesScalar_TestDvec4xDouble_lit.frag
@@ -21,8 +21,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = insertelement <4 x double> undef, double %{{.*}}, i32 0
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <4 x i32> zeroinitializer
+; SHADERTEST: %{{.*}} = insertelement <4 x double> {{undef|poison}}, double %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> {{undef|poison}}, <4 x i32> zeroinitializer
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract <4 x double> %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -10,7 +10,7 @@
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to <4 x i32> addrspace(4)*
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 undef, i32 undef, i32 -1, i32 151468>, i32 %{{.*}}, {{i32|i64}} 0
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 {{undef|poison}}, i32 {{undef|poison}}, i32 -1, i32 151468>, i32 %{{.*}}, {{i32|i64}} 0
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, {{i32|i64}} 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)
 ; SHADERTEST: bitcast <4 x i32> %{{.*}} to <2 x double>

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -16,7 +16,7 @@
 ; SHADERTEST:  [[f0:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 0, i32 0, i32 immarg 116, i32 immarg 0)
 ; SHADERTEST:  [[f1:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 4, i32 0, i32 immarg 116, i32 immarg 0)
 ; SHADERTEST:  [[f2:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 8, i32 0, i32 immarg 116, i32 immarg 0)
-; SHADERTEST:  [[vectmp0:%.*]] = insertelement <4 x i32> <i32 undef, i32 undef, i32 undef, i32 1065353216>, i32 [[f0]], i32 0
+; SHADERTEST:  [[vectmp0:%.*]] = insertelement <4 x i32> <i32 {{undef|poison}}, i32 {{undef|poison}}, i32 {{undef|poison}}, i32 1065353216>, i32 [[f0]], i32 0
 ; SHADERTEST:  [[vectmp1:%.*]] = insertelement <4 x i32> [[vectmp0]], i32 [[f1]], i32 1
 ; SHADERTEST:  [[vecf:%.*]] = insertelement <4 x i32> [[vectmp1]], i32 [[f2]], i32 2
 ; Check that the attribute is cast to float so that it will be placed in a VGPR


### PR DESCRIPTION
The upcoming upstream LLVM merge rolls out a series of
changes to replace undef with poison as a placeholder
in insertelement or shufflevector (e.g. D93586, D93989).

Update tests by allowing both undef and poison.