### PR TITLE
Refine scalarizeGenericInput

### DIFF
--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2817,16 +2817,14 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
   bool unknownElementsUsed = false;
   for (User *user : call->users()) {
     if (auto extract = dyn_cast<ExtractElementInst>(user)) {
-      // NOTE: If the extracted index is constant, we mark the specified indexing element as used. Otherwise, we have to
-      // mark all elements as used.
+      // NOTE: The extracted index is allowed to be constant or not. For non-constant, we just break the loop and mark
+      // as unknownElementsUsed.
       if (auto extractIndex = dyn_cast<ConstantInt>(extract->getIndexOperand())) {
         unsigned idx = extractIndex->getZExtValue();
         assert(idx < scalarizeBy);
         elementUsed[idx] = true;
-      } else {
-        memset(elementUsed, true, sizeof(elementUsed));
+        continue;
       }
-      continue;
     }
     if (auto shuffle = dyn_cast<ShuffleVectorInst>(user)) {
       SmallVector<int, 4> mask;

--- a/lgc/test/ScalarizeInputWithDynamicIndexUser.lgc
+++ b/lgc/test/ScalarizeInputWithDynamicIndexUser.lgc
@@ -1,0 +1,102 @@
+; Check that if the generic input has an extract instruction user whose index is dynamic, the input should be scalarized for each component.
+; RUN: lgc -mcpu=gfx900 --print-after=lgc-patch-resource-collect %s -emit-llvm -o=- 2>&1 | FileCheck %s
+
+; ModuleID = 'lgcPipeline'
+source_filename = "lgcPipeline"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn--amdpal"
+
+; CHECK: IR Dump After Patch LLVM for resource collecting
+; CHECK: define dllexport spir_func void @lgc.shader.VS.main()
+; CHECK: call void @lgc.output.export.generic.i32.i32.v4f32(i32 2, i32 0, <4 x float> %[[#]])
+; CHECK: define dllexport spir_func void @lgc.shader.FS.main()
+; CHECK: [[IMPORT0:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i32.i32(i32 2, i32 0, i32 0, i32 1)
+; CHECK-NEXT: [[INSERTELEMENT0:%[0-9]+]] = insertelement <4 x float> undef, float [[IMPORT0]], i64 0
+; CHECK-NEXT: [[IMPORT1:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i32.i32(i32 2, i32 1, i32 0, i32 1)
+; CHECK-NEXT: [[INSERTELEMENT1:%[0-9]+]] = insertelement <4 x float> [[INSERTELEMENT0]], float [[IMPORT1]], i64 1
+; CHECK-NEXT: [[IMPORT2:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i32.i32(i32 2, i32 2, i32 0, i32 1)
+; CHECK-NEXT: [[INSERTELEMENT2:%[0-9]+]] = insertelement <4 x float> [[INSERTELEMENT1]], float [[IMPORT2]], i64 2
+; CHECK-NEXT: [[IMPORT3:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i32.i32(i32 2, i32 3, i32 0, i32 1)
+; CHECK-NEXT: [[INSERTELEMENT3:%[0-9]+]] = insertelement <4 x float> [[INSERTELEMENT2]], float [[IMPORT3]], i64 3
+; CHECK-NEXT: [[UBFE:%[0-9]+]] = call i32 @llvm.amdgcn.ubfe.i32(i32 12816, i32 0, i32 4)
+; CHECK-NEXT: [[SELECT:%[0-9]+]] = select i1 false, i32 12816, i32 [[UBFE]]
+; CHECK-NEXT: [[SELECT1:%[0-9]+]] = select i1 false, i32 0, i32 [[SELECT]]
+; CHECK-NEXT: [[EXTRACTELEMENT:%[0-9]+]] = extractelement <4 x float> [[INSERTELEMENT3]], i32 [[SELECT1]]
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !15 !lgc.shaderstage !15 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 2, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  %1 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 1, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  %2 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %2, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<4 x float> %0, i32 2, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind readonly willreturn
+declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spirv.ExecutionModel !16 !lgc.shaderstage !16 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 2, i32 0, i32 0, i32 0, i32 16, i32 undef)
+  %1 = call i32 (...) @lgc.create.extract.bit.field.i32(i32 12816, i32 0, i32 4, i1 false)
+  %2 = extractelement <4 x float> %0, i32 %1
+  %3 = call i32 (...) @lgc.create.extract.bit.field.i32(i32 12816, i32 4, i32 4, i1 false)
+  %4 = extractelement <4 x float> %0, i32 %3
+  %5 = call i32 (...) @lgc.create.extract.bit.field.i32(i32 12816, i32 8, i32 4, i1 false)
+  %6 = extractelement <4 x float> %0, i32 %5
+  %7 = call i32 (...) @lgc.create.extract.bit.field.i32(i32 12816, i32 12, i32 4, i1 false)
+  %8 = extractelement <4 x float> %0, i32 %7
+  %9 = insertelement <4 x float> undef, float %2, i32 0
+  %10 = insertelement <4 x float> %9, float %4, i32 1
+  %11 = insertelement <4 x float> %10, float %6, i32 2
+  %12 = insertelement <4 x float> %11, float %8, i32 3
+  call void (...) @lgc.create.write.generic.output(<4 x float> %12, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare i32 @lgc.create.extract.bit.field.i32(...) local_unnamed_addr #3
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { nounwind readnone }
+attributes #4 = { nofree nosync nounwind readnone speculatable willreturn }
+
+!llpc.shader.mode.VS = !{!0}
+!llpc.shader.mode.FS = !{!0}
+!lgc.client = !{!1}
+!lgc.options = !{!2}
+!lgc.options.VS = !{!3}
+!lgc.options.FS = !{!4}
+!lgc.user.data.nodes = !{!5, !6, !7}
+!lgc.vertex.inputs = !{!8, !9, !10}
+!lgc.color.export.formats = !{!11}
+!lgc.input.assembly.state = !{!12}
+!lgc.rasterizer.state = !{!13}
+!amdgpu.pal.metadata.msgpack = !{!14}
+
+!0 = !{i32 0, i32 0, i32 0, i32 1}
+!1 = !{!"Vulkan"}
+!2 = !{i32 -1861977700, i32 -726079217, i32 -248869534, i32 2063972137, i32 1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2, i32 1}
+!3 = !{i32 1581426283, i32 -161330761, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 20, i32 1800}
+!4 = !{i32 -1618560552, i32 -939433038, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 20, i32 1800}
+!5 = !{!"StreamOutTableVaPtr", i32 0, i32 1, i32 0}
+!6 = !{!"DescriptorBuffer", i32 1, i32 4, i32 0, i32 0, i32 4}
+!7 = !{!"IndirectUserDataVaPtr", i32 5, i32 1, i32 12}
+!8 = !{i32 0, i32 0, i32 0, i32 12, i32 11, i32 7, i32 -1}
+!9 = !{i32 1, i32 1, i32 0, i32 12, i32 10, i32 0, i32 -1}
+!10 = !{i32 2, i32 2, i32 0, i32 4, i32 4, i32 7, i32 -1}
+!11 = !{i32 10, i32 0, i32 1, i32 1}
+!12 = !{i32 2, i32 3}
+!13 = !{i32 0, i32 0, i32 0, i32 1, i32 0, i32 0, i32 0, i32 0, i32 1}
+!14 = !{!"\82\B0amdpal.pipelines\91\84\AA.registers\80\B0.spill_threshold\CE\FF\FF\FF\FF\B0.user_data_limit\00\AF.xgl_cache_info\82\B3.128_bit_cache_hash\92\CF\D2=9\F1\99\1BM\8E\CF\A8y\98tI\99\D7'\AD.llpc_version\A446.1\AEamdpal.version\92\02\03"}
+!15 = !{i32 0}
+!16 = !{i32 4}

--- a/llpc/test/shaderdb/PipelineVsFs_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_TestInOutPacking.pipe
@@ -2,14 +2,56 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}7
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}38, i32 {{.*}}7
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}15
-; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}15
-
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 4, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 4, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 4, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 4, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 3, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 2, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 2, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 2, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 2, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 3, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 3, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -32,7 +74,6 @@ layout(location = 7) out i8vec2 v2i8_0;
 layout(location = 8) out i16vec2 v2i16_0;
 layout(location = 9) out f16vec4 v4f16_2;
 layout(location = 10) out vec3 interp;
-layout(location = 11) out vec4 v4f32;
 void main()
 {
     v2f_0 = vec2(1.0, 0.0);
@@ -45,7 +86,6 @@ void main()
     v2i16_0 = i16vec2(1, 1);
     v4f16_2 = f16vec4(0.1, 0.1, 0.1, 1.0);
     interp = vec3(0.5, 0.5, 0.5);
-    v4f32 = vec4(3);
 }
 
 [VsInfo]
@@ -68,7 +108,6 @@ layout(location = 7) flat in i8vec2 v2i8_0;
 layout(location = 8) flat in i16vec2 v2i16_0;
 layout(location = 9) flat in f16vec4 v4f16_2;
 layout(location = 10) __explicitInterpAMD in vec3 interp;
-layout(location = 11) in vec4 color;
 layout(location = 0) out vec4 fragColor;
 
 void main()
@@ -84,13 +123,7 @@ void main()
     vec3 result_2 = interpolateAtVertexAMD(interp, 0u);
 
     vec3 expect_result = v.x * result_0 + v.y * result_1 + v.z * result_2;
-
-    int id0 = bitfieldExtract(12816, 0, 4);
-    int id1 = bitfieldExtract(12816, 4, 4);
-    int id2 = bitfieldExtract(12816, 8, 4);
-    int id4 = bitfieldExtract(12816, 12, 4);
-
-    fragColor =  all(lessThan(expect_result, vec3(v.w)))? vec4(color[id0], color[id1], color[id2], 1.0) : vec4(0.0, 1.0, 0.0, 1.0);
+    fragColor =  all(lessThan(expect_result, vec3(v.w)))? vec4(1.0, 0.0, 0.0, 1.0) : vec4(0.0, 1.0, 0.0, 1.0);
 }
 
 [FsInfo]


### PR DESCRIPTION
For non-constant index of ExtractElementInst, we just skip it in
`PatchResourceCollect::scalarizeGenericInput`. There is no need assign
the array `elementUsed` all false as in commit 1dda2ad.