### PR TITLE
Place the merge Es shader at the start of the text section.

### DIFF
--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -142,11 +142,13 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
   uint64_t inRegMask = 0;
   auto entryPointTy = generateLsHsEntryPointType(&inRegMask);
 
-  // Create the entrypoint for the merged shader, and insert it just before the old HS.
+  // Create the entrypoint for the merged shader, and insert it at the start.  This has to be done for unlinked shaders
+  // because the vertex fetch shader will be prepended to this module and expect the fall through into the merged
+  // shader.
   Function *entryPoint = Function::Create(entryPointTy, GlobalValue::ExternalLinkage, lgcName::LsHsEntryPoint);
   entryPoint->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
   auto module = hsEntryPoint->getParent();
-  module->getFunctionList().insert(hsEntryPoint->getIterator(), entryPoint);
+  module->getFunctionList().push_front(entryPoint);
 
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)
@@ -554,10 +556,12 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
   uint64_t inRegMask = 0;
   auto entryPointTy = generateEsGsEntryPointType(&inRegMask);
 
-  // Create the entrypoint for the merged shader, and insert it just before the old GS.
+  // Create the entrypoint for the merged shader, and insert it at the start.  This has to be done for unlinked shaders
+  // because the vertex fetch shader will be prepended to this module and expect the fall through into the merged
+  // shader.
   Function *entryPoint = Function::Create(entryPointTy, GlobalValue::ExternalLinkage, lgcName::EsGsEntryPoint);
   entryPoint->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
-  module->getFunctionList().insert(gsEntryPoint->getIterator(), entryPoint);
+  module->getFunctionList().push_front(entryPoint);
 
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)

--- a/lgc/test/ShaderStages.lgc
+++ b/lgc/test/ShaderStages.lgc
@@ -83,14 +83,15 @@ attributes #0 = { nounwind }
 ; CHECK-NO-NGG3: !8 = !{i32 3}
 ; CHECK-NO-NGG3: !9 = !{i32 4}
 
-; CHECK-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
-; CHECK-NGG3: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG3: !6 = !{i32 6}
-; CHECK-NGG3: !7 = !{i32 3}
-; CHECK-NGG3: !8 = !{i32 4}
+; _amdgpu_gs_main must be first, so it can be linked with a potential vertex fetch shader.
+; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage [[geom_stage:![0-9]*]] {
+; CHECK-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage [[copy_stage:![0-9]*]] {
+; CHECK-NGG3: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage [[geom_stage:![0-9]*]] {
+; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} !lgc.shaderstage [[geom_stage]] {
+; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage [[frag_stage:![0-8]*]] {
+; CHECK-NGG3-DAG: [[geom_stage]] = !{i32 3}
+; CHECK-NGG3-DAG: [[copy_stage]] = !{i32 6}
+; CHECK-NGG3-DAG: [[frag_stage]] = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !6 {
 .entry:
@@ -396,18 +397,19 @@ attributes #1 = { nounwind readonly }
 ; CHECK-NO-NGG7: !11 = !{i32 3}
 ; CHECK-NO-NGG7: !12 = !{i32 4}
 
-; CHECK-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG7: define internal dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !10 {
-; CHECK-NGG7: !7 = !{i32 6}
-; CHECK-NGG7: !8 = !{i32 1}
-; CHECK-NGG7: !9 = !{i32 3}
-; CHECK-NGG7: !10 = !{i32 4}
+; _amdgpu_gs_main must be first, so it can be linked with a potential vertex fetch shader.
+; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage [[geom_stage:![0-9]*]] {
+; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage [[tc_stage:![0-9]*]] {
+; CHECK-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage [[copy_stage:![0-9]*]] {
+; CHECK-NGG7: define internal dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage [[tc_stage]] {
+; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage [[tc_stage]] {
+; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage [[geom_stage]] {
+; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage [[geom_stage]] {
+; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage [[frag_stage:![0-9]*]] {
+; CHECK-NGG7-DAG: [[copy_stage]] = !{i32 6}
+; CHECK-NGG7-DAG: [[tc_stage]] = !{i32 1}
+; CHECK-NGG7-DAG: [[geom_stage]] = !{i32 3}
+; CHECK-NGG7-DAG: [[frag_stage]] = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !6 {
 .entry:


### PR DESCRIPTION
When linking unlinked shader in LGC, the vertex fetch shader will be
prepended to the text section.  So the start of the text section must
contian the function to which the fetch shader should be added.  This is
why we want the merged Es shader at the start of text section.