### PR TITLE
Move PatchResourceCollect::m_inOutPackState to PipelineState

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -578,7 +578,7 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
     xfbOutInfo.is16bit = valueToWrite->getType()->getScalarSizeInBits() == 16;
 
     // For packed generic GS output, the XFB output should be scalarized to align with the scalarized GS output
-    if (!getPipelineState()->isUnlinked() && !isBuiltIn) {
+    if (getPipelineState()->canPackOutput(m_shaderStage) && !isBuiltIn) {
       Type *elementTy = valueToWrite->getType();
       unsigned scalarizeBy = 1;
       if (auto vectorTy = dyn_cast<FixedVectorType>(elementTy)) {

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -296,6 +296,15 @@ public:
   // Set error message to be returned to the client by it calling getLastError
   void setError(const llvm::Twine &message);
 
+  // Initialize the packable state of generic input/output
+  void initializeInOutPackState();
+
+  // Get whehter the input locations of the specified shader stage can be packed
+  bool canPackInput(ShaderStage shaderStage) const { return m_inputPackState[shaderStage]; }
+
+  // Get whehter the output locations of the specified shader stage can be packed
+  bool canPackOutput(ShaderStage shaderStage) const { return m_outputPackState[shaderStage]; }
+
   // -----------------------------------------------------------------------------------------------------------------
   // Utility methods
 
@@ -446,6 +455,8 @@ private:
   std::unique_ptr<InterfaceData> m_interfaceData[ShaderStageCompute + 1] = {}; // Per-shader InterfaceData
   PalMetadata *m_palMetadata = nullptr;                                        // PAL metadata object
   unsigned m_waveSize[ShaderStageCountInternal] = {};                          // Per-shader wave size
+  bool m_inputPackState[ShaderStageGfxCount] = {};  // The input packable state per shader stage
+  bool m_outputPackState[ShaderStageGfxCount] = {}; // The output packable state per shader stage
 };
 
 // =====================================================================================================================

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -429,7 +429,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
 
   if (resUsage->inOutUsage.enableXfb) {
     // Export XFB output
-    if (!m_pipelineState->isUnlinked()) {
+    if (m_pipelineState->canPackOutput(ShaderStageGeometry)) {
       // With packing locations, we should collect the XFB output value at an origianl location
       DenseMap<unsigned, SmallVector<Value *, 4>> origLocElemsMap;
       for (const auto &locInfoXfbInfoPair : locInfoXfbOutInfoMap) {

--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -86,7 +86,6 @@ private:
 
   void updateInputLocInfoMapWithUnpack();
   void updateOutputLocInfoMapWithUnpack();
-  void packInOutLocation(bool isInput);
   void updateInputLocInfoMapWithPack();
   void updateOutputLocInfoMapWithPack();
   void reassembleOutputExportCalls();
@@ -113,8 +112,6 @@ private:
   ResourceUsage *m_resUsage;  // Pointer to shader resource usage
   std::unique_ptr<InOutLocationInfoMapManager>
       m_locationInfoMapManager; // Pointer to InOutLocationInfoMapManager instance
-  bool m_inOutPackStates[ShaderStageGfxCount][2] = {
-      {false, false}}; // The input and output packable state of each shader stage, 0-input, 1-output
 };
 
 // Represents the compatibility info of input/output

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1324,6 +1324,23 @@ StringRef PipelineState::getBuiltInName(BuiltInKind builtIn) {
 }
 
 // =====================================================================================================================
+// Set the packable state of generic input/output
+//
+void PipelineState::initializeInOutPackState() {
+  // If the pipeline is not unlinked, the state of input/output pack in specified shader stages is enabled
+  if (!m_unlinked) {
+    // The generic input import of {TCS, GS, FS} are packed by default
+    m_inputPackState[ShaderStageTessControl] = true;
+    m_inputPackState[ShaderStageGeometry] = true;
+    m_inputPackState[ShaderStageFragment] = true;
+    // The generic output exports of {VS, TES, GS} are packed by default
+    m_outputPackState[ShaderStageVertex] = true;
+    m_outputPackState[ShaderStageTessEval] = true;
+    m_outputPackState[ShaderStageGeometry] = true;
+  }
+}
+
+// =====================================================================================================================
 // Get (create if necessary) the PipelineState from this wrapper pass.
 //
 // @param module : IR module
@@ -1332,6 +1349,7 @@ PipelineState *PipelineStateWrapper::getPipelineState(Module *module) {
     m_allocatedPipelineState = std::make_unique<PipelineState>(m_builderContext);
     m_pipelineState = &*m_allocatedPipelineState;
     m_pipelineState->readState(module);
+    m_pipelineState->initializeInOutPackState();
   }
   return m_pipelineState;
 }


### PR DESCRIPTION
The change aims to ensure the generic input/output of a stage can go
througth the same handling either packing or no-packing in different
places. This will fix some potential issues.
In InOutBuilder::CreateWriteXfbOutput, the generic XFB output is
scalarized without considering the packable state while the generic
output of GS is scalarized based on the packable state, which will cause
mismatch.