### PR TITLE
Remove redundant passes in patching

### DIFF
--- a/lgc/test/FsComputeLibrary.lgc
+++ b/lgc/test/FsComputeLibrary.lgc
@@ -5,7 +5,7 @@
 ; CHECK: define spir_func void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
 ; CHECK: !5 = !{i32 4}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) local_unnamed_addr #0 !lgc.shaderstage !5 {
+; CHECK: define amdgpu_gfx void @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17) #0 !lgc.shaderstage !5 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"


### PR DESCRIPTION
Remove passes that are not suited to our target or have
been run already so there is no use running them again.

This patch does not change the generated code when tested on a
large sample of real-world shaders.

This does not address the elephant in the room: instcombine and
also peephole, but rationalizing them changes generated code, so
it will be done separately.