### PR TITLE
Add a PipelineOption to control interpMode patch

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -71,6 +71,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     46.3 | Added enableInterpModePatch to PipelineOptions                                                       |
 //  |     46.1 | Added dynamicVertexStride to GraphicsPipelineBuildInfo                                                |
 //  |     46.0 | Removed the member 'depthBiasEnable' of rsState                                                       |
 //  |     45.5 | Added new enum type ThreadGroupSwizzleMode for thread group swizzling for compute shaders             |
@@ -358,6 +359,7 @@ struct PipelineOptions {
   unsigned shadowDescriptorTablePtrHigh;                 ///< Sets high part of VA ptr for shadow descriptor table.
   ExtendedRobustness extendedRobustness;                 ///< ExtendedRobustness is intended to correspond to the
                                                          ///  features of VK_EXT_robustness2.
+  bool enableInterpModePatch; ///< If set, per-sample interpolation for nonperspective and smooth input is enabled
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -42,11 +42,6 @@
 using namespace lgc;
 using namespace llvm;
 
-// -disable-interp-mode-patch: disable interpolation at sample location when perSampleShading is enabled
-// TODO: It is a temporary option, it will be removed once crunch test is updated.
-static cl::opt<bool> DisableInterpModePatch("disable-interp-mode-patch", cl::desc("Disable interpolation mode patch"),
-                                            cl::init(true));
-
 // =====================================================================================================================
 // Create a read of (part of) a generic (user) input value, passed from the previous shader stage.
 // The result type is as specified by pResultTy, a scalar or vector type with no more than four elements.
@@ -383,7 +378,7 @@ void InOutBuilder::markInterpolationInfo(InOutInfo &interpInfo) {
   // per-sample interpolation.
   // NOTE: if the input is used by interpolation functions (has auxiliary value), we should not modify its interpLoc
   // because it is used for modifyAuxInterpValue.
-  if (!DisableInterpModePatch && getPipelineState()->getRasterizerState().perSampleShading &&
+  if (getPipelineState()->getOptions().enableInterpModePatch &&
       interpInfo.getInterpLoc() == InOutInfo::InterpLocCenter && !interpInfo.hasInterpAux() &&
       (resUsage->builtInUsage.fs.smooth || resUsage->builtInUsage.fs.noperspective))
     interpInfo.setInterpLoc(InOutInfo::InterpLocSample);
@@ -1226,7 +1221,7 @@ void InOutBuilder::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySiz
       break;
     case BuiltInBaryCoordNoPersp:
       usage.fs.baryCoordNoPersp = true;
-      if (!DisableInterpModePatch && getPipelineState()->getRasterizerState().perSampleShading) {
+      if (getPipelineState()->getOptions().enableInterpModePatch) {
         usage.fs.baryCoordNoPerspSample = true;
         builtIn = BuiltInBaryCoordNoPerspSample;
       }
@@ -1239,7 +1234,7 @@ void InOutBuilder::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySiz
       break;
     case BuiltInBaryCoordSmooth:
       usage.fs.baryCoordSmooth = true;
-      if (!DisableInterpModePatch && getPipelineState()->getRasterizerState().perSampleShading) {
+      if (getPipelineState()->getOptions().enableInterpModePatch) {
         usage.fs.baryCoordSmoothSample = true;
         builtIn = BuiltInBaryCoordSmoothSample;
       }

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -126,6 +126,7 @@ struct Options {
   unsigned reserved0f;                 // Reserved for future functionality
   unsigned reserved10;                 // Reserved for future functionality
   unsigned reserved1f; // Reserved for funture functionality
+  unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -337,6 +337,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline) const {
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;
   options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
+  options.enableInterpModePatch = getPipelineOptions()->enableInterpModePatch;
 
   pipeline->setOptions(options);
 


### PR DESCRIPTION
This change is based on fdfc7ee. We use
PipelineOptions::enableInterpModePatch to control the per-sample
interplation for smooth and nonperspective input. Because there is an
expection case so that we should need set enableInterpModePatch in the icd.

Fixes:dEQP-VK.pipeline.multisample.sample_locations_ext.draw.color.samples_8.separate_renderpass_clear_image_same_pattern