### PR TITLE
Drop const from ICompiler::buildShaderModules

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -518,7 +518,7 @@ void Compiler::Destroy() {
 //
 // @param shaderInfo : Info to build this shader module
 // @param [out] shaderOut : Output of building this shader module
-Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, ShaderModuleBuildOut *shaderOut) const {
+Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, ShaderModuleBuildOut *shaderOut) {
   Result result = Result::Success;
   void *allocBuf = nullptr;
   const void *cacheData = nullptr;

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -98,7 +98,7 @@ public:
 
   virtual void VKAPI_CALL Destroy();
 
-  virtual Result BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, ShaderModuleBuildOut *shaderOut) const;
+  virtual Result BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, ShaderModuleBuildOut *shaderOut);
 
   virtual unsigned ConvertColorBufferFormatToExportFormat(const ColorTarget *target,
                                                           const bool enableAlphaToCoverage) const;

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -228,8 +228,7 @@ public:
   /// @param [out] pShaderOut : Output of building this shader module
   ///
   /// @returns : Result::Success if successful. Other return codes indicate failure.
-  virtual Result BuildShaderModule(const ShaderModuleBuildInfo *pShaderInfo,
-                                   ShaderModuleBuildOut *pShaderOut) const = 0;
+  virtual Result BuildShaderModule(const ShaderModuleBuildInfo *pShaderInfo, ShaderModuleBuildOut *pShaderOut) = 0;
 
   /// Build graphics pipeline from the specified info.
   ///

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -841,7 +841,7 @@ static Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *c
 //
 // @param compiler : LLPC compiler object
 // @param [in/out] compileInfo : Compilation info of LLPC standalone tool
-static Result buildShaderModules(const ICompiler *compiler, CompileInfo *compileInfo) {
+static Result buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo) {
   Result result = Result::Success;
 
   for (unsigned i = 0; i < compileInfo->shaderModuleDatas.size(); ++i) {


### PR DESCRIPTION
Allow standalone compiler implementations to modify the class state.

Required for https://github.com/GPUOpen-Drivers/llpc/pull/1372.