### PR TITLE
Refactor for adjusting wave size heuristically

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -142,6 +142,7 @@ target_sources(LLVMlgc PRIVATE
     patch/ShaderMerger.cpp
     patch/SystemValues.cpp
     patch/VertexFetch.cpp
+    patch/PatchWaveSizeAdjust.cpp
 )
 
 # lgc/state

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -61,6 +61,7 @@ void initializePatchResourceCollectPass(PassRegistry &);
 void initializePatchSetupTargetFeaturesPass(PassRegistry &);
 void initializePatchWorkaroundsPass(PassRegistry &);
 void initializePatchReadFirstLanePass(PassRegistry &);
+void initializePatchWaveSizeAdjustPass(PassRegistry &);
 
 } // namespace llvm
 
@@ -89,6 +90,7 @@ inline static void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializePatchSetupTargetFeaturesPass(passRegistry);
   initializePatchWorkaroundsPass(passRegistry);
   initializePatchReadFirstLanePass(passRegistry);
+  initializePatchWaveSizeAdjustPass(passRegistry);
 }
 
 llvm::ModulePass *createLowerFragColorExport();
@@ -108,6 +110,7 @@ llvm::ModulePass *createPatchResourceCollect();
 llvm::ModulePass *createPatchSetupTargetFeatures();
 llvm::ModulePass *createPatchWorkarounds();
 llvm::FunctionPass *createPatchReadFirstLane();
+llvm::ModulePass *createPatchWaveSizeAdjust();
 
 class PipelineState;
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -263,6 +263,9 @@ public:
   // Gets wave size for the specified shader stage
   unsigned getShaderWaveSize(ShaderStage stage);
 
+  // Set the default wave size for the specified shader stage
+  void setShaderDefaultWaveSize(ShaderStage stage);
+
   // Get NGG control settings
   NggControl *getNggControl() { return &m_nggControl; }
 
@@ -433,6 +436,7 @@ private:
   std::unique_ptr<ResourceUsage> m_resourceUsage[ShaderStageCompute + 1] = {}; // Per-shader ResourceUsage
   std::unique_ptr<InterfaceData> m_interfaceData[ShaderStageCompute + 1] = {}; // Per-shader InterfaceData
   PalMetadata *m_palMetadata = nullptr;                                        // PAL metadata object
+  unsigned m_waveSize[ShaderStageCountInternal] = {};                          // Per-shader wave size
 };
 
 // =====================================================================================================================

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -111,6 +111,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Patch resource collecting, remove inactive resources (should be the first preliminary pass)
   passMgr.add(createPatchResourceCollect());
 
+  // Patch wave size adjusting heuristic
+  passMgr.add(createPatchWaveSizeAdjust());
+
   // Patch workarounds
   passMgr.add(createPatchWorkarounds());
 

--- a/lgc/patch/PatchWaveSizeAdjust.cpp
+++ b/lgc/patch/PatchWaveSizeAdjust.cpp
@@ -1,0 +1,105 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchWaveSizeAdjust.cpp
+ * @brief LLPC source file: PatchWaveSizeAdjust pass
+ ***********************************************************************************************************************
+ */
+#include "lgc/patch/Patch.h"
+#include "lgc/state/PipelineShaders.h"
+#include "lgc/state/PipelineState.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "lgc-patch-wave-size-adjust"
+
+using namespace lgc;
+using namespace llvm;
+
+namespace {
+
+// =====================================================================================================================
+// Pass to adjust wave size per shader stage heuristically.
+class PatchWaveSizeAdjust final : public ModulePass {
+public:
+  PatchWaveSizeAdjust();
+
+  void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
+    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<PipelineStateWrapper>();
+    analysisUsage.setPreservesAll();
+  }
+
+  bool runOnModule(Module &module) override;
+
+  static char ID;
+
+private:
+  PatchWaveSizeAdjust(const PatchWaveSizeAdjust &) = delete;
+  PatchWaveSizeAdjust &operator=(const PatchWaveSizeAdjust &) = delete;
+};
+
+} // namespace
+
+char PatchWaveSizeAdjust::ID = 0;
+
+// =====================================================================================================================
+// Create PatchWaveSizeAdjust pass
+//
+// @param pipeline : Pipeline object
+ModulePass *lgc::createPatchWaveSizeAdjust() {
+  return new PatchWaveSizeAdjust();
+}
+
+// =====================================================================================================================
+// Constructor
+//
+// @param pipeline : Pipeline object
+PatchWaveSizeAdjust::PatchWaveSizeAdjust() : ModulePass(ID) {
+}
+
+// =====================================================================================================================
+// Run the PatchWaveSizeAdjust pass on a module
+//
+// @param module : Module to run this pass on
+bool PatchWaveSizeAdjust::runOnModule(Module &module) {
+  LLVM_DEBUG(dbgs() << "Running the pass of adjusting wave size heuristic\n");
+
+  auto pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  for (int stageIdx = 0; stageIdx < ShaderStageCount; ++stageIdx) {
+    ShaderStage shaderStage = static_cast<ShaderStage>(stageIdx);
+    if (pipelineState->hasShaderStage(shaderStage)) {
+      pipelineState->setShaderDefaultWaveSize(shaderStage);
+      if (shaderStage == ShaderStageGeometry)
+        pipelineState->setShaderDefaultWaveSize(ShaderStageCopyShader);
+    }
+  }
+  return false;
+}
+
+// =====================================================================================================================
+// Initializes the pass
+INITIALIZE_PASS(PatchWaveSizeAdjust, DEBUG_TYPE, "Patch LLVM for per-shader wave size adjustment", false, false)

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1070,51 +1070,62 @@ unsigned PipelineState::getShaderWaveSize(ShaderStage stage) {
   }
 
   assert(stage <= ShaderStageCompute);
+  if (!m_waveSize[stage])
+    setShaderDefaultWaveSize(stage);
+  return m_waveSize[stage];
+}
 
-  unsigned waveSize = getTargetInfo().getGpuProperty().waveSize;
-
-  if (getTargetInfo().getGfxIpVersion().major >= 10) {
-    // NOTE: GPU property wave size is used in shader, unless:
-    //  1) A stage-specific default is preferred.
-    //  2) If specified by tuning option, use the specified wave size.
-    //  3) If gl_SubgroupSize is used in shader, use the specified subgroup size when required.
-
-    if (stage == ShaderStageFragment) {
-      // Per programming guide, it's recommended to use wave64 for fragment shader.
-      waveSize = 64;
-    } else if (hasShaderStage(ShaderStageGeometry)) {
-      // Legacy (non-NGG) hardware path for GS does not support wave32.
-      waveSize = 64;
-    }
-
-    // Experimental data from performance tuning show that wave64 is more efficient than wave32 in most cases for CS
-    // on GFX10.3. Hence, set the wave size to wave64 by default.
-    if (getTargetInfo().getGfxIpVersion() >= GfxIpVersion({10, 3}) && stage == ShaderStageCompute)
-      waveSize = 64;
-
-    unsigned waveSizeOption = getShaderOptions(stage).waveSize;
-    if (waveSizeOption != 0)
-      waveSize = waveSizeOption;
-
-    if (stage == ShaderStageGeometry && !hasShaderStage(ShaderStageGeometry)) {
-      // NOTE: For NGG, GS could be absent and VS/TES acts as part of it in the merged shader.
-      // In such cases, we check the property of VS or TES.
-      if (hasShaderStage(ShaderStageTessEval))
-        return getShaderWaveSize(ShaderStageTessEval);
-      return getShaderWaveSize(ShaderStageVertex);
-    }
-
-    // If subgroup size is used in any shader in the pipeline, use the specified subgroup size as wave size.
-    if (getShaderModes()->getAnyUseSubgroupSize()) {
-      unsigned subgroupSize = getShaderOptions(stage).subgroupSize;
-      if (subgroupSize != 0)
-        waveSize = subgroupSize;
-    }
-
-    assert(waveSize == 32 || waveSize == 64);
+// =====================================================================================================================
+// Set the default wave size for the specified shader stage
+//
+// @param stage : Shader stage
+void PipelineState::setShaderDefaultWaveSize(ShaderStage stage) {
+  ShaderStage checkingStage = stage;
+  const bool isGfx10Plus = getTargetInfo().getGfxIpVersion().major >= 10;
+  if (isGfx10Plus && stage == ShaderStageGeometry && !hasShaderStage(ShaderStageGeometry)) {
+    // NOTE: For NGG, GS could be absent and VS/TES acts as part of it in the merged shader.
+    // In such cases, we check the property of VS or TES.
+    checkingStage = hasShaderStage(ShaderStageTessEval) ? ShaderStageTessEval : ShaderStageVertex;
   }
 
-  return waveSize;
+  if (!m_waveSize[checkingStage]) {
+    unsigned waveSize = getTargetInfo().getGpuProperty().waveSize;
+    if (isGfx10Plus) {
+      // NOTE: GPU property wave size is used in shader, unless:
+      //  1) A stage-specific default is preferred.
+      //  2) If specified by tuning option, use the specified wave size.
+      //  3) If gl_SubgroupSize is used in shader, use the specified subgroup size when required.
+
+      if (checkingStage == ShaderStageFragment) {
+        // Per programming guide, it's recommended to use wave64 for fragment shader.
+        waveSize = 64;
+      } else if (hasShaderStage(ShaderStageGeometry)) {
+        // Legacy (non-NGG) hardware path for GS does not support wave32.
+        waveSize = 64;
+      }
+
+      // Experimental data from performance tuning show that wave64 is more efficient than wave32 in most cases for CS
+      // on post-GFX10.3. Hence, set the wave size to wave64 by default.
+      if (getTargetInfo().getGfxIpVersion() >= GfxIpVersion({10, 3}) && stage == ShaderStageCompute)
+        waveSize = 64;
+
+      unsigned waveSizeOption = getShaderOptions(checkingStage).waveSize;
+      if (waveSizeOption != 0)
+        waveSize = waveSizeOption;
+
+      // If subgroup size is used in any shader in the pipeline, use the specified subgroup size as wave size.
+      if (getShaderModes()->getAnyUseSubgroupSize()) {
+        unsigned subgroupSize = getShaderOptions(checkingStage).subgroupSize;
+        if (subgroupSize != 0)
+          waveSize = subgroupSize;
+      }
+
+      assert(waveSize == 32 || waveSize == 64);
+    }
+    m_waveSize[checkingStage] = waveSize;
+  }
+  if (stage != checkingStage)
+    m_waveSize[stage] = m_waveSize[checkingStage];
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
In order to adjust wave size flexibly and adapt heuristic rules in
future, we need hold per-shader wave size somewhere and refactor the
code of setting and getting wave size. The change will includes:
-Add `PipelineState::m_waveSize[ShaderStageCountInternal]` to record
per-stage wave size.
-Move the logic of setting the default wave size from
`PipelineStage::getShaderWaveSize(ShaderStage)` to new added
`PipelineStage::setShaderDefaultWaveSize(ShaderStage)`.
-Refactor `PipelineStage::getShaderWaveSize(ShaderStage)` to return
valid `m_waveSize[stage]`.
-Add a WaveSizeAdjust module pass. Calling
`PipelineStage::getShaderWaveSize(ShaderStage)` for each stage.