### PR TITLE
[CI] Temporarily disable sanitizer builds

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -18,7 +18,7 @@ jobs:
         base-image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s_%s:nightly"]
         config:              [Release]
         assertions:          ["OFF", "ON"]
-        feature-set:         ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
+        feature-set:         ["+gcc", "+clang", "+clang+shadercache"]
     steps:
       - name: Free up disk space
         if: contains(matrix.feature-set, '+sanitizers')


### PR DESCRIPTION
AMDVLK no longer builds with sanitizers enabled on the GitHub actions runners.

This is most likely caused by clang running out of memory when compiling files in
`llvm/utils/TableGen`.