### PR TITLE
Rewrite getVsEntryRegInfo

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -229,6 +229,7 @@ constexpr unsigned mmSPI_SHADER_PGM_RSRC1_ES = 0x2CCA;
 constexpr unsigned mmSPI_SHADER_PGM_RSRC1_GS = 0x2C8A;
 constexpr unsigned mmSPI_SHADER_PGM_RSRC1_VS = 0x2C4A;
 constexpr unsigned mmSPI_SHADER_PGM_RSRC1_PS = 0x2C0A;
+constexpr unsigned mmCOMPUTE_PGM_RSRC1 = 0x2E12;
 
 // RSRC2 register. We only specify one, as each graphics shader stage has its RSRC2 register at the same
 // offset (-1) from its USER_DATA_*_0 register.

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -39,6 +39,7 @@
 #include "lgc/Pipeline.h"
 #include "lgc/state/AbiMetadata.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
+#include <map>
 
 namespace llvm {
 class Module;
@@ -219,6 +220,18 @@ private:
 
   // The maximum possible value for the spill threshold entry in the PAL meatadata.
   static constexpr uint64_t MAX_SPILL_THRESHOLD = UINT_MAX;
+
+  unsigned getUserDataCount(unsigned callingConv);
+  unsigned getCallingConventionForFirstHardwareShaderStage();
+  unsigned getFirstUserDataReg(unsigned callingConv);
+  unsigned getNumberOfSgprsBeforeUserData(unsigned conv);
+  unsigned getOffsetOfUserDataReg(std::map<llvm::msgpack::DocNode, llvm::msgpack::DocNode>::iterator firstUserDataNode,
+                                  UserDataMapping userDataMapping);
+  unsigned getNumberOfSgprsAfterUserData(unsigned callingConv);
+  unsigned getVertexIdOffset(unsigned callingConv);
+  unsigned getInstanceIdOffset(unsigned callingConv);
+  unsigned getVgprCount(unsigned callingConv);
+  bool isWave32(unsigned callingConv);
 
   PipelineState *m_pipelineState;             // PipelineState
   llvm::msgpack::Document *m_document;        // The MsgPack document


### PR DESCRIPTION
The function getVsEntryRegInfo is a little long, and mixes a lot of word
together.  There is also a problem because on GFX9 the HW shader stage
does not match the user data registers as expected.  That is, a GS
shader uses the ES user data entries.

This PR will rewrite that code and fix up this problem.