### PR TITLE
Add llpc flag to disable linking stdc++

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -332,7 +332,7 @@ PRIVATE
 set_compiler_options(amdllpc ${LLPC_ENABLE_WERROR})
 
 if(UNIX)
-    target_link_libraries(amdllpc PRIVATE llpc vfx dl stdc++)
+    target_link_libraries(amdllpc PRIVATE llpc vfx dl)
 elseif(WIN32)
     target_link_libraries(amdllpc PRIVATE llpc vfx)
 endif()


### PR DESCRIPTION
For memory sanitizer support, the LLVM libc++ needs to be used instead
of the gcc standard library, so make it possible to opt-out of linking
stdc++.

I’m not sure if stdc++ needs to be linked in *at all* or if we can just remove it, but I don’t want to break anything.