### PR TITLE
Disable floating-point contraction and reassociation when invariant variable is used

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -409,6 +409,7 @@ struct ShaderModuleUsage {
   bool useSpecConstant;        ///< Whether specializaton constant is used
   bool keepUnusedFunctions;    ///< Whether to keep unused function
   bool useIsNan;               ///< Whether IsNan is used
+  bool useInvariant;           ///< Whether invariant variable is used
 };
 
 /// Represents common part of shader module data

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -973,6 +973,8 @@ FastMathFlags SPIRVToLLVM::getFastMathFlags(SPIRVValue *bv) {
   }
   // Enable contraction when "NoContraction" decoration is not specified
   bool allowContract = !bv->hasDecorate(DecorationNoContraction);
+  // If invariant variable is used, we cannot enable contraction
+  allowContract &= !m_moduleUsage->useInvariant;
   // Do not set AllowContract or AllowReassoc if DenormFlushToZero is on, to
   // avoid an FP operation being simplified to a move that does not flush
   // denorms.

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -89,6 +89,15 @@ Result ShaderModuleHelper::collectInfoFromSpirvBinary(const BinaryData *spvBinCo
       }
       break;
     }
+    case OpDecorate:
+    case OpMemberDecorate: {
+      auto decoration =
+          (opCode == OpDecorate) ? static_cast<Decoration>(codePos[2]) : static_cast<Decoration>(codePos[3]);
+      if (decoration == DecorationInvariant) {
+        shaderModuleUsage->useInvariant = true;
+      }
+      break;
+    }
     case OpDPdx:
     case OpDPdy:
     case OpDPdxCoarse:


### PR DESCRIPTION
When invariant variable is used in shader, contracting and reassociating floating-point instructions may cause result to be variant.

The issue appears after #969, old GVN pass removes some fast math flags while NewGVN pass does not, resulting in some test failure.