### PR TITLE
Add the new pass manager class

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -40,6 +40,7 @@ add_llvm_library(LLVMlgc LINK_COMPONENTS
     Linker
     MC
     Object
+    Passes
     ScalarOpts
     SelectionDAG
     Support

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -52,6 +52,7 @@ namespace lgc {
 
 class Builder;
 class LegacyPassManager;
+class PassManager;
 class PassManagerCache;
 class Pipeline;
 class TargetInfo;
@@ -118,6 +119,10 @@ public:
 
   // Utility method to create a start/stop timer pass
   static llvm::ModulePass *createStartStopTimer(llvm::Timer *timer, bool starting);
+
+  // Utility method to create a start/stop timer pass and add it to the given
+  // pass manager
+  static void createAndAddStartStopTimer(lgc::PassManager &passMgr, llvm::Timer *timer, bool starting);
 
   // Set and get a pointer to the stream used for LLPC_OUTS. This is initially nullptr,
   // signifying no output from LLPC_OUTS. Setting this to a stream means that LLPC_OUTS

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/PassManager.h"
 
 namespace lgc {
 
@@ -41,6 +42,16 @@ public:
   static LegacyPassManager *Create();
   virtual ~LegacyPassManager() {}
   virtual void stop() = 0;
+  virtual void setPassIndex(unsigned *passIndex) = 0;
+};
+
+// =====================================================================================================================
+// Public interface of LLPC middle-end's PassManager override
+class PassManager : public llvm::ModulePassManager {
+public:
+  static PassManager *Create();
+  virtual ~PassManager() {}
+  virtual void run(llvm::Module &module) = 0;
   virtual void setPassIndex(unsigned *passIndex) = 0;
 };
 

--- a/lgc/util/StartStopTimer.cpp
+++ b/lgc/util/StartStopTimer.cpp
@@ -29,6 +29,7 @@
 ***********************************************************************************************************************
 */
 #include "lgc/LgcContext.h"
+#include "lgc/PassManager.h"
 #include "lgc/util/Internal.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
@@ -55,10 +56,9 @@ public:
 
   bool runImpl(Module &module);
 
-private:
-  StartStopTimer(const StartStopTimer &) = delete;
-  StartStopTimer &operator=(const StartStopTimer &) = delete;
+  static StringRef name() { return "Start or stop timer"; }
 
+private:
   Timer *m_timer;  // The timer to start or stop when the pass is run
   bool m_starting; // True to start the timer, false to stop it
 };
@@ -92,6 +92,18 @@ char LegacyStartStopTimer::ID = 0;
 // @param starting : True to start the timer, false to stop it
 ModulePass *LgcContext::createStartStopTimer(Timer *timer, bool starting) {
   return new LegacyStartStopTimer(timer, starting);
+}
+
+// =====================================================================================================================
+// Create a start/stop timer pass and add it to the pass manager.  This is a
+// static method in LgcContext, so it can be accessed by the front-end to add
+// to its pass manager.
+//
+// @param passMgr : Pass manager to add the pass to
+// @param timer : The timer to start or stop when the pass is run
+// @param starting : True to start the timer, false to stop it
+void LgcContext::createAndAddStartStopTimer(lgc::PassManager &passMgr, Timer *timer, bool starting) {
+  passMgr.addPass(StartStopTimer(timer, starting));
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -41,6 +41,7 @@
 #include "llpcShaderModuleHelper.h"
 #include "llpcSpirvLower.h"
 #include "llpcSpirvLowerResourceCollect.h"
+#include "llpcSpirvLowerTranslator.h"
 #include "llpcSpirvLowerUtil.h"
 #include "llpcTimerProfiler.h"
 #include "spirvExt.h"
@@ -158,6 +159,9 @@ opt<int> ContextReuseLimit("context-reuse-limit",
 
 // -fatal-llvm-errors: Make all LLVM errors fatal
 opt<bool> FatalLlvmErrors("fatal-llvm-errors", cl::desc("Make all LLVM errors fatal"), init(false));
+
+// -new-pass-manager: Use LLVM's new pass manager (experimental)
+opt<bool> NewPassManager("new-pass-manager", cl::desc("Use LLVM's new pass manager (experimental)"), init(false));
 
 extern opt<bool> EnableOuts;
 
@@ -1233,31 +1237,56 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       if (!shaderInfoEntry || !shaderInfoEntry->pModuleData || (stageSkipMask & shaderStageToMask(entryStage)))
         continue;
 
-      std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
-      lowerPassMgr->setPassIndex(&passIndex);
-
       // Set the shader stage in the Builder.
       context->getBuilder()->setShaderStage(getLgcShaderStage(entryStage));
 
-      // Start timer for translate.
-      timerProfiler.addTimerStartStopPass(&*lowerPassMgr, TimerTranslate, true);
+      if (cl::NewPassManager) {
+        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+        lowerPassMgr->setPassIndex(&passIndex);
 
-      // SPIR-V translation, then dump the result.
-      lowerPassMgr->add(createSpirvLowerTranslator(entryStage, shaderInfoEntry));
-      if (EnableOuts()) {
-        lowerPassMgr->add(createPrintModulePass(
-            outs(), "\n"
-                    "===============================================================================\n"
-                    "// LLPC SPIRV-to-LLVM translation results\n"));
-      }
-      // Stop timer for translate.
-      timerProfiler.addTimerStartStopPass(&*lowerPassMgr, TimerTranslate, false);
+        // Start timer for translate.
+        timerProfiler.addTimerStartStopPass(*lowerPassMgr, TimerTranslate, true);
 
-      // Run the passes.
-      bool success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
-      if (!success) {
-        LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
-        result = Result::ErrorInvalidShader;
+        // SPIR-V translation, then dump the result.
+        lowerPassMgr->addPass(SpirvLowerTranslator(entryStage, shaderInfoEntry));
+        if (EnableOuts()) {
+          lowerPassMgr->addPass(PrintModulePass(
+              outs(), "\n"
+                      "===============================================================================\n"
+                      "// LLPC SPIRV-to-LLVM translation results\n"));
+        }
+        // Stop timer for translate.
+        timerProfiler.addTimerStartStopPass(*lowerPassMgr, TimerTranslate, false);
+
+        bool success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
+        if (!success) {
+          LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
+          result = Result::ErrorInvalidShader;
+        }
+      } else {
+        std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
+        lowerPassMgr->setPassIndex(&passIndex);
+
+        // Start timer for translate.
+        timerProfiler.addTimerStartStopPass(&*lowerPassMgr, TimerTranslate, true);
+
+        // SPIR-V translation, then dump the result.
+        lowerPassMgr->add(createSpirvLowerTranslator(entryStage, shaderInfoEntry));
+        if (EnableOuts()) {
+          lowerPassMgr->add(createPrintModulePass(
+              outs(), "\n"
+                      "===============================================================================\n"
+                      "// LLPC SPIRV-to-LLVM translation results\n"));
+        }
+        // Stop timer for translate.
+        timerProfiler.addTimerStartStopPass(&*lowerPassMgr, TimerTranslate, false);
+
+        // Run the passes.
+        bool success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
+        if (!success) {
+          LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
+          result = Result::ErrorInvalidShader;
+        }
       }
     }
     SmallVector<Module *, 5> modulesToLink;
@@ -1905,11 +1934,33 @@ Context *Compiler::acquireContext() const {
 }
 
 // =====================================================================================================================
-// Run a pass manager's passes on a module, catching any LLVM fatal error and returning a success indication
+// Run legacy pass manager's passes on a module, catching any LLVM fatal error and returning a success indication
 //
 // @param passMgr : Pass manager
 // @param [in/out] module : Module
 bool Compiler::runPasses(lgc::LegacyPassManager *passMgr, Module *module) const {
+  bool success = false;
+#if LLPC_ENABLE_EXCEPTION
+  try
+#endif
+  {
+    passMgr->run(*module);
+    success = true;
+  }
+#if LLPC_ENABLE_EXCEPTION
+  catch (const char *) {
+    success = false;
+  }
+#endif
+  return success;
+}
+
+// =====================================================================================================================
+// Run pass manager's passes on a module, catching any LLVM fatal error and returning a success indication
+//
+// @param passMgr : Pass manager
+// @param [in/out] module : Module
+bool Compiler::runPasses(lgc::PassManager *passMgr, Module *module) const {
   bool success = false;
 #if LLPC_ENABLE_EXCEPTION
   try

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -47,6 +47,7 @@ class Module;
 namespace lgc {
 
 class LegacyPassManager;
+class PassManager;
 
 } // namespace lgc
 
@@ -151,6 +152,7 @@ private:
   void releaseContext(Context *context) const;
 
   bool runPasses(lgc::LegacyPassManager *passMgr, llvm::Module *module) const;
+  bool runPasses(lgc::PassManager *passMgr, llvm::Module *module) const;
   void linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context);
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo,
                                           const GraphicsPipelineBuildInfo *pipelineInfo);

--- a/llpc/lower/llpcSpirvLowerTranslator.h
+++ b/llpc/lower/llpcSpirvLowerTranslator.h
@@ -49,6 +49,8 @@ public:
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
   bool runImpl(llvm::Module &module);
 
+  static llvm::StringRef name() { return "LLPC translate SPIR-V binary to LLVM IR"; }
+
 private:
   void translateSpirvToLlvm(const PipelineShaderInfo *shaderInfo, llvm::Module *module);
 

--- a/llpc/util/llpcTimerProfiler.cpp
+++ b/llpc/util/llpcTimerProfiler.cpp
@@ -125,6 +125,17 @@ void TimerProfiler::addTimerStartStopPass(lgc::LegacyPassManager *passMgr, Timer
 }
 
 // =====================================================================================================================
+// Adds pass to start or stop timer in PassManager
+//
+// @param passMgr : Pass Manager
+// @param timerKind : Kind of phase timer
+// @param start : Start or  stop timer
+void TimerProfiler::addTimerStartStopPass(lgc::PassManager &passMgr, TimerKind timerKind, bool start) {
+  if (TimePassesIsEnabled || cl::EnableTimerProfile)
+    lgc::LgcContext::createAndAddStartStopTimer(passMgr, &m_phaseTimers[timerKind], start);
+}
+
+// =====================================================================================================================
 // Starts or stop specified timer.
 //
 // @param timerKind : Kind of phase timer

--- a/llpc/util/llpcTimerProfiler.h
+++ b/llpc/util/llpcTimerProfiler.h
@@ -38,6 +38,7 @@
 namespace lgc {
 
 class LegacyPassManager;
+class PassManager;
 
 } // namespace lgc
 
@@ -65,6 +66,7 @@ public:
   ~TimerProfiler();
 
   void addTimerStartStopPass(lgc::LegacyPassManager *passMgr, TimerKind timerKind, bool start);
+  void addTimerStartStopPass(lgc::PassManager &passMgr, TimerKind timerKind, bool start);
 
   void startStopTimer(TimerKind name, bool start);
 


### PR DESCRIPTION
This patch adds the (still WIP) new `PassManager` class. This class implements LLVM's new pass manager interface. Unlike in the legacy PassManager class, we inject custom code between passes using the new instrumentation callback system provided by LLVM. We also rely on LLVM's standard instrumentation classes to implement the `-verify-ir` option. There are currently two known issues with this new implementation: 1. `--dump-cfg-after` does not work because there is no mechanism to register a pass with an ID to the instrumentation system. 2. `--time-passes` does not work because we need to use the standard instrumentation classes to make it work. These two issues will be addressed in subsequent patches when we'll have more passes ported to the new PM to experiment with.

The patch also adds the `-experimental-new-pm` flag that is used to test the new pass manager implementation. The option will eventually be removed when the switch is complete.

One of the uses of the pass manager in `llpcCompiler.cpp` is ported to that new `PassManager` class and is guarded by that new experimental flag.