### PR TITLE
Use updated api of CloneFunctionInto

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -2885,7 +2885,11 @@ void NggPrimShader::splitEs(Module *module) {
     valueMap[&arg] = newArg++;
 
   SmallVector<ReturnInst *, 8> retInsts;
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 379998
   CloneFunctionInto(esCullDataFetchFunc, esEntryPoint, valueMap, false, retInsts);
+#else
+  CloneFunctionInto(esCullDataFetchFunc, esEntryPoint, valueMap, CloneFunctionChangeType::LocalChangesOnly, retInsts);
+#endif
   esCullDataFetchFunc->setName(lgcName::NggEsCullDataFetch);
 
   // Find the return block, remove all exports, and mutate return type


### PR DESCRIPTION
In upstream LLVM 22a52dfddcefad4f275eb8ad1cc0e200074c2d8a
they changed the visibility of changes from a bool to an enum.