### PR TITLE
Not enforce readfirstlane on descriptor with constant indexing

### DIFF
--- a/llpc/test/shaderdb/ObjNonUniform_TestImageSample.frag
+++ b/llpc/test/shaderdb/ObjNonUniform_TestImageSample.frag
@@ -30,9 +30,11 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 0
 ; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 0
-; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 384
+; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 0
 ; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 384
 ; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 24
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST-COUNT-12: call i32 @llvm.amdgcn.readfirstlane
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: {{%[0-9]*}} = call float @llvm.amdgcn.interp.mov
 ; SHADERTEST: {{%[0-9]*}} = bitcast float {{%[0-9]*}} to i32

--- a/llpc/test/shaderdb/OpAtomicXXX_TestImage_lit.frag
+++ b/llpc/test/shaderdb/OpAtomicXXX_TestImage_lit.frag
@@ -49,7 +49,7 @@ void main()
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 2, i32 0, i32 0, i32 0, <8 x i32>
-; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 4, i32 1, i32 128, i32 0, <8 x i32>
+; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 4, i32 1, i32 0, i32 0, <8 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 6, i32 1, i32 128, i32 0, <8 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 8, i32 6, i32 0, i32 0, <8 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 9, i32 0, i32 0, i32 0, <8 x i32>
@@ -57,7 +57,7 @@ void main()
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 0, i32 0, i32 0, i32 0, <8 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.compare.swap.i32(i32 0, i32 0, i32 0, <8 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 2, i32 3, i32 0, i32 0, <8 x i32>
-; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 5, i32 0, i32 128, i32 0, <4 x i32>
+; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 5, i32 0, i32 0, i32 0, <4 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 7, i32 0, i32 128, i32 0, <4 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 8, i32 7, i32 0, i32 0, <8 x i32>
 ; SHADERTEST: call i32 (...) @lgc.create.image.atomic.i32(i32 9, i32 3, i32 0, i32 0, <8 x i32>

--- a/llpc/test/shaderdb/OpImageSampleImplicitLod_TestArrayDirectAccess_lit.frag
+++ b/llpc/test/shaderdb/OpImageSampleImplicitLod_TestArrayDirectAccess_lit.frag
@@ -14,11 +14,11 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.image.sample.v4f32(i32 1, i32 384, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <4 x i32> %{{[-0-9A-Za0z_.]+}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.image.sample.v4f32(i32 1, i32 0, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <4 x i32> %{{[-0-9A-Za0z_.]+}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: call {{.*}} @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 0, i32 0)
-; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 384, {{.*}}, {{.*}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 0, {{.*}}, {{.*}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: load <4 x i32>, <4 x i32> addrspace(4)* %{{[0-9]*}}

--- a/llpc/test/shaderdb/OpImageSampleImplicitLod_TestMultiDimArrayDirectAccess_lit.frag
+++ b/llpc/test/shaderdb/OpImageSampleImplicitLod_TestMultiDimArrayDirectAccess_lit.frag
@@ -14,11 +14,11 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.image.sample.v4f32(i32 1, i32 384, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <4 x i32> %{{[-0-9A-Za0z_.]+}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.image.sample.v4f32(i32 1, i32 0, <8 x i32> %{{[-0-9A-Za0z_.]+}}, <4 x i32> %{{[-0-9A-Za0z_.]+}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: call {{.*}} @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 0, i32 0)
-; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 384, {{.*}}, {{.*}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
+; SHADERTEST: call {{.*}} @lgc.create.image.sample.v4f32(i32 1, i32 0, {{.*}}, {{.*}}, i32 1, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-LABEL: load <4 x i32>, <4 x i32> addrspace(4)* %{{[0-9]*}}


### PR DESCRIPTION
b8bc enforces readfirstlanes on the image/sampler descriptors that
accessed from an array. If the index is constant, there is no need to
enforce readfirstlane on the descriptor. Otherwise, extra
v_writelane_b32/v_readlane_b32 for descrtiptor data may be introduced in
some special case, which will cause performance drop.
Refine the code to set `ImageFlagEnforceReadFirstLane{Image,Sampler}`
for dynamic indexing.
Fixes: a peformance drop case from a game