### PR TITLE
Refine the control of input/output packing

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -299,11 +299,17 @@ public:
   // Initialize the packable state of generic input/output
   void initializeInOutPackState();
 
-  // Get whehter the input locations of the specified shader stage can be packed
-  bool canPackInput(ShaderStage shaderStage) const { return m_inputPackState[shaderStage]; }
+  // Get whether the input locations of the specified shader stage can be packed
+  bool canPackInput(ShaderStage shaderStage);
 
-  // Get whehter the output locations of the specified shader stage can be packed
-  bool canPackOutput(ShaderStage shaderStage) const { return m_outputPackState[shaderStage]; }
+  // Get whether the output locations of the specified shader stage can be packed
+  bool canPackOutput(ShaderStage shaderStage);
+
+  // Set the flag to pack the input locations of the specified shader stage
+  void setPackInput(ShaderStage shaderStage, bool pack) { m_inputPackState[shaderStage] = pack; }
+
+  // Set the flag to pack the output locations of the specified shader stage
+  void setPackOutput(ShaderStage shaderStage, bool pack) { m_outputPackState[shaderStage] = pack; }
 
   // -----------------------------------------------------------------------------------------------------------------
   // Utility methods

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -350,7 +350,6 @@ bool PatchCopyShader::runOnModule(Module &module) {
 void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
   const auto &outputLocInfoMap = resUsage->inOutUsage.outputLocInfoMap;
-  const bool isPack = !m_pipelineState->isUnlinked();
   std::set<InOutLocationInfo> visitedLocInfos;
 
   // Collect the byte sizes of the output value at each mapped location
@@ -379,7 +378,7 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
         unsigned byteSize = 4;
         auto &newLocByteSizesMap = m_newLocByteSizesMapArray[origLocInfo.getStreamId()];
         const unsigned newLoc = locInfoMapIt->second.getLocation();
-        if (isPack) {
+        if (m_pipelineState->canPackOutput(ShaderStageGeometry)) {
           newLocByteSizesMap[newLoc] += byteSize;
         } else {
           unsigned compCount = 1;

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -579,9 +579,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
             loc = resUsage->inOutUsage.perPatchInputLocMap[value];
           }
         } else {
-          if (!m_pipelineState->isUnlinked() &&
-              (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageTessControl ||
-               m_shaderStage == ShaderStageGeometry)) {
+          if (m_pipelineState->canPackInput(m_shaderStage)) {
             // The inputLocInfoMap of {TCS, GS, FS} maps original InOutLocationInfo to tightly compact InOutLocationInfo
             const bool isTcs = m_shaderStage == ShaderStageTessControl;
             const uint32_t elemIdxArgIdx = (isInterpolantInputImport || isTcs) ? 2 : 1;
@@ -883,7 +881,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         exist = true;
         loc = value;
       } else {
-        if (!m_pipelineState->isUnlinked()) {
+        if (m_pipelineState->canPackOutput(m_shaderStage)) {
           const bool isVs = (m_shaderStage == ShaderStageVertex);
           const bool isGs = (m_shaderStage == ShaderStageGeometry);
           assert(isVs || isGs || m_shaderStage == ShaderStageTessEval);

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1341,6 +1341,34 @@ void PipelineState::initializeInOutPackState() {
 }
 
 // =====================================================================================================================
+// Get whether the input locations of the specified shader stage can be packed
+//
+// @param shaderStage : The given shader stage
+bool PipelineState::canPackInput(ShaderStage shaderStage) {
+  ShaderStage preStage = getPrevShaderStage(shaderStage);
+  // The input packable state of the current stage should match the output packable state of the previous stage, except
+  // that the current stage has no previous and it is a null FS.
+  if (preStage != ShaderStageInvalid &&
+      !(shaderStage == ShaderStageFragment && getShaderResourceUsage(shaderStage)->inOutUsage.fs.isNullFs))
+    assert(m_inputPackState[shaderStage] == m_outputPackState[preStage]);
+  return m_inputPackState[shaderStage];
+}
+
+// =====================================================================================================================
+// Get whether the output locations of the specified shader stage can be packed
+//
+// @param shaderStage : The given shader stage
+bool PipelineState::canPackOutput(ShaderStage shaderStage) {
+  ShaderStage nextStage = getNextShaderStage(shaderStage);
+  // The output packable state of the current stage should match the input packable state of the next stage, except that
+  // the current stage has no next stage or a null FS.
+  if (nextStage != ShaderStageInvalid &&
+      !(nextStage == ShaderStageFragment && getShaderResourceUsage(nextStage)->inOutUsage.fs.isNullFs))
+    assert(m_outputPackState[shaderStage] == m_inputPackState[nextStage]);
+  return m_outputPackState[shaderStage];
+}
+
+// =====================================================================================================================
 // Get (create if necessary) the PipelineState from this wrapper pass.
 //
 // @param module : IR module


### PR DESCRIPTION
The refinement is based on b031c5d.
- Add assertion to ensure each pair of the input packable state of
  current stage and output packable state of the previous stage can
  match.
- Use `canPackInput` or `canPackOutput` as the condition to choose either
  pack or no-pack code path.
- Fix a bug in `collectGsGenericOutputInfo` that is treating GS output as
  pack mode all time.
- Add `setPackInput` and `setPackOutput` utility functions.