### PR TITLE
Enable the --gfxip option in addition to -gfxip

### DIFF
--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -378,6 +378,8 @@ static Result init(int argc, char *argv[], ICompiler **ppCompiler) {
     // Before we get to LLVM command-line option parsing, we need to find the -gfxip option value.
     for (int i = 1; i != argc; ++i) {
       StringRef arg = argv[i];
+      if (arg.startswith("--gfxip"))
+        arg = arg.drop_front(1);
       if (!arg.startswith("-gfxip"))
         continue;
       StringRef gfxipStr;


### PR DESCRIPTION
The --help option currently shows that the --gfxip option must be used to
select graphics IP version. However, only -gfxip works (single dash).
Using two dashes actually silently uses the default version which is
gfx8. This can be quite annoying for people using llpc for the first time.