### PR TITLE
lgc minor tidyup

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -95,8 +95,10 @@ if(WIN32)
 endif()
 
 target_include_directories(LLVMlgc
+PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interface>
+    $<INSTALL_INTERFACE:interface>
 PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/interface
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/imported
 )

--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -49,8 +49,6 @@ add_llvm_library(LLVMlgc LINK_COMPONENTS
 
 ### Cached Project Options #############################################################################################
 option(LLPC_BUILD_RENOIR  "LLPC support for Renoir?"    ON)
-option(LLPC_BUILD_NAVI21 "LLPC support for NAVI21?" OFF)
-option(LLPC_BUILD_GFX103 "LLPC support for GFX103?" OFF)
 option(LLPC_ENABLE_WERROR "Build LLPC with more errors" OFF)
 
 ### Compiler Options ###################################################################################################
@@ -68,23 +66,13 @@ target_compile_definitions(LLVMlgc PRIVATE
         CHIP_HDR_VEGA20
         CHIP_HDR_RAVEN2
         CHIP_HDR_NAVI14
+        CHIP_HDR_NAVI21
         )
 
 if (LLPC_BUILD_RENOIR)
     target_compile_definitions(LLVMlgc PRIVATE LLPC_BUILD_RENOIR)
     target_compile_definitions(LLVMlgc PRIVATE CHIP_HDR_RENOIR)
 endif()
-  if(LLPC_BUILD_NAVI21)
-    target_compile_definitions(LLVMlgc PRIVATE
-        LLPC_BUILD_NAVI21
-        CHIP_HDR_NAVI21
-    )
-  endif()
-  if(LLPC_BUILD_GFX103)
-    target_compile_definitions(LLVMlgc PRIVATE
-        LLPC_BUILD_GFX103
-    )
-  endif()
 
 if(WIN32)
     target_compile_definitions(LLVMlgc PRIVATE

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1155,7 +1155,7 @@ public:
   // @param builtIn : Built-in kind, one of the BuiltIn* constants
   // @param outputInfo : Extra output info (shader-defined array length; GS stream id)
   // @param vertexIndex : For TCS per-vertex output: vertex index, else nullptr
-  // @param index : Array or vector index to access part of an input, else nullptr
+  // @param index : For TCS: array or vector index to access part of an output, else nullptr
   virtual llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn,
                                                       InOutInfo outputInfo, llvm::Value *vertexIndex,
                                                       llvm::Value *index) = 0;

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -51,60 +51,55 @@
 //
 // If this file is included without the BUILTIN macro defined, then it declares the BuiltInKind enum.
 
-BUILTIN(BaryCoordNoPersp, 4992, N, P, v2f32)         // Linearly-interpolated (I,J) at pixel center
-BUILTIN(BaryCoordNoPerspCentroid, 4993, N, P, v2f32) // Linearly-interpolated (I,J) at pixel centroid
-BUILTIN(BaryCoordNoPerspSample, 4994, N, P, v2f32)   // Linearly-interpolated (I,J) at each covered sample
-BUILTIN(BaryCoordPullModel, 4998, N, P, v3f32)       // (1/w,1/I,1/J) at pixel center
-BUILTIN(BaryCoordSmooth, 4995, N, P, v2f32)          // Perspective-interpolated (I,J) at pixel center
-BUILTIN(BaryCoordSmoothCentroid, 4996, N, P, v2f32)  // Perspective-interpolated (I,J) at pixel centroid
-BUILTIN(BaryCoordSmoothSample, 4997, N, P, v2f32)    // Perspective-interpolated (I,J) at each covered sample
-BUILTIN(BaseInstance, 4425, N, V, i32)               // Base instance ID
-BUILTIN(BaseVertex, 4424, N, V, i32)                 // Base vertex
-BUILTIN(ClipDistance, 3, MVHDG, HDGP, af32)          // Array of clip distances
-BUILTIN(CullDistance, 4, MVHDG, HDGP, af32)          // Array of cull distances
-BUILTIN(DeviceIndex, 4438, N, TMVHDGPC, i32)         // Device index of the physical device
-BUILTIN(DrawIndex, 4426, N, TMV, i32)                // Draw index
-BUILTIN(FragCoord, 15, N, P, v4f32)                  // (x,y,z,1/w) of the current fragment
-BUILTIN(FragDepth, 22, P, N, f32)                    // Fragment depth
-BUILTIN(FragStencilRef, 5014, P, N, i32)             // Stencil reference value
-BUILTIN(FrontFacing, 17, N, P, i1)                   // Front-facing fragment flag
-BUILTIN(GlobalInvocationId, 28, N, TMC, v3i32)       // Invocation ID within global workgroup
-BUILTIN(HelperInvocation, 23, N, P, i1)              // Helper invocation flag
-BUILTIN(InstanceIndex, 43, N, V, i32)                // Instance index
-BUILTIN(InvocationId, 8, N, HG, i32)                 // Invocation ID
-BUILTIN(Layer, 9, MVDG, P, i32)                      // Layer of multi-layer framebuffer attachment
-BUILTIN(LocalInvocationId, 27, N, TMC, v3i32)        // Invocation location within local workgroup
-BUILTIN(LocalInvocationIndex, 29, N, TMC, i32)       // Linearized LocalInvocationId
-BUILTIN(NumSubgroups, 38, N, TMC, i32)               // Number of subgroups in the local workgroup
-BUILTIN(NumWorkgroups, 24, N, TMC, v3i32)            // Number of local workgroups in the dispatch
-BUILTIN(PatchVertices, 14, N, HD, i32)               // Number of vertices in the input patch
-BUILTIN(PointCoord, 16, N, P, v2f32)                 // Coord of current fragment within the point
-BUILTIN(PointSize, 1, MVHDG, HDG, f32)               // Size of point primitives
-BUILTIN(Position, 0, MVHDG, HDG, v4f32)              // Vertex position
-BUILTIN(PrimitiveId, 7, MG, HDGP, i32)               // Index of the current primitive
-BUILTIN(SampleId, 18, N, P, i32)         // Sample ID
-BUILTIN(SampleMask, 20, P, P, ai32)      // Sample mask coverage
-BUILTIN(SamplePosition, 19, N, P, v2f32) // Sub-pixel position of the sample being shaded
-BUILTIN(SubgroupEqMask, 4416, N, TMVHDGPC,
-        v4i32) // Subgroup invocations bitmask where bit index == SubgroupLocalInvocationId
-BUILTIN(SubgroupGeMask, 4417, N, TMVHDGPC,
-        v4i32) // Subgroup invocations bitmask where bit index >= SubgroupLocalInvocationId
-BUILTIN(SubgroupGtMask, 4418, N, TMVHDGPC,
-        v4i32)                       // Subgroup invocations bitmask where bit index > SubgroupLocalInvocationId
-BUILTIN(SubgroupId, 40, N, TMC, i32) // Index of subgroup within local workgroup
-BUILTIN(SubgroupLeMask, 4419, N, TMVHDGPC,
-        v4i32) // Subgroup invocations bitmask where bit index <= SubgroupLocalInvocationId
+BUILTIN(BaryCoordNoPersp, 4992, N, P, v2f32)             // Linearly-interpolated (I,J) at pixel center
+BUILTIN(BaryCoordNoPerspCentroid, 4993, N, P, v2f32)     // Linearly-interpolated (I,J) at pixel centroid
+BUILTIN(BaryCoordNoPerspSample, 4994, N, P, v2f32)       // Linearly-interpolated (I,J) at each covered sample
+BUILTIN(BaryCoordPullModel, 4998, N, P, v3f32)           // (1/w,1/I,1/J) at pixel center
+BUILTIN(BaryCoordSmooth, 4995, N, P, v2f32)              // Perspective-interpolated (I,J) at pixel center
+BUILTIN(BaryCoordSmoothCentroid, 4996, N, P, v2f32)      // Perspective-interpolated (I,J) at pixel centroid
+BUILTIN(BaryCoordSmoothSample, 4997, N, P, v2f32)        // Perspective-interpolated (I,J) at each covered sample
+BUILTIN(BaseInstance, 4425, N, V, i32)                   // Base instance ID
+BUILTIN(BaseVertex, 4424, N, V, i32)                     // Base vertex
+BUILTIN(ClipDistance, 3, MVHDG, HDGP, af32)              // Array of clip distances
+BUILTIN(CullDistance, 4, MVHDG, HDGP, af32)              // Array of cull distances
+BUILTIN(DeviceIndex, 4438, N, TMVHDGPC, i32)             // Device index of the physical device
+BUILTIN(DrawIndex, 4426, N, TMV, i32)                    // Draw index
+BUILTIN(FragCoord, 15, N, P, v4f32)                      // (x,y,z,1/w) of the current fragment
+BUILTIN(FragDepth, 22, P, N, f32)                        // Fragment depth
+BUILTIN(FragStencilRef, 5014, P, N, i32)                 // Stencil reference value
+BUILTIN(FrontFacing, 17, N, P, i1)                       // Front-facing fragment flag
+BUILTIN(GlobalInvocationId, 28, N, TMC, v3i32)           // Invocation ID within global workgroup
+BUILTIN(HelperInvocation, 23, N, P, i1)                  // Helper invocation flag
+BUILTIN(InstanceIndex, 43, N, V, i32)                    // Instance index
+BUILTIN(InvocationId, 8, N, HG, i32)                     // Invocation ID
+BUILTIN(Layer, 9, MVDG, P, i32)                          // Layer of multi-layer framebuffer attachment
+BUILTIN(LocalInvocationId, 27, N, TMC, v3i32)            // Invocation location within local workgroup
+BUILTIN(LocalInvocationIndex, 29, N, TMC, i32)           // Linearized LocalInvocationId
+BUILTIN(NumSubgroups, 38, N, TMC, i32)                   // Number of subgroups in the local workgroup
+BUILTIN(NumWorkgroups, 24, N, TMC, v3i32)                // Number of local workgroups in the dispatch
+BUILTIN(PatchVertices, 14, N, HD, i32)                   // Number of vertices in the input patch
+BUILTIN(PointCoord, 16, N, P, v2f32)                     // Coord of current fragment within the point
+BUILTIN(PointSize, 1, MVHDG, HDG, f32)                   // Size of point primitives
+BUILTIN(Position, 0, MVHDG, HDG, v4f32)                  // Vertex position
+BUILTIN(PrimitiveId, 7, MG, HDGP, i32)                   // Index of the current primitive
+BUILTIN(PrimitiveShadingRate, 4432, MVG, N, i32)         // Shading rate used for fragments generated for this primitive
+BUILTIN(SampleId, 18, N, P, i32)                         // Sample ID
+BUILTIN(SampleMask, 20, P, P, ai32)                      // Sample mask coverage
+BUILTIN(SamplePosition, 19, N, P, v2f32)                 // Sub-pixel position of the sample being shaded
+BUILTIN(ShadingRate, 4444, N, P, i32)                    // Current fragment's shading rate
+BUILTIN(SubgroupEqMask, 4416, N, TMVHDGPC, v4i32)        // Subgroup mask where bit index == SubgroupLocalInvocationId
+BUILTIN(SubgroupGeMask, 4417, N, TMVHDGPC, v4i32)        // Subgroup mask where bit index >= SubgroupLocalInvocationId
+BUILTIN(SubgroupGtMask, 4418, N, TMVHDGPC, v4i32)        // Subgroup mask where bit index > SubgroupLocalInvocationId
+BUILTIN(SubgroupId, 40, N, TMC, i32)                     // Index of subgroup within local workgroup
+BUILTIN(SubgroupLeMask, 4419, N, TMVHDGPC, v4i32)        // Subgroup mask where bit index <= SubgroupLocalInvocationId
 BUILTIN(SubgroupLocalInvocationId, 41, N, TMVHDGPC, i32) // Index of invocation within subgroup
-BUILTIN(SubgroupLtMask, 4420, N, TMVHDGPC,
-        v4i32)                              // Subgroup invocations bitmask where bit index < SubgroupLocalInvocationId
-BUILTIN(SubgroupSize, 36, N, TMVHDGPC, i32) // Number of invocations in the subgroup
-BUILTIN(TessCoord, 13, N, D, v3f32)         // (u,v,w) coord of tessellated vertex in patch
-BUILTIN(TessLevelInner, 12, H, D, a2f32)    // Tessellation inner levels
-BUILTIN(TessLevelOuter, 11, H, D, a4f32)    // Tessellation outer levels
-BUILTIN(VertexIndex, 42, N, V, i32)         // Index of current vertex
-BUILTIN(ViewIndex, 4440, N, VHDGP, i32)     // View index
-BUILTIN(ViewportIndex, 10, MVDG, P, i32)    // Viewport index
-BUILTIN(WorkgroupId, 26, N, TMC, v3i32)     // ID of global workgroup
-BUILTIN(WorkgroupSize, 25, N, C, v3i32)     // Size of global workgroup
-BUILTIN(PrimitiveShadingRate, 4432, MVG, N, i32) // Shading rate used for fragments generated for this primitive
-BUILTIN(ShadingRate, 4444, N, P, i32)            // Current fragment's shading rate
+BUILTIN(SubgroupLtMask, 4420, N, TMVHDGPC, v4i32)        // Subgroup mask where bit index < SubgroupLocalInvocationId
+BUILTIN(SubgroupSize, 36, N, TMVHDGPC, i32)              // Number of invocations in the subgroup
+BUILTIN(TessCoord, 13, N, D, v3f32)                      // (u,v,w) coord of tessellated vertex in patch
+BUILTIN(TessLevelInner, 12, H, D, a2f32)                 // Tessellation inner levels
+BUILTIN(TessLevelOuter, 11, H, D, a4f32)                 // Tessellation outer levels
+BUILTIN(VertexIndex, 42, N, V, i32)                      // Index of current vertex
+BUILTIN(ViewIndex, 4440, N, VHDGP, i32)                  // View index
+BUILTIN(ViewportIndex, 10, MVDG, P, i32)                 // Viewport index
+BUILTIN(WorkgroupId, 26, N, TMC, v3i32)                  // ID of global workgroup
+BUILTIN(WorkgroupSize, 25, N, C, v3i32)                  // Size of global workgroup

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -322,7 +322,10 @@ struct VertexInputDescription {
   unsigned location;  // Location of input, as provided to CreateReadGenericInput
   unsigned binding;   // Index of the vertex buffer descriptor in the vertex buffer table
   unsigned offset;    // Byte offset of the input in the binding's vertex buffer
-  unsigned stride;    // Byte stride of per-vertex/per-instance elements in the vertex buffer
+  unsigned stride;    // Byte stride of per-vertex/per-instance elements in the vertex buffer, 0 if unknown.
+                      // The stride is passed only to ensure that a valid load is used, not to actually calculate
+                      // the load address. Instead, we use the index as the index in a structured tbuffer load
+                      // instruction, and rely on the driver setting up the descriptor with the correct stride.
   BufDataFormat dfmt; // Data format of input; one of the BufDataFormat* values
   BufNumFormat nfmt;  // Numeric format of input; one of the BufNumFormat* values
   unsigned inputRate; // Vertex input rate for the binding

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -924,6 +924,10 @@ Value *VertexFetchImpl::loadVertexBufferDescriptor(unsigned binding, BuilderBase
 // =====================================================================================================================
 // Inserts instructions to do vertex fetch operations.
 //
+// The stride is passed only to ensure that a valid load is used, not to actually calculate the load address.
+// Instead, we use the index as the index in a structured tbuffer load instruction, and rely on the driver
+// setting up the descriptor with the correct stride.
+//
 // @param vbDesc : Vertex buffer descriptor
 // @param numChannels : Valid number of channels
 // @param is16bitFetch : Whether it is 16-bit vertex fetch


### PR DESCRIPTION
1927384e7 lgc cmake: change LLPC_BUILD_NAVI21 default to ON for standalone lgc build
7657dcefc lgc: restore built-ins list to alphabetical order
852dd3cd2 lgc: Minor comment improvements
f0ca53e31 cmake: Make lgc's interface directory public
