### PR TITLE
Fix regression of transform feedback

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -549,7 +549,9 @@ Value *InOutBuilder::adjustIj(Value *value, Value *offset) {
 Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuiltIn, unsigned location,
                                                 unsigned xfbBuffer, unsigned xfbStride, Value *xfbOffset,
                                                 InOutInfo outputInfo) {
-  // Can currently only cope with constant pXfbOffset.
+  // xfbStride must be a non-zero value
+  assert(xfbStride > 0);
+  // Can currently only cope with constant xfbOffset.
   assert(isa<ConstantInt>(xfbOffset));
 
   // Ignore if not in last-vertex-stage shader (excluding copy shader).

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6726,9 +6726,10 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
 
       SPIRVWord xfbOffset = SPIRVID_INVALID;
       if (bv->hasDecorate(DecorationOffset, 0, &xfbOffset)) {
-        // NOTE: Transform feedback is triggered only if "xfb_offset"
-        // is specified.
-        inOutDec.IsXfb = true;
+        // NOTE: Transform feedback is triggered only if "xfb_offset" is specified. And in such case, "xfb_stride"
+        // must be specified as well.
+        if (inOutDec.XfbStride > 0)
+          inOutDec.IsXfb = true;
         inOutDec.XfbOffset = xfbOffset;
       }
 
@@ -7216,7 +7217,10 @@ Constant *SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecora
         inOutDec.XfbStride = xfbStride;
 
       if (bt->hasMemberDecorate(memberIdx, DecorationOffset, 0, &xfbOffset)) {
-        inOutDec.IsXfb = true;
+        // NOTE: Transform feedback is triggered only if "xfb_offset" is specified. And in such case, "xfb_stride"
+        // must be specified as well.
+        if (inOutDec.XfbStride > 0)
+          inOutDec.IsXfb = true;
         if (xfbOffset < blockXfbOffset)
           blockXfbOffset = xfbOffset;
       }


### PR DESCRIPTION
The CTS case "VK.spirv_assembly.instruction.graphics.variable_init.
output.struct" uses DecorationOffset for structure members of an output.
In such case, We shouldn't enable transform feedback because the
DecorationOffset doesn't correspond to xfb_offset. We should check
the existence of xfb_stride at the same time.

Change-Id: I2378ea8b720d35348b2a685dc5d48dfb697d7a5e