### PR TITLE
Remove the resource collect pass from lowering

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -154,9 +154,6 @@ void LegacySpirvLower::addPasses(Context *context, ShaderStage stage, legacy::Pa
   if (lowerTimer)
     passMgr.add(LgcContext::createStartStopTimer(lowerTimer, true));
 
-  // Lower SPIR-V resource collecting
-  passMgr.add(createSpirvLowerResourceCollect(false));
-
   // Function inlining. Use the "always inline" pass, since we want to inline all functions, and
   // we marked (non-entrypoint) functions as "always inline" just after SPIR-V reading.
   passMgr.add(createAlwaysInlinerLegacyPass());

--- a/llpc/lower/llpcSpirvLowerResourceCollect.h
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.h
@@ -68,14 +68,15 @@ public:
   bool detailUsageValid() { return m_detailUsageValid; }
 
   virtual bool runOnModule(llvm::Module &module);
-  void visitCalls(llvm::Module &module);
-  llvm::Value *findCallAndGetIndexValue(llvm::Module &module, llvm::CallInst *const targetCall);
 
   static char ID; // ID of this pass
 
 private:
   SpirvLowerResourceCollect(const SpirvLowerResourceCollect &) = delete;
   SpirvLowerResourceCollect &operator=(const SpirvLowerResourceCollect &) = delete;
+
+  void visitCalls(llvm::Module &module);
+  llvm::Value *findCallAndGetIndexValue(llvm::Module &module, llvm::CallInst *const targetCall);
 
   unsigned getFlattenArrayElementCount(const llvm::Type *ty) const;
   const llvm::Type *getFlattenArrayElementType(const llvm::Type *ty) const;


### PR DESCRIPTION
It seems that this pass is used to collect information about modules and to
remove dead global variables. In LegacySpirvLower::addPasses, the pass is almost
directly followed by LLVM's global DCE pass that can also remove these globals.
Also, it seems the collected information is never used for this instance, so the
pass can probably be removed from there. I tried compiling 10K+ shaders with and
without the pass and the generated code is exactly the same in all cases.