### PR TITLE
Fix unlinked copy shader.

### DIFF
--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -86,6 +86,7 @@ private:
 
   void updateInputLocInfoMapWithUnpack();
   void updateOutputLocInfoMapWithUnpack();
+  bool canChangeOutputLocationsForGs();
   void updateInputLocInfoMapWithPack();
   void updateOutputLocInfoMapWithPack();
   void reassembleOutputExportCalls();

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineGs_TestOutputLocations.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineGs_TestOutputLocations.pipe
@@ -1,0 +1,69 @@
+// This test case checks that a pipeline with geometry shader will place the Gs outputs in a position that matches the
+// Fs inputs.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s
+; RUN: llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: <_amdgpu_vs_main>:
+; SHADERTEST: exp param[[loc:[0-9]*]] v{{[0-9]*}}, v{{[0-9]*}}, v{{[0-9]*}}, v{{[0-9]*}}
+; SHADERTEST-LABEL: <_amdgpu_ps_main>:
+; SHADERTEST: v_interp_p1_f32_e32 v{{[0-9]*}}, v{{[0-9]*}}, attr[[loc]].x
+; SHADERTEST: v_interp_p1_f32_e32 v{{[0-9]*}}, v{{[0-9]*}}, attr[[loc]].y
+; SHADERTEST: v_interp_p2_f32_e32 v{{[0-9]*}}, v{{[0-9]*}}, attr[[loc]].x
+; SHADERTEST: v_interp_p2_f32_e32 v{{[0-9]*}}, v{{[0-9]*}}, attr[[loc]].y
+
+; END_SHADERTEST
+
+[Version]
+version = 49
+
+[VsGlsl]
+#version 450
+
+void main()
+{
+    gl_PointSize = 1.0;
+}
+
+[VsInfo]
+entryPoint = main
+
+[GsGlsl]
+#version 450
+layout(points) in;
+layout(max_vertices = 2, line_strip) out;
+
+layout(location = 1) out vec4 o1;
+
+void main()
+{
+    gl_Position = vec4(0.0, 1.0, 2.0, 1.0);
+    o1 = vec4(3.0, 4.0, 5.0, 1.0);
+    EmitVertex();
+    gl_Position.x = 1.0;
+    EmitVertex();
+}
+
+
+[GsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+layout(location = 1) in vec4 v1;
+layout(location = 0) out vec4 o0;
+
+void main()
+{
+    o0 = vec4(v1.xy, 0.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 1
+colorBuffer[0].blendSrcAlphaToColor = 0


### PR DESCRIPTION
The copy shader for a Gs output was changing the locations for the
output so they are densly numbered from 0 to n.  This is a problem
because the Fs inputs may not match causing the the Fs to pick up the
wrong value for the input.

To fix this we will do what was done for the Vs output.  The channel for
the output will be the same as the SPIR-V location for the output.