### PR TITLE
Delete depthbiasEnable

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -44,10 +44,10 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 45
+#define LLPC_INTERFACE_MAJOR_VERSION 46
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 4
+#define LLPC_INTERFACE_MINOR_VERSION 0
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -71,8 +71,9 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     46.0 | Removed the member 'depthBiasEnable' of rsState                                                       |
 //  |     45.4 | Added disableLicmThreshold, unrollHintThreshold, and dontUnrollHintThreshold to PipelineShaderOptions |
-//  |     45.3 | Add pipelinedump function to enable BeginPipelineDump and GetPipelineName                             |                                                               |
+//  |     45.3 | Add pipelinedump function to enable BeginPipelineDump and GetPipelineName                             |
 //  |     45.2 | Add GFX IP plus checker to GfxIpVersion                                                               |
 //  |     45.1 | Add pipelineCacheAccess, stageCacheAccess(es) to GraphicsPipelineBuildOut/ComputePipelineBuildOut     |
 //  |     45.0 | Remove the member 'enableFastLaunch' of NGG state                                                     |
@@ -735,7 +736,9 @@ struct GraphicsPipelineBuildInfo {
     VkPolygonMode polygonMode;    ///< Triangle rendering mode
     VkCullModeFlags cullMode;     ///< Fragment culling mode
     VkFrontFace frontFace;        ///< Front-facing triangle orientation
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     bool depthBiasEnable;         ///< Whether to bias fragment depth values
+#endif
   } rsState;                      ///< Rasterizer State
 
   struct {

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -414,7 +414,9 @@ struct RasterizerState {
   PolygonMode polygonMode;          // Polygon mode
   CullModeFlags cullMode;           // Fragment culling mode
   unsigned frontFaceClockwise;      // Front-facing triangle orientation: false=counter, true=clockwise
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
   unsigned depthBiasEnable;         // Whether to bias fragment depth values
+#endif
 };
 
 // =====================================================================================================================

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -417,8 +417,10 @@ void PatchResourceCollect::buildNggCullingControlRegister(NggControl &nggControl
   PaSuScModeCntl paSuScModeCntl;
   paSuScModeCntl.u32All = 0;
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
   paSuScModeCntl.bits.polyOffsetFrontEnable = rsState.depthBiasEnable;
   paSuScModeCntl.bits.polyOffsetBackEnable = rsState.depthBiasEnable;
+#endif
   paSuScModeCntl.bits.multiPrimIbEna = true;
 
   paSuScModeCntl.bits.polyMode = rsState.polygonMode != PolygonModeFill;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -655,7 +655,9 @@ void PipelineContext::setGraphicsStateInPipeline(Pipeline *pipeline) const {
   rasterizerState.polygonMode = static_cast<PolygonMode>(inputRsState.polygonMode);
   rasterizerState.cullMode = static_cast<CullModeFlags>(inputRsState.cullMode);
   rasterizerState.frontFaceClockwise = inputRsState.frontFace != VK_FRONT_FACE_COUNTER_CLOCKWISE;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
   rasterizerState.depthBiasEnable = inputRsState.depthBiasEnable;
+#endif
 
   pipeline->setGraphicsState(inputAssemblyState, viewportState, rasterizerState);
 }

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -770,7 +770,9 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
   dumpFile << "polygonMode = " << pipelineInfo->rsState.polygonMode << "\n";
   dumpFile << "cullMode = " << static_cast<VkCullModeFlagBits>(pipelineInfo->rsState.cullMode) << "\n";
   dumpFile << "frontFace = " << pipelineInfo->rsState.frontFace << "\n";
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
   dumpFile << "depthBiasEnable = " << pipelineInfo->rsState.depthBiasEnable << "\n";
+#endif
   dumpFile << "alphaToCoverageEnable = " << pipelineInfo->cbState.alphaToCoverageEnable << "\n";
   dumpFile << "dualSourceBlendEnable = " << pipelineInfo->cbState.dualSourceBlendEnable << "\n";
 
@@ -1045,7 +1047,9 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
     hasher->Update(rsState->polygonMode);
     hasher->Update(rsState->cullMode);
     hasher->Update(rsState->frontFace);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     hasher->Update(rsState->depthBiasEnable);
+#endif
   }
 
   if (isCacheHash) {

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -467,7 +467,9 @@ struct DrawState {
   VkPolygonMode polygonMode;                            // Triangle rendering mode
   VkCullModeFlags cullMode;                             // Fragment culling mode
   VkFrontFace frontFace;                                // Front-facing triangle orientation
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
   unsigned depthBiasEnable;                             // Whether to bias fragment depth values
+#endif
   unsigned patchControlPoints;                          // Patch control points
   IUFValue dispatch;                                    // Dispatch dimension
   unsigned width;                                       // Window width
@@ -502,7 +504,9 @@ struct GraphicsPipelineState {
   VkPolygonMode polygonMode;        // Triangle rendering mode
   VkCullModeFlags cullMode;         // Fragment culling mode
   VkFrontFace frontFace;            // Front-facing triangle orientation
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
   unsigned depthBiasEnable;         // Whether to bias fragment depth values
+#endif
   unsigned patchControlPoints;      // Patch control points
   unsigned deviceIndex;             // Device index for device group
   unsigned disableVertexReuse;      // Disable reusing vertex shader output for indexed draws

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -123,7 +123,9 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
     gfxPipelineInfo->rsState.polygonMode = graphicState.polygonMode;
     gfxPipelineInfo->rsState.cullMode = graphicState.cullMode;
     gfxPipelineInfo->rsState.frontFace = graphicState.frontFace;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     gfxPipelineInfo->rsState.depthBiasEnable = graphicState.depthBiasEnable != 0;
+#endif
 
     gfxPipelineInfo->cbState.alphaToCoverageEnable = graphicState.alphaToCoverageEnable != 0;
     gfxPipelineInfo->cbState.dualSourceBlendEnable = graphicState.dualSourceBlendEnable != 0;

--- a/tool/vfx/vfxRenderSection.h
+++ b/tool/vfx/vfxRenderSection.h
@@ -367,7 +367,9 @@ public:
     state.polygonMode = VK_POLYGON_MODE_FILL;
     state.cullMode = VK_CULL_MODE_NONE;
     state.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     state.depthBiasEnable = false;
+#endif
     state.width = 0;
     state.height = 0;
     state.lineWidth = 1.0f;
@@ -386,7 +388,9 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, polygonMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, cullMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, frontFace, MemberTypeEnum, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, depthBiasEnable, MemberTypeInt, false);
+#endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, patchControlPoints, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, dispatch, MemberTypeIVec4, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDrawState, width, MemberTypeInt, false);

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -447,7 +447,9 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, polygonMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, cullMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, frontFace, MemberTypeEnum, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, depthBiasEnable, MemberTypeInt, false);
+#endif
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, patchControlPoints, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, deviceIndex, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, disableVertexReuse, MemberTypeInt, false);


### PR DESCRIPTION
The member 'depthbiasEnable' of rsState will be deprecated, remove it to reduce the use of the register.