### PR TITLE
Expose spvgen build path to XGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,12 @@ if(ICD_BUILD_LLPC)
     )
 
     add_subdirectory(llpc ${PROJECT_BINARY_DIR}/llpc)
-    # Export the LLVM build path so that it's available in XGL.
+
+    # Export the LLVM and spvgen build paths so that they are available in XGL.
     set(XGL_LLVM_BUILD_PATH ${XGL_LLVM_BUILD_PATH} PARENT_SCOPE)
+    if(DEFINED XGL_SPVGEN_BUILD_PATH)
+        set(XGL_SPVGEN_BUILD_PATH ${XGL_SPVGEN_BUILD_PATH} PARENT_SCOPE)
+    endif()
 
     target_link_libraries(vkgc INTERFACE llpc)
 endif()

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -384,6 +384,8 @@ endif()
 if(EXISTS ${XGL_SPVGEN_PATH})
     set(SPVGEN_ENABLE_WERROR ${LLPC_ENABLE_WERROR} CACHE BOOL "${PROJECT_NAME} override." FORCE)
     add_subdirectory(${XGL_SPVGEN_PATH} ${CMAKE_BINARY_DIR}/spvgen EXCLUDE_FROM_ALL)
+    # Propagate the spvgen build directory to the parent scope so that XGL tests can use it.
+    set(XGL_SPVGEN_BUILD_PATH ${CMAKE_BINARY_DIR}/spvgen PARENT_SCOPE)
 endif()
 
 # Lit tests


### PR DESCRIPTION
This propagates the spvgen build location to the XGL scope so that we can use it in XGL's tests that use amdllpc.