### PR TITLE
Fix transform feedback defects

### DIFF
--- a/llpc/test/shaderdb/ObjXfb_TestBasic_lit.vert
+++ b/llpc/test/shaderdb/ObjXfb_TestBasic_lit.vert
@@ -14,8 +14,6 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call void @lgc.output.export.xfb.i32.i32.i32.v4f32(i32 0, i32 0, i32 0, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
-; SHADERTEST: call void @lgc.output.export.xfb.i32.i32.i32.f32(i32 0, i32 0, i32 0
 ; SHADERTEST: call void @lgc.output.export.xfb.i32.i32.i32.v4f32(i32 0, i32 16, i32 0, <4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>)
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6717,20 +6717,18 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
         inOutDec.StreamId = streamId;
 
       SPIRVWord xfbBuffer = SPIRVID_INVALID;
-      if (bv->hasDecorate(DecorationXfbBuffer, 0, &xfbBuffer)) {
-        inOutDec.IsXfb = true;
+      if (bv->hasDecorate(DecorationXfbBuffer, 0, &xfbBuffer))
         inOutDec.XfbBuffer = xfbBuffer;
-      }
+
       SPIRVWord xfbStride = SPIRVID_INVALID;
-      if (bv->hasDecorate(DecorationXfbStride, 0, &xfbStride)) {
-        inOutDec.IsXfb = true;
+      if (bv->hasDecorate(DecorationXfbStride, 0, &xfbStride))
         inOutDec.XfbStride = xfbStride;
-      }
 
       SPIRVWord xfbOffset = SPIRVID_INVALID;
       if (bv->hasDecorate(DecorationOffset, 0, &xfbOffset)) {
         // NOTE: Transform feedback is triggered only if "xfb_offset"
         // is specified.
+        inOutDec.IsXfb = true;
         inOutDec.XfbOffset = xfbOffset;
       }
 
@@ -7211,19 +7209,17 @@ Constant *SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecora
     // Enable transform feedback buffer if transform feedback offset is declared, and then
     // find the minimum member transform feedback offset as starting block transform feedback offset
     for (auto memberIdx = 0; memberIdx < numMembers; ++memberIdx) {
-      if (bt->hasMemberDecorate(memberIdx, DecorationXfbBuffer, 0, &xfbBuffer)) {
-        inOutDec.IsXfb = true;
+      if (bt->hasMemberDecorate(memberIdx, DecorationXfbBuffer, 0, &xfbBuffer))
         inOutDec.XfbBuffer = xfbBuffer;
-      }
 
-      if (bt->hasMemberDecorate(memberIdx, DecorationXfbStride, 0, &xfbStride)) {
-        inOutDec.IsXfb = true;
+      if (bt->hasMemberDecorate(memberIdx, DecorationXfbStride, 0, &xfbStride))
         inOutDec.XfbStride = xfbStride;
-      }
 
-      if (bt->hasMemberDecorate(memberIdx, DecorationOffset, 0, &xfbOffset))
+      if (bt->hasMemberDecorate(memberIdx, DecorationOffset, 0, &xfbOffset)) {
+        inOutDec.IsXfb = true;
         if (xfbOffset < blockXfbOffset)
           blockXfbOffset = xfbOffset;
+      }
     }
 
     for (auto memberIdx = 0; memberIdx < numMembers; ++memberIdx) {


### PR DESCRIPTION
1. According to GLSL spec, transform feedback capturing is only enabled
   for those qualified with explicit xfb_offset. Otherwise, the output
   is not captured even if xfb_buffer or xfb_stride is specified.

2. HW support dwordx3 buffer store. We should make use of this instruction
   and don't split vec3 to vec2 and scalar. This will save a tbuffer store.

Change-Id: I35b3bbd219cb7e4867d68fccbe14b880be4072ea