### PR TITLE
Port the StartStopTimer pass to LLVM's new PM

### DIFF
--- a/lgc/include/lgc/util/Internal.h
+++ b/lgc/include/lgc/util/Internal.h
@@ -46,7 +46,7 @@ class PassRegistry;
 class Type;
 class Value;
 
-void initializeStartStopTimerPass(PassRegistry &);
+void initializeLegacyStartStopTimerPass(PassRegistry &);
 
 } // namespace llvm
 
@@ -62,7 +62,7 @@ static const unsigned SizeOfVec4 = sizeof(float) * 4;
 //
 // @param passRegistry : Pass registry
 inline static void initializeUtilPasses(llvm::PassRegistry &passRegistry) {
-  initializeStartStopTimerPass(passRegistry);
+  initializeLegacyStartStopTimerPass(passRegistry);
 }
 
 // Emits a LLVM function call (inserted before the specified instruction), builds it automically based on return type


### PR DESCRIPTION
This PR starts the work for switching to LLVM's new pass manager.
We will start with the lowering pipelines (in llpcCompiler.cpp)
because they are smaller than the middle-end pipelines. 
We first port the passes to the new PM then we'll switch these
pipelines to the new PM.

This patch ports the StartStopTimer pass.
It renames the legacy StartStopTimer pass to LegacyStartStopTimer and
adds the StartStopTimer class implementing the new PM interface.
The LegacyStartStopTimer pass is now a simple wrapper to that new class.