### PR TITLE
Mark calls for generic.input and generic.output as WillReturn.

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1914,6 +1914,8 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::ReadGenericOutput:
       // Functions that only read memory.
       func->addFnAttr(Attribute::ReadOnly);
+      // Must be marked as returning for DCE.
+      func->addFnAttr(Attribute::WillReturn);
       break;
     case Opcode::ImageStore:
       // Functions that only write memory.

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -182,7 +182,7 @@ Value *InOutBuilder::readGenericInputOutput(bool isOutput, Type *resultTy, unsig
 
   std::string callName(baseCallName);
   addTypeMangling(resultTy, args, callName);
-  Value *result = emitCall(callName, resultTy, args, Attribute::ReadOnly, &*GetInsertPoint());
+  Value *result = emitCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn}, &*GetInsertPoint());
 
   result->setName(instName);
   return result;
@@ -741,7 +741,7 @@ Value *InOutBuilder::readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo i
   std::string callName = isOutput ? lgcName::OutputImportBuiltIn : lgcName::InputImportBuiltIn;
   callName += PipelineState::getBuiltInName(builtIn);
   addTypeMangling(resultTy, args, callName);
-  Value *result = emitCall(callName, resultTy, args, Attribute::ReadOnly, &*GetInsertPoint());
+  Value *result = emitCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn}, &*GetInsertPoint());
 
   if (instName.isTriviallyEmpty())
     result->setName(PipelineState::getBuiltInName(builtIn));


### PR DESCRIPTION
Upstream LLVM now will not DCE calls which are not marked with
WillReturn.  There seems to be some assumption that unused inputs
will be removed by DCE.
Without these changes there is an exposion in LDS usage.