### PR TITLE
Modify and add new pipeline shader option

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -608,6 +608,9 @@ struct PipelineShaderOptions {
 
   /// Threshold to use for loops with "DontUnroll" hint (0 = use llvm.llop.unroll.disable).
   unsigned dontUnrollHintThreshold;
+
+  ///< Whether fastmath contract could be disabled
+  bool useNoContract;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -610,7 +610,7 @@ struct PipelineShaderOptions {
   unsigned dontUnrollHintThreshold;
 
   ///< Whether fastmath contract could be disabled
-  bool useNoContract;
+  bool noContract;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor


### PR DESCRIPTION
1. Refactor SPIRVGenFastMath option to enable more fastmathflag setting
   through -spirv-gen-fast-math in llpcOptions
2. Add new shader pipeline option to disable contract fastmath flag for
   the dot product

Fastmath contract flag could generate v_fma_f32 in the dot product
function.

fma in the dot function somehow has some errors.

v1:-0.499996 -0.374997 -0.999991, v1:0.110096 -0.110096 -0.013762

dot(v0,v1)

before:
c++: 0x31000000    float:1.86265e-09
llpc:   0xAFB54C20   float:-3.29778e-10

after:
llpc:   0x31000000    float:1.86265e-09

sp3 code:
before:
v_mul_f32 v2, v6, v2
v_fma_f32 v0, v4, v0, v2
v_fma_f32 v0, v8, v10, v0

after:
v_mul_f32 v0, v4, v0
v_mul_f32 v2, v6, v2
v_mul_f32 v4, v8, v10
v_add_f32 v0, v0, v2
v_add_f32 v0, v4, v0