### PR TITLE
Remove output export call if the output value is undefined

### DIFF
--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1130,12 +1130,35 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
     unsigned builtInId = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
     m_importedOutputBuiltIns.insert(builtInId);
   } else if (mangledName.startswith(lgcName::OutputExportGeneric)) {
-    m_outputCalls.push_back(&callInst);
+    auto outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
+    if (m_shaderStage != ShaderStageFragment && isa<UndefValue>(outputValue)) {
+      // NOTE: If an output value of vertex processing stages is undefined, we can safely drop it and remove the output
+      // export call.
+      m_deadCalls.push_back(&callInst);
+
+      InOutLocationInfo outLocInfo;
+      outLocInfo.setLocation(cast<ConstantInt>(callInst.getArgOperand(0))->getZExtValue());
+      outLocInfo.setComponent(cast<ConstantInt>(callInst.getArgOperand(1))->getZExtValue());
+      if (m_shaderStage == ShaderStageGeometry)
+        outLocInfo.setStreamId(cast<ConstantInt>(callInst.getArgOperand(2))->getZExtValue());
+      // Also, we remove the output location info from the map if it exists
+      auto &outLocInfoMap = m_resUsage->inOutUsage.outputLocInfoMap;
+      if (outLocInfoMap.count(outLocInfo) > 0)
+        outLocInfoMap.erase(outLocInfo);
+      // For GS, we remove transform feedback location info as well if it exists
+      if (m_shaderStage == ShaderStageGeometry) {
+        auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.gs.locInfoXfbOutInfoMap;
+        if (locInfoXfbOutInfoMap.count(outLocInfo) > 0)
+          locInfoXfbOutInfoMap.erase(outLocInfo);
+      }
+    } else {
+      m_outputCalls.push_back(&callInst);
+    }
   } else if (mangledName.startswith(lgcName::OutputExportBuiltIn)) {
-    // NOTE: If output value is undefined one, we can safely drop it and remove the output export call.
+    // NOTE: If an output value is undefined, we can safely drop it and remove the output export call.
     // Currently, do this for geometry shader.
     if (m_shaderStage == ShaderStageGeometry) {
-      auto *outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
+      auto outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
       if (isa<UndefValue>(outputValue))
         m_deadCalls.push_back(&callInst);
       else {
@@ -1146,7 +1169,7 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
   } else if (mangledName.startswith(lgcName::OutputExportXfb)) {
     auto outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
     if (isa<UndefValue>(outputValue)) {
-      // NOTE: If output value is undefined one, we can safely drop it and remove the transform feedback output export
+      // NOTE: If an output value is undefined, we can safely drop it and remove the transform feedback output export
       // call.
       m_deadCalls.push_back(&callInst);
     }


### PR DESCRIPTION
This is to remove unnecessary output export calls. These calls are
generated when we lower aggregate-typed outputs. For example, if
part of a structure-typed output are written, we export the whole of
it but some members are dead outputs. There is no need of doing this
and the dead output export calls will waste HW instructions, such
as LDS/buffer write.

Change-Id: I3b07eab59c42f080dca12acd51e9fe2dafb20bd3