### PR TITLE
Fix LLVM_MAIN_REVISION to a correct value for flag day change in PR#1177

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -346,7 +346,7 @@ void NggLdsManager::atomicOpWithLds(AtomicRMWInst::BinOp atomicOp, Value *atomic
 
   Value *atomicPtr = m_builder->CreateGEP(m_lds, {m_builder->getInt32(0), ldsOffset});
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
   // Old version of the code
   auto atomicInst = m_builder->CreateAtomicRMW(atomicOp, atomicPtr, atomicValue, AtomicOrdering::SequentiallyConsistent,
                                                SyncScope::System);

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -175,7 +175,7 @@ void PatchBufferOp::visitAtomicCmpXchgInst(AtomicCmpXchgInst &atomicCmpXchgInst)
 
     Value *const compareValue = atomicCmpXchgInst.getCompareOperand();
     Value *const newValue = atomicCmpXchgInst.getNewValOperand();
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
     // Old version of the code
     AtomicCmpXchgInst *const newAtomicCmpXchg =
         m_builder->CreateAtomicCmpXchg(atomicPointer, compareValue, newValue, successOrdering, failureOrdering);
@@ -282,7 +282,7 @@ void PatchBufferOp::visitAtomicRMWInst(AtomicRMWInst &atomicRmwInst) {
 
     atomicPointer = m_builder->CreateBitCast(atomicPointer, storeType->getPointerTo(ADDR_SPACE_GLOBAL));
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
     // Old version of the code
     AtomicRMWInst *const newAtomicRmw = m_builder->CreateAtomicRMW(
         atomicRmwInst.getOperation(), atomicPointer, atomicRmwInst.getValOperand(), atomicRmwInst.getOrdering());

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1778,7 +1778,7 @@ Value *SPIRVToLLVM::transAtomicRMW(SPIRVValue *const spvValue, const AtomicRMWIn
   Value *const atomicValue = transValue(spvAtomicInst->getOpValue(3), getBuilder()->GetInsertBlock()->getParent(),
                                         getBuilder()->GetInsertBlock());
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
   // Old version of the code
   return getBuilder()->CreateAtomicRMW(binOp, atomicPointer, atomicValue, ordering, scope);
 #else
@@ -1996,7 +1996,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpAtomicIIncrement>(SPIRVVa
 
   Value *const one = ConstantInt::get(atomicPointer->getType()->getPointerElementType(), 1);
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
   // Old version of the code
   return getBuilder()->CreateAtomicRMW(AtomicRMWInst::Add, atomicPointer, one, ordering, scope);
 #else
@@ -2026,7 +2026,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpAtomicIDecrement>(SPIRVVa
 
   Value *const one = ConstantInt::get(atomicPointer->getType()->getPointerElementType(), 1);
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
   // Old version of the code
   return getBuilder()->CreateAtomicRMW(AtomicRMWInst::Sub, atomicPointer, one, ordering, scope);
 #else
@@ -2060,7 +2060,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpAtomicCompareExchange>(SP
   Value *const compareValue = transValue(spvAtomicInst->getOpValue(5), getBuilder()->GetInsertBlock()->getParent(),
                                          getBuilder()->GetInsertBlock());
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 383129
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
   // Old version of the code
   AtomicCmpXchgInst *const atomicCmpXchg = getBuilder()->CreateAtomicCmpXchg(atomicPointer, compareValue, exchangeValue,
                                                                              successOrdering, failureOrdering, scope);


### PR DESCRIPTION
The LLVM_MAIN_REVISION was calculated incorrectly in the previous change

Confirmed this builds with both versions of LLVM (pre and post change), as well as verifying that next merge has the correct revision number.