### PR TITLE
Refactor amdllpc input file processing

### DIFF
--- a/llpc/tool/llpcInputUtils.h
+++ b/llpc/tool/llpcInputUtils.h
@@ -33,11 +33,18 @@
 
 #include "llpc.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 #include <vector>
 
 namespace Llpc {
 namespace StandaloneCompiler {
+
+using InputFilesGroup = llvm::SmallVector<std::string, 2>;
+// Split the list of input file paths into groups. Each group will be compiled in its own context.
+// Validates the input files and returns Error on failure.
+llvm::Expected<llvm::SmallVector<InputFilesGroup>> groupInputFiles(llvm::ArrayRef<std::string> inputFiles);
 
 // Represents allowed extensions of LLPC source files.
 namespace Ext {

--- a/llpc/unittests/CMakeLists.txt
+++ b/llpc/unittests/CMakeLists.txt
@@ -55,13 +55,12 @@ function(llpc_add_unittest_impl test_suite test_name)
 
   target_link_libraries(${test_name} PRIVATE ${LLVM_GTEST_LIBS})
   target_compile_definitions(${test_name} PRIVATE
-    ${LLVM_DEFINITIONS}
     LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION}  # Required by vkgcDefs.h.
   )
   target_include_directories(${test_name} PRIVATE
-    ${XGL_LLVM_SRC_PATH}/include
     ${LLVM_INCLUDE_DIRS}  # This is necessary to discover the auto-generated llvm-config.h header.
   )
+  set_compiler_options(${test_name} ${LLPC_ENABLE_WERROR})
 
   get_target_property(test_suite_folder ${test_suite} FOLDER)
   if(test_suite_folder)


### PR DESCRIPTION
-  Disallow mixing .pipe and shader inputs.
-  Compile all shader files in the same context.
-  Add input grouping tests.

`processPipeline` is stil not as simple as I would like, but I'd like to
submit more invasive changes separately.