### PR TITLE
Remove workaround in ArithBuilder::CreateSMod

### DIFF
--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -110,8 +110,6 @@ struct WorkaroundFlags {
 
   union {
     struct {
-      unsigned disableI32ModToI16Mod : 1;
-
       unsigned waTessFactorBufferSizeLimitGeUtcl1Underflow : 1;
       unsigned waTessIncorrectRelativeIndex : 1;
       unsigned waShaderInstPrefetch123 : 1;

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -293,7 +293,6 @@ static void setGfx10Info(TargetInfo *targetInfo) {
   targetInfo->getGpuProperty().supportSpiPrefPriority = true;
 
   // Hardware workarounds for GFX10 based GPU's:
-  targetInfo->getGpuWorkarounds().gfx10.disableI32ModToI16Mod = 1;
   targetInfo->getGpuWorkarounds().gfx10.waLimitedMaxOutputVertexCount = 1;
   targetInfo->getGpuWorkarounds().gfx10.waGeNggMaxVertOutWithGsInstancing = 1;
 }


### PR DESCRIPTION
The comments mention a backend bug relating to i16 mod, but I think it
must have been fixed because Vulkan CTS testing shows no failures on a
variety of different hardware.