### PR TITLE
Amend Unroll loop hint handling

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -151,7 +151,6 @@ void LgcContext::initialize() {
   setOptionDefault("filetype", "obj");
   setOptionDefault("amdgpu-unroll-max-block-to-analyze", "20");
   setOptionDefault("unroll-max-percent-threshold-boost", "1000");
-  setOptionDefault("pragma-unroll-threshold", "1000");
   setOptionDefault("unroll-allow-partial", "1");
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -116,7 +116,7 @@ static cl::opt<int>
 // -unroll-hint-threshold: loop unroll threshold to use for loops with Unroll hint
 static cl::opt<int> UnrollHintThreshold("unroll-hint-threshold",
                                         cl::desc("loop unroll threshold to use for loops with Unroll hint"),
-                                        cl::init(0));
+                                        cl::init(1800));
 
 // -dontunroll-hint-threshold: loop unroll threshold to use for loops with DontUnroll hint
 static cl::opt<int> DontUnrollHintThreshold("dontunroll-hint-threshold",


### PR DESCRIPTION
Added a default value of 1800 for -unroll-hint-threshold.
This will be used as the default loop threshold when unrolling loops with the SPIR-V Unroll hint. This value may be amended by the AMDGPU specific heuristics.

Removed the default value for -pragma-unroll-threshold as that is no longer required.