### PR TITLE
Amend Unroll loop hint handling

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -151,7 +151,7 @@ void LgcContext::initialize() {
   setOptionDefault("filetype", "obj");
   setOptionDefault("amdgpu-unroll-max-block-to-analyze", "20");
   setOptionDefault("unroll-max-percent-threshold-boost", "1000");
-  setOptionDefault("pragma-unroll-threshold", "1000");
+  setOptionDefault("unroll-hint-threshold", "1800");
   setOptionDefault("unroll-allow-partial", "1");
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8


### PR DESCRIPTION
Added a default value of 1800 for -unroll-hint-threshold.
This will be used as the default loop threshold when unrolling loops with the SPIR-V Unroll hint. This value may be amended by the AMDGPU specific heuristics.
Removed the default value for -pragma-unroll-threshold as that is no longer required.