### PR TITLE
Updates to handle llvm flag day change to CreateAtomicCmpXchg

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -346,8 +346,15 @@ void NggLdsManager::atomicOpWithLds(AtomicRMWInst::BinOp atomicOp, Value *atomic
 
   Value *atomicPtr = m_builder->CreateGEP(m_lds, {m_builder->getInt32(0), ldsOffset});
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+  // Old version of the code
   auto atomicInst = m_builder->CreateAtomicRMW(atomicOp, atomicPtr, atomicValue, AtomicOrdering::SequentiallyConsistent,
                                                SyncScope::System);
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  auto atomicInst = m_builder->CreateAtomicRMW(atomicOp, atomicPtr, atomicValue, MaybeAlign(),
+                                               AtomicOrdering::SequentiallyConsistent, SyncScope::System);
+#endif
   atomicInst->setVolatile(true);
 }
 

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -175,8 +175,15 @@ void PatchBufferOp::visitAtomicCmpXchgInst(AtomicCmpXchgInst &atomicCmpXchgInst)
 
     Value *const compareValue = atomicCmpXchgInst.getCompareOperand();
     Value *const newValue = atomicCmpXchgInst.getNewValOperand();
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+    // Old version of the code
     AtomicCmpXchgInst *const newAtomicCmpXchg =
         m_builder->CreateAtomicCmpXchg(atomicPointer, compareValue, newValue, successOrdering, failureOrdering);
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    AtomicCmpXchgInst *const newAtomicCmpXchg = m_builder->CreateAtomicCmpXchg(
+        atomicPointer, compareValue, newValue, MaybeAlign(), successOrdering, failureOrdering);
+#endif
     newAtomicCmpXchg->setVolatile(atomicCmpXchgInst.isVolatile());
     newAtomicCmpXchg->setSyncScopeID(atomicCmpXchgInst.getSyncScopeID());
     newAtomicCmpXchg->setWeak(atomicCmpXchgInst.isWeak());
@@ -275,8 +282,16 @@ void PatchBufferOp::visitAtomicRMWInst(AtomicRMWInst &atomicRmwInst) {
 
     atomicPointer = m_builder->CreateBitCast(atomicPointer, storeType->getPointerTo(ADDR_SPACE_GLOBAL));
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+    // Old version of the code
     AtomicRMWInst *const newAtomicRmw = m_builder->CreateAtomicRMW(
         atomicRmwInst.getOperation(), atomicPointer, atomicRmwInst.getValOperand(), atomicRmwInst.getOrdering());
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    AtomicRMWInst *const newAtomicRmw =
+        m_builder->CreateAtomicRMW(atomicRmwInst.getOperation(), atomicPointer, atomicRmwInst.getValOperand(),
+                                   atomicRmwInst.getAlign(), atomicRmwInst.getOrdering());
+#endif
     newAtomicRmw->setVolatile(atomicRmwInst.isVolatile());
     newAtomicRmw->setSyncScopeID(atomicRmwInst.getSyncScopeID());
     copyMetadata(newAtomicRmw, &atomicRmwInst);


### PR DESCRIPTION
Usual guards for old/new versions to be removed once everything has propagated.