### PR TITLE
lgc: Minor resource binding and buffer load tidy-up

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -263,8 +263,8 @@ public:
   DescBuilder(LgcContext *builderContext) : BuilderImplBase(builderContext) {}
 
   // Create a load of a buffer descriptor.
-  llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, bool isNonUniform,
-                                    bool isWritten, llvm::Type *pointeeTy, const llvm::Twine &instName) override final;
+  llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, unsigned flags,
+                                    llvm::Type *pointeeTy, const llvm::Twine &instName) override final;
 
   // Create a get of the stride (in bytes) of a descriptor.
   llvm::Value *CreateGetDescStride(ResourceNodeType descType, unsigned descSet, unsigned binding,

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -991,19 +991,17 @@ Value *BuilderRecorder::CreateFindSMsb(Value *value, const Twine &instName) {
 // @param descSet : Descriptor set
 // @param binding : Descriptor binding
 // @param descIndex : Descriptor index
-// @param isNonUniform : Whether the descriptor index is non-uniform
-// @param isWritten : Whether the buffer is written to
+// @param flags : BufferFlag* bit settings
 // @param pointeeTy : Type that the returned pointer should point to
 // @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Value *descIndex, bool isNonUniform,
-                                             bool isWritten, Type *pointeeTy, const Twine &instName) {
+Value *BuilderRecorder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Value *descIndex, unsigned flags,
+                                             Type *pointeeTy, const Twine &instName) {
   return record(Opcode::LoadBufferDesc, getBufferDescTy(pointeeTy),
                 {
                     getInt32(descSet),
                     getInt32(binding),
                     descIndex,
-                    getInt1(isNonUniform),
-                    getInt1(isWritten),
+                    getInt32(flags),
                 },
                 instName);
 }

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -342,8 +342,8 @@ public:
   // -----------------------------------------------------------------------------------------------------------------
   // Descriptor operations
 
-  llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, bool isNonUniform,
-                                    bool isWritten, llvm::Type *pointeeTy, const llvm::Twine &instName) override final;
+  llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, unsigned flags,
+                                    llvm::Type *pointeeTy, const llvm::Twine &instName) override final;
 
   llvm::Value *CreateGetDescStride(ResourceNodeType descType, unsigned descSet, unsigned binding,
                                    const llvm::Twine &instName) override final;

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -414,8 +414,7 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     return m_builder->CreateLoadBufferDesc(cast<ConstantInt>(args[0])->getZExtValue(), // descSet
                                            cast<ConstantInt>(args[1])->getZExtValue(), // binding
                                            args[2],                                    // pDescIndex
-                                           cast<ConstantInt>(args[3])->getZExtValue(), // isNonUniform
-                                           cast<ConstantInt>(args[4])->getZExtValue(), // isWritten
+                                           cast<ConstantInt>(args[3])->getZExtValue(), // flags
                                            isa<PointerType>(call->getType()) ? call->getType()->getPointerElementType()
                                                                              : nullptr); // pPointeeTy
   }

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -395,6 +395,7 @@ private:
   llvm::ArrayRef<llvm::MDString *> getResourceTypeNames();
   llvm::MDString *getResourceTypeName(ResourceNodeType type);
   ResourceNodeType getResourceTypeFromName(llvm::MDString *typeName);
+  bool matchResourceNode(const ResourceNode &node, ResourceNodeType nodeType, unsigned descSet, unsigned binding) const;
 
   // Device index handling
   void recordDeviceIndex(llvm::Module *module);

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -656,6 +656,14 @@ public:
   //    ways). This API is formulated to allow the front-end to implement that. Step (c) can be
   //    performed without needing to see the resource node used in (a).
 
+  // Bit settings for flags argument in CreateLoadBufferDesc.
+  enum {
+    BufferFlagNonUniform = 1, // Descriptor index is non-uniform
+    BufferFlagWritten = 2,    // Buffer is (or might be) written to
+    BufferFlagReserved4 = 4,  // Reserved for future functionality
+    BufferFlagReserved8 = 8,  // Reserved for future functionality
+  };
+
   // Get the type of pointer returned by CreateLoadBufferDesc.
   llvm::PointerType *getBufferDescTy(llvm::Type *pointeeTy);
 
@@ -664,13 +672,11 @@ public:
   // @param descSet : Descriptor set
   // @param binding : Descriptor binding
   // @param descIndex : Descriptor index
-  // @param isNonUniform : Whether the descriptor index is non-uniform
-  // @param isWritten : Whether the buffer is (or might be) written to
+  // @param flags : BufferFlag* bit settings
   // @param pointeeTy : Type that the returned pointer should point to.
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex,
-                                            bool isNonUniform, bool isWritten, llvm::Type *pointeeTy,
-                                            const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, unsigned flags,
+                                            llvm::Type *pointeeTy, const llvm::Twine &instName = "") = 0;
 
   // Get the type of a descriptor
   //

--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -68,7 +68,9 @@ enum class ResourceNodeType : unsigned {
   StreamOutTableVaPtr,       ///< Stream-out buffer table VA pointer
   DescriptorReserved12,
   InlineBuffer, ///< Inline buffer, with descriptor set and binding
-  Count,        ///< Count of resource mapping node types.
+  DescriptorReserved14,
+  DescriptorReserved15,
+  Count, ///< Count of resource mapping node types.
 };
 
 } // namespace lgc

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -123,6 +123,8 @@ struct Options {
                                        //   ShadowDescriptorTableDisable to disable shadow descriptor tables
   unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
   unsigned disableImageResourceCheck;  // Don't do image resource type check
+  unsigned reserved0f;                 // Reserved for future functionality
+  unsigned reserved10;                 // Reserved for future functionality
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/test/CallLibFromCs-indirect.lgc
+++ b/lgc/test/CallLibFromCs-indirect.lgc
@@ -13,20 +13,20 @@ target triple = "amdgcn--amdpal"
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
-  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
-  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i32 2)
   %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
   %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
-  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i32 2)
   %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
   %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
   %8 = add <4 x i32> %4, %7
-  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i32 2)
   %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
   %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
   %12 = add <4 x i32> %8, %11
-  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i32 2)
   %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
   %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
   %16 = add <4 x i32> %12, %15

--- a/lgc/test/CallLibFromCs.lgc
+++ b/lgc/test/CallLibFromCs.lgc
@@ -16,20 +16,20 @@ declare spir_func i32 @compute_library_func() #0
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
-  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
-  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i32 2)
   %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
   %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
-  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i32 2)
   %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
   %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
   %8 = add <4 x i32> %4, %7
-  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i32 2)
   %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
   %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
   %12 = add <4 x i32> %8, %11
-  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i32 2)
   %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
   %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
   %16 = add <4 x i32> %12, %15

--- a/lgc/test/CsBuiltIns.lgc
+++ b/lgc/test/CsBuiltIns.lgc
@@ -8,7 +8,7 @@
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 4438, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4
@@ -42,7 +42,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 4438, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4
@@ -73,7 +73,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 25, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -109,7 +109,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 24, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -144,7 +144,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 26, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -177,7 +177,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -213,7 +213,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 36, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4
@@ -247,7 +247,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 41, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4
@@ -280,7 +280,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 38, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4
@@ -324,7 +324,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 28, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -362,7 +362,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 29, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4
@@ -406,7 +406,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call i32 (...) @lgc.create.read.builtin.input.i32(i32 40, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to i32 addrspace(7)*
   store i32 %1, i32 addrspace(7)* %2, align 4

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -14,20 +14,20 @@ target triple = "amdgcn--amdpal"
 ; Function Attrs: nounwind
 define spir_func void @func() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i1 false, i1 true)
-  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
-  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i32 2)
   %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
   %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
-  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i1 false, i1 true)
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i32 2)
   %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
   %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
   %8 = add <4 x i32> %4, %7
-  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i1 false, i1 true)
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i32 2)
   %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
   %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
   %12 = add <4 x i32> %8, %11
-  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i1 false, i1 true)
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i32 2)
   %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
   %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
   %16 = add <4 x i32> %12, %15

--- a/lgc/test/CsReconfigWorkgroup.lgc
+++ b/lgc/test/CsReconfigWorkgroup.lgc
@@ -9,7 +9,7 @@
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -44,7 +44,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
@@ -91,7 +91,7 @@ attributes #0 = { nounwind }
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 true)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4

--- a/lgc/test/FetchShaderSingleInput.lgc
+++ b/lgc/test/FetchShaderSingleInput.lgc
@@ -76,7 +76,7 @@ target triple = "amdgcn--amdpal"
 
 define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !5 {
 .entry:
-  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i1 false, i1 false)
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 0)
   %1 = call {}* @llvm.invariant.start.p7i8(i64 -1, i8 addrspace(7)* %0)
   %2 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
   %3 = bitcast i8 addrspace(7)* %0 to <4 x float> addrspace(7)*

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1710,9 +1710,9 @@ void SpirvLowerGlobal::lowerBufferBlock() {
         for (BitCastInst *const bitCast : bitCastsToModify) {
           m_builder->SetInsertPoint(bitCast);
 
-          Value *const bufferDesc =
-              m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0),
-                                              /*isNonUniform=*/false, !global.isConstant(), m_builder->getInt8Ty());
+          Value *const bufferDesc = m_builder->CreateLoadBufferDesc(
+              descSet, binding, m_builder->getInt32(0), global.isConstant() ? 0 : lgc::Builder::BufferFlagWritten,
+              m_builder->getInt8Ty());
 
           // If the global variable is a constant, the data it points to is invariant.
           if (global.isConstant())
@@ -1769,8 +1769,13 @@ void SpirvLowerGlobal::lowerBufferBlock() {
             }
           }
 
-          Value *const bufferDesc = m_builder->CreateLoadBufferDesc(descSet, binding, blockIndex, isNonUniform,
-                                                                    !global.isConstant(), m_builder->getInt8Ty());
+          unsigned bufferFlags = 0;
+          if (isNonUniform)
+            bufferFlags |= lgc::Builder::BufferFlagNonUniform;
+          if (!global.isConstant())
+            bufferFlags |= lgc::Builder::BufferFlagWritten;
+          Value *const bufferDesc =
+              m_builder->CreateLoadBufferDesc(descSet, binding, blockIndex, bufferFlags, m_builder->getInt8Ty());
 
           // If the global variable is a constant, the data it points to is invariant.
           if (global.isConstant())
@@ -1797,9 +1802,9 @@ void SpirvLowerGlobal::lowerBufferBlock() {
       } else {
         m_builder->SetInsertPoint(&func->getEntryBlock(), func->getEntryBlock().getFirstInsertionPt());
 
-        Value *const bufferDesc =
-            m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0),
-                                            /*isNonUniform=*/false, !global.isConstant(), m_builder->getInt8Ty());
+        Value *const bufferDesc = m_builder->CreateLoadBufferDesc(
+            descSet, binding, m_builder->getInt32(0), global.isConstant() ? 0 : lgc::Builder::BufferFlagWritten,
+            m_builder->getInt8Ty());
 
         // If the global variable is a constant, the data it points to is invariant.
         if (global.isConstant())

--- a/llpc/test/shaderdb/ObjNonUniform_TestMinNonUniform.spvasm
+++ b/llpc/test/shaderdb/ObjNonUniform_TestMinNonUniform.spvasm
@@ -1,7 +1,7 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
-; SHADERTEST: call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 {{.*}}, i1 true, i1 true)
+; SHADERTEST: call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 {{.*}}, i32 3)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/ObjStorageBlock_TestIndirectIndex_lit.frag
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestIndirectIndex_lit.frag
@@ -35,7 +35,7 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = getelementptr [2 x <{ i32, [12 x i8], [4 x float], [2 x [4 x float]] }>], [2 x <{ i32, [12 x i8], [4 x float], [2 x [4 x float]] }>] addrspace(7)* @{{[0-9]}}, i32 0, i32 %{{[0-9]*}}, i32 3, i32 %{{[0-9]*}}
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-COUNT-3: call i8 addrspace(7)* {{.*}} @lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 0, i32 %{{[0-9]*}}, i1 false,
+; SHADERTEST-COUNT-3: call i8 addrspace(7)* {{.*}} @lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 0, i32 %{{[0-9]*}},
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/ObjStorageBlock_TestMemoryQualifier_lit.frag
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestMemoryQualifier_lit.frag
@@ -21,7 +21,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.{{[0-9a-z]*}}(i32 1, i32 0, i32 0, i1 false,
+; SHADERTEST: %{{[0-9]*}} = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.{{[0-9a-z]*}}(i32 1, i32 0, i32 0,
 ; SHADERTEST: %{{[0-9]*}} = load atomic <4 x float>, <4 x float> addrspace(7)* %{{[0-9]*}} unordered, align 16
 ; SHADERTEST: store atomic float %{{[0-9a-z.]*}}, float addrspace(7)* %{{[0-9]*}} unordered, align 4
 

--- a/llpc/test/shaderdb/ObjStorageBlock_TestVectorComponentStore_lit.comp
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestVectorComponentStore_lit.comp
@@ -16,7 +16,7 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call i8 addrspace(7)* {{.*}} @lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 0, i32 0, i1 false,
+; SHADERTEST: %{{[0-9]*}} = call i8 addrspace(7)* {{.*}} @lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 0, i32 0,
 ; SHADERTEST: %{{[0-9]*}} = load float, float addrspace(7)* %{{[0-9]*}}, align 4
 ; SHADERTEST: %{{[0-9]*}} = getelementptr inbounds i8, i8 addrspace(7)* %{{[0-9]*}}, i64 4
 ; SHADERTEST: store float %{{[0-9]*}}, float addrspace(7)* %{{[0-9]*}}, align 4

--- a/llpc/test/shaderdb/OpAccessChain_TestMultiLevelChain_lit.spvasm
+++ b/llpc/test/shaderdb/OpAccessChain_TestMultiLevelChain_lit.spvasm
@@ -7,7 +7,7 @@
 ; SHADERTEST: getelementptr [4 x float], [4 x float] addrspace({{.*}})* %{{[0-9]*}}, i32 0, i32 1
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: @lgc.create.load.buffer.desc{{.*}}(i32 0, i32 0, i32 0, i1 false,
+; SHADERTEST: @lgc.create.load.buffer.desc{{.*}}(i32 0, i32 0, i32 0,
 ; SHADERTEST: load i32, i32 addrspace({{.*}})* {{.*}}
 ; SHADERTEST: load float, float addrspace({{.*}})* {{.*}}
 

--- a/llpc/test/shaderdb/PipelineCs_TestDynDescNoSpill_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestDynDescNoSpill_lit.pipe
@@ -2,7 +2,7 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0, i1 false,
+; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0,
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 0, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -3,7 +3,7 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0, i1 false,
+; SHADERTEST: %{{.*}} = call {{.*}} {{.*}}@lgc.create.load.buffer.desc.{{[0-9a-z.]*}}(i32 0, i32 1, i32 0,
 ; SHADERTEST: getelementptr inbounds i8, i8 addrspace(7)* %{{.*}}, i64 64
 ; SHADERTEST: bitcast i8 addrspace(7)* %{{.*}} to <2 x double> addrspace(7)*
 ; SHADERTEST: load <2 x double>, <2 x double> addrspace(7)* %{{.*}}, align 16


### PR DESCRIPTION
Including changing the Builder::CreateLoadBufferDesc API to consolidate
the two flags into a single flags word, to make it easier to add new
flags in the future.

Change-Id: Ibb7febd9134b7c023a601f89d42b5256419fd7d7