### PR TITLE
Refactor the store of tessellation factors

### DIFF
--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -173,10 +173,10 @@ private:
 
   llvm::Value *calcTessFactorOffset(bool isOuter, llvm::Value *elemIdx, llvm::Instruction *insertPos);
 
-  void storeTessFactorToBuffer(const llvm::SmallVectorImpl<llvm::Value *> &tessFactors, llvm::Value *tessFactorOffset,
+  void storeTessFactorToBuffer(llvm::ArrayRef<llvm::Value *> tessFactors, llvm::Value *tessFactorOffset,
                                llvm::Instruction *insertPos);
 
-  void createTessBufferStoreFunction(llvm::StringRef funcName, unsigned compCount);
+  void createTessBufferStoreFunction(llvm::StringRef funcName, unsigned compCount, llvm::Type *tfValueTy);
 
   unsigned calcPatchCountPerThreadGroup(unsigned inVertexCount, unsigned inVertexStride, unsigned outVertexCount,
                                         unsigned outVertexStride, unsigned patchConstCount,
@@ -211,6 +211,10 @@ private:
   void recordVertexAttribExport(unsigned location, llvm::ArrayRef<llvm::Value *> attribValues);
   void exportVertexAttribs(llvm::Instruction *insertPos);
 
+  void storeTessFactors();
+  void doTessFactorBufferStore(llvm::ArrayRef<llvm::Value *> outerTessFactors,
+                               llvm::ArrayRef<llvm::Value *> innerTessFactors, llvm::Instruction *insertPos);
+
   GfxIpVersion m_gfxIp;                     // Graphics IP version info
   PipelineSystemValues m_pipelineSysValues; // Cache of ShaderSystemValues objects, one per shader stage
 
@@ -242,6 +246,9 @@ private:
 
   std::set<unsigned> m_expLocs; // The locations that already have an export instruction for the vertex shader.
   const std::array<unsigned char, 4> *m_buffFormats; // The format of MTBUF instructions for specified GFX
+
+  llvm::SmallVector<llvm::Instruction *, 4> m_tessLevelOuterInsts; // Collect the instructions of TessLevelOuter
+  llvm::SmallVector<llvm::Instruction *, 2> m_tessLevelInnerInsts; // Collect the instructions of TessLevelInner
 };
 
 } // namespace lgc

--- a/llpc/test/shaderdb/PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe
+++ b/llpc/test/shaderdb/PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe
@@ -7,7 +7,7 @@
 ; SHADERTEST: Patch constant size: 0
 ; SHADERTEST: Patch constant total size: 0
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.raw.tbuffer.store.i32
+; SHADERTEST: call void @llvm.amdgcn.raw.tbuffer.store.f32
 ; SHADERTEST-NEXT: ret void
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST


### PR DESCRIPTION
This change is a preparation for some future functionalities. The
refactor is to collect all tessellation factors in
patchTcsBuiltInOutputExport and process them together.  The changes
include:
- Add two member data to hold the instructions
`lgc.output.export.builtin.TessLevel*` in patchTcsBuiltInOutputExport.
- Move the process of storing tessellaton factors in a new member
function `storeTessFactors()` which is called after `processFunction()`.
- Remove the useless bitcast from float to int as the data to be stored
in TF buffer.