### PR TITLE
Remove PackInOut llvm option

### DIFF
--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -101,7 +101,6 @@ bool BuilderReplayer::runOnModule(Module &module) {
   // Set up the pipeline state from the specified linked IR module.
   PipelineState *pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
   pipelineState->readState(&module);
-  pipelineState->initializePackInOut();
 
   // Create the BuilderImpl to replay into, passing it the PipelineState
   LgcContext *builderContext = pipelineState->getLgcContext();

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -576,7 +576,7 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
     xfbOutInfo.xfbExtraOffset = 0;
 
     // For packed generic GS output, the XFB output should be scalarized to align with the scalarized GS output
-    if (getPipelineState()->canPackInOut() && !isBuiltIn) {
+    if (!getPipelineState()->isUnlinked() && !isBuiltIn) {
       Type *elementTy = valueToWrite->getType();
       unsigned scalarizeBy = 1;
       if (auto vectorTy = dyn_cast<FixedVectorType>(elementTy)) {

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -257,15 +257,6 @@ public:
   // ring is on-chip.
   bool isGsOnChip() const { return m_gsOnChip; }
 
-  // Initialize the state of input/output packing
-  void initializePackInOut();
-
-  // Set the state of input/output packing
-  void setPackInOut(bool isPack) { m_packInOut = isPack; }
-
-  // Check whether input/output packing can be used
-  bool canPackInOut() const { return m_packInOut; }
-
   // Gets wave size for the specified shader stage
   unsigned getShaderWaveSize(ShaderStage stage);
 
@@ -427,7 +418,6 @@ private:
   // Cached MDString for each resource node type
 
   bool m_gsOnChip = false;                                                     // Whether to use GS on-chip mode
-  bool m_packInOut = false;                                                    // Whether to use packing on input/output
   NggControl m_nggControl = {};                                                // NGG control settings
   ShaderModes m_shaderModes;                                                   // Shader modes for this pipeline
   unsigned m_deviceIndex = 0;                                                  // Device index

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -287,7 +287,7 @@ bool PatchCopyShader::runOnModule(Module &module) {
 void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
   const auto &outputLocInfoMap = resUsage->inOutUsage.outputLocInfoMap;
-  const bool isPack = m_pipelineState->canPackInOut();
+  const bool isPack = !m_pipelineState->isUnlinked();
   std::set<InOutLocationInfo> visitedLocInfos;
 
   // Collect the byte sizes of the output value at each mapped location
@@ -366,7 +366,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
 
   if (resUsage->inOutUsage.enableXfb) {
     // Export XFB output
-    if (m_pipelineState->canPackInOut()) {
+    if (!m_pipelineState->isUnlinked()) {
       // With packing locations, we should collect the XFB output value at an origianl location
       DenseMap<unsigned, SmallVector<Value *, 4>> origLocElemsMap;
       for (const auto &locInfoXfbInfoPair : locInfoXfbOutInfoMap) {

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -577,7 +577,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
             loc = resUsage->inOutUsage.perPatchInputLocMap[value];
           }
         } else {
-          if (m_pipelineState->canPackInOut() &&
+          if (!m_pipelineState->isUnlinked() &&
               (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl ||
                m_shaderStage == ShaderStageGeometry)) {
             // The inputLocInfoMap of {TCS, GS, FS} maps original InOutLocationInfo to tightly compact InOutLocationInfo
@@ -881,7 +881,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         exist = true;
         loc = value;
       } else {
-        if (m_pipelineState->canPackInOut()) {
+        if (!m_pipelineState->isUnlinked()) {
           const bool isVs = (m_shaderStage == ShaderStageVertex);
           const bool isGs = (m_shaderStage == ShaderStageGeometry);
           assert(isVs || isGs || m_shaderStage == ShaderStageTessEval);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -80,7 +80,7 @@ bool PatchResourceCollect::runOnModule(Module &module) {
   m_pipelineShaders = &getAnalysis<PipelineShaders>();
   m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
 
-  if (m_pipelineState->canPackInOut()) {
+  if (!m_pipelineState->isUnlinked()) {
     m_locationInfoMapManager = std::make_unique<InOutLocationInfoMapManager>();
     // Supported packing input and ouput
     m_inOutPackStates[ShaderStageFragment][0] = true;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -48,8 +48,6 @@ using namespace llvm;
 // -enable-tess-offchip: enable tessellation off-chip mode
 static cl::opt<bool> EnableTessOffChip("enable-tess-offchip", cl::desc("Enable tessellation off-chip mode"),
                                        cl::init(false));
-// -pack-in-out: pack input/output
-static cl::opt<bool> PackInOut("pack-in-out", cl::desc("Pack input/output"), cl::init(true));
 
 // Names for named metadata nodes when storing and reading back pipeline state
 static const char UnlinkedMetadataName[] = "lgc.unlinked";
@@ -1047,15 +1045,6 @@ void PipelineState::readGraphicsState(Module *module) {
 bool PipelineState::isTessOffChip() {
   // For GFX9+, always enable tessellation off-chip mode
   return EnableTessOffChip || getLgcContext()->getTargetInfo().getGfxIpVersion().major >= 9;
-}
-
-// =====================================================================================================================
-// Initialize the state of input/output packing
-void PipelineState::initializePackInOut() {
-  // Pack input/output requirements:
-  // 1) -pack-in-out option is on
-  // 2) It is a linked pipeline
-  m_packInOut = PackInOut && !m_unlinked;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The pack input/output code has stably run for a period of time. The "-pack-in-out" option isn't necessary and can be removed.