### PR TITLE
Add vertex attributes as parameters to merged shaders

### DIFF
--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -142,11 +142,13 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
   uint64_t inRegMask = 0;
   auto entryPointTy = generateLsHsEntryPointType(&inRegMask);
 
-  // Create the entrypoint for the merged shader, and insert it just before the old HS.
+  // Create the entrypoint for the merged shader, and insert it at the start.  This has to be done for unlinked shaders
+  // because the vertex fetch shader will be prepended to this module and expect the fall through into the merged
+  // shader.
   Function *entryPoint = Function::Create(entryPointTy, GlobalValue::ExternalLinkage, lgcName::LsHsEntryPoint);
   entryPoint->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
   auto module = hsEntryPoint->getParent();
-  module->getFunctionList().insert(hsEntryPoint->getIterator(), entryPoint);
+  module->getFunctionList().push_front(entryPoint);
 
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)
@@ -554,10 +556,12 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
   uint64_t inRegMask = 0;
   auto entryPointTy = generateEsGsEntryPointType(&inRegMask);
 
-  // Create the entrypoint for the merged shader, and insert it just before the old GS.
+  // Create the entrypoint for the merged shader, and insert it at the start.  This has to be done for unlinked shaders
+  // because the vertex fetch shader will be prepended to this module and expect the fall through into the merged
+  // shader.
   Function *entryPoint = Function::Create(entryPointTy, GlobalValue::ExternalLinkage, lgcName::EsGsEntryPoint);
   entryPoint->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
-  module->getFunctionList().insert(gsEntryPoint->getIterator(), entryPoint);
+  module->getFunctionList().push_front(entryPoint);
 
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)

--- a/lgc/test/ShaderStages.lgc
+++ b/lgc/test/ShaderStages.lgc
@@ -83,14 +83,15 @@ attributes #0 = { nounwind }
 ; CHECK-NO-NGG3: !8 = !{i32 3}
 ; CHECK-NO-NGG3: !9 = !{i32 4}
 
-; CHECK-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !6 {
-; CHECK-NGG3: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG3: !6 = !{i32 6}
-; CHECK-NGG3: !7 = !{i32 3}
-; CHECK-NGG3: !8 = !{i32 4}
+; _amdgpu_gs_main must be first, so it can be linked with a potential vertex fetch shader.
+; CHECK-NGG3: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage [[geom_stage:![0-9]*]] {
+; CHECK-NGG3: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage [[copy_stage:![0-9]*]] {
+; CHECK-NGG3: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage [[geom_stage:![0-9]*]] {
+; CHECK-NGG3: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.1{{.*}} !lgc.shaderstage [[geom_stage]] {
+; CHECK-NGG3: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage [[frag_stage:![0-8]*]] {
+; CHECK-NGG3-DAG: [[geom_stage]] = !{i32 3}
+; CHECK-NGG3-DAG: [[copy_stage]] = !{i32 6}
+; CHECK-NGG3-DAG: [[frag_stage]] = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc.shaderstage !6 {
 .entry:
@@ -396,18 +397,19 @@ attributes #1 = { nounwind readonly }
 ; CHECK-NO-NGG7: !11 = !{i32 3}
 ; CHECK-NO-NGG7: !12 = !{i32 4}
 
-; CHECK-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage !7 {
-; CHECK-NGG7: define internal dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage !8 {
-; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage !9 {
-; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage !10 {
-; CHECK-NGG7: !7 = !{i32 6}
-; CHECK-NGG7: !8 = !{i32 1}
-; CHECK-NGG7: !9 = !{i32 3}
-; CHECK-NGG7: !10 = !{i32 4}
+; _amdgpu_gs_main must be first, so it can be linked with a potential vertex fetch shader.
+; CHECK-NGG7: define dllexport amdgpu_gs void @_amdgpu_gs_main{{.*}} !lgc.shaderstage [[geom_stage:![0-9]*]] {
+; CHECK-NGG7: define dllexport amdgpu_hs void @_amdgpu_hs_main{{.*}} !lgc.shaderstage [[tc_stage:![0-9]*]] {
+; CHECK-NGG7: define dllexport amdgpu_vs void @_amdgpu_vs_main{{.*}} !lgc.shaderstage [[copy_stage:![0-9]*]] {
+; CHECK-NGG7: define internal dllexport amdgpu_ls void @_amdgpu_ls_main{{.*}} !lgc.shaderstage [[tc_stage]] {
+; CHECK-NGG7: define internal dllexport amdgpu_hs void @_amdgpu_hs_main.1{{.*}} !lgc.shaderstage [[tc_stage]] {
+; CHECK-NGG7: define internal dllexport amdgpu_es void @_amdgpu_es_main{{.*}} !lgc.shaderstage [[geom_stage]] {
+; CHECK-NGG7: define internal dllexport amdgpu_gs void @_amdgpu_gs_main.2{{.*}} !lgc.shaderstage [[geom_stage]] {
+; CHECK-NGG7: define dllexport amdgpu_ps void @_amdgpu_ps_main{{.*}} !lgc.shaderstage [[frag_stage:![0-9]*]] {
+; CHECK-NGG7-DAG: [[copy_stage]] = !{i32 6}
+; CHECK-NGG7-DAG: [[tc_stage]] = !{i32 1}
+; CHECK-NGG7-DAG: [[geom_stage]] = !{i32 3}
+; CHECK-NGG7-DAG: [[frag_stage]] = !{i32 4}
 
 define dllexport spir_func void @lgc.shader.TCS.main() local_unnamed_addr #0 !spirv.ExecutionModel !5 !lgc.shaderstage !6 {
 .entry:

--- a/lgc/test/UnlinkedVsGsInputs.lgc
+++ b/lgc/test/UnlinkedVsGsInputs.lgc
@@ -1,0 +1,82 @@
+; Check that after merging the VS and GS shader the result has the vertex input as the last parameter, and it is being passed
+; to the vertex shader, which expects it as the last parameter.
+; RUN: lgc -mcpu=gfx900 %s -o /dev/null -print-after=lgc-patch-prepare-pipeline-abi 2>&1 | FileCheck --check-prefixes=CHECK %s
+; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI (lgc-patch-prepare-pipeline-abi) 
+; CHECK: IR Dump After Patch LLVM for preparing pipeline ABI (lgc-patch-prepare-pipeline-abi) 
+; CHECK: define dllexport amdgpu_gs void @_amdgpu_gs_main_fetchless({{.*}}, <2 x float> [[vertInput:%[0-9]*]])
+; CHECK: call void @_amdgpu_es_main_fetchless({{.*}}, <2 x float> [[vertInput]])
+; CHECK: define internal dllexport amdgpu_es void @_amdgpu_es_main_fetchless({{.*}}, <2 x float> %vertex0.0)
+
+; ModuleID = 'lgcPipeline'
+source_filename = "lgcPipeline"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spirv.ExecutionModel !9 !lgc.shaderstage !9 {
+.entry:
+  %0 = call <2 x float> (...) @lgc.create.read.generic.input.v2f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  call void (...) @lgc.create.write.generic.output(<2 x float> %0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+  ret void
+}
+
+; Function Attrs: nounwind readonly willreturn
+declare <2 x float> @lgc.create.read.generic.input.v2f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.GS.main() local_unnamed_addr #0 !spirv.ExecutionModel !10 !lgc.shaderstage !10 {
+.entry:
+  %0 = call <4 x float> (...) @lgc.create.read.builtin.input.v4f32(i32 0, i32 0, i32 0, i32 undef)
+  %1 = call <4 x float> (...) @lgc.create.read.builtin.input.v4f32(i32 0, i32 0, i32 1, i32 undef)
+  %2 = call <4 x float> (...) @lgc.create.read.builtin.input.v4f32(i32 0, i32 0, i32 2, i32 undef)
+  call void (...) @lgc.create.write.builtin.output(<4 x float> %0, i32 0, i32 1024, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output(float undef, i32 1, i32 1024, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output([1 x float] undef, i32 3, i32 5120, i32 undef, i32 undef)
+  call void (...) @lgc.create.emit.vertex(i32 0)
+  call void (...) @lgc.create.write.builtin.output(<4 x float> %1, i32 0, i32 1024, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output(float undef, i32 1, i32 1024, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output([1 x float] undef, i32 3, i32 5120, i32 undef, i32 undef)
+  call void (...) @lgc.create.emit.vertex(i32 0)
+  call void (...) @lgc.create.write.builtin.output(<4 x float> %2, i32 0, i32 1024, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output(float undef, i32 1, i32 1024, i32 undef, i32 undef)
+  call void (...) @lgc.create.write.builtin.output([1 x float] undef, i32 3, i32 5120, i32 undef, i32 undef)
+  call void (...) @lgc.create.emit.vertex(i32 0)
+  ret void
+}
+
+; Function Attrs: nounwind readonly willreturn
+declare <4 x float> @lgc.create.read.builtin.input.v4f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.builtin.output(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind
+declare void @lgc.create.emit.vertex(...) local_unnamed_addr #0
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly willreturn }
+
+!llpc.geometry.mode = !{!0}
+!lgc.client = !{!1}
+!lgc.unlinked = !{!2}
+!lgc.options = !{!3}
+!lgc.options.VS = !{!4}
+!lgc.options.GS = !{!5}
+!lgc.input.assembly.state = !{!6}
+!lgc.rasterizer.state = !{!7}
+!amdgpu.pal.metadata.msgpack = !{!8}
+
+!0 = !{i32 3, i32 2, i32 1, i32 3}
+!1 = !{!"Vulkan"}
+!2 = !{i32 1}
+!3 = !{i32 820310003, i32 2145276876, i32 -448892402, i32 165796324, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 2}
+!4 = !{i32 -314154943, i32 -596910625, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 20, i32 1800}
+!5 = !{i32 -701582401, i32 -711308304, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 20, i32 1800}
+!6 = !{i32 2, i32 3}
+!7 = !{i32 0, i32 0, i32 0, i32 1}
+!8 = !{!"\82\B0amdpal.pipelines\91\84\AA.registers\80\B0.spill_threshold\CE\FF\FF\FF\FF\B0.user_data_limit\00\AF.xgl_cache_info\82\B3.128_bit_cache_hash\92\CF:\0F#\A0\01\E1s\E3\CFi3\02\D8\80\DD\FE\85\AD.llpc_version\A449.0\AEamdpal.version\92\02\03"}
+!9 = !{i32 0}
+!10 = !{i32 3}


### PR DESCRIPTION
When merging an unlinked VS and GS shader, the vertex attributes must be
added as inputs to the merged shader.  Then the fetch shader will fetch
the values in the appropriate registers.