### PR TITLE
Move updating of col format metadata

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -649,6 +649,9 @@ void ElfLinkerImpl::writePalMetadata() {
   // Fix up user data registers.
   PalMetadata *palMetadata = m_pipelineState->getPalMetadata();
   palMetadata->fixUpRegisters();
+  for (auto &glueShader : m_glueShaders)
+    glueShader->updatePalMetadata(*palMetadata);
+
   // Finalize the PAL metadata, writing pipeline state items into it.
   palMetadata->finalizePipeline();
   // Write the MsgPack document into a blob.

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -76,6 +76,10 @@ public:
   // Get the name of this glue shader.
   virtual llvm::StringRef getName() const = 0;
 
+  // Update the PAL metadata entries that require the glue code data and the
+  // pipeline state.
+  virtual void updatePalMetadata(PalMetadata &palMetadata) = 0;
+
 protected:
   GlueShader(LgcContext *lgcContext) : m_lgcContext(lgcContext) {}
 


### PR DESCRIPTION
When we are linking shader, the col format metadata entry is set while
compiling the color export shader.  This is a problem when we want to
cache the color export shader elf blob because the this side effect will
not be reflected in the elf blob in the cache.

I've considered a few alternatives:

1. The the col format in the metadata for the elf blob.  That cannot be
done because the col format is determined by the pipeline state as well
as the export info used to build the color export shader.  This will not
work.

2. Set the col format when finalizing the pipeline.  To do this, we
would have to make the export info available when finalizing the
pipeline.  This could be done by leaving the export info in the pal
metadata until then.  Then we could read it a second time. I believe we
had rejected this earlier because it would mean leaving information
intended for the color export shader to be deleted later.  However, I
have no problem with this solution.

3. We refactor `PipelineState::computeExportFormat` so that it does not
depend on a pipeline state object explicitly.  Then get the glue shader
compile step to modify the entry in the pal metadata in elf blob.  This
would potentially be time consuming having the read and write the elf.

4. The solution I implemented here is to have a separate glue shader
function that will update the pal metadata that requires both the
pipeline state and the information used to build the glue shader.