### PR TITLE
Fix the update of outputLocInfoMap

### DIFF
--- a/lgc/test/InOutPackingNonZeroBase.lgc
+++ b/lgc/test/InOutPackingNonZeroBase.lgc
@@ -21,8 +21,7 @@ target triple = "amdgcn--amdpal"
 ; CHECK:       (VS) Input:  loc = 0, comp = 0 =>  Mapped = 0, 0
 ; CHECK-NEXT:  (VS) Input:  loc = 1, comp = 0 =>  Mapped = 1, 0
 ;
-; CHECK:       (VS) Output: loc = 0, comp = 3  =>  Mapped = 0, 0
-; CHECK-NEXT:  (VS) Output: loc = 3, comp = 0  =>  Mapped = 0, 1
+; CHECK:  (VS) Output: loc = 3, comp = 0  =>  Mapped = 0, 1
 ; CHECK-NEXT:  (VS) Output: loc = 3, comp = 1  =>  Mapped = 0, 2
 ; CHECK-NEXT:  (VS) Output: loc = 3, comp = 2  =>  Mapped = 0, 3
 


### PR DESCRIPTION
The original way of updating outputLocInfoMap cannot represent the
reality of the outputs:
```
m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.outputLocInfoMap
=
m_pipelineState->getShaderResourceUsage(nextStage)->inOutUsage.inputLocInfoMap;
```
expecially when there is no generic output in the current stage and
there are some inputs of the next stage without corresponding outputs in
the current stage. This change will correct it by setting the mapping
for each output with correpsonding input.
Besides, some refactors are included:
1)Removed the useless code in `reassembleOutputExportCalls` since VS-TCS
  will not treated by this function.
  2)Each generic outupt export call must exsit and can be found in
    outputLocInfoMap in PatchInOutImportExport pass.