### PR TITLE
Add cache hash note to shader ELF

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -166,6 +166,7 @@ target_sources(LLVMlgc PRIVATE
 target_sources(LLVMlgc PRIVATE
     util/AddressExtender.cpp
     util/Debug.cpp
+    util/ElfNoteEntryInsertionUtil.cpp
     util/GfxRegHandlerBase.cpp
     util/GfxRegHandler.cpp
     util/Internal.cpp

--- a/lgc/interface/lgc/ElfNoteEntryInsertionUtil.h
+++ b/lgc/interface/lgc/ElfNoteEntryInsertionUtil.h
@@ -1,0 +1,75 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  ElfNoteEntryInsertionUtil.h
+ * @brief LLPC header file: declaration of lgc::addNotesToElf interface
+ *
+ * @details The function addNotesToElf adds given note entries to the given ELF.
+ ***********************************************************************************************************************
+ */
+
+#pragma once
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+
+namespace lgc {
+
+// Note entry that will be added to the note section.
+struct NoteEntry {
+  llvm::StringRef name;
+  llvm::ArrayRef<uint8_t> desc;
+  unsigned type;
+};
+
+// =====================================================================================================================
+// Adds the given note entries to the given ELF if the given ELF has a note section.
+// Otherwise, it does nothing.
+//
+// ELF layouts before/after adding new "note" entries to the existing note section:
+//
+// |-------------|             |-------------|
+// | ELF header  |             | ELF header  |
+// |-------------|             |-------------|
+// | Sections    |             | Sections    |
+// | ...         |             | ...         |
+// |-------------|             |-------------|
+// | Note section|     ==>     | Note section|
+// | ...         |             |             |
+// |-------------|<--(Will be  | + New note  |
+// | ...         |    Shifted) |   entries   |
+// |-------------| |        |  | ...         |
+// | Section     | |        \->|-------------|
+// | headers     | V           | ...         |
+// | ...         |             |-------------|
+//                             | Section     |
+//                             | headers     |
+//                             | ...         |
+//
+void addNotesToElf(llvm::SmallVectorImpl<char> &elf, llvm::ArrayRef<NoteEntry> notes, const char *noteSectionName);
+
+} // namespace lgc

--- a/lgc/util/ElfNoteEntryInsertionUtil.cpp
+++ b/lgc/util/ElfNoteEntryInsertionUtil.cpp
@@ -1,0 +1,275 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+#include "lgc/ElfNoteEntryInsertionUtil.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/BinaryByteStream.h"
+#include "llvm/Support/BinaryStreamReader.h"
+#include "llvm/Support/BinaryStreamWriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace lgc;
+
+// The implementation of ELF rewriting is based on "Linux Programmer's Manual ELF(5)".
+// In particular, see "Notes (Nhdr)" for the document of the note section.
+
+namespace {
+
+// It is similar to struct NoteHeader defined in llpc/util/vkgcElfReader.h, but
+// it allows us to use Elf_Nhdr_Impl<object::ELF64LE>::Align and it does not
+// have the size limitation of note name.
+using NoteHeader = object::Elf_Nhdr_Impl<object::ELF64LE>;
+
+// An array of zeros. We use it for the note alignment.
+constexpr char ZerosForNoteAlign[NoteHeader::Align] = {'\0'};
+
+// =====================================================================================================================
+// Contents of a section to be shifted and its new offset.
+struct SectionShiftInfo {
+  SmallString<64> section;
+  ELF::Elf64_Off newOffset;
+};
+
+// =====================================================================================================================
+// Generates a StringRef from the given SmallVector.
+//
+// @param input : The SmallVector to be converted to StringRef.
+// @returns     : The generated StringRef.
+template <typename T> StringRef stringRefFromSmallVector(const SmallVectorImpl<T> &input) {
+  return StringRef(reinterpret_cast<const char *>(input.data()), sizeof(T) * input.size());
+}
+
+// =====================================================================================================================
+// Add an entry to the note section.
+//
+// Reference: Linux Programmer's Manual ELF(5) "Notes (Nhdr)".
+//
+// @param noteEntry             : The note entry to be added to the note section.
+// @param [out] noteEntryWriter : The .note section where the note entry will be added to.
+void addNoteEntry(const NoteEntry &noteEntry, BinaryStreamWriter &noteEntryWriter) {
+  NoteHeader noteHeader = {};
+  noteHeader.n_namesz = noteEntry.name.size() + 1;
+  noteHeader.n_descsz = noteEntry.desc.size();
+  noteHeader.n_type = static_cast<ELF::Elf64_Word>(noteEntry.type);
+  auto error = noteEntryWriter.writeObject(noteHeader);
+  (void)error;
+  assert(!error);
+
+  // Write the note name terminated by zero and zeros for the alignment.
+  error = noteEntryWriter.writeCString(noteEntry.name);
+  assert(!error);
+  error = noteEntryWriter.writeFixedString(StringRef(
+      ZerosForNoteAlign, offsetToAlignment(noteEntryWriter.getLength(), Align::Constant<NoteHeader::Align>())));
+  assert(!error);
+
+  // Write the note description and zeros for the alignment.
+  error = noteEntryWriter.writeBytes(noteEntry.desc);
+  assert(!error);
+  error = noteEntryWriter.writeFixedString(StringRef(
+      ZerosForNoteAlign, offsetToAlignment(noteEntryWriter.getLength(), Align::Constant<NoteHeader::Align>())));
+  assert(!error);
+}
+
+// =====================================================================================================================
+// Writes note entries to a byte-stream.
+//
+// @param notes                 : The array of note entries to be added to the note section.
+// @param newNoteEntryOffset    : The offset in ELF where the note entries will be added.
+// @param [out] noteEntryStream : The byte-stream to be filled with the note entries.
+void writeNoteEntriesToByteStream(ArrayRef<NoteEntry> notes, const ELF::Elf64_Off newNoteEntryOffset,
+                                  AppendingBinaryByteStream &noteEntryStream) {
+  BinaryStreamWriter noteEntryWriter(noteEntryStream);
+  auto error = noteEntryWriter.writeFixedString(
+      StringRef(ZerosForNoteAlign, offsetToAlignment(newNoteEntryOffset, Align::Constant<NoteHeader::Align>())));
+  (void)error;
+  assert(!error);
+
+  // Write the note entries.
+  for (const auto &note : notes)
+    addNoteEntry(note, noteEntryWriter);
+}
+
+// =====================================================================================================================
+// Updates the offsets of sections to their new offsets to be shifted. After updating offsets
+// it returns the contents of sections and their new offsets.
+//
+// @param elf                       : The input ELF.
+// @param shiftStartingOffset       : The first offset of ELF contents that will be shifted.
+//                                  All sections after this offset will be shifted.
+// @param lengthToBeShifted         : The length how much sections after shiftStartingOffset will be shift.
+// @param sectionHeaders            : The array of section headers.
+// @param [out] sectionAndNewOffset : The array of the contents of sections to be shifted and their new
+//                                  offset sorted by the new offset in the increasing order.
+void updateSectionOffsetsForShift(const SmallVectorImpl<char> &elf, const ELF::Elf64_Off shiftStartingOffset,
+                                  ELF::Elf64_Off lengthToBeShifted, MutableArrayRef<ELF::Elf64_Shdr> sectionHeaders,
+                                  SmallVectorImpl<SectionShiftInfo> &sectionAndNewOffset) {
+  // If a section is located after shiftStartingOffset, it must be shifted.
+  for (auto &sectionHeader : sectionHeaders) {
+    if (sectionHeader.sh_offset < shiftStartingOffset)
+      continue;
+    const auto newOffset = alignTo(sectionHeader.sh_offset + lengthToBeShifted, Align(sectionHeader.sh_addralign));
+    sectionAndNewOffset.push_back(
+        {SmallString<64>(StringRef(elf.data() + sectionHeader.sh_offset, sectionHeader.sh_size)), newOffset});
+    lengthToBeShifted = newOffset - sectionHeader.sh_offset;
+
+    // Update the offset of section pointed by the section header to its new offset.
+    sectionHeader.sh_offset = newOffset;
+  }
+
+  // Sort sectionAndNewOffset by the new offset of each section in the increasing order.
+  sort(sectionAndNewOffset,
+       [](const SectionShiftInfo &i0, const SectionShiftInfo &i1) { return i0.newOffset < i1.newOffset; });
+}
+
+// =====================================================================================================================
+// Inserts the new contents to the given ELF.
+//
+// @param [in/out] elf        : The ELF to insert the new contents.
+// @param insertionOffset     : The offset of the new contents to be inserted.
+// @param elfContentStream    : The ELF contents to be inserted.
+// @param sectionAndNewOffset : The sections to be shifted and their new offsets.
+void insertContentsToELF(SmallVectorImpl<char> &elf, const ELF::Elf64_Off insertionOffset,
+                         AppendingBinaryByteStream &elfContentStream,
+                         const SmallVectorImpl<SectionShiftInfo> &sectionAndNewOffset) {
+  // Strip sections after the insertion offset of the new contents.
+  elf.resize(insertionOffset);
+
+  // Write the new contents.
+  raw_svector_ostream elfStream(elf);
+  ArrayRef<uint8_t> contents;
+  auto error = elfContentStream.readBytes(0, elfContentStream.getLength(), contents);
+  (void)error;
+  assert(!error);
+  elfStream << toStringRef(contents);
+
+  // Write the sections after the insertion offset.
+  for (const auto &sectionAndNewOffsetInfo : sectionAndNewOffset) {
+    elfStream.write_zeros(sectionAndNewOffsetInfo.newOffset - elfStream.str().size());
+    elfStream << sectionAndNewOffsetInfo.section.str();
+  }
+}
+
+// =====================================================================================================================
+// Write the section header table to the given offset.
+//
+// @param [in/out] elf             : The ELF to write the section header table.
+// @param sectionHeaderTableOffset : The offset where it will write the section header table.
+// @param sectionHeaderTable       : The section header table to be written to the ELF.
+void writeSectionHeaderTable(SmallVectorImpl<char> &elf, const ELF::Elf64_Off sectionHeaderTableOffset,
+                             const SmallVectorImpl<ELF::Elf64_Shdr> &sectionHeaderTable) {
+  if (sectionHeaderTable.size() == 0)
+    return;
+
+  raw_svector_ostream elfStream(elf);
+  const unsigned minElfSizeForSectionHeaders =
+      sectionHeaderTableOffset + sizeof(ELF::Elf64_Shdr) * sectionHeaderTable.size();
+  if (minElfSizeForSectionHeaders > elf.size())
+    elfStream.write_zeros(minElfSizeForSectionHeaders - elf.size());
+  auto sectionHeaderTableInString = stringRefFromSmallVector(sectionHeaderTable);
+  elfStream.pwrite(sectionHeaderTableInString.data(), sectionHeaderTableInString.size(), sectionHeaderTableOffset);
+}
+
+} // anonymous namespace
+
+namespace lgc {
+
+// =====================================================================================================================
+// Adds the given note entries to the note section with the given section name in the given ELF.
+// If the note section with the given name does not exist, it uses any other note section.
+//
+// @param [in/out] elf    : ELF to be updated with the new note entries.
+// @param notes           : An array of note entries to be inserted to the existing note section.
+// @param noteSectionName : The name of note section to where note entries will be inserted.
+void addNotesToElf(SmallVectorImpl<char> &elf, ArrayRef<NoteEntry> notes, const char *noteSectionName) {
+  // Get ELF header that contains information for section header table offset
+  // and the number of section headers.
+  //
+  // Reference: http://www.skyfree.org/linux/references/ELF_Format.pdf
+  ELF::Elf64_Ehdr *ehdr = reinterpret_cast<ELF::Elf64_Ehdr *>(elf.data());
+
+  // Get the section headers and the existing note section whose name is noteSectionName.
+  MutableArrayRef<ELF::Elf64_Shdr> sectionHeaders(reinterpret_cast<ELF::Elf64_Shdr *>(elf.data() + ehdr->e_shoff),
+                                                  ehdr->e_shnum);
+  auto existingNoteSection =
+      find_if(sectionHeaders, [&elf, ehdr, &sectionHeaders, noteSectionName](const ELF::Elf64_Shdr &sectionHeader) {
+        if (sectionHeader.sh_type != ELF::SHT_NOTE)
+          return false;
+        const char *stringTableForSectionNames = elf.data() + sectionHeaders[ehdr->e_shstrndx].sh_offset;
+        return !strcmp(noteSectionName, &stringTableForSectionNames[sectionHeader.sh_name]);
+      });
+  // If a note section with noteSectionName does not exist, use any other note section.
+  if (existingNoteSection == sectionHeaders.end()) {
+    existingNoteSection = find_if(
+        sectionHeaders, [](const ELF::Elf64_Shdr &sectionHeader) { return sectionHeader.sh_type == ELF::SHT_NOTE; });
+  }
+
+  // We assume that the given ELF already contains a note section. Since AMD GPU
+  // accepts only ELFs with AMD related metadata, the assumption will be satisfied.
+  assert(existingNoteSection != sectionHeaders.end());
+
+  // Prepare the new note entries to be added to the existing note section.
+  const ELF::Elf64_Off newNoteEntryOffset = existingNoteSection->sh_offset + existingNoteSection->sh_size;
+  AppendingBinaryByteStream noteEntryStream(support::little);
+  writeNoteEntriesToByteStream(notes, newNoteEntryOffset, noteEntryStream);
+
+  // Get the last section located just before the section header table.
+  auto sectionBeforeSectionHeaderTable =
+      std::max_element(sectionHeaders.begin(), sectionHeaders.end(),
+                       [ehdr](const ELF::Elf64_Shdr &largest, const ELF::Elf64_Shdr &current) {
+                         if (current.sh_offset > ehdr->e_shoff)
+                           return false;
+                         return current.sh_offset > largest.sh_offset;
+                       });
+
+  // Update the offset information of sections after the offset of new note entries.
+  // The new offset should be the offset where each section will be shifted to.
+  SmallVector<SectionShiftInfo> sectionAndNewOffset;
+  updateSectionOffsetsForShift(elf, newNoteEntryOffset, noteEntryStream.getLength(), sectionHeaders,
+                               sectionAndNewOffset);
+
+  // Increase the size of the existing note section to include new note entries.
+  existingNoteSection->sh_size += noteEntryStream.getLength();
+
+  // Prepare the section header table shift if we have to shift it. Note that inserting note entries requires
+  // rewriting sections, which results in overwriting the section header table. Therefore, the contents
+  // pointed by the MutableArrayRef sectionHeaders will not be the section header table. In that case, we
+  // have to create a backup for the section header table.
+  SmallVector<ELF::Elf64_Shdr> sectionHeaderTableBackup;
+  if (ehdr->e_shoff > newNoteEntryOffset) {
+    ehdr->e_shoff = sectionBeforeSectionHeaderTable->sh_offset + sectionBeforeSectionHeaderTable->sh_size;
+    sectionHeaderTableBackup.append(sectionHeaders.begin(), sectionHeaders.end());
+  }
+
+  // Insert the stream of note entries to the ELF.
+  insertContentsToELF(elf, newNoteEntryOffset, noteEntryStream, sectionAndNewOffset);
+
+  // Write section header table.
+  writeSectionHeaderTable(elf, ehdr->e_shoff, sectionHeaderTableBackup);
+}
+
+} // namespace lgc

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -135,6 +135,7 @@ public:
 
   Result buildPipelineInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo, bool unlinked,
                                ElfPackage *pipelineElf);
+  MetroHash::Hash convertToHashUsedForCacheLookup(const MetroHash::Hash &hash);
 
   // Gets the count of compiler instance.
   static unsigned getInstanceCount() { return m_instanceCount; }

--- a/llpc/context/llpcContext.h
+++ b/llpc/context/llpcContext.h
@@ -121,7 +121,7 @@ public:
 
   GfxIpVersion getGfxIpVersion() const { return m_gfxIp; }
 
-  uint64_t getPiplineHashCode() const { return m_pipelineContext->getPiplineHashCode(); }
+  uint64_t getPipelineHashCode() const { return m_pipelineContext->getPipelineHashCode(); }
 
   uint64_t getCacheHashCode() const { return m_pipelineContext->getCacheHashCode(); }
 

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -256,7 +256,7 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, bool unlinked) const 
 // @param [in/out] pipeline : Middle-end pipeline object
 void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
   Options options = {};
-  options.hash[0] = getPiplineHashCode();
+  options.hash[0] = getPipelineHashCode();
   options.hash[1] = getCacheHashCode();
 
   options.includeDisassembly = (cl::EnablePipelineDump || EnableOuts() || getPipelineOptions()->includeDisassembly);

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -120,8 +120,16 @@ public:
   GfxIpVersion getGfxIpVersion() const { return m_gfxIp; }
 
   // Gets pipeline hash code
-  uint64_t getPiplineHashCode() const { return MetroHash::compact64(&m_pipelineHash); }
+  uint64_t getPipelineHashCode() const { return MetroHash::compact64(&m_pipelineHash); }
   uint64_t getCacheHashCode() const { return MetroHash::compact64(&m_cacheHash); }
+
+  // Gets pipeline hash code without compacting it to 64bits-hash. Note that
+  // this method returns the pipeline hash code without compacting it while
+  // `getPipelineHashCode()` returns the hash code compacted to 64bits.
+  MetroHash::Hash getPipelineHashCodeWithoutCompact() const { return m_pipelineHash; }
+
+  // Sets pipeline hash code
+  void setPipelineHashCode(const MetroHash::Hash &hash) { m_pipelineHash = hash; }
 
   virtual ShaderHash getShaderHashCode(ShaderStage stage) const;
 

--- a/llpc/test/CMakeLists.txt
+++ b/llpc/test/CMakeLists.txt
@@ -35,7 +35,7 @@ project(shadertest
 
 if(DEFINED XGL_LLVM_SRC_PATH)
   # This is a build where LLPC lit testing is integrated into AMDVLK cmake files.
-  set(AMDLLPC_TEST_DEPS amdllpc spvgen FileCheck llvm-objdump count not)
+  set(AMDLLPC_TEST_DEPS amdllpc spvgen FileCheck llvm-objdump llvm-readelf count not)
   set(LLVM_DIR ${XGL_LLVM_SRC_PATH})
 endif()
 

--- a/llpc/test/lit.cfg.py
+++ b/llpc/test/lit.cfg.py
@@ -71,6 +71,6 @@ config.substitutions.append(('%spvgendir%', config.spvgen_dir))
 
 tool_dirs = [config.llvm_tools_dir, config.amdllpc_dir]
 
-tools = ['amdllpc', 'llvm-objdump']
+tools = ['amdllpc', 'llvm-objdump', 'llvm-readelf']
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/llpc/test/shaderdb/relocatable_shaders/TriangleVs_CheckNoteSectionForCacheHash.spvasm
+++ b/llpc/test/shaderdb/relocatable_shaders/TriangleVs_CheckNoteSectionForCacheHash.spvasm
@@ -1,0 +1,84 @@
+; This test case checks that amdllpc with the `-add-hash-to-elf` option correctly
+; adds a note section to ELF, which contains the cache hash and the version of LLPC.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -gfxip=9 -unlinked -enable-relocatable-shader-elf -v -o %t.elf -add-hash-to-elf %s > %t.log && llvm-readelf -a %t.elf >> %t.log && cat %t.log | FileCheck --check-prefixes=CHECK %s
+
+; CHECK: LLPC version: 0x0000[[major_ver0:[a-z0-9][a-z0-9]]][[major_ver1:[a-z0-9][a-z0-9]]]0000[[minor_ver0:[a-z0-9][a-z0-9]]][[minor_ver1:[a-z0-9][a-z0-9]]]
+; CHECK: Hash for vertex stage cache lookup: [[hash0:[a-z0-9][a-z0-9]]][[hash1:[a-z0-9][a-z0-9]]][[hash2:[a-z0-9][a-z0-9]]][[hash3:[a-z0-9][a-z0-9]]]
+
+; CHECK: Displaying notes found in: .note
+; CHECK:   Owner                Data size 	Description
+; CHECK:   llpc_cache_hash      0x00000010	Unknown note type: (0x00000000)
+; CHECK:    description data: [[hash0]] [[hash1]] [[hash2]] [[hash3]]
+; CHECK:   llpc_version         0x00000008	Unknown note type: (0x00000000)
+; CHECK:    description data: [[major_ver1]] [[major_ver0]] 00 00 [[minor_ver1]] [[minor_ver0]] 00 00
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 7
+; Bound: 36
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %outColor %inColor %_ %inPos
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %outColor "outColor"
+               OpName %inColor "inColor"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpName %_ ""
+               OpName %PushConsts "PushConsts"
+               OpMemberName %PushConsts 0 "mvp"
+               OpName %pushConsts "pushConsts"
+               OpName %inPos "inPos"
+               OpDecorate %outColor Location 0
+               OpDecorate %inColor Location 1
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpDecorate %gl_PerVertex Block
+               OpMemberDecorate %PushConsts 0 ColMajor
+               OpMemberDecorate %PushConsts 0 Offset 0
+               OpMemberDecorate %PushConsts 0 MatrixStride 16
+               OpDecorate %PushConsts Block
+               OpDecorate %inPos Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+   %outColor = OpVariable %_ptr_Output_v3float Output
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+    %inColor = OpVariable %_ptr_Input_v3float Input
+    %v4float = OpTypeVector %float 4
+%gl_PerVertex = OpTypeStruct %v4float
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%mat4v4float = OpTypeMatrix %v4float 4
+ %PushConsts = OpTypeStruct %mat4v4float
+%_ptr_PushConstant_PushConsts = OpTypePointer PushConstant %PushConsts
+ %pushConsts = OpVariable %_ptr_PushConstant_PushConsts PushConstant
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+      %inPos = OpVariable %_ptr_Input_v3float Input
+    %float_1 = OpConstant %float 1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %12 = OpLoad %v3float %inColor
+               OpStore %outColor %12
+         %24 = OpAccessChain %_ptr_PushConstant_mat4v4float %pushConsts %int_0
+         %25 = OpLoad %mat4v4float %24
+         %27 = OpLoad %v3float %inPos
+         %29 = OpCompositeExtract %float %27 0
+         %30 = OpCompositeExtract %float %27 1
+         %31 = OpCompositeExtract %float %27 2
+         %32 = OpCompositeConstruct %v4float %29 %30 %31 %float_1
+         %33 = OpMatrixTimesVector %v4float %25 %32
+         %35 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %35 %33
+               OpReturn
+               OpFunctionEnd

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -307,8 +307,8 @@ void ElfWriter<Elf>::mergeMetaNote(Context *pContext, const ElfNote *pNote1, con
 
   // Update pipeline hash
   auto pipelineHash = destPipeline.getMap(true)[Util::Abi::PipelineMetadataKey::InternalPipelineHash].getArray(true);
-  pipelineHash[0] = destDocument.getNode(pContext->getPiplineHashCode());
-  pipelineHash[1] = destDocument.getNode(pContext->getPiplineHashCode());
+  pipelineHash[0] = destDocument.getNode(pContext->getPipelineHashCode());
+  pipelineHash[1] = destDocument.getNode(pContext->getPipelineHashCode());
 
   // List of fragment shader related registers.
   static const unsigned PsRegNumbers[] = {


### PR DESCRIPTION
Add cache hash note to shader ELF

When LLPC checks shader and pipeline caches, it uses the hash for
the identifier to check if required ELF files exist in the cache file.
Since the cache file keeps the mapping between the hashes and the ELF
files, we do not keep the hash value in the ELF file.

On the other hand, we need the cache creator proposed in
https://github.com/GPUOpen-Drivers/xgl/issues/64 to build the cache
for relocatable shader ELFs, but the cache creator does not have any
information about the hash. It is because the hash is generated by
LLPC (or amdllpc) and the cache creator is a separate program.

We want to let the LLPC compiler create a new note section for the
cache hash.  It can be used for the cache creator to create the cache
file with the correct mapping between the hash and ELF.

ELF layouts before/after adding new note entries for cache hash and
LLPC version to the existing note section:

```
|-------------|             |-------------|
| ELF header  |             | ELF header  |
|-------------|             |-------------|
| Sections    |             | Sections    |
| ...         |             | ...         |
|-------------|             |-------------|
| Note section|     ==>     | Note section|
| ...         |             |             |
|-------------|<--(Will be  | + New note  |
| ...         |    Shifted) |   entries   |
|-------------| |        |  | ...         |
| Section     | |        \->|-------------|
| headers     | V           | ...         |
| ...         |             |-------------|
                            | Section     |
                            | headers     |
                            | ...         |
```

New note entries:
 1. Note name with "llpc_cache_hash" and note description with the cache hash used for the cache lookup.
 2. Note name with "llpc_version" and note description with the LLPC version - both major and minor.
    The LLPC version information will help us to understand the hash generation algorithm. We have to
    use a correct hash algorithm for the cache lookup.

For example, if the hash is "4EDBED25 ADF15238 B8C92579 423DA423" and the LLPC version is 45.4
(the major version is 45=0x2D and the minor version is 4=0x04), two new note entries will be

```
 Unknown(0)                (name = llpc_cache_hash  size = 16)
       0:4EDBED25 ADF15238 B8C92579 423DA423
 Unknown(0)                (name = llpc_version  size = 8)
       0:0000002D 00000004
```