### PR TITLE
Fix nested OpSpecConstantOp

### DIFF
--- a/llpc/test/shaderdb/OpSpecConstantOp_TestNestedSpecConstOp.spvasm
+++ b/llpc/test/shaderdb/OpSpecConstantOp_TestNestedSpecConstOp.spvasm
@@ -1,0 +1,66 @@
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 41
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %4 "main"
+               OpExecutionMode %4 LocalSize 1 1 1
+               OpSource GLSL 450
+               OpName %4 "main"
+               OpName %9 "foo("
+               OpName %39 "test"
+               OpDecorate %13 SpecId 0
+               OpDecorate %14 SpecId 1
+               OpDecorate %17 BuiltIn WorkgroupSize
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeInt 32 1
+          %7 = OpTypeVector %6 2
+          %8 = OpTypeFunction %7
+         %11 = OpConstant %6 1024
+         %12 = OpTypeInt 32 0
+         %13 = OpSpecConstant %12 8
+         %14 = OpSpecConstant %12 8
+         %15 = OpConstant %12 1
+         %16 = OpTypeVector %12 3
+         %17 = OpSpecConstantComposite %16 %13 %14 %15
+         %18 = OpTypeVector %12 2
+         %19 = OpSpecConstantOp %18 VectorShuffle %17 %17 0 1
+         %20 = OpConstant %12 0
+         %21 = OpConstantComposite %18 %20 %20
+         %22 = OpSpecConstantOp %7 IAdd %19 %21
+         %23 = OpConstant %6 1
+         %24 = OpConstantComposite %7 %23 %23
+         %25 = OpSpecConstantOp %7 ShiftRightArithmetic %22 %24
+         %26 = OpConstantComposite %7 %11 %11
+         %27 = OpSpecConstantOp %7 IAdd %26 %25
+         %28 = OpSpecConstantOp %6 CompositeExtract %27 0
+         %29 = OpSpecConstantOp %6 CompositeExtract %27 1
+         %30 = OpSpecConstantComposite %7 %28 %29
+         %31 = OpSpecConstantOp %18 VectorShuffle %17 %17 0 1
+         %32 = OpConstantComposite %18 %15 %15
+         %33 = OpSpecConstantOp %18 ISub %31 %32
+         %34 = OpSpecConstantOp %7 IAdd %33 %21
+         %35 = OpSpecConstantOp %7 SDiv %30 %34
+         %38 = OpTypePointer Function %7
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+         %39 = OpVariable %38 Function
+         %40 = OpFunctionCall %7 %9
+               OpStore %39 %40
+               OpReturn
+               OpFunctionEnd
+          %9 = OpFunction %7 None %8
+         %10 = OpLabel
+               OpReturnValue %35
+               OpFunctionEnd

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -239,6 +239,8 @@ uint64_t getConstantValue(SPIRVValue *BV, uint32_t I = 0) {
   else if (BV->getOpCode() == OpConstantNull ||
            BV->getOpCode() == OpUndef)
     ConstVal = 0;
+  else if (BV->getOpCode() == OpSpecConstantOp)
+    ConstVal = getConstantValue(static_cast<SPIRVSpecConstantOp *>(BV)->getMappedConstant());
   else
     llvm_unreachable("Invalid op code");
   return ConstVal;


### PR DESCRIPTION
This patch fixes the case of nested OpSpecConstantOp, for example:

%1 = OpSpecConstant
%2 = OpSpecConstantOp ... %1
%3 = OpSpecConstantComposite ... %2
%4 = OpSpecConstantOp ... %3          <- This one

by getting its mapped constant value.