### PR TITLE
Add clang-tidy to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
  # Do not modify llpc.h, vkgcDefs.h, anything in the SPIRV library, or vfx.h, or anything in lgc/imported.
 HeaderFilterRegex: '.*/vfx/vfx..*\\.h|.*/dumper/vkgc.*\\.h|.*/util/vkgc.*\\.h|.*/lgc/include/.*\\.h|.*/context/llpc[^/]*\\.h|.*/util/llpc[^/]*\\.h|.*/lower/llpc[^/]*\\.h|.*/builder/llpc[^/]*\\.h|.*/patch.*/llpc[^/]*\\.h|.*/tool/[^/]*\\.h'
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
+Checks: '-*,clang-diagnostic-*,llvm-*,-llvm-qualified-auto,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
 CheckOptions:
   - { key: readability-identifier-naming.ParameterCase, value: camelBack }
   - { key: readability-identifier-naming.ParameterRemovePrefixes, value: 'p,b,pfn' }
@@ -8,7 +8,7 @@ CheckOptions:
   - { key: readability-identifier-naming.VariableRemovePrefixes, value: 'p,b,pfn' }
   # Need to ignore static field 'ID' because otherwise clang-tidy dives into an llvm
   # include file and changes 'ID' to 'm_id' there, which is bad.
-  - { key: readability-identifier-naming.ClassMemberIgnoreRegex, value: '^ID|mmSPI_.*$' }
+  - { key: readability-identifier-naming.ClassMemberIgnoredRegexp, value: '^ID|mm.*$' }
   - { key: readability-identifier-naming.ClassMemberCase, value: camelBack }
   - { key: readability-identifier-naming.ClassMemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
   - { key: readability-identifier-naming.ClassMemberPrefix, value: m_ }
@@ -16,22 +16,22 @@ CheckOptions:
   - { key: readability-identifier-naming.ClassConstantRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
   - { key: readability-identifier-naming.StaticVariableCase, value: CamelCase }
   - { key: readability-identifier-naming.StaticVariableRemovePrefixes, value: 'p,b,pfn,s_,s_p' }
-  - { key: readability-identifier-naming.GlobalVariableIgnoreRegex, value: 'mmSPI_.*' }
+  - { key: readability-identifier-naming.GlobalVariableIgnoredRegexp, value: 'mm.*' }
   - { key: readability-identifier-naming.GlobalVariableCase, value: CamelCase }
   - { key: readability-identifier-naming.GlobalVariableRemovePrefixes, value: 'p,b,pfn,g_,g_p' }
-  - { key: readability-identifier-naming.ConstantMemberIgnoreRegex, value: 'mmSPI_.*' }
+  - { key: readability-identifier-naming.ConstantMemberIgnoredRegexp, value: 'mm.*' }
   - { key: readability-identifier-naming.ConstantMemberCase, value: CamelCase }
   - { key: readability-identifier-naming.ConstantMemberPrefix, value: '' }
   - { key: readability-identifier-naming.PublicMemberCase, value: camelBack }
-  - { key: readability-identifier-naming.PublicMemberIgnoreRegex, value: '^pSymName$' }
+  - { key: readability-identifier-naming.PublicMemberIgnoredRegexp, value: '^pSymName$' }
   - { key: readability-identifier-naming.PublicMemberPrefix, value: '' }
   - { key: readability-identifier-naming.PublicMemberRemovePrefixes, value: 'p,b,pfn,m_,m_p,m_b' }
   - { key: readability-identifier-naming.MemberCase, value: camelBack }
   - { key: readability-identifier-naming.MemberPrefix, value: m_ }
   - { key: readability-identifier-naming.MemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
   - { key: readability-identifier-naming.MethodCase, value: camelBack }
-  - { key: readability-identifier-naming.MethodIgnoreRegex, value: '^Create$|^CreateACos$|^CreateACosh$|^CreateASin$|^CreateASinh$|^CreateATan$|^CreateATan2$|^CreateATanh$|^CreateBarrier$|^CreateBinaryIntrinsic$|^CreateCosh$|^CreateCrossProduct$|^CreateCubeFace.*$|^CreateDemoteToHelperInvocation$|^CreateDerivative$|^CreateDeterminant$|^CreateDotProduct$|^CreateEmitVertex$|^CreateEndPrimitive$|^CreateExp$|^CreateExtract.*$|^CreateFaceForward$|^CreateFClamp$|^CreateFindSMsb$|^CreateFma$|^CreateFMax$|^CreateFMax3$|^CreateFMid3$|^CreateFMin$|^CreateFMin3$|^CreateFMod$|^CreateFpTruncWithRounding$|^CreateFract$|^CreateFSign$|^CreateGet.*$|^CreateImage.*$|^CreateIndexDescPtr$|^CreateInsertBitField$|^CreateIntrinsic$|^CreateInverseSqrt$|^CreateIs.*$|^CreateKill$|^CreateLdexp$|^CreateLoad.*$|^CreateLog$|^CreateMapToInt32$|^CreateMatrix.*$|^CreateNormalizeVector$|^CreateOuterProduct$|^CreatePower$|^CreateQuantizeToFp16$|^CreateRead.*$|^CreateReflect$|^CreateRefract$|^CreateSAbs$|^CreateSinh$|^CreateSMod$|^CreateSmoothStep$|^CreateSSign$|^CreateSubgroup.*$|^CreateTan$|^CreateTanh$|^CreateTransposeMatrix$|^CreateUnaryIntrinsic$|^CreateVectorTimesMatrix$|^CreateWrite.*Output$|^Serialize$|^Merge$|^Destroy$|^ConvertColorBufferFormatToExportFormat$|^BuildShaderModule$|^BuildGraphicsPipeline$|^BuildComputePipeline$|^IsVertexFormatSupported$|^DumpSpirvBinary$|^BeginPipelineDump$|^EndPipelineDump$|^DumpPipelineBinary$|^DumpPipelineExtraInfo$|^GetShaderHash$|^GetPipelineHash$|^GetPipelineName$|^CreateShaderCache$|^ReadFromBuffer$|^GetSectionIndex$|^GetSymbolsBySectionIndex$|^GetSectionData$' }
-  - { key: readability-identifier-naming.FunctionIgnoreRegex, value: 'EnableOuts|EnableErrs' }
+  - { key: readability-identifier-naming.MethodIgnoredRegexp, value: '^Create$|^CreateACos$|^CreateACosh$|^CreateASin$|^CreateASinh$|^CreateATan$|^CreateATan2$|^CreateATanh$|^CreateBarrier$|^CreateBinaryIntrinsic$|^CreateCosh$|^CreateCrossProduct$|^CreateCubeFace.*$|^CreateDemoteToHelperInvocation$|^CreateDerivative$|^CreateDeterminant$|^CreateDotProduct$|^CreateEmitVertex$|^CreateEndPrimitive$|^CreateExp$|^CreateExtract.*$|^CreateFaceForward$|^CreateFClamp$|^CreateFindSMsb$|^CreateFma$|^CreateFMax$|^CreateFMax3$|^CreateFMid3$|^CreateFMin$|^CreateFMin3$|^CreateFMod$|^CreateFpTruncWithRounding$|^CreateFract$|^CreateFSign$|^CreateGet.*$|^CreateImage.*$|^CreateIndexDescPtr$|^CreateInsertBitField$|^CreateIntrinsic$|^CreateInverseSqrt$|^CreateIs.*$|^CreateKill$|^CreateLdexp$|^CreateLoad.*$|^CreateLog$|^CreateMapToInt32$|^CreateMatrix.*$|^CreateNormalizeVector$|^CreateOuterProduct$|^CreatePower$|^CreateQuantizeToFp16$|^CreateRead.*$|^CreateReflect$|^CreateRefract$|^CreateSAbs$|^CreateSinh$|^CreateSMod$|^CreateSmoothStep$|^CreateSSign$|^CreateSubgroup.*$|^CreateTan$|^CreateTanh$|^CreateTransposeMatrix$|^CreateUnaryIntrinsic$|^CreateVectorTimesMatrix$|^CreateWrite.*Output$|^Serialize$|^Merge$|^Destroy$|^ConvertColorBufferFormatToExportFormat$|^BuildShaderModule$|^BuildGraphicsPipeline$|^BuildComputePipeline$|^IsVertexFormatSupported$|^DumpSpirvBinary$|^BeginPipelineDump$|^EndPipelineDump$|^DumpPipelineBinary$|^DumpPipelineExtraInfo$|^GetShaderHash$|^GetPipelineHash$|^GetPipelineName$|^CreateShaderCache$|^ReadFromBuffer$|^GetSectionIndex$|^GetSymbolsBySectionIndex$|^GetSectionData$' }
+  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: 'EnableOuts|EnableErrs' }
   - { key: readability-identifier-naming.FunctionCase, value: camelBack }
   - { key: readability-identifier-naming.TypeCase, value: CamelCase }
   - { key: readability-identifier-naming.TypeRemovePrefixes, value: PFN_ }

--- a/.github/workflows/check-clang-tidy-llpc.yml
+++ b/.github/workflows/check-clang-tidy-llpc.yml
@@ -1,0 +1,28 @@
+name: Code style check
+
+on:
+  pull_request:
+
+jobs:
+  clang-tidy:
+    name: clang-tidy
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout LLPC
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY}.git .
+          git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
+          git checkout ${GITHUB_SHA}
+      - name: Generate Docker base image tag string
+        run: |
+          echo "IMAGE_TAG=gcr.io/stadia-open-source/amdvlk_release_clang_on:nightly" | tee -a $GITHUB_ENV
+      - name: Fetch the latest prebuilt AMDVLK
+        run: docker pull "$IMAGE_TAG"
+      - name: Build and Test with Docker
+        run: docker build . --file docker/llpc-clang-tidy.Dockerfile
+                            --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
+                            --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
+                            --build-arg LLPC_REPO_REF="${GITHUB_REF}"
+                            --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"
+                            --build-arg LLPC_BASE_REF="${{ github.base_ref }}"
+                            --tag llpc/ci-shaderdb

--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -36,7 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && export TZ=America/New_York \
     && apt-get update \
     && TOOLCHAIN_PACKAGES="gcc g++ binutils-gold" \
     && if echo "$FEATURES" | grep -q "+clang" ; then \
-         TOOLCHAIN_PACKAGES="clang-9 libclang-common-9-dev lld-9"; \
+         TOOLCHAIN_PACKAGES="clang-9 libclang-common-9-dev lld-9 clang-tidy-10"; \
        fi \
     && apt-get install -yqq --no-install-recommends \
        build-essential pkg-config ninja-build \
@@ -66,6 +66,9 @@ RUN wget -P /usr/bin/ https://storage.googleapis.com/git-repo-downloads/repo \
     && touch ./env.sh \
     && cd /vulkandriver/drivers/spvgen/external \
     && python3 fetch_external_sources.py
+
+# Copy update script into container
+COPY docker/update-llpc.sh /vulkandriver/
 
 # Build LLPC.
 WORKDIR /vulkandriver/builds/ci-build

--- a/docker/llpc-clang-tidy.Dockerfile
+++ b/docker/llpc-clang-tidy.Dockerfile
@@ -1,0 +1,64 @@
+#
+# Dockerfile for LLPC Continuous Integration.
+# Sample invocation:
+#    docker build . --file docker/llpc-clang-tidy.Dockerfile                                  \
+#                   --build-arg AMDVLK_IMAGE=gcr.io/stadia-open-source/amdvlk:nightly         \
+#                   --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                           \
+#                   --build-arg LLPC_REPO_REF=<GIT_REF>                                       \
+#                   --build-arg LLPC_REPO_SHA=<GIT_SHA>                                       \
+#                   --build-arg LLPC_BASE_REF=<GIT_REF>                                       \
+#                   --tag llpc-ci/llpc
+#
+# Required arguments:
+# - AMDVLK_IMAGE: Base image name for prebuilt amdvlk
+# - LLPC_REPO_NAME: Name of the llpc repository to clone
+# - LLPC_REPO_REF: ref name to checkout
+# - LLPC_REPO_SHA: SHA of the commit to checkout
+# - LLPC_BASE_REF: ref name for the base of the tested change
+#
+
+# Resume build from the specified image.
+ARG AMDVLK_IMAGE
+FROM "$AMDVLK_IMAGE"
+
+ARG LLPC_REPO_NAME
+ARG LLPC_REPO_REF
+ARG LLPC_REPO_SHA
+ARG LLPC_BASE_REF
+
+# Use bash instead of sh in this docker file.
+SHELL ["/bin/bash", "-c"]
+
+# TODO Remove once the base image is rebuilt
+RUN export DEBIAN_FRONTEND=noninteractive && export TZ=America/New_York \
+    && apt-get update \
+    && apt-get install -yqq --no-install-recommends clang-tidy-10
+COPY docker/update-llpc.sh /vulkandriver/
+
+RUN /vulkandriver/update-llpc.sh
+RUN git -C /vulkandriver/drivers/llpc fetch origin "$LLPC_BASE_REF" --update-head-ok
+
+# Run CMake.
+WORKDIR /vulkandriver/builds/ci-build
+RUN source /vulkandriver/env.sh \
+    && cmake .
+
+# Run clang-tidy. Detect failures by searching for a colon. An empty line or "No relevant changes found." signals success.
+WORKDIR /vulkandriver/drivers/llpc
+RUN ln -s /vulkandriver/builds/ci-build/compile_commands.json \
+    && git diff "origin/$LLPC_BASE_REF" -U0 | /vulkandriver/drivers/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py \
+        -p1 -j$(nproc) >not-tidy.diff \
+    && if ! grep -q : not-tidy.diff ; then \
+        echo "Clean code. Success."; \
+    else \
+        echo "Code not tidy."; \
+        echo "Please run clang-tidy-diff on your changes and push again:"; \
+        echo "    git diff origin/$LLPC_BASE_REF -U0 --no-color | ../llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -p1 -fix"; \
+        echo ""; \
+        echo "To disable a lint, add `// NOLINT` at the end of the line."; \
+        echo ""; \
+        echo "Diff:"; \
+        cat not-tidy.diff; \
+        echo ""; \
+        exit 3; \
+    fi

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -26,12 +26,10 @@ ARG LLPC_REPO_SHA
 # Use bash instead of sh in this docker file.
 SHELL ["/bin/bash", "-c"]
 
+COPY docker/update-llpc.sh /vulkandriver/
+
 # Sync the repos. Replace the base LLPC with a freshly checked-out one.
-RUN cat /vulkandriver/build_info.txt \
-    && (cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc)) \
-    && git -C /vulkandriver/drivers/llpc remote add origin https://github.com/"$LLPC_REPO_NAME".git \
-    && git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" --update-head-ok \
-    && git -C /vulkandriver/drivers/llpc checkout "$LLPC_REPO_SHA"
+RUN /vulkandriver/update-llpc.sh
 
 # Build LLPC.
 WORKDIR /vulkandriver/builds/ci-build

--- a/docker/update-llpc.sh
+++ b/docker/update-llpc.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Update the driver and clone a specified version of LLPC.
+# Shared code between docker containers.
+set -e
+
+# Sync the repos. Replace the base LLPC with a freshly checked-out one.
+cat /vulkandriver/build_info.txt
+(cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc))
+git -C /vulkandriver/drivers/llpc remote add origin https://github.com/"$LLPC_REPO_NAME".git
+git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" --update-head-ok
+git -C /vulkandriver/drivers/llpc checkout "$LLPC_REPO_SHA"


### PR DESCRIPTION
Run clang-tidy-diff on pull-requests.

Two of the clang-tidy warnings that are enabled cause some warnings on
the current code. If we want to disable them instead, I'll change that.

Using `if () return; else ...` creates a warning:
```
llpc/lower/llpcSpirvLowerGlobal.cpp:1405:7: warning: do not use 'else' after 'return' [llvm-else-after-return]
    } else {
      ^~~~~~
```

Using `#pragma once` instead of header guards creates a warning:
```
llpc/tool/amdllpc.h:1:1: warning: header is missing header guard [llvm-header-guard]
/*
^
```

I disabled one warning that is enabled in LLVM: llvm-qualified-auto
It would suggest to use `const auto*` instead of only `auto` if
possible.

The ignore-options in the clang tidy configuration are only understood
by clang-tidy >= 13.0. The docker containers have clang-tidy 10.0, so
there will be a few false positives.