### PR TITLE
Add GS multi-stream support to NGG

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -70,10 +70,12 @@ const unsigned NggLdsManager::LdsRegionSizes[LdsRegionCount] = {
     //
     // ES-GS ring size is dynamically calculated (don't use it)
     InvalidValue,                                             // LdsRegionEsGsRing
-    // 1 dword (uint32) per thread
-    SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionOutPrimData
-    // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group
-    SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword, // LdsRegionOutVertCountInWaves
+    // 1 dword (uint32) per thread, 4 GS streams
+    (SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup) * MaxGsStreams,
+                                                              // LdsRegionOutPrimData
+    // 1 dword per wave (8 potential waves) + 1 dword for the entire sub-group, 4 GS streams
+    (SizeOfDword * Gfx9::NggMaxWavesPerSubgroup + SizeOfDword) * MaxGsStreams,
+                                                              // LdsRegionOutVertCountInWaves
     // 1 dword (uint32) per thread
     SizeOfDword * Gfx9::NggMaxThreadsPerSubgroup,             // LdsRegionOutVertThreadIdMap
     // GS-VS ring size is dynamically calculated (don't use it)

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -205,9 +205,9 @@ private:
   llvm::Function *createGsCutHandler(llvm::Module *module, unsigned streamId);
 
   llvm::Value *readPerThreadDataFromLds(llvm::Type *readDataTy, llvm::Value *threadId, NggLdsRegionType region,
-                                        bool useDs128 = false);
+                                        unsigned offsetInRegion = 0, bool useDs128 = false);
   void writePerThreadDataToLds(llvm::Value *writeData, llvm::Value *threadId, NggLdsRegionType region,
-                               bool useDs128 = false);
+                               unsigned offsetInRegion = 0, bool useDs128 = false);
 
   llvm::Value *readVertexCullInfoFromLds(llvm::Type *readDataTy, llvm::Value *vertexItemOffset, unsigned dataOffset);
   void writeVertexCullInfoToLds(llvm::Value *writeData, llvm::Value *vertexItemOffset, unsigned dataOffset);


### PR DESCRIPTION
In this change, we enlarge some LDS regions to support multi-streams. In
non XFB cases, non raster streams will be ignored without any operations.
But in XFB cases, the captured data of non raster streams will be stored
and we will perform XFB exporting after that. This change is preparation
work to support NGG GS XFB.

Change-Id: I6dfaaac4f8c3ff2a21416201eb2370e53cedc36e