### PR TITLE
Add enum iteration utility

### DIFF
--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "EnumIterator.h"
 #include <array>
 #include <cstdint>
 
@@ -78,5 +79,8 @@ enum class ResourceNodeType : unsigned {
   DescriptorReserved15,
   Count, ///< Count of resource mapping node types.
 };
+
+// Enable iteration over resource node type with `lgc::enumRange<ResourceNodeType>()`.
+LGC_DEFINE_DEFAULT_ITERABLE_ENUM(ResourceNodeType);
 
 } // namespace lgc

--- a/lgc/interface/lgc/EnumIterator.h
+++ b/lgc/interface/lgc/EnumIterator.h
@@ -1,0 +1,161 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  EnumIterator.h
+ * @brief LGC header file: defines utilities for iterating over enums
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/iterator.h"
+#include "llvm/ADT/iterator_range.h"
+#include <array>
+#include <cassert>
+#include <iterator>
+#include <type_traits>
+
+namespace lgc {
+
+// Traits providing information about how to iterate C++ enum types. By default, enums are not considered iterable.
+// To make an enum type iterable, provide a specialization of this struct for you enum. This will allow you to use
+// `lgc::enum_iterator` and `lgc::enum_range()`.
+// For now, only continuous enums are supported.
+template <typename EnumT> struct iterable_enum_traits {
+  static_assert(std::is_enum<EnumT>::value, "enum_traits can only be used with enums");
+  using underlying_type = std::underlying_type_t<EnumT>;
+  static constexpr bool is_iteratable = false;
+
+  /*
+  Specializations must provide the following:
+  static constexpr EnumT first_value = ...;
+  static constexpr underlying_type first_underlying_value = ...;
+  static constexpr EnumT end_value = ...;
+  static constexpr underlying_type end_underlying_value = ...;
+  */
+};
+
+// Common iterable_enum_traits for enums with continuous values, i.e., `first, first + 1, ..., end - 1`.
+template <typename EnumT, EnumT first, EnumT end> struct continuous_iterable_enum_traits {
+  static_assert(std::is_enum<EnumT>::value, "enum_traits can only be used with enums");
+  using underlying_type = std::underlying_type_t<EnumT>;
+  static constexpr bool is_iterable = true;
+
+  static constexpr EnumT first_value = first;
+  static constexpr underlying_type first_underlying_value = static_cast<underlying_type>(first);
+  static constexpr EnumT end_value = end;
+  static constexpr underlying_type end_underlying_value = static_cast<underlying_type>(end);
+};
+
+// Common iterable_enum_traits for continuous enums that start at 0 and have a `::Count` value indicating the number of
+// values.
+template <typename EnumT>
+struct default_continuous_iterable_enum_traits : continuous_iterable_enum_traits<EnumT, EnumT{}, EnumT::Count> {};
+
+// Convenience macro to make an enum iterable. Requires the enum type to start at 0 and have a `::Count` value
+// indicating the number of values.
+#define LGC_DEFINE_DEFAULT_ITERABLE_ENUM(ENUM_TYPE)                                                                    \
+  template <> struct iterable_enum_traits<ENUM_TYPE> : default_continuous_iterable_enum_traits<ENUM_TYPE> {}
+
+// =====================================================================================================================
+// Converts enum to its underlying integer value.
+//
+// @param value : The enum value.
+// @returns : Copy of the enum value converted to its integer type.
+template <typename EnumT> constexpr std::underlying_type_t<EnumT> toUnderlying(EnumT value) {
+  return static_cast<std::underlying_type_t<EnumT>>(value);
+}
+
+// Random access iterator for iterating over enums. Enum types must implement the `iterable_enum_traits` by providing
+// its specialization.
+// Implementation inspired by `value_sequence_iterator` from `llvm/ADT/Sequence.h`.
+template <typename EnumT>
+class enum_iterator
+    : public llvm::iterator_facade_base<enum_iterator<EnumT>, std::random_access_iterator_tag, const EnumT> {
+  using BaseT = typename enum_iterator::iterator_facade_base;
+  using TraitsT = iterable_enum_traits<EnumT>;
+  static_assert(TraitsT::is_iterable, "enum not iterable or iterable_enum_traits missing");
+
+public:
+  using UnderlyingT = typename TraitsT::underlying_type;
+  using DifferenceT = typename BaseT::difference_type;
+  using ReferenceT = typename BaseT::reference;
+
+  // Default constructor creates an end iterator.
+  enum_iterator() = default;
+
+  enum_iterator(EnumT value) : m_value(value) {
+    assert(toUnderlying(m_value) >= TraitsT::first_underlying_value && "Invalid enum value");
+    assert(toUnderlying(m_value) <= TraitsT::end_underlying_value && "Invalid enum value");
+  }
+
+  // Copyable and moveable.
+  enum_iterator(const enum_iterator &) = default;
+  enum_iterator &operator=(const enum_iterator &) = default;
+  enum_iterator(enum_iterator &&) = default;
+  enum_iterator &operator=(enum_iterator &&) = default;
+
+  enum_iterator &operator+=(DifferenceT n) {
+    m_value = toEnum(toUnderlying(m_value) + n);
+    assert(toUnderlying(m_value) <= TraitsT::end_underlying_value && "Invalid enum value");
+    return *this;
+  }
+  enum_iterator &operator-=(DifferenceT n) {
+    m_value = toEnum(toUnderlying(m_value) - n);
+    assert(toUnderlying(m_value) >= TraitsT::first_underlying_value && "Invalid enum value");
+    return *this;
+  }
+  using BaseT::operator-;
+  DifferenceT operator-(const enum_iterator &rhs) const { return toUnderlying(m_value) - toUnderlying(rhs.m_value); }
+
+  bool operator==(const enum_iterator &rhs) const { return m_value == rhs.m_value; }
+  bool operator<(const enum_iterator &rhs) const { return toUnderlying(m_value) < toUnderlying(rhs.m_value); }
+  ReferenceT operator*() const { return m_value; }
+
+private:
+  static EnumT toEnum(UnderlyingT value) { return static_cast<EnumT>(value); }
+
+  EnumT m_value = TraitsT::end_value;
+};
+
+// =====================================================================================================================
+// Creates the range of enum values: `[from, to]`. By default, this will range over all enum values (except `::Count`).
+// EnumT must provide the `iterable_enum_traits` trait. E.g.:
+// - for (MyEnum value : enumRange<MyEnum>())  // Iterates over all values of `MyEnum`.
+// - llvm::is_contained(enumRange(MyEnum::A, MyEnum::C), value)  // Checks if `value` is in `[A, C]`.
+//
+// @param from : The first value in the range. By default, this is the enum value `0`.
+// @param to : The last value in the range. By default, this is the enum value before `::Count`. Note that unlike most
+//             C++ ranges, this parameter should be the last element, non the one-past-last (end).
+// @returns : The enum range: `from, form + 1, ..., to - 1, to`.
+template <typename EnumT>
+llvm::iterator_range<enum_iterator<EnumT>>
+enumRange(EnumT from = iterable_enum_traits<EnumT>::first_value,
+          EnumT to = static_cast<EnumT>(iterable_enum_traits<EnumT>::end_underlying_value - 1)) {
+  return {enum_iterator<EnumT>(from), enum_iterator<EnumT>(static_cast<EnumT>(toUnderlying(to) + 1))};
+}
+
+} // namespace lgc

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "lgc/state/PipelineState.h"
+#include "lgc/CommonDefs.h"
 #include "lgc/LgcContext.h"
 #include "lgc/PassManager.h"
 #include "lgc/patch/FragColorExport.h"
@@ -867,9 +868,8 @@ ResourceNodeType PipelineState::getResourceTypeFromName(MDString *typeName) {
 // data nodes.
 ArrayRef<MDString *> PipelineState::getResourceTypeNames() {
   if (!m_resourceNodeTypeNames[0]) {
-    for (unsigned type = 0; type < static_cast<unsigned>(ResourceNodeType::Count); ++type) {
-      m_resourceNodeTypeNames[type] =
-          MDString::get(getContext(), getResourceNodeTypeName(static_cast<ResourceNodeType>(type)));
+    for (ResourceNodeType type : enumRange<ResourceNodeType>()) {
+      m_resourceNodeTypeNames[toUnderlying(type)] = MDString::get(getContext(), getResourceNodeTypeName(type));
     }
   }
   return ArrayRef<MDString *>(m_resourceNodeTypeNames);


### PR DESCRIPTION
This allows to iterate over enums using iterators and ranges, e.g.:
```
for (ResourceNodeType type : enumRange<ResourceNodeType>())
```

In addition to loops over all enum values, you can define iterators/ranges
of certain enum values and use them with STL functions, e.g.:
```
if (llvm::is_contained(enumRange(MyEnum::A, MyEnum::C), value))
```

Right now, only continuous enums are supported. The API could be extended
to support non-continuous ones if necessary in the future.

Because not all enums are iterable, enums must be opt into iteration support,
e.g.:
```
enum class TestEnum3 : uint8_t { A, B, C, Count };
LGC_DEFINE_DEFAULT_ITERABLE_ENUM(TestEnum3);
```

The alternative is to either perform ad-hoc enum/integer casts where
necessary, and/or implement pre-/post- increment operators, like in
https://github.com/GPUOpen-Drivers/llpc/pull/1264.
