### PR TITLE
Refine CreateIntegerDotProduct

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -350,8 +350,8 @@ Value *BuilderRecorder::CreateDotProduct(Value *const vector1, Value *const vect
 // =====================================================================================================================
 // Create code to calculate the dot product of two integer vectors, with optional accumulator, using hardware support
 // where available.
-// The accumulator input must be i32; use a value of 0 for no accumulation.
-// The result type is i32.
+// Use a value of 0 for no accumulation and the value type is consistent with the result type. The result is saturated
+// if there is an accumulator. The component type of input vectors can have 8-bit/16-bit/32-bit and i32/i16/i8 result.
 //
 // @param vector1 : The integer vector 1
 // @param vector2 : The integer vector 2
@@ -360,7 +360,8 @@ Value *BuilderRecorder::CreateDotProduct(Value *const vector1, Value *const vect
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateIntegerDotProduct(Value *vector1, Value *vector2, Value *accumulator, unsigned flags,
                                                 const Twine &instName) {
-  return record(Opcode::IntegerDotProduct, getInt32Ty(), {vector1, vector2, accumulator, getInt32(flags)}, instName);
+  return record(Opcode::IntegerDotProduct, accumulator->getType(), {vector1, vector2, accumulator, getInt32(flags)},
+                instName);
 }
 
 // =====================================================================================================================

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -204,8 +204,8 @@ public:
 
   // Create code to calculate the dot product of two integer vectors, with optional accumulator, using hardware support
   // where available.
-  // The accumulator input must be i32; use a value of 0 for no accumulation.
-  // The result type is i32.
+  // Use a value of 0 for no accumulation and the value type is consistent with the result type. The result is saturated
+  // if there is an accumulator. The component type of input vectors can have 8-bit/16-bit/32-bit and i32/i16/i8 result.
   //
   // @param vector1 : The integer vector 1
   // @param vector2 : The integer vector 2


### PR DESCRIPTION
This change is to refine `CreateIntegerDotProduct` to make various
output type work well. In current `CreateIntegerDotProduct`, there
are two code pathes for non-HW support and HW support. Non-HW support
should do manul clamping in spir-v reader while some cases of HW support
can do it by the inherent intrisic. It's hard to distinguish the two
cases.
Therefore, we have to move the code piece of emulating dot product of
32-bit/64-bit vectors and clamping manually from spir-v reader to
`CreateIntegerDotProduct`. Besides, it can make the code more concise.