### PR TITLE
Add the finalized 128-bit cache hash to the PAL metadata

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -94,6 +94,9 @@ namespace PipelineMetadataKey {
 static constexpr char Name[] = ".name";
 static constexpr char Type[] = ".type";
 static constexpr char InternalPipelineHash[] = ".internal_pipeline_hash";
+static constexpr char XglCacheInfo[] = ".xgl_cache_info";
+static constexpr char CacheHash128Bits[] = ".128_bit_cache_hash";
+static constexpr char LlpcVersion[] = ".llpc_version";
 static constexpr char Shaders[] = ".shaders";
 static constexpr char HardwareStages[] = ".hardware_stages";
 static constexpr char Registers[] = ".registers";

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -155,6 +155,9 @@ public:
   // Updates the PS register information that depends on the exports.
   void updateSpiShaderColFormat(llvm::ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled);
 
+  // Sets the finalized 128-bit cache hash.  The version identifies the version of LLPC used to generate the hash.
+  void setFinalized128BitCacheHash(const lgc::Hash128 &finalizedCacheHash, const llvm::VersionTuple &version);
+
 private:
   // Initialize the PalMetadata object after reading in already-existing PAL metadata if any
   void initialize();

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -154,6 +154,9 @@ public:
   void setGraphicsState(const InputAssemblyState &iaState, const ViewportState &vpState,
                         const RasterizerState &rsState) override final;
 
+  // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache for the given version of LLPC.
+  void set128BitCacheHash(const Hash128 &finalizedCacheHash, const llvm::VersionTuple &version) override final;
+
   // Link the individual shader IR modules into a single pipeline module
   llvm::Module *irLink(llvm::ArrayRef<llvm::Module *> modules, bool unlinked) override final;
 

--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -30,7 +30,13 @@
  */
 #pragma once
 
+#include <array>
+#include <cstdint>
+
 namespace lgc {
+
+// Type used to hold a 128-bit hash value in LGC and LLPC.
+using Hash128 = std::array<uint64_t, 2>;
 
 /// Enumerates LGC shader stages.
 enum ShaderStage : unsigned {

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -592,6 +592,9 @@ public:
   virtual void setGraphicsState(const InputAssemblyState &iaState, const ViewportState &vpState,
                                 const RasterizerState &rsState) = 0;
 
+  // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache for the given version of LLPC.
+  virtual void set128BitCacheHash(const Hash128 &finalizedCacheHash, const llvm::VersionTuple &version) = 0;
+
   // Set entire pipeline state from metadata in an IR module. This is used by the lgc command-line utility
   // for its link option.
   virtual void setStateFromModule(llvm::Module *module) = 0;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1007,6 +1007,16 @@ void PipelineState::setGraphicsState(const InputAssemblyState &iaState, const Vi
 }
 
 // =====================================================================================================================
+// Set the finalized 128-bit cache hash that is used to find this pipeline in the cache.
+//
+// @param finalizedCacheHash: The 128-bit hash value.
+// @param version: The version of LLPC used to compute the hash.  This will let other tools know if the hashs are
+//                 comparable.
+void PipelineState::set128BitCacheHash(const Hash128 &finalizedCacheHash, const VersionTuple &version) {
+  getPalMetadata()->setFinalized128BitCacheHash(finalizedCacheHash, version);
+}
+
+// =====================================================================================================================
 // Record device index into the IR metadata
 //
 // @param [in/out] module : IR module to record into

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -38,6 +38,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/VersionTuple.h"
 
 #define DEBUG_TYPE "llpc-pipeline-context"
 
@@ -224,6 +225,8 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, bool unlinked) const 
       lgcStageMask |= 1 << getLgcShaderStage(static_cast<ShaderStage>(stage));
   }
   pipeline->setShaderStageMask(lgcStageMask);
+  pipeline->set128BitCacheHash(get128BitCacheHashCode(),
+                               VersionTuple(LLPC_INTERFACE_MAJOR_VERSION, LLPC_INTERFACE_MINOR_VERSION));
 
   // Give the pipeline options to the middle-end.
   setOptionsInPipeline(pipeline);

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -126,11 +126,11 @@ public:
   uint64_t get64BitCacheHashCode() const { return MetroHash::compact64(&m_cacheHash); }
 
   // Gets the finalized 128-bit cache hash code.
-  std::array<uint8_t, 16> get128BitCacheHashCode() const {
-    std::array<uint8_t, 16> finalizedCacheData = {};
+  lgc::Hash128 get128BitCacheHashCode() const {
+    lgc::Hash128 finalizedCacheData = {};
     Util::MetroHash128 hash128 = {};
     hash128.Update(m_cacheHash);
-    hash128.Finalize(finalizedCacheData.data());
+    hash128.Finalize(reinterpret_cast<uint8_t *>(finalizedCacheData.data()));
     return finalizedCacheData;
   }
 

--- a/llpc/test/shaderdb/relocatable_shaders/TriangleVs_CheckNoteSectionForCacheHash.spvasm
+++ b/llpc/test/shaderdb/relocatable_shaders/TriangleVs_CheckNoteSectionForCacheHash.spvasm
@@ -1,25 +1,16 @@
-; This test case checks that amdllpc with the `-add-hash-to-elf` option correctly
-; adds a note section to ELF, which contains the cache hash and the version of LLPC.
-
+; This test case checks that the 128-bit cache hash is correctly added to the PAL metadata.
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -gfxip=9 -unlinked -enable-relocatable-shader-elf -v -o %t.elf -add-hash-to-elf %s > %t.log \
-; RUN:   && llvm-readelf -a %t.elf >> %t.log \
-; RUN:   && cat %t.log | FileCheck --check-prefix=CHECK %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -gfxip=9 -unlinked -enable-relocatable-shader-elf -v -o %t.elf %s | FileCheck --check-prefix=CHECK %s
 
 ; CHECK-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
 ; CHECK-LABEL: Building pipeline with relocatable shader elf.
-; CHECK-NEXT:  LLPC version: [[llpc_version:([0-9a-f]{2} ?){8}]]{{$}}
-; CHECK:       Hash for vertex stage cache lookup: [[llpc_vert_hash:([a-f0-9]{2} ?){16}]]{{$}}
+; CHECK-NEXT:  LLPC version: [[llpc_version:([0-9]*\.[0-9]*)]]{{$}}
+; CHECK: {{^Finalized}} hash for vertex stage cache lookup: 0x[[#%.16x,llpc_vert_hash_qword1:]] 0x[[#%.16x,llpc_vert_hash_qword2:]]
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 
+; CHECK:       128_bit_cache_hash: [ 0x[[#%.16X,llpc_vert_hash_qword1]] 0x[[#%.16X,llpc_vert_hash_qword2]]
+; CHECK-NEXT:  .llpc_version: [[llpc_version]]
 ; CHECK-LABEL: {{^=====}}  AMDLLPC SUCCESS  =====
-
-; CHECK-LABEL: {{^Displaying}} notes found in: .note
-; CHECK-NEXT:  Owner Data size Description
-; CHECK-LABEL: {{^ +AMD_llpc_cache_hash *}} 0x00000010 Unknown note type: (0x00000000)
-; CHECK-NEXT:  description data: [[llpc_vert_hash]]{{$}}
-; CHECK-LABEL: {{^ +AMD_llpc_version *}} 0x00000008	Unknown note type: (0x00000000)
-; CHECK-NEXT:  description data: [[llpc_version]]{{$}}
 ; END_SHADERTEST
 
 ; SPIR-V


### PR DESCRIPTION
This adds the 128-bit cache hash to the PAL metadata.  This will be used by the XGL cache creator.  The ELF note that contains the same data will be removed in a later PR.

This is build on top of #1166 
