### PR TITLE
Don't update output loc info for undef outputs.

### DIFF
--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1175,20 +1175,22 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
       // export call.
       m_deadCalls.push_back(&callInst);
 
-      InOutLocationInfo outLocInfo;
-      outLocInfo.setLocation(cast<ConstantInt>(callInst.getArgOperand(0))->getZExtValue());
-      outLocInfo.setComponent(cast<ConstantInt>(callInst.getArgOperand(1))->getZExtValue());
-      if (m_shaderStage == ShaderStageGeometry)
-        outLocInfo.setStreamId(cast<ConstantInt>(callInst.getArgOperand(2))->getZExtValue());
-      // Also, we remove the output location info from the map if it exists
-      auto &outLocInfoMap = m_resUsage->inOutUsage.outputLocInfoMap;
-      if (outLocInfoMap.count(outLocInfo) > 0)
-        outLocInfoMap.erase(outLocInfo);
-      // For GS, we remove transform feedback location info as well if it exists
-      if (m_shaderStage == ShaderStageGeometry) {
-        auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.gs.locInfoXfbOutInfoMap;
-        if (locInfoXfbOutInfoMap.count(outLocInfo) > 0)
-          locInfoXfbOutInfoMap.erase(outLocInfo);
+      if (m_pipelineState->canPackOutput(m_shaderStage)) {
+        InOutLocationInfo outLocInfo;
+        outLocInfo.setLocation(cast<ConstantInt>(callInst.getArgOperand(0))->getZExtValue());
+        outLocInfo.setComponent(cast<ConstantInt>(callInst.getArgOperand(1))->getZExtValue());
+        if (m_shaderStage == ShaderStageGeometry)
+          outLocInfo.setStreamId(cast<ConstantInt>(callInst.getArgOperand(2))->getZExtValue());
+        // Also, we remove the output location info from the map if it exists
+        auto &outLocInfoMap = m_resUsage->inOutUsage.outputLocInfoMap;
+        if (outLocInfoMap.count(outLocInfo) > 0)
+          outLocInfoMap.erase(outLocInfo);
+        // For GS, we remove transform feedback location info as well if it exists
+        if (m_shaderStage == ShaderStageGeometry) {
+          auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.gs.locInfoXfbOutInfoMap;
+          if (locInfoXfbOutInfoMap.count(outLocInfo) > 0)
+            locInfoXfbOutInfoMap.erase(outLocInfo);
+        }
       }
     } else {
       m_outputCalls.push_back(&callInst);

--- a/llpc/test/shaderdb/UndefVertexOutput.spvasm
+++ b/llpc/test/shaderdb/UndefVertexOutput.spvasm
@@ -1,0 +1,55 @@
+; Make sure that the export channels match the location in the spir-v.
+; This is how the PS knows which channel from which to read the value.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: _amdgpu_vs_main_fetchless:
+; SHADERTEST: v_mov_b32_e32 [[zero:v[0-9]*]], 0
+; SHADERTEST: v_mov_b32_e32 [[one:v[0-9]*]], 1.0
+; SHADERTEST-DAG: exp param8 [[one]], [[zero]], [[zero]], [[one]]
+; SHADERTEST-DAG: exp param7 [[zero]], [[zero]], [[one]], [[one]]
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %2 "main" %3 %gl_Position %5 %6 %7
+          %8 = OpString ""
+               OpDecorate %3 Location 1
+               OpDecorate %3 Binding 0
+               OpDecorate %gl_Position Binding 0
+               OpDecorate %gl_Position BuiltIn Position
+               OpDecorate %5 Location 5
+               OpDecorate %5 Binding 0
+               OpDecorate %6 Location 7
+               OpDecorate %6 Binding 0
+               OpDecorate %7 Location 8
+               OpDecorate %7 Binding 0
+       %void = OpTypeVoid
+         %10 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+          %3 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+          %5 = OpVariable %_ptr_Output_v3float Output
+          %6 = OpVariable %_ptr_Output_v4float Output
+          %7 = OpVariable %_ptr_Output_v4float Output
+         %17 = OpUndef %v3float
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+         %20 = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+         %21 = OpConstantComposite %v4float %float_0 %float_0 %float_1 %float_1
+          %2 = OpFunction %void None %10
+         %22 = OpLabel
+         %23 = OpLoad %v4float %3
+               OpStore %gl_Position %23
+               OpStore %5 %17
+               OpStore %6 %21
+               OpStore %7 %20
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
When there is an explict store to a vertex shader output that is an
undef value, then it will be removed.  That is fair.  However, the
output location map is updated to remove this output dropping the
channel that is used for other output.  This does not work for unlinked
shaders because the pixel shader will then read its inputs from the
wrong channel.