### PR TITLE
Fix ptrdiff of buffer fat pointers

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -285,6 +285,9 @@ public:
   llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
                                          const llvm::Twine &instName = "") override final;
 
+  // Return the i64 difference between two pointers, dividing out the size of the pointed-to objects.
+  llvm::Value *CreatePtrDiff(llvm::Value *lhs, llvm::Value *rhs, const llvm::Twine &instName = "") override final;
+
 private:
   DescBuilder() = delete;
   DescBuilder(const DescBuilder &) = delete;

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -156,6 +156,8 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "load.push.constants.ptr";
   case Opcode::GetBufferDescLength:
     return "get.buffer.desc.length";
+  case Opcode::PtrDiff:
+    return "buffer.ptrdiff";
   case Opcode::ReadGenericInput:
     return "read.generic.input";
   case Opcode::ReadGenericOutput:
@@ -1073,6 +1075,16 @@ Value *BuilderRecorder::CreateGetBufferDescLength(Value *const bufferDesc, Value
 }
 
 // =====================================================================================================================
+// Return the i64 difference between two buffer fat pointer values, dividing out the size of the pointed-to objects.
+//
+// @param lhs : Left hand side of the subtraction.
+// @param rhs : Reft hand side of the subtraction.
+// @param instName : Name to give instruction(s)
+Value *BuilderRecorder::CreatePtrDiff(llvm::Value *lhs, llvm::Value *rhs, const llvm::Twine &instName) {
+  return record(Opcode::PtrDiff, getInt64Ty(), {lhs, rhs}, instName);
+}
+
+// =====================================================================================================================
 // Create an image load.
 //
 // @param resultTy : Result type
@@ -1904,6 +1916,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::MatrixTimesVector:
     case Opcode::NormalizeVector:
     case Opcode::OuterProduct:
+    case Opcode::PtrDiff:
     case Opcode::QuantizeToFp16:
     case Opcode::Reflect:
     case Opcode::Refract:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -136,6 +136,7 @@ public:
     GetDescPtr,
     LoadPushConstantsPtr,
     GetBufferDescLength,
+    PtrDiff,
 
     // Image
     ImageLoad,
@@ -359,6 +360,8 @@ public:
 
   llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
                                          const llvm::Twine &instName = "") override final;
+
+  llvm::Value *CreatePtrDiff(llvm::Value *lhs, llvm::Value *rhs, const llvm::Twine &instName = "") override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Image operations

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -437,6 +437,11 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
                                                 args[1]); // offset
   }
 
+  case BuilderRecorder::Opcode::PtrDiff: {
+    return m_builder->CreatePtrDiff(args[0],  // lhs
+                                    args[1]); // rhs
+  }
+
   // Replayer implementations of ImageBuilder methods
   case BuilderRecorder::Opcode::ImageLoad: {
     unsigned dim = cast<ConstantInt>(args[0])->getZExtValue();

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -87,6 +87,7 @@ const static char ShaderInput[] = "lgc.shader.input.";
 const static char LaterCallPrefix[] = "lgc.late.";
 const static char LateLaunderFatPointer[] = "lgc.late.launder.fat.pointer";
 const static char LateBufferLength[] = "lgc.late.buffer.desc.length";
+const static char LateBufferPtrDiff[] = "lgc.late.buffer.ptrdiff";
 
 // Names of global variables
 const static char ImmutableSamplerGlobal[] = "lgc.immutable.sampler";

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -741,6 +741,14 @@ public:
   virtual llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
                                                  const llvm::Twine &instName = "") = 0;
 
+  // Return the i64 difference between two pointers, dividing out the size of the pointed-to objects.
+  // For buffer fat pointers, delays the translation to patch phase.
+  //
+  // @param lhs : Left hand side of the subtraction.
+  // @param rhs : Reft hand side of the subtraction.
+  // @param instName : Name to give instruction(s)
+  virtual llvm::Value *CreatePtrDiff(llvm::Value *lhs, llvm::Value *rhs, const llvm::Twine &instName = "") = 0;
+
   // -----------------------------------------------------------------------------------------------------------------
   // Image operations
 


### PR DESCRIPTION
CreatePtrDiff in LLVM converts the pointers to numbers with ptrtoint.
However, addrspace(7) (Buffer fat pointers) is marked as non-integral,
which means pointers cannot be converted to integers.

Use an lgc intrinsic function to lower the ptrdiff in PatchBufferOp,
when the pointers are not in addrspace(7) anymore.

Fixes dEQP-VK.spirv_assembly.instruction.spirv1p4.opptrdiff.variable_pointers_vars_ssbo_diff
and dEQP-VK.spirv_assembly.instruction.spirv1p4.opptrdiff.variable_pointers_vars_ssbo_2_diff
with upstream LLVM.