### PR TITLE
Update powi intrinsic creation ready for upstream changes

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -4191,8 +4191,13 @@ Function *NggPrimShader::createBackfaceCuller(Module *module) {
 
     // threeshold = (10 ^ (-backfaceExponent)) / |w0 * w1 * w2|
     auto threshold = m_builder->CreateNeg(backfaceExponent);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 391319
     threshold = m_builder->CreateIntrinsic(Intrinsic::powi, m_builder->getFloatTy(),
                                            {ConstantFP::get(m_builder->getFloatTy(), 10.0), threshold});
+#else
+    threshold = m_builder->CreateIntrinsic(Intrinsic::powi, {m_builder->getFloatTy(), threshold->getType()},
+                                           {ConstantFP::get(m_builder->getFloatTy(), 10.0), threshold});
+#endif
 
     auto rcpAbsW0W1W2 = m_builder->CreateFDiv(ConstantFP::get(m_builder->getFloatTy(), 1.0), absW0W1W2);
     threshold = m_builder->CreateFMul(threshold, rcpAbsW0W1W2);


### PR DESCRIPTION
Type of powi exponent is also becoming part of the overloading, so extra type is
now required on creation.

Flag day change so requires usual guards