### PR TITLE
Differentiate between an internal and an application cache hit

### DIFF
--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -85,8 +85,11 @@ void CacheAccessor::lookUpInCaches(const MetroHash::Hash &hash) {
   memcpy(&hashId.bytes, &hash.bytes, sizeof(hash));
 
   Result cacheResult = Result::Unsupported;
-  if (getInternalCache())
+  if (getInternalCache()) {
     cacheResult = lookUpInCache(getInternalCache(), !getApplicationCache(), hashId);
+    if (cacheResult == Result::Success)
+      m_internalCacheHit = true;
+  }
   if (getApplicationCache() && cacheResult != Result::Success)
     cacheResult = lookUpInCache(getApplicationCache(), true, hashId);
   m_cacheResult = cacheResult;

--- a/llpc/util/llpcCacheAccessor.h
+++ b/llpc/util/llpcCacheAccessor.h
@@ -93,7 +93,7 @@ public:
     if (!isInCache())
       return false;
     if (m_cacheResult == Result::Success) {
-      return true;
+      return m_internalCacheHit;
     }
     return getApplicationShaderCache() == m_shaderCache;
   }
@@ -157,6 +157,9 @@ private:
 
   // The result of checking the ICache.
   Result m_cacheResult = Result::ErrorUnknown;
+
+  // Whether the cache hit came from the internal cache.
+  bool m_internalCacheHit = false;
 
   // The handle to the entry in the cache.
   Vkgc::EntryHandle m_cacheEntry;


### PR DESCRIPTION
Right now an application cache hit is reported as internal. I've added a flag that tracks whether the cache hit happens in the internal or application cache.