### PR TITLE
lgc testing lit test check strings can no longer be unused

### DIFF
--- a/lgc/test/FetchShaderSingleInput.lgc
+++ b/lgc/test/FetchShaderSingleInput.lgc
@@ -4,8 +4,8 @@
 ; RUN: lgc -mcpu=gfx900 -extract=2 - <%s | FileCheck --check-prefixes=VS-ISA,VS-NOTNGG-ISA %s
 ; RUN: lgc -mcpu=gfx1010 -extract=2 - <%s | FileCheck --check-prefixes=VS-ISA,VS-NGG-ISA %s
 ; VS-ISA: .p2align 8
-; VS-ISA-NOTNGG-LABEL: _amdgpu_vs_main_fetchless:
-; VS-ISA-NGG-LABEL: _amdgpu_gs_main_fetchless:
+; VS-NOTNGG-ISA-LABEL: _amdgpu_vs_main_fetchless:
+; VS-NGG-ISA-LABEL: _amdgpu_gs_main_fetchless:
 ; VS-ISA: exp pos0
 ; VS-ISA: s_endpgm
 ; VS-ISA: .vertexInputs:

--- a/lgc/test/ShaderStages.lgc
+++ b/lgc/test/ShaderStages.lgc
@@ -3,7 +3,8 @@
 
 ; RUN: lgc -extract=1 -print-after=lgc-patch-setup-target-features -mcpu=gfx900 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK1,CHECK-NO-NGG1 %s
 ; RUN: lgc -extract=1 -print-after=lgc-patch-setup-target-features -mcpu=gfx1010 %s -o /dev/null 2>&1 | FileCheck --check-prefixes=CHECK1,CHECK-NGG1 %s
-; CHECK1: define dllexport amdgpu_cs void @_amdgpu_cs_main{{.*}} !lgc.shaderstage !3 {
+; CHECK-NO-NGG1: define dllexport amdgpu_cs void @_amdgpu_cs_main{{.*}} !lgc.shaderstage !3 {
+; CHECK-NGG1: define dllexport amdgpu_cs void @_amdgpu_cs_main{{.*}} !lgc.shaderstage !3 {
 ; CHECK1: !3 = !{i32 5}
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !0 {


### PR DESCRIPTION
Changes to how lit testing works mean that you can't define check labels on the
RUN line and not use them in the test body.

Fix one malformed case and adjust another test to allow for different labels for
NGG