### PR TITLE
Don't use the PS_IN_CONTROL from glue shaders when linking

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -245,6 +245,7 @@ constexpr unsigned mmCB_SHADER_MASK = 0xA08F;
 // PS register numbers in PAL metadata
 constexpr unsigned mmSPI_PS_INPUT_ENA = 0xA1B3;
 constexpr unsigned mmSPI_PS_INPUT_ADDR = 0xA1B4;
+constexpr unsigned mmSPI_PS_IN_CONTROL = 0xA1B6;
 constexpr unsigned mmPA_SC_SHADER_CONTROL = 0xA310;
 constexpr unsigned mmPA_SC_AA_CONFIG = 0xA2F8;
 

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -225,7 +225,8 @@ void PalMetadata::mergeFromBlob(llvm::StringRef blob, bool isGlueCode) {
             return 0;
           }
           case mmSPI_PS_INPUT_ENA:
-          case mmSPI_PS_INPUT_ADDR: {
+          case mmSPI_PS_INPUT_ADDR:
+          case mmSPI_PS_IN_CONTROL: {
             if (!isGlueCode) {
               *destNode = srcNode.getUInt();
             }

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocCheckPsInControl.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocCheckPsInControl.pipe
@@ -1,0 +1,38 @@
+// This test case checks that the PS_IN_CONTROL has the correct value for GFX10.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf -gfxip=10.1.2 %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: SPI_PS_IN_CONTROL                             0x0000000000000000
+; END_SHADERTEST
+
+[Version]
+version = 32
+
+[VsGlsl]
+#version 430
+
+void main() {
+}
+
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) out vec4 outColor;
+
+void main() {
+	outColor = vec4(0.0, 1.0, 1.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_PsInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_PsInput.pipe
@@ -3,6 +3,7 @@
 ; SHADERTEST: SPI_PS_INPUT_CNTL_0                           0x0000000000000000
 ; SHADERTEST: SPI_PS_INPUT_ENA                              0x0000000000000002
 ; SHADERTEST: SPI_PS_INPUT_ADDR                             0x0000000000000002
+; SHADERTEST: SPI_PS_IN_CONTROL                             0x0000000000000001
 ; END_SHADERTEST
 
 [Version]


### PR DESCRIPTION
The PS_IN_CONTROL for the glue shaders does not have all of the data
needed to geneerate the value correctly, so it needs to be ignored.

Fixes https://github.com/GPUOpen-Drivers/llpc/issues/1049