### PR TITLE
[ComputeLibs] Append system arguments

### DIFF
--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -199,7 +199,8 @@ public:
 
   // Get argument types for shader inputs
   uint64_t getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage,
-                           llvm::SmallVectorImpl<llvm::Type *> &argTys, llvm::SmallVectorImpl<std::string> &argNames);
+                           llvm::SmallVectorImpl<llvm::Type *> &argTys, llvm::SmallVectorImpl<std::string> &argNames,
+                           unsigned argOffset);
 
 private:
   // Usage for one system shader input in one shader stage

--- a/lgc/include/lgc/state/ShaderStage.h
+++ b/lgc/include/lgc/state/ShaderStage.h
@@ -61,8 +61,8 @@ bool isShaderEntryPoint(const llvm::Function *func);
 // Gets name string of the abbreviation for the specified shader stage
 const char *getShaderStageAbbreviation(ShaderStage shaderStage);
 
-// Add args to a function. The new args are put before any existing ones. This creates a new function with the
-// added args, then moves everything from the old function across to it.
+// Add args to a function. This creates a new function with the added args, then moves everything from the old function
+// across to it.
 // If this changes the return type, then all the return instructions will be invalid.
 // This does not erase the old function, as the caller needs to do something with its uses (if any).
 //
@@ -70,9 +70,10 @@ const char *getShaderStageAbbreviation(ShaderStage shaderStage);
 // @param retTy : New return type, nullptr to use the same as in the original function
 // @param argTys : Types of new args
 // @param inRegMask : Bitmask of which args should be marked "inreg", to be passed in SGPRs
+// @param append : Append new arguments if true, prepend new arguments if false
 // @returns : The new function
 llvm::Function *addFunctionArgs(llvm::Function *oldFunc, llvm::Type *retTy, llvm::ArrayRef<llvm::Type *> argTys,
-                                llvm::ArrayRef<std::string> argNames, uint64_t inRegMask = 0);
+                                llvm::ArrayRef<std::string> argNames, uint64_t inRegMask = 0, bool append = false);
 
 // Get the ABI-mandated entry-point name for a shader stage
 //

--- a/lgc/include/lgc/util/Internal.h
+++ b/lgc/include/lgc/util/Internal.h
@@ -38,6 +38,7 @@
 
 namespace llvm {
 
+class Argument;
 class BasicBlock;
 class CallInst;
 class Function;
@@ -83,7 +84,7 @@ void getTypeName(llvm::Type *ty, llvm::raw_ostream &nameStream);
 std::string getTypeName(llvm::Type *ty);
 
 // Gets the argument from the specified function according to the argument index.
-llvm::Value *getFunctionArgument(llvm::Function *func, unsigned idx, const llvm::Twine &name = "");
+llvm::Argument *getFunctionArgument(llvm::Function *func, unsigned idx, const llvm::Twine &name = "");
 
 // Checks if one type can be bitcasted to the other (type1 -> type2).
 bool canBitCast(const llvm::Type *ty1, const llvm::Type *ty2);

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -180,11 +180,11 @@ private:
   void processShader(ShaderInputs *shaderInputs);
   void processComputeFuncs(ShaderInputs *shaderInputs, Module &module);
   void processCalls(Function &func, SmallVectorImpl<Type *> &shaderInputTys,
-                    SmallVectorImpl<std::string> &shaderInputNames, uint64_t inRegMask);
+                    SmallVectorImpl<std::string> &shaderInputNames, uint64_t inRegMask, unsigned argOffset);
   void setFuncAttrs(Function *entryPoint);
 
   uint64_t generateEntryPointArgTys(ShaderInputs *shaderInputs, SmallVectorImpl<Type *> &argTys,
-                                    SmallVectorImpl<std::string> &argNames);
+                                    SmallVectorImpl<std::string> &argNames, unsigned argOffset);
 
   void addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> &userDataArgs,
                               SmallVectorImpl<UserDataArg> &specialUserDataArgs, IRBuilder<> &builder);
@@ -494,7 +494,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
     AddressExtender addressExtender(&func);
     if (userDataUsage->spillTable.entryArgIdx != 0) {
       builder.SetInsertPoint(addressExtender.getFirstInsertionPt());
-      Argument *arg = func.getArg(userDataUsage->spillTable.entryArgIdx);
+      Argument *arg = getFunctionArgument(&func, userDataUsage->spillTable.entryArgIdx);
       spillTable = addressExtender.extend(arg, builder.getInt32(HighAddrPc),
                                           builder.getInt8Ty()->getPointerTo(ADDR_SPACE_CONST), builder);
     }
@@ -515,7 +515,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
         if (pushConstOffset.entryArgIdx) {
           // This offset into the push constant is unspilled. Replace the loads with the entry arg, with a
           // bitcast. (We know that all loads are non-aggregates of the same size, so we can bitcast.)
-          Argument *arg = func.getArg(pushConstOffset.entryArgIdx);
+          Argument *arg = getFunctionArgument(&func, pushConstOffset.entryArgIdx);
           for (Instruction *&load : pushConstOffset.users) {
             if (load && load->getFunction() == &func) {
               builder.SetInsertPoint(load);
@@ -586,7 +586,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
         continue;
       if (rootDescriptor.entryArgIdx != 0) {
         // The root descriptor is unspilled, and uses an entry arg.
-        Argument *arg = func.getArg(rootDescriptor.entryArgIdx);
+        Argument *arg = getFunctionArgument(&func, rootDescriptor.entryArgIdx);
         for (Instruction *&call : rootDescriptor.users) {
           if (call && call->getFunction() == &func) {
             call->replaceAllUsesWith(arg);
@@ -625,7 +625,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
           std::string namePrefix = "descTable";
           if (descriptorTable.entryArgIdx != 0) {
             // The descriptor set is unspilled, and uses an entry arg.
-            descTableVal = func.getArg(descriptorTable.entryArgIdx);
+            descTableVal = getFunctionArgument(&func, descriptorTable.entryArgIdx);
             if (isa<ConstantInt>(highHalf)) {
               // Set builder to insert the 32-to-64 extension code at the start of the function.
               builder.SetInsertPoint(addressExtender.getFirstInsertionPt());
@@ -684,7 +684,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
           // it with UndefValue.
           arg = UndefValue::get(specialUserData.users[0]->getType());
         } else {
-          arg = func.getArg(specialUserData.entryArgIdx);
+          arg = getFunctionArgument(&func, specialUserData.entryArgIdx);
         }
         for (Instruction *&inst : specialUserData.users) {
           if (inst && inst->getFunction() == &func) {
@@ -716,7 +716,7 @@ void PatchEntryPointMutate::processShader(ShaderInputs *shaderInputs) {
   // Create new entry-point from the original one
   SmallVector<Type *, 8> argTys;
   SmallVector<std::string, 8> argNames;
-  uint64_t inRegMask = generateEntryPointArgTys(shaderInputs, argTys, argNames);
+  uint64_t inRegMask = generateEntryPointArgTys(shaderInputs, argTys, argNames, 0);
 
   Function *origEntryPoint = m_entryPoint;
 
@@ -728,8 +728,9 @@ void PatchEntryPointMutate::processShader(ShaderInputs *shaderInputs) {
   setFuncAttrs(entryPoint);
 
   // Remove original entry-point
+  int argOffset = origEntryPoint->getFunctionType()->getNumParams();
   origEntryPoint->eraseFromParent();
-  processCalls(*entryPoint, argTys, argNames, inRegMask);
+  processCalls(*entryPoint, argTys, argNames, inRegMask, argOffset);
 }
 
 // =====================================================================================================================
@@ -744,21 +745,24 @@ void PatchEntryPointMutate::processComputeFuncs(ShaderInputs *shaderInputs, Modu
   if (m_pipelineState->getLgcContext()->getPalAbiVersion() < 624)
     report_fatal_error("Compute shader not supported before PAL version 624");
 
-  // Determine what args need to be added on to all functions.
-  SmallVector<Type *, 20> shaderInputTys;
-  SmallVector<std::string, 20> shaderInputNames;
-  uint64_t inRegMask = generateEntryPointArgTys(shaderInputs, shaderInputTys, shaderInputNames);
-
   // Process each function definition.
   SmallVector<Function *, 4> origFuncs;
   for (Function &func : module) {
     if (!func.isDeclaration())
       origFuncs.push_back(&func);
   }
+
   for (Function *origFunc : origFuncs) {
+    auto *origType = origFunc->getFunctionType();
+    // Determine what args need to be added on to all functions.
+    SmallVector<Type *, 20> shaderInputTys;
+    SmallVector<std::string, 20> shaderInputNames;
+    uint64_t inRegMask =
+        generateEntryPointArgTys(shaderInputs, shaderInputTys, shaderInputNames, origType->getNumParams());
+
     // Create the new function and transfer code and attributes to it.
-    Function *newFunc = addFunctionArgs(origFunc, origFunc->getFunctionType()->getReturnType(), shaderInputTys,
-                                        shaderInputNames, inRegMask);
+    Function *newFunc =
+        addFunctionArgs(origFunc, origType->getReturnType(), shaderInputTys, shaderInputNames, inRegMask, true);
 
     // Set Attributes on new function.
     setFuncAttrs(newFunc);
@@ -772,16 +776,11 @@ void PatchEntryPointMutate::processComputeFuncs(ShaderInputs *shaderInputs, Modu
       *use = bitCastFunc;
 
     // Remove original function.
+    int argOffset = origType->getNumParams();
     origFunc->eraseFromParent();
-  }
 
-  if (!isComputeWithCalls())
-    return;
-
-  for (Function &func : module) {
-    if (func.isDeclaration())
-      continue;
-    processCalls(func, shaderInputTys, shaderInputNames, inRegMask);
+    if (isComputeWithCalls())
+      processCalls(*newFunc, shaderInputTys, shaderInputNames, inRegMask, argOffset);
   }
 }
 
@@ -790,19 +789,18 @@ void PatchEntryPointMutate::processComputeFuncs(ShaderInputs *shaderInputs, Modu
 //
 // @param [in/out] module : Module
 void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *> &shaderInputTys,
-                                         SmallVectorImpl<std::string> &shaderInputNames, uint64_t inRegMask) {
+                                         SmallVectorImpl<std::string> &shaderInputNames, uint64_t inRegMask,
+                                         unsigned argOffset) {
   // This is one of:
   // - a compute pipeline with non-inlined functions;
   // - a compute pipeline with calls to library functions;
   // - a compute library.
-  // We need to scan the code and modify each call to prepend the extra args.
+  // We need to scan the code and modify each call to append the extra args.
   IRBuilder<> builder(func.getContext());
   for (BasicBlock &block : func) {
-    for (auto it = block.begin(), end = block.end(); it != end;) {
-      // Get the instruction and increment the iterator beyond it, so we can safely erase the instruction.
-      Instruction *inst = &*it;
-      ++it;
-      auto call = dyn_cast<CallInst>(inst);
+    // Use early increment iterator, so we can safely erase the instruction.
+    for (Instruction &inst : make_early_inc_range(block)) {
+      auto call = dyn_cast<CallInst>(&inst);
       if (!call)
         continue;
       // Got a call. Skip it if it calls an intrinsic or an internal lgc.* function.
@@ -818,13 +816,13 @@ void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *>
       // inputs), plus the original args on the call.
       SmallVector<Type *, 20> argTys;
       SmallVector<Value *, 20> args;
-      for (unsigned idx = 0; idx != shaderInputTys.size(); ++idx) {
-        argTys.push_back(func.getArg(idx)->getType());
-        args.push_back(func.getArg(idx));
-      }
       for (unsigned idx = 0; idx != call->getNumArgOperands(); ++idx) {
         argTys.push_back(call->getArgOperand(idx)->getType());
         args.push_back(call->getArgOperand(idx));
+      }
+      for (unsigned idx = 0; idx != shaderInputTys.size(); ++idx) {
+        argTys.push_back(func.getArg(idx + argOffset)->getType());
+        args.push_back(func.getArg(idx + argOffset));
       }
       // Get the new called value as a bitcast of the old called value. If the old called value is already
       // the inverse bitcast, just drop that bitcast.
@@ -848,7 +846,7 @@ void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *>
       // Mark sgpr arguments as inreg
       for (unsigned idx = 0; idx != shaderInputTys.size(); ++idx) {
         if ((inRegMask >> idx) & 1)
-          newCall->addParamAttr(idx, Attribute::InReg);
+          newCall->addParamAttr(idx + call->getNumArgOperands(), Attribute::InReg);
       }
 
       // Replace and erase the old one.
@@ -977,7 +975,7 @@ void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
 //                          arg needs to have an "inreg" attribute to put the arg into SGPRs rather than VGPRs
 //
 uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInputs, SmallVectorImpl<Type *> &argTys,
-                                                         SmallVectorImpl<std::string> &argNames) {
+                                                         SmallVectorImpl<std::string> &argNames, unsigned argOffset) {
 
   uint64_t inRegMask = 0;
   IRBuilder<> builder(*m_context);
@@ -1024,7 +1022,7 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
   unsigned userDataIdx = 0;
   for (const auto &userDataArg : unspilledArgs) {
     if (userDataArg.argIndex)
-      *userDataArg.argIndex = argTys.size();
+      *userDataArg.argIndex = argTys.size() + argOffset;
     unsigned dwordSize = userDataArg.argDwordSize;
     if (userDataArg.userDataValue != static_cast<unsigned>(UserDataMapping::Invalid)) {
       m_pipelineState->getPalMetadata()->setUserDataEntry(m_shaderStage, userDataIdx, userDataArg.userDataValue,
@@ -1033,7 +1031,7 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
         unsigned index = userDataArg.userDataValue - static_cast<unsigned>(UserDataMapping::GlobalTable);
         auto &specialUserData = getUserDataUsage(m_shaderStage)->specialUserData;
         if (index < specialUserData.size())
-          specialUserData[index].entryArgIdx = argTys.size();
+          specialUserData[index].entryArgIdx = argTys.size() + argOffset;
       }
     }
     argTys.push_back(userDataArg.argTy);
@@ -1045,7 +1043,7 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
   inRegMask = (1ull << argTys.size()) - 1;
 
   // Push the fixed system (not user data) register args.
-  inRegMask |= shaderInputs->getShaderArgTys(m_pipelineState, m_shaderStage, argTys, argNames);
+  inRegMask |= shaderInputs->getShaderArgTys(m_pipelineState, m_shaderStage, argTys, argNames, argOffset);
 
   return inRegMask;
 }

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2267,7 +2267,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
                      ConstantInt::get(Type::getInt32Ty(*m_context), 4)};
     auto sampleId = emitCall("llvm.amdgcn.ubfe.i32", Type::getInt32Ty(*m_context), args, {}, insertPos);
 
-    auto sampleMaskIn = sampleCoverage;
+    Value *sampleMaskIn = sampleCoverage;
     if (m_pipelineState->getRasterizerState().perSampleShading) {
       // gl_SampleMaskIn[0] = (SampleCoverage & (1 << gl_SampleID))
       sampleMaskIn =
@@ -2420,7 +2420,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
 
     // Emulation for "in float gl_ClipDistance[]" or "in float gl_CullDistance[]"
     auto primMask = getFunctionArgument(m_entryPoint, entryArgIdxs.primMask);
-    auto ij = getFunctionArgument(m_entryPoint, entryArgIdxs.linearInterp.center);
+    Value *ij = getFunctionArgument(m_entryPoint, entryArgIdxs.linearInterp.center);
 
     ij = new BitCastInst(ij, FixedVectorType::get(Type::getFloatTy(*m_context), 2), "", insertPos);
     auto coordI = ExtractElementInst::Create(ij, ConstantInt::get(Type::getInt32Ty(*m_context), 0), "", insertPos);
@@ -3672,7 +3672,7 @@ void PatchInOutImportExport::storeValueToStreamOutBuffer(Value *storeValue, unsi
   assert(xfbBuffer < MaxTransformFeedbackBuffers);
   assert(streamOffsets[xfbBuffer] != 0);
 
-  auto streamOffset = getFunctionArgument(m_entryPoint, streamOffsets[xfbBuffer]);
+  Value *streamOffset = getFunctionArgument(m_entryPoint, streamOffsets[xfbBuffer]);
 
   streamOffset =
       BinaryOperator::CreateMul(streamOffset, ConstantInt::get(Type::getInt32Ty(*m_context), 4), "", insertPos);
@@ -3684,7 +3684,7 @@ void PatchInOutImportExport::storeValueToStreamOutBuffer(Value *storeValue, unsi
   Value *vertexCount = emitCall("llvm.amdgcn.ubfe.i32", Type::getInt32Ty(*m_context), ubfeArgs, {}, &*insertPos);
 
   // Setup write index for stream-out
-  auto writeIndexVal = getFunctionArgument(m_entryPoint, writeIndex);
+  Value *writeIndexVal = getFunctionArgument(m_entryPoint, writeIndex);
 
   if (m_gfxIp.major >= 9)
     writeIndexVal = BinaryOperator::CreateAdd(writeIndexVal, m_threadId, "", insertPos);
@@ -4397,7 +4397,7 @@ void PatchInOutImportExport::storeTessFactorToBuffer(ArrayRef<Value *> tessFacto
   const auto &calcFactor = inOutUsage.calcFactor;
 
   auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageTessControl)->entryArgIdxs.tcs;
-  auto tfBufferBase = getFunctionArgument(m_entryPoint, entryArgIdxs.tfBufferBase);
+  Value *tfBufferBase = getFunctionArgument(m_entryPoint, entryArgIdxs.tfBufferBase);
 
   auto tessFactorStride = ConstantInt::get(Type::getInt32Ty(*m_context), calcFactor.tessFactorStride);
 

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -310,7 +310,7 @@ void ShaderInputs::fixupUses(Module &module, PipelineState *pipelineState) {
     for (unsigned kind = 0; kind != static_cast<unsigned>(ShaderInput::Count); ++kind) {
       ShaderInputUsage *inputUsage = inputsUsage->inputs[kind].get();
       if (inputUsage && inputUsage->entryArgIdx != 0) {
-        Argument *arg = func.getArg(inputUsage->entryArgIdx);
+        Argument *arg = getFunctionArgument(&func, inputUsage->entryArgIdx);
         arg->setName(getInputName(static_cast<ShaderInput>(kind)));
         for (Instruction *&call : inputUsage->users) {
           if (call && call->getFunction() == &func) {
@@ -488,7 +488,8 @@ static const ShaderInputDesc CsVgprInputs[] = {
 // @param [in/out] argNames : Argument names vector to add to
 // @returns : Bitmap with bits set for SGPR arguments so caller can set "inreg" attribute on the args
 uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage,
-                                       SmallVectorImpl<Type *> &argTys, SmallVectorImpl<std::string> &argNames) {
+                                       SmallVectorImpl<Type *> &argTys, SmallVectorImpl<std::string> &argNames,
+                                       unsigned argOffset) {
 
   bool hasTs = pipelineState->hasShaderStage(ShaderStageTessControl);
   bool hasGs = pipelineState->hasShaderStage(ShaderStageGeometry);
@@ -608,9 +609,10 @@ uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage
       }
       // Store the argument index.
       if (inputDesc.entryArgIdx != 0)
-        *reinterpret_cast<unsigned *>((reinterpret_cast<char *>(intfData) + inputDesc.entryArgIdx)) = argTys.size();
+        *reinterpret_cast<unsigned *>((reinterpret_cast<char *>(intfData) + inputDesc.entryArgIdx)) =
+            argTys.size() + argOffset;
       if (inputUsage)
-        inputUsage->entryArgIdx = argTys.size();
+        inputUsage->entryArgIdx = argTys.size() + argOffset;
       // Add the argument type.
       argTys.push_back(getInputType(inputDesc.inputKind, *pipelineState->getLgcContext()));
       argNames.push_back(ShaderInputs::getInputName(inputDesc.inputKind));

--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -109,8 +109,8 @@ const char *lgc::getShaderStageAbbreviation(ShaderStage shaderStage) {
 }
 
 // =====================================================================================================================
-// Add args to a function. The new args are put before any existing ones. This creates a new function with the
-// added args, then moves everything from the old function across to it.
+// Add args to a function. This creates a new function with the added args, then moves everything from the old function
+// across to it.
 // If this changes the return type, then all the return instructions will be invalid.
 // This does not erase the old function, as the caller needs to do something with its uses (if any).
 //
@@ -118,14 +118,20 @@ const char *lgc::getShaderStageAbbreviation(ShaderStage shaderStage) {
 // @param retTy : New return type, nullptr to use the same as in the original function
 // @param argTys : Types of new args
 // @param inRegMask : Bitmask of which args should be marked "inreg", to be passed in SGPRs
+// @param append : Append new arguments if true, prepend new arguments if false
 // @returns : The new function
 Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> argTys, ArrayRef<std::string> argNames,
-                               uint64_t inRegMask) {
+                               uint64_t inRegMask, bool append) {
   // Gather all arg types: first the new ones, then the ones from the original function.
   FunctionType *oldFuncTy = oldFunc->getFunctionType();
   SmallVector<Type *, 8> allArgTys;
+  // Old arguments first if new arguments are appended.
+  if (append)
+    allArgTys.append(oldFuncTy->params().begin(), oldFuncTy->params().end());
   allArgTys.append(argTys.begin(), argTys.end());
-  allArgTys.append(oldFuncTy->params().begin(), oldFuncTy->params().end());
+  // Old arguments last if new arguments are prepended.
+  if (!append)
+    allArgTys.append(oldFuncTy->params().begin(), oldFuncTy->params().end());
 
   // Create new empty function.
   if (!retTy)
@@ -148,22 +154,37 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
   // bit is set in inRegMask.
   AttributeList oldAttrList = oldFunc->getAttributes();
   SmallVector<AttributeSet, 8> argAttrs;
+  if (append) {
+    // Old arguments first.
+    for (unsigned idx = 0; idx != oldFuncTy->getNumParams(); ++idx)
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
+      // Old version of the code
+      argAttrs.push_back(oldAttrList.getParamAttributes(idx));
+#else
+      // New version of the code (also handles unknown version, which we treat as latest)
+      argAttrs.push_back(oldAttrList.getParamAttrs(idx));
+#endif
+  }
+
   // New arguments.
   AttributeSet emptyAttrSet;
   AttributeSet inRegAttrSet = emptyAttrSet.addAttribute(oldFunc->getContext(), Attribute::InReg);
   for (unsigned idx = 0; idx != argTys.size(); ++idx)
     argAttrs.push_back((inRegMask >> idx) & 1 ? inRegAttrSet : emptyAttrSet);
-  // Old arguments.
-  for (unsigned idx = 0; idx != argTys.size(); ++idx)
+  if (!append) {
+    // Old arguments.
+    for (unsigned idx = 0; idx != argTys.size(); ++idx)
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-    // Old version of the code
-    argAttrs.push_back(oldAttrList.getParamAttributes(idx));
+      // Old version of the code
+      argAttrs.push_back(oldAttrList.getParamAttributes(idx));
+  }
   // Construct new AttributeList and set it on the new function.
   newFunc->setAttributes(AttributeList::get(oldFunc->getContext(), oldAttrList.getFnAttributes(),
                                             oldAttrList.getRetAttributes(), argAttrs));
 #else
-    // New version of the code (also handles unknown version, which we treat as latest)
-    argAttrs.push_back(oldAttrList.getParamAttrs(idx));
+      // New version of the code (also handles unknown version, which we treat as latest)
+      argAttrs.push_back(oldAttrList.getParamAttrs(idx));
+  }
   // Construct new AttributeList and set it on the new function.
   newFunc->setAttributes(
       AttributeList::get(oldFunc->getContext(), oldAttrList.getFnAttrs(), oldAttrList.getRetAttrs(), argAttrs));
@@ -177,7 +198,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
   // to the Function, and the attribute copy above copied the arg attributes at their original arg numbers.
   // Also set name of each new arg that comes from old arg.
   for (unsigned idx = 0; idx != argTys.size(); ++idx) {
-    Argument *arg = newFunc->getArg(idx);
+    Argument *arg = newFunc->getArg(append ? idx + oldFuncTy->getNumParams() : idx);
     arg->setName(argNames[idx]);
     if ((inRegMask >> idx) & 1)
       arg->addAttr(Attribute::InReg);
@@ -185,7 +206,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
       arg->removeAttr(Attribute::AttrKind::InReg);
   }
   for (unsigned idx = 0; idx != oldFuncTy->params().size(); ++idx) {
-    Argument *arg = newFunc->getArg(idx + argTys.size());
+    Argument *arg = newFunc->getArg(append ? idx : idx + argTys.size());
     Argument *oldArg = oldFunc->getArg(idx);
     arg->setName(oldArg->getName());
     oldArg->replaceAllUsesWith(arg);

--- a/lgc/test/CallLibFromCsPayload.lgc
+++ b/lgc/test/CallLibFromCsPayload.lgc
@@ -1,0 +1,66 @@
+; Call an extern compute library function from a compute shader.
+; Ensure that the first argument uses the same registers as the return value of the called function.
+
+; RUN: lgc -mcpu=gfx1010 -o - - <%s | FileCheck %s
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+declare spir_func <10 x i32> @compute_library_func(<10 x i32>) #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+; CHECK: v_mov_b32_e32 v0, 42
+; CHECK: s_swappc_b64 s[30:31], s[26:27]
+; CHECK-NEXT: v_mov_b32_e32 v40, v0
+; CHECK-NEXT: buffer_store_dwordx4 v[40:43], off, s[36:39], 0
+.entry:
+  %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
+  %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)
+  %2 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 0, i32 2)
+  %3 = bitcast i8 addrspace(7)* %2 to <4 x i32> addrspace(7)*
+  %4 = load <4 x i32>, <4 x i32> addrspace(7)* %3, align 16
+  %5 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 1, i32 2)
+  %6 = bitcast i8 addrspace(7)* %5 to <4 x i32> addrspace(7)*
+  %7 = load <4 x i32>, <4 x i32> addrspace(7)* %6, align 16
+  %8 = add <4 x i32> %4, %7
+  %9 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 2, i32 2)
+  %10 = bitcast i8 addrspace(7)* %9 to <4 x i32> addrspace(7)*
+  %11 = load <4 x i32>, <4 x i32> addrspace(7)* %10, align 16
+  %12 = add <4 x i32> %8, %11
+  %13 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 1, i32 3, i32 2)
+  %14 = bitcast i8 addrspace(7)* %13 to <4 x i32> addrspace(7)*
+  %15 = load <4 x i32>, <4 x i32> addrspace(7)* %14, align 16
+  %16 = add <4 x i32> %12, %15
+  %17 = bitcast i8 addrspace(7)* %0 to <4 x i32> addrspace(7)*
+  %18 = load <4 x i32>, <4 x i32> addrspace(7)* %17, align 16
+  %19 = add <4 x i32> %16, %18
+  %20 = bitcast i8 addrspace(7)* %1 to <4 x i32> addrspace(7)*
+  %arg = insertelement <10 x i32> undef, i32 42, i32 0
+  %r = call spir_func <10 x i32> @compute_library_func(<10 x i32> %arg)
+  %ri = extractelement <10 x i32> %r, i32 0
+  %v = insertelement <4 x i32> %19, i32 %ri, i32 0
+  store <4 x i32> %v, <4 x i32> addrspace(7)* %20, align 16
+  ret void
+}
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/CsComputeLibraryPayload.lgc
+++ b/lgc/test/CsComputeLibraryPayload.lgc
@@ -1,0 +1,54 @@
+; Define a compute library that can be called from a compute shader.
+; Ensure that the first argument uses the same registers as the return value.
+; The assembly should not have any movs of vector registers.
+
+; RUN: lgc -mcpu=gfx1010 -o - - <%s | FileCheck --check-prefixes=CHECK %s
+
+; ModuleID = 'lgcPipeline'
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define spir_func <10 x i32> @func(<10 x i32> %arg) local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
+; CHECK-LABEL: func:
+; CHECK: s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT: s_waitcnt_vscnt null, 0x0
+; CHECK-NEXT: s_getpc_b64 s[4:5]
+; CHECK-NEXT: v_mov_b32_e32 v10, s20
+; CHECK-NEXT: s_mov_b32 s9, s5
+; CHECK-NEXT: v_mov_b32_e32 v11, s21
+; CHECK-NEXT: s_load_dwordx4 s[4:7], s[8:9], 0x0
+; CHECK-NEXT: v_mov_b32_e32 v12, s22
+; CHECK-NEXT: s_waitcnt lgkmcnt(0)
+; CHECK-NEXT: buffer_store_dwordx3 v[10:12], off, s[4:7], 0
+; CHECK-NEXT: s_waitcnt_vscnt null, 0x0
+; CHECK-NEXT: s_setpc_b64 s[30:31]
+.entry:
+  %id = call <3 x i32> @lgc.shader.input.LocalInvocationId(i32 0)
+  %buf = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
+  %buf2 = bitcast i8 addrspace(7)* %buf to <3 x i32> addrspace(7)*
+  store <3 x i32> %id, <3 x i32> addrspace(7)* %buf2, align 4
+  ret <10 x i32> %arg
+}
+
+declare <3 x i32> @lgc.shader.input.LocalInvocationId(i32) #1
+
+; Function Attrs: nounwind readonly
+declare i8 addrspace(7)* @lgc.create.load.buffer.desc.p7i8(...) local_unnamed_addr #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llpc.compute.mode = !{!0}
+!lgc.options = !{!1}
+!lgc.options.CS = !{!2}
+!lgc.user.data.nodes = !{!3, !4, !5, !6}
+
+!0 = !{i32 2, i32 3, i32 1}
+!1 = !{i32 2113342239, i32 1385488414, i32 -1007072744, i32 -815526592, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!2 = !{i32 1792639877, i32 1348715323, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3}
+!3 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 0, i32 4}
+!4 = !{!"DescriptorBuffer", i32 4, i32 16, i32 0, i32 1, i32 4}
+!5 = !{!"DescriptorTableVaPtr", i32 20, i32 1, i32 1}
+!6 = !{!"DescriptorBuffer", i32 0, i32 4, i32 0, i32 2, i32 4}
+!7 = !{i32 5}

--- a/lgc/test/VsComputeLibrary.lgc
+++ b/lgc/test/VsComputeLibrary.lgc
@@ -2,10 +2,10 @@
 
 ; RUN: lgc -mcpu=gfx1010 -print-after=lgc-patch-entry-point-mutate -print-after=lgc-patch-prepare-pipeline-abi -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 ; CHECK: IR Dump After Patch LLVM for entry-point mutation
-; CHECK: define spir_func <4 x float> @func(i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId, <4 x float> %11) #2 !lgc.shaderstage !4 {
+; CHECK: define spir_func <4 x float> @func(<4 x float> %0, i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #2 !lgc.shaderstage !4 {
 ; CHECK: !4 = !{i32 0}
 ; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI
-; CHECK: define amdgpu_gfx <4 x float> @func(i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId, <4 x float> %11) #0 !lgc.shaderstage !4 {
+; CHECK: define amdgpu_gfx <4 x float> @func(<4 x float> %0, i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %10, i32 inreg %11, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #0 !lgc.shaderstage !4 {
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -172,7 +172,7 @@ void addTypeMangling(Type *returnTy, ArrayRef<Value *> args, std::string &name) 
 // @param func : LLVM function
 // @param idx : Index of the query argument
 // @param name : Name to give the argument if currently empty
-Value *getFunctionArgument(Function *func, unsigned idx, const Twine &name) {
+Argument *getFunctionArgument(Function *func, unsigned idx, const Twine &name) {
   assert(idx < func->arg_end() - func->arg_begin() && "Out of range function argument");
   Argument *arg = &func->arg_begin()[idx];
   if (!name.isTriviallyEmpty() && arg->getName() == "")


### PR DESCRIPTION
This is a fixed version of #1235.

The first commit ‘[ComputeLibs] Append system arguments’ is the rebased original pr.
The second commit ‘Fix appending system arguments’ fixes the issue with `entryArgIdx` being set to the wrong argument index.
The third commit is a short cleanup, I can put that in a separate pr if needed.

I’m not sure if adding the `argOffset` (i.e. the user-defined arguments to a compute library function) onto the `entryArgIdx` is the right thing to do. As the `entryArgIdx`s are global state, this limits a module to only contain a single compute library function. Although probably it’s already limited to a single function, even without adding the function-specific `argOffset`?