### PR TITLE
Add stream ID to transform feedback calls

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -572,10 +572,10 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
   if (m_shaderStage == ShaderStageGeometry) {
     // Mark the XFB output for copy shader generation.
     XfbOutInfo xfbOutInfo = {};
+    xfbOutInfo.streamId = streamId;
     xfbOutInfo.xfbBuffer = xfbBuffer;
     xfbOutInfo.xfbOffset = cast<ConstantInt>(xfbOffset)->getZExtValue();
     xfbOutInfo.is16bit = valueToWrite->getType()->getScalarSizeInBits() == 16;
-    xfbOutInfo.xfbExtraOffset = 0;
 
     // For packed generic GS output, the XFB output should be scalarized to align with the scalarized GS output
     if (!getPipelineState()->isUnlinked() && !isBuiltIn) {
@@ -616,12 +616,12 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
     }
   }
 
-  // XFB: @llpc.output.export.xfb.%Type%(i32 xfbBuffer, i32 xfbOffset, i32 xfbExtraOffset, %Type% outputValue)
+  // XFB: @llpc.output.export.xfb.%Type%(i32 xfbBuffer, i32 xfbOffset, i32 streamId, %Type% outputValue)
   SmallVector<Value *, 4> args;
   std::string instName = lgcName::OutputExportXfb;
   args.push_back(getInt32(xfbBuffer));
   args.push_back(xfbOffset);
-  args.push_back(getInt32(0));
+  args.push_back(getInt32(streamId));
   args.push_back(valueToWrite);
   addTypeMangling(nullptr, args, instName);
   return emitCall(instName, getVoidTy(), args, {}, &*GetInsertPoint());

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -68,10 +68,10 @@ union DescriptorPair {
 // Represents transform feedback output info
 union XfbOutInfo {
   struct {
-    unsigned xfbBuffer : 2;       // Transform feedback buffer
-    unsigned xfbOffset : 16;      // Transform feedback offset
-    unsigned xfbExtraOffset : 13; // Transform feedback extra offset
-    unsigned is16bit : 1;         // Whether it is 16-bit data for transform feedback
+    unsigned streamId : 2;   // Output stream ID
+    unsigned xfbBuffer : 2;  // Transform feedback buffer
+    unsigned xfbOffset : 27; // Transform feedback offset
+    unsigned is16bit : 1;    // Whether it is 16-bit data for transform feedback
   };
   unsigned u32All;
 };

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -654,7 +654,7 @@ void PatchCopyShader::exportXfbOutput(Value *outputValue, const XfbOutInfo &xfbO
   }
 
   Value *args[] = {builder.getInt32(xfbOutInfo.xfbBuffer), builder.getInt32(xfbOutInfo.xfbOffset),
-                   builder.getInt32(xfbOutInfo.xfbExtraOffset), outputValue};
+                   builder.getInt32(xfbOutInfo.streamId), outputValue};
 
   std::string instName(lgcName::OutputExportXfb);
   addTypeMangling(nullptr, args, instName);

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -133,11 +133,11 @@ private:
   void patchCopyShaderGenericOutputExport(llvm::Value *output, unsigned location, llvm::Instruction *insertPos);
   void patchCopyShaderBuiltInOutputExport(llvm::Value *output, unsigned builtInId, llvm::Instruction *insertPos);
 
-  void patchXfbOutputExport(llvm::Value *output, unsigned xfbBuffer, unsigned xfbOffset, unsigned locOffset,
+  void patchXfbOutputExport(llvm::Value *output, unsigned xfbBuffer, unsigned xfbOffset, unsigned streamId,
                             llvm::Instruction *insertPos);
 
   void storeValueToStreamOutBuffer(llvm::Value *storeValue, unsigned xfbBuffer, unsigned xfbOffset, unsigned xfbStride,
-                                   llvm::Value *streamOutBufDesc, llvm::Instruction *insertPos);
+                                   unsigned streamId, llvm::Value *streamOutBufDesc, llvm::Instruction *insertPos);
 
   void createStreamOutBufferStoreFunction(llvm::Value *storeValue, unsigned xfbStrde, std::string &funcName);
 


### PR DESCRIPTION
We add xfbExtraOffset as an argument to transform feedback calls. It is
never used so we remove it in this change. Rather, we need stream ID as
an argument passed to those calls. Current GPU doesn't need this to do
transform feedback exporting, but future implementation will require this
info.

Change-Id: I2c49b8259bdaa2559c55793f01695ea08327e81c