### PR TITLE
Don't use nullptr as GEP element type

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -3762,7 +3762,8 @@ void PatchInOutImportExport::storeValueToEsGsRing(Value *storeValue, unsigned lo
     if (m_pipelineState->isGsOnChip() || m_gfxIp.major >= 9) // ES -> GS ring is always on-chip on GFX9+
     {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
-      Value *storePtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
+      auto ldsType = m_lds->getType()->getPointerElementType();
+      Value *storePtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       new StoreInst(storeValue, storePtr, false, m_lds->getAlign().getValue(), insertPos);
     } else {
       Value *esGsRingBufDesc = m_pipelineSysValues.get(m_entryPoint)->getEsGsRingBufDesc();
@@ -3830,7 +3831,8 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
     if (m_pipelineState->isGsOnChip() || m_gfxIp.major >= 9) // ES -> GS ring is always on-chip on GFX9
     {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
-      Value *loadPtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
+      auto ldsType = m_lds->getType()->getPointerElementType();
+      Value *loadPtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       auto loadInst = new LoadInst(loadPtr->getType()->getPointerElementType(), loadPtr, "", false,
                                    m_lds->getAlign().getValue(), insertPos);
       loadValue = loadInst;
@@ -3952,7 +3954,8 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
 
     if (m_pipelineState->isGsOnChip()) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
-      Value *storePtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
+      auto ldsType = m_lds->getType()->getPointerElementType();
+      Value *storePtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       new StoreInst(storeValue, storePtr, false, m_lds->getAlign().getValue(), insertPos);
     } else {
       // NOTE: Here we use tbuffer_store instruction instead of buffer_store because we have to do explicit
@@ -4190,7 +4193,8 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
   {
     for (unsigned i = 0; i < numChannels; ++i) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ldsOffset};
-      Value *loadPtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
+      auto ldsType = m_lds->getType()->getPointerElementType();
+      Value *loadPtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       auto loadTy = loadPtr->getType()->getPointerElementType();
       auto loadInst = new LoadInst(loadTy, loadPtr, "", false, m_lds->getAlign().getValue(), insertPos);
       loadValues[i] = loadInst;
@@ -4287,7 +4291,8 @@ void PatchInOutImportExport::writeValueToLds(Value *writeValue, Value *ldsOffset
   {
     for (unsigned i = 0; i < numChannels; ++i) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ldsOffset};
-      Value *storePtr = GetElementPtrInst::Create(nullptr, m_lds, idxs, "", insertPos);
+      auto ldsType = m_lds->getType()->getPointerElementType();
+      Value *storePtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       new StoreInst(storeValues[i], storePtr, false, m_lds->getAlign().getValue(), insertPos);
 
       ldsOffset =

--- a/lgc/patch/PatchPeepholeOpt.cpp
+++ b/lgc/patch/PatchPeepholeOpt.cpp
@@ -544,7 +544,8 @@ void PatchPeepholeOpt::visitIntToPtr(IntToPtrInst &intToPtr) {
 
   // Create a getelementptr instruction (using offset / size).
   const DataLayout &dataLayout = intToPtr.getModule()->getDataLayout();
-  const uint64_t size = dataLayout.getTypeAllocSize(intToPtr.getType()->getPointerElementType());
+  auto elementType = intToPtr.getType()->getPointerElementType();
+  const uint64_t size = dataLayout.getTypeAllocSize(elementType);
   APInt index = constOffset->getValue().udiv(size);
   if (constOffset->getValue().urem(size) != 0)
     return;
@@ -554,7 +555,7 @@ void PatchPeepholeOpt::visitIntToPtr(IntToPtrInst &intToPtr) {
   insertAfter(*newIntToPtr, *binaryOperator);
 
   auto *const getElementPtr =
-      GetElementPtrInst::Create(nullptr, newIntToPtr, ConstantInt::get(newIntToPtr->getContext(), index));
+      GetElementPtrInst::Create(elementType, newIntToPtr, ConstantInt::get(newIntToPtr->getContext(), index));
   insertAfter(*getElementPtr, *newIntToPtr);
 
   // Set every instruction to use the newly calculated pointer.

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -329,7 +329,8 @@ Value *ShaderSystemValues::getStreamOutBufDesc(unsigned xfbBuffer) {
     Value *idxs[] = {ConstantInt::get(Type::getInt64Ty(*m_context), 0),
                      ConstantInt::get(Type::getInt64Ty(*m_context), xfbBuffer)};
 
-    auto streamOutBufDescPtr = GetElementPtrInst::Create(nullptr, streamOutTablePtr, idxs, "", insertPos);
+    auto streamOutTableType = streamOutTablePtr->getType()->getPointerElementType();
+    auto streamOutBufDescPtr = GetElementPtrInst::Create(streamOutTableType, streamOutTablePtr, idxs, "", insertPos);
     streamOutBufDescPtr->setMetadata(MetaNameUniform, MDNode::get(streamOutBufDescPtr->getContext(), {}));
     auto streamOutBufDescTy = streamOutBufDescPtr->getType()->getPointerElementType();
 

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -144,7 +144,8 @@ GetElementPtrInst *SpirvLowerAccessChain::tryToCoalesceChain(GetElementPtrInst *
     } while (!chainedInsts.empty());
 
     // Create the coalesced "getelementptr" instruction (do combining)
-    coalescedGetElemPtr = GetElementPtrInst::Create(nullptr, blockPtr, idxs, "", getElemPtr);
+    auto blockType = blockPtr->getType()->getPointerElementType();
+    coalescedGetElemPtr = GetElementPtrInst::Create(blockType, blockPtr, idxs, "", getElemPtr);
     getElemPtr->replaceAllUsesWith(coalescedGetElemPtr);
 
     // Remove dead "getelementptr" instructions where possible.

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
@@ -157,7 +157,8 @@ StoreInst *SpirvLowerConstImmediateStore::findSingleStore(AllocaInst *allocaInst
 // @param storeInst : The single constant store into the "alloca"
 void SpirvLowerConstImmediateStore::convertAllocaToReadOnlyGlobal(StoreInst *storeInst) {
   auto allocaInst = cast<AllocaInst>(storeInst->getPointerOperand());
-  auto global = new GlobalVariable(*m_module, allocaInst->getType()->getElementType(),
+  auto globalType = allocaInst->getType()->getElementType();
+  auto global = new GlobalVariable(*m_module, globalType,
                                    true, // isConstant
                                    GlobalValue::InternalLinkage, cast<Constant>(storeInst->getValueOperand()), "",
                                    nullptr, GlobalValue::NotThreadLocal, SPIRAS_Constant);
@@ -178,7 +179,7 @@ void SpirvLowerConstImmediateStore::convertAllocaToReadOnlyGlobal(StoreInst *sto
         for (auto idxIt = origGetElemPtrInst->idx_begin(), idxItEnd = origGetElemPtrInst->idx_end(); idxIt != idxItEnd;
              ++idxIt)
           indices.push_back(*idxIt);
-        auto newGetElemPtrInst = GetElementPtrInst::Create(nullptr, global, indices, "", origGetElemPtrInst);
+        auto newGetElemPtrInst = GetElementPtrInst::Create(globalType, global, indices, "", origGetElemPtrInst);
         newGetElemPtrInst->takeName(origGetElemPtrInst);
         newGetElemPtrInst->setIsInBounds(origGetElemPtrInst->isInBounds());
         newGetElemPtrInst->copyMetadata(*origGetElemPtrInst);

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -2038,7 +2038,7 @@ void SpirvLowerGlobal::interpolateInputElement(unsigned interpLoc, Value *auxInt
 
     new StoreInst(loadValue, interpPtr, &callInst);
 
-    auto interpElemPtr = GetElementPtrInst::Create(nullptr, interpPtr, operands, "", &callInst);
+    auto interpElemPtr = GetElementPtrInst::Create(inputTy, interpPtr, operands, "", &callInst);
     auto interpElemTy = interpElemPtr->getType()->getPointerElementType();
 
     // only get the value that the original getElemPtr points to

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -121,7 +121,7 @@ void SpirvLowerMemoryOp::visitExtractElementInst(ExtractElementInst &extractElem
       auto castPtrTy = castTy->getPointerTo(addrSpace);
       auto castPtr = new BitCastInst(loadPtr, castPtrTy, "", &extractElementInst);
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), extractElementInst.getOperand(1)};
-      auto elementPtr = GetElementPtrInst::Create(nullptr, castPtr, idxs, "", &extractElementInst);
+      auto elementPtr = GetElementPtrInst::Create(castTy, castPtr, idxs, "", &extractElementInst);
       auto elementTy = elementPtr->getType()->getPointerElementType();
       auto newLoad = new LoadInst(elementTy, elementPtr, "", &extractElementInst);
       extractElementInst.replaceAllUsesWith(newLoad);


### PR DESCRIPTION
Since https://reviews.llvm.org/D105653, LLVM's GetElementPtrInst::Create
checks that it is passed a correct non-null element type.