### PR TITLE
[CI] Enable XGL cache creator in non-sanitizer builds

### DIFF
--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -88,6 +88,8 @@ RUN EXTRA_FLAGS="" \
          EXTRA_FLAGS="$EXTRA_FLAGS -DXGL_USE_SANITIZER=Address;Undefined"; \
          echo "export ASAN_OPTIONS=detect_leaks=0" >> /vulkandriver/env.sh; \
          echo "export LD_PRELOAD=/usr/lib/llvm-9/lib/clang/9.0.1/lib/linux/libclang_rt.asan-x86_64.so" >> /vulkandriver/env.sh; \
+       else \
+         EXTRA_FLAGS="$EXTRA_FLAGS -DXGL_BUILD_CACHE_CREATOR=ON"; \
        fi \
     && echo "Extra CMake flags: $EXTRA_FLAGS" \
     && echo "Extra env vars (/vulkandriver/env.sh): " \


### PR DESCRIPTION
This enables XGL cache creator in base AMDVLK images built by the cron job.
These images can be then used by upcoming CI checks in XGL.

We don't enable cache creator tools in sanitizer builds because they are
already close to exceeding the disk quota for free GitHub runners.