### PR TITLE
Fix a latent issue of CTS linkage test

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -78,16 +78,17 @@ union XfbOutInfo {
 
 // Represents interpolation info of fragment shader input
 struct FsInterpInfo {
-  unsigned loc; // Mapped input location (tightly packed)
-  bool flat;    // Whether it is "flat" interpolation
-  bool custom;  // Whether it is "custom" interpolation
-  bool is16bit; // Whether it is 16-bit interpolation
+  unsigned loc;    // Mapped input location (tightly packed)
+  bool flat;       // Whether it is "flat" interpolation
+  bool noVsMatch;  // Whether there is no HW VS match
+  bool custom;     // Whether it is "custom" interpolation
+  bool is16bit;    // Whether it is 16-bit interpolation
   bool attr0Valid; // Whether the location has a valid low half
   bool attr1Valid; // Wheterh the location has a valid high half
 };
 
 // Invalid interpolation info
-static const FsInterpInfo InvalidFsInterpInfo = {InvalidValue, false, false, false, false, false};
+static const FsInterpInfo InvalidFsInterpInfo = {InvalidValue};
 
 // Represents the location information on an input or output
 class InOutLocationInfo {

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -944,7 +944,7 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   // NOTE: PAL expects at least one mmSPI_PS_INPUT_CNTL_0 register set, so we always patch it at least one if none
   // were identified in the shader.
-  const std::vector<FsInterpInfo> dummyInterpInfo{{0, false, false, false, false, false}};
+  const std::vector<FsInterpInfo> dummyInterpInfo{{}};
   const auto &fsInterpInfo = resUsage->inOutUsage.fs.interpInfo;
   const auto *interpInfo = fsInterpInfo.size() == 0 ? &dummyInterpInfo : &fsInterpInfo;
 
@@ -985,6 +985,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
       // NOTE: Use default value 0 for viewport array index if it is only used in FS (not set in other stages)
       spiPsInputCntl.bits.OFFSET = UseDefaultVal;
       spiPsInputCntl.bits.FLAT_SHADE = false;
+    } else if (interpInfoElem.noVsMatch) {
+      spiPsInputCntl.bits.OFFSET = spiPsInputCntl.bits.OFFSET | UseDefaultVal;
     }
 
     appendConfig(mmSPI_PS_INPUT_CNTL_0 + i, spiPsInputCntl.u32All);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1876,7 +1876,7 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
 
   // NOTE: PAL expects at least one mmSPI_PS_INPUT_CNTL_0 register set, so we always patch it at least one if none
   // were identified in the shader.
-  const std::vector<FsInterpInfo> dummyInterpInfo{{0, false, false, false, false, false}};
+  const std::vector<FsInterpInfo> dummyInterpInfo{{}};
   const auto &fsInterpInfo = resUsage->inOutUsage.fs.interpInfo;
   const auto *interpInfo = fsInterpInfo.size() == 0 ? &dummyInterpInfo : &fsInterpInfo;
 
@@ -1916,6 +1916,8 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
       // NOTE: Use default value 0 for viewport array index if it is only used in FS (not set in other stages)
       spiPsInputCntl.bits.OFFSET = UseDefaultVal;
       spiPsInputCntl.bits.FLAT_SHADE = false;
+    } else if (interpInfoElem.noVsMatch) {
+      spiPsInputCntl.bits.OFFSET = spiPsInputCntl.bits.OFFSET | UseDefaultVal;
     }
 
     appendConfig(mmSPI_PS_INPUT_CNTL_0 + i, spiPsInputCntl.u32All);

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -142,7 +142,7 @@ bool PatchNullFragShader::runOnModule(Module &module) {
   pipelineState->setShaderStageMask(pipelineState->getShaderStageMask() | shaderStageToMask(ShaderStageFragment));
 
   // Add usage info for dummy input
-  FsInterpInfo interpInfo = {0, false, false, false, false, false};
+  FsInterpInfo interpInfo = {};
   resUsage->builtInUsage.fs.smooth = true;
   InOutLocationInfo origLocInfo;
   origLocInfo.setLocation(0);

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_PsInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsPs_PsInput.pipe
@@ -1,6 +1,6 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST: SPI_PS_INPUT_CNTL_0                           0x0000000000000000
+; SHADERTEST: SPI_PS_INPUT_CNTL_0                           0x0000000000000020
 ; SHADERTEST: SPI_PS_INPUT_ENA                              0x0000000000000002
 ; SHADERTEST: SPI_PS_INPUT_ADDR                             0x0000000000000002
 ; SHADERTEST: SPI_PS_IN_CONTROL                             0x0000000000000001


### PR DESCRIPTION
This issue is found by the test VK.glsl.linkage.varying.rules.
vertex_declare_fragment_use.

When HW VS doesn't export any output to PS yet PS still reads from those
generic inputs, HW expects us to set the register field
SPI_PS_INPUT_CNTL_X.OFFSET to (loc | 0x20). This will cause HW to generate
a default value for a PS input. Such pipeline is invalid in real Vulkan
Apps but CTS could test this. Real HW doesn't expose this issue because no
one cares about the input value since it could be any value actually.

Change-Id: I26f7f842c20968cf1ff1bf25c677c24983e38eea