### PR TITLE
Fix linking lgc with shared libs

### DIFF
--- a/lgc/tool/lgc/CMakeLists.txt
+++ b/lgc/tool/lgc/CMakeLists.txt
@@ -28,6 +28,8 @@ set(LLVM_LINK_COMPONENTS
     AMDGPUAsmParser
     AMDGPUCodeGen
     AMDGPUDisassembler
+    AsmParser
+    Support
 )
 
 add_llvm_tool(lgc


### PR DESCRIPTION
This allows using lgc with -DBUILD_SHARED_LIBS=ON.