### PR TITLE
Use llvm intrinsic smin, smax, umin and umax instead of icmp and select

### DIFF
--- a/llpc/test/shaderdb/ExtShaderInt64_TestBuiltInFunc_lit.frag
+++ b/llpc/test/shaderdb/ExtShaderInt64_TestBuiltInFunc_lit.frag
@@ -47,27 +47,19 @@ void main()
 ; SHADERTEST: = call <3 x i64> (...) @lgc.create.sabs.v3i64(<3 x i64>
 ; SHADERTEST: call <3 x i64> (...) @lgc.create.ssign.v3i64(<3 x i64>
 
-; SHADERTEST: %[[UMINCMP:.*]] = icmp ult <3 x i64> %[[UMIN1:.*]], %[[UMIN2:.*]]
-; SHADERTEST: = select <3 x i1> %[[UMINCMP]], <3 x i64> %[[UMIN1]], <3 x i64> %[[UMIN2]]
+; SHADERTEST: = call <3 x i64> @llvm.umin.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64> %{{[0-9]*}})
 
-; SHADERTEST: %[[SMINCMP:.*]] = icmp slt <3 x i64> %[[SMIN1:.*]], %[[SMIN2:.*]]
-; SHADERTEST: = select <3 x i1> %[[SMINCMP]], <3 x i64> %[[SMIN1]], <3 x i64> %[[SMIN2]]
+; SHADERTEST: = call <3 x i64> @llvm.smin.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64> %{{[0-9]*}})
 
-; SHADERTEST: %[[UMAXCMP:.*]] = icmp ult <3 x i64> %[[UMAX1:.*]], %[[UMAX2:.*]]
-; SHADERTEST: = select <3 x i1> %[[UMAXCMP]], <3 x i64> %[[UMAX2]], <3 x i64> %[[UMAX1]]
+; SHADERTEST: = call <3 x i64> @llvm.umax.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64> %{{[0-9]*}})
 
-; SHADERTEST: %[[SMAXCMP:.*]] = icmp slt <3 x i64> %[[SMAX1:.*]], %[[SMAX2:.*]]
-; SHADERTEST: = select <3 x i1> %[[SMAXCMP]], <3 x i64> %[[SMAX2]], <3 x i64> %[[SMAX1]]
+; SHADERTEST: = call <3 x i64> @llvm.smax.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64> %{{[0-9]*}})
 
-; SHADERTEST: %[[UCLAMPCMP1:.*]] = icmp ugt <3 x i64> %[[UCLAMP1:.*]], %[[UCLAMP2:.*]]
-; SHADERTEST: %[[UCLAMPMAX:.*]] = select <3 x i1> %[[UCLAMPCMP1]], <3 x i64> %[[UCLAMP1]], <3 x i64> %[[UCLAMP2]]
-; SHADERTEST: %[[UCLAMPCMP2:.*]] = icmp ult <3 x i64> %[[UCLAMP3:.*]], %[[UCLAMPCMP1:.*]]
-; SHADERTEST: = select <3 x i1> %[[UCLAMPCMP2]], <3 x i64> %[[UCLAMP3]], <3 x i64> %[[UCLAMPCMP1]]
+; SHADERTEST:  %[[UCLAMPMAX:.*]] = call <3 x i64> @llvm.umax.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64> %{{[0-9]*}})
+; SHADERTEST:  = call <3 x i64> @llvm.umin.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64>  %[[UCLAMPMAX:.*]])
 
-; SHADERTEST: %[[SCLAMPCMP1:.*]] = icmp sgt <3 x i64> %[[SCLAMP1:.*]], %[[SCLAMP2:.*]]
-; SHADERTEST: %[[SCLAMPMAX:.*]] = select <3 x i1> %[[SCLAMPCMP1]], <3 x i64> %[[SCLAMP1]], <3 x i64> %[[SCLAMP2]]
-; SHADERTEST: %[[SCLAMPCMP2:.*]] = icmp slt <3 x i64> %[[SCLAMP3:.*]], %[[SCLAMPCMP1:.*]]
-; SHADERTEST: = select <3 x i1> %[[SCLAMPCMP2]], <3 x i64> %[[SCLAMP3]], <3 x i64> %[[SCLAMPCMP1]]
+; SHADERTEST:  %[[SCLAMPMAX:.*]] = call <3 x i64> @llvm.smax.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64> %{{[0-9]*}})
+; SHADERTEST:  = call <3 x i64> @llvm.smin.v3i64(<3 x i64> %{{[0-9]*}}, <3 x i64>  %[[SCLAMPMAX:.*]])
 
 ; SHADERTEST: bitcast <3 x double> %{{[0-9]*}} to <3 x i64>
 ; SHADERTEST: bitcast <3 x i64> %{{[0-9]*}} to <3 x double>

--- a/llpc/test/shaderdb/OpExtInst_TestMaxBasic_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestMaxBasic_lit.frag
@@ -19,10 +19,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.maxnum.v4f32(<4 x float>
-; SHADERTEST: = icmp slt <4 x i32>
-; SHADERTEST: = select <4 x i1> %{{.*}}, <4 x i32>
-; SHADERTEST: = icmp ult <4 x i32>
-; SHADERTEST: = select <4 x i1> %{{.*}}, <4 x i32>
+; SHADERTEST: = call <4 x i32> @llvm.smax.v4i32(<4 x i32> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}})
+; SHADERTEST: = call <4 x i32> @llvm.umax.v4i32(<4 x i32> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestMaxInt_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestMaxInt_lit.frag
@@ -20,10 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = icmp slt i32
-; SHADERTEST: = select i1 %{{.*}}, i32
-; SHADERTEST: = icmp slt <3 x i32>
-; SHADERTEST: = select <3 x i1> %{{.*}}, <3 x i32>
+; SHADERTEST: = call i32 @llvm.smax.i32(i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: = call <3 x i32> @llvm.smax.v3i32(<3 x i32> %{{[0-9]*}}, <3 x i32> %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestMaxUint_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestMaxUint_lit.frag
@@ -20,10 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = icmp ult i32
-; SHADERTEST: = select i1 %{{.*}}, i32
-; SHADERTEST: = icmp ult <3 x i32>
-; SHADERTEST: = select <3 x i1> %{{.*}}, <3 x i32>
+; SHADERTEST: = call i32 @llvm.umax.i32(i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: = call <3 x i32> @llvm.umax.v3i32(<3 x i32> %{{[0-9]*}}, <3 x i32> %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestMinBasic_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestMinBasic_lit.frag
@@ -18,10 +18,8 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.minnum.v4f32(<4 x float>
-; SHADERTEST: = icmp slt <4 x i32>
-; SHADERTEST: = select <4 x i1> %{{.*}}, <4 x i32>
-; SHADERTEST: = icmp ult <4 x i32>
-; SHADERTEST: = select <4 x i1> %{{.*}}, <4 x i32>
+; SHADERTEST: = call <4 x i32> @llvm.smin.v4i32(<4 x i32> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}})
+; SHADERTEST: = call <4 x i32> @llvm.umin.v4i32(<4 x i32> %{{[0-9]*}}, <4 x i32> %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestMinInt_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestMinInt_lit.frag
@@ -20,10 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = icmp slt i32
-; SHADERTEST: = select i1 %{{.*}}, i32
-; SHADERTEST: = icmp slt <3 x i32>
-; SHADERTEST: = select <3 x i1> %{{.*}}, <3 x i32>
+; SHADERTEST: = call i32 @llvm.smin.i32(i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: = call i32 @llvm.smin.i32(i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/OpExtInst_TestMinUint_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestMinUint_lit.frag
@@ -20,10 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = icmp ult i32
-; SHADERTEST: = select i1 %{{.*}}, i32
-; SHADERTEST: = icmp ult <3 x i32>
-; SHADERTEST: = select <3 x i1> %{{.*}}, <3 x i32>
+; SHADERTEST: = call i32 @llvm.umin.i32(i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
+; SHADERTEST: = call i32 @llvm.umin.i32(i32 %{{[0-9]*}}, i32 %{{[0-9]*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7607,14 +7607,12 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450UMin: {
     // Unsigned integer minimum
-    Value *cmp = getBuilder()->CreateICmpULT(args[1], args[0]);
-    return getBuilder()->CreateSelect(cmp, args[1], args[0]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::umin, args[0], args[1]);
   }
 
   case GLSLstd450SMin: {
     // Signed integer minimum
-    Value *cmp = getBuilder()->CreateICmpSLT(args[1], args[0]);
-    return getBuilder()->CreateSelect(cmp, args[1], args[0]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::smin, args[0], args[1]);
   }
 
   case GLSLstd450FMax:
@@ -7629,14 +7627,12 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450UMax: {
     // Unsigned integer maximum
-    Value *cmp = getBuilder()->CreateICmpULT(args[1], args[0]);
-    return getBuilder()->CreateSelect(cmp, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::umax, args[0], args[1]);
   }
 
   case GLSLstd450SMax: {
     // Signed integer maximum
-    Value *cmp = getBuilder()->CreateICmpSLT(args[1], args[0]);
-    return getBuilder()->CreateSelect(cmp, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::smax, args[0], args[1]);
   }
 
   case GLSLstd450FClamp:
@@ -7654,18 +7650,14 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450UClamp: {
     // Unsigned integer clamp
-    Value *cmp = getBuilder()->CreateICmpUGT(args[1], args[0]);
-    Value *max1 = getBuilder()->CreateSelect(cmp, args[1], args[0]);
-    cmp = getBuilder()->CreateICmpULT(args[2], max1);
-    return getBuilder()->CreateSelect(cmp, args[2], max1);
+    Value *max1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::umax, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::umin, args[2], max1);
   }
 
   case GLSLstd450SClamp: {
     // Signed integer clamp
-    Value *cmp = getBuilder()->CreateICmpSGT(args[1], args[0]);
-    Value *max1 = getBuilder()->CreateSelect(cmp, args[1], args[0]);
-    cmp = getBuilder()->CreateICmpSLT(args[2], max1);
-    return getBuilder()->CreateSelect(cmp, args[2], max1);
+    Value *max1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::smax, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::smin, args[2], max1);
   }
 
   case GLSLstd450FMix: {
@@ -7929,58 +7921,42 @@ Value *SPIRVToLLVM::transTrinaryMinMaxExtInst(SPIRVExtInst *extInst, BasicBlock 
 
   case UMin3AMD: {
     // Minimum of three unsigned integer values.
-    Value *cond = getBuilder()->CreateICmpULT(args[0], args[1]);
-    Value *min1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpULT(min1, args[2]);
-    return getBuilder()->CreateSelect(cond, min1, args[2]);
+    Value *min1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::umin, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::umin, min1, args[2]);
   }
 
   case UMax3AMD: {
     // Maximum of three unsigned integer values.
-    Value *cond = getBuilder()->CreateICmpUGT(args[0], args[1]);
-    Value *max1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpUGT(max1, args[2]);
-    return getBuilder()->CreateSelect(cond, max1, args[2]);
+    Value *max1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::umax, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::umax, max1, args[2]);
   }
 
   case UMid3AMD: {
     // Middle of three unsigned integer values.
-    Value *cond = getBuilder()->CreateICmpULT(args[0], args[1]);
-    Value *min1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpUGT(args[0], args[1]);
-    Value *max1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpULT(max1, args[2]);
-    Value *min2 = getBuilder()->CreateSelect(cond, max1, args[2]);
-    cond = getBuilder()->CreateICmpUGT(min1, min2);
-    return getBuilder()->CreateSelect(cond, min1, min2);
+    Value *min1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::umin, args[0], args[1]);
+    Value *max1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::umax, args[0], args[1]);
+    Value *min2 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::umin, max1, args[2]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::umax, min1, min2);
   }
 
   case SMin3AMD: {
     // Minimum of three signed integer values.
-    Value *cond = getBuilder()->CreateICmpSLT(args[0], args[1]);
-    Value *min1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpSLT(min1, args[2]);
-    return getBuilder()->CreateSelect(cond, min1, args[2]);
+    Value *min1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::smin, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::smin, min1, args[2]);
   }
 
   case SMax3AMD: {
     // Maximum of three signed integer values.
-    Value *cond = getBuilder()->CreateICmpSGT(args[0], args[1]);
-    Value *max1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpSGT(max1, args[2]);
-    return getBuilder()->CreateSelect(cond, max1, args[2]);
+    Value *max1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::smax, args[0], args[1]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::smax, max1, args[2]);
   }
 
   case SMid3AMD: {
     // Middle of three signed integer values.
-    Value *cond = getBuilder()->CreateICmpSLT(args[0], args[1]);
-    Value *min1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpSGT(args[0], args[1]);
-    Value *max1 = getBuilder()->CreateSelect(cond, args[0], args[1]);
-    cond = getBuilder()->CreateICmpSLT(max1, args[2]);
-    Value *min2 = getBuilder()->CreateSelect(cond, max1, args[2]);
-    cond = getBuilder()->CreateICmpSGT(min1, min2);
-    return getBuilder()->CreateSelect(cond, min1, min2);
+    Value *min1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::smin, args[0], args[1]);
+    Value *max1 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::smax, args[0], args[1]);
+    Value *min2 = getBuilder()->CreateBinaryIntrinsic(Intrinsic::smin, max1, args[2]);
+    return getBuilder()->CreateBinaryIntrinsic(Intrinsic::smax, min1, min2);
   }
 
   default:


### PR DESCRIPTION
LLVM IR intrinsics were introduced in D84125.