### PR TITLE
Resolve some build warnings

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -5484,14 +5484,14 @@ Function *NggPrimShader::createFetchCullingRegister(Module *module) {
 
     primShaderTableAddr = m_builder->CreateBitCast(primShaderTableAddr, m_builder->getInt64Ty());
 
-    auto primShaderTablePtrTy = PointerType::get(ArrayType::get(m_builder->getInt32Ty(), 256),
-                                                 ADDR_SPACE_CONST); // [256 x i32]
+    auto primShaderTableEltTy = ArrayType::get(m_builder->getInt32Ty(), 256);
+    auto primShaderTablePtrTy = PointerType::get(primShaderTableEltTy, ADDR_SPACE_CONST); // [256 x i32]
     auto primShaderTablePtr = m_builder->CreateIntToPtr(primShaderTableAddr, primShaderTablePtrTy);
 
     // regOffset = regOffset >> 2
     regOffset = m_builder->CreateLShr(regOffset, 2); // To dword offset
 
-    auto loadPtr = m_builder->CreateGEP(primShaderTablePtr, {m_builder->getInt32(0), regOffset});
+    auto loadPtr = m_builder->CreateGEP(primShaderTableEltTy, primShaderTablePtr, {m_builder->getInt32(0), regOffset});
     cast<Instruction>(loadPtr)->setMetadata(MetaNameUniform, MDNode::get(m_builder->getContext(), {}));
 
     auto regValue = m_builder->CreateAlignedLoad(m_builder->getInt32Ty(), loadPtr, Align(4));

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -608,7 +608,8 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
     assert(m_lds);
 
     Value *ringOffset = calcGsVsRingOffsetForInput(location, 0, streamId, builder);
-    Value *loadPtr = builder.CreateGEP(m_lds, {builder.getInt32(0), ringOffset});
+    Value *loadPtr = builder.CreateGEP(m_lds->getType()->getScalarType()->getPointerElementType(), m_lds,
+                                       {builder.getInt32(0), ringOffset});
     loadPtr = builder.CreateBitCast(loadPtr, PointerType::get(loadTy, m_lds->getType()->getPointerAddressSpace()));
 
     return builder.CreateAlignedLoad(loadTy, loadPtr, m_lds->getAlign());

--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -147,7 +147,7 @@ void PatchInitializeWorkgroupMemory::initializeWithZero(Value *pointer, Type *va
     if (!isPowerOf2_32(alignment))
       alignment = NextPowerOf2(alignment);
     if (!indices.empty())
-      pointer = builder.CreateGEP(pointer->getType()->getPointerElementType(), pointer, indices);
+      pointer = builder.CreateGEP(pointer->getType()->getScalarType()->getPointerElementType(), pointer, indices);
     builder.CreateAlignedStore(zero, pointer, Align(alignment));
     return;
   } else if (valueTy->isArrayTy()) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -50,7 +50,7 @@ namespace Llpc {
 GraphicsContext::GraphicsContext(GfxIpVersion gfxIp, const GraphicsPipelineBuildInfo *pipelineInfo,
                                  MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash)
     : PipelineContext(gfxIp, pipelineHash, cacheHash), m_pipelineInfo(pipelineInfo), m_stageMask(0),
-      m_activeStageCount(0), m_gsOnChip(false) {
+      m_activeStageCount(0) {
   setUnlinked(pipelineInfo->unlinked);
   const PipelineShaderInfo *shaderInfo[ShaderStageGfxCount] = {
       &pipelineInfo->vs, &pipelineInfo->tcs, &pipelineInfo->tes, &pipelineInfo->gs, &pipelineInfo->fs,

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -76,8 +76,6 @@ private:
 
   unsigned m_stageMask;        // Mask of active shader stages bound to this graphics pipeline
   unsigned m_activeStageCount; // Count of active shader stages
-
-  bool m_gsOnChip; // Whether to enable GS on-chip mode
 };
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1865,9 +1865,9 @@ void SpirvLowerGlobal::lowerBufferBlock() {
               Value *newGetElemPtr = nullptr;
 
               if (getElemPtr->isInBounds())
-                newGetElemPtr = m_builder->CreateInBoundsGEP(base, newIndices);
+                newGetElemPtr = m_builder->CreateInBoundsGEP(elementType, base, newIndices);
               else
-                newGetElemPtr = m_builder->CreateGEP(base, newIndices);
+                newGetElemPtr = m_builder->CreateGEP(elementType, base, newIndices);
 
               getElemPtr->replaceAllUsesWith(newGetElemPtr);
               getElemPtr->eraseFromParent();


### PR DESCRIPTION
Mainly due to changes to CreateGEP and variants - requirement is now to provide
the element type as part of the call (rather than rely on getting this from the
pointer itself).
In a lot of cases the element type is now provided - in others it is derived
from the pointer type first. This latter approach will require modification in
the future.

Also removed a now redundant member variable.