### PR TITLE
Fix generating fmf flags with matrix ops

### DIFF
--- a/llpc/test/shaderdb/OpMatrixTimesMatrix_TestMat4xMat4_lit.frag
+++ b/llpc/test/shaderdb/OpMatrixTimesMatrix_TestMat4xMat4_lit.frag
@@ -28,6 +28,9 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: [4 x <4 x float>] (...) @lgc.create.matrix.times.matrix.a4v4f32
 
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching
+; SHADERTEST: fmul {{.*}}contract {{.*}}float
+
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: fmul {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}
 ; SHADERTEST: fadd {{.*}}float %{{[^, ]*}}, %{{[^, ]*}}

--- a/llpc/test/shaderdb/OpMatrixTimesScalar_TestMat3X4xFloat_lit.frag
+++ b/llpc/test/shaderdb/OpMatrixTimesScalar_TestMat3X4xFloat_lit.frag
@@ -27,6 +27,9 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: [3 x <4 x float>] (...) @lgc.create.matrix.times.scalar.a3v4f32
 
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching
+; SHADERTEST: fmul {{.*}}contract {{.*}}float
+
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: fmul {{.*}}float
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -963,6 +963,8 @@ FastMathFlags SPIRVToLLVM::getFastMathFlags(SPIRVValue *bv) {
   SPIRVType *ty = bv->getType();
   if (ty->isTypeVector())
     ty = ty->getVectorComponentType();
+  else if (ty->isTypeMatrix())
+    ty = ty->getMatrixColumnType()->getVectorComponentType();
   if (!ty->isTypeFloat())
     return fmf;
 


### PR DESCRIPTION
Fix generating fast math flags with OpMatrixTimesScalar
and OpMatrixTimesMatrix.