### PR TITLE
Missing include for cl.

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -45,6 +45,7 @@
 #include "SPIRVType.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace std;
 using namespace SPIRVDebug::Operand;


### PR DESCRIPTION
Currently, the compiler fails to build on:

gcc version 10.3.0 (Ubuntu 10.3.0-1ubuntu1~20.04)

For me. This is due to the following part:

```extern opt<bool> TrimDebugInfo;```

Here, my compiler doesn't recognize ```opt``` as a template, leading to failures when using it in this implementation file.
I think, the CommandLine.h gets included implicitly on different compilers, and that's why this error doesn't show up.
To fix this, the CommandLine.h header should be included explicitly.