### PR TITLE
Fix spvasm tests using Sampled Type of 64-bit int

### DIFF
--- a/llpc/test/shaderdb/OpAtomicAnd_TestInt64ImageAtomicAnd.spvasm
+++ b/llpc/test/shaderdb/OpAtomicAnd_TestInt64ImageAtomicAnd.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicCompareExchange_TestInt64ImageAtomicCompSwap.spvasm
+++ b/llpc/test/shaderdb/OpAtomicCompareExchange_TestInt64ImageAtomicCompSwap.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicExchange_TestInt64ImageAtomicExchange.spvasm
+++ b/llpc/test/shaderdb/OpAtomicExchange_TestInt64ImageAtomicExchange.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicIAdd_TestInt64ImageAtomicAdd.spvasm
+++ b/llpc/test/shaderdb/OpAtomicIAdd_TestInt64ImageAtomicAdd.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicIDecrement_TestInt64ImageAtomicDecrement.spvasm
+++ b/llpc/test/shaderdb/OpAtomicIDecrement_TestInt64ImageAtomicDecrement.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicIIncrement_TestInt64ImageAtomicIncrement.spvasm
+++ b/llpc/test/shaderdb/OpAtomicIIncrement_TestInt64ImageAtomicIncrement.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicISub_TestInt64ImageAtomicSub.spvasm
+++ b/llpc/test/shaderdb/OpAtomicISub_TestInt64ImageAtomicSub.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicLoad_TestInt64ImageAtomicLoad.spvasm
+++ b/llpc/test/shaderdb/OpAtomicLoad_TestInt64ImageAtomicLoad.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicOr_TestInt64ImageAtomicOr.spvasm
+++ b/llpc/test/shaderdb/OpAtomicOr_TestInt64ImageAtomicOr.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicSMax_TestInt64ImageAtomicMax.spvasm
+++ b/llpc/test/shaderdb/OpAtomicSMax_TestInt64ImageAtomicMax.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicSMin_TestInt64ImageAtomicMin.spvasm
+++ b/llpc/test/shaderdb/OpAtomicSMin_TestInt64ImageAtomicMin.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicStore_TestInt64ImageAtomicStore.spvasm
+++ b/llpc/test/shaderdb/OpAtomicStore_TestInt64ImageAtomicStore.spvasm
@@ -13,6 +13,8 @@
 ; Schema: 0
                OpCapability Shader
                OpCapability Int64
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicUMax_TestInt64ImageAtomicMax.spvasm
+++ b/llpc/test/shaderdb/OpAtomicUMax_TestInt64ImageAtomicMax.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicUMin_TestInt64ImageAtomicMin.spvasm
+++ b/llpc/test/shaderdb/OpAtomicUMin_TestInt64ImageAtomicMin.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpAtomicXor_TestInt64ImageAtomicXor.spvasm
+++ b/llpc/test/shaderdb/OpAtomicXor_TestInt64ImageAtomicXor.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability Int64Atomics
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"

--- a/llpc/test/shaderdb/OpImageRead_TestInt64ImageLoad.spvasm
+++ b/llpc/test/shaderdb/OpImageRead_TestInt64ImageLoad.spvasm
@@ -13,6 +13,8 @@
 ; Schema: 0
                OpCapability Shader
                OpCapability Int64
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %i64v4

--- a/llpc/test/shaderdb/OpImageSparseRead_TestInt64SparseImageLoad.spvasm
+++ b/llpc/test/shaderdb/OpImageSparseRead_TestInt64SparseImageLoad.spvasm
@@ -14,6 +14,8 @@
                OpCapability Shader
                OpCapability Int64
                OpCapability SparseResidency
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %i64v4

--- a/llpc/test/shaderdb/OpImageWrite_TestInt64ImageStore.spvasm
+++ b/llpc/test/shaderdb/OpImageWrite_TestInt64ImageStore.spvasm
@@ -13,6 +13,8 @@
 ; Schema: 0
                OpCapability Shader
                OpCapability Int64
+               OpCapability Int64ImageEXT
+               OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %u64v4


### PR DESCRIPTION
Some of the spvasm tests use Sampled Type of 64-bit int.
Strictly these should have:
OpCapability Int64ImageEXT
OpExtension "SPV_EXT_shader_image_int64"

Recent changes mean that these tests will fail without these lines being added
(improved verification).