### PR TITLE
Fail to link reloc shader because of builtin fs input

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -165,6 +165,9 @@ public:
   // Link the unlinked shader/part-pipeline ELFs and the compiled glue code into a pipeline ELF
   bool link(raw_pwrite_stream &outStream) override final;
 
+  // Returns true if the fragment shader uses a builtin input that gets mapped.
+  bool fragmentShaderUsesMappedBuiltInInputs() override final;
+
   // -----------------------------------------------------------------------------------------------------------------
   // Accessors
 
@@ -588,6 +591,12 @@ bool ElfLinkerImpl::link(raw_pwrite_stream &outStream) {
                    sizeof(m_ehdr));
 
   return m_pipelineState->getLastError() == "";
+}
+
+// =====================================================================================================================
+// Returns true if the fragment shader uses a builtin input that gets mapped.
+bool ElfLinkerImpl::fragmentShaderUsesMappedBuiltInInputs() {
+  return m_pipelineState->getPalMetadata()->fragmentShaderUsesMappedBuiltInInputs();
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -192,6 +192,9 @@ public:
   // Erase the PAL metadata for FS input mappings. Used when finalizing the PAL metadata in the link.
   void eraseFragmentInputInfo();
 
+  // Returns true if the fragment input info has an entry for a builtin.
+  bool fragmentShaderUsesMappedBuiltInInputs();
+
 private:
   // Initialize the PalMetadata object after reading in already-existing PAL metadata if any
   void initialize();

--- a/lgc/interface/lgc/ElfLinker.h
+++ b/lgc/interface/lgc/ElfLinker.h
@@ -99,6 +99,9 @@ public:
   //           getLastError() to get a textual representation of the error, for use in logging or in error
   //           reporting in a command-line utility.
   virtual bool link(llvm::raw_pwrite_stream &outStream) = 0;
+
+  // Returns true if the fragment input info has an entry for a builtin.
+  virtual bool fragmentShaderUsesMappedBuiltInInputs() = 0;
 };
 
 } // namespace lgc

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -969,3 +969,14 @@ void PalMetadata::eraseFragmentInputInfo() {
   if (array2It != m_pipelineNode.end())
     m_pipelineNode.erase(array2It);
 }
+
+// =====================================================================================================================
+// Returns true if the fragment input info has an entry for a builtin.
+bool PalMetadata::fragmentShaderUsesMappedBuiltInInputs() {
+  auto array2It = m_pipelineNode.find(m_document->getNode(PipelineMetadataKey::FragInputMapping2));
+  if (array2It != m_pipelineNode.end()) {
+    auto fragInputMappingArray2 = array2It->second.getArray(true);
+    return !fragInputMappingArray2.empty();
+  }
+  return false;
+}

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -963,7 +963,7 @@ Result Compiler::buildPipelineWithRelocatableElf(Context *context, ArrayRef<cons
       bool hasError = false;
       context->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>(&hasError));
 
-      linkRelocatableShaderElf(elf, pipelineElf, context);
+      hasError |= !linkRelocatableShaderElf(elf, pipelineElf, context);
       context->setDiagnosticHandler(nullptr);
 
       if (hasError)
@@ -1505,10 +1505,12 @@ Result Compiler::buildGraphicsPipelineInternal(GraphicsContext *graphicsContext,
                                                MutableArrayRef<CacheAccessInfo> stageCacheAccesses) {
   Context *context = acquireContext();
   context->attachPipelineContext(graphicsContext);
-  Result result = Result::Success;
+  Result result = Result::ErrorUnavailable;
   if (buildingRelocatableElf) {
     result = buildPipelineWithRelocatableElf(context, shaderInfo, pipelineElf, stageCacheAccesses);
-  } else {
+  }
+
+  if (result != Result::Success) {
     result = buildPipelineInternal(context, shaderInfo, /*unlinked=*/false, pipelineElf);
   }
   releaseContext(context);
@@ -1640,12 +1642,14 @@ Result Compiler::buildComputePipelineInternal(ComputeContext *computeContext,
   std::vector<const PipelineShaderInfo *> shadersInfo = {
       nullptr, nullptr, nullptr, nullptr, nullptr, &pipelineInfo->cs,
   };
-  Result result;
+  Result result = Result::ErrorUnavailable;
   if (buildingRelocatableElf) {
     CacheAccessInfo stageCacheAccesses[ShaderStageCount] = {};
     result = buildPipelineWithRelocatableElf(context, shadersInfo, pipelineElf, stageCacheAccesses);
     *stageCacheAccess = stageCacheAccesses[ShaderStageCompute];
-  } else {
+  }
+
+  if (result != Result::Success) {
     result = buildPipelineInternal(context, shadersInfo, /*unlinked=*/false, pipelineElf);
   }
   releaseContext(context);
@@ -2030,13 +2034,13 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
 }
 
 // =====================================================================================================================
-// Link relocatable shader elf file into a pipeline elf file and apply relocations.
+// Link relocatable shader elf file into a pipeline elf file and apply relocations.  Returns true if successful.
 //
 // @param shaderElfs : An array of pipeline elf packages, indexed by stage, containing relocatable elf.
 //                     TODO: This has an implicit length of ShaderStageNativeStageCount. Use ArrayRef instead.
 // @param [out] pipelineElf : Elf package containing the pipeline elf
 // @param context : Acquired context
-void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context) {
+bool Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context) {
   assert(!context->getPipelineContext()->isUnlinked() && "Not supposed to link this pipeline.");
 
   // Set up middle-end objects, including setting up pipeline state.
@@ -2052,6 +2056,11 @@ void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipe
   }
   std::unique_ptr<ElfLinker> elfLinker(pipeline->createElfLinker(elfs));
 
+  if (elfLinker->fragmentShaderUsesMappedBuiltInInputs()) {
+    LLPC_OUTS("Failed to link relocatable shaders because FS uses builtin inputs.");
+    return false;
+  }
+
   setGlueBinaryBlobsInLinker(elfLinker.get(), context, this);
   // Do the link.
   raw_svector_ostream outStream(*pipelineElf);
@@ -2060,7 +2069,7 @@ void Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipe
     // TODO: Action this failure by doing a full pipeline compile.
     report_fatal_error("Link failed; need full pipeline compile instead: " + pipeline->getLastError());
   }
-  return;
+  return true;
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -153,7 +153,7 @@ private:
 
   bool runPasses(lgc::LegacyPassManager *passMgr, llvm::Module *module) const;
   bool runPasses(lgc::PassManager *passMgr, llvm::Module *module) const;
-  void linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context);
+  bool linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipelineElf, Context *context);
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo,
                                           const GraphicsPipelineBuildInfo *pipelineInfo);
   bool canUseRelocatableComputeShaderElf(const ComputePipelineBuildInfo *pipelineInfo);

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestFsBuiltInInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestFsBuiltInInput.pipe
@@ -1,0 +1,46 @@
+; Test that the relocatable shaders cannot be linked, but that the compilation still succeeds.
+; If this pipeline was compiled by linking relocatable shaders, the VS would write the clip distance to channel 1, but
+; the FS would try to read it from channel 0.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-relocatable-shader-elf -auto-layout-desc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: Failed to link relocatable shaders because FS uses builtin inputs.
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+
+[Version]
+version = 38
+
+[VsGlsl]
+#version 450
+
+out float gl_ClipDistance[1];
+
+layout(location = 0) out vec3 _2;
+
+void main()
+{
+    gl_Position = vec4(0.5);
+    gl_ClipDistance[0] = 0.4;
+    _2 = vec3(0.5);
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+in float gl_ClipDistance[1];
+
+layout(location = 0) out vec4 _3;
+
+void main()
+{
+    _3 = vec4(gl_ClipDistance[0u]);
+}
+
+
+[FsInfo]
+entryPoint = main


### PR DESCRIPTION
When a builtin is used that LLPC must assign a HW channel to pass it
from the vertex processing stage to the fragment stage, relocatable
shaders could fail.  This will happen when the vertex outputs do not
match the fragment inputs exactly.  In this case, LLPC has no way to
consistently assign a channel to the builtin.

For a quick solution to this problem, we will fail when trying to link
relocatable shaders that have builtin FS input, and then fall back to
whole pipeline compilation.