### PR TITLE
Implement OpExecutionModeId

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -390,6 +390,19 @@ void SPIRVExecutionMode::decode(std::istream &I) {
     getOrCreateTarget()->addExecutionMode(this);
 }
 
+void SPIRVExecutionModeId::decode(std::istream &I) {
+  getDecoder(I) >> Target >> ExecMode;
+  switch (ExecMode) {
+  case ExecutionModeLocalSizeId:
+    Operands.resize(3);
+    break;
+  default:
+    // Do nothing. Keep this to avoid VS2013 warning.
+    break;
+  }
+  getDecoder(I) >> Operands;
+}
+
 SPIRVForward *SPIRVAnnotationGeneric::getOrCreateTarget() const {
   SPIRVEntry *Entry = nullptr;
   bool Found = Module->exist(Target, &Entry);

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -594,6 +594,19 @@ protected:
   std::vector<SPIRVWord> WordLiterals;
 };
 
+class SPIRVExecutionModeId : public SPIRVAnnotation<OpExecutionModeId> {
+public:
+  // Incomplete constructor
+  SPIRVExecutionModeId() {}
+  _SPIRV_DCL_DECODE
+  const std::vector<SPIRVId> &getOperands() const { return Operands; }
+  SPIRVExecutionModeKind getExecutionMode() const { return ExecMode; }
+
+protected:
+  SPIRVExecutionModeKind ExecMode;
+  std::vector<SPIRVId> Operands;
+};
+
 class SPIRVComponentExecutionModes {
   typedef std::map<SPIRVExecutionModeKind, SPIRVExecutionMode *>
       SPIRVExecutionModeMap;
@@ -731,7 +744,6 @@ bool isa(SPIRVEntry *E) {
 // This is also an indication of how much work is left.
 #define _SPIRV_OP(x, ...) typedef SPIRVEntryOpCodeOnly<Op##x> SPIRV##x;
 _SPIRV_OP(SizeOf)
-_SPIRV_OP(ExecutionModeId)
 _SPIRV_OP(DecorateId)
 // NOTE: These 4 OpCodes are reserved by SPIR-V spec, they are invalid unless
 // some extensions expose them.


### PR DESCRIPTION
This spirv instruction declares an execution mode for entry point.LocalSizeId execution mode, which can be used as an alternative to LocalSize to specify the local workgroup size with specialization constants.