### PR TITLE
Refactor NGG GS with minor improvement

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -193,16 +193,15 @@ private:
   void exportGsOutput(llvm::Value *output, unsigned location, unsigned compIdx, unsigned streamId,
                       llvm::Value *threadIdInSubgroup, llvm::Value *emitVerts);
 
-  llvm::Value *importGsOutput(llvm::Type *outputTy, unsigned location, unsigned compIdx, unsigned streamId,
-                              llvm::Value *vertexOffset);
+  llvm::Value *importGsOutput(llvm::Type *outputTy, unsigned location, unsigned streamId, llvm::Value *vertexOffset);
 
   void processGsEmit(llvm::Module *module, unsigned streamId, llvm::Value *threadIdInSubgroup,
                      llvm::Value *emitVertsPtr, llvm::Value *outVertsPtr);
 
   void processGsCut(llvm::Module *module, unsigned streamId, llvm::Value *outVertsPtr);
 
-  llvm::Function *createGsEmitHandler(llvm::Module *module, unsigned streamId);
-  llvm::Function *createGsCutHandler(llvm::Module *module, unsigned streamId);
+  llvm::Function *createGsEmitHandler(llvm::Module *module);
+  llvm::Function *createGsCutHandler(llvm::Module *module);
 
   llvm::Value *readPerThreadDataFromLds(llvm::Type *readDataTy, llvm::Value *threadId, NggLdsRegionType region,
                                         unsigned offsetInRegion = 0, bool useDs128 = false);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -224,7 +224,7 @@ bool PatchCopyShader::runOnModule(Module &module) {
     } else {
       // If NGG, esGsLdsSize is not used
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = InvalidValue;
-      intfData->userDataUsage.gs.copyShaderStreamOutTable = 2;
+      intfData->userDataUsage.gs.copyShaderStreamOutTable = 1;
     }
   }
 


### PR DESCRIPTION
In this change, we make some minor improvement of NGG GS.

1. The GS_EMIT/GS_CUT handler is simplified with new processing
   of streamId.

2. importGsOutput() doesn't need compIdx as a function parameter.
   Remove it.

3. The initialization out vertex count blocks are moved after GS
   main function.

4. In copy shader emulation, we skip any non-rasterization stream
   handling.

Change-Id: Ic2aef9a9f2b6cfae339c1071157ed24d1b3c4569