### PR TITLE
Fixes for asserts caused by atomic-float2

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -342,7 +342,7 @@ void PatchBufferOp::visitAtomicRMWInst(AtomicRMWInst &atomicRmwInst) {
         break;
       }
 
-      Value *const atomicCall = m_builder->CreateIntrinsic(intrinsic, cast<IntegerType>(storeType),
+      Value *const atomicCall = m_builder->CreateIntrinsic(intrinsic, storeType,
                                                            {atomicRmwInst.getValOperand(), bufferDesc, baseIndex,
                                                             m_builder->getInt32(0), m_builder->getInt32(isSlc * 2)});
       copyMetadata(atomicCall, &atomicRmwInst);

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5934,6 +5934,9 @@ Value *SPIRVToLLVM::transSPIRVImageAtomicOpFromInst(SPIRVInstruction *bi, BasicB
     result = getBuilder()->CreateImageAtomic(atomicOp, imageInfo.dim, imageInfo.flags, ordering, imageInfo.imageDesc,
                                              coord, inputData);
   }
+  if (bi->getOpCode() == OpAtomicLoad && bi->getType()->isTypeFloat())
+    result = getBuilder()->CreateBitCast(result, transFPType(bi->getType()));
+
   return result;
 }
 


### PR DESCRIPTION
Changes introduced in https://github.com/GPUOpen-Drivers/llpc/pull/1384 caused
regressions when asserts enabled.

Add fixes to ensure that types are consistent.
For the atomic image load variation, the solution was to use a bitcast for the
non-float atomic load (implemented as add), rather than using the fadd variant.