### PR TITLE
[CI] Free up disk space

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -21,6 +21,12 @@ jobs:
         feature-set:    ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
         generator:      [Ninja]
     steps:
+      - name: Free up disk space
+        if: contains(matrix.feature-set, '+sanitizers')
+        run: |
+          echo 'Before:' && df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc
+          echo 'After:' && df -h
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -20,6 +20,12 @@ jobs:
         assertions:          ["OFF", "ON"]
         feature-set:         ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
     steps:
+      - name: Free up disk space
+        if: contains(matrix.feature-set, '+sanitizers')
+        run: |
+          echo 'Before:' && df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc
+          echo 'After:' && df -h
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .


### PR DESCRIPTION
Remove unnecessary frameworks in sanitizer builds.
This reclaims about 36GB of disk space. It's possible to reclaim more
by removing unused docker images, but this would consume extra runtime.

Sample run: https://github.com/kuhar/llpc/runs/2007250785?check_suite_focus=true.

This is based on a hack from `gfbuild-amber` by @paulthomson.

Issue: https://github.com/GPUOpen-Drivers/llpc/issues/1179.