### PR TITLE
Rework the argument layout of copy shader

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1161,9 +1161,11 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
         userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), UserDataMapping::StreamOutTable,
                                            &intfData->entryArgIdxs.tes.streamOutData.tablePtr));
         break;
-      // Allocate dummy stream-out register for Geometry shader
       case ShaderStageGeometry:
-        userDataArgs.push_back(UserDataArg(builder.getInt32Ty()));
+        if (m_pipelineState->getTargetInfo().getGfxIpVersion().major <= 10) {
+          // Allocate dummy stream-out register for geometry shader
+          userDataArgs.push_back(UserDataArg(builder.getInt32Ty()));
+        }
         break;
       default:
         llvm_unreachable("Should never be called!");


### PR DESCRIPTION
Previously, non-NGG pipeline containing a GS needs a HW VS as copy shader.
The layout of arguments is fixed. Now, if NGG, this layout is verbose with
several unnecessary arguments because copy shader is not a real HW VS and
will be incorporated into NGG primitive shader eventually. We therefore
define a reduced layout with essential arguments merely.

Meanwhile, a copy shader with multiple stream exports for NGG could have
such handling:

  void copyShader() {

     Export outputs for stream0
     ...
     Export outputs for rasterization stream
     ...
     Export outputs for stream3
  }

This modification is because we don't have real HW executions for multiple
times to support multiple streams. If NGG, a copy shader is virtually
executed once in NGG primitive shader.

Change-Id: I5e12cd46f400e463122e77b05506211846db4717