### PR TITLE
Support merging ELF binaries containing relocs

### DIFF
--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -89,8 +89,8 @@ bool PatchCheckShaderCache::runOnModule(Module &module) {
   Patch::init(&module);
 
   // NOTE: Global constants are either added to the end of the .text section, or in a separate .rodata section with
-  // relocs in the .text section to refer to them. We can't merge ELF binaries if relocs are used because llpcElfWriter
-  // doesn't know how to merge them.
+  // relocs in the .text section to refer to them. We can't merge ELF binaries if relocs are used in non-fragment shader
+  // stages.
   for (auto &global : module.globals()) {
     if (auto globalVar = dyn_cast<GlobalVariable>(&global)) {
       if (globalVar->isConstant()) {
@@ -102,7 +102,8 @@ bool PatchCheckShaderCache::runOnModule(Module &module) {
               vals.push_back(user);
               continue;
             }
-            return false;
+            if (getShaderStage(cast<Instruction>(user)->getFunction()) != ShaderStageFragment)
+              return false;
           }
         }
       }


### PR DESCRIPTION
ELF binary containing reloc section isn't implemented in
ElfWriter<Elf>::mergeElfBinary. Thus, partial pipeline caching is
disabled as a workaround for this case to avoid regressions in the cts
tests VK.robustness.robustness2.*. mergeELfBinary merges the ELF binary
of fragment shader into ELF bianry of non-fragment shader. This change
will includes:
- Enable partial pipeline caching for reclos
- If the ELF binary of non-fragment binary contain relco, remove reloc
section and symbol
- If the ELF binary of fragment binary contain reloc, add reloc section
and symbol, and update reloc offset and the corresponding data.

Fixes: VK.robustness.robustness2.*