### PR TITLE
Update test PipelineVsFs_MultiTableDescSet

### DIFF
--- a/llpc/test/shaderdb/avoid/PipelineVsFs_MultiTableDescSet.pipe
+++ b/llpc/test/shaderdb/avoid/PipelineVsFs_MultiTableDescSet.pipe
@@ -9,21 +9,23 @@
 ; The low half should come from the user data node at offet 0. The 0 offset if
 ; found in the PAL metadata.
 ; SHADERTEST-LABEL: _amdgpu_vs_main:
-; SHADERTEST: s_getpc_b64 s{{\[}}[[VS_PC:[0-9]*]]:{{[0-9]*}}]
-; SHADERTEST: s_mov_b64 s{{\[}}[[T0_ADDR:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[VS_PC]]:{{[0-9]*}}]
-; SHADERTEST: s_mov_b32 s[[T0_ADDR]], s[[table0:[0-9]*]]
-; SHADERTEST: s_load_dwordx4 s{{\[}}[[T0_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T0_ADDR]]:{{[0-9]*}}], 0x0
+; SHADERTEST: s_getpc_b64 s{{\[}}[[VS_PC_LO:[0-9]*]]:[[VS_PC_HI:[0-9]*]]]
+; SHADERTEST: s_mov_b32
+; SHADERTEST: s_mov_b32
+; SHADERTEST: s_load_dwordx4
+; SHADERTEST: s_mov_b32 s[[TO_ADDR_HI:[0-9]*]], s[[VS_PC_HI]]
+; SHADERTEST: s_load_dwordx4 s{{\[}}[[T0_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[table0:[0-9]*]]:[[TO_ADDR_HI]]], 0x0
 ; SHADERTEST: s_buffer_load_dwordx16 s[0:15], s{{\[}}[[T0_DESC]]:{{[0-9]*}}], 0x0
 ; Now check that the image sample in the pixel shader uses the correct
 ; descriptors.  The high half of the descriptor load should come from the PC.
 ; The low half should come from the user data node at offet 1 and 2.
 ; SHADERTEST-LABEL: _amdgpu_ps_main:
-; SHADERTEST: s_getpc_b64 s{{\[}}[[T1_ADDR:[0-9]*]]:{{[0-9]*}}]
-; SHADERTEST: s_mov_b64 s{{\[}}[[T2_ADDR:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T1_ADDR]]:{{[0-9]*}}]
-; SHADERTEST: s_mov_b32 s[[T2_ADDR]], s[[table2:[0-9]*]]
-; SHADERTEST: s_mov_b32 s[[T1_ADDR]], s[[table1:[0-9]*]]
-; SHADERTEST: s_load_dwordx8 s{{\[}}[[T1_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T1_ADDR]]:{{[0-9]*}}], 0x0
-; SHADERTEST: s_load_dwordx4 s{{\[}}[[T2_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T2_ADDR]]:{{[0-9]*}}], 0x0
+; SHADERTEST: s_getpc_b64 s{{\[}}[[VS_PC_LO:[0-9]*]]:[[VS_PC_HI:[0-9]*]]]
+; SHADERTEST: s_mov_b32 s[[T2_ADDR_LO:[0-9]*]], s[[table2:[0-9]*]]
+; SHADERTEST: s_mov_b32 s[[T2_ADDR_HI:[0-9]*]], s[[VS_PC_HI]]
+; SHADERTEST: s_mov_b32 s[[T1_ADDR_HI:[0-9]*]], s[[VS_PC_HI]]
+; SHADERTEST: s_load_dwordx8 s{{\[}}[[T1_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[table1:[0-9]*]]:[[T1_ADDR_HI]]], 0x0
+; SHADERTEST: s_load_dwordx4 s{{\[}}[[T2_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T2_ADDR_LO]]:[[T2_ADDR_HI]]], 0x0
 ; SHADERTEST: image_sample v[{{[0-9]*:[0-9]*}}], v[{{[0-9]*:[0-9]*}}], s{{\[}}[[T1_DESC]]:{{[0-9]*}}], s{{\[}}[[T2_DESC]]:{{[0-9]*}}]
 ; SHADERTEST-LABEL: PalMetadata
 ; SHADERTEST-LABEL: .registers:


### PR DESCRIPTION
Update test and temporarily disable it.

An upcoming merge from upstream significantly changes the generated
code which is being matched in the tests. In similar situations we
usually extend tests to accept both versions, but this one is tricky,
due to the chains of instructions being changed.

The updated test can be re-enabled after the LLVM code is updated.