### PR TITLE
Fix a crash in PatchResourceCollect::scalarizeGenericInput

### DIFF
--- a/llpc/test/shaderdb/PipelineVsFs_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_TestInOutPacking.pipe
@@ -2,56 +2,14 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}7
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}38, i32 {{.*}}7
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}15
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}15
+
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -74,6 +32,7 @@ layout(location = 7) out i8vec2 v2i8_0;
 layout(location = 8) out i16vec2 v2i16_0;
 layout(location = 9) out f16vec4 v4f16_2;
 layout(location = 10) out vec3 interp;
+layout(location = 11) out vec4 v4f32;
 void main()
 {
     v2f_0 = vec2(1.0, 0.0);
@@ -86,6 +45,7 @@ void main()
     v2i16_0 = i16vec2(1, 1);
     v4f16_2 = f16vec4(0.1, 0.1, 0.1, 1.0);
     interp = vec3(0.5, 0.5, 0.5);
+    v4f32 = vec4(3);
 }
 
 [VsInfo]
@@ -108,6 +68,7 @@ layout(location = 7) flat in i8vec2 v2i8_0;
 layout(location = 8) flat in i16vec2 v2i16_0;
 layout(location = 9) flat in f16vec4 v4f16_2;
 layout(location = 10) __explicitInterpAMD in vec3 interp;
+layout(location = 11) in vec4 color;
 layout(location = 0) out vec4 fragColor;
 
 void main()
@@ -123,7 +84,13 @@ void main()
     vec3 result_2 = interpolateAtVertexAMD(interp, 0u);
 
     vec3 expect_result = v.x * result_0 + v.y * result_1 + v.z * result_2;
-    fragColor =  all(lessThan(expect_result, vec3(v.w)))? vec4(1.0, 0.0, 0.0, 1.0) : vec4(0.0, 1.0, 0.0, 1.0);
+
+    int id0 = bitfieldExtract(12816, 0, 4);
+    int id1 = bitfieldExtract(12816, 4, 4);
+    int id2 = bitfieldExtract(12816, 8, 4);
+    int id4 = bitfieldExtract(12816, 12, 4);
+
+    fragColor =  all(lessThan(expect_result, vec3(v.w)))? vec4(color[id0], color[id1], color[id2], 1.0) : vec4(0.0, 1.0, 0.0, 1.0);
 }
 
 [FsInfo]


### PR DESCRIPTION
When marking the unused input call elements before scalarization, we
alway treat the index operand of an ExtractElementInst user as
ConstantInt. This assumption is incorrect if the index is not constant.
The fix is conversative to mark all element of the input call as used
for non-contant case.