### PR TITLE
Remove the PushConst branch in pipeline dump

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -429,7 +429,7 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
   case ResourceMappingNodeType::DescriptorBuffer:
   case ResourceMappingNodeType::DescriptorFmask:
   case ResourceMappingNodeType::DescriptorBufferCompact:
-  {
+  case ResourceMappingNodeType::PushConst: {
     dumpFile << prefix << ".set = " << userDataNode->srdRange.set << "\n";
     dumpFile << prefix << ".binding = " << userDataNode->srdRange.binding << "\n";
     break;
@@ -447,11 +447,6 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
     break;
   }
   case ResourceMappingNodeType::StreamOutTableVaPtr: {
-    break;
-  }
-  case ResourceMappingNodeType::PushConst: {
-    dumpFile << prefix << ".set = " << userDataNode->srdRange.set << "\n";
-    dumpFile << prefix << ".binding = " << userDataNode->srdRange.binding << "\n";
     break;
   }
   default: {

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -430,7 +430,9 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
   case ResourceMappingNodeType::DescriptorFmask:
   case ResourceMappingNodeType::DescriptorBufferCompact:
   case ResourceMappingNodeType::PushConst: {
-    dumpFile << prefix << ".set = " << userDataNode->srdRange.set << "\n";
+    char setHexvalue[64] = {};
+    snprintf(setHexvalue, 64, "0x%08" PRIX32, userDataNode->srdRange.set);
+    dumpFile << prefix << ".set = " << setHexvalue << "\n";
     dumpFile << prefix << ".binding = " << userDataNode->srdRange.binding << "\n";
     break;
   }


### PR DESCRIPTION
Remove the switch case PushConst branch in pipeline dump as it is the duplicated code, same
logic as other ResourceMappingNode branch.