### PR TITLE
NGG GS: Fix an issue of uninitialized global table

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -186,7 +186,7 @@ private:
 
   llvm::Function *mutateGs(llvm::Module *module);
 
-  void runCopyShader(llvm::Module *module);
+  void runCopyShader(llvm::Module *module, llvm::Argument *sysValueStart);
 
   llvm::Function *mutateCopyShader(llvm::Module *module);
 


### PR DESCRIPTION
We don't initialize global table for copy shader. We juts initialized
vertex offset. However, global table will be used in some cases. These
cases, such as stream-out, are not taken into account.

Change-Id: I78e095a9ebf62a390d5dd5658e45826ed30373bd