### PR TITLE
[ComputeLibs] Set workgroup size

### DIFF
--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -134,7 +134,7 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       // Force s_barrier to be present (ignore optimization)
       builder.addAttribute("amdgpu-flat-work-group-size", "128,128");
     }
-    if (func->getCallingConv() == CallingConv::AMDGPU_CS) {
+    if (func->getCallingConv() == CallingConv::AMDGPU_CS || func->getCallingConv() == CallingConv::AMDGPU_Gfx) {
       // Set the work group size
       const auto &csBuiltInUsage = m_pipelineState->getShaderModes()->getComputeShaderMode();
       unsigned flatWorkGroupSize =

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -1,11 +1,14 @@
 ; Define a compute library that can be called from a compute shader.
 
-; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
+; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -print-after=lgc-patch-setup-target-features -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
 ; CHECK: define spir_func void @func(i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %descTable2, i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #1 !lgc.shaderstage !7 {
 ; CHECK: !7 = !{i32 5}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
 ; CHECK: define amdgpu_gfx void @func(i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %descTable2, i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #1 !lgc.shaderstage !7 {
+
+; CHECK: IR Dump After Patch LLVM to set up target features
+; CHECK: attributes #1 = { nounwind "amdgpu-flat-work-group-size"="6,6"
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"


### PR DESCRIPTION
Before, the registers were implicitly limited to 64 VGPRs. Setting the
workgroup size allows LLVM to use more registers.