### PR TITLE
Add caching for glue shaders

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -301,13 +301,12 @@ ArrayRef<StringRef> ElfLinkerImpl::getGlueInfo() {
 }
 
 // =====================================================================================================================
-// Add a blob for a particular chunk of glue code, typically retrieved from a cache. The blob is not copied,
-// and remains in use until the first of the link completing or the ElfLinker's parent Pipeline being destroyed.
+// Add a blob for a particular chunk of glue code, typically retrieved from a cache.
 //
 // @param glueIndex : Index into the array that was returned by getGlueInfo()
 // @param blob : Blob for the glue code
 void ElfLinkerImpl::addGlue(unsigned glueIndex, StringRef blob) {
-  llvm_unreachable("Not implemented");
+  m_glueShaders[glueIndex]->setElfBlob(blob);
 }
 
 // =====================================================================================================================

--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -649,6 +649,9 @@ void ElfLinkerImpl::writePalMetadata() {
   // Fix up user data registers.
   PalMetadata *palMetadata = m_pipelineState->getPalMetadata();
   palMetadata->fixUpRegisters();
+  for (auto &glueShader : m_glueShaders)
+    glueShader->updatePalMetadata(*palMetadata);
+
   // Finalize the PAL metadata, writing pipeline state items into it.
   palMetadata->finalizePipeline();
   // Write the MsgPack document into a blob.

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -64,6 +64,9 @@ public:
     return m_elfBlob;
   }
 
+  // Set the ELF for this glue shader so that it does not have to be compiled.
+  void setElfBlob(llvm::StringRef elfBlob) { m_elfBlob = elfBlob; }
+
   // Get the symbol name of the main shader that this glue shader is prolog or epilog for
   virtual llvm::StringRef getMainShaderName() = 0;
 

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -76,6 +76,10 @@ public:
   // Get the name of this glue shader.
   virtual llvm::StringRef getName() const = 0;
 
+  // Update the PAL metadata entries that require the glue code data and the
+  // pipeline state.
+  virtual void updatePalMetadata(PalMetadata &palMetadata) = 0;
+
 protected:
   GlueShader(LgcContext *lgcContext) : m_lgcContext(lgcContext) {}
 

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -238,7 +238,7 @@ static void setGlueBinaryBlobFromCacheData(ElfLinker *elfLinker, unsigned glueIn
 //
 // @param cacheAccessor : The cache accessor for the entry to be updated.
 // @param elfData : The data to use to update the cache.
-static void updateCache(CacheAccessor &cacheAccessor, const StringRef &elfData) {
+static void updateCache(CacheAccessor &cacheAccessor, StringRef elfData) {
   BinaryData elfBin = {elfData.size(), elfData.data()};
   cacheAccessor.setElfInCache(elfBin);
 }

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
@@ -1,18 +1,16 @@
-; XFAIL: *
-
 ; This test case checks shader cache creation in the standalone compilation mode.
 ; BEGIN_SHADERTEST
 ; RUN: rm -rf %t_dir && \
 ; RUN: mkdir -p %t_dir && \
 ; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
-; RUN:         -build-shader-cache -shader-cache-mode=2 \
+; RUN:         -shader-cache-mode=2 \
 ; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=CREATE %s
 ; REQUIRES: llpc-shader-cache
 ; CREATE: Building pipeline with relocatable shader elf.
-; CREATE: Cache miss for shader stage 5
-; CREATE: Updating the cache for shader stage 5
+; CREATE: Cache miss for shader stage compute
+; CREATE: Updating the cache for shader stage compute
 ; CREATE: =====  AMDLLPC SUCCESS  =====
 ; END_SHADERTEST
 
@@ -27,14 +25,14 @@
 ; No new cache entries should be added.
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
-; RUN:         -build-shader-cache -shader-cache-mode=4 \
+; RUN:         -shader-cache-mode=4 \
 ; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=LOAD %s
 ; REQUIRES: llpc-shader-cache
 ; LOAD: Building pipeline with relocatable shader elf.
-; LOAD: Cache hit for shader stage 5
-; LOAD-NOT: Updating the cache for shader stage 5
+; LOAD: Cache hit for shader stage compute
+; LOAD-NOT: Updating the cache for shader stage compute
 ; LOAD: =====  AMDLLPC SUCCESS  =====
 ; END_SHADERTEST
 
@@ -43,14 +41,14 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
 ; RUN:         -vgpr-limit=64 \
-; RUN:         -build-shader-cache -shader-cache-mode=3 \
+; RUN:         -shader-cache-mode=3 \
 ; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=MODIFY %s
 ; REQUIRES: llpc-shader-cache
 ; MODIFY: Building pipeline with relocatable shader elf.
-; MODIFY: Cache miss for shader stage 5
-; MODIFY: Updating the cache for shader stage 5
+; MODIFY: Cache miss for shader stage compute
+; MODIFY: Updating the cache for shader stage compute
 ; MODIFY: =====  AMDLLPC SUCCESS  =====
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_GlueCache.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_GlueCache.pipe
@@ -1,0 +1,121 @@
+; This test checks that all of the shaders in a graphics pipeline are correctly add to the shader cache and retrieved from it.
+; We only check the internal shader cache because of the limitation on the testing infrastructure.
+
+; BEGIN_SHADERTEST
+; RUN: rm -rf %t_dir && \
+; RUN: mkdir -p %t_dir && \
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
+; RUN:         -shader-cache-mode=2 \
+; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
+; RUN:         -enable-relocatable-shader-elf \
+; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=CREATE %s
+; REQUIRES: llpc-shader-cache
+; CREATE: Building pipeline with relocatable shader elf.
+; CREATE: Cache miss for shader stage vertex
+; CREATE: Updating the cache for shader stage vertex
+; CREATE: Cache miss for shader stage fragment
+; CREATE: Updating the cache for shader stage fragment
+; CREATE: ID for glue shader0: 00000000000000007632663332570000000200000003000000040000000F00000000000000030000000400000000000000000000000000000000000000000000000E0000000700000000000000
+; CREATE: Cache miss for glue shader 0
+; CREATE: Updating the cache for glue shader 0
+; CREATE: ID for glue shader1: 0000000000000000007634663332090000000000000000000000000000000000000000000000000000000000000000
+; CREATE: Cache miss for glue shader 1
+; CREATE: Updating the cache for glue shader 1
+; CREATE: =====  AMDLLPC SUCCESS  =====
+; END_SHADERTEST
+
+; Check that the cache file exists under the expected location and is not empty.
+; BEGIN_SHADERTEST
+; RUN: ls -s %t_dir/AMD/LlpcCache/cache.bin | FileCheck -check-prefix=SIZE %s
+; REQUIRES: llpc-shader-cache
+; SIZE: {{[1-9][0-9]*}} {{.*}}cache.bin
+; END_SHADERTEST
+
+; Now, attempt to load the shader cache from the previous run in the read-only mode.
+; No new cache entries should be added.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip \
+; RUN:         -shader-cache-mode=4 \
+; RUN:         -shader-cache-filename=cache.bin -shader-cache-file-dir=%t_dir \
+; RUN:         -enable-relocatable-shader-elf \
+; RUN:         -o %t.elf %s -v | FileCheck -check-prefix=LOAD %s
+; REQUIRES: llpc-shader-cache
+; LOAD: Building pipeline with relocatable shader elf.
+; LOAD: Cache hit for shader stage vertex
+; LOAD-NOT: Updating the cache for shader stage vertex
+; LOAD: Cache hit for shader stage fragment
+; LOAD-NOT: Updating the cache for shader stage fragment
+; LOAD: ID for glue shader0: 00000000000000007632663332570000000200000003000000040000000F00000000000000030000000400000000000000000000000000000000000000000000000E0000000700000000000000
+; LOAD: Cache hit for glue shader 0
+; LOAD-NOT: Updating the cache for glue shader
+; LOAD: ID for glue shader1: 0000000000000000007634663332090000000000000000000000000000000000000000000000000000000000000000
+; LOAD: Cache hit for glue shader 1
+; LOAD-NOT: Updating the cache for glue shader
+; LOAD: =====  AMDLLPC SUCCESS  =====
+; END_SHADERTEST
+
+[Version]
+version = 38
+
+[VsGlsl]
+#version 450
+
+layout(location = 0) in vec2 inPosition;
+layout(location = 0) out vec2 outUV;
+
+void main() {
+    outUV = inPosition;
+}
+
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450 core
+
+layout(set = 0, binding = 0) uniform sampler s;
+layout(set = 0, binding = 1) uniform texture2D tex;
+layout(location = 0) in vec2 inUV;
+layout(location = 0) out vec4 oColor;
+
+void main()
+{
+    ivec2 iUV = ivec2(inUV);
+    oColor = texture(sampler2D(tex, s), iUV);
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 17
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 11
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorSampler
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 4
+userDataNode[0].next[0].set = 0
+userDataNode[0].next[0].binding = 0
+userDataNode[0].next[1].type = DescriptorResource
+userDataNode[0].next[1].offsetInDwords = 0
+userDataNode[0].next[1].sizeInDwords = 8
+userDataNode[0].next[1].set = 0
+userDataNode[0].next[1].binding = 1
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 1
+
+[VertexInputState]
+binding[0].binding = 1
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0

--- a/llpc/util/llpcCacheAccessor.h
+++ b/llpc/util/llpcCacheAccessor.h
@@ -51,6 +51,36 @@ public:
     initializeUsingBuildInfo(buildInfo, cacheHash, compiler);
   }
 
+  CacheAccessor(CacheAccessor &&ca) { *this = std::move(ca); }
+
+  CacheAccessor &operator=(CacheAccessor &&ca) {
+    this->m_userCache = ca.m_userCache;
+    ca.m_userCache = nullptr;
+    this->m_userShaderCache = ca.m_userShaderCache;
+    ca.m_userShaderCache = nullptr;
+
+    this->m_compiler = ca.m_compiler;
+    ca.m_compiler = nullptr;
+
+    this->m_shaderCacheEntryState = ca.m_shaderCacheEntryState;
+    ca.m_shaderCacheEntryState = ShaderEntryState::Unavailable;
+
+    this->m_shaderCacheEntry = ca.m_shaderCacheEntry;
+    ca.m_shaderCacheEntry = nullptr;
+
+    this->m_shaderCache = ca.m_shaderCache;
+    ca.m_shaderCache = nullptr;
+
+    this->m_cacheResult = ca.m_cacheResult;
+    ca.m_cacheResult = Result::ErrorUnknown;
+
+    this->m_cacheEntry = std::move(ca.m_cacheEntry);
+
+    this->m_elf = ca.m_elf;
+    ca.m_elf = {0, nullptr};
+    return *this;
+  }
+
   CacheAccessor(Context *context, MetroHash::Hash &cacheHash, Compiler *compiler);
 
   // Finalizes the cache access by releasing any handles that need to be released.
@@ -77,6 +107,10 @@ public:
   }
 
 private:
+  CacheAccessor() = delete;
+  CacheAccessor(const CacheAccessor &) = delete;
+  CacheAccessor &operator=(const CacheAccessor &) = delete;
+
   Vkgc::ICache *getUserCache() const { return m_userCache; }
   IShaderCache *getUserShaderCache() const { return m_userShaderCache; }
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1328,6 +1328,14 @@ void PipelineDumper::updateHashForResourceMappingNode(const ResourceMappingNode 
   }
 }
 
+const Hash PipelineDumper::generateHashForGlueShader(BinaryData glueShaderString) {
+  MetroHash64 hasher;
+  hasher.Update(reinterpret_cast<const uint8_t *>(glueShaderString.pCode), glueShaderString.codeSize);
+  MetroHash::Hash hash = {};
+  hasher.Finalize(hash.bytes);
+  return hash;
+}
+
 // =====================================================================================================================
 // Outputs text with specified range to output stream.
 template <class OStream>

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -103,6 +103,9 @@ public:
   // Get name of register, or "" if not known
   static const char *getRegisterNameString(unsigned regNumber);
 
+  // Returns the hash for the glue shader that corresponds to the given glue shader string.
+  static const MetroHash::Hash generateHashForGlueShader(BinaryData glueShaderString);
+
 private:
   static std::string getSpirvBinaryFileName(const MetroHash::Hash *hash);
 


### PR DESCRIPTION
This commit will add caching for glue shaders.  It also adds tests that
check that the relocatable shader path will correctly write and read
from the shader cache.

This is based on https://github.com/GPUOpen-Drivers/llpc/pull/1251.  Only the latest commit should be reviewed a part of this PR.