### PR TITLE
Remove code for old llvm versions

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -346,15 +346,8 @@ void NggLdsManager::atomicOpWithLds(AtomicRMWInst::BinOp atomicOp, Value *atomic
 
   Value *atomicPtr = m_builder->CreateGEP(m_lds, {m_builder->getInt32(0), ldsOffset});
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-  // Old version of the code
-  auto atomicInst = m_builder->CreateAtomicRMW(atomicOp, atomicPtr, atomicValue, AtomicOrdering::SequentiallyConsistent,
-                                               SyncScope::System);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   auto atomicInst = m_builder->CreateAtomicRMW(atomicOp, atomicPtr, atomicValue, MaybeAlign(),
                                                AtomicOrdering::SequentiallyConsistent, SyncScope::System);
-#endif
   atomicInst->setVolatile(true);
 }
 

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -2885,11 +2885,7 @@ void NggPrimShader::splitEs(Module *module) {
     valueMap[&arg] = newArg++;
 
   SmallVector<ReturnInst *, 8> retInsts;
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 379998
-  CloneFunctionInto(esCullDataFetchFunc, esEntryPoint, valueMap, false, retInsts);
-#else
   CloneFunctionInto(esCullDataFetchFunc, esEntryPoint, valueMap, CloneFunctionChangeType::LocalChangesOnly, retInsts);
-#endif
   esCullDataFetchFunc->setName(lgcName::NggEsCullDataFetch);
 
   // Find the return block, remove all exports, and mutate return type

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -175,15 +175,8 @@ void PatchBufferOp::visitAtomicCmpXchgInst(AtomicCmpXchgInst &atomicCmpXchgInst)
 
     Value *const compareValue = atomicCmpXchgInst.getCompareOperand();
     Value *const newValue = atomicCmpXchgInst.getNewValOperand();
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-    // Old version of the code
-    AtomicCmpXchgInst *const newAtomicCmpXchg =
-        m_builder->CreateAtomicCmpXchg(atomicPointer, compareValue, newValue, successOrdering, failureOrdering);
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
     AtomicCmpXchgInst *const newAtomicCmpXchg = m_builder->CreateAtomicCmpXchg(
         atomicPointer, compareValue, newValue, MaybeAlign(), successOrdering, failureOrdering);
-#endif
     newAtomicCmpXchg->setVolatile(atomicCmpXchgInst.isVolatile());
     newAtomicCmpXchg->setSyncScopeID(atomicCmpXchgInst.getSyncScopeID());
     newAtomicCmpXchg->setWeak(atomicCmpXchgInst.isWeak());
@@ -282,16 +275,9 @@ void PatchBufferOp::visitAtomicRMWInst(AtomicRMWInst &atomicRmwInst) {
 
     atomicPointer = m_builder->CreateBitCast(atomicPointer, storeType->getPointerTo(ADDR_SPACE_GLOBAL));
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-    // Old version of the code
-    AtomicRMWInst *const newAtomicRmw = m_builder->CreateAtomicRMW(
-        atomicRmwInst.getOperation(), atomicPointer, atomicRmwInst.getValOperand(), atomicRmwInst.getOrdering());
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
     AtomicRMWInst *const newAtomicRmw =
         m_builder->CreateAtomicRMW(atomicRmwInst.getOperation(), atomicPointer, atomicRmwInst.getValOperand(),
                                    atomicRmwInst.getAlign(), atomicRmwInst.getOrdering());
-#endif
     newAtomicRmw->setVolatile(atomicRmwInst.isVolatile());
     newAtomicRmw->setSyncScopeID(atomicRmwInst.getSyncScopeID());
     copyMetadata(newAtomicRmw, &atomicRmwInst);

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1800,13 +1800,7 @@ Value *SPIRVToLLVM::transAtomicRMW(SPIRVValue *const spvValue, const AtomicRMWIn
   Value *const atomicValue = transValue(spvAtomicInst->getOpValue(3), getBuilder()->GetInsertBlock()->getParent(),
                                         getBuilder()->GetInsertBlock());
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-  // Old version of the code
-  return getBuilder()->CreateAtomicRMW(binOp, atomicPointer, atomicValue, ordering, scope);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   return getBuilder()->CreateAtomicRMW(binOp, atomicPointer, atomicValue, MaybeAlign(), ordering, scope);
-#endif
 }
 
 // =====================================================================================================================
@@ -2018,13 +2012,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpAtomicIIncrement>(SPIRVVa
 
   Value *const one = ConstantInt::get(atomicPointer->getType()->getPointerElementType(), 1);
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-  // Old version of the code
-  return getBuilder()->CreateAtomicRMW(AtomicRMWInst::Add, atomicPointer, one, ordering, scope);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   return getBuilder()->CreateAtomicRMW(AtomicRMWInst::Add, atomicPointer, one, MaybeAlign(), ordering, scope);
-#endif
 }
 
 // =====================================================================================================================
@@ -2048,13 +2036,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpAtomicIDecrement>(SPIRVVa
 
   Value *const one = ConstantInt::get(atomicPointer->getType()->getPointerElementType(), 1);
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-  // Old version of the code
-  return getBuilder()->CreateAtomicRMW(AtomicRMWInst::Sub, atomicPointer, one, ordering, scope);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   return getBuilder()->CreateAtomicRMW(AtomicRMWInst::Sub, atomicPointer, one, MaybeAlign(), ordering, scope);
-#endif
 }
 
 // =====================================================================================================================
@@ -2082,15 +2064,8 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpAtomicCompareExchange>(SP
   Value *const compareValue = transValue(spvAtomicInst->getOpValue(5), getBuilder()->GetInsertBlock()->getParent(),
                                          getBuilder()->GetInsertBlock());
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381087
-  // Old version of the code
-  AtomicCmpXchgInst *const atomicCmpXchg = getBuilder()->CreateAtomicCmpXchg(atomicPointer, compareValue, exchangeValue,
-                                                                             successOrdering, failureOrdering, scope);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   AtomicCmpXchgInst *const atomicCmpXchg = getBuilder()->CreateAtomicCmpXchg(
       atomicPointer, compareValue, exchangeValue, MaybeAlign(), successOrdering, failureOrdering, scope);
-#endif
 
   // LLVM cmpxchg returns { <ty>, i1 }, for SPIR-V we only care about the <ty>.
   return getBuilder()->CreateExtractValue(atomicCmpXchg, 0);

--- a/llpc/util/llpcTimerProfiler.cpp
+++ b/llpc/util/llpcTimerProfiler.cpp
@@ -162,12 +162,8 @@ const StringMap<TimeRecord> &TimerProfiler::getDummyTimeRecords() {
       double t2;
       double t3;
       ssize_t m1;
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 379663
-    } hackedTimeRecord = {1e-100, 1e-100, 1e-100, 0};
-#else
       uint64_t i1;
     } hackedTimeRecord = {1e-100, 1e-100, 1e-100, 0, 0};
-#endif
     static_assert(sizeof(timeRecord) == sizeof(hackedTimeRecord), "Unexpected Size!");
     memcpy(&timeRecord, &hackedTimeRecord, sizeof(TimeRecord));
     DummyTimeRecords["DUMMY"] = timeRecord;


### PR DESCRIPTION
Remove code that was needed for merges, but is not used anymore.

An internal version of this patch is on sneubaue/remove-old-llvm-compat.