### PR TITLE
[CI] Enable inline suppressions for cppcheck

### DIFF
--- a/.github/workflows/check-cppcheck-llpc.yml
+++ b/.github/workflows/check-cppcheck-llpc.yml
@@ -17,4 +17,4 @@ jobs:
           git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
           git checkout ${GITHUB_SHA}
       - name: Run cppcheck
-        run: cppcheck -q -j$(( $(nproc) * 4 )) --error-exitcode=1 .
+        run: cppcheck -q -j$(( $(nproc) * 4 )) --error-exitcode=1 --std=c++14 --inline-suppr .


### PR DESCRIPTION
With this flags, it's possible to suppress false positives directly in the source code, e.g.:
```
// cppcheck-suppress syntaxError
TEST(InputUtilsTests, PlaceholderPass) {
```

Required for https://github.com/GPUOpen-Drivers/llpc/pull/1372.