### PR TITLE
Fix some remaining issues when we remove 'depthBiasEnable' from rsState

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -741,14 +741,16 @@ struct GraphicsPipelineBuildInfo {
                                   ///  with this pipeline.
     uint8_t usrClipPlaneMask;     ///< Mask to indicate the enabled user defined clip planes
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 48
-    VkPolygonMode polygonMode;    ///< Triangle rendering mode
+    VkPolygonMode polygonMode; ///< Triangle rendering mode
 #endif
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 47
     VkCullModeFlags cullMode; ///< Fragment culling mode
     VkFrontFace frontFace;    ///< Front-facing triangle orientation
 #endif
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
     bool depthBiasEnable; ///< Whether to bias fragment depth values
-  } rsState;              ///< Rasterizer State
+#endif
+  } rsState; ///< Rasterizer State
 
   struct {
     bool alphaToCoverageEnable; ///< Enable alpha to coverage

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -378,9 +378,6 @@ struct RasterizerState {
                                     //  matches the sample pattern used by the rasterizer when rendering
                                     //  with this pipeline.
   unsigned usrClipPlaneMask;        // Mask to indicate the enabled user defined clip planes
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
-  unsigned depthBiasEnable; // Whether to bias fragment depth values
-#endif
 };
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -670,9 +670,6 @@ void PipelineContext::setGraphicsStateInPipeline(Pipeline *pipeline) const {
   rasterizerState.numSamples = inputRsState.numSamples;
   rasterizerState.samplePatternIdx = inputRsState.samplePatternIdx;
   rasterizerState.usrClipPlaneMask = inputRsState.usrClipPlaneMask;
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 46
-  rasterizerState.depthBiasEnable = inputRsState.depthBiasEnable;
-#endif
 
   pipeline->setGraphicsState(inputAssemblyState, rasterizerState);
 }


### PR DESCRIPTION
LGC should completely remove it and we should gate this with LLPC
interface version in vkgcDefs.h.

Change-Id: I8a2f30499b0393057e1068ecd992188bec85e305