### PR TITLE
Add new option enableUberFetchShader

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 48
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -71,6 +71,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     48.1 | Added enableUberFetchShader to GraphicsPipelineBuildInfo                                              |
 //  |     48.0 | Removed the member 'polygonMode' of rsState                                                           |
 //  |     47.0 | Always get culling controls from primitive shader table                                               |
 //  |     46.3 | Added enableInterpModePatch to PipelineOptions                                                        |
@@ -127,7 +128,10 @@ namespace Vkgc {
 
 static const unsigned Version = LLPC_INTERFACE_MAJOR_VERSION;
 static const unsigned InternalDescriptorSetId = static_cast<unsigned>(-1);
+static const unsigned MaxVertexAttribs = 64;
 static const unsigned MaxColorTargets = 8;
+static const unsigned FetchShaderInternalBufferBinding = 4;
+static const unsigned MaxFetchShaderInternalBufferSize = 16 * MaxVertexAttribs;
 
 // Forward declarations
 class IShaderCache;
@@ -757,6 +761,7 @@ struct GraphicsPipelineBuildInfo {
   PipelineOptions options;  ///< Per pipeline tuning/debugging options
   bool unlinked;            ///< True to build an "unlinked" half-pipeline ELF
   bool dynamicVertexStride; ///< Dynamic Vertex input Stride is enabled.
+  bool enableUberFetchShader; ///< Use uber fetch shader
 };
 
 /// Represents info to build a compute pipeline.

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2000,7 +2000,8 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
 
     // Update vertex input state
     if (stage == ShaderStageVertex)
-      PipelineDumper::updateHashForVertexInputState(pipelineInfo->pVertexInput, &hasher);
+      PipelineDumper::updateHashForVertexInputState(pipelineInfo->pVertexInput, pipelineInfo->dynamicVertexStride,
+                                                    &hasher);
 
     MetroHash::Hash hash = {};
     hasher.Finalize(hash.bytes);

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -82,7 +82,7 @@ public:
                                                MetroHash64 *hasher, bool isRelocatableShader);
 
   static void updateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo *vertexInput,
-                                            MetroHash64 *hasher);
+                                            bool dynamicVertexStride, MetroHash64 *hasher);
 
   // Update hash for map object
   template <class MapType> static void updateHashForMap(MapType &m, MetroHash64 *hasher) {

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -534,6 +534,7 @@ struct GraphicsPipelineState {
 
   ColorBuffer colorBuffer[Vkgc::MaxColorTargets]; // Color target state.
   bool dynamicVertexStride; // Dynamic Vertex input Stride is enabled.
+  bool enableUberFetchShader; // Use uber fetch shader
 };
 
 // =====================================================================================================================

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -143,6 +143,8 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
 
     gfxPipelineInfo->options = graphicState.options;
     gfxPipelineInfo->nggState = graphicState.nggState;
+    gfxPipelineInfo->dynamicVertexStride = graphicState.dynamicVertexStride;
+    gfxPipelineInfo->enableUberFetchShader = graphicState.enableUberFetchShader;
   }
 
   // Section "ComputePipelineState"
@@ -246,6 +248,12 @@ bool PipelineDocument::validate() {
       }
     }
   }
+
+  if (stageMask == 0) {
+    PARSE_ERROR(m_errorMsg, 0, "No Shader source section in pipeline!\n");
+    return false;
+  }
+
   const unsigned graphicsStageMask =
       ((1 << SpvGenStageVertex) | (1 << SpvGenStageTessControl) | (1 << SpvGenStageTessEvaluation) |
        (1 << SpvGenStageGeometry) | (1 << SpvGenStageFragment));

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -454,6 +454,7 @@ public:
                                    Vkgc::MaxColorTargets, true);
 
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableUberFetchShader, MemberTypeBool, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -469,7 +470,7 @@ public:
 
 private:
   SectionNggState m_nggState;
-  static const unsigned MemberCount = 25;
+  static const unsigned MemberCount = 26;
   static StrToMemberAddr m_addrTable[MemberCount];
   SubState m_state;
   SectionColorBuffer m_colorBuffer[Vkgc::MaxColorTargets]; // Color buffer


### PR DESCRIPTION
1. Add new option enableUberFetchShader to support uber fetch shder in the furture
2. Support dump new option in VFX
3. When this option is enabled, vertex input isn't inlcuded in hash calculation, just like isRelocatableShader
4. Exclude stride info in hash when dynamic vertex stride is enabled.