### PR TITLE
Move cache related code out of compiler class

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -130,10 +130,10 @@ opt<int> RelocatableShaderElfLimit("relocatable-shader-elf-limit",
 // 2 - Cache to disk
 // 3 - Use internal on-disk cache in read/write mode.
 // 4 - Use internal on-disk cache in read-only mode.
-static opt<unsigned> ShaderCacheMode("shader-cache-mode",
-                                     desc("Shader cache mode, 0 - disable, 1 - runtime cache, 2 - cache to disk, 3 - "
-                                          "load on-disk cache for read/write, 4 - load on-disk cache for read only"),
-                                     init(0));
+opt<unsigned> ShaderCacheMode("shader-cache-mode",
+                              desc("Shader cache mode, 0 - disable, 1 - runtime cache, 2 - cache to disk, 3 - "
+                                   "load on-disk cache for read/write, 4 - load on-disk cache for read only"),
+                              init(0));
 
 // -executable-name: executable file name
 static opt<std::string> ExecutableName("executable-name", desc("Executable file name"), value_desc("filename"),
@@ -217,7 +217,7 @@ static void fatalErrorHandler(void *userData, const std::string &reason, bool ge
 static CacheAccessor checkCacheForGlueShader(StringRef glueShaderIdentifier, Context *context, Compiler *compiler) {
   Hash glueShaderCacheHash =
       PipelineDumper::generateHashForGlueShader({glueShaderIdentifier.size(), glueShaderIdentifier.data()});
-  return CacheAccessor(context, glueShaderCacheHash, compiler);
+  return CacheAccessor(context, glueShaderCacheHash, compiler->getInternalCaches());
 }
 
 // =====================================================================================================================
@@ -907,7 +907,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
                                     << format_hex(context->getPipelineContext()->get128BitCacheHashCode()[1], 18)
                                     << '\n');
 
-    CacheAccessor cacheAccessor(context, cacheHash, this);
+    CacheAccessor cacheAccessor(context, cacheHash, getInternalCaches());
     if (cacheAccessor.isInCache()) {
       BinaryData elfBin = cacheAccessor.getElfFromCache();
       auto data = reinterpret_cast<const char *>(elfBin.pCode);
@@ -1031,7 +1031,7 @@ static bool hasUnrelocatableDescriptorNode(const ResourceMappingData *resourceMa
   }
 
   // If there is no 1-to-1 mapping between descriptor sets and descriptor tables, then relocatable shaders will fail.
-  llvm::SmallSet<unsigned, 8> descriptorSetsSeen;
+  SmallSet<unsigned, 8> descriptorSetsSeen;
   for (unsigned i = 0; i < resourceMapping->userDataNodeCount; ++i) {
     const ResourceMappingNode *node = &resourceMapping->pUserDataNodes[i].node;
     if (node->type != ResourceMappingNodeType::DescriptorTableVaPtr)
@@ -1362,7 +1362,7 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, unsigned stageM
   Compiler::buildShaderCacheHash(m_context, stageMask, stageHashes, &fragmentHash, &nonFragmentHash);
 
   if (stageMask & shaderStageToMask(ShaderStageFragment)) {
-    m_fragmentCacheAccessor.emplace(m_context, fragmentHash, m_compiler);
+    m_fragmentCacheAccessor.emplace(m_context, fragmentHash, m_compiler->getInternalCaches());
     if (m_fragmentCacheAccessor->isInCache()) {
       // Remove fragment shader stages.
       stageMask &= ~shaderStageToMask(ShaderStageFragment);
@@ -1370,7 +1370,7 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, unsigned stageM
   }
 
   if (stageMask & ~shaderStageToMask(ShaderStageFragment)) {
-    m_nonFragmentCacheAccessor.emplace(m_context, nonFragmentHash, m_compiler);
+    m_nonFragmentCacheAccessor.emplace(m_context, nonFragmentHash, m_compiler->getInternalCaches());
     if (m_nonFragmentCacheAccessor->isInCache()) {
       // Remove non-fragment shader stages.
       stageMask &= shaderStageToMask(ShaderStageFragment);
@@ -1558,9 +1558,9 @@ Result Compiler::BuildGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline
     PipelineDumper::DumpPipelineExtraInfo(reinterpret_cast<PipelineDumpFile *>(pipelineDumpFile), &extraInfo);
   }
 
-  llvm::Optional<CacheAccessor> cacheAccessor;
+  Optional<CacheAccessor> cacheAccessor;
   if (!buildingRelocatableElf) {
-    cacheAccessor.emplace(pipelineInfo, cacheHash, this);
+    cacheAccessor.emplace(pipelineInfo, cacheHash, getInternalCaches());
   }
 
   ElfPackage candidateElf;
@@ -1680,7 +1680,7 @@ Result Compiler::BuildComputePipeline(const ComputePipelineBuildInfo *pipelineIn
 
   std::unique_ptr<CacheAccessor> cacheAccessor;
   if (!buildingRelocatableElf) {
-    cacheAccessor = std::make_unique<CacheAccessor>(pipelineInfo, cacheHash, this);
+    cacheAccessor = std::make_unique<CacheAccessor>(pipelineInfo, cacheHash, getInternalCaches());
   }
 
   ElfPackage candidateElf;
@@ -1918,145 +1918,6 @@ void Compiler::releaseContext(Context *context) const {
   std::lock_guard<sys::Mutex> lock(m_contextPoolMutex);
   context->reset();
   context->setInUse(false);
-}
-
-// =====================================================================================================================
-// Lookup in the shader caches with the given pipeline hash code.
-// It will try App's pipelince cache first if that's available.
-// Then try on the internal shader cache next if it misses.
-//
-// Upon hit, Ready is returned and pElfBin is filled in. Upon miss, Compiling is returned and ppShaderCache and
-// phEntry are filled in.
-//
-// @param appPipelineCache : App's pipeline cache
-// @param cacheHash : Hash code of the shader
-// @param [out] elfBin : Pointer to shader data
-// @param [out] ppShaderCache : Shader cache to use
-// @param [out] phEntry : Handle to use
-ShaderEntryState Compiler::lookUpShaderCaches(IShaderCache *appPipelineCache, MetroHash::Hash *cacheHash,
-                                              BinaryData *elfBin, ShaderCache **ppShaderCache,
-                                              CacheEntryHandle *phEntry) {
-  ShaderCache *shaderCache[2];
-  unsigned shaderCacheCount = 0;
-
-  shaderCache[shaderCacheCount++] = m_shaderCache.get();
-
-  if (appPipelineCache && cl::ShaderCacheMode != ShaderCacheForceInternalCacheOnDisk) {
-    // Put the application's cache last so that we prefer adding entries there (only relevant with old
-    // client version).
-    shaderCache[shaderCacheCount++] = static_cast<ShaderCache *>(appPipelineCache);
-  }
-
-  for (unsigned i = 0; i < shaderCacheCount; i++) {
-    // Lookup the shader. Allocate on miss when we've reached the last cache.
-    bool allocateOnMiss = (i + 1) == shaderCacheCount;
-    CacheEntryHandle currentEntry;
-    ShaderEntryState cacheEntryState = shaderCache[i]->findShader(*cacheHash, allocateOnMiss, &currentEntry);
-    if (cacheEntryState == ShaderEntryState::Ready) {
-      Result result = shaderCache[i]->retrieveShader(currentEntry, &elfBin->pCode, &elfBin->codeSize);
-      if (result == Result::Success)
-        return ShaderEntryState::Ready;
-    } else if (cacheEntryState == ShaderEntryState::Compiling) {
-      *ppShaderCache = shaderCache[i];
-      *phEntry = currentEntry;
-      return ShaderEntryState::Compiling;
-    }
-  }
-
-  // Unable to allocate an entry in a cache, but we can compile anyway.
-  *ppShaderCache = nullptr;
-  *phEntry = nullptr;
-
-  return ShaderEntryState::Compiling;
-}
-
-// =====================================================================================================================
-// Update the shader caches with the given entry handle, based on the "insert" flag.
-//
-// @param insert : To insert data or reset the shader cache
-// @param elfBin : Pointer to shader data
-// @param shaderCache : Shader cache to update (may be nullptr for default)
-// @param hEntry : Handle to update
-void Compiler::updateShaderCache(bool insert, const BinaryData *elfBin, ShaderCache *shaderCache,
-                                 CacheEntryHandle hEntry) {
-  if (!hEntry)
-    return;
-
-  if (!shaderCache)
-    shaderCache = m_shaderCache.get();
-
-  if (insert) {
-    assert(elfBin->codeSize > 0);
-    shaderCache->insertShader(hEntry, elfBin->pCode, elfBin->codeSize);
-  } else
-    shaderCache->resetShader(hEntry);
-}
-
-// =====================================================================================================================
-// Lookup in the shader caches with the given pipeline hash code.
-// It will try App's pipelince cache first if that's available.
-// Then try on the internal shader cache next if it misses.
-//
-// Upon hit, Ready is returned and pElfBin is filled in. Upon miss, NotFound is returned and ppShaderCache and
-// phEntry are filled in. If NotReady is returned, means cache will be updated by another thread.
-// The returned phEntry must be released by calling ReleaseCacheEntry().
-//
-// @param appPipelineCache : App's pipeline cache
-// @param cacheHash : Hash code of the shader
-// @param [out] elfBin : Pointer to shader data
-// @param [out] entryHandle : Handle to use
-Result Compiler::lookUpCaches(ICache *appPipelineCache, HashId *cacheHash, BinaryData *elfBin,
-                              EntryHandle *entryHandle) {
-  Result cacheResult = Result::Unsupported;
-
-  auto LookUpCache = [](ICache *cache, bool allocateOnMiss, HashId *cacheHash, BinaryData *elfBin,
-                        EntryHandle *entryHandle) -> Result {
-    EntryHandle currentEntry;
-    Result cacheResult = Result::Unsupported;
-
-    cacheResult = cache->GetEntry(*cacheHash, allocateOnMiss, &currentEntry);
-
-    if (cacheResult == Result::NotReady)
-      cacheResult = currentEntry.WaitForEntry();
-
-    if (cacheResult == Result::Success) {
-      cacheResult = currentEntry.GetValueZeroCopy(&elfBin->pCode, &elfBin->codeSize);
-      *entryHandle = std::move(currentEntry);
-    } else if (allocateOnMiss && (cacheResult == Result::NotFound)) {
-      *entryHandle = std::move(currentEntry);
-    }
-
-    return cacheResult;
-  };
-
-  if (m_cache)
-    cacheResult = LookUpCache(m_cache, !appPipelineCache, cacheHash, elfBin, entryHandle);
-
-  if (appPipelineCache && cacheResult != Result::Success)
-    cacheResult = LookUpCache(appPipelineCache, true, cacheHash, elfBin, entryHandle);
-
-  return cacheResult;
-}
-
-// =====================================================================================================================
-// Release cache Entry and update the shader caches with the given entry handle, based on the "withValue" flag.
-//
-// @param withValue : Whether insert value to cache
-// @param elfBin : Pointer to shader data
-// @param cache : Shader cache to update (may be nullptr for default)
-// @param entryHandle : Handle to update
-void Compiler::ReleaseCacheEntry(bool withValue, const BinaryData *elfBin, EntryHandle *entryHandle) {
-
-  if (entryHandle->IsEmpty())
-    return;
-
-  if (withValue) {
-    assert(elfBin->codeSize > 0);
-    entryHandle->SetValue(withValue, elfBin->pCode, elfBin->codeSize);
-  }
-
-  // Empty EntryHandle
-  EntryHandle::ReleaseHandle(std::move(*entryHandle));
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -141,21 +141,11 @@ public:
   virtual Result CreateShaderCache(const ShaderCacheCreateInfo *pCreateInfo, IShaderCache **ppShaderCache);
 #endif
 
-  ShaderEntryState lookUpShaderCaches(IShaderCache *appPipelineCache, MetroHash::Hash *cacheHash, BinaryData *elfBin,
-                                      ShaderCache **ppShaderCache, CacheEntryHandle *phEntry);
-
-  void updateShaderCache(bool insert, const BinaryData *elfBin, ShaderCache *shaderCache, CacheEntryHandle phEntry);
-
-  Vkgc::Result lookUpCaches(Vkgc::ICache *appPipelineCache, Vkgc::HashId *cacheHash, BinaryData *elfBin,
-                            Vkgc::EntryHandle *entryHandle);
-
-  void ReleaseCacheEntry(bool withValue, const BinaryData *elfBin, Vkgc::EntryHandle *entryHandle);
-
-  bool IsCacheValid() { return m_cache != nullptr; }
-
   static void buildShaderCacheHash(Context *context, unsigned stageMask,
                                    llvm::ArrayRef<llvm::ArrayRef<uint8_t>> stageHashes, MetroHash::Hash *fragmentHash,
                                    MetroHash::Hash *nonFragmentHash);
+
+  CachePair getInternalCaches() { return {m_cache, m_shaderCache.get()}; }
 
 private:
   Compiler() = delete;

--- a/llpc/util/llpcCacheAccessor.h
+++ b/llpc/util/llpcCacheAccessor.h
@@ -34,54 +34,46 @@
 #include "llpc.h"
 #include "llpcShaderCache.h"
 #include "vkgcMetroHash.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace Llpc {
 
-class Compiler;
 class Context;
+
+struct CachePair {
+  Vkgc::ICache *cache = nullptr;
+  IShaderCache *shaderCache = nullptr;
+};
 
 class CacheAccessor {
 public:
-  // Checks the caches in the build info and compiler objects for an entry with the given hash.
+  // Checks the caches in the build info and the internal caches for an entry with the given hash.
   //
   // @param buildInfo : The build information that will give the caches from the application.
   // @param hash : The hash for the entry to access.
-  // @param compiler : The compiler object with the internal caches.
-  template <class BuildInfo> CacheAccessor(BuildInfo *buildInfo, MetroHash::Hash &cacheHash, Compiler *compiler) {
-    initializeUsingBuildInfo(buildInfo, cacheHash, compiler);
+  // @param internalCaches : The internal caches to check.
+  template <class BuildInfo> CacheAccessor(BuildInfo *buildInfo, MetroHash::Hash &cacheHash, CachePair internalCaches) {
+    initializeUsingBuildInfo(buildInfo, cacheHash, internalCaches);
   }
 
   CacheAccessor(CacheAccessor &&ca) { *this = std::move(ca); }
 
   CacheAccessor &operator=(CacheAccessor &&ca) {
-    this->m_userCache = ca.m_userCache;
-    ca.m_userCache = nullptr;
-    this->m_userShaderCache = ca.m_userShaderCache;
-    ca.m_userShaderCache = nullptr;
+    m_applicationCaches = ca.m_applicationCaches;
+    m_internalCaches = ca.m_internalCaches;
+    m_shaderCacheEntryState = ca.m_shaderCacheEntryState;
+    m_shaderCacheEntry = ca.m_shaderCacheEntry;
+    m_shaderCache = ca.m_shaderCache;
+    m_cacheResult = ca.m_cacheResult;
+    m_cacheEntry = std::move(ca.m_cacheEntry);
+    m_elf = ca.m_elf;
 
-    this->m_compiler = ca.m_compiler;
-    ca.m_compiler = nullptr;
-
-    this->m_shaderCacheEntryState = ca.m_shaderCacheEntryState;
-    ca.m_shaderCacheEntryState = ShaderEntryState::Unavailable;
-
-    this->m_shaderCacheEntry = ca.m_shaderCacheEntry;
-    ca.m_shaderCacheEntry = nullptr;
-
-    this->m_shaderCache = ca.m_shaderCache;
-    ca.m_shaderCache = nullptr;
-
-    this->m_cacheResult = ca.m_cacheResult;
-    ca.m_cacheResult = Result::ErrorUnknown;
-
-    this->m_cacheEntry = std::move(ca.m_cacheEntry);
-
-    this->m_elf = ca.m_elf;
-    ca.m_elf = {0, nullptr};
+    // Reinitialize ca with not caches.  It needs to be in an appropriate state for the destructor.
+    ca.initialize(nullptr, nullptr, {nullptr, nullptr});
     return *this;
   }
 
-  CacheAccessor(Context *context, MetroHash::Hash &cacheHash, Compiler *compiler);
+  CacheAccessor(Context *context, MetroHash::Hash &cacheHash, CachePair internalCaches);
 
   // Finalizes the cache access by releasing any handles that need to be released.
   ~CacheAccessor() { setElfInCache({0, nullptr}); }
@@ -103,7 +95,7 @@ public:
     if (m_cacheResult == Result::Success) {
       return true;
     }
-    return getUserShaderCache() == m_shaderCache;
+    return getApplicationShaderCache() == m_shaderCache;
   }
 
 private:
@@ -111,16 +103,22 @@ private:
   CacheAccessor(const CacheAccessor &) = delete;
   CacheAccessor &operator=(const CacheAccessor &) = delete;
 
-  Vkgc::ICache *getUserCache() const { return m_userCache; }
-  IShaderCache *getUserShaderCache() const { return m_userShaderCache; }
+  const Vkgc::ICache *getApplicationCache() const { return m_applicationCaches.cache; }
+  const IShaderCache *getApplicationShaderCache() const { return m_applicationCaches.shaderCache; }
+  const Vkgc::ICache *getInternalCache() const { return m_internalCaches.cache; }
+  const IShaderCache *getInternalShaderCache() const { return m_internalCaches.shaderCache; }
+  Vkgc::ICache *getApplicationCache() { return m_applicationCaches.cache; }
+  IShaderCache *getApplicationShaderCache() { return m_applicationCaches.shaderCache; }
+  Vkgc::ICache *getInternalCache() { return m_internalCaches.cache; }
+  IShaderCache *getInternalShaderCache() { return m_internalCaches.shaderCache; }
 
   // Access the given caches using the hash.
   //
   // @param buildInfo : The build info object that the caches from the application.
   // @param hash : The hash for the entry to access.
-  // @param compiler : The compiler object with the internal caches.
+  // @param internalCaches : The internal caches to check.
   template <class BuildInfo>
-  void initializeUsingBuildInfo(const BuildInfo *buildInfo, MetroHash::Hash &hash, Compiler *compiler) {
+  void initializeUsingBuildInfo(const BuildInfo *buildInfo, MetroHash::Hash &hash, CachePair internalCaches) {
     assert(buildInfo);
     Vkgc::ICache *userCache = buildInfo->cache;
 
@@ -129,22 +127,27 @@ private:
     userShaderCache = reinterpret_cast<IShaderCache *>(buildInfo->pShaderCache);
 #endif
 
-    initialize(hash, userCache, userShaderCache, compiler);
+    initialize(userCache, userShaderCache, internalCaches);
+    lookUpInCaches(hash);
+    if (m_cacheResult != Result::Success)
+      lookUpInShaderCaches(hash);
   }
 
-  void initialize(MetroHash::Hash &hash, Vkgc::ICache *userCache, IShaderCache *userShaderCache, Compiler *compiler);
+  void initialize(Vkgc::ICache *userCache, IShaderCache *userShaderCache, CachePair internalCaches);
 
-  // The application caches
-  Vkgc::ICache *m_userCache = nullptr;
-  IShaderCache *m_userShaderCache = nullptr;
+  void lookUpInCaches(const MetroHash::Hash &hash);
+  Result lookUpInCache(Vkgc::ICache *cache, bool allocateOnMiss, const Vkgc::HashId &hashId);
 
-  // The compiler object holds the internal caches.  Used for the functions to access those caches as well.
-  // TODO: We should write a new class that holds the internal and external cache.  Move the function to check the
-  //  caches from the compiler class, so we will not need the compiler object here.
-  Compiler *m_compiler = nullptr;
+  void lookUpInShaderCaches(MetroHash::Hash &hash);
+  bool lookUpInShaderCache(const MetroHash::Hash &hash, bool allocateOnMiss, ShaderCache *cache);
+  void updateShaderCache(BinaryData &elf);
+  void resetShaderCacheTrackingData();
+
+  CachePair m_applicationCaches;
+  CachePair m_internalCaches;
 
   // The state of the shader cache look up.
-  ShaderEntryState m_shaderCacheEntryState = ShaderEntryState::Unavailable;
+  ShaderEntryState m_shaderCacheEntryState = ShaderEntryState::New;
 
   // The handle to the entry in the shader cache.
   CacheEntryHandle m_shaderCacheEntry = nullptr;


### PR DESCRIPTION
We want to move the code that deals with the cache out of the compiler class and into the CacheAccessor class.

I have this divided into multiple commits.  You can look at each one on its own.  I can sqash them once everything is approved.  I can also make each one a separate PR it you other would like.