### PR TITLE
Fix path/filename limits in the codebase

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -414,7 +414,7 @@ Compiler::Compiler(GfxIpVersion gfxIp, unsigned optionCount, const char *const *
     // LLVM fatal error handler only can be installed once.
     install_fatal_error_handler(fatalErrorHandler);
 
-    // Initiailze m_pContextPool.
+    // Initialize m_pContextPool.
     {
       std::lock_guard<sys::Mutex> lock(m_contextPoolMutex);
 
@@ -441,8 +441,8 @@ Compiler::Compiler(GfxIpVersion gfxIp, unsigned optionCount, const char *const *
 #endif
   }
 
-  if (strlen(shaderCachePath) >= Llpc::MaxFilePathLen) {
-    LLPC_ERRS("The shader-cache-file-dir exceed the maximum length (" << Llpc::MaxFilePathLen << ")\n");
+  if (strlen(shaderCachePath) >= Llpc::MaxPathLen) {
+    LLPC_ERRS("The shader-cache-file-dir exceed the maximum length (" << Llpc::MaxPathLen << ")\n");
     llvm_unreachable("ShaderCacheFileDir is too long");
   }
   auxCreateInfo.cacheFilePath = shaderCachePath;

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -112,8 +112,6 @@ struct ShaderCacheSerializedHeader {
   size_t shaderDataEnd;  // Offset to the end of shader data
 };
 
-constexpr unsigned MaxFilePathLen = 512;
-
 typedef void *CacheEntryHandle;
 
 // =====================================================================================================================
@@ -182,7 +180,7 @@ private:
   size_t m_shaderDataEnd;
   size_t m_totalShaders;
 
-  char m_fileFullPath[MaxFilePathLen]; // Full path/filename of the shader cache on-disk file
+  char m_fileFullPath[PathBufferLen]; // Full path/filename of the shader cache on-disk file
 
   std::list<std::pair<uint8_t *, size_t>> m_allocationList; // Memory allcoated by GetCacheSpace
   unsigned m_serializedSize;                                // Serialized byte size of whole shader cache

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -75,6 +75,7 @@
 #endif
 #include "llpc.h"
 #include "llpcDebug.h"
+#include "llpcFile.h"
 #include "llpcShaderModuleHelper.h"
 #include "llpcSpirvLowerUtil.h"
 #include "llpcUtil.h"
@@ -427,8 +428,7 @@ static Result init(int argc, char *argv[], ICompiler **ppCompiler) {
     if (!envString)
       envString = getenv("LOCALAPPDATA");
 #else
-    constexpr unsigned MaxFilePathLen = 512;
-    char shaderCacheFileRootDir[MaxFilePathLen];
+    char shaderCacheFileRootDir[PathBufferLen];
 
     //   2. Find XDG_CACHE_HOME.
     //   3. If AMD_SHADER_DISK_CACHE_PATH and XDG_CACHE_HOME both not set,

--- a/llpc/util/llpcFile.h
+++ b/llpc/util/llpcFile.h
@@ -31,9 +31,26 @@
 #pragma once
 
 #include "llpc.h"
+#include <climits>
 #include <cstdio>
 
 namespace Llpc {
+
+// On Linux, NAME_MAX is the maximum filename length, while PATH_MAX defines the maximum path length.
+// On Windows, maximum file and path lengths are defined by _MAX_FNAME and MAX_PATH, respectively.
+#if defined(__unix__)
+constexpr size_t MaxFilenameLen = NAME_MAX;
+constexpr size_t MaxPathLen = PATH_MAX;
+#else
+constexpr size_t MaxFilenameLen = _MAX_FNAME;
+constexpr size_t MaxPathLen = _MAX_PATH;
+#endif
+
+// We add 1 to accommodate a null terminator.
+// Note that PathBufferLen already considers the full path length, including the file name part, so
+// there's no need to add them when creating buffers.
+constexpr size_t FilenameBufferLen = MaxFilenameLen + 1;
+constexpr size_t PathBufferLen = MaxPathLen + 1;
 
 // Enumerates access modes that may be required on an opened file. Can be bitwise ORed together to specify multiple
 // simultaneous modes.


### PR DESCRIPTION
Make sure LLPC uses the same limits everywhere.
The previous limits were too short on Linux.

Also fix a few typos in the surrounding code.