### PR TITLE
Fix the operand type of the atomic store instruction

### DIFF
--- a/llpc/test/shaderdb/ObjStorageBlock_TestMemoryQualifier_lit.frag
+++ b/llpc/test/shaderdb/ObjStorageBlock_TestMemoryQualifier_lit.frag
@@ -22,7 +22,7 @@ void main()
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{[0-9]*}} = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.{{[0-9a-z]*}}(i32 1, i32 0, i32 0,
-; SHADERTEST: %{{[0-9]*}} = load atomic <4 x float>, <4 x float> addrspace(7)* %{{[0-9]*}} unordered, align 16
+; SHADERTEST: %{{[0-9]*}} = load atomic float, float addrspace(7)* %{{[0-9]*}} unordered, align 4
 ; SHADERTEST: store atomic float %{{[0-9a-z.]*}}, float addrspace(7)* %{{[0-9]*}} unordered, align 4
 
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
In IR verification, Atomic store and load operand must be integer,pointer, or
floating point type. For vector type, we need to spilt the each compent.