### PR TITLE
Fix minor issues relevant to NGG

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -311,6 +311,9 @@ public:
   // Set the flag to pack the output locations of the specified shader stage
   void setPackOutput(ShaderStage shaderStage, bool pack) { m_outputPackState[shaderStage] = pack; }
 
+  // Get the count of vertices per primitive
+  unsigned getVerticesPerPrimitive();
+
   // -----------------------------------------------------------------------------------------------------------------
   // Utility methods
 

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -246,9 +246,6 @@ private:
   llvm::Value *fetchCullDistanceSignMask(llvm::Value *vertexId);
   llvm::Value *calcVertexItemOffset(unsigned streamId, llvm::Value *vertexId);
 
-  unsigned getVerticesPerPrimitive() const;
-  unsigned getOutputVerticesPerPrimitive() const;
-
   // Checks if NGG culling operations are enabled
   bool enableCulling() const {
     return m_nggControl->enableBackfaceCulling || m_nggControl->enableFrustumCulling ||


### PR DESCRIPTION
- Update the LDS calculation of NGG. Refactor the handling when we
  overallocate LDS.
- Move the helper function getVerticesPerPrimitive to pipeline state.
- Check transform feedback export call and remove the calls if their
  output values are undefined after LLVM optimization. We didn't handle
  this previously

Change-Id: I98f338c9bcf14b67ad4ee02839cee41229a0bcac