### PR TITLE
Update SubgroupBroadcast to handle non-valid non-uniform id

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -659,6 +659,10 @@ public:
   llvm::Value *CreateSubgroupBroadcast(llvm::Value *const value, llvm::Value *const index,
                                        const llvm::Twine &instName) override final;
 
+  // Create a subgroup broadcast that may have non-uniform index.
+  llvm::Value *CreateSubgroupBroadcastWaterfall(llvm::Value *const value, llvm::Value *const index,
+                                                const llvm::Twine &instName) override final;
+
   // Create a subgroup broadcast first.
   llvm::Value *CreateSubgroupBroadcastFirst(llvm::Value *const value, const llvm::Twine &instName) override final;
 

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -242,6 +242,8 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "subgroup.all.equal";
   case SubgroupBroadcast:
     return "subgroup.broadcast";
+  case SubgroupBroadcastWaterfall:
+    return "subgroup.broadcast.waterfall";
   case SubgroupBroadcastFirst:
     return "subgroup.broadcast.first";
   case SubgroupBallot:
@@ -1579,6 +1581,17 @@ Value *BuilderRecorder::CreateSubgroupBroadcast(Value *const value, Value *const
 }
 
 // =====================================================================================================================
+// Create a subgroup broadcast that may have a non-uniform index.
+//
+// @param value : The value to broadcast
+// @param index : The index to broadcast from
+// @param instName : Name to give instruction(s)
+Value *BuilderRecorder::CreateSubgroupBroadcastWaterfall(Value *const value, Value *const index,
+                                                         const Twine &instName) {
+  return record(Opcode::SubgroupBroadcastWaterfall, value->getType(), {value, index}, instName);
+}
+
+// =====================================================================================================================
 // Create a subgroup broadcast first.
 //
 // @param value : The value to broadcast
@@ -1970,6 +1983,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::SubgroupAny:
     case Opcode::SubgroupBallot:
     case Opcode::SubgroupBroadcast:
+    case Opcode::SubgroupBroadcastWaterfall:
     case Opcode::SubgroupBroadcastFirst:
     case Opcode::SubgroupClusteredExclusive:
     case Opcode::SubgroupClusteredInclusive:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -189,6 +189,7 @@ public:
     SubgroupAny,
     SubgroupAllEqual,
     SubgroupBroadcast,
+    SubgroupBroadcastWaterfall,
     SubgroupBroadcastFirst,
     SubgroupBallot,
     SubgroupInverseBallot,
@@ -503,6 +504,8 @@ public:
   llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupBroadcast(llvm::Value *const value, llvm::Value *const index,
                                        const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupBroadcastWaterfall(llvm::Value *const value, llvm::Value *const index,
+                                                const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupBroadcastFirst(llvm::Value *const value, const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupBallot(llvm::Value *const value, const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupInverseBallot(llvm::Value *const value, const llvm::Twine &instName) override final;

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -732,6 +732,9 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   case BuilderRecorder::Opcode::SubgroupBroadcast: {
     return m_builder->CreateSubgroupBroadcast(args[0], args[1]);
   }
+  case BuilderRecorder::Opcode::SubgroupBroadcastWaterfall: {
+    return m_builder->CreateSubgroupBroadcastWaterfall(args[0], args[1]);
+  }
   case BuilderRecorder::Opcode::SubgroupBroadcastFirst: {
     return m_builder->CreateSubgroupBroadcastFirst(args[0]);
   }

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1348,6 +1348,14 @@ public:
   virtual llvm::Value *CreateSubgroupBroadcast(llvm::Value *const value, llvm::Value *const index,
                                                const llvm::Twine &instName = "") = 0;
 
+  // Create a subgroup broadcast that can potentially have a non-uniform index
+  //
+  // @param value : The value to broadcast
+  // @param index : The index to broadcast from
+  // @param instName : Name to give instruction(s)
+  virtual llvm::Value *CreateSubgroupBroadcastWaterfall(llvm::Value *const value, llvm::Value *const index,
+                                                        const llvm::Twine &instName = "") = 0;
+
   // Create a subgroup broadcast first.
   //
   // @param value : The value to broadcast

--- a/llpc/test/shaderdb/OpGroupNonUniformBroadcast_ToWaterfall.spvasm
+++ b/llpc/test/shaderdb/OpGroupNonUniformBroadcast_ToWaterfall.spvasm
@@ -1,0 +1,39 @@
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: call i32 (...) @lgc.create.subgroup.broadcast.waterfall.i32(
+; SHADERTEST-NOT: call i32 (...) @lgc.create.subgroup.broadcast.i32(
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.3
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 14
+; Schema: 0
+               OpCapability Shader
+               OpCapability GroupNonUniform
+               OpCapability GroupNonUniformBallot
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_KHR_shader_subgroup_ballot"
+               OpSourceExtension "GL_KHR_shader_subgroup_basic"
+               OpName %main "main"
+               OpName %i "i"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+     %int_10 = OpConstant %int 10
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+     %uint_3 = OpConstant %uint 3
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+         %13 = OpGroupNonUniformBroadcast %int %uint_3 %int_10 %uint_1
+               OpStore %i %13
+               OpReturn
+               OpFunctionEnd

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3196,7 +3196,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformBroadcast>
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const value = transValue(spvOperands[1], func, block);
   Value *const index = transValue(spvOperands[2], func, block);
-  return getBuilder()->CreateSubgroupBroadcast(value, index);
+  return getBuilder()->CreateSubgroupBroadcastWaterfall(value, index);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
In cases where shaders incorrectly supply SubgroupBroadcast op with a
non-uniform id - we can more elegantly handle this by using a waterfall loop.

It is safe to globally apply this change since if id is constant or uniform,
then the backend will remove the waterfall loop.