### PR TITLE
Add interface to check the caches in LLPC.

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -221,6 +221,7 @@ if(ICD_BUILD_LLPC)
 
 # llpc/util
     target_sources(llpc PRIVATE
+        util/llpcCacheAccessor.cpp
         util/llpcDebug.cpp
         util/llpcElfWriter.cpp
         util/llpcFile.cpp

--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -1,0 +1,105 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcCacheAccessor.cpp
+ * @brief LLPC source file: Implementation of a class that will create an interface to easily check the caches that need
+ * to be checked (independent of LLVM use).
+ ***********************************************************************************************************************
+ */
+#include "llpcCacheAccessor.h"
+#include "llpcCompiler.h"
+#include "llpcContext.h"
+
+#define DEBUG_TYPE "llpc-cache-accessor"
+
+namespace Llpc {
+
+// =====================================================================================================================
+// Access the given caches using the hash.
+//
+// @param context : The context that will give the caches from the application.
+// @param hash : The hash for the entry to access.
+// @param compiler : The compiler object with the internal caches.
+CacheAccessor::CacheAccessor(Context *context, MetroHash::Hash &cacheHash, Compiler *compiler) {
+  assert(context);
+  if (context->isGraphics()) {
+    auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
+    initializeUsingBuildInfo(pipelineInfo, cacheHash, compiler);
+  } else {
+    auto pipelineInfo = reinterpret_cast<const ComputePipelineBuildInfo *>(context->getPipelineBuildInfo());
+    initializeUsingBuildInfo(pipelineInfo, cacheHash, compiler);
+  }
+}
+
+// =====================================================================================================================
+// Initializes all of the member variable using the data provided.
+//
+// @param hash : The hash for the entry to access.
+// @param userCache : The ICache supplied by the application. nullptr if no cache is provided.
+// @param userShaderCache : The shader cache supplied by the application. nullptr if no cache is provided.
+// @param compiler : The compiler object with the internal caches.
+void CacheAccessor::initialize(MetroHash::Hash &hash, Vkgc::ICache *userCache, IShaderCache *userShaderCache,
+                               Compiler *compiler) {
+  assert(compiler);
+  m_compiler = compiler;
+  m_userCache = userCache;
+  m_userShaderCache = userShaderCache;
+  m_shaderCache = nullptr;
+  m_shaderCacheEntryState = ShaderEntryState::New;
+  m_elf = {0, nullptr};
+
+  Vkgc::HashId hashId = {};
+  memcpy(&hashId.bytes, &hash.bytes, sizeof(hash));
+  m_cacheResult = m_compiler->lookUpCaches(m_userCache, &hashId, &m_elf, &m_cacheEntry);
+  if (m_cacheResult == Result::Success)
+    return;
+  m_shaderCacheEntryState =
+      m_compiler->lookUpShaderCaches(m_userShaderCache, &hash, &m_elf, &m_shaderCache, &m_shaderCacheEntry);
+}
+
+// =====================================================================================================================
+// Sets the ELF entry for the hash on a cache miss.  Does nothing if there was a cache hit or the ELF has already been
+// set.
+//
+// @param elf : The binary encoding of the elf to place in the cache.
+void CacheAccessor::setElfInCache(BinaryData elf) {
+  if (m_shaderCacheEntryState == ShaderEntryState::Compiling && m_shaderCacheEntry) {
+    m_compiler->updateShaderCache(elf.pCode, &elf, m_shaderCache, m_shaderCacheEntry);
+    m_shaderCache->retrieveShader(m_shaderCacheEntry, &m_elf.pCode, &m_elf.codeSize);
+    m_shaderCacheEntryState = ShaderEntryState::Ready;
+  }
+
+  if (!m_cacheEntry.IsEmpty()) {
+    if (elf.pCode) {
+      m_cacheEntry.SetValue(true, elf.pCode, elf.codeSize);
+      m_cacheEntry.GetValueZeroCopy(&m_elf.pCode, &m_elf.codeSize);
+    }
+    Vkgc::EntryHandle::ReleaseHandle(std::move(m_cacheEntry));
+    m_cacheResult = elf.pCode ? Result::Success : Result::ErrorUnknown;
+  }
+}
+
+} // namespace Llpc

--- a/llpc/util/llpcCacheAccessor.h
+++ b/llpc/util/llpcCacheAccessor.h
@@ -1,0 +1,131 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ * @file  llpcCacheAccessor.h
+ * @brief LLPC header file: Implementation of a class that will create an interface to easily check the caches that need
+ * to be checked (independent of LLVM use).
+ ***********************************************************************************************************************
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpc.h"
+#include "llpcShaderCache.h"
+#include "vkgcMetroHash.h"
+
+namespace Llpc {
+
+class Compiler;
+class Context;
+
+class CacheAccessor {
+public:
+  // Checks the caches in the build info and compiler objects for an entry with the given hash.
+  //
+  // @param buildInfo : The build information that will give the caches from the application.
+  // @param hash : The hash for the entry to access.
+  // @param compiler : The compiler object with the internal caches.
+  template <class BuildInfo> CacheAccessor(BuildInfo *buildInfo, MetroHash::Hash &cacheHash, Compiler *compiler) {
+    initializeUsingBuildInfo(buildInfo, cacheHash, compiler);
+  }
+
+  CacheAccessor(Context *context, MetroHash::Hash &cacheHash, Compiler *compiler);
+
+  // Finalizes the cache access by releasing any handles that need to be released.
+  ~CacheAccessor() { setElfInCache({0, nullptr}); }
+
+  // Returns true of the entry was in at least on of the caches or has been added to the cache.
+  bool isInCache() const {
+    return m_cacheResult == Result::Success || m_shaderCacheEntryState == ShaderEntryState::Ready;
+  }
+
+  // Returns the ELF that was found in the cache.
+  BinaryData getElfFromCache() const { return m_elf; }
+
+  void setElfInCache(BinaryData elf);
+
+  // Returns true if there was a cache hit in an internal cache.
+  bool hitInternalCache() const {
+    if (!isInCache())
+      return false;
+    if (m_cacheResult == Result::Success) {
+      return true;
+    }
+    return getUserShaderCache() == m_shaderCache;
+  }
+
+private:
+  Vkgc::ICache *getUserCache() const { return m_userCache; }
+  IShaderCache *getUserShaderCache() const { return m_userShaderCache; }
+
+  // Access the given caches using the hash.
+  //
+  // @param buildInfo : The build info object that the caches from the application.
+  // @param hash : The hash for the entry to access.
+  // @param compiler : The compiler object with the internal caches.
+  template <class BuildInfo>
+  void initializeUsingBuildInfo(const BuildInfo *buildInfo, MetroHash::Hash &hash, Compiler *compiler) {
+    assert(buildInfo);
+    Vkgc::ICache *userCache = buildInfo->cache;
+
+    IShaderCache *userShaderCache = nullptr;
+#if LLPC_ENABLE_SHADER_CACHE
+    userShaderCache = reinterpret_cast<IShaderCache *>(buildInfo->pShaderCache);
+#endif
+
+    initialize(hash, userCache, userShaderCache, compiler);
+  }
+
+  void initialize(MetroHash::Hash &hash, Vkgc::ICache *userCache, IShaderCache *userShaderCache, Compiler *compiler);
+
+  // The application caches
+  Vkgc::ICache *m_userCache = nullptr;
+  IShaderCache *m_userShaderCache = nullptr;
+
+  // The compiler object holds the internal caches.  Used for the functions to access those caches as well.
+  // TODO: We should write a new class that holds the internal and external cache.  Move the function to check the
+  //  caches from the compiler class, so we will not need the compiler object here.
+  Compiler *m_compiler = nullptr;
+
+  // The state of the shader cache look up.
+  ShaderEntryState m_shaderCacheEntryState = ShaderEntryState::Unavailable;
+
+  // The handle to the entry in the shader cache.
+  CacheEntryHandle m_shaderCacheEntry = nullptr;
+
+  // The shader cache that the entry refers to.
+  ShaderCache *m_shaderCache = nullptr;
+
+  // The result of checking the ICache.
+  Result m_cacheResult = Result::ErrorUnknown;
+
+  // The handle to the entry in the cache.
+  Vkgc::EntryHandle m_cacheEntry;
+
+  // The ELF corresponding to the entry.
+  BinaryData m_elf = {0, nullptr};
+};
+
+} // namespace Llpc


### PR DESCRIPTION
The code to check the caches is repeated in three places.  This code is
also hard to read and easy to get wrong.  The cache handles have to be
expliticly released or it could mess up checking the cache at other
times.

The code is also complicated by the fact that there are potentially 4
different caches with two different types: The ICache and the
IShaderCache.  This can lead to inconsistencies in how the various
caches interact.

I'm proposing that we add a class that will make take care of all of
this, and hopefully make the code easier to read and less error prone.