### PR TITLE
Support pointer type as the user input/output

### DIFF
--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -636,6 +636,8 @@ void SpirvLowerGlobal::mapInputToProxy(GlobalVariable *input) {
 
   const auto &dataLayout = m_module->getDataLayout();
   Type *inputTy = input->getType()->getContainedType(0);
+  if (inputTy->isPointerTy())
+    inputTy = m_builder->getInt64Ty();
   Twine prefix = LlpcName::InputProxyPrefix;
   auto insertPos = m_entryPoint->begin()->getFirstInsertionPt();
 
@@ -674,6 +676,8 @@ void SpirvLowerGlobal::mapOutputToProxy(GlobalVariable *output) {
 
   const auto &dataLayout = m_module->getDataLayout();
   Type *outputTy = output->getType()->getContainedType(0);
+  if (outputTy->isPointerTy())
+    outputTy = m_builder->getInt64Ty();
   Twine prefix = LlpcName::OutputProxyPrefix;
 
   auto proxy = new AllocaInst(outputTy, dataLayout.getAllocaAddrSpace(), prefix + output->getName(), &*insertPos);
@@ -1117,6 +1121,9 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
       lgc::InOutInfo inOutInfo;
       if (!locOffset)
         locOffset = m_builder->getInt32(0);
+
+      if (inOutTy->isPointerTy())
+        inOutTy = m_builder->getInt64Ty();
 
       if (addrSpace == SPIRAS_Input) {
         if (m_shaderStage == ShaderStageFragment) {

--- a/llpc/test/shaderdb/PipelineVsFs_TestPointerInOut.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_TestPointerInOut.pipe
@@ -1,0 +1,167 @@
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: %{{[0-9]*}} = call i64 (...) @lgc.create.read.generic.input.i64(i32 1, i32 0, i32 0, i32 0, i32 0, i32 undef)
+; SHADERTEST: call void (...) @lgc.create.write.generic.output(i64 %{{[0-9]*}}, i32 1, i32 0, i32 0, i32 0, i32 0, i32 undef)
+; SHADERTEST: %{{[0-9]*}} = call i64 (...) @lgc.create.read.generic.input.i64(i32 1, i32 0, i32 0, i32 0, i32 17, i32 undef)
+; SHADERTEST: inttoptr i64 %{{[0-9]*}} to <{ [4294967295 x [4 x float]] }> addrspace(1)*
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+
+[Version]
+version = 3
+
+[VsSpirv]
+
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 33
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_KHR_physical_storage_buffer"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint Vertex %1 "main" %2 %3 %4 %gl_VertexIndex %6 %7
+               OpDecorate %_struct_8 Block
+               OpDecorate %gl_VertexIndex BuiltIn VertexIndex
+               OpDecorate %3 Location 0
+               OpDecorate %6 Location 1
+               OpDecorate %6 RestrictPointer
+               OpDecorate %7 RestrictPointer
+               OpDecorate %4 Location 0
+               OpDecorate %7 Location 1
+               OpMemberDecorate %_struct_8 0 BuiltIn Position
+               OpMemberDecorate %_struct_8 1 BuiltIn PointSize
+               OpMemberDecorate %_struct_8 2 BuiltIn ClipDistance
+               OpMemberDecorate %_struct_8 3 BuiltIn CullDistance
+               OpDecorate %_struct_9 Block
+               OpMemberDecorate %_struct_9 0 Offset 0
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+       %void = OpTypeVoid
+         %12 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+  %_struct_9 = OpTypeStruct %_runtimearr_v4float
+%_ptr_PhysicalStorageBuffer__struct_9 = OpTypePointer PhysicalStorageBuffer %_struct_9
+%_ptr_Input__ptr_PhysicalStorageBuffer__struct_9 = OpTypePointer Input %_ptr_PhysicalStorageBuffer__struct_9
+%_ptr_Output__ptr_PhysicalStorageBuffer__struct_9 = OpTypePointer Output %_ptr_PhysicalStorageBuffer__struct_9
+          %6 = OpVariable %_ptr_Input__ptr_PhysicalStorageBuffer__struct_9 Input
+          %7 = OpVariable %_ptr_Output__ptr_PhysicalStorageBuffer__struct_9 Output
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_ptr_PhysicalStorageBuffer_v4float = OpTypePointer PhysicalStorageBuffer %v4float
+          %3 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Input_int = OpTypePointer Input %int
+%_ptr_Output_int = OpTypePointer Output %int
+%gl_VertexIndex = OpVariable %_ptr_Input_int Input
+          %4 = OpVariable %_ptr_Output_int Output
+%_arr_float_int_1 = OpTypeArray %float %int_1
+  %_struct_8 = OpTypeStruct %v4float %float %_arr_float_int_1 %_arr_float_int_1
+%_ptr_Output__struct_8 = OpTypePointer Output %_struct_8
+          %2 = OpVariable %_ptr_Output__struct_8 Output
+          %1 = OpFunction %void None %12
+         %28 = OpLabel
+         %29 = OpLoad %v4float %3
+         %30 = OpAccessChain %_ptr_Output_v4float %2 %int_0
+               OpStore %30 %29
+         %31 = OpLoad %int %gl_VertexIndex
+               OpStore %4 %31
+         %32 = OpLoad %_ptr_PhysicalStorageBuffer__struct_9 %6 Aligned 8
+               OpStore %7 %32
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 25
+; Schema: 0
+               OpCapability Shader
+               OpCapability PhysicalStorageBufferAddresses
+               OpExtension "SPV_KHR_physical_storage_buffer"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint Fragment %1 "main" %2 %3 %4
+               OpExecutionMode %1 OriginUpperLeft
+               OpDecorate %2 Location 0
+               OpDecorate %2 Flat
+               OpDecorate %3 Location 1
+               OpDecorate %3 AliasedPointer
+               OpDecorate %3 Flat
+               OpDecorate %4 Location 0
+               OpDecorate %_runtimearr_v4float ArrayStride 16
+               OpDecorate %_ptr_PhysicalStorageBuffer_v4float ArrayStride 16
+               OpDecorate %_struct_7 Block
+               OpMemberDecorate %_struct_7 0 Offset 0
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_runtimearr_v4float = OpTypeRuntimeArray %v4float
+      %int_0 = OpConstant %int 0
+%_ptr_Input_int = OpTypePointer Input %int
+          %2 = OpVariable %_ptr_Input_int Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %4 = OpVariable %_ptr_Output_v4float Output
+  %_struct_7 = OpTypeStruct %_runtimearr_v4float
+%_ptr_PhysicalStorageBuffer__struct_7 = OpTypePointer PhysicalStorageBuffer %_struct_7
+%_ptr_Input__ptr_PhysicalStorageBuffer__struct_7 = OpTypePointer Input %_ptr_PhysicalStorageBuffer__struct_7
+          %3 = OpVariable %_ptr_Input__ptr_PhysicalStorageBuffer__struct_7 Input
+%_ptr_PhysicalStorageBuffer__runtimearr_v4float = OpTypePointer PhysicalStorageBuffer %_runtimearr_v4float
+%_ptr_Input__runtimearr_v4float = OpTypePointer Input %_runtimearr_v4float
+%_ptr_PhysicalStorageBuffer_v4float = OpTypePointer PhysicalStorageBuffer %v4float
+          %1 = OpFunction %void None %9
+         %20 = OpLabel
+         %21 = OpLoad %int %2
+         %22 = OpLoad %_ptr_PhysicalStorageBuffer__struct_7 %3
+         %23 = OpAccessChain %_ptr_PhysicalStorageBuffer_v4float %22 %int_0 %21
+         %24 = OpLoad %v4float %23 Aligned 16
+               OpStore %4 %24
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST
+patchControlPoints = 0
+deviceIndex = 0
+disableVertexReuse = 0
+depthClipEnable = 1
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 0
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 32
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R64_UINT
+attribute[1].offset = 16
+dynamicVertexStride = 0

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7097,8 +7097,8 @@ Constant *SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecora
   if (bt->hasDecorate(DecorationXfbStride, 0, &xfbStride))
     inOutDec.XfbStride = xfbStride;
 
-  if (bt->isTypeScalar() || bt->isTypeVector()) {
-    // Hanlde scalar or vector type
+  if (bt->isTypeScalar() || bt->isTypeVector() || bt->isTypePointer()) {
+    // Hanlde scalar or vector type or pointer type
     assert(inOutDec.Value.U32All != SPIRVID_INVALID);
 
     // Build metadata for the scala/vector
@@ -7136,7 +7136,7 @@ Constant *SPIRVToLLVM::buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecora
 
     // Update next location value
     if (!inOutDec.IsBuiltIn) {
-      auto width = bt->getBitWidth();
+      unsigned width = bt->isTypePointer() ? 64 : bt->getBitWidth();
       if (bt->isTypeVector())
         width *= bt->getVectorComponentCount();
       assert(width <= 64 * 4);


### PR DESCRIPTION
Physical storage buffer extension allows the user input/output to be
pointer type in graphic stage. The implementation will take a pointer as
i64 to make the lower pass work.
Add a lit test `PipelineVsFs_TestPointerInOut.pipe`.