### PR TITLE
Move utility code out of amdllpc.cpp. NFCI. (Do not merge)

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -602,6 +602,7 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
     bool enableOpt = cl::EnableShaderModuleOpt;
     enableOpt = enableOpt || shaderInfo->options.enableOpt;
     enableOpt = moduleDataEx.common.usage.useSpecConstant ? false : enableOpt;
+    enableOpt = false;
 
     if (enableOpt) {
       // Check internal cache for shader module build result


### PR DESCRIPTION
The high level goal is to make the code in `amdllpc.cpp` reusable so that can create new compiler tools based on the same
common logic, and to be able to test parts of that logic with unit tests.

This shared code lives in a new library: `llpc_standalone_compiler`, which `amdllpc` and the unit tests link with.
The goal is to keep this library free of global state (including command line options).

I tried keep the changes to the code minimal. I only simplified some of the input utils, and added unit tests for all
functions that I modified beyond stylistic changes.

In the future PRs, I plan to move more code out of `amdllpc.cpp`.