### PR TITLE
Allow immutable sampler in relocatable shaders

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -866,10 +866,6 @@ static bool isUnrelocatableResourceMappingRootNode(const ResourceMappingNode *no
 //
 // @param [in] resourceMapping : resource mapping data, containing user data nodes
 static bool hasUnrelocatableDescriptorNode(const ResourceMappingData *resourceMapping) {
-  // The code to handle an immutable sampler cannot be easily patched.
-  if (resourceMapping->staticDescriptorValueCount != 0)
-    return true;
-
   for (unsigned i = 0; i < resourceMapping->userDataNodeCount; ++i) {
     if (isUnrelocatableResourceMappingRootNode(&resourceMapping->pUserDataNodes[i].node))
       return true;

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ImmutableSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ImmutableSampler.pipe
@@ -4,7 +4,7 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
-; SHADERTEST-LABEL: {{^Warning:}} Relocatable shader compilation requested but not possible
+; SHADERTEST-LABEL: Building pipeline with relocatable shader elf.
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: {{^=====}} AMDLLPC SUCCESS
 ; END_SHADERTEST


### PR DESCRIPTION
LLPC will currently fall back to full pipeline compilation when it notices an immutable sampler in the pipeline state.  This was because the relocatable shaders try to load the samplers from the descriptor set, but the sampler data was not there.

A recent change to XGL (https://github.com/GPUOpen-Drivers/xgl/pull/129) writes the immutable sampler to the descriptor set.  This means LLPC does not have to fall back to full pipeline compilation anymore.