### PR TITLE
Use enumRange to iterate over lgc::ShaderStage

### DIFF
--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -56,6 +56,9 @@ enum ShaderStage : unsigned {
   ShaderStageCountInternal,                 ///< Count of shader stages (internal-use)
 };
 
+// Enable iteration over shader stages with `lgc::enumRange<lgc::ShaderStage>()`.
+LGC_DEFINE_ZERO_BASED_ITERABLE_ENUM(ShaderStage, ShaderStage::ShaderStageCountInternal);
+
 // Enumerates the function of a particular node in a shader's resource mapping graph. Also used as descriptor
 // type in Builder descriptor functions.
 enum class ResourceNodeType : unsigned {

--- a/lgc/interface/lgc/EnumIterator.h
+++ b/lgc/interface/lgc/EnumIterator.h
@@ -160,16 +160,32 @@ private:
 // Creates the range of enum values: `[begin, end)`. By default, this will range over all enum values (except
 // `::Count`). EnumT must provide the `iterable_enum_traits` trait. E.g.:
 // - for (MyEnum value : enumRange<MyEnum>())  // Iterates over all values of `MyEnum`.
+// - for (MyEnum value : enumRange(MyEnum::C))  // Iterates over values of `MyEnum` until (but excluding `C`).
 // - llvm::is_contained(enumRange(MyEnum::A, MyEnum::C), value)  // Checks if `value` is in `[A, C)` (without `C`).
 // - llvm::is_contained(enumRange(MyEnum::A, enumInc(MyEnum::C)), value)  // Checks if `value` is in `[A, C]`.
 //
 // @param begin : The first value in the range. By default, this is the enum value `0`.
 // @param end : The one-past the last value in the range. By default, this is the enum value `::Count`.
 // @returns : The enum range: `begin, begin + 1, ..., end - 1`.
-template <typename EnumT>
-llvm::iterator_range<enum_iterator<EnumT>> enumRange(EnumT begin = iterable_enum_traits<EnumT>::first_value,
-                                                     EnumT end = iterable_enum_traits<EnumT>::end_value) {
+template <typename EnumT> llvm::iterator_range<enum_iterator<EnumT>> enumRange(EnumT begin, EnumT end) {
   return {enum_iterator<EnumT>(begin), enum_iterator<EnumT>(end)};
+}
+
+// =====================================================================================================================
+// Creates the range of enum values: `[first_val, end)`. See `enumRange(EnumT begin, EnumT end)` above.
+//
+// @param end : The one-past the last value in the range. By default, this is the enum value `::Count`.
+// @returns : The enum range: `first_value, first_value + 1, ..., end - 1`.
+template <typename EnumT> llvm::iterator_range<enum_iterator<EnumT>> enumRange(EnumT end) {
+  return enumRange<EnumT>(iterable_enum_traits<EnumT>::first_value, end);
+}
+
+// =====================================================================================================================
+// Creates the range of all enum values of `EnumT`. See `enumRange(EnumT begin, EnumT end)` above.
+//
+// @returns : The enum range: `first_value, first_value + 1, ..., end_value - 1`.
+template <typename EnumT> llvm::iterator_range<enum_iterator<EnumT>> enumRange() {
+  return enumRange<EnumT>(iterable_enum_traits<EnumT>::first_value, iterable_enum_traits<EnumT>::end_value);
 }
 
 } // namespace lgc

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "PatchCheckShaderCache.h"
+#include "lgc/CommonDefs.h"
 #include "lgc/state/PipelineShaders.h"
 #include "llvm/Support/Debug.h"
 
@@ -115,7 +116,7 @@ bool PatchCheckShaderCache::runOnModule(Module &module) {
   auto stageMask = pipelineState->getShaderStageMask();
 
   // Build input/output layout hash per shader stage
-  for (auto stage = ShaderStageVertex; stage < ShaderStageGfxCount; stage = static_cast<ShaderStage>(stage + 1)) {
+  for (const ShaderStage stage : enumRange(ShaderStageGfxCount)) {
     if ((stageMask & shaderStageToMask(stage)) == 0)
       continue;
 

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -143,12 +143,12 @@ LGC_DEFINE_ZERO_BASED_ITERABLE_ENUM(Vkgc::UnlinkedShaderStage, Vkgc::UnlinkedSta
 namespace Llpc {
 // Returns the range of all native ShaderStages.
 inline auto nativeShaderStages() {
-  return lgc::enumRange(Vkgc::ShaderStage{}, Vkgc::ShaderStage::ShaderStageNativeStageCount);
+  return lgc::enumRange(Vkgc::ShaderStage::ShaderStageNativeStageCount);
 }
 
 // Returns the range of all graphics ShaderStages.
 inline auto gfxShaderStages() {
-  return lgc::enumRange(Vkgc::ShaderStage{}, Vkgc::ShaderStage::ShaderStageGfxCount);
+  return lgc::enumRange(Vkgc::ShaderStage::ShaderStageGfxCount);
 }
 
 // Returns the range of all internal ShaderStages.


### PR DESCRIPTION
Change 1-argument version of `enumRange` to behave like Python's `range(X)`:
make `enumRange(X)` iterate up until `X` instead of starting from `X`.