### PR TITLE
Remove peephole for icmp instructions

### DIFF
--- a/lgc/patch/PatchPeepholeOpt.h
+++ b/lgc/patch/PatchPeepholeOpt.h
@@ -62,7 +62,6 @@ public:
   void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override;
 
   void visitBitCast(llvm::BitCastInst &bitCast);
-  void visitICmp(llvm::ICmpInst &iCmp);
   void visitExtractElement(llvm::ExtractElementInst &extractElement);
   void visitPHINode(llvm::PHINode &phiNode);
   void visitIntToPtr(llvm::IntToPtrInst &intToPtr);


### PR DESCRIPTION
The peephole converts "icmp ugt %x, c" into "icmp ult %x, (c+1)" and
adjusts all the users, ostensibly because it "helps the loop analysis
passes detect more loops that can be trivially unrolled". But I can't
find any evidence that this still helps. Perhaps the LLVM loop analysis
passes have been improved since this was implemented.