### PR TITLE
Handle upstream changes for hasFnAttrs

### DIFF
--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -155,7 +155,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
     argAttrs.push_back((inRegMask >> idx) & 1 ? inRegAttrSet : emptyAttrSet);
   // Old arguments.
   for (unsigned idx = 0; idx != argTys.size(); ++idx)
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396483
     // Old version of the code
     argAttrs.push_back(oldAttrList.getParamAttributes(idx));
   // Construct new AttributeList and set it on the new function.

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -167,7 +167,7 @@ void SpirvLowerTranslator::translateSpirvToLlvm(const PipelineShaderInfo *shader
     }
     // Not shader entry-point.
     func.setLinkage(GlobalValue::InternalLinkage);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396483
     // Old version of the code
     if (func.getAttributes().hasFnAttribute(Attribute::NoInline))
       func.removeFnAttr(Attribute::NoInline);


### PR DESCRIPTION
Guard for a previous fix was using a version that was too late (so missed some
cases).