### PR TITLE
Use patch control point only for TCS/TES hash

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1017,7 +1017,8 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
   auto iaState = &pipeline->iaState;
   if (enableNgg)
     hasher->Update(iaState->topology);
-  hasher->Update(iaState->patchControlPoints);
+  if (pipeline->gs.pModuleData || pipeline->tcs.pModuleData || pipeline->tes.pModuleData)
+    hasher->Update(iaState->patchControlPoints);
   hasher->Update(iaState->disableVertexReuse);
   hasher->Update(iaState->switchWinding);
   hasher->Update(iaState->enableMultiView);


### PR DESCRIPTION
Use patch control point only when GS/TCS/TES is given

Based on my code analysis, the patch control point may have an impact on
the geometry shader, tessellation control shader, and tessellation
evaluation shader ELFs. However, it does not have any impact on the
ELF of a vertex, compute, or fragment shader. Therefore, we have to
exclude the patch control point data from the hash.

The initial motivation of this fix is to make the hash value of amdllpc
and LLPC used for ICD the same. The existing
`PipelineDumper::updateHashForNonFragmentState()` includes
patch control point data to generate the hash for non-fragment shaders.
Since amdllpc sets `patchControlPoints` to 3 when its given value is 0,
amdllpc has a different hash value from LLPC used for ICD. This CL
fixes the issue.