### PR TITLE
Improve codegen for conditional relocs

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -316,7 +316,7 @@ Value *DescBuilder::getDescPtr(ResourceNodeType resType, unsigned descSet, unsig
 
       // Use a relocation to select between the two.
       Value *useShadowReloc = CreateRelocationConstant(reloc::ShadowDescriptorTableEnabled);
-      Value *useShadowTable = CreateZExtOrTrunc(useShadowReloc, getInt1Ty());
+      Value *useShadowTable = CreateICmpNE(useShadowReloc, getInt32(0));
       return CreateSelect(useShadowTable, shadowAddr, nonShadowAddr);
     }
   };
@@ -335,7 +335,7 @@ Value *DescBuilder::getDescPtr(ResourceNodeType resType, unsigned descSet, unsig
     Value *spillDescPtr = GetSpillTablePtr();
     Value *descriptorTableDescPtr = GetDescriptorSetPtr();
     Value *reloc = CreateRelocationConstant(reloc::DescriptorUseSpillTable + Twine(descSet) + "_" + Twine(binding));
-    Value *useSpillTable = CreateZExtOrTrunc(reloc, getInt1Ty());
+    Value *useSpillTable = CreateICmpNE(reloc, getInt32(0));
     descPtr = CreateSelect(useSpillTable, spillDescPtr, descriptorTableDescPtr);
   } else {
     descPtr = GetDescriptorSetPtr();

--- a/llpc/test/shaderdb/relocatable_shaders/DescBufferReloc.vert
+++ b/llpc/test/shaderdb/relocatable_shaders/DescBufferReloc.vert
@@ -4,9 +4,8 @@
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: _amdgpu_vs_main_fetchless:
-; SHADERTEST: s_and_b32 s[[RELOCCOND:[0-9]+]], dusespill_0_0@abs32@lo, 1
-; SHADERTEST: s_cmp_eq_u32 s[[RELOCCOND]], 0
-; SHADERTEST: s_cselect_b32 s[[RELOCCOND]], s[[ds0:[0-9]*]], s[[spill:[0-9]*]]
+; SHADERTEST: s_cmp_eq_u32 dusespill_0_0@abs32@lo, 0
+; SHADERTEST: s_cselect_b32 s[[RELOCCOND:[0-9]+]], s[[ds0:[0-9]*]], s[[spill:[0-9]*]]
 ; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], doff_0_0_b@abs32@lo
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]]
 // register is reserved for the user data node holding descriptor set 0.

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocConst.pipe
@@ -5,13 +5,13 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_vs_main>:
-; SHADERTEST: s_and_b32 s[[RELOCCOND:[0-9]+]], 0, 1 //{{.*}}
-; SHADERTEST: s_cmp_eq_u32 s[[RELOCCOND]], 0 //{{.*}}
-; SHADERTEST: s_cselect_b32 s[[RELOCCOND]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
+; SHADERTEST: s_cmp_eq_u32 0, 0 //{{.*}}
+; SHADERTEST: s_cselect_b32 s[[RELOCCOND:[0-9]+]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
 ; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 12 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
 ; SHADERTEST: {{[0-9A-Za-z]+}} <_amdgpu_ps_main>:
-; SHADERTEST: s_and_b32 s[[RELOCCOND1:[0-9]+]], 0, 1 //{{.*}}
+; SHADERTEST: s_cmp_eq_u32 0, 0 //{{.*}}
+; SHADERTEST: s_cselect_b32 s[[RELOCCOND1:[0-9]+]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
 ; SHADERTEST: s_mov_b32 s[[RELOREG1:[0-9]+]], 12 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG1]] //{{.*}}
 ; END_SHADERTEST
@@ -21,8 +21,7 @@
 ; SHADERTEST1-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST1-LABEL: _amdgpu_vs_main_fetchless
 ; SHADERTEST1: %[[SPILLCONST:.+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[SPILLNODE:[0-9]+]])
-; SHADERTEST1: %[[CONSTAND:.+]] = and i32 %[[SPILLCONST]], 1
-; SHADERTEST1: %[[CONSTICMP:.+]] = icmp eq i32 %[[CONSTAND]], 0
+; SHADERTEST1: %[[CONSTICMP:.+]] = icmp eq i32 %[[SPILLCONST]], 0
 ; SHADERTEST1: %[[DESCPTRSELECT:.+]] = select i1 %[[CONSTICMP]], {{.*}}
 ; SHADERTEST1: %[[OFFCONST:.+]] = call i32 @llvm.amdgcn.reloc.constant(metadata ![[OFFNODE:[0-9]+]])
 ; SHADERTEST1: %[[OFFCONSTEXT:.+]] = zext i32 %[[OFFCONST]] to i64

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocTopLevelDescBuffer.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocTopLevelDescBuffer.pipe
@@ -6,13 +6,13 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_vs_main>:
-; SHADERTEST: s_and_b32 s[[RELOCCOND:[0-9]+]], 1, 1 //{{.*}}
-; SHADERTEST: s_cmp_eq_u32 s[[RELOCCOND]], 0 //{{.*}}
-; SHADERTEST: s_cselect_b32 s[[RELOCCOND]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
+; SHADERTEST: s_cmp_eq_u32 1, 0 //{{.*}}
+; SHADERTEST: s_cselect_b32 s[[RELOCCOND:[0-9]+]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
 ; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 0 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
 ; SHADERTEST: {{[0-9A-Za-z]+}} <_amdgpu_ps_main>:
-; SHADERTEST: s_and_b32 s[[RELOCCOND1:[0-9]+]], 1, 1 //{{.*}}
+; SHADERTEST: s_cmp_eq_u32 1, 0 //{{.*}}
+; SHADERTEST: s_cselect_b32 s[[RELOCCOND1:[0-9]+]], s{{[0-9]+}}, s{{[0-9]+}} //{{.*}}
 ; SHADERTEST: s_mov_b32 s[[RELOREG1:[0-9]+]], 0 //{{.*}}
 ; SHADERTEST: s_load_dwordx4 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG1]] //{{.*}}
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
@@ -13,8 +13,7 @@
 ; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: _amdgpu_ps_main
 ; SHADERTEST1: s_getpc_b64 s[0:1]
-; SHADERTEST1: s_and_b32 [[enabled:s[0-9]*]], 1, 1
-; SHADERTEST1: s_cmp_eq_u32 [[enabled]], 0
+; SHADERTEST1: s_cmp_eq_u32 1, 0
 ; SHADERTEST1: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0xffff
 ; SHADERTEST1: s_mov_b32 [[offset:s[0-9]*]], 48
 ; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
@@ -13,8 +13,7 @@
 ; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: _amdgpu_ps_main
 ; SHADERTEST1: s_getpc_b64 s[0:1]
-; SHADERTEST1: s_and_b32 [[enabled:s[0-9]*]], 1, 1
-; SHADERTEST1: s_cmp_eq_u32 [[enabled]], 0
+; SHADERTEST1: s_cmp_eq_u32 1, 0
 ; SHADERTEST1: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0xffff
 ; SHADERTEST1: s_mov_b32 [[offset:s[0-9]*]], 16
 ; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]

--- a/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
+++ b/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
@@ -15,9 +15,8 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST: s_getpc_b64 s[0:1]
-; SHADERTEST: s_and_b32 [[enabled:s[0-9]*]], 0, 1
+; SHADERTEST: s_cmp_eq_u32 0, 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowenabled
-; SHADERTEST: s_cmp_eq_u32 [[enabled]], 0
 ; SHADERTEST: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowdesctable
 ; SHADERTEST: s_mov_b32 [[offset:s[0-9]*]], 0


### PR DESCRIPTION
Truncating the reloc value to i1 forces the backend to generate code
that ignores the high bits of the reloc value. Using a compare with
zero instead lets the backend generate slightly simpler code by folding
the reloc into a compare instruction.