### PR TITLE
Port the SpirvLower class and SpirvLowerTranslator pass to the new pass manager

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -681,8 +681,8 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
           timerProfiler.addTimerStartStopPass(&*lowerPassMgr, TimerTranslate, false);
 
           // Per-shader SPIR-V lowering passes.
-          SpirvLower::addPasses(context, static_cast<ShaderStage>(entryNames[i].stage), *lowerPassMgr,
-                                timerProfiler.getTimer(TimerLower)
+          LegacySpirvLower::addPasses(context, static_cast<ShaderStage>(entryNames[i].stage), *lowerPassMgr,
+                                      timerProfiler.getTimer(TimerLower)
           );
 
           lowerPassMgr->add(createBitcodeWriterPass(moduleBinaryStream));
@@ -1266,7 +1266,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
       lowerPassMgr->setPassIndex(&passIndex);
 
-      SpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower)
+      LegacySpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower)
       );
       // Run the passes.
       bool success = runPasses(&*lowerPassMgr, modules[shaderIndex]);

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -145,7 +145,7 @@ void SpirvLower::removeConstantExpr(Context *context, GlobalVariable *global) {
 // @param stage : Shader stage
 // @param [in/out] passMgr : Pass manager to add passes to
 // @param lowerTimer : Timer to time lower passes with, nullptr if not timing
-void SpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassManager &passMgr, Timer *lowerTimer
+void LegacySpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassManager &passMgr, Timer *lowerTimer
 ) {
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
   context->getLgcContext()->preparePassManager(&passMgr);

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -54,7 +54,7 @@ ModulePass *createSpirvLowerAccessChain() {
 }
 
 // =====================================================================================================================
-SpirvLowerAccessChain::SpirvLowerAccessChain() : SpirvLower(ID) {
+SpirvLowerAccessChain::SpirvLowerAccessChain() : LegacySpirvLower(ID) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerAccessChain.h
+++ b/llpc/lower/llpcSpirvLowerAccessChain.h
@@ -37,7 +37,7 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for access chain.
-class SpirvLowerAccessChain : public SpirvLower, public llvm::InstVisitor<SpirvLowerAccessChain> {
+class SpirvLowerAccessChain : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerAccessChain> {
 public:
   SpirvLowerAccessChain();
 

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
@@ -54,7 +54,7 @@ ModulePass *createSpirvLowerConstImmediateStore() {
 }
 
 // =====================================================================================================================
-SpirvLowerConstImmediateStore::SpirvLowerConstImmediateStore() : SpirvLower(ID) {
+SpirvLowerConstImmediateStore::SpirvLowerConstImmediateStore() : LegacySpirvLower(ID) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.h
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.h
@@ -41,7 +41,7 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering operations for constant immediate store
-class SpirvLowerConstImmediateStore : public SpirvLower {
+class SpirvLowerConstImmediateStore : public LegacySpirvLower {
 public:
   SpirvLowerConstImmediateStore();
 

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -178,7 +178,7 @@ ModulePass *createSpirvLowerGlobal() {
 
 // =====================================================================================================================
 SpirvLowerGlobal::SpirvLowerGlobal()
-    : SpirvLower(ID), m_retBlock(nullptr), m_lowerInputInPlace(false), m_lowerOutputInPlace(false) {
+    : LegacySpirvLower(ID), m_retBlock(nullptr), m_lowerInputInPlace(false), m_lowerOutputInPlace(false) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -41,7 +41,7 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for globals (global variables, inputs, and outputs).
-class SpirvLowerGlobal : public SpirvLower, public llvm::InstVisitor<SpirvLowerGlobal> {
+class SpirvLowerGlobal : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerGlobal> {
 public:
   SpirvLowerGlobal();
 

--- a/llpc/lower/llpcSpirvLowerInstMetaRemove.cpp
+++ b/llpc/lower/llpcSpirvLowerInstMetaRemove.cpp
@@ -53,7 +53,7 @@ ModulePass *createSpirvLowerInstMetaRemove() {
 }
 
 // =====================================================================================================================
-SpirvLowerInstMetaRemove::SpirvLowerInstMetaRemove() : SpirvLower(ID), m_changed(false) {
+SpirvLowerInstMetaRemove::SpirvLowerInstMetaRemove() : LegacySpirvLower(ID), m_changed(false) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerInstMetaRemove.h
+++ b/llpc/lower/llpcSpirvLowerInstMetaRemove.h
@@ -36,7 +36,7 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for removing the instruction metadata.
-class SpirvLowerInstMetaRemove : public SpirvLower {
+class SpirvLowerInstMetaRemove : public LegacySpirvLower {
 public:
   SpirvLowerInstMetaRemove();
 

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -57,11 +57,11 @@ namespace {
 
 // =====================================================================================================================
 // SPIR-V lowering operations for math transformation.
-class SpirvLowerMath : public SpirvLower {
+class SpirvLowerMath : public LegacySpirvLower {
 public:
   explicit SpirvLowerMath(char &ID)
-      : SpirvLower(ID), m_changed(false), m_fp16DenormFlush(false), m_fp32DenormFlush(false), m_fp64DenormFlush(false),
-        m_fp16RoundToZero(false) {}
+      : LegacySpirvLower(ID), m_changed(false), m_fp16DenormFlush(false), m_fp32DenormFlush(false),
+        m_fp64DenormFlush(false), m_fp16RoundToZero(false) {}
 
   void init(llvm::Module &module);
 

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -55,7 +55,7 @@ ModulePass *createSpirvLowerMemoryOp() {
 }
 
 // =====================================================================================================================
-SpirvLowerMemoryOp::SpirvLowerMemoryOp() : SpirvLower(ID) {
+SpirvLowerMemoryOp::SpirvLowerMemoryOp() : LegacySpirvLower(ID) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerMemoryOp.h
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.h
@@ -51,7 +51,7 @@ struct StoreExpandInfo {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering memory operations.
-class SpirvLowerMemoryOp : public SpirvLower, public llvm::InstVisitor<SpirvLowerMemoryOp> {
+class SpirvLowerMemoryOp : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerMemoryOp> {
 public:
   SpirvLowerMemoryOp();
 

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -65,7 +65,7 @@ ModulePass *createSpirvLowerResourceCollect(bool collectDetailUsage) {
 //
 // @param collectDetailUsage : Whether to collect detailed usages of resource node datas and FS output infos
 SpirvLowerResourceCollect::SpirvLowerResourceCollect(bool collectDetailUsage)
-    : SpirvLower(ID), m_collectDetailUsage(collectDetailUsage), m_pushConstSize(0), m_detailUsageValid(false) {
+    : LegacySpirvLower(ID), m_collectDetailUsage(collectDetailUsage), m_pushConstSize(0), m_detailUsageValid(false) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerResourceCollect.h
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.h
@@ -59,7 +59,7 @@ struct ResNodeDataSortingComparer {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for resource collecting.
-class SpirvLowerResourceCollect : public SpirvLower, public llvm::InstVisitor<SpirvLowerResourceCollect> {
+class SpirvLowerResourceCollect : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerResourceCollect> {
 public:
   SpirvLowerResourceCollect(bool collectDetailUsage = false);
   auto &getResourceNodeDatas() { return m_resNodeDatas; }

--- a/llpc/lower/llpcSpirvLowerTerminator.cpp
+++ b/llpc/lower/llpcSpirvLowerTerminator.cpp
@@ -52,7 +52,7 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering terminators.
-class SpirvLowerTerminator : public SpirvLower, public llvm::InstVisitor<SpirvLowerTerminator> {
+class SpirvLowerTerminator : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerTerminator> {
 public:
   SpirvLowerTerminator();
 
@@ -81,7 +81,7 @@ ModulePass *createSpirvLowerTerminator() {
 }
 
 // =====================================================================================================================
-SpirvLowerTerminator::SpirvLowerTerminator() : SpirvLower(ID) {
+SpirvLowerTerminator::SpirvLowerTerminator() : LegacySpirvLower(ID) {
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -41,7 +41,7 @@
 using namespace llvm;
 using namespace Llpc;
 
-char SpirvLowerTranslator::ID = 0;
+char LegacySpirvLowerTranslator::ID = 0;
 
 // =====================================================================================================================
 // Creates the pass of translating SPIR-V to LLVM IR.
@@ -49,14 +49,24 @@ char SpirvLowerTranslator::ID = 0;
 // @param stage : Shader stage
 // @param shaderInfo : Shader info for this shader
 ModulePass *Llpc::createSpirvLowerTranslator(ShaderStage stage, const PipelineShaderInfo *shaderInfo) {
-  return new SpirvLowerTranslator(stage, shaderInfo);
+  return new LegacySpirvLowerTranslator(stage, shaderInfo);
 }
 
 // =====================================================================================================================
 // Run the pass on the specified LLVM module.
 //
 // @param [in/out] module : LLVM module to be run on (empty on entry)
-bool SpirvLowerTranslator::runOnModule(Module &module) {
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+llvm::PreservedAnalyses SpirvLowerTranslator::run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager) {
+  runImpl(module);
+  return llvm::PreservedAnalyses::none();
+}
+
+// =====================================================================================================================
+// Run the pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on (empty on entry)
+bool SpirvLowerTranslator::runImpl(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Translator\n");
 
   SpirvLower::init(&module);
@@ -70,6 +80,14 @@ bool SpirvLowerTranslator::runOnModule(Module &module) {
   // Translate SPIR-V binary to machine-independent LLVM module
   translateSpirvToLlvm(m_shaderInfo, &module);
   return true;
+}
+
+// =====================================================================================================================
+// Run the pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on (empty on entry)
+bool LegacySpirvLowerTranslator::runOnModule(Module &module) {
+  return Impl.runImpl(module);
 }
 
 // =====================================================================================================================
@@ -157,4 +175,4 @@ void SpirvLowerTranslator::translateSpirvToLlvm(const PipelineShaderInfo *shader
 
 // =====================================================================================================================
 // Initializes the pass
-INITIALIZE_PASS(SpirvLowerTranslator, DEBUG_TYPE, "LLPC translate SPIR-V binary to LLVM IR", false, false)
+INITIALIZE_PASS(LegacySpirvLowerTranslator, DEBUG_TYPE, "LLPC translate SPIR-V binary to LLVM IR", false, false)


### PR DESCRIPTION
This patch splits the SpirvLower class, which is the base class for all the
lower passes, into two separate classes: (i) LegacySpirvLower is used as the
base class for all the lower passes implementing the legacy pass manager
interface. (ii) SpirvLower is used as the base class for all the lower passes
implementing the new pass manager interface. This split is designed in a way
that once we fully switch to the new pass manager, we'll only need to remove
the Legacy* classes from the tree and no additional work will be required.
The patch also ports the SpirvLowerTranslator pass to the new pass manager
using that new SpirvLower class.