### PR TITLE
Revert "Start porting the lowering passes to the new pass manager"

### DIFF
--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -108,17 +108,11 @@ public:
   // @param useBuilderRecorder : True to use BuilderRecorder, false to use BuilderImpl
   Builder *createBuilder(Pipeline *pipeline, bool useBuilderRecorder);
 
-  // Prepare a legacy pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
-  // think that we have library functions.
-  //
-  // @param [in/out] passMgr : Pass manager
-  void preparePassManager(llvm::legacy::PassManager *passMgr);
-
   // Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
   // think that we have library functions.
   //
   // @param [in/out] passMgr : Pass manager
-  void preparePassManager(lgc::PassManager &passMgr);
+  void preparePassManager(llvm::legacy::PassManager *passMgr);
 
   // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
   void addTargetPasses(lgc::LegacyPassManager &passMgr, llvm::Timer *codeGenTimer, llvm::raw_pwrite_stream &outStream);

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -51,14 +51,8 @@ class PassManager : public llvm::ModulePassManager {
 public:
   static PassManager *Create();
   virtual ~PassManager() {}
-  template <typename PassBuilderT> bool registerFunctionAnalysis(PassBuilderT &&PassBuilder) {
-    return functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));
-  }
   virtual void run(llvm::Module &module) = 0;
   virtual void setPassIndex(unsigned *passIndex) = 0;
-
-protected:
-  llvm::FunctionAnalysisManager functionAnalysisManager;
 };
 
 } // namespace lgc

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -269,25 +269,6 @@ void LgcContext::preparePassManager(legacy::PassManager *passMgr) {
 }
 
 // =====================================================================================================================
-// Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not think that
-// we have library functions.
-//
-// @param [in/out] passMgr : Pass manager
-void LgcContext::preparePassManager(lgc::PassManager &passMgr) {
-  TargetLibraryInfoImpl targetLibInfo(getTargetMachine()->getTargetTriple());
-
-  // Adjust it to allow memcpy and memset.
-  // TODO: Investigate why the latter is necessary. I found that
-  // test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
-  // got unrolled far too much, and at too late a stage for the descriptor loads to be commoned up. It might
-  // be an unfortunate interaction between LoopIdiomRecognize and fat pointer laundering.
-  targetLibInfo.setAvailable(LibFunc_memcpy);
-  targetLibInfo.setAvailable(LibFunc_memset);
-
-  passMgr.registerFunctionAnalysis([&] { return TargetLibraryAnalysis(targetLibInfo); });
-}
-
-// =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
 //
 // @param [in/out] passMgr : Pass manager to add passes to

--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -98,11 +98,10 @@ private:
 
   // -----------------------------------------------------------------------------------------------------------------
 
-  ModuleAnalysisManager moduleAnalysisManager; // Module analysis manager used when running the passes.
+  ModuleAnalysisManager analysisManager;       // Analysis manager used when running the passes.
   PassInstrumentationCallbacks instrCallbacks; // Instrumentation callbacks ran when running the passes.
   VerifyInstrumentation instrVerify;           // Verify instrumentation, run module verifier after each pass.
-  unsigned *m_passIndex = nullptr;             // Pass Index.
-  bool initialized = false;                    // Wether the pass manager is initialized or not.
+  unsigned *m_passIndex = nullptr;             // Pass Index
 };
 
 } // namespace
@@ -168,6 +167,8 @@ PassManagerImpl::PassManagerImpl() : PassManager(), instrVerify(getLgcOuts()) {
   registerCallbacks();
   if (cl::VerifyIr)
     instrVerify.registerCallbacks(instrCallbacks);
+  PassBuilder passBuilder(nullptr, PipelineTuningOptions(), None, &instrCallbacks);
+  passBuilder.registerModuleAnalyses(analysisManager);
 }
 
 // =====================================================================================================================
@@ -175,16 +176,7 @@ PassManagerImpl::PassManagerImpl() : PassManager(), instrVerify(getLgcOuts()) {
 //
 // @param module : Module to run the passes on
 void PassManagerImpl::run(Module &module) {
-  // We register LLVM's default analysis sets late to be sure our custom
-  // analyses are added beforehand.
-  if (!initialized) {
-    PassBuilder passBuilder(nullptr, PipelineTuningOptions(), None, &instrCallbacks);
-    passBuilder.registerModuleAnalyses(moduleAnalysisManager);
-    passBuilder.registerFunctionAnalyses(functionAnalysisManager);
-    moduleAnalysisManager.registerPass([&] { return FunctionAnalysisManagerModuleProxy(functionAnalysisManager); });
-    initialized = true;
-  }
-  ModulePassManager::run(module, moduleAnalysisManager);
+  ModulePassManager::run(module, analysisManager);
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1274,22 +1274,12 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       }
 
       context->getBuilder()->setShaderStage(getLgcShaderStage(entryStage));
-      bool success;
-      if (cl::NewPassManager) {
-        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
-        lowerPassMgr->setPassIndex(&passIndex);
+      std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
+      lowerPassMgr->setPassIndex(&passIndex);
 
-        SpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower));
-        // Run the passes.
-        success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
-      } else {
-        std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
-        lowerPassMgr->setPassIndex(&passIndex);
-
-        LegacySpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower));
-        // Run the passes.
-        success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
-      }
+      LegacySpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower));
+      // Run the passes.
+      bool success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
       if (!success) {
         LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
         result = Result::ErrorInvalidShader;
@@ -1952,9 +1942,6 @@ bool Compiler::runPasses(lgc::PassManager *passMgr, Module *module) const {
   {
     passMgr->run(*module);
     success = true;
-    // TODO Only some passes have been ported to the new pass manager. So running
-    // the lowering passes with the new pass manager results in a fatal error for now.
-    report_fatal_error("The new pass manager is not fully implemented yet.");
   }
 #if LLPC_ENABLE_EXCEPTION
   catch (const char *) {

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -31,7 +31,6 @@
 #include "llpcSpirvLower.h"
 #include "llpcContext.h"
 #include "llpcDebug.h"
-#include "llpcSpirvLowerAccessChain.h"
 #include "llpcSpirvLowerUtil.h"
 #include "lgc/Builder.h"
 #include "lgc/LgcContext.h"
@@ -45,7 +44,6 @@
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/ForceFunctionAttrs.h"
 #include "llvm/Transforms/IPO/FunctionAttrs.h"
-#include "llvm/Transforms/IPO/GlobalDCE.h"
 #include "llvm/Transforms/IPO/InferFunctionAttrs.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Instrumentation.h"
@@ -147,30 +145,6 @@ void SpirvLower::removeConstantExpr(Context *context, GlobalVariable *global) {
 // @param stage : Shader stage
 // @param [in/out] passMgr : Pass manager to add passes to
 // @param lowerTimer : Timer to time lower passes with, nullptr if not timing
-void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager &passMgr, Timer *lowerTimer) {
-  // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-  context->getLgcContext()->preparePassManager(passMgr);
-
-  // Start timer for lowering passes.
-  if (lowerTimer)
-    LgcContext::createAndAddStartStopTimer(passMgr, lowerTimer, true);
-
-  // Function inlining. Use the "always inline" pass, since we want to inline all functions, and
-  // we marked (non-entrypoint) functions as "always inline" just after SPIR-V reading.
-  passMgr.addPass(AlwaysInlinerPass());
-  passMgr.addPass(GlobalDCEPass());
-
-  // Lower SPIR-V access chain
-  passMgr.addPass(SpirvLowerAccessChain());
-}
-
-// =====================================================================================================================
-// Add per-shader lowering passes to pass manager
-//
-// @param context : LLPC context
-// @param stage : Shader stage
-// @param [in/out] passMgr : Pass manager to add passes to
-// @param lowerTimer : Timer to time lower passes with, nullptr if not timing
 void LegacySpirvLower::addPasses(Context *context, ShaderStage stage, legacy::PassManager &passMgr, Timer *lowerTimer
 ) {
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
@@ -186,7 +160,7 @@ void LegacySpirvLower::addPasses(Context *context, ShaderStage stage, legacy::Pa
   passMgr.add(createGlobalDCEPass());
 
   // Lower SPIR-V access chain
-  passMgr.add(createLegacySpirvLowerAccessChain());
+  passMgr.add(createSpirvLowerAccessChain());
 
   // Lower SPIR-V terminators
   passMgr.add(createSpirvLowerTerminator());

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -47,7 +47,7 @@ class PassManager;
 } // namespace legacy
 
 class PassRegistry;
-void initializeLegacySpirvLowerAccessChainPass(PassRegistry &);
+void initializeSpirvLowerAccessChainPass(PassRegistry &);
 void initializeSpirvLowerMathConstFoldingPass(PassRegistry &);
 void initializeSpirvLowerMathFloatOpPass(PassRegistry &);
 void initializeSpirvLowerConstImmediateStorePass(PassRegistry &);
@@ -62,7 +62,6 @@ void initializeLegacySpirvLowerTranslatorPass(PassRegistry &);
 namespace lgc {
 
 class Builder;
-class PassManager;
 
 } // namespace lgc
 
@@ -72,7 +71,7 @@ namespace Llpc {
 //
 // @param passRegistry : Pass registry
 inline static void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
-  initializeLegacySpirvLowerAccessChainPass(passRegistry);
+  initializeSpirvLowerAccessChainPass(passRegistry);
   initializeSpirvLowerConstImmediateStorePass(passRegistry);
   initializeSpirvLowerMathConstFoldingPass(passRegistry);
   initializeSpirvLowerMathFloatOpPass(passRegistry);
@@ -86,7 +85,7 @@ inline static void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
 
 class Context;
 
-llvm::ModulePass *createLegacySpirvLowerAccessChain();
+llvm::ModulePass *createSpirvLowerAccessChain();
 llvm::ModulePass *createSpirvLowerConstImmediateStore();
 llvm::ModulePass *createSpirvLowerMathConstFolding();
 llvm::ModulePass *createSpirvLowerMathFloatOp();
@@ -103,9 +102,6 @@ class SpirvLower {
 public:
   explicit SpirvLower()
       : m_module(nullptr), m_context(nullptr), m_shaderStage(ShaderStageInvalid), m_entryPoint(nullptr) {}
-
-  // Add per-shader lowering passes to pass manager
-  static void addPasses(Context *context, ShaderStage stage, lgc::PassManager &passMgr, llvm::Timer *lowerTimer);
 
   static void removeConstantExpr(Context *context, llvm::GlobalVariable *global);
   static void replaceConstWithInsts(Context *context, llvm::Constant *const constVal);

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -45,41 +45,23 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Initializes static members.
-char LegacySpirvLowerAccessChain::ID = 0;
+char SpirvLowerAccessChain::ID = 0;
 
 // =====================================================================================================================
 // Pass creator, creates the pass of SPIR-V lowering operations for access chain
-ModulePass *createLegacySpirvLowerAccessChain() {
-  return new LegacySpirvLowerAccessChain();
+ModulePass *createSpirvLowerAccessChain() {
+  return new SpirvLowerAccessChain();
 }
 
 // =====================================================================================================================
-LegacySpirvLowerAccessChain::LegacySpirvLowerAccessChain() : LegacySpirvLower(ID) {
-}
-
-// =====================================================================================================================
-// Executes this SPIR-V lowering pass on the specified LLVM module.
-//
-// @param [in/out] module : LLVM module to be run on
-bool LegacySpirvLowerAccessChain::runOnModule(Module &module) {
-  return Impl.runImpl(module);
+SpirvLowerAccessChain::SpirvLowerAccessChain() : LegacySpirvLower(ID) {
 }
 
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
 // @param [in/out] module : LLVM module to be run on
-// @param [in/out] analysisManager : Analysis manager to use for this transformation
-PreservedAnalyses SpirvLowerAccessChain::run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager) {
-  runImpl(module);
-  return PreservedAnalyses::none();
-}
-
-// =====================================================================================================================
-// Executes this SPIR-V lowering pass on the specified LLVM module.
-//
-// @param [in/out] module : LLVM module to be run on
-bool SpirvLowerAccessChain::runImpl(llvm::Module &module) {
+bool SpirvLowerAccessChain::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Access-Chain\n");
 
   SpirvLower::init(&module);
@@ -188,4 +170,4 @@ GetElementPtrInst *SpirvLowerAccessChain::tryToCoalesceChain(GetElementPtrInst *
 
 // =====================================================================================================================
 // Initializes the pass of SPIR-V lowering opertions for access chain.
-INITIALIZE_PASS(LegacySpirvLowerAccessChain, DEBUG_TYPE, "Lower SPIR-V access chain", false, false)
+INITIALIZE_PASS(SpirvLowerAccessChain, DEBUG_TYPE, "Lower SPIR-V access chain", false, false)

--- a/llpc/lower/llpcSpirvLowerAccessChain.h
+++ b/llpc/lower/llpcSpirvLowerAccessChain.h
@@ -32,40 +32,25 @@
 
 #include "llpcSpirvLower.h"
 #include "llvm/IR/InstVisitor.h"
-#include "llvm/IR/PassManager.h"
 
 namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for access chain.
-class SpirvLowerAccessChain : public SpirvLower, public llvm::InstVisitor<SpirvLowerAccessChain> {
+class SpirvLowerAccessChain : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerAccessChain> {
 public:
-  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
-  virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElemPtrInst);
-
-  bool runImpl(llvm::Module &module);
-
-  static llvm::StringRef name() { return "Lower SPIR-V access chain"; }
-
-private:
-  llvm::GetElementPtrInst *tryToCoalesceChain(llvm::GetElementPtrInst *getElemPtr, unsigned addrSpace);
-};
-
-// =====================================================================================================================
-// Represents the pass of SPIR-V lowering opertions for access chain.
-class LegacySpirvLowerAccessChain : public LegacySpirvLower {
-public:
-  LegacySpirvLowerAccessChain();
+  SpirvLowerAccessChain();
 
   virtual bool runOnModule(llvm::Module &module);
+  virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElemPtrInst);
 
   static char ID; // ID of this pass
 
 private:
-  LegacySpirvLowerAccessChain(const LegacySpirvLowerAccessChain &) = delete;
-  LegacySpirvLowerAccessChain &operator=(const LegacySpirvLowerAccessChain &) = delete;
+  SpirvLowerAccessChain(const SpirvLowerAccessChain &) = delete;
+  SpirvLowerAccessChain &operator=(const SpirvLowerAccessChain &) = delete;
 
-  SpirvLowerAccessChain Impl;
+  llvm::GetElementPtrInst *tryToCoalesceChain(llvm::GetElementPtrInst *getElemPtr, unsigned addrSpace);
 };
 
 } // namespace Llpc


### PR DESCRIPTION
This reverts commit 20f9d999a3cd78031cf6e347da5d68eb9fdf0fd3.

Reverting for now - causing internal test failures.