### PR TITLE
Remove adjusting vertex offset for DynamicStride

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 46
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -71,6 +71,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     46.1 | Added dynamicVertexStride to GraphicsPipelineBuildInfo                                                |
 //  |     46.0 | Removed the member 'depthBiasEnable' of rsState                                                       |
 //  |     45.4 | Added disableLicmThreshold, unrollHintThreshold, and dontUnrollHintThreshold to PipelineShaderOptions |
 //  |     45.3 | Add pipelinedump function to enable BeginPipelineDump and GetPipelineName                             |
@@ -736,9 +737,7 @@ struct GraphicsPipelineBuildInfo {
     VkPolygonMode polygonMode;    ///< Triangle rendering mode
     VkCullModeFlags cullMode;     ///< Fragment culling mode
     VkFrontFace frontFace;        ///< Front-facing triangle orientation
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     bool depthBiasEnable;         ///< Whether to bias fragment depth values
-#endif
   } rsState;                      ///< Rasterizer State
 
   struct {
@@ -748,9 +747,10 @@ struct GraphicsPipelineBuildInfo {
     ColorTarget target[MaxColorTargets]; ///< Per-MRT color target info
   } cbState;                             ///< Color target state
 
-  NggState nggState;       ///< NGG state used for tuning and debugging
-  PipelineOptions options; ///< Per pipeline tuning/debugging options
-  bool unlinked;           ///< True to build an "unlinked" half-pipeline ELF
+  NggState nggState;        ///< NGG state used for tuning and debugging
+  PipelineOptions options;  ///< Per pipeline tuning/debugging options
+  bool unlinked;            ///< True to build an "unlinked" half-pipeline ELF
+  bool dynamicVertexStride; ///< Dynamic Vertex input Stride is enabled.
 };
 
 /// Represents info to build a compute pipeline.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -722,7 +722,9 @@ void PipelineContext::setVertexInputDescriptions(Pipeline *pipeline) const {
           attrib->location,
           attrib->binding,
           attrib->offset,
-          binding->stride,
+          (static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->dynamicVertexStride
+               ? 0
+               : binding->stride),
           dfmt,
           nfmt,
           binding->inputRate,

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -841,6 +841,8 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
       dumpFile << "divisor[" << i << "].divisor = " << divisor->divisor << "\n";
     }
   }
+
+  dumpFile << "dynamicVertexStride = " << pipelineInfo->dynamicVertexStride << "\n";
 }
 
 // =====================================================================================================================
@@ -1032,6 +1034,8 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     auto rsState = &pipeline->rsState;
     hasher->Update(rsState->rasterizerDiscardEnable);
   }
+
+  hasher->Update(pipeline->dynamicVertexStride);
 
   bool passthroughMode = !nggState->enableVertexReuse && !nggState->enableBackfaceCulling &&
                          !nggState->enableFrustumCulling && !nggState->enableBoxFilterCulling &&

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -525,6 +525,8 @@ struct GraphicsPipelineState {
   Vkgc::NggState nggState; // NGG state
 
   ColorBuffer colorBuffer[Vkgc::MaxColorTargets]; // Color target state.
+
+  bool dynamicVertexStride; // Dynamic Vertex input Stride is enabled
 };
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -467,6 +467,7 @@ public:
     INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_nggState, MemberTypeNggState, true);
     INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, m_colorBuffer, MemberTypeColorBufferItem,
                                    Vkgc::MaxColorTargets, true);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
@@ -481,7 +482,7 @@ public:
 
 private:
   SectionNggState m_nggState;
-  static const unsigned MemberCount = 24;
+  static const unsigned MemberCount = 25;
   static StrToMemberAddr m_addrTable[MemberCount];
   SubState m_state;
   SectionColorBuffer m_colorBuffer[Vkgc::MaxColorTargets]; // Color buffer


### PR DESCRIPTION
If the vertex offset is greater than vertex stride, we have to adjust both vertex index and offset
accordingly. Otherwise, vertex fetch might behave unexpectedly. It cannot be applied to DynamicVertexStride.
Setting stride to 0 disallow for that adjustment.