### PR TITLE
Disable phi-of-op optimization in NewGVN

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -153,6 +153,9 @@ void LgcContext::initialize() {
   setOptionDefault("amdgpu-unroll-max-block-to-analyze", "20");
   setOptionDefault("unroll-max-percent-threshold-boost", "1000");
   setOptionDefault("unroll-allow-partial", "1");
+  // TODO: phi-of-ops optimization in NewGVN has some problems, we temporarily
+  // disable this to avoid mis-compile, see (https://github.com/GPUOpen-Drivers/llpc/issues/1206).
+  setOptionDefault("enable-phi-of-ops", "0");
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");


### PR DESCRIPTION
The phi-of-op optimization is buggy. Although there are recently some new
patches by Florian to fix outstanding issues (D66924, D99987), the issue
that block us is still not fixed (https://bugs.llvm.org/show_bug.cgi?id=49873),
I haven't come up with a proper fix for my reported issue, and I believe
there may be more underlying issue in the dependency tracking part for phi-of-ops
optimization. I think we need a long way to make the algorithm sound.
I would like to disable this specific optimization to avoid miscompile unkown
user program. I will keep on eye on the NewGVN progress and will turn on
when I believe this specific optimization is mature.

We original switch to NewGVN to mainly fix (https://github.com/GPUOpen-Drivers/llpc/issues/957)
I have tested the NewGVN can still optimize off this pattern with this
patch.