### PR TITLE
Fix OpPtrDiff - take 2

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -399,7 +399,6 @@ Value *DescBuilder::scalarizeIfUniform(Value *value, bool isNonUniform) {
 Value *DescBuilder::CreateGetBufferDescLength(Value *const bufferDesc, Value *offset, const Twine &instName) {
   // In future this should become a full LLVM intrinsic, but for now we patch in a late intrinsic that is cleaned up
   // in patch buffer op.
-  std::string callName = lgcName::LateBufferLength;
   return CreateNamedCall(lgcName::LateBufferLength, getInt32Ty(), {bufferDesc, offset}, Attribute::ReadNone);
 }
 
@@ -418,7 +417,8 @@ Value *DescBuilder::CreatePtrDiff(llvm::Value *lhs, llvm::Value *rhs, const llvm
     return IRBuilderBase::CreatePtrDiff(lhs, rhs, instName);
 
   std::string callName = lgcName::LateBufferPtrDiff;
-  return CreateNamedCall(lgcName::LateBufferPtrDiff, getInt64Ty(), {lhs, rhs}, Attribute::ReadNone);
+  addTypeMangling(getInt64Ty(), {lhs, rhs}, callName);
+  return CreateNamedCall(callName, getInt64Ty(), {lhs, rhs}, Attribute::ReadNone);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
OpPtrDiff can be called multiple times with multiple pointer types.
This failed an LLVM assert, because the arguments get set by
`CreateNamedCall` on the first call, and the second call tries to call
the function with the wrong arguments.

Use a vararg function like in the recorder/replayer to fix that.

Fixes dEQP-VK.spirv_assembly.instruction.spirv1p4.opptrdiff.ssbo_comparisons_diff
with assertions enabled.