### PR TITLE
Replace llvm::sys::fs::F_Text with llvm::sys::fs::OF_Text

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -124,7 +124,7 @@ static void dumpLLVM(Module *m, const std::string &fName) {
   std::error_code ec;
   static int DumpIdx = 0;
   std::string uniqueFName = fName + "_" + std::to_string(DumpIdx++) + ".ll";
-  raw_fd_ostream fs(uniqueFName, ec, sys::fs::F_None);
+  raw_fd_ostream fs(uniqueFName, ec, sys::fs::OF_None);
   if (!ec) {
     fs << *m;
     fs.close();

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -128,7 +128,7 @@ void redirectLogOutput(bool restoreToDefault, unsigned optionCount, const char *
       if (needDebugOut) {
         std::error_code errCode;
 
-        static raw_fd_ostream NewDbgFile(cl::LogFileDbgs.c_str(), errCode, sys::fs::F_Text);
+        static raw_fd_ostream NewDbgFile(cl::LogFileDbgs.c_str(), errCode, sys::fs::OF_Text);
         assert(!errCode);
         if (!DbgFile) {
           NewDbgFile.SetUnbuffered();
@@ -148,7 +148,7 @@ void redirectLogOutput(bool restoreToDefault, unsigned optionCount, const char *
       } else {
         std::error_code errCode;
 
-        static raw_fd_ostream NewOutFile(cl::LogFileOuts.c_str(), errCode, sys::fs::F_Text);
+        static raw_fd_ostream NewOutFile(cl::LogFileOuts.c_str(), errCode, sys::fs::OF_Text);
         assert(!errCode);
         if (!OutFile) {
           NewOutFile.SetUnbuffered();


### PR DESCRIPTION
The former is deprecated.
OF_Text has been available in LLVM since 2018-06.

-----

Available since https://reviews.llvm.org/rG1f67a3cba9b09636c56e2109d8a35ae96dc15782