### PR TITLE
Fix up and temporarily disable DebugInfo llpc lit tests

### DIFF
--- a/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugCompilationUnit.spvasm
+++ b/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugCompilationUnit.spvasm
@@ -3,9 +3,8 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: {{![0-9]*}} = !{i32 {{[0-9]*}}, !"Dwarf Version", i32 4}
 ; SHADERTEST: {{![0-9]*}} = !{i32 {{[0-9]*}}, !"Debug Info Version", i32 3}
-; SHADERTEST: {{![0-9]*}} = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D1:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: [[D2:![0-9]*]])
+; SHADERTEST: {{![0-9]*}} = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D1:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 ; SHADERTEST: [[D1]] = !DIFile(filename: "simple.hlsl", directory: ".")
-; SHADERTEST: [[D2]] = !{}
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugDeclare.spvasm
+++ b/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugDeclare.spvasm
@@ -1,15 +1,15 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: [[D3:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D4:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: [[D5:![0-9]*]])
+; SHADERTEST: [[D3:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D4:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 ; SHADERTEST: [[D4]] = !DIFile(filename: "simple.hlsl", directory: ".")
-; SHADERTEST: [[D5]] = !{}
-; SHADERTEST: [[D8:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: [[D4]], line: 1, type: [[D9:![0-9]*]], scopeLine: 1, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: [[D3]], templateParams: [[D5]], retainedNodes: [[D11:![0-9]*]])
+; SHADERTEST: [[D8:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: [[D4]], line: 1, type: [[D9:![0-9]*]], scopeLine: 1, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: [[D3]], templateParams: [[D5:![0-9]*]], retainedNodes: [[D11:![0-9]*]])
 ; SHADERTEST: [[D9]] = !DISubroutineType(types: [[D10:![0-9]*]])
 ; SHADERTEST: [[D10]] = !{null}
 ; SHADERTEST: [[D11]] = !{[[D7:![0-9]*]]}
 ; SHADERTEST: [[D7]] = !DILocalVariable(name: "foo", scope: [[D8]], file: [[D4]], line: 1, type: [[D12:![0-9]*]])
 ; SHADERTEST: [[D12]] = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+; SHADERTEST: [[D5]] = !{}
 ; SHADERTEST: [[D6:![0-9]*]] = !{i32 0}
 ; SHADERTEST: [[D13:![0-9]*]] = !DILocation(line: 1, scope: [[D8]])
 ; SHADERTEST: {{^// LLPC}} SPIR-V lowering results

--- a/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugFunctionDeclaration.spvasm
+++ b/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugFunctionDeclaration.spvasm
@@ -1,11 +1,11 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -trim-debug-info=false -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: [[D1:![0-9]*]] = !{}
-; SHADERTEST: [[D2:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "v4f_main_f", scope: null, file: !{{[0-9]*}}, line: 12, type: [[D3:![0-9]*]], scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !{{[0-9]*}}, templateParams: [[D1]], declaration: [[D4:![0-9]*]], retainedNodes: !{{[0-9]*}})
+; SHADERTEST: [[D2:![0-9]*]] = distinct !DISubprogram(name: "main", linkageName: "v4f_main_f", scope: null, file: !{{[0-9]*}}, line: 12, type: [[D3:![0-9]*]], scopeLine: 13, flags: DIFlagPublic, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !{{[0-9]*}}, templateParams: [[D1:![0-9]*]], declaration: [[D4:![0-9]*]], retainedNodes: !{{[0-9]*}})
 ; SHADERTEST: [[D3]] = !DISubroutineType(types: [[D5:![0-9]*]])
 ; SHADERTEST: [[D5]] = !{null}
 ; SHADERTEST: [[D4]] = !DISubprogram(name: "main", linkageName: "v4f_main_f", scope: null, file: !{{[0-9]*}}, line: 12, type: [[D3]], flags: DIFlagPublic, spFlags: 0, templateParams: [[D1]])
+; SHADERTEST: [[D1]] = !{}
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugSourceNoText.spvasm
+++ b/llpc/test/shaderdb/debug_info/avoid/DebugInfo_DebugSourceNoText.spvasm
@@ -3,9 +3,8 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: {{![0-9]*}} = !{i32 7, !"Dwarf Version", i32 4}
 ; SHADERTEST: {{![0-9]*}} = !{i32 2, !"Debug Info Version", i32 3}
-; SHADERTEST: {{![0-9]*}} = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D1:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: [[D2:![0-9]*]])
+; SHADERTEST: {{![0-9]*}} = distinct !DICompileUnit(language: DW_LANG_Cobol74, file: [[D1:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
 ; SHADERTEST: [[D1]] = !DIFile(filename: "simple.hlsl", directory: ".")
-; SHADERTEST: [[D2]] = !{}
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/debug_info/avoid/DebugInfo_TestFsBasic.frag
+++ b/llpc/test/shaderdb/debug_info/avoid/DebugInfo_TestFsBasic.frag
@@ -32,11 +32,11 @@ void main()
 ; SHADERTEST: [[D2]] = !{{.*}} i64, i64 } { i64 {{[0-9]*}}, i64 0
 ; SHADERTEST: [[D7:![0-9]*]] = !{i32 2, !"Dwarf Version", i32 4}
 ; SHADERTEST: [[D8:![0-9]*]] = !{i32 2, !"Debug Info Version", i32 3}
-; SHADERTEST: [[D9:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_C99, file: [[D10:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: [[D11:![0-9]*]])
+; SHADERTEST: [[D9:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_C99, file: [[D10:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly)
 ; SHADERTEST: [[D10]] = !DIFile(filename: "DebugInfo_TestFsBasic.frag", directory: "{{.*}}")
-; SHADERTEST: [[D11]] = !{}
-; SHADERTEST: [[D12]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: [[D10:![0-9]*]], file: [[D10]], line: 11, type: [[D13:![0-9]*]], scopeLine: 11, spFlags: DISPFlagDefinition, unit: [[D9]], retainedNodes: [[D11]])
+; SHADERTEST: [[D12]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: [[D10:![0-9]*]], file: [[D10]], line: 11, type: [[D13:![0-9]*]], scopeLine: 11, spFlags: DISPFlagDefinition, unit: [[D9]], retainedNodes: [[D11:![0-9]*]])
 ; SHADERTEST: [[D13]] = !DISubroutineType(types: [[D11]])
+; SHADERTEST: [[D11]] = !{}
 ; SHADERTEST: [[D3]] = !{i32 4}
 ; SHADERTEST: [[D4]] = !DILocation(line: 11, scope: [[D12]])
 ; SHADERTEST: [[D15:![0-9]*]] = !DILocation(line: 12, scope: [[D12]])

--- a/llpc/test/shaderdb/debug_info/avoid/DebugInfo_TestVsBasic.vert
+++ b/llpc/test/shaderdb/debug_info/avoid/DebugInfo_TestVsBasic.vert
@@ -38,11 +38,11 @@ void main()
 ; SHADERTEST: [[D3]] = !{{.*}} i64, i64 }, { i64, i64 },
 ; SHADERTEST: [[D10:![0-9]*]] = !{i32 2, !"Dwarf Version", i32 4}
 ; SHADERTEST: [[D11:![0-9]*]] = !{i32 2, !"Debug Info Version", i32 3}
-; SHADERTEST: [[D12:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_C99, file: [[D13:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: [[D14:![0-9]*]])
+; SHADERTEST: [[D12:![0-9]*]] = distinct !DICompileUnit(language: DW_LANG_C99, file: [[D13:![0-9]*]], producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly)
 ; SHADERTEST: [[D13]] = !DIFile(filename: "DebugInfo_TestVsBasic.vert", directory: "{{.*}}")
-; SHADERTEST: [[D14]] = !{}
-; SHADERTEST: [[D15]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: [[D13:![0-9]*]], file: [[D13]], line: 9, type: [[D16:![0-9]*]], scopeLine: 9, spFlags: DISPFlagDefinition, unit: [[D12]], retainedNodes: [[D14]])
+; SHADERTEST: [[D15]] = distinct !DISubprogram(name: "main", linkageName: "main", scope: [[D13:![0-9]*]], file: [[D13]], line: 9, type: [[D16:![0-9]*]], scopeLine: 9, spFlags: DISPFlagDefinition, unit: [[D12]], retainedNodes: [[D14:![0-9]*]])
 ; SHADERTEST: [[D16]] = !DISubroutineType(types: [[D14]])
+; SHADERTEST: [[D14]] = !{}
 ; SHADERTEST: [[D4]] = !{i32 0}
 ; SHADERTEST: [[D5]] = !DILocation(line: 9, scope: [[D15]])
 ; SHADERTEST: [[D6:![0-9]*]] = !DILocation(line: 10, scope: [[D15]])


### PR DESCRIPTION
An upstream llvm change will slightly change the DebugInfo syntax in
metadata. The required changes are applied and the tests temporarily moved into
the avoid directory.

Once the upstream merge is complete, the tests can be reinstated (with the
changes)