### PR TITLE
Fixup cache hash note test

### DIFF
--- a/llpc/test/shaderdb/ObjOutput_TestOpt.frag
+++ b/llpc/test/shaderdb/ObjOutput_TestOpt.frag
@@ -10,7 +10,7 @@ void main()
 ; RUN: amdllpc --opt=quick   -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck --check-prefixes=SHADERTEST,OPT_QUICK %s
 ; RUN: amdllpc --opt=default -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck --check-prefixes=SHADERTEST,OPT_DEFAULT %s
 ; RUN: amdllpc --opt=fast    -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck --check-prefixes=SHADERTEST,OPT_FAST %s
-; SHADERTEST-LABEL: {{^// LLPC}} calculated hash results (graphics pipline)
+; SHADERTEST-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
 ; OPT_NONE:  TargetMachine optimization level = 0
 ; OPT_QUICK:  TargetMachine optimization level = 1
 ; OPT_DEFAULT:  TargetMachine optimization level = 2

--- a/llpc/test/shaderdb/relocatable_shaders/TriangleVs_CheckNoteSectionForCacheHash.spvasm
+++ b/llpc/test/shaderdb/relocatable_shaders/TriangleVs_CheckNoteSectionForCacheHash.spvasm
@@ -2,17 +2,24 @@
 ; adds a note section to ELF, which contains the cache hash and the version of LLPC.
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -gfxip=9 -unlinked -enable-relocatable-shader-elf -v -o %t.elf -add-hash-to-elf %s > %t.log && llvm-readelf -a %t.elf >> %t.log && cat %t.log | FileCheck --check-prefixes=CHECK %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -gfxip=9 -unlinked -enable-relocatable-shader-elf -v -o %t.elf -add-hash-to-elf %s > %t.log \
+; RUN:   && llvm-readelf -a %t.elf >> %t.log \
+; RUN:   && cat %t.log | FileCheck --check-prefix=CHECK %s
 
-; CHECK: LLPC version: 0x0000[[major_ver0:[a-z0-9][a-z0-9]]][[major_ver1:[a-z0-9][a-z0-9]]]0000[[minor_ver0:[a-z0-9][a-z0-9]]][[minor_ver1:[a-z0-9][a-z0-9]]]
-; CHECK: Hash for vertex stage cache lookup: [[hash0:[a-z0-9][a-z0-9]]][[hash1:[a-z0-9][a-z0-9]]][[hash2:[a-z0-9][a-z0-9]]][[hash3:[a-z0-9][a-z0-9]]]
+; CHECK-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
+; CHECK-LABEL: Building pipeline with relocatable shader elf.
+; CHECK-NEXT:  LLPC version: [[llpc_version:([0-9a-f]{2} ?){8}]]{{$}}
+; CHECK:       Hash for vertex stage cache lookup: [[llpc_vert_hash:([a-f0-9]{2} ?){16}]]{{$}}
+; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 
-; CHECK: Displaying notes found in: .note
-; CHECK:   Owner                Data size 	Description
-; CHECK:   llpc_cache_hash      0x00000010	Unknown note type: (0x00000000)
-; CHECK:    description data: [[hash0]] [[hash1]] [[hash2]] [[hash3]]
-; CHECK:   llpc_version         0x00000008	Unknown note type: (0x00000000)
-; CHECK:    description data: [[major_ver1]] [[major_ver0]] 00 00 [[minor_ver1]] [[minor_ver0]] 00 00
+; CHECK-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
+
+; CHECK-LABEL: {{^Displaying}} notes found in: .note
+; CHECK-NEXT:  Owner Data size Description
+; CHECK-LABEL: {{^ +AMD_llpc_cache_hash *}} 0x00000010 Unknown note type: (0x00000000)
+; CHECK-NEXT:  description data: [[llpc_vert_hash]]{{$}}
+; CHECK-LABEL: {{^ +AMD_llpc_version *}} 0x00000008	Unknown note type: (0x00000000)
+; CHECK-NEXT:  description data: [[llpc_version]]{{$}}
 ; END_SHADERTEST
 
 ; SPIR-V


### PR DESCRIPTION
Make the following fixes/changes:
-  Update the note names to match the code: add missing 'AMD_' prefix
-  Update comments with the missing 'AMD_` note name prefix
-  Make sure there are now unmatched prefixes and suffixes in debug lines
-  Match hex digits instead of all alphanum characters
-  Don't match SPIR-V parsing comments comming from the test itself (i.e., `; CHECK: `)
-  Change debug prints to match the note description output format from llvm-readelf
-  Fix typo in `pipeline`
-  Reflow the `RUN: ` command to fit on screen