### PR TITLE
Set the user data limit is set to max when there is user data spill

### DIFF
--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -171,6 +171,15 @@ private:
   // Set userDataLimit to maximum
   void setUserDataLimit();
 
+  // Returns true of the some of the user data nodes are spilled.
+  bool userDataNodesAreSpilled() const { return m_spillThreshold->getUInt() != MAX_SPILL_THRESHOLD; }
+
+  // Returns true of the setting in the PAL meta data require all of the user data nodes.
+  bool pipelineRequiresAllUserData() const;
+
+  // The maximum possible value for the spill threshold entry in the PAL meatadata.
+  static constexpr uint64_t MAX_SPILL_THRESHOLD = UINT_MAX;
+
   PipelineState *m_pipelineState;             // PipelineState
   llvm::msgpack::Document *m_document;        // The MsgPack document
   llvm::msgpack::MapDocNode m_pipelineNode;   // MsgPack map node for amdpal.pipelines[0]

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_CheckUserDataLimitWithSpill.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_CheckUserDataLimitWithSpill.pipe
@@ -1,0 +1,114 @@
+; Test that the user data limit is set to the maximum because the spill area
+; is accessed because of the dynamic descriptor. The max is the offset and
+; size of the last user data node that is not a stream out or vertex buffer.
+; In this case, it is the sum of the offset and size of userDataNode[2], which
+; is 37 (0x24 in hex).
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: .user_data_limit: 0x0000000000000025
+; END_SHADERTEST
+
+[Version]
+version = 46
+
+[VsSpirv]
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpExtension "SPV_GOOGLE_user_type"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main" %5 %gl_Position
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorate %5 Location 3
+               OpDecorate %8 DescriptorSet 0
+               OpDecorate %8 Binding 2
+               OpMemberDecorate %_struct_7 0 Offset 128
+               OpMemberDecorate %_struct_7 0 MatrixStride 16
+               OpMemberDecorate %_struct_7 0 RowMajor
+               OpDecorate %_struct_7 Block
+               OpDecorateString %8 UserTypeGOOGLE "cbuffer"
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+    %v4float = OpTypeVector %float 4
+%mat4v4float = OpTypeMatrix %v4float 4
+  %_struct_7 = OpTypeStruct %mat4v4float
+%_ptr_Uniform__struct_7 = OpTypePointer Uniform %_struct_7
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+         %23 = OpTypeFunction %void
+%_ptr_Uniform_mat4v4float = OpTypePointer Uniform %mat4v4float
+          %8 = OpVariable %_ptr_Uniform__struct_7 Uniform
+          %5 = OpVariable %_ptr_Input_v4float Input
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+         %25 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+      %int_0 = OpConstant %int 0
+          %1 = OpFunction %void None %23
+         %26 = OpLabel
+         %30 = OpLoad %v4float %5
+         %31 = OpCompositeConstruct %mat4v4float %25 %25 %30 %25
+         %36 = OpVectorTimesMatrix %v4float %25 %31
+         %37 = OpAccessChain %_ptr_Uniform_mat4v4float %8 %int_0
+         %38 = OpLoad %mat4v4float %37
+         %39 = OpVectorTimesMatrix %v4float %25 %38
+               OpStore %gl_Position %39
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+               OpExtension "SPV_GOOGLE_hlsl_functionality1"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %1 "main"
+               OpExecutionMode %1 OriginUpperLeft
+       %void = OpTypeVoid
+          %7 = OpTypeFunction %void
+          %1 = OpFunction %void None %7
+          %8 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 17
+userDataNode[0].type = DescriptorBuffer
+userDataNode[0].offsetInDwords = 8
+userDataNode[0].sizeInDwords = 4
+userDataNode[0].set = 0
+userDataNode[0].binding = 2
+userDataNode[1].visibility = 17
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 32
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = DescriptorResource
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 0
+userDataNode[1].next[0].binding = 8
+userDataNode[2].visibility = 17
+userDataNode[2].type = DescriptorBuffer
+userDataNode[2].offsetInDwords = 33
+userDataNode[2].sizeInDwords = 4
+userDataNode[2].set = 1
+userDataNode[2].binding = 0
+userDataNode[3].visibility = 1
+userDataNode[3].type = IndirectUserDataVaPtr
+userDataNode[3].offsetInDwords = 50
+userDataNode[3].sizeInDwords = 1
+userDataNode[3].indirectUserDataCount = 20
+
+[VertexInputState]
+binding[0].binding = 4
+binding[0].stride = 80
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_INSTANCE
+attribute[0].location = 3
+attribute[0].binding = 4
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 32


### PR DESCRIPTION
When linking shader, the user data limit is set to the max only if no
user data nodes are used, but there are some.  This is insufficiant
because it needs to happen whenever the spill table is used.

This commit moves the code that set the user data limit when spill is
used to when the pipeline is finalized.  That way it will be called on
all paths.