### PR TITLE
Update llpc-lit tests to use new -validate-spirv option

### DIFF
--- a/llpc/test/shaderdb/Hlsl_TestCBufferArrayPacking.spvasm
+++ b/llpc/test/shaderdb/Hlsl_TestCBufferArrayPacking.spvasm
@@ -1,5 +1,5 @@
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -val=false | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -validate-spirv=false | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/Hlsl_TestCBufferArrayPackingFullStruct.spvasm
+++ b/llpc/test/shaderdb/Hlsl_TestCBufferArrayPackingFullStruct.spvasm
@@ -1,5 +1,5 @@
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -val=false | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s -validate-spirv=false | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/Hlsl_TestLoadRowMajorMatrixInStruct.spvasm
+++ b/llpc/test/shaderdb/Hlsl_TestLoadRowMajorMatrixInStruct.spvasm
@@ -1,5 +1,5 @@
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --val=false | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --validate-spirv=false | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 4, i32 0)
 ; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 16, i32 0)

--- a/llpc/test/shaderdb/Hlsl_TestStoreRowMajorMatrixInStruct.spvasm
+++ b/llpc/test/shaderdb/Hlsl_TestStoreRowMajorMatrixInStruct.spvasm
@@ -1,5 +1,5 @@
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --val=false | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --validate-spirv=false | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 0, <4 x i32> %{{[0-9]*}}, i32 64, i32 0, i32 0)
 ; SHADERTEST : AMDLLPC SUCCESS

--- a/llpc/test/testShaders.py
+++ b/llpc/test/testShaders.py
@@ -177,7 +177,7 @@ if __name__=='__main__':
                             file = open(SHADER_SRC + "/" + gfx + "/" + f, "r")
                             fileContents = file.read()
                             file.close()
-                            if re.search("RUN:.*-val=false", fileContents):
+                            if re.search("RUN:.*-validate-spirv=false", fileContents):
                                 val = "-val=false"
 
                         cmd = COMPILER + gfxip + " " + val + " -enable-outs=0 " + SHADER_SRC + "/" + gfx + "/" + f + " 2>&1 >> " + RESULT + "/" + gfx + "/" + f + ".log"


### PR DESCRIPTION
-val=false no longer works, need to use the new -validate-spirv=false option
instead.