### PR TITLE
Refactor relocatable shader compilation

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -200,6 +200,14 @@ enum ShaderStageBit : unsigned {
   ShaderStageComputeBit = (1 << ShaderStageCompute),         ///< Compute shader bit
 };
 
+/// Enumerates LLPC types of unlinked shader elf.
+enum UnlinkedShaderStage : unsigned {
+  UnlinkedStageVertexProcess,
+  UnlinkedStageFragment,
+  UnlinkedStageCompute,
+  UnlinkedStageCount
+};
+
 static_assert((1 << (ShaderStageCount - 1)) == ShaderStageComputeBit,
               "Vkgc::ShaderStage has been updated. Please update Vkgc::ShaderStageBit as well.");
 

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -876,7 +876,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
   bool isUnlinkedPipeline = context->getPipelineContext()->isUnlinked();
   context->getPipelineContext()->setUnlinked(true);
 
-  ElfPackage elf[ShaderStageNativeStageCount];
+  ElfPackage elf[UnlinkedStageCount];
   assert(stageCacheAccesses.size() >= shaderInfo.size());
 
   const MetroHash::Hash originalCacheHash = context->getPipelineContext()->getCacheHashCodeWithoutCompact();
@@ -884,13 +884,15 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
   LLPC_OUTS("LLPC version: " << VersionTuple(LLPC_INTERFACE_MAJOR_VERSION, LLPC_INTERFACE_MINOR_VERSION) << "\n");
   LLPC_OUTS("Hash for pipeline cache lookup: " << formatBytesLittleEndian<uint8_t>(originalCacheHash.bytes) << "\n");
 
-  for (unsigned stage = 0; stage < shaderInfo.size() && result == Result::Success; ++stage) {
-    if (!shaderInfo[stage] || !shaderInfo[stage]->pModuleData)
+  for (UnlinkedShaderStage stage = static_cast<UnlinkedShaderStage>(0);
+       stage < UnlinkedStageCount && result == Result::Success; ++stage) {
+    if (!hasDataForUnlinkedShaderType(stage, shaderInfo))
       continue;
 
-    context->getPipelineContext()->setShaderStageMask(shaderStageToMask(static_cast<ShaderStage>(stage)));
+    unsigned shaderStageMask = getShaderStageMaskForType(stage) & originalShaderStageMask;
+    context->getPipelineContext()->setShaderStageMask(shaderStageMask);
 
-    // Check the cache for the relocatable shader for this stage.
+    // Check the cache for the relocatable shader for this stage .
     MetroHash::Hash cacheHash = {};
     if (context->isGraphics()) {
       auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
@@ -902,7 +904,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
     // Note that this code updates m_pipelineHash of the pipeline context. It
     // must be restored before we link the pipeline ELF at the end of this for-loop.
     context->getPipelineContext()->setHashForCacheLookUp(cacheHash);
-    LLPC_OUTS("Finalized hash for " << getShaderStageName(static_cast<ShaderStage>(stage)) << " stage cache lookup: "
+    LLPC_OUTS("Finalized hash for " << getUnlinkedShaderStageName(stage) << " stage cache lookup: "
                                     << format_hex(context->getPipelineContext()->get128BitCacheHashCode()[0], 18) << ' '
                                     << format_hex(context->getPipelineContext()->get128BitCacheHashCode()[1], 18)
                                     << '\n');
@@ -912,19 +914,29 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
       BinaryData elfBin = cacheAccessor.getElfFromCache();
       auto data = reinterpret_cast<const char *>(elfBin.pCode);
       elf[stage].assign(data, data + elfBin.codeSize);
-      LLPC_OUTS("Cache hit for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
-      stageCacheAccesses[stage] =
-          cacheAccessor.hitInternalCache() ? CacheAccessInfo::InternalCacheHit : CacheAccessInfo::CacheHit;
+      LLPC_OUTS("Cache hit for shader stage " << getUnlinkedShaderStageName(stage) << "\n");
+      for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1)) {
+        if (shaderStageMask & shaderStageToMask(stage))
+          stageCacheAccesses[stage] =
+              cacheAccessor.hitInternalCache() ? CacheAccessInfo::InternalCacheHit : CacheAccessInfo::CacheHit;
+      }
       continue;
     }
-    LLPC_OUTS("Cache miss for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
-    stageCacheAccesses[stage] = CacheAccessInfo::CacheMiss;
+    LLPC_OUTS("Cache miss for shader stage " << getUnlinkedShaderStageName(stage) << "\n");
+    for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1)) {
+      if (shaderStageMask & shaderStageToMask(stage))
+        stageCacheAccesses[stage] = CacheAccessInfo::CacheMiss;
+    }
 
     // There was a cache miss, so we need to build the relocatable shader for
     // this stage.
     const PipelineShaderInfo *singleStageShaderInfo[ShaderStageNativeStageCount] = {nullptr, nullptr, nullptr,
                                                                                     nullptr, nullptr, nullptr};
-    singleStageShaderInfo[stage] = shaderInfo[stage];
+
+    for (unsigned stage = ShaderStageVertex; stage != ShaderStageNativeStageCount; ++stage) {
+      if (shaderStageMask & shaderStageToMask(static_cast<ShaderStage>(stage)))
+        singleStageShaderInfo[stage] = shaderInfo[stage];
+    }
 
     result = buildPipelineInternal(context, singleStageShaderInfo, /*unlinked=*/true, &elf[stage]);
 
@@ -932,7 +944,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
     if (result == Result::Success) {
       BinaryData elfBin = {elf[stage].size(), elf[stage].data()};
       cacheAccessor.setElfInCache(elfBin);
-      LLPC_OUTS("Updating the cache for shader stage " << getShaderStageName(static_cast<ShaderStage>(stage)) << "\n");
+      LLPC_OUTS("Updating the cache for unlinked shader stage " << getUnlinkedShaderStageName(stage) << "\n");
     }
   }
   context->getPipelineContext()->setHashForCacheLookUp(originalCacheHash);
@@ -952,7 +964,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
         result = Result::ErrorInvalidShader;
     } else {
       // Return the first relocatable shader, since we can only return one anyway.
-      for (unsigned stage = 0; stage < ShaderStageNativeStageCount; ++stage) {
+      for (unsigned stage = 0; stage < UnlinkedStageCount; ++stage) {
         if (elf[stage].empty())
           continue;
         *pipelineElf = elf[stage];
@@ -1998,9 +2010,6 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
 // @param [out] pipelineElf : Elf package containing the pipeline elf
 // @param context : Acquired context
 void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context) {
-  assert(shaderElfs[ShaderStageTessControl].empty() && "Cannot link tessellation shaders yet.");
-  assert(shaderElfs[ShaderStageTessEval].empty() && "Cannot link tessellation shaders yet.");
-  assert(shaderElfs[ShaderStageGeometry].empty() && "Cannot link geometry shaders yet.");
   assert(!context->getPipelineContext()->isUnlinked() && "Not supposed to link this pipeline.");
 
   // Set up middle-end objects, including setting up pipeline state.
@@ -2010,9 +2019,9 @@ void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipe
 
   // Create linker, passing ELFs to it.
   SmallVector<MemoryBufferRef, 3> elfs;
-  for (unsigned stage = 0; stage != ShaderStageNativeStageCount; ++stage) {
+  for (UnlinkedShaderStage stage = static_cast<UnlinkedShaderStage>(0); stage != UnlinkedStageCount; ++stage) {
     if (!shaderElfs[stage].empty())
-      elfs.push_back(MemoryBufferRef(shaderElfs[stage].str(), getShaderStageName(static_cast<ShaderStage>(stage))));
+      elfs.push_back(MemoryBufferRef(shaderElfs[stage].str(), getUnlinkedShaderStageName(stage)));
   }
   std::unique_ptr<ElfLinker> elfLinker(pipeline->createElfLinker(elfs));
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ShaderCache.pipe
@@ -10,7 +10,7 @@
 ; REQUIRES: llpc-shader-cache
 ; CREATE: Building pipeline with relocatable shader elf.
 ; CREATE: Cache miss for shader stage compute
-; CREATE: Updating the cache for shader stage compute
+; CREATE: Updating the cache for unlinked shader stage compute
 ; CREATE: =====  AMDLLPC SUCCESS  =====
 ; END_SHADERTEST
 
@@ -48,7 +48,7 @@
 ; REQUIRES: llpc-shader-cache
 ; MODIFY: Building pipeline with relocatable shader elf.
 ; MODIFY: Cache miss for shader stage compute
-; MODIFY: Updating the cache for shader stage compute
+; MODIFY: Updating the cache for unlinked shader stage compute
 ; MODIFY: =====  AMDLLPC SUCCESS  =====
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_GlueCache.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_GlueCache.pipe
@@ -12,9 +12,9 @@
 ; REQUIRES: llpc-shader-cache
 ; CREATE: Building pipeline with relocatable shader elf.
 ; CREATE: Cache miss for shader stage vertex
-; CREATE: Updating the cache for shader stage vertex
+; CREATE: Updating the cache for unlinked shader stage vertex
 ; CREATE: Cache miss for shader stage fragment
-; CREATE: Updating the cache for shader stage fragment
+; CREATE: Updating the cache for unlinked shader stage fragment
 ; CREATE: ID for glue shader0: 00000000000000007632663332570000000200000003000000040000000F00000000000000030000000400000000000000000000000000000000000000000000000E0000000700000000000000
 ; CREATE: Cache miss for glue shader 0
 ; CREATE: Updating the cache for glue shader 0

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -34,6 +34,7 @@
 #include "llpc.h"
 #include "spirv.hpp"
 #include "vkgcUtil.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace Llpc {
 
@@ -114,4 +115,30 @@ inline unsigned log2(T u) {
   return logValue;
 }
 
+// Returns true if shaderInfo has the information required to compile an unlinked shader of the given type.
+bool hasDataForUnlinkedShaderType(Vkgc::UnlinkedShaderStage type,
+                                  llvm::ArrayRef<const Vkgc::PipelineShaderInfo *> shaderInfo);
+
+// Returns the shader stage mask for all shader stages that can be part of the given unlinked shader type.
+unsigned getShaderStageMaskForType(Vkgc::UnlinkedShaderStage type);
+
+// Returns the name of the given unlinked shader stage.
+const char *getUnlinkedShaderStageName(Vkgc::UnlinkedShaderStage type);
+
+// Pre-increment operator on the unlinked shader stage.
+inline Vkgc::UnlinkedShaderStage operator++(Vkgc::UnlinkedShaderStage &type) {
+  type = static_cast<Vkgc::UnlinkedShaderStage>(type + 1);
+  return type;
+}
+
+// Post-increment operator on the unlinked shader stage.
+inline Vkgc::UnlinkedShaderStage operator++(Vkgc::UnlinkedShaderStage &type, int) {
+  Vkgc::UnlinkedShaderStage oldValue = type;
+  type = static_cast<Vkgc::UnlinkedShaderStage>(type + 1);
+  return oldValue;
+}
+
+inline bool doesShaderStageExist(llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo, ShaderStage stage) {
+  return stage < shaderInfo.size() && shaderInfo[stage] && shaderInfo[stage]->pModuleData;
+}
 } // namespace Llpc

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -886,26 +886,20 @@ void PipelineDumper::dumpGraphicsPipelineInfo(std::ostream *dumpFile, const char
 // @param stage : The stage for which we are building the hash. ShaderStageInvalid if building for the entire pipeline.
 MetroHash::Hash PipelineDumper::generateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline,
                                                                 bool isCacheHash, bool isRelocatableShader,
-                                                                unsigned stage) {
+                                                                UnlinkedShaderStage unlinkedShaderType) {
   MetroHash64 hasher;
 
-  switch (stage) {
-  case ShaderStageVertex:
+  switch (unlinkedShaderType) {
+  case UnlinkedStageVertexProcess:
     updateHashForPipelineShaderInfo(ShaderStageVertex, &pipeline->vs, isCacheHash, &hasher, isRelocatableShader);
-    break;
-  case ShaderStageTessControl:
     updateHashForPipelineShaderInfo(ShaderStageTessControl, &pipeline->tcs, isCacheHash, &hasher, isRelocatableShader);
-    break;
-  case ShaderStageTessEval:
     updateHashForPipelineShaderInfo(ShaderStageTessEval, &pipeline->tes, isCacheHash, &hasher, isRelocatableShader);
-    break;
-  case ShaderStageGeometry:
     updateHashForPipelineShaderInfo(ShaderStageGeometry, &pipeline->gs, isCacheHash, &hasher, isRelocatableShader);
     break;
-  case ShaderStageFragment:
+  case UnlinkedStageFragment:
     updateHashForPipelineShaderInfo(ShaderStageFragment, &pipeline->fs, isCacheHash, &hasher, isRelocatableShader);
     break;
-  case ShaderStageInvalid:
+  case UnlinkedStageCount:
     updateHashForPipelineShaderInfo(ShaderStageVertex, &pipeline->vs, isCacheHash, &hasher, isRelocatableShader);
     updateHashForPipelineShaderInfo(ShaderStageTessControl, &pipeline->tcs, isCacheHash, &hasher, isRelocatableShader);
     updateHashForPipelineShaderInfo(ShaderStageTessEval, &pipeline->tes, isCacheHash, &hasher, isRelocatableShader);
@@ -926,13 +920,13 @@ MetroHash::Hash PipelineDumper::generateHashForGraphicsPipeline(const GraphicsPi
   // Relocatable shaders force an unlinked compilation.
   hasher.Update(pipeline->unlinked || isRelocatableShader);
 
-  if (stage != ShaderStageFragment) {
+  if (unlinkedShaderType != UnlinkedStageFragment) {
     if (!isRelocatableShader)
       updateHashForVertexInputState(pipeline->pVertexInput, &hasher);
     updateHashForNonFragmentState(pipeline, isCacheHash, &hasher, isRelocatableShader);
   }
 
-  if (stage == ShaderStageFragment || stage == ShaderStageInvalid)
+  if (unlinkedShaderType != UnlinkedStageVertexProcess)
     updateHashForFragmentState(pipeline, &hasher, isRelocatableShader);
 
   MetroHash::Hash hash = {};

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -67,7 +67,8 @@ public:
   static void DumpPipelineExtraInfo(PipelineDumpFile *binaryFile, const std::string *str);
 
   static MetroHash::Hash generateHashForGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline, bool isCacheHash,
-                                                         bool isRelocatableShader, unsigned stage = ShaderStageInvalid);
+                                                         bool isRelocatableShader,
+                                                         UnlinkedShaderStage unlinkedShaderType = UnlinkedStageCount);
 
   static MetroHash::Hash generateHashForComputePipeline(const ComputePipelineBuildInfo *pipeline, bool isCacheHash,
                                                         bool isRelocatableShader);


### PR DESCRIPTION
To match other work that is being done, we want relocatable shader
compilation to be divided into vertex processing and fragment stages.
The current implementation tries to compile each shader stage separatly.
This is currently a difference without distinction because only handle
CS and VsFs pipelines.

When we will try to handle geometry shader, we want to compile the vertex
shader and the geometry shader together.   We want to refactor the
relocatable shader code to make that easier.