### PR TITLE
Fix a build error

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -786,7 +786,7 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
 Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<const PipelineShaderInfo *> shaderInfo,
                                                  ElfPackage *pipelineElf,
                                                  MutableArrayRef<CacheAccessInfo> stageCacheAccesses) {
-  LLPC_OUTS("Building pipeline with relocatable shader elf.\n")
+  LLPC_OUTS("Building pipeline with relocatable shader elf.\n");
   Result result = Result::Success;
 
   unsigned originalShaderStageMask = context->getPipelineContext()->getShaderStageMask();


### PR DESCRIPTION
';' is missing after using the macro LLPC_OUTS.

Change-Id: I6798c5795b1062535b640ddd9fb6b1fb8274d0ce