### PR TITLE
Set wave64 as default for compute shaders on GFX10.3

### DIFF
--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1075,6 +1075,11 @@ unsigned PipelineState::getShaderWaveSize(ShaderStage stage) {
       waveSize = 64;
     }
 
+    // Experimental data from performance tuning show that wave64 is more efficient than wave32 in most cases for CS
+    // on GFX10.3. Hence, set the wave size to wave64 by default.
+    if (getTargetInfo().getGfxIpVersion().minor >= 3 && stage == ShaderStageCompute)
+      waveSize = 64;
+
     unsigned waveSizeOption = getShaderOptions(stage).waveSize;
     if (waveSizeOption != 0)
       waveSize = waveSizeOption;


### PR DESCRIPTION
In general, compute shaders with wave64 are better than wave32 on
GFX10.3.