### PR TITLE
Restrict the address space to be local for workgroup initialization

### DIFF
--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -93,7 +93,8 @@ bool PatchInitializeWorkgroupMemory::runOnModule(Module &module) {
 
   SmallVector<GlobalVariable *> zeroGlobals;
   for (GlobalVariable &global : module.globals()) {
-    if (global.hasInitializer() && global.getInitializer()->isNullValue())
+    if (global.getType()->getPointerAddressSpace() == ADDR_SPACE_LOCAL && global.hasInitializer() &&
+        global.getInitializer()->isNullValue())
       zeroGlobals.push_back(&global);
   }
 
@@ -146,7 +147,7 @@ void PatchInitializeWorkgroupMemory::initializeWithZero(Value *pointer, Type *va
     if (!isPowerOf2_32(alignment))
       alignment = NextPowerOf2(alignment);
     if (!indices.empty())
-      pointer = builder.CreateGEP(pointer, indices);
+      pointer = builder.CreateGEP(pointer->getType()->getPointerElementType(), pointer, indices);
     builder.CreateAlignedStore(zero, pointer, Align(alignment));
     return;
   } else if (valueTy->isArrayTy()) {


### PR DESCRIPTION
In commit Basic support of VK_KHR_zero_initialize_workgroup_memory
(95b2dfd5426d0d58ec6872a0ec3bddc21c7a6eba), the global variables with
null initializer will be initialized which doesn't follow the extension.
The requirement should be shared global variable with null initializer.