### PR TITLE
Refine SPIRVToLLVMDbgTran code

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -59,7 +59,7 @@ namespace SPIRV {
 
 SPIRVToLLVMDbgTran::SPIRVToLLVMDbgTran(SPIRVModule *TBM, Module *TM, SPIRVToLLVM *Reader)
     : BM(TBM), M(TM), Builder(*M), SPIRVReader(Reader) {
-  Enable = BM->hasDebugInfo() && !llvm::cl::TrimDebugInfo;
+  Enable = BM->hasDebugInfo() && !cl::TrimDebugInfo;
 }
 
 void SPIRVToLLVMDbgTran::createCompilationUnit() {

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -49,11 +49,17 @@
 using namespace std;
 using namespace SPIRVDebug::Operand;
 
+namespace llvm {
+namespace cl {
+extern opt<bool> TrimDebugInfo;
+} // namespace cl
+} // namespace llvm
+
 namespace SPIRV {
 
 SPIRVToLLVMDbgTran::SPIRVToLLVMDbgTran(SPIRVModule *TBM, Module *TM, SPIRVToLLVM *Reader)
     : BM(TBM), M(TM), Builder(*M), SPIRVReader(Reader) {
-  Enable = BM->hasDebugInfo();
+  Enable = BM->hasDebugInfo() && !llvm::cl::TrimDebugInfo;
 }
 
 void SPIRVToLLVMDbgTran::createCompilationUnit() {

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -141,9 +141,10 @@ public:
     return SrcLang;
   }
 
-   SPIRVString *getSourceFile(uint32_t FileId) const override {
-    return SrcFiles.size() == 0 ? nullptr : get<SPIRVString>(SrcFiles[FileId]);
+  SPIRVString *getSourceFile(uint32_t FileId) const override {
+    return SrcFiles.size() > FileId ? get<SPIRVString>(SrcFiles[FileId]) : nullptr;
   }
+
   std::set<std::string> &getSourceExtension() override { return SrcExtension; }
   virtual SPIRVEntryPoint* getEntryPoint(SPIRVId) const override;
   virtual SPIRVEntryPoint*

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -141,7 +141,9 @@ public:
     return SrcLang;
   }
 
-  SPIRVString *getSourceFile(uint32_t FileId) const override { return get<SPIRVString>(SrcFiles[FileId]); }
+   SPIRVString *getSourceFile(uint32_t FileId) const override {
+    return SrcFiles.size() == 0 ? nullptr : get<SPIRVString>(SrcFiles[FileId]);
+  }
   std::set<std::string> &getSourceExtension() override { return SrcExtension; }
   virtual SPIRVEntryPoint* getEntryPoint(SPIRVId) const override;
   virtual SPIRVEntryPoint*


### PR DESCRIPTION
1. The pal does not support elf with debug section, so be careful not to
generate the dbg section when spirv has OpLine ops.
2. Add check to getSourceFile function