### PR TITLE
Improve type translation caching

### DIFF
--- a/llpc/test/shaderdb/OpAccessChain_TestBlockVectorExtract_lit.frag
+++ b/llpc/test/shaderdb/OpAccessChain_TestBlockVectorExtract_lit.frag
@@ -37,15 +37,15 @@ void main()
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 
-; SHADERTEST: %llpc.matrix.column = type <{ [3 x float], [4 x i8] }>
-; SHADERTEST: %llpc.matrix.column.2 = type <{ [4 x double] }>
+; SHADERTEST: %[[COLUMN1:.*]] = type <{ [3 x float], [4 x i8] }>
+; SHADERTEST: %[[COLUMN2:.*]] = type <{ [4 x double] }>
 
-; SHADERTEST: getelementptr inbounds (<{ [3 x float], [4 x i8], [2 x %llpc.matrix.column] }>, <{ [3 x float], [4 x i8], [2 x %llpc.matrix.column] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 0, i32 1
-; SHADERTEST: getelementptr <{ [3 x float], [4 x i8], [2 x %llpc.matrix.column] }>, <{ [3 x float], [4 x i8], [2 x %llpc.matrix.column] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 2, i32 1, i32 0, i32 %{{[0-9]*}}
-; SHADERTEST: getelementptr <{ [3 x float], [4 x i8], [2 x %llpc.matrix.column] }>, <{ [3 x float], [4 x i8], [2 x %llpc.matrix.column] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 2, i32 %{{[0-9]*}}, i32 0, i32 1
-; SHADERTEST: getelementptr <{ [4 x double], [4 x %llpc.matrix.column.2] }>, <{ [4 x double], [4 x %llpc.matrix.column.2] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 0, i32 %{{[0-9]*}}
-; SHADERTEST: getelementptr inbounds (<{ [4 x double], [4 x %llpc.matrix.column.2] }>, <{ [4 x double], [4 x %llpc.matrix.column.2] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 1, i32 2, i32 0, i32 3
-; SHADERTEST: getelementptr <{ [4 x double], [4 x %llpc.matrix.column.2] }>, <{ [4 x double], [4 x %llpc.matrix.column.2] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 1, i32 %{{[0-9]*}}, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: getelementptr inbounds (<{ [3 x float], [4 x i8], [2 x %[[COLUMN1]]] }>, <{ [3 x float], [4 x i8], [2 x %[[COLUMN1]]] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 0, i32 1
+; SHADERTEST: getelementptr <{ [3 x float], [4 x i8], [2 x %[[COLUMN1]]] }>, <{ [3 x float], [4 x i8], [2 x %[[COLUMN1]]] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 2, i32 1, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: getelementptr <{ [3 x float], [4 x i8], [2 x %[[COLUMN1]]] }>, <{ [3 x float], [4 x i8], [2 x %[[COLUMN1]]] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 2, i32 %{{[0-9]*}}, i32 0, i32 1
+; SHADERTEST: getelementptr <{ [4 x double], [4 x %[[COLUMN2]]] }>, <{ [4 x double], [4 x %[[COLUMN2]]] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 0, i32 %{{[0-9]*}}
+; SHADERTEST: getelementptr inbounds (<{ [4 x double], [4 x %[[COLUMN2]]] }>, <{ [4 x double], [4 x %[[COLUMN2]]] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 1, i32 2, i32 0, i32 3
+; SHADERTEST: getelementptr <{ [4 x double], [4 x %[[COLUMN2]]] }>, <{ [4 x double], [4 x %[[COLUMN2]]] }> addrspace({{.*}})* @{{.*}}, i32 0, i32 1, i32 %{{[0-9]*}}, i32 0, i32 %{{[0-9]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -673,6 +673,18 @@ Type *SPIRVToLLVM::transTypeWithOpcode<OpTypeVector>(SPIRVType *const spvType, c
 
 Type *SPIRVToLLVM::transType(SPIRVType *t, unsigned matrixStride, bool columnMajor, bool parentIsPointer,
                              bool explicitlyLaidOut) {
+  SPIRVTypeContext ctx(t, matrixStride, columnMajor, parentIsPointer, explicitlyLaidOut);
+  auto it = m_fullTypeMap.find(ctx.asTuple());
+  if (it != m_fullTypeMap.end())
+    return it->second;
+
+  auto res = transTypeImpl(t, matrixStride, columnMajor, parentIsPointer, explicitlyLaidOut);
+  m_fullTypeMap[ctx.asTuple()] = res;
+  return res;
+}
+
+Type *SPIRVToLLVM::transTypeImpl(SPIRVType *t, unsigned matrixStride, bool columnMajor, bool parentIsPointer,
+                                 bool explicitlyLaidOut) {
   // If the type is not a sub-part of a pointer or it is a forward pointer, we can look in the map.
   if (!parentIsPointer || t->isTypeForwardPointer()) {
     auto loc = m_typeMap.find(t);


### PR DESCRIPTION
This patch adds higher-level SPIRV to LLVM type caching.

On a number of pipeliens from a real-world game, this reduces the number of type
translations from 149124 to 694, resulting in a compile time reduction of ~1.6%.