### PR TITLE
Fix pushconst relocation value

### DIFF
--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -174,7 +174,7 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
   }
   if (name == reloc::Pushconst) {
     auto *pushConstantNode = m_pipelineState->findPushConstantResourceNode();
-    value = pushConstantNode->offsetInDwords;
+    value = pushConstantNode->offsetInDwords * 4;
     getPipelineState()->getPalMetadata()->setUserDataSpillUsage(pushConstantNode->offsetInDwords);
     return true;
   }

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_PushConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_PushConst.pipe
@@ -1,0 +1,94 @@
+; Test that the offset to the push constant area is correct when the push constants are spilled.
+; This may be a fragile test because the conditions in which the push constatns are spilled might change.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s
+; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
+; This tries to match the sequece that loads the vector from the puch constant.  This is the only 2 element load in the
+; code.  The "4" is the offset of the push constant area in the root table.
+; SHADERTEST: s_mov_b32 [[r1:s[0-9]+]], 4 //
+; SHADERTEST: s_ashr_i32 s[[r2:[0-9]+]], [[r1]], 31
+; SHADERTEST: s_add_u32 s[[addr1:[0-9]+]], {{s[0-9]+}}, [[r1]]
+; SHADERTEST: s_addc_u32 s[[addr2:[0-9]+]], {{s[0-9]+}}, s[[r2]]
+; SHADERTEST: s_load_dwordx2 {{s\[[0-9]+:[0-9]+\]}}, {{s\[}}[[addr1]]:[[addr2]]{{\]}}, 0x0
+; END_SHADERTEST
+
+[Version]
+version = 46
+
+[CsGlsl]
+#version 450
+layout(local_size_x = 512, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std430) writeonly buffer output_layout
+{
+    uint output_buffer[];
+} _7;
+
+layout( push_constant ) uniform push_constants_layout
+{
+    ivec2 output_resolution;
+} push_constants;
+
+void main()
+{
+    if (gl_LocalInvocationIndex < 4u)
+    {
+        _7.output_buffer[gl_LocalInvocationIndex] = all(lessThan(uvec2(0u), uvec2(push_constants.output_resolution))) ? 0u : 1u;
+    }
+    else
+    {
+        _7.output_buffer[push_constants.output_resolution.y] = 0u;
+    }
+}
+
+[CsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 1
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 32
+userDataNode[1].type = PushConst
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 9
+userDataNode[1].set = 0xFFFFFFFF
+userDataNode[1].binding = 0
+userDataNode[2].visibility = 32
+userDataNode[2].type = DescriptorTableVaPtr
+userDataNode[2].offsetInDwords = 10
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].next[0].type = DescriptorCombinedTexture
+userDataNode[2].next[0].offsetInDwords = 0
+userDataNode[2].next[0].sizeInDwords = 12
+userDataNode[2].next[0].set = 0x00000000
+userDataNode[2].next[0].binding = 0
+userDataNode[2].next[1].type = DescriptorBuffer
+userDataNode[2].next[1].offsetInDwords = 12
+userDataNode[2].next[1].sizeInDwords = 4
+userDataNode[2].next[1].set = 0x00000000
+userDataNode[2].next[1].binding = 1
+userDataNode[2].next[2].type = DescriptorBuffer
+userDataNode[2].next[2].offsetInDwords = 16
+userDataNode[2].next[2].sizeInDwords = 4
+userDataNode[2].next[2].set = 0x00000000
+userDataNode[2].next[2].binding = 2
+userDataNode[2].next[3].type = DescriptorBuffer
+userDataNode[2].next[3].offsetInDwords = 20
+userDataNode[2].next[3].sizeInDwords = 4
+userDataNode[2].next[3].set = 0x00000000
+userDataNode[2].next[3].binding = 3
+userDataNode[2].next[4].type = DescriptorBuffer
+userDataNode[2].next[4].offsetInDwords = 24
+userDataNode[2].next[4].sizeInDwords = 4
+userDataNode[2].next[4].set = 0x00000000
+userDataNode[2].next[4].binding = 5
+userDataNode[2].next[5].type = DescriptorBuffer
+userDataNode[2].next[5].offsetInDwords = 28
+userDataNode[2].next[5].sizeInDwords = 4
+userDataNode[2].next[5].set = 0x00000000
+userDataNode[2].next[5].binding = 6
+


### PR DESCRIPTION
The pushconst value is suppose to be the offset in bytes of the
pushconstant area.  However, we currently replace it with the
number of dwords.  This commit will fix that up.