### PR TITLE
Add unit testing support for LLPC and LGC

### DIFF
--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -108,8 +108,8 @@ RUN EXTRA_FLAGS="" \
 
 # Run the lit test suite.
 RUN source /vulkandriver/env.sh \
-    && cmake --build . --target check-amdllpc -- -v \
-    && cmake --build . --target check-lgc -- -v
+    && cmake --build . --target check-amdllpc check-amdllpc-units -- -v \
+    && cmake --build . --target check-lgc check-lgc-units -- -v
 
 # Save build info to /vulkandriver/build_info.txt.
 RUN cd /vulkandriver \

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -42,5 +42,5 @@ RUN source /vulkandriver/env.sh \
 
 # Run the lit test suite.
 RUN source /vulkandriver/env.sh \
-    && cmake --build . --target check-amdllpc -- -v \
-    && cmake --build . --target check-lgc -- -v
+    && cmake --build . --target check-amdllpc check-amdllpc-units -- -v \
+    && cmake --build . --target check-lgc check-lgc-units -- -v

--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -189,3 +189,4 @@ target_sources(LLVMlgc PRIVATE
 add_subdirectory(disassembler)
 add_subdirectory(tool/lgc)
 add_subdirectory(test)
+add_subdirectory(unittests)

--- a/lgc/unittests/CMakeLists.txt
+++ b/lgc/unittests/CMakeLists.txt
@@ -1,0 +1,57 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+# LGC Unit tests.
+# To execute all LLPC unit tests, run:
+#   cmake --build . --target check-lgc-units
+
+add_custom_target(LgcUnitTests)
+set_target_properties(LgcUnitTests PROPERTIES FOLDER "LGC Tests")
+
+function(add_lgc_unittest test_dirname)
+  add_unittest(LgcUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
+add_subdirectory(interface)
+
+# Add a LIT target to execute all unit tests.
+# Required by lit.site.cfg.py.in.
+set(LGC_UNIT_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(LGC_UNIT_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+# Main config for unit tests.
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+add_lit_testsuite(check-lgc-units "Running the LGC unit tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${exclude_from_check_all}
+  DEPENDS
+    LgcUnitTests
+)

--- a/lgc/unittests/interface/CMakeLists.txt
+++ b/lgc/unittests/interface/CMakeLists.txt
@@ -1,0 +1,32 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+add_lgc_unittest(LgcUtilTests
+  PlaceholderTest.cpp
+)
+
+target_link_libraries(LgcUtilTests PRIVATE
+  LLVMlgc
+)

--- a/lgc/unittests/interface/PlaceholderTest.cpp
+++ b/lgc/unittests/interface/PlaceholderTest.cpp
@@ -1,0 +1,37 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "lgc/CommonDefs.h"
+#include "gmock/gmock.h"
+#include <climits>
+
+TEST(LgcInterfaceTests, PlaceholderPass) {
+  EXPECT_TRUE(true);
+}
+
+// Minimal test to ensure we can access LGC headers.
+TEST(LgcInterfaceTests, HashSize) {
+  EXPECT_EQ(sizeof(lgc::Hash128) * CHAR_BIT, 128u);
+}

--- a/lgc/unittests/lit.cfg.py
+++ b/lgc/unittests/lit.cfg.py
@@ -1,0 +1,60 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+# Configuration file for the 'lit' test runner for lgc unit tests. Based on the MLIR unit test config.
+import os
+
+import lit.formats
+
+# name: The name of this test suite.
+config.name = 'LLPC_Unit'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = config.lgc_unit_test_binary_dir
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'Tests')
+
+# Propagate the temp directory. Windows requires this because it uses \Windows\
+# if none of these are present.
+if 'TMP' in os.environ:
+    config.environment['TMP'] = os.environ['TMP']
+if 'TEMP' in os.environ:
+    config.environment['TEMP'] = os.environ['TEMP']
+
+# Propagate HOME as it can be used to override incorrect homedir in passwd
+# that causes the tests to fail.
+if 'HOME' in os.environ:
+    config.environment['HOME'] = os.environ['HOME']
+
+# Propagate path to symbolizer for ASan/MSan.
+for symbolizer in ['ASAN_SYMBOLIZER_PATH', 'MSAN_SYMBOLIZER_PATH']:
+    if symbolizer in os.environ:
+        config.environment[symbolizer] = os.environ[symbolizer]

--- a/lgc/unittests/lit.site.cfg.py.in
+++ b/lgc/unittests/lit.site.cfg.py.in
@@ -1,0 +1,22 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_BUILD_MAIN_SRC_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.lgc_unit_test_binary_dir = "@LGC_UNIT_TEST_BINARY_DIR@"
+
+# Support substitution of the tools and libs dirs with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@LGC_UNIT_TEST_SOURCE_DIR@/lit.cfg.py")

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -321,7 +321,6 @@ PRIVATE
     ${PROJECT_SOURCE_DIR}/builder
     ${PROJECT_SOURCE_DIR}/context
     ${PROJECT_SOURCE_DIR}/../imported/spirv
-    ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/lower
     ${PROJECT_SOURCE_DIR}/patch
@@ -354,8 +353,11 @@ target_link_libraries(amdllpc PRIVATE cwpack)
 endif()
 ### Add Subdirectories #################################################################################################
 if(ICD_BUILD_LLPC)
-# Lit tests
-if(LLPC_BUILD_LIT)
-    add_subdirectory(test)
-endif()
+    if(LLPC_BUILD_TESTS OR LLPC_BUILD_LIT)
+        # Unit tests.
+        add_subdirectory(unittests)
+
+        # Lit tests.
+        add_subdirectory(test)
+    endif()
 endif()

--- a/llpc/unittests/CMakeLists.txt
+++ b/llpc/unittests/CMakeLists.txt
@@ -1,0 +1,96 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+# LLPC Unit tests.
+# To execute all LLPC unit tests, run:
+#   cmake --build . --target check-llpc-units
+
+add_custom_target(LlpcUnitTests)
+set_target_properties(LlpcUnitTests PROPERTIES FOLDER "LLPC Tests")
+
+list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm")
+include(LLVMConfig)
+
+# Required to use LIT on Windows.
+find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
+  COMPONENTS Interpreter)
+
+# Find all the LLVM libraries necessary to use the LLVM components in gtest/gmock.
+set(LLVM_GTEST_LIBS gtest gtest_main)
+if(LLVM_PTHREAD_LIB)
+  list(APPEND LLVM_GTEST_LIBS pthread)
+endif()
+
+# Based on add_unittest in llvm/cmake/modules/AddLLVM.cmake. Note that because LLPC is not an
+# (internal) LLVM project in the CMake sense, we cannot use the LLVM implementation here.
+function(llpc_add_unittest_impl test_suite test_name)
+  add_executable(${test_name})
+  add_dependencies(${test_suite} ${test_name})
+  target_sources(${test_name} PRIVATE ${ARGN})
+
+  set(outdir ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR})
+  set_output_directory(${test_name} BINARY_DIR ${outdir} LIBRARY_DIR ${outdir})
+
+  target_link_libraries(${test_name} PRIVATE ${LLVM_GTEST_LIBS})
+  target_compile_definitions(${test_name} PRIVATE
+    ${LLVM_DEFINITIONS}
+    LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION}  # Required by vkgcDefs.h.
+  )
+  target_include_directories(${test_name} PRIVATE
+    ${XGL_LLVM_SRC_PATH}/include
+    ${LLVM_INCLUDE_DIRS}  # This is necessary to discover the auto-generated llvm-config.h header.
+  )
+
+  get_target_property(test_suite_folder ${test_suite} FOLDER)
+  if(test_suite_folder)
+    set_property(TARGET ${test_name} PROPERTY FOLDER "${test_suite_folder}")
+  endif()
+endfunction()
+
+function(add_llpc_unittest test_dirname)
+  llpc_add_unittest_impl(LlpcUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
+add_subdirectory(util)
+
+# Add a LIT target to execute all unit tests.
+# Required by lit.site.cfg.py.in.
+set(AMDLLPC_UNIT_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+# Required by configure_lit_site_cfg.
+set(LLVM_LIT_OUTPUT_DIR ${LLVM_TOOLS_BINARY_DIR})
+
+# Main config for unit tests.
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+add_lit_testsuite(check-amdllpc-units "Running the AMDLLPC unit tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS
+    LlpcUnitTests
+)

--- a/llpc/unittests/lit.cfg.py
+++ b/llpc/unittests/lit.cfg.py
@@ -1,0 +1,60 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+# Configuration file for the 'lit' test runner for llpc unit tests. Based on the MLIR unit test config.
+import os
+
+import lit.formats
+
+# name: The name of this test suite.
+config.name = 'LLPC_Unit'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.amdllpc_dir, 'unittests')
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'Tests')
+
+# Propagate the temp directory. Windows requires this because it uses \Windows\
+# if none of these are present.
+if 'TMP' in os.environ:
+    config.environment['TMP'] = os.environ['TMP']
+if 'TEMP' in os.environ:
+    config.environment['TEMP'] = os.environ['TEMP']
+
+# Propagate HOME as it can be used to override incorrect homedir in passwd
+# that causes the tests to fail.
+if 'HOME' in os.environ:
+    config.environment['HOME'] = os.environ['HOME']
+
+# Propagate path to symbolizer for ASan/MSan.
+for symbolizer in ['ASAN_SYMBOLIZER_PATH', 'MSAN_SYMBOLIZER_PATH']:
+    if symbolizer in os.environ:
+        config.environment[symbolizer] = os.environ[symbolizer]

--- a/llpc/unittests/lit.site.cfg.py.in
+++ b/llpc/unittests/lit.site.cfg.py.in
@@ -1,0 +1,22 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_BUILD_MAIN_SRC_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.amdllpc_dir = "@AMDLLPC_DIR@"
+
+# Support substitution of the tools and libs dirs with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@AMDLLPC_UNIT_TEST_SOURCE_DIR@/lit.cfg.py")

--- a/llpc/unittests/util/CMakeLists.txt
+++ b/llpc/unittests/util/CMakeLists.txt
@@ -1,0 +1,32 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+add_llpc_unittest(LlpcUtilTests
+  PlaceholderTest.cpp
+)
+
+target_link_libraries(LlpcUtilTests PRIVATE
+  llpc
+)

--- a/llpc/unittests/util/PlaceholderTest.cpp
+++ b/llpc/unittests/util/PlaceholderTest.cpp
@@ -1,0 +1,37 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "llpc.h"
+#include "llvm/ADT/StringRef.h"
+#include "gmock/gmock.h"
+
+TEST(LlpcUtilTests, PlaceholderPass) {
+  EXPECT_TRUE(true);
+}
+
+// Minimal test to ensure that we can access LLPC and LLVM headers.
+TEST(LlpcUtilTests, VkIcdName) {
+  EXPECT_EQ(Llpc::VkIcdName, llvm::StringRef("amdvlk"));
+}


### PR DESCRIPTION
Units tests follow the LLVM conventions:
- Are in new `unittests` project directories
- Use the LLVM's copy of `gtest` and `gmock`
- Can be run through a Lit target with `ninja check-*-units`

Units tests are not built by default and require a CMake configuration
flag, like LIT tests. Temporarily, they can be enabled with both
`LLPC_BUILD_LIT` and `LLPC_BUILT_TESTS`, but I propose to deprecate
the former once and update the XGL's CMake to use the new flag.

This also updates the CI scripts to run the unit tests.

For now, I only added two placeholder tests that make sure we can
build and run the new test targets, and that they can access the
LLPC/LGC code.