### PR TITLE
Add a new out of bounds check for scratch accesses to the frontend.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -354,6 +354,8 @@ struct PipelineOptions {
                                    ///  then linking them, when possible.  When not possible this option is ignored.
   bool disableImageResourceCheck;  ///< If set, the pipeline shader will not contain code to check and fix invalid image
                                    ///  descriptors.
+  bool enableScratchAccessBoundsChecks; ///< If set, out of bounds guards will be inserted in the LLVM IR for OpLoads
+                                        ///< and OpStores in private and function memory storage.
   ShadowDescriptorTableUsage shadowDescriptorTableUsage; ///< Controls shadow descriptor table.
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
   ExtendedRobustness extendedRobustness;                 ///< ExtendedRobustness is intended to correspond to the

--- a/llpc/test/shaderdb/OOB_Check_Load_Array_Loop_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Load_Array_Loop_lit.frag
@@ -1,0 +1,42 @@
+// This test checks if using a loop of unknown length to access an array
+// will be transformed to an out of bounds checks against all bounds of the array, moving the load into a conditionally executed BB.
+// The OOB check will possibly zero out the load results.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[parent:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [2048 x <4 x float>], align 16, addrspace(5)
+; SHADERTEST: {{.*}}:
+; SHADERTEST: {{.*}}:
+; SHADERTEST: [[check:[a-z0-9]+]]:
+; SHADERTEST: %[[idx1:[0-9]+]] = load i32, i32 addrspace(5)* %{{.*}}, align 4
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [2048 x <4 x float>], [2048 x <4 x float>] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]]
+; SHADERTEST: %[[cmp:[0-9]+]] = icmp ult i32 %[[idx1]], 2048
+; SHADERTEST: br i1 %[[cmp]], label %{{.*}}, label %{{.*}}
+; SHADERTEST: {{.*}}:
+; SHADERTEST: {{.*}}:
+; SHADERTEST: [[load:[a-z0-9]+]]:
+; SHADERTEST: %[[loadResult:[0-9]+]] = load <4 x float>, <4 x float> addrspace(5)* %[[gep]], align 16
+; SHADERTEST: br label %{{.*}}
+; SHADERTEST: [[final:[a-z0-9]+]]:
+; SHADERTEST: %{{.*}} = phi reassoc nnan nsz arcp contract afn <4 x float> [ zeroinitializer, %[[check]] ], [ %[[loadResult]], %[[load]] ]
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+void main() {
+  vec4 data[2048];
+
+  for (int i = 0; i < c.array_index; ++i) {
+    outFragColor += inColor * data[i];
+  }
+}

--- a/llpc/test/shaderdb/OOB_Check_Load_Array_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Load_Array_lit.frag
@@ -1,0 +1,38 @@
+// This test checks if load access to a 2D (multidimensional) array using a runtime index
+// will be transformed to an out of bounds checks against all bounds of the array, moving the load into a conditionally executed BB.
+// The OOB check will possibly zero out the load results.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[entry:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [2048 x [2 x <4 x float>]], align 16, addrspace(5)
+; SHADERTEST: load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[idx1:[0-9]+]] = add i32 %{{.*}}, 2048
+; SHADERTEST: load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[idx2:[0-9]+]] = add i32 %{{.*}}, 2048
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [2048 x [2 x <4 x float>]], [2048 x [2 x <4 x float>]] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]], i32 %[[idx2]]
+; SHADERTEST-NEXT: %[[B:[0-9]+]] = icmp ult i32 %[[A:[0-9]+]], 2048
+; SHADERTEST-NEXT: %[[D:[0-9]+]] = icmp ult i32 %[[C:[0-9]+]], 2
+; SHADERTEST-NEXT: %[[cmp:[0-9]+]] = and i1 %[[B]], %[[D]]
+; SHADERTEST-NEXT: br i1 %[[cmp]], label %{{.*}}, label %{{.*}}
+; SHADERTEST: [[load:[a-z0-9]+]]:
+; SHADERTEST: %[[loadResult:[0-9]+]] = load <4 x float>, <4 x float> addrspace(5)* %[[gep]], align 16
+; SHADERTEST: [[final:[a-z0-9]+]]:
+; SHADERTEST: %{{.*}} = phi reassoc nnan nsz arcp contract afn <4 x float> [ zeroinitializer, %.[[entry]] ], [ %[[loadResult]], %[[load]] ]
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+void main() {
+  vec4 data[2048][2];
+  outFragColor = inColor * data[c.array_index + 2048][c.array_index + 2048];
+}

--- a/llpc/test/shaderdb/OOB_Check_Load_Array_with_Struct_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Load_Array_with_Struct_lit.frag
@@ -1,0 +1,38 @@
+// This test checks if load access to an array including a simple struct using a runtime index
+// will be transformed to an out of bounds checks against the bounds of the array, moving the load into a conditionally executed BB.
+// The OOB check will possibly zero out the load results.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[entry:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [5 x { <4 x float> }], align 16, addrspace(5)
+; SHADERTEST: %[[idx1:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [5 x { <4 x float> }], [5 x { <4 x float> }] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]], i32 0
+; SHADERTEST: %[[cmp:[0-9]+]] = icmp ult i32 %[[A:[0-9]+]], 5
+; SHADERTEST-NEXT: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}
+; SHADERTEST: [[load:[a-z0-9]+]]:
+; SHADERTEST: [[loadResult:[0-9]+]] = load <4 x float>, <4 x float> addrspace(5)* %{{.*}}, align 16
+; SHADERTEST: [[final:[a-z0-9]+]]:
+; SHADERTEST: %{{.*}} = phi reassoc nnan nsz arcp contract afn <4 x float> [ zeroinitializer, %.[[entry]] ], [ %[[loadResult]], %[[load]] ]
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+struct BaseStruct {
+	vec4 data;
+};
+
+void main() {
+  BaseStruct checker[5];
+
+  outFragColor = inColor * checker[c.array_index].data;
+}

--- a/llpc/test/shaderdb/OOB_Check_Load_Nested_Struct_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Load_Nested_Struct_lit.frag
@@ -1,0 +1,53 @@
+// This test checks if load access to an array of nested structs which use arrays using some runtime indices
+// will be transformed to an out of bounds checks against all accessed elements, moving the load into a conditionally executed BB.
+// The OOB check will possibly zero out the load results.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[entry:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [5 x { [10 x <4 x float>], [12 x { [4 x <4 x float>] }] }], align 16, addrspace(5)
+; SHADERTEST: {{.*}}:
+; SHADERTEST: [[parent:[a-z0-9]+]]:
+; SHADERTEST: %[[idx1:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[tmp:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[idx2:[0-9]+]] = add i32 %[[tmp]], 2
+; SHADERTEST: %[[idx3:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [5 x { [10 x <4 x float>], [12 x { [4 x <4 x float>] }] }], [5 x { [10 x <4 x float>], [12 x { [4 x <4 x float>] }] }] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]], i32 1, i32 %[[idx2]], i32 0, i32 %[[idx3]]
+; SHADERTEST: %[[A:[0-9]+]] = icmp ult i32 %[[idx1]], 5
+; SHADERTEST: %[[B:[0-9]+]] = icmp ult i32 %[[idx2]], 12
+; SHADERTEST: %[[C:[0-9]+]] = and i1 %[[A]], %[[B]]
+; SHADERTEST: %[[D:[0-9]+]] = icmp ult i32 %[[idx3]], 4
+; SHADERTEST: %[[cmp:[0-9]+]] = and i1 %[[C]], %[[D]]
+; SHADERTEST: br i1 %[[cmp]], label %{{.*}}, label %{{.*}}
+; SHADERTEST: [[load:[a-z0-9]+]]:
+; SHADERTEST: %[[loadResult:[0-9]+]] = load <4 x float>, <4 x float> addrspace(5)* %[[gep]], align 16
+; SHADERTEST: br label %{{.*}}
+; SHADERTEST: [[final:[a-z0-9]+]]:
+; SHADERTEST: %{{.*}} = phi reassoc nnan nsz arcp contract afn <4 x float> [ zeroinitializer, %{{.*}} ], [ %[[loadResult]], %[[load]] ]
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+struct NestedStruct {
+  vec4 nested[4];
+};
+
+struct BaseStruct {
+	vec4 data[10];
+	NestedStruct data2[12];
+};
+
+void main() {
+  BaseStruct checker[5];
+
+  outFragColor = inColor * checker[c.array_index].data[c.array_index + 1] + checker[c.array_index].data2[c.array_index + 2].nested[c.array_index];
+}

--- a/llpc/test/shaderdb/OOB_Check_Load_Struct_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Load_Struct_lit.frag
@@ -1,0 +1,46 @@
+// This test checks if load access to an array inside a array of structs using some runtime indices
+// will be transformed to an out of bounds checks against all accessed elements, moving the load into a conditionally executed BB.
+// The OOB check will possibly zero out the load results.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[entry:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [5 x { [10 x <4 x float>], [12 x <4 x float>] }], align 16, addrspace(5)
+; SHADERTEST: {{.*}}:
+; SHADERTEST: [[parent:[a-z0-9]+]]:
+; SHADERTEST: %[[idx1:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[tmp:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @2, i32 0, i32 0), align 4
+; SHADERTEST: %[[idx2:[0-9]+]] = add i32 %[[tmp]], 2
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [5 x { [10 x <4 x float>], [12 x <4 x float>] }], [5 x { [10 x <4 x float>], [12 x <4 x float>] }] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]], i32 1, i32 %[[idx2]]
+; SHADERTEST-NEXT: icmp ult i32 %[[idx1]], 5
+; SHADERTEST-NEXT: icmp ult i32 %[[idx2]], 12
+; SHADERTEST-NEXT: %[[cmp:[0-9]+]] = and i1 %{{.*}}, %{{.*}}
+; SHADERTEST-NEXT: br i1 %[[cmp]], label %{{.*}}, label %{{.*}}
+; SHADERTEST: [[load:[0-9]+]]:
+; SHADERTEST: %[[loadResult:[0-9]+]] = load <4 x float>, <4 x float> addrspace(5)* %[[gep]], align 16
+; SHADERTEST: br label %{{.*}}
+; SHADERTEST: [[final:[0-9]+]]:
+; SHADERTEST: %{{.*}} = phi reassoc nnan nsz arcp contract afn <4 x float> [ zeroinitializer, %[[parent]] ], [ %[[loadResult]], %[[load]] ]
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+struct BaseStruct {
+	vec4 data[10];
+	vec4 data2[12];
+};
+
+void main() {
+  BaseStruct checker[5];
+
+  outFragColor = inColor * checker[c.array_index].data[c.array_index + 1] + checker[c.array_index].data2[c.array_index + 2];
+}

--- a/llpc/test/shaderdb/OOB_Check_Optimization_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Optimization_lit.frag
@@ -1,0 +1,37 @@
+// This test checks if an OOB check will get optimized away. It does so by checking if there
+// are no phi nodes left at the end.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
+; SHADERTEST-NOT: phi
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { uint array_index; vec4 data[14]; } c;
+
+struct NestedStruct {
+  vec4 nested[4];
+};
+
+struct BaseStruct {
+	vec4 data[10];
+	NestedStruct data2[12];
+};
+
+void main() {
+  BaseStruct checker[5];
+  for (int i = 0; i < 5; i++) {
+    for (int j = 0; j < 10; j++) {
+      checker[i].data[j] = c.data[i + j];
+    }
+  }
+
+  outFragColor = checker[c.array_index % 5].data[c.array_index % 10];
+}

--- a/llpc/test/shaderdb/OOB_Check_Store_Array_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Store_Array_lit.frag
@@ -1,0 +1,38 @@
+// This test checks if store access to an array inside a 2D (multidimensional) array using some runtime indices
+// will be transformed to an out of bounds checks against all accessed elements, moving the store into a conditionally executed BB.
+// The OOB check will possibly omit the store.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[entry:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [2048 x [2 x <4 x float>]], align 16, addrspace(5)
+; SHADERTEST: %[[idx1:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @0, i32 0, i32 0), align 4
+; SHADERTEST: %[[idx2:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @0, i32 0, i32 0), align 4
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [2048 x [2 x <4 x float>]], [2048 x [2 x <4 x float>]] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]], i32 %[[idx2]]
+; SHADERTEST-NEXT: %[[B:[0-9]+]] = icmp ult i32 %[[A:[0-9]+]], 2048
+; SHADERTEST-NEXT: %[[D:[0-9]+]] = icmp ult i32 %[[C:[0-9]+]], 2
+; SHADERTEST-NEXT: %[[cmp:[0-9]+]] = and i1 %[[B]], %[[D]]
+; SHADERTEST-NEXT: br i1 %[[cmp]], label %{{.*}}, label %{{.*}}
+; SHADERTEST: [[store:[a-z0-9]+]]:
+; SHADERTEST: store <4 x float> %{{.*}}, <4 x float> addrspace(5)* %[[gep]], align 16
+; SHADERTEST: br label %{{.*}}
+; SHADERTEST: [[final:[a-z0-9]+]]:
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+void main() {
+  vec4 data[2048][2];
+  data[c.array_index][c.array_index] = inColor.rrrr;
+
+  outFragColor = inColor * data[c.array_index + 2048][c.array_index + 2048];
+}

--- a/llpc/test/shaderdb/OOB_Check_Store_Struct_lit.frag
+++ b/llpc/test/shaderdb/OOB_Check_Store_Struct_lit.frag
@@ -1,0 +1,43 @@
+// This test checks if store access to an array inside a array of structs using some runtime indices
+// will be transformed to an out of bounds checks against all accessed elements, moving the store into a conditionally executed BB.
+// The OOB check will possibly omit the store.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -enable-scratch-bounds-checks | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: .[[entry:[a-z0-9]+]]:
+; SHADERTEST: %[[arr:[0-9]+]] = alloca [5 x { [10 x <4 x float>] }], align 16, addrspace(5)
+; SHADERTEST: %[[idx1:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @0, i32 0, i32 0), align 4
+; SHADERTEST: %[[tmp:[0-9]+]] = load i32, i32 addrspace(7)* getelementptr inbounds (<{ i32 }>, <{ i32 }> addrspace(7)* @0, i32 0, i32 0), align 4
+; SHADERTEST: %[[idx2:[0-9]+]] = add i32 %[[tmp]], 1
+; SHADERTEST: %[[gep:[0-9]+]] = getelementptr [5 x { [10 x <4 x float>] }], [5 x { [10 x <4 x float>] }] addrspace(5)* %[[arr]], i32 0, i32 %[[idx1]], i32 0, i32 %[[idx2]]
+; SHADERTEST: icmp ult i32 %{{.*}}, 5
+; SHADERTEST: icmp ult i32 %{{.*}}, 10
+; SHADERTEST: %[[cmp:[0-9]+]] = and i1 %{{.*}}, %{{.*}}
+; SHADERTEST-NEXT: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}
+; SHADERTEST: [[store:[a-z0-9]+]]:
+; SHADERTEST: store <4 x float> %{{.*}}, <4 x float> addrspace(5)* %[[gep]], align 16
+; SHADERTEST: br label %{{.*}}
+; SHADERTEST: [[final:[a-z0-9]+]]:
+
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450 core
+
+layout (location = 0) in vec4 inColor;
+layout (location = 0) out vec4 outFragColor;
+layout (binding = 0) uniform Constant { int array_index; } c;
+
+struct BaseStruct {
+	vec4 data[10];
+};
+
+void main() {
+  BaseStruct checker[5];
+  checker[c.array_index].data[c.array_index + 1] = inColor * 4.0;
+
+  outFragColor = inColor + checker[c.array_index].data[c.array_index + 1];
+}

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -232,10 +232,16 @@ static cl::opt<bool> EnableRelocatableShaderElf("enable-relocatable-shader-elf",
                                                 cl::desc("Compile pipelines using relocatable shader elf"),
                                                 cl::init(false));
 
-// -check-auto-layout-compatible: check if auto descriptor layout got from spv file is commpatible with real layout
+// -check-auto-layout-compatible: check if auto descriptor layout got from spv file is compatible with real layout
 static cl::opt<bool> CheckAutoLayoutCompatible(
     "check-auto-layout-compatible",
-    cl::desc("check if auto descriptor layout got from spv file is commpatible with real layout"));
+    cl::desc("Check if auto descriptor layout got from spv file is compatible with real layout"));
+
+// -enable-scratch-bounds-checks: insert scratch access bounds checks on loads and stores
+static cl::opt<bool>
+    EnableScratchAccessBoundsChecks("enable-scratch-bounds-checks",
+                                    cl::desc("Insert scratch access bounds checks on loads and stores"),
+                                    cl::init(false));
 
 namespace llvm {
 
@@ -1042,6 +1048,7 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
 
     pipelineInfo->options.robustBufferAccess = RobustBufferAccess;
     pipelineInfo->options.enableRelocatableShaderElf = EnableRelocatableShaderElf;
+    pipelineInfo->options.enableScratchAccessBoundsChecks = EnableScratchAccessBoundsChecks;
 
     void *pipelineDumpHandle = nullptr;
     if (cl::EnablePipelineDump) {
@@ -1117,6 +1124,7 @@ static Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo) {
     pipelineInfo->unlinked = compileInfo->unlinked;
     pipelineInfo->options.robustBufferAccess = RobustBufferAccess;
     pipelineInfo->options.enableRelocatableShaderElf = EnableRelocatableShaderElf;
+    pipelineInfo->options.enableScratchAccessBoundsChecks = EnableScratchAccessBoundsChecks;
 
     void *pipelineDumpHandle = nullptr;
     if (cl::EnablePipelineDump) {


### PR DESCRIPTION
According to https://github.com/GPUOpen-Drivers/llpc/pull/990, some applications run memory accesses on stack-allocated arrays in scratch space with runtime indices which are sometimes out of bounds, leading to crashes.
Above PR mentioned a complete solution (https://github.com/GPUOpen-Drivers/llpc/pull/990#issuecomment-714743101) to prevent these accesses. We decided not to go with this path but to insert out of bounds accesses when translating SPIR-V to LLVM IR on OpLoads and OpStores which operate on either private or function class storage. If the check is enabled, all loads and stores generated from OpLoads and OpStores should be guarded by changing the control flow. If an invalid array element gets accessed, the loads will be yielding zero and stores will simply be NOPed.
This PR aims to implement the OOB checks described above. For now, the new checks (the argument is called `--scratch-bounds-checks` are disabled by default.

I am open to suggestions as this is my first change involving LLPC.
The goal should be to have this enabled by default, but for now, we should just check for correctness of the transformation and maybe enable it by default at a later stage.