### PR TITLE
Explicitly include MathExtras.h for alignTo

### DIFF
--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -28,8 +28,9 @@
  * @brief VKGC source file: contains implementation of VKGC ELF reading utilities.
  ***********************************************************************************************************************
  */
-#include <algorithm>
 #include "vkgcElfReader.h"
+#include "llvm/Support/MathExtras.h"
+#include <algorithm>
 #include <string.h>
 
 #define DEBUG_TYPE "vkgc-elf-reader"


### PR DESCRIPTION
This is no longer implicitly included due to some changes to upstream
LLVM headers. Also re-sort the includes.