### PR TITLE
Warn when relocatable compilation is requested but not possible

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_TestUnsupportedShader.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_TestUnsupportedShader.pipe
@@ -1,0 +1,53 @@
+; Check that a warning is printed when relocatable compilation is requested but not possible.
+; Force this compute shader to use whole-pipeline compilation by using the
+; `--relocatable-shader-elf-limit` dev flag.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-relocatable-shader-elf -relocatable-shader-elf-limit=0 -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} calculated hash results (compute pipeline)
+; SHADERTEST-LABEL: {{^Warning:}} Relocatable shader compilation requested but not possible
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: {{^=====}} AMDLLPC SUCCES
+; END_SHADERTEST
+
+
+[CsGlsl]
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(binding = 0) uniform UniformBufferObject {
+    vec4 i;
+} ubo;
+
+layout(set = 1, binding = 0, std430) buffer OUT
+{
+    vec4 o;
+};
+
+layout(local_size_x = 2, local_size_y = 3) in;
+void main() {
+    o = ubo.i;
+}
+
+
+[CsInfo]
+entryPoint = main
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 6
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].set = 0
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 4
+userDataNode[0].next[0].sizeInDwords = 8
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 7
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].set = 1
+userDataNode[1].next[0].type = DescriptorBuffer
+userDataNode[1].next[0].offsetInDwords = 4
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 1
+userDataNode[1].next[0].binding = 0

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsGs_TestUnsupportedShader.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsGs_TestUnsupportedShader.pipe
@@ -1,0 +1,59 @@
+; Check that a warning is printed when relocatable compilation is requested but not possible.
+; Use a geometry shader, as this stage is not yet supported in the relocatable compilation flow.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
+; SHADERTEST-LABEL: {{^Warning:}} Relocatable shader compilation requested but not possible
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: {{^=====}} AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[VsGlsl]
+#version 450 core
+
+void main()
+{
+    gl_Position = vec4(0);
+    gl_PointSize = 0;
+    gl_ClipDistance[2] = 0;
+    gl_CullDistance[2] = 0;
+}
+
+[VsInfo]
+entryPoint = main
+
+[GsGlsl]
+#version 450 core
+layout(triangles) in;
+layout(triangle_strip, max_vertices = 3) out;
+
+layout(location = 2) out vec4 outColor;
+
+void main()
+{
+    for (int i = 0; i < gl_in.length(); ++i)
+    {
+        outColor    = gl_in[i].gl_Position;
+        outColor.x += gl_in[i].gl_PointSize;
+        outColor.y += gl_in[i].gl_ClipDistance[2];
+        outColor.z += gl_in[i].gl_CullDistance[2];
+        outColor.w += float(gl_PrimitiveIDIn + gl_InvocationID);
+
+        EmitVertex();
+    }
+
+    EndPrimitive();
+}
+
+[GsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+patchControlPoints = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0


### PR DESCRIPTION
Make it easier to debug offline caches. This warning allows us to tell
if a stage cache miss is caused by an unsupported shader.