### PR TITLE
Start porting the lowering passes to the new pass manager

### DIFF
--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -108,11 +108,17 @@ public:
   // @param useBuilderRecorder : True to use BuilderRecorder, false to use BuilderImpl
   Builder *createBuilder(Pipeline *pipeline, bool useBuilderRecorder);
 
-  // Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
+  // Prepare a legacy pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
   // think that we have library functions.
   //
   // @param [in/out] passMgr : Pass manager
   void preparePassManager(llvm::legacy::PassManager *passMgr);
+
+  // Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
+  // think that we have library functions.
+  //
+  // @param [in/out] passMgr : Pass manager
+  void preparePassManager(lgc::PassManager &passMgr);
 
   // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
   void addTargetPasses(lgc::LegacyPassManager &passMgr, llvm::Timer *codeGenTimer, llvm::raw_pwrite_stream &outStream);

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -51,8 +51,14 @@ class PassManager : public llvm::ModulePassManager {
 public:
   static PassManager *Create();
   virtual ~PassManager() {}
+  template <typename PassBuilderT> bool registerFunctionAnalysis(PassBuilderT &&PassBuilder) {
+    return functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));
+  }
   virtual void run(llvm::Module &module) = 0;
   virtual void setPassIndex(unsigned *passIndex) = 0;
+
+protected:
+  llvm::FunctionAnalysisManager functionAnalysisManager;
 };
 
 } // namespace lgc

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -269,6 +269,25 @@ void LgcContext::preparePassManager(legacy::PassManager *passMgr) {
 }
 
 // =====================================================================================================================
+// Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not think that
+// we have library functions.
+//
+// @param [in/out] passMgr : Pass manager
+void LgcContext::preparePassManager(lgc::PassManager &passMgr) {
+  TargetLibraryInfoImpl targetLibInfo(getTargetMachine()->getTargetTriple());
+
+  // Adjust it to allow memcpy and memset.
+  // TODO: Investigate why the latter is necessary. I found that
+  // test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
+  // got unrolled far too much, and at too late a stage for the descriptor loads to be commoned up. It might
+  // be an unfortunate interaction between LoopIdiomRecognize and fat pointer laundering.
+  targetLibInfo.setAvailable(LibFunc_memcpy);
+  targetLibInfo.setAvailable(LibFunc_memset);
+
+  passMgr.registerFunctionAnalysis([&] { return TargetLibraryAnalysis(targetLibInfo); });
+}
+
+// =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
 //
 // @param [in/out] passMgr : Pass manager to add passes to

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1275,13 +1275,22 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       }
 
       context->getBuilder()->setShaderStage(getLgcShaderStage(entryStage));
-      std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
-      lowerPassMgr->setPassIndex(&passIndex);
+      bool success;
+      if (cl::NewPassManager) {
+        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+        lowerPassMgr->setPassIndex(&passIndex);
 
-      LegacySpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower)
-      );
-      // Run the passes.
-      bool success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
+        SpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower));
+        // Run the passes.
+        success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
+      } else {
+        std::unique_ptr<lgc::LegacyPassManager> lowerPassMgr(lgc::LegacyPassManager::Create());
+        lowerPassMgr->setPassIndex(&passIndex);
+
+        LegacySpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower));
+        // Run the passes.
+        success = runPasses(&*lowerPassMgr, modules[shaderIndex]);
+      }
       if (!success) {
         LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
         result = Result::ErrorInvalidShader;
@@ -1948,6 +1957,9 @@ bool Compiler::runPasses(lgc::PassManager *passMgr, Module *module) const {
   {
     passMgr->run(*module);
     success = true;
+    // TODO Only some passes have been ported to the new pass manager. So running
+    // the lowering passes with the new pass manager results in a fatal error for now.
+    report_fatal_error("The new pass manager is not fully implemented yet.");
   }
 #if LLPC_ENABLE_EXCEPTION
   catch (const char *) {

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -47,7 +47,7 @@ class PassManager;
 } // namespace legacy
 
 class PassRegistry;
-void initializeSpirvLowerAccessChainPass(PassRegistry &);
+void initializeLegacySpirvLowerAccessChainPass(PassRegistry &);
 void initializeSpirvLowerMathConstFoldingPass(PassRegistry &);
 void initializeSpirvLowerMathFloatOpPass(PassRegistry &);
 void initializeSpirvLowerConstImmediateStorePass(PassRegistry &);
@@ -62,6 +62,7 @@ void initializeLegacySpirvLowerTranslatorPass(PassRegistry &);
 namespace lgc {
 
 class Builder;
+class PassManager;
 
 } // namespace lgc
 
@@ -71,7 +72,7 @@ namespace Llpc {
 //
 // @param passRegistry : Pass registry
 inline static void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
-  initializeSpirvLowerAccessChainPass(passRegistry);
+  initializeLegacySpirvLowerAccessChainPass(passRegistry);
   initializeSpirvLowerConstImmediateStorePass(passRegistry);
   initializeSpirvLowerMathConstFoldingPass(passRegistry);
   initializeSpirvLowerMathFloatOpPass(passRegistry);
@@ -85,7 +86,7 @@ inline static void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
 
 class Context;
 
-llvm::ModulePass *createSpirvLowerAccessChain();
+llvm::ModulePass *createLegacySpirvLowerAccessChain();
 llvm::ModulePass *createSpirvLowerConstImmediateStore();
 llvm::ModulePass *createSpirvLowerMathConstFolding();
 llvm::ModulePass *createSpirvLowerMathFloatOp();
@@ -102,6 +103,10 @@ class SpirvLower {
 public:
   explicit SpirvLower()
     : m_module(nullptr), m_context(nullptr), m_shaderStage(ShaderStageInvalid), m_entryPoint(nullptr) {}
+
+  // Add per-shader lowering passes to pass manager
+  static void addPasses(Context *context, ShaderStage stage, lgc::PassManager &passMgr, llvm::Timer *lowerTimer);
+
   static void removeConstantExpr(Context *context, llvm::GlobalVariable *global);
   static void replaceConstWithInsts(Context *context, llvm::Constant *const constVal);
 

--- a/llpc/lower/llpcSpirvLowerAccessChain.cpp
+++ b/llpc/lower/llpcSpirvLowerAccessChain.cpp
@@ -45,23 +45,41 @@ namespace Llpc {
 
 // =====================================================================================================================
 // Initializes static members.
-char SpirvLowerAccessChain::ID = 0;
+char LegacySpirvLowerAccessChain::ID = 0;
 
 // =====================================================================================================================
 // Pass creator, creates the pass of SPIR-V lowering operations for access chain
-ModulePass *createSpirvLowerAccessChain() {
-  return new SpirvLowerAccessChain();
+ModulePass *createLegacySpirvLowerAccessChain() {
+  return new LegacySpirvLowerAccessChain();
 }
 
 // =====================================================================================================================
-SpirvLowerAccessChain::SpirvLowerAccessChain() : LegacySpirvLower(ID) {
+LegacySpirvLowerAccessChain::LegacySpirvLowerAccessChain() : ModulePass(ID) {
 }
 
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
 //
 // @param [in/out] module : LLVM module to be run on
-bool SpirvLowerAccessChain::runOnModule(Module &module) {
+bool LegacySpirvLowerAccessChain::runOnModule(Module &module) {
+  return Impl.runImpl(module);
+}
+
+// =====================================================================================================================
+// Executes this SPIR-V lowering pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+PreservedAnalyses SpirvLowerAccessChain::run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager) {
+  runImpl(module);
+  return PreservedAnalyses::none();
+}
+
+// =====================================================================================================================
+// Executes this SPIR-V lowering pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+bool SpirvLowerAccessChain::runImpl(llvm::Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Access-Chain\n");
 
   SpirvLower::init(&module);
@@ -171,4 +189,4 @@ GetElementPtrInst *SpirvLowerAccessChain::tryToCoalesceChain(GetElementPtrInst *
 
 // =====================================================================================================================
 // Initializes the pass of SPIR-V lowering opertions for access chain.
-INITIALIZE_PASS(SpirvLowerAccessChain, DEBUG_TYPE, "Lower SPIR-V access chain", false, false)
+INITIALIZE_PASS(LegacySpirvLowerAccessChain, DEBUG_TYPE, "Lower SPIR-V access chain", false, false)

--- a/llpc/lower/llpcSpirvLowerAccessChain.h
+++ b/llpc/lower/llpcSpirvLowerAccessChain.h
@@ -32,25 +32,40 @@
 
 #include "llpcSpirvLower.h"
 #include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/PassManager.h"
 
 namespace Llpc {
 
 // =====================================================================================================================
 // Represents the pass of SPIR-V lowering opertions for access chain.
-class SpirvLowerAccessChain : public LegacySpirvLower, public llvm::InstVisitor<SpirvLowerAccessChain> {
+class SpirvLowerAccessChain : public SpirvLower, public llvm::InstVisitor<SpirvLowerAccessChain> {
 public:
-  SpirvLowerAccessChain();
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+  virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElemPtrInst);
+
+  bool runImpl(llvm::Module &module);
+
+  static llvm::StringRef name() { return "Lower SPIR-V access chain"; }
+
+private:
+  llvm::GetElementPtrInst *tryToCoalesceChain(llvm::GetElementPtrInst *getElemPtr, unsigned addrSpace);
+};
+
+// =====================================================================================================================
+// Represents the pass of SPIR-V lowering opertions for access chain.
+class LegacySpirvLowerAccessChain : public llvm::ModulePass {
+public:
+  LegacySpirvLowerAccessChain();
 
   virtual bool runOnModule(llvm::Module &module);
-  virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElemPtrInst);
 
   static char ID; // ID of this pass
 
 private:
-  SpirvLowerAccessChain(const SpirvLowerAccessChain &) = delete;
-  SpirvLowerAccessChain &operator=(const SpirvLowerAccessChain &) = delete;
+  LegacySpirvLowerAccessChain(const LegacySpirvLowerAccessChain &) = delete;
+  LegacySpirvLowerAccessChain &operator=(const LegacySpirvLowerAccessChain &) = delete;
 
-  llvm::GetElementPtrInst *tryToCoalesceChain(llvm::GetElementPtrInst *getElemPtr, unsigned addrSpace);
+  SpirvLowerAccessChain Impl;
 };
 
 } // namespace Llpc


### PR DESCRIPTION
This patch starts porting the lowering passes added in SpirvLower::addPasses to
the new pass manager. It also makes some changes to the infrastructure for the
new pass manager to allow adding function analyses.

This PR is the same as https://github.com/GPUOpen-Drivers/llpc/pull/1304 that was merged and reverted because a windows regression was detected. That regression should be fixed now.