### PR TITLE
Add a missing capability to TestInt64ImageAtomicStore

### DIFF
--- a/llpc/test/shaderdb/OpAtomicStore_TestInt64ImageAtomicStore.spvasm
+++ b/llpc/test/shaderdb/OpAtomicStore_TestInt64ImageAtomicStore.spvasm
@@ -13,6 +13,7 @@
 ; Schema: 0
                OpCapability Shader
                OpCapability Int64
+               OpCapability Int64Atomics
                OpCapability Int64ImageEXT
                OpExtension "SPV_EXT_shader_image_int64"
           %1 = OpExtInstImport "GLSL.std.450"


### PR DESCRIPTION
Fix validation failure with newer spirv-tools.