### PR TITLE
Correct the GPU property 'ldsSizePerThreadGroup'

### DIFF
--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -54,8 +54,7 @@ struct GfxIpVersion {
 struct GpuProperty {
   unsigned numShaderEngines;                  // Number of shader engines present
   unsigned waveSize;                          // Wavefront size
-  unsigned ldsSizePerCu;                      // LDS size per compute unit
-  unsigned ldsSizePerThreadGroup;             // LDS size per thread group
+  unsigned ldsSizePerThreadGroup;             // LDS size per thread group in dwords
   unsigned gsOnChipDefaultPrimsPerSubgroup;   // Default target number of primitives per subgroup for GS on-chip mode.
   unsigned gsOnChipDefaultLdsSizePerSubgroup; // Default value for the maximum LDS size per subgroup for
   unsigned gsOnChipMaxLdsSize;                // Max LDS size used by GS on-chip mode (in dwords)

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -298,8 +298,8 @@ GlobalVariable *Patch::getLdsVariable(PipelineState *pipelineState, Module *modu
   }
   // Now we can create LDS.
   // Construct LDS type: [ldsSize * i32], address space 3
-  auto ldsSize = pipelineState->getTargetInfo().getGpuProperty().ldsSizePerCu;
-  auto ldsTy = ArrayType::get(Type::getInt32Ty(*context), ldsSize / sizeof(unsigned));
+  auto ldsSize = pipelineState->getTargetInfo().getGpuProperty().ldsSizePerThreadGroup;
+  auto ldsTy = ArrayType::get(Type::getInt32Ty(*context), ldsSize);
 
   auto lds = new GlobalVariable(*module, ldsTy, false, GlobalValue::ExternalLinkage, nullptr, "lds", nullptr,
                                 GlobalValue::NotThreadLocal, ADDR_SPACE_LOCAL);

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -49,7 +49,6 @@ static void setGfx6BaseInfo(TargetInfo *targetInfo) {
   // Initial settings (could be adjusted later according to graphics IP version info)
   targetInfo->getGpuProperty().waveSize = 64;
 
-  targetInfo->getGpuProperty().ldsSizePerThreadGroup = 32 * 1024;
   targetInfo->getGpuProperty().numShaderEngines = 4;
   targetInfo->getGpuProperty().maxSgprsAvailable = 104;
   targetInfo->getGpuProperty().maxVgprsAvailable = 256;
@@ -77,7 +76,7 @@ static void setGfx6BaseInfo(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx6Info(TargetInfo *targetInfo) {
   setGfx6BaseInfo(targetInfo);
-  targetInfo->getGpuProperty().ldsSizePerCu = 32768;
+  targetInfo->getGpuProperty().ldsSizePerThreadGroup = 8192;
   targetInfo->getGpuProperty().ldsSizeDwordGranularityShift = 6;
 
   // Hardware workarounds for GFX6 based GPU's:
@@ -125,7 +124,7 @@ static void setGfx602Info(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx7BaseInfo(TargetInfo *targetInfo) {
   setGfx6BaseInfo(targetInfo);
-  targetInfo->getGpuProperty().ldsSizePerCu = 65536;
+  targetInfo->getGpuProperty().ldsSizePerThreadGroup = 16384;
   targetInfo->getGpuProperty().ldsSizeDwordGranularityShift = 7;
 }
 


### PR DESCRIPTION
The value is enlarged from GFX7+. For convenience, we use the size
in dwords. That is 8912 for GFX6 and 16384 for GFX7+. Meanwhile,
remove the property 'ldsSizePerCu'. It is redundant. And later GPU
has WGP mode so the term is not an accurate one.

Change-Id: Idfbf4682eaa039218f1c8e9b4ccc74657c663cac