### PR TITLE
Remove unused private fields

### DIFF
--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -80,16 +80,9 @@ private:
   llvm::Optional<CacheAccessor> m_nonFragmentCacheAccessor;
   llvm::Optional<CacheAccessor> m_fragmentCacheAccessor;
 
-  ShaderEntryState m_fragmentCacheEntryState = ShaderEntryState::New;
-  ShaderCache *m_fragmentShaderCache = nullptr;
-  CacheEntryHandle m_hFragmentEntry = {};
-  BinaryData m_fragmentElf = {};
-
   // New ICache
-  Vkgc::Result m_nonFragmentCacheResult = Vkgc::Result::ErrorUnknown;
   Vkgc::EntryHandle m_nonFragmentEntry;
 
-  Vkgc::Result m_fragmentCacheResult = Vkgc::Result::ErrorUnknown;
   Vkgc::EntryHandle m_fragmentEntry;
 };
 


### PR DESCRIPTION
These became unused in #1239 "Use CacheAccessor in the
GraphicsShaderCacheChecker".

Change-Id: I0a01723905e74ca39a3d6037cce974ee6f8be900