### PR TITLE
[ComputeLibs] Append system arguments

### DIFF
--- a/lgc/include/lgc/state/ShaderStage.h
+++ b/lgc/include/lgc/state/ShaderStage.h
@@ -61,8 +61,8 @@ bool isShaderEntryPoint(const llvm::Function *func);
 // Gets name string of the abbreviation for the specified shader stage
 const char *getShaderStageAbbreviation(ShaderStage shaderStage);
 
-// Add args to a function. The new args are put before any existing ones. This creates a new function with the
-// added args, then moves everything from the old function across to it.
+// Add args to a function. This creates a new function with the added args, then moves everything from the old function
+// across to it.
 // If this changes the return type, then all the return instructions will be invalid.
 // This does not erase the old function, as the caller needs to do something with its uses (if any).
 //
@@ -70,9 +70,10 @@ const char *getShaderStageAbbreviation(ShaderStage shaderStage);
 // @param retTy : New return type, nullptr to use the same as in the original function
 // @param argTys : Types of new args
 // @param inRegMask : Bitmask of which args should be marked "inreg", to be passed in SGPRs
+// @param append : Append new arguments if true, prepend new arguments if false
 // @returns : The new function
 llvm::Function *addFunctionArgs(llvm::Function *oldFunc, llvm::Type *retTy, llvm::ArrayRef<llvm::Type *> argTys,
-                                uint64_t inRegMask = 0);
+                                uint64_t inRegMask = 0, bool append = false);
 
 // Get the ABI-mandated entry-point name for a shader stage
 //

--- a/lgc/test/CallLibFromCsPayload.lgc
+++ b/lgc/test/CallLibFromCsPayload.lgc
@@ -1,0 +1,66 @@
+; Call an extern compute library function from a compute shader.
+; Ensure that the first argument uses the same registers as the return value of the called function.
+
+; RUN: lgc -mcpu=gfx1010 -o - - <%s | FileCheck %s
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare spir_func <10 x i32> @compute_library_func(<10 x i32>) #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+; CHECK: v_mov_b32_e32 v0, 42
+; CHECK: s_swappc_b64 s[30:31], s[26:27]
+; CHECK-NEXT: v_mov_b32_e32 v40, v0
+; CHECK-NEXT: buffer_store_dwordx4 v[40:43], off, s[36:39], 0
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i32 2)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i32 2)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i32 2)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i32 2)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  %arg = insertelement <10 x i32> undef, i32 42, i32 0
+  %r = call spir_func <10 x i32> @compute_library_func(<10 x i32> %arg)
+  %ri = extractelement <10 x i32> %r, i32 0
+  %v = insertelement <4 x i32> %19, i32 %ri, i32 0
+  store <4 x i32> %v, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/CsComputeLibraryPayload.lgc
+++ b/lgc/test/CsComputeLibraryPayload.lgc
@@ -1,0 +1,35 @@
+; Define a compute library that can be called from a compute shader.
+; Ensure that the first argument uses the same registers as the return value.
+; The assembly should not have any movs.
+
+; RUN: lgc -mcpu=gfx1010 -o - - <%s | FileCheck --check-prefixes=CHECK %s
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func <10 x i32> @func(<10 x i32> %arg) local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+; CHECK-LABEL: func:
+; CHECK: s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT: s_waitcnt_vscnt null, 0x0
+; CHECK-NEXT: s_setpc_b64 s[30:31]
+.entry:
+  ret <10 x i32> %arg
+}
+
+attributes #0 = { nounwind }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/VsComputeLibrary.lgc
+++ b/lgc/test/VsComputeLibrary.lgc
@@ -2,10 +2,10 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define spir_func <4 x float> @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #2 !lgc.shaderstage !4 {
+; CHECK: define spir_func <4 x float> @func(<4 x float> %0, i32 inreg %1, i32 inreg %2, <3 x i32> addrspace(4)* inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %15, <3 x i32> inreg %16, i32 inreg %17, <3 x i32> %18) #2 !lgc.shaderstage !4 {
 ; CHECK: !4 = !{i32 0}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx <4 x float> @func(i32 inreg %0, i32 inreg %1, <3 x i32> addrspace(4)* inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, <3 x i32> inreg %15, i32 inreg %16, <3 x i32> %17, <4 x float> %18) #0 !lgc.shaderstage !4 {
+; CHECK: define amdgpu_gfx <4 x float> @func(<4 x float> %0, i32 inreg %1, i32 inreg %2, <3 x i32> addrspace(4)* inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %12, i32 inreg %13, i32 inreg %14, i32 inreg %15, <3 x i32> inreg %16, i32 inreg %17, <3 x i32> %18) #0 !lgc.shaderstage !4 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"


### PR DESCRIPTION
Currently lgc adds the local invocation id as the first argument to
compute library functions. This moves all frontend arguments to
v[3:...]. As return values are put into v0 onwards, returning the first
argument needs to move all registers.

This patch changes that, so all arguments added to library functions by
lgc are appended instead of prepended. This gets rid of the mov
instructions.