### PR TITLE
Remove redundant passes in lowering

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -184,12 +184,10 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassMana
   // It is required by SpirvLowerImageOp.
   passMgr.add(createSROAPass());
   passMgr.add(createGlobalOptimizerPass());
-  passMgr.add(createGlobalDCEPass());
   passMgr.add(createPromoteMemoryToRegisterPass());
   passMgr.add(createAggressiveDCEPass());
   passMgr.add(createInstructionCombiningPass(3));
   passMgr.add(createCFGSimplificationPass());
-  passMgr.add(createSROAPass());
   passMgr.add(createEarlyCSEPass());
   passMgr.add(createCFGSimplificationPass());
   passMgr.add(createIPSCCPPass());


### PR DESCRIPTION
Both DCE and SROA were run earlier in the same pass list and they
do not need to be run again.

This patch does not change the generated code when tested on a
large sample of real-world shaders.

Note: we probably do not need to run simplifycfg twice here either,
but earlycse opens up some more opportunities for cfg simplification,
so it is not that clear.