### PR TITLE
Remove adjusting vertex offset for DynamicStride

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -766,6 +766,7 @@ struct ComputePipelineBuildInfo {
 #endif
   PipelineOptions options; ///< Per pipeline tuning options
   bool unlinked;           ///< True to build an "unlinked" half-pipeline ELF
+  bool dynamicVertexStride; ///< Dynamic Vertex input Stride is enabled.
 };
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -720,7 +720,8 @@ void PipelineContext::setVertexInputDescriptions(Pipeline *pipeline) const {
           attrib->location,
           attrib->binding,
           attrib->offset,
-          binding->stride,
+          (static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->dynamicVertexStride ?
+          0 : binding->stride),
           dfmt,
           nfmt,
           binding->inputRate,

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -839,6 +839,8 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
       dumpFile << "divisor[" << i << "].divisor = " << divisor->divisor << "\n";
     }
   }
+
+  dumpFile << "dynamicVertexStride = " << pipelineInfo->dynamicVertexStride << "\n";
 }
 
 // =====================================================================================================================
@@ -1030,6 +1032,8 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     auto rsState = &pipeline->rsState;
     hasher->Update(rsState->rasterizerDiscardEnable);
   }
+
+  hasher->Update(pipeline->dynamicVertexStride);
 
   bool passthroughMode = !nggState->enableVertexReuse && !nggState->enableBackfaceCulling &&
                          !nggState->enableFrustumCulling && !nggState->enableBoxFilterCulling &&

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -521,6 +521,8 @@ struct GraphicsPipelineState {
   Vkgc::NggState nggState; // NGG state
 
   ColorBuffer colorBuffer[Vkgc::MaxColorTargets]; // Color target state.
+
+  bool dynamicVertexStride; // Dynamic Vertex input Stride is enabled
 };
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -465,6 +465,7 @@ public:
     INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_nggState, MemberTypeNggState, true);
     INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, m_colorBuffer, MemberTypeColorBufferItem,
                                    Vkgc::MaxColorTargets, true);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
@@ -479,7 +480,7 @@ public:
 
 private:
   SectionNggState m_nggState;
-  static const unsigned MemberCount = 24;
+  static const unsigned MemberCount = 25;
   static StrToMemberAddr m_addrTable[MemberCount];
   SubState m_state;
   SectionColorBuffer m_colorBuffer[Vkgc::MaxColorTargets]; // Color buffer


### PR DESCRIPTION
If the vertex offset is greater than vertex stride, we have to adjust both vertex index and offset
accordingly. Otherwise, vertex fetch might behave unexpectedly. It cannot be applied to DynamicVertexStride.
Setting stride to 0 disallow for that adjustment.