### PR TITLE
Stop calling deprecated CreateLoad and CreateAlignedLoad methods

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -301,7 +301,7 @@ Value *NggLdsManager::readValueFromLds(Type *readTy, Value *ldsOffset, bool useD
   Value *readPtr = m_builder->CreateGEP(lds, ldsOffset);
   readPtr = m_builder->CreateBitCast(readPtr, PointerType::get(readTy, ADDR_SPACE_LOCAL));
 
-  return m_builder->CreateAlignedLoad(readPtr, Align(alignment));
+  return m_builder->CreateAlignedLoad(readTy, readPtr, Align(alignment));
 }
 
 // =====================================================================================================================

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3170,7 +3170,7 @@ Function *NggPrimShader::mutateGs(Module *module) {
         assert(streamId < MaxGsStreams);
         Value *output = call->getOperand(3);
 
-        auto emitVerts = m_builder->CreateLoad(emitVertsPtrs[streamId]);
+        auto emitVerts = m_builder->CreateLoad(m_builder->getInt32Ty(), emitVertsPtrs[streamId]);
         exportGsOutput(output, location, compIdx, streamId, threadIdInSubgroup, emitVerts);
 
         removeCalls.push_back(call);
@@ -3589,8 +3589,8 @@ Function *NggPrimShader::createGsEmitHandler(Module *module, unsigned streamId) 
   {
     m_builder->SetInsertPoint(entryBlock);
 
-    emitVerts = m_builder->CreateLoad(emitVertsPtr);
-    outVerts = m_builder->CreateLoad(outVertsPtr);
+    emitVerts = m_builder->CreateLoad(m_builder->getInt32Ty(), emitVertsPtr);
+    outVerts = m_builder->CreateLoad(m_builder->getInt32Ty(), outVertsPtr);
 
     // emitVerts++
     emitVerts = m_builder->CreateAdd(emitVerts, m_builder->getInt32(1));
@@ -5472,7 +5472,7 @@ Function *NggPrimShader::createFetchCullingRegister(Module *module) {
     auto loadPtr = m_builder->CreateGEP(primShaderTablePtr, {m_builder->getInt32(0), regOffset});
     cast<Instruction>(loadPtr)->setMetadata(MetaNameUniform, MDNode::get(m_builder->getContext(), {}));
 
-    auto regValue = m_builder->CreateAlignedLoad(loadPtr, Align(4));
+    auto regValue = m_builder->CreateAlignedLoad(m_builder->getInt32Ty(), loadPtr, Align(4));
     regValue->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(m_builder->getContext(), {}));
 
     m_builder->CreateRet(regValue);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -548,7 +548,7 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
     Value *loadPtr = builder.CreateGEP(m_lds, {builder.getInt32(0), ringOffset});
     loadPtr = builder.CreateBitCast(loadPtr, PointerType::get(loadTy, m_lds->getType()->getPointerAddressSpace()));
 
-    return builder.CreateAlignedLoad(loadPtr, m_lds->getAlign());
+    return builder.CreateAlignedLoad(loadTy, loadPtr, m_lds->getAlign());
   } else {
     assert(m_gsVsRingBufDesc);
 
@@ -601,12 +601,13 @@ Value *PatchCopyShader::loadGsVsRingBufferDescriptor(BuilderBase &builder) {
 
   auto gsVsRingBufDescPtr = builder.CreateAdd(internalTablePtr, builder.getInt64(SiDrvTableVsRingInOffs << 4));
 
-  auto int32x4PtrTy = PointerType::get(FixedVectorType::get(builder.getInt32Ty(), 4), ADDR_SPACE_CONST);
+  auto int32x4Ty = FixedVectorType::get(builder.getInt32Ty(), 4);
+  auto int32x4PtrTy = PointerType::get(int32x4Ty, ADDR_SPACE_CONST);
   gsVsRingBufDescPtr = builder.CreateIntToPtr(gsVsRingBufDescPtr, int32x4PtrTy);
   cast<Instruction>(gsVsRingBufDescPtr)
       ->setMetadata(MetaNameUniform, MDNode::get(gsVsRingBufDescPtr->getContext(), {}));
 
-  auto gsVsRingBufDesc = builder.CreateLoad(gsVsRingBufDescPtr);
+  auto gsVsRingBufDesc = builder.CreateLoad(int32x4Ty, gsVsRingBufDescPtr);
   gsVsRingBufDesc->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(gsVsRingBufDesc->getContext(), {}));
 
   return gsVsRingBufDesc;


### PR DESCRIPTION
LLVM has deprecated the the forms of these builder methods that do not
take an explicit load type. This fixes compiler warnings when building
with clang like:
PatchBufferOp.cpp:567:42: warning: 'CreateAlignedLoad' is deprecated: Use the version that explicitly specifies the loaded type instead [-Wdeprecated-declarations]