### PR TITLE
Change immutable samplers in pipeline state to plain data

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -445,8 +445,10 @@ private:
   std::vector<ShaderOptions> m_shaderOptions;           // Per-shader options
   std::unique_ptr<ResourceNode[]> m_allocUserDataNodes; // Allocated buffer for user data
   llvm::ArrayRef<ResourceNode> m_userDataNodes;         // Top-level user data node table
-  llvm::MDString *m_resourceNodeTypeNames[unsigned(ResourceNodeType::Count)] = {};
+  // Allocated buffers for immutable sampler data
+  llvm::SmallVector<std::unique_ptr<uint32_t[]>, 4> m_immutableValueAllocs;
   // Cached MDString for each resource node type
+  llvm::MDString *m_resourceNodeTypeNames[unsigned(ResourceNodeType::Count)] = {};
 
   bool m_gsOnChip = false;                                                     // Whether to use GS on-chip mode
   NggControl m_nggControl = {};                                                // NGG control settings

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -58,8 +58,10 @@ class TargetInfo;
 
 // Size in bytes of resource (image) descriptor
 static constexpr unsigned DescriptorSizeResource = 8 * sizeof(uint32_t);
+// Size in dwords of sampler descriptor
+static constexpr unsigned DescriptorSizeSamplerInDwords = 4;
 // Size in bytes of sampler descriptor
-static constexpr unsigned DescriptorSizeSampler = 4 * sizeof(uint32_t);
+static constexpr unsigned DescriptorSizeSampler = DescriptorSizeSamplerInDwords * sizeof(uint32_t);
 // Size in bytes of buffer descriptor
 static constexpr unsigned DescriptorSizeBuffer = 4 * sizeof(uint32_t);
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -228,7 +228,8 @@ struct ResourceNode {
       unsigned set;                   // Descriptor set
       unsigned binding;               // Binding
       unsigned stride;                // Size of each descriptor in the indexable range in dwords.
-      llvm::Constant *immutableValue; // Array of vectors of i32 constants for immutable value
+      unsigned immutableSize;         // Size (in units of DescriptorSizeSampler bytes) of immutableValue array
+      const uint32_t *immutableValue; // Array of dwords for immutable sampler.
     };
 
     // Info for DescriptorTableVaPtr
@@ -237,15 +238,6 @@ struct ResourceNode {
     // Info for indirect data nodes (IndirectUserDataVaPtr, StreamOutVaTablePtr)
     unsigned indirectSizeInDwords;
   };
-};
-
-/// Represents the info of immutable descriptor.
-struct ImmutableDescriptor {
-  ResourceNodeType type; ///< Type of this resource node (currently, only sampler is supported)
-  unsigned set;          ///< ID of descriptor set
-  unsigned binding;      ///< ID of descriptor binding
-  unsigned arraySize;    ///< Element count for arrayed binding
-  const unsigned *value; ///< Static SRDs
 };
 
 // =====================================================================================================================

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -135,9 +135,7 @@ Module *PipelineState::irLink(ArrayRef<Module *> modules, bool unlinked) {
     pipelineModule = modules[0];
     pipelineModule->setModuleIdentifier("lgcPipeline");
   } else {
-    // Create an empty module then link each shader module into it. We record pipeline state into IR
-    // metadata before the link, to avoid problems with a Constant for an immutable descriptor value
-    // disappearing when modules are deleted.
+    // Create an empty module then link each shader module into it.
     bool result = true;
     pipelineModule = new Module("lgcPipeline", getContext());
     TargetMachine *targetMachine = getLgcContext()->getTargetMachine();

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -558,6 +558,7 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
       destNode.set = node.srdRange.set;
       destNode.binding = node.srdRange.binding;
       destNode.immutableValue = nullptr;
+      destNode.immutableSize = 0;
       switch (node.type) {
       case ResourceMappingNodeType::DescriptorResource:
       case ResourceMappingNodeType::DescriptorFmask:
@@ -610,15 +611,8 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
             destNode.stride /= immutableNode.arraySize;
           }
 
-          constexpr unsigned SamplerDescriptorSize = 4;
-
-          for (unsigned compIdx = 0; compIdx < immutableNode.arraySize; ++compIdx) {
-            Constant *compValues[SamplerDescriptorSize] = {};
-            for (unsigned i = 0; i < SamplerDescriptorSize; ++i)
-              compValues[i] = builder.getInt32(immutableNode.pValue[compIdx * SamplerDescriptorSize + i]);
-            values.push_back(ConstantVector::get(compValues));
-          }
-          destNode.immutableValue = ConstantArray::get(ArrayType::get(values[0]->getType(), values.size()), values);
+          destNode.immutableSize = immutableNode.arraySize;
+          destNode.immutableValue = immutableNode.pValue;
         }
       }
       break;


### PR DESCRIPTION
LGC pipeline state was keeping an IR constant (an array of <4 x i32>) for each
immutable sampler. It is a bit dodgy keeping an IR value outside of IR
beyond a single pass, and we were running into problems.

This commit changes pipeline state to keep immutable samplers as plain
data. It gets converted to an IR constant in DescBuilder when it
constructs the constant global variable to represent the immutable
sampler.