### PR TITLE
Add print IR instrumentation and registration mechanism to the NPM

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1215,6 +1215,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       if (cl::NewPassManager) {
         std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
         lowerPassMgr->setPassIndex(&passIndex);
+        SpirvLower::registerPasses(*lowerPassMgr);
 
         // Start timer for translate.
         timerProfiler.addTimerStartStopPass(*lowerPassMgr, TimerTranslate, true);
@@ -1281,6 +1282,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       if (cl::NewPassManager) {
         std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
         lowerPassMgr->setPassIndex(&passIndex);
+        SpirvLower::registerPasses(*lowerPassMgr);
 
         SpirvLower::addPasses(context, entryStage, *lowerPassMgr, timerProfiler.getTimer(TimerLower));
         // Run the passes.

--- a/llpc/lower/PassRegistry.def
+++ b/llpc/lower/PassRegistry.def
@@ -1,7 +1,7 @@
 /*
  ***********************************************************************************************************************
  *
- *  Copyright (c) 2018-2021 Advanced Micro Devices, Inc. All Rights Reserved.
+ *  Copyright (c) 2021 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -24,43 +24,19 @@
  **********************************************************************************************************************/
 /**
  ***********************************************************************************************************************
- * @file  PassManager.h
- * @brief LLPC header file: contains declaration of class lgc::LegacyPassManager.
+ * @file  PassRegistry.def
+ * @brief LLPC header file: used as the registry of LLPC lowering passes
  ***********************************************************************************************************************
  */
-#pragma once
 
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/IR/PassManager.h"
+LLPC_PASS("llpc-spirv-lower-access-chain", SpirvLowerAccessChain())
+LLPC_PASS("llpc-spirv-lower-const-immediate-store", SpirvLowerConstImmediateStore())
+LLPC_PASS("llpc-spirv-lower-inst-meta-remove", SpirvLowerInstMetaRemove())
+LLPC_PASS("llpc-spirv-lower-terminator", SpirvLowerTerminator())
+LLPC_PASS("llpc-spirv-lower-translator", SpirvLowerTranslator())
+LLPC_PASS("llpc-spirv-lower-global", SpirvLowerGlobal())
+LLPC_PASS("llpc-spirv-lower-math-const-folding", SpirvLowerMathConstFolding())
+LLPC_PASS("llpc-spirv-lower-math-float-op", SpirvLowerMathFloatOp())
+LLPC_PASS("llpc-spirv-lower-memory-op", SpirvLowerMemoryOp())
 
-namespace lgc {
-
-// =====================================================================================================================
-// Public interface of LLPC middle-end's legacy::PassManager override
-class LegacyPassManager : public llvm::legacy::PassManager {
-public:
-  static LegacyPassManager *Create();
-  virtual ~LegacyPassManager() {}
-  virtual void stop() = 0;
-  virtual void setPassIndex(unsigned *passIndex) = 0;
-};
-
-// =====================================================================================================================
-// Public interface of LLPC middle-end's PassManager override
-class PassManager : public llvm::ModulePassManager {
-public:
-  static PassManager *Create();
-  virtual ~PassManager() {}
-  template <typename PassBuilderT> bool registerFunctionAnalysis(PassBuilderT &&PassBuilder) {
-    return functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));
-  }
-  // Register a pass to identify it with a short name in the pass manager
-  virtual void registerPass(llvm::StringRef passName, llvm::StringRef className) = 0;
-  virtual void run(llvm::Module &module) = 0;
-  virtual void setPassIndex(unsigned *passIndex) = 0;
-
-protected:
-  llvm::FunctionAnalysisManager functionAnalysisManager;
-};
-
-} // namespace lgc
+#undef LLPC_PASS

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -38,6 +38,7 @@
 #include "llpcSpirvLowerMath.h"
 #include "llpcSpirvLowerMemoryOp.h"
 #include "llpcSpirvLowerTerminator.h"
+#include "llpcSpirvLowerTranslator.h"
 #include "llpcSpirvLowerUtil.h"
 #include "lgc/Builder.h"
 #include "lgc/LgcContext.h"
@@ -219,6 +220,15 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
                                     "===============================================================================\n"
                                     "// LLPC SPIR-V lowering results\n"));
   }
+}
+
+// =====================================================================================================================
+// Register a pass to identify it with a short name in the pass manager
+//
+// @param [in/out] passMgr : Pass manager
+void SpirvLower::registerPasses(lgc::PassManager &passMgr) {
+#define LLPC_PASS(NAME, CLASS) passMgr.registerPass(NAME, decltype(CLASS)::name());
+#include "PassRegistry.def"
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -106,6 +106,8 @@ public:
 
   // Add per-shader lowering passes to pass manager
   static void addPasses(Context *context, ShaderStage stage, lgc::PassManager &passMgr, llvm::Timer *lowerTimer);
+  // Register all the lowering passes into the given pass manager
+  static void registerPasses(lgc::PassManager &passMgr);
 
   static void removeConstantExpr(Context *context, llvm::GlobalVariable *global);
   static void replaceConstWithInsts(Context *context, llvm::Constant *const constVal);


### PR DESCRIPTION
This patch adds the print IR instrumentation to the new pass manager to support the `--print-before` and `--print-after options`.
To have these options working (and any other option taking a short pass name as argument), we need to register the passes, with their associated short names, into the `PassInstrumentationCallbacks` object. This patch introduces a new file, `llpc/lower/PassRegistry.def`, that is used as the registry of the LLPC lowering passes and must be updated when a new pass is added to LLPC (I will document the whole process later, after the PR is reviewed). This file works in a very similar way to the LLVM's pass registry files.