### PR TITLE
Move builPipeline out of amdllpc.cpp. NFC.

### DIFF
--- a/llpc/tool/llpcAutoLayout.h
+++ b/llpc/tool/llpcAutoLayout.h
@@ -37,6 +37,8 @@
 namespace Llpc {
 namespace StandaloneCompiler {
 
+struct CompileInfo; // Defined in llpcCompilationUtils.h.
+
 struct ResourceNodeSet {
   std::vector<ResourceMappingNode> nodes;  // Vector of resource mapping nodes
   std::map<unsigned, unsigned> bindingMap; // Map from binding to index in nodes vector
@@ -56,6 +58,9 @@ void doAutoLayoutDesc(ShaderStage shaderStage, BinaryData spirvBin, GraphicsPipe
 // on a single SPIR-V or GLSL shader, rather than on a .pipe file.
 void buildTopLevelMapping(unsigned shaderMask, const ResourceMappingNodeMap &resNodeSets, unsigned pushConstSize,
                           ResourceMappingData *resourceMapping, bool autoLayoutDesc);
+
+// Check autolayout compatible.
+Result checkAutoLayoutCompatibleFunc(const ICompiler *compiler, CompileInfo *compileInfo);
 
 bool checkResourceMappingComptible(const ResourceMappingData *resourceMapping, unsigned autoLayoutUserDataNodeCount,
                                    const ResourceMappingRootNode *autoLayoutUserDataNodes);

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "llpcCompilationUtils.h"
+#include "llpcAutoLayout.h"
 #include "llpcDebug.h"
 #include "llpcInputUtils.h"
 #include "llpcUtil.h"
@@ -321,6 +322,167 @@ Result buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo) {
       LLPC_ERRS("Fails to build " << getShaderStageName(compileInfo->shaderModuleDatas[i].shaderStage)
                                   << " shader module:\n");
       break;
+    }
+  }
+
+  return result;
+}
+
+// =====================================================================================================================
+// Builds pipeline and does linking.
+//
+// @param compiler : LLPC compiler object
+// @param [in/out] compileInfo : Compilation info of LLPC standalone tool
+// @param compileInfo : Pipeline dump options. Pipeline dumps are disabled when this is llvm::None.
+// @param timePasses : Whether to time compiler passes
+// @returns : Result::Success on success, other status codes on failure
+Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo,
+                     llvm::Optional<Vkgc::PipelineDumpOptions> pipelineDumpOptions, bool timePasses) {
+  Result result = Result::Success;
+
+  bool isGraphics = (compileInfo->stageMask & (shaderStageToMask(ShaderStageCompute) - 1)) != 0;
+  if (isGraphics) {
+    // Build graphics pipeline
+    GraphicsPipelineBuildInfo *pipelineInfo = &compileInfo->gfxPipelineInfo;
+    GraphicsPipelineBuildOut *pipelineOut = &compileInfo->gfxPipelineOut;
+
+    // Fill pipeline shader info
+    PipelineShaderInfo *shaderInfos[ShaderStageGfxCount] = {
+        &pipelineInfo->vs, &pipelineInfo->tcs, &pipelineInfo->tes, &pipelineInfo->gs, &pipelineInfo->fs,
+    };
+
+    ResourceMappingNodeMap nodeSets;
+    unsigned pushConstSize = 0;
+    for (unsigned i = 0; i < compileInfo->shaderModuleDatas.size(); ++i) {
+
+      PipelineShaderInfo *shaderInfo = shaderInfos[compileInfo->shaderModuleDatas[i].shaderStage];
+      const ShaderModuleBuildOut *shaderOut = &(compileInfo->shaderModuleDatas[i].shaderOut);
+
+      if (!shaderInfo->pEntryTarget) {
+        // If entry target is not specified, use the one from command line option
+        shaderInfo->pEntryTarget = compileInfo->entryTarget.c_str();
+      }
+      shaderInfo->pModuleData = shaderOut->pModuleData;
+      shaderInfo->entryStage = compileInfo->shaderModuleDatas[i].shaderStage;
+
+      // If not compiling from pipeline, lay out user data now.
+      if (compileInfo->doAutoLayout) {
+        doAutoLayoutDesc(compileInfo->shaderModuleDatas[i].shaderStage, compileInfo->shaderModuleDatas[i].spirvBin,
+                         pipelineInfo, shaderInfo, nodeSets, pushConstSize, /*checkAutoLayoutCompatible =*/false,
+                         /*autoLayoutDesc = */ compileInfo->autoLayoutDesc);
+      }
+    }
+
+    if (compileInfo->doAutoLayout) {
+      buildTopLevelMapping(compileInfo->stageMask, nodeSets, pushConstSize, &pipelineInfo->resourceMapping,
+                           compileInfo->autoLayoutDesc);
+    }
+
+    pipelineInfo->pInstance = nullptr; // Dummy, unused
+    pipelineInfo->pUserData = &compileInfo->pipelineBuf;
+    pipelineInfo->pfnOutputAlloc = allocateBuffer;
+    pipelineInfo->unlinked = compileInfo->unlinked;
+
+    // NOTE: If number of patch control points is not specified, we set it to 3.
+    if (pipelineInfo->iaState.patchControlPoints == 0)
+      pipelineInfo->iaState.patchControlPoints = 3;
+
+    pipelineInfo->options.robustBufferAccess = compileInfo->robustBufferAccess;
+    pipelineInfo->options.enableRelocatableShaderElf = compileInfo->relocatableShaderElf;
+    pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo->scratchAccessBoundsChecks;
+
+    void *pipelineDumpHandle = nullptr;
+    if (pipelineDumpOptions) {
+      PipelineBuildInfo localPipelineInfo = {};
+      localPipelineInfo.pGraphicsInfo = pipelineInfo;
+      pipelineDumpHandle = Vkgc::IPipelineDumper::BeginPipelineDump(&*pipelineDumpOptions, localPipelineInfo);
+    }
+
+    if (timePasses) {
+      auto hash = Vkgc::IPipelineDumper::GetPipelineHash(pipelineInfo);
+      outs() << "LLPC PipelineHash: " << format("0x%016" PRIX64, hash) << " Files: " << compileInfo->fileNames << "\n";
+      outs().flush();
+    }
+
+    result = compiler->BuildGraphicsPipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
+
+    if (result == Result::Success) {
+      if (pipelineDumpOptions) {
+        Vkgc::BinaryData pipelineBinary = {};
+        pipelineBinary.codeSize = pipelineOut->pipelineBin.codeSize;
+        pipelineBinary.pCode = pipelineOut->pipelineBin.pCode;
+        Vkgc::IPipelineDumper::DumpPipelineBinary(pipelineDumpHandle, compileInfo->gfxIp, &pipelineBinary);
+
+        Vkgc::IPipelineDumper::EndPipelineDump(pipelineDumpHandle);
+      }
+
+      result = decodePipelineBinary(&pipelineOut->pipelineBin, compileInfo, true);
+    }
+  } else {
+    // Build compute pipeline
+    assert(compileInfo->shaderModuleDatas.size() == 1);
+    assert(compileInfo->shaderModuleDatas[0].shaderStage == ShaderStageCompute);
+
+    ComputePipelineBuildInfo *pipelineInfo = &compileInfo->compPipelineInfo;
+    ComputePipelineBuildOut *pipelineOut = &compileInfo->compPipelineOut;
+
+    PipelineShaderInfo *shaderInfo = &pipelineInfo->cs;
+    const ShaderModuleBuildOut *shaderOut = &compileInfo->shaderModuleDatas[0].shaderOut;
+
+    if (!shaderInfo->pEntryTarget) {
+      // If entry target is not specified, use the one from command line option
+      shaderInfo->pEntryTarget = compileInfo->entryTarget.c_str();
+    }
+
+    shaderInfo->entryStage = ShaderStageCompute;
+    shaderInfo->pModuleData = shaderOut->pModuleData;
+
+    // If not compiling from pipeline, lay out user data now.
+    if (compileInfo->doAutoLayout) {
+      ResourceMappingNodeMap nodeSets;
+      unsigned pushConstSize = 0;
+      doAutoLayoutDesc(ShaderStageCompute, compileInfo->shaderModuleDatas[0].spirvBin, nullptr, shaderInfo, nodeSets,
+                       pushConstSize, /*checkAutoLayoutCompatible = */ false,
+                       /*autoLayoutDesc =*/compileInfo->autoLayoutDesc);
+
+      buildTopLevelMapping(ShaderStageComputeBit, nodeSets, pushConstSize, &pipelineInfo->resourceMapping,
+                           compileInfo->autoLayoutDesc);
+    }
+
+    pipelineInfo->pInstance = nullptr; // Dummy, unused
+    pipelineInfo->pUserData = &compileInfo->pipelineBuf;
+    pipelineInfo->pfnOutputAlloc = allocateBuffer;
+    pipelineInfo->unlinked = compileInfo->unlinked;
+    pipelineInfo->options.robustBufferAccess = compileInfo->robustBufferAccess;
+    pipelineInfo->options.enableRelocatableShaderElf = compileInfo->relocatableShaderElf;
+    pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo->scratchAccessBoundsChecks;
+
+    void *pipelineDumpHandle = nullptr;
+    if (pipelineDumpOptions) {
+      PipelineBuildInfo localPipelineInfo = {};
+      localPipelineInfo.pComputeInfo = pipelineInfo;
+      pipelineDumpHandle = Vkgc::IPipelineDumper::BeginPipelineDump(&*pipelineDumpOptions, localPipelineInfo);
+    }
+
+    if (timePasses) {
+      auto hash = Vkgc::IPipelineDumper::GetPipelineHash(pipelineInfo);
+      outs() << "LLPC PipelineHash: " << format("0x%016" PRIX64, hash) << " Files: " << compileInfo->fileNames << "\n";
+      outs().flush();
+    }
+
+    result = compiler->BuildComputePipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
+
+    if (result == Result::Success) {
+      if (pipelineDumpOptions) {
+        Vkgc::BinaryData pipelineBinary = {};
+        pipelineBinary.codeSize = pipelineOut->pipelineBin.codeSize;
+        pipelineBinary.pCode = pipelineOut->pipelineBin.pCode;
+        Vkgc::IPipelineDumper::DumpPipelineBinary(pipelineDumpHandle, compileInfo->gfxIp, &pipelineBinary);
+
+        Vkgc::IPipelineDumper::EndPipelineDump(pipelineDumpHandle);
+      }
+
+      result = decodePipelineBinary(&pipelineOut->pipelineBin, compileInfo, false);
     }
   }
 

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -60,10 +60,15 @@ struct CompileInfo {
   void *pipelineBuf;                                                   // Alllocation buffer of building pipeline
   void *pipelineInfoFile;                                              // VFX-style file containing pipeline info
   const char *fileNames;                                               // Names of input shader source files
+  std::string entryTarget;                                             // Name of the entry target function.
   bool unlinked;                  // Whether to generate unlinked shader/part-pipeline ELF
+  bool relocatableShaderElf;      // Whether to enable relocatable shader compilation
   bool doAutoLayout;              // Whether to auto layout descriptors
   bool checkAutoLayoutCompatible; // Whether to comapre if auto layout descriptors is
                                   // same as specified pipeline layout
+  bool autoLayoutDesc;            // Whether to automatically create descriptor layout based on resource usages
+  bool robustBufferAccess;        // Whether to enable robust buffer access
+  bool scratchAccessBoundsChecks; // Whether to enable scratch access bounds checks
 };
 
 // Callback function to allocate buffer for building shader module and building pipeline.
@@ -84,6 +89,10 @@ Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileI
 
 // Builds shader module based on the specified SPIR-V binary.
 Result buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
+
+// Builds pipeline and does linking.
+Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo,
+                     llvm::Optional<Vkgc::PipelineDumpOptions> pipelineDumpOptions, bool timePasses);
 
 // Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
 Result outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile, llvm::StringRef firstInFile);


### PR DESCRIPTION
Extend the `CompileInfo` struct with missing options to avoid global variables.

Required for https://github.com/GPUOpen-Drivers/llpc/pull/1372.