### PR TITLE
Fix latent translation issues of GLSL built-in pack functions

### DIFF
--- a/llpc/test/shaderdb/OpExtInst_TestPackSnorm2x16_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackSnorm2x16_lit.frag
@@ -19,7 +19,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %[[CLAMP:.*]] = call <2 x float> (...) @lgc.create.fclamp.v2f32(<2 x float> %{{.*}}, <2 x float> <float -1.000000e+00, float -1.000000e+00>, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
 ; SHADERTEST: %[[SCALE:.*]] = fmul <2 x float> %[[CLAMP]], <float 3.276700e+04, float 3.276700e+04>
-; SHADERTEST: %[[CONV:.*]] = fptosi <2 x float> %[[SCALE]] to <2 x i16>
+; SHADERTEST: %[[RINT:.*]] = call <2 x float> @llvm.rint.v2f32(<2 x float> %[[SCALE]])
+; SHADERTEST: %[[CONV:.*]] = fptosi <2 x float> %[[RINT]] to <2 x i16>
 ; SHADERTEST: = bitcast <2 x i16> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestPackUnorm2x16_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackUnorm2x16_lit.frag
@@ -19,7 +19,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %[[CLAMP:.*]] = call <2 x float> (...) @lgc.create.fclamp.v2f32(<2 x float> %1, <2 x float> zeroinitializer, <2 x float> <float 1.000000e+00, float 1.000000e+00>)
 ; SHADERTEST: %[[SCALE:.*]] = fmul <2 x float> %[[CLAMP]], <float 6.553500e+04, float 6.553500e+04>
-; SHADERTEST: %[[CONV:.*]] = fptoui <2 x float> %[[SCALE]] to <2 x i16>
+; SHADERTEST: %[[RINT:.*]] = call <2 x float> @llvm.rint.v2f32(<2 x float> %[[SCALE]])
+; SHADERTEST: %[[CONV:.*]] = fptoui <2 x float> %[[RINT]] to <2 x i16>
 ; SHADERTEST: = bitcast <2 x i16> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/OpExtInst_TestPackUnorm4x8_lit.frag
+++ b/llpc/test/shaderdb/OpExtInst_TestPackUnorm4x8_lit.frag
@@ -19,7 +19,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %[[CLAMP:.*]] = call <4 x float> (...) @lgc.create.fclamp.v4f32(<4 x float> %{{.*}}, <4 x float> zeroinitializer, <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>)
 ; SHADERTEST: %[[SCALE:.*]] = fmul <4 x float> %[[CLAMP]], <float 2.550000e+02, float 2.550000e+02, float 2.550000e+02, float 2.550000e+02>
-; SHADERTEST: %[[CONV:.*]] = fptoui <4 x float> %[[SCALE]] to <4 x i8>
+; SHADERTEST: %[[RINT:.*]] = call <4 x float> @llvm.rint.v4f32(<4 x float> %[[SCALE]])
+; SHADERTEST: %[[CONV:.*]] = fptoui <4 x float> %[[RINT]] to <4 x i8>
 ; SHADERTEST: = bitcast <4 x i8> %[[CONV]] to i32
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7957,6 +7957,7 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450PackSnorm4x8: {
     // Convert <4 x float> into signed normalized <4 x i8> then pack into i32.
+    // round(clamp(c, -1, +1) * 127.0)
     Value *val = getBuilder()->CreateFClamp(args[0], ConstantFP::get(args[0]->getType(), -1.0),
                                             ConstantFP::get(args[0]->getType(), 1.0));
     val = getBuilder()->CreateFMul(val, ConstantFP::get(args[0]->getType(), 127.0));
@@ -7967,28 +7968,33 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450PackUnorm4x8: {
     // Convert <4 x float> into unsigned normalized <4 x i8> then pack into i32.
+    // round(clamp(c, 0, +1) * 255.0)
     Value *val = getBuilder()->CreateFClamp(args[0], Constant::getNullValue(args[0]->getType()),
                                             ConstantFP::get(args[0]->getType(), 1.0));
     val = getBuilder()->CreateFMul(val, ConstantFP::get(args[0]->getType(), 255.0));
+    val = getBuilder()->CreateUnaryIntrinsic(Intrinsic::rint, val);
     val = getBuilder()->CreateFPToUI(val, FixedVectorType::get(getBuilder()->getInt8Ty(), 4));
     return getBuilder()->CreateBitCast(val, getBuilder()->getInt32Ty());
   }
 
   case GLSLstd450PackSnorm2x16: {
     // Convert <2 x float> into signed normalized <2 x i16> then pack into i32.
+    // round(clamp(c, -1, +1) * 32767.0)
     Value *val = getBuilder()->CreateFClamp(args[0], ConstantFP::get(args[0]->getType(), -1.0),
                                             ConstantFP::get(args[0]->getType(), 1.0));
     val = getBuilder()->CreateFMul(val, ConstantFP::get(args[0]->getType(), 32767.0));
+    val = getBuilder()->CreateUnaryIntrinsic(Intrinsic::rint, val);
     val = getBuilder()->CreateFPToSI(val, FixedVectorType::get(getBuilder()->getInt16Ty(), 2));
     return getBuilder()->CreateBitCast(val, getBuilder()->getInt32Ty());
   }
 
   case GLSLstd450PackUnorm2x16: {
-    // Convert <2 x float> into unsigned normalized <2 x i16> then pack into
-    // i32.
+    // Convert <2 x float> into unsigned normalized <2 x i16> then pack into i32.
+    // round(clamp(c, 0, +1) * 65535.0)
     Value *val = getBuilder()->CreateFClamp(args[0], Constant::getNullValue(args[0]->getType()),
                                             ConstantFP::get(args[0]->getType(), 1.0));
     val = getBuilder()->CreateFMul(val, ConstantFP::get(args[0]->getType(), 65535.0));
+    val = getBuilder()->CreateUnaryIntrinsic(Intrinsic::rint, val);
     val = getBuilder()->CreateFPToUI(val, FixedVectorType::get(getBuilder()->getInt16Ty(), 2));
     return getBuilder()->CreateBitCast(val, getBuilder()->getInt32Ty());
   }


### PR DESCRIPTION
The pack functions packUnorm4x8/packSnorm4x8/packUnorm2x16/packSnorm2x16
always need a rounding calculation. This is missing in the translation.

Change-Id: Ib8e53debf56b94fde54225592bf85db498cc3391