### PR TITLE
Fix invalid test

### DIFF
--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_ISelAlignment.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_ISelAlignment.spvasm
@@ -43,6 +43,7 @@
         %459 = OpLabel
         %733 = OpVariable %732 Function %1038
         %461 = OpVariable %456 Function %460
+               OpSelectionMerge %475 None
                OpSwitch %1038 %463
         %463 = OpLabel
                OpBranch %475

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
@@ -34,6 +34,7 @@
                OpBranch %205
         %205 = OpLabel
         %279 = OpPhi %73 %76 %5 %76 %233
+               OpSelectionMerge %233 None
                OpSwitch %22 %242
         %242 = OpLabel
         %217 = OpAccessChain %23 %199 %279 %22

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpPhisAtLoopHeader.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpPhisAtLoopHeader.spvasm
@@ -38,6 +38,7 @@
           %4 = OpFunction %2 None %3
           %5 = OpLabel
          %55 = OpVariable %447 Function
+               OpSelectionMerge %43 None
                OpSwitch %28 %443
         %443 = OpLabel
                OpBranch %43


### PR DESCRIPTION
Spirv-tools started verifying that OpSwitch has a OpSelectionMerge
(https://github.com/KhronosGroup/SPIRV-Tools/commit/939bc02603933200da5e375cb33f3a381472861c).
If we want to be able to use LLPC with the latest spir-v tools, these
tests need to be updated.