### PR TITLE
Rename the PassManager class to LegacyPassManager

### DIFF
--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -62,7 +62,7 @@ void GlueShader::compile(raw_pwrite_stream &outStream) {
   delete palMetadata;
 
   // Get the pass manager and run it on the module, generating ELF.
-  PassManager &passManager = m_lgcContext->getPassManagerCache()->getGlueShaderPassManager(outStream);
+  LegacyPassManager &passManager = m_lgcContext->getPassManagerCache()->getGlueShaderPassManager(outStream);
   passManager.run(*module);
   m_lgcContext->getPassManagerCache()->resetStream();
 }

--- a/lgc/include/lgc/state/PassManagerCache.h
+++ b/lgc/include/lgc/state/PassManagerCache.h
@@ -81,15 +81,15 @@ public:
   PassManagerCache(LgcContext *lgcContext) : m_lgcContext(lgcContext) {}
 
   // Get pass manager for glue shader compilation
-  PassManager &getGlueShaderPassManager(llvm::raw_pwrite_stream &outStream);
+  LegacyPassManager &getGlueShaderPassManager(llvm::raw_pwrite_stream &outStream);
 
   void resetStream();
 
 private:
-  PassManager &getPassManager(const PassManagerInfo &info, llvm::raw_pwrite_stream &outStream);
+  LegacyPassManager &getPassManager(const PassManagerInfo &info, llvm::raw_pwrite_stream &outStream);
 
   LgcContext *m_lgcContext;
-  llvm::StringMap<std::unique_ptr<PassManager>> m_cache;
+  llvm::StringMap<std::unique_ptr<LegacyPassManager>> m_cache;
   raw_proxy_ostream m_proxyStream;
 };
 

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -51,7 +51,7 @@ class PassManager;
 namespace lgc {
 
 class Builder;
-class PassManager;
+class LegacyPassManager;
 class PassManagerCache;
 class Pipeline;
 class TargetInfo;
@@ -112,7 +112,7 @@ public:
   void preparePassManager(llvm::legacy::PassManager *passMgr);
 
   // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
-  void addTargetPasses(lgc::PassManager &passMgr, llvm::Timer *codeGenTimer, llvm::raw_pwrite_stream &outStream);
+  void addTargetPasses(lgc::LegacyPassManager &passMgr, llvm::Timer *codeGenTimer, llvm::raw_pwrite_stream &outStream);
 
   // Utility method to create a start/stop timer pass
   static llvm::ModulePass *createStartStopTimer(llvm::Timer *timer, bool starting);

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -36,10 +36,10 @@ namespace lgc {
 
 // =====================================================================================================================
 // Public interface of LLPC middle-end's legacy::PassManager override
-class PassManager : public llvm::legacy::PassManager {
+class LegacyPassManager : public llvm::legacy::PassManager {
 public:
-  static PassManager *Create();
-  virtual ~PassManager() {}
+  static LegacyPassManager *Create();
+  virtual ~LegacyPassManager() {}
   virtual void stop() = 0;
   virtual void setPassIndex(unsigned *passIndex) = 0;
 };

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -25,7 +25,7 @@
 /**
  ***********************************************************************************************************************
  * @file  PassManager.h
- * @brief LLPC header file: contains declaration of class lgc::PassManager.
+ * @brief LLPC header file: contains declaration of class lgc::LegacyPassManager.
  ***********************************************************************************************************************
  */
 #pragma once

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -195,7 +195,7 @@ bool PipelineState::generate(std::unique_ptr<Module> pipelineModule, raw_pwrite_
   Timer *codeGenTimer = timers.size() >= 3 ? timers[2] : nullptr;
 
   // Set up "whole pipeline" passes, where we have a single module representing the whole pipeline.
-  std::unique_ptr<PassManager> passMgr(PassManager::Create());
+  std::unique_ptr<LegacyPassManager> passMgr(LegacyPassManager::Create());
   passMgr->setPassIndex(&passIndex);
   passMgr->add(createTargetTransformInfoWrapperPass(getLgcContext()->getTargetMachine()->getTargetIRAnalysis()));
 

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -274,7 +274,7 @@ void LgcContext::preparePassManager(legacy::PassManager *passMgr) {
 // @param [in/out] passMgr : Pass manager to add passes to
 // @param codeGenTimer : Timer to time target passes with, nullptr if not timing
 // @param [out] outStream : Output stream
-void LgcContext::addTargetPasses(lgc::PassManager &passMgr, Timer *codeGenTimer, raw_pwrite_stream &outStream) {
+void LgcContext::addTargetPasses(lgc::LegacyPassManager &passMgr, Timer *codeGenTimer, raw_pwrite_stream &outStream) {
   // Start timer for codegen passes.
   if (codeGenTimer)
     passMgr.add(createStartStopTimer(codeGenTimer, true));

--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -54,7 +54,7 @@ struct PassManagerInfo {
 // Get pass manager for glue shader compilation
 //
 // @param outStream : Stream to output ELF info
-lgc::PassManager &PassManagerCache::getGlueShaderPassManager(raw_pwrite_stream &outStream) {
+lgc::LegacyPassManager &PassManagerCache::getGlueShaderPassManager(raw_pwrite_stream &outStream) {
   PassManagerInfo info = {};
   info.isGlue = true;
   return getPassManager(info, outStream);
@@ -65,12 +65,12 @@ lgc::PassManager &PassManagerCache::getGlueShaderPassManager(raw_pwrite_stream &
 //
 // @param info : PassManagerInfo to direct how to create the pass manager
 // @param outStream : Stream to output ELF info
-lgc::PassManager &PassManagerCache::getPassManager(const PassManagerInfo &info, raw_pwrite_stream &outStream) {
+lgc::LegacyPassManager &PassManagerCache::getPassManager(const PassManagerInfo &info, raw_pwrite_stream &outStream) {
   // Set our single proxy stream to use the provided stream.
   m_proxyStream.setUnderlyingStream(&outStream);
 
   // Check the cache.
-  std::unique_ptr<lgc::PassManager> &passManager =
+  std::unique_ptr<lgc::LegacyPassManager> &passManager =
       m_cache[StringRef(reinterpret_cast<const char *>(&info), sizeof(info))];
   if (passManager)
     return *passManager;
@@ -79,7 +79,7 @@ lgc::PassManager &PassManagerCache::getPassManager(const PassManagerInfo &info, 
   // TODO: Creation of a normal compilation pass manager, not just one for a glue shader.
   assert(info.isGlue && "Non-glue shader compilation not implemented yet");
 
-  passManager.reset(PassManager::Create());
+  passManager.reset(LegacyPassManager::Create());
   passManager->add(createTargetTransformInfoWrapperPass(m_lgcContext->getTargetMachine()->getTargetIRAnalysis()));
 
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.

--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -63,7 +63,7 @@ namespace {
 // =====================================================================================================================
 // LLPC's legacy::PassManager override.
 // This is the implementation subclass of the PassManager class declared in PassManager.h
-class PassManagerImpl final : public lgc::PassManager {
+class PassManagerImpl final : public lgc::LegacyPassManager {
 public:
   PassManagerImpl();
   ~PassManagerImpl() override {}
@@ -109,12 +109,12 @@ static AnalysisID getPassIdFromName(StringRef passName) {
 
 // =====================================================================================================================
 // Create a PassManagerImpl
-lgc::PassManager *lgc::PassManager::Create() {
+lgc::LegacyPassManager *lgc::LegacyPassManager::Create() {
   return new PassManagerImpl;
 }
 
 // =====================================================================================================================
-PassManagerImpl::PassManagerImpl() : PassManager() {
+PassManagerImpl::PassManagerImpl() : LegacyPassManager() {
   if (!cl::DumpCfgAfter.empty())
     m_dumpCfgAfter = getPassIdFromName(cl::DumpCfgAfter);
 

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -650,7 +650,7 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
           context->setModuleTargetMachine(module);
 
           unsigned passIndex = 0;
-          std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+          std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
           lowerPassMgr->setPassIndex(&passIndex);
 
           // Set the shader stage in the Builder.
@@ -1221,7 +1221,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       if (!shaderInfoEntry || !shaderInfoEntry->pModuleData || (stageSkipMask & shaderStageToMask(entryStage)))
         continue;
 
-      std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+      std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
       lowerPassMgr->setPassIndex(&passIndex);
 
       // Set the shader stage in the Builder.
@@ -1263,7 +1263,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       }
 
       context->getBuilder()->setShaderStage(getLgcShaderStage(entryStage));
-      std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+      std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
       lowerPassMgr->setPassIndex(&passIndex);
 
       SpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower)
@@ -1893,7 +1893,7 @@ Context *Compiler::acquireContext() const {
 //
 // @param passMgr : Pass manager
 // @param [in/out] module : Module
-bool Compiler::runPasses(lgc::PassManager *passMgr, Module *module) const {
+bool Compiler::runPasses(lgc::LegacyPassManager *passMgr, Module *module) const {
   bool success = false;
 #if LLPC_ENABLE_EXCEPTION
   try

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -46,7 +46,7 @@ class Module;
 
 namespace lgc {
 
-class PassManager;
+class LegacyPassManager;
 
 } // namespace lgc
 
@@ -150,7 +150,7 @@ private:
   Context *acquireContext() const;
   void releaseContext(Context *context) const;
 
-  bool runPasses(lgc::PassManager *passMgr, llvm::Module *module) const;
+  bool runPasses(lgc::LegacyPassManager *passMgr, llvm::Module *module) const;
   void linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context);
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo,
                                           const GraphicsPipelineBuildInfo *pipelineInfo);

--- a/llpc/util/llpcTimerProfiler.cpp
+++ b/llpc/util/llpcTimerProfiler.cpp
@@ -119,7 +119,7 @@ TimerProfiler::~TimerProfiler() {
 // @param passMgr : Pass Manager
 // @param timerKind : Kind of phase timer
 // @param start : Start or  stop timer
-void TimerProfiler::addTimerStartStopPass(lgc::PassManager *passMgr, TimerKind timerKind, bool start) {
+void TimerProfiler::addTimerStartStopPass(lgc::LegacyPassManager *passMgr, TimerKind timerKind, bool start) {
   if (TimePassesIsEnabled || cl::EnableTimerProfile)
     passMgr->add(lgc::LgcContext::createStartStopTimer(&m_phaseTimers[timerKind], start));
 }

--- a/llpc/util/llpcTimerProfiler.h
+++ b/llpc/util/llpcTimerProfiler.h
@@ -37,7 +37,7 @@
 
 namespace lgc {
 
-class PassManager;
+class LegacyPassManager;
 
 } // namespace lgc
 
@@ -64,7 +64,7 @@ public:
 
   ~TimerProfiler();
 
-  void addTimerStartStopPass(lgc::PassManager *passMgr, TimerKind timerKind, bool start);
+  void addTimerStartStopPass(lgc::LegacyPassManager *passMgr, TimerKind timerKind, bool start);
 
   void startStopTimer(TimerKind name, bool start);
 


### PR DESCRIPTION
For the switch to the new pass manager, we want the 'PassManager' class
name available to implement LLVM's new pass manager interface. So this patch
renames the current PassManager class to LegacyPassManager. The new
PassManager class, implementing the new interface, will be posted in
subsequent patches.