### PR TITLE
Refactor the checking conditon of NGG runtime passthrough

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -303,6 +303,8 @@ private:
   bool m_hasTes; // Whether the pipeline has tessellation evaluation shader
   bool m_hasGs;  // Whether the pipeline has geometry shader
 
+  bool m_constPositionZ; // Whether the Z channel of vertex position data is constant
+
   // Base offsets (in dwords) of GS output vertex streams in GS-VS ring
   unsigned m_gsStreamBases[MaxGsStreams];
 


### PR DESCRIPTION
For the Z channel of vertex position data, if it is evaluated as
constant, NGG culling mode could be disabled and we go to runtime
passthrough instead. This is because vertices are in the same Z
plane.

Change-Id: I4657022bec6898bca315fa4766f312ce76e05187