### PR TITLE
Fix amdllpc -regalloc=pbqp

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -40,6 +40,7 @@
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/CodeGen/CommandFlags.h"
+#include "llvm/CodeGen/LinkAllCodegenComponents.h"
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/CodeGen.h"


### PR DESCRIPTION
Include LinkAllCodegenComponents.h to force RegAllocPBQP to be linked
into the amdllpc executable, so that the appropriate command line
options get registered at startup to allow -regalloc=pbqp to work. This
is the same technique used by standard command line tools like llc.