### PR TITLE
Fix unsafe use ArrayRef in CreateIntegerDotProduct

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -144,7 +144,7 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
     if (isDot4) {
       if (compCount < 4) {
         // Extend <3xi8> or <2xi8> to <4xi8>
-        ArrayRef<int> indices = compCount == 3 ? ArrayRef<int>({0, 1, 2, 3}) : ArrayRef<int>({0, 1, 2, 2});
+        std::array<int, 4> indices = {0, 1, 2, 3};
         input1 = CreateShuffleVector(input1, Constant::getNullValue(inputTy), indices);
         input2 = CreateShuffleVector(input2, Constant::getNullValue(inputTy), indices);
       }
@@ -159,8 +159,8 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
         scalar = CreateIntrinsic(intrinsicDot2, {}, {input1, input2, accumulator, clamp}, nullptr, instName);
       } else {
         Value *intermediateRes = getInt32(0);
-        auto indices = ArrayRef<int>({0, 1});
         scalar = getInt32(0);
+        std::array<int, 2> indices = {0, 1};
         if (compCount == 3) {
           // Split <3xi16> up with an integer multiplication, a 16-bit integer dot product
           Value *w1 = CreateExtractElement(input1, 2);
@@ -181,7 +181,8 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
           intermediateRes =
               CreateIntrinsic(intrinsicDot2, {}, {vec1, vec2, getInt32(0), getInt1(false)}, nullptr, instName);
 
-          indices = ArrayRef<int>({2, 3});
+          indices[0] = 2;
+          indices[1] = 3;
           input1 = CreateShuffleVector(input1, Constant::getNullValue(inputTy), indices);
           input2 = CreateShuffleVector(input2, Constant::getNullValue(inputTy), indices);
           scalar =


### PR DESCRIPTION
Store a llvm::ArrayRef object is not safe and it causes some crash in
related cts tests in release mode.