### PR TITLE
Add amdllpc option for scalar block layout

### DIFF
--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -229,6 +229,9 @@ static cl::opt<std::string> SpvGenDir("spvgen-dir", cl::desc("Directory to load 
 static cl::opt<bool> RobustBufferAccess("robust-buffer-access", cl::desc("Validate if the index is out of bounds"),
                                         cl::init(false));
 
+static cl::opt<bool> ScalarBlockLayout("scalar-block-layout", cl::desc("Allows scalar block layout of types"),
+                                       cl::init(false));
+
 static cl::opt<bool> EnableRelocatableShaderElf("enable-relocatable-shader-elf",
                                                 cl::desc("Compile pipelines using relocatable shader elf"),
                                                 cl::init(false));
@@ -397,6 +400,7 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
   compileInfo->checkAutoLayoutCompatible = CheckAutoLayoutCompatible;
   compileInfo->autoLayoutDesc = AutoLayoutDesc;
   compileInfo->robustBufferAccess = RobustBufferAccess;
+  compileInfo->scalarBlockLayout = ScalarBlockLayout;
   compileInfo->scratchAccessBoundsChecks = EnableScratchAccessBoundsChecks;
 
   // Set NGG control settings

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -393,6 +393,7 @@ Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo,
 
     pipelineInfo->options.robustBufferAccess = compileInfo->robustBufferAccess;
     pipelineInfo->options.enableRelocatableShaderElf = compileInfo->relocatableShaderElf;
+    pipelineInfo->options.scalarBlockLayout = compileInfo->scalarBlockLayout;
     pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo->scratchAccessBoundsChecks;
 
     void *pipelineDumpHandle = nullptr;
@@ -459,6 +460,7 @@ Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo,
     pipelineInfo->unlinked = compileInfo->unlinked;
     pipelineInfo->options.robustBufferAccess = compileInfo->robustBufferAccess;
     pipelineInfo->options.enableRelocatableShaderElf = compileInfo->relocatableShaderElf;
+    pipelineInfo->options.scalarBlockLayout = compileInfo->scalarBlockLayout;
     pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo->scratchAccessBoundsChecks;
 
     void *pipelineDumpHandle = nullptr;

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -57,12 +57,13 @@ struct CompileInfo {
   Llpc::GraphicsPipelineBuildOut gfxPipelineOut;                       // Output of building graphics pipeline
   Llpc::ComputePipelineBuildInfo compPipelineInfo;                     // Info to build compute pipeline
   Llpc::ComputePipelineBuildOut compPipelineOut;                       // Output of building compute pipeline
-  void *pipelineBuf;                                                   // Alllocation buffer of building pipeline
+  void *pipelineBuf;                                                   // Allocation buffer of building pipeline
   void *pipelineInfoFile;                                              // VFX-style file containing pipeline info
   const char *fileNames;                                               // Names of input shader source files
   std::string entryTarget;                                             // Name of the entry target function.
   bool unlinked;                  // Whether to generate unlinked shader/part-pipeline ELF
   bool relocatableShaderElf;      // Whether to enable relocatable shader compilation
+  bool scalarBlockLayout;         // Whether to enable scalar block layout
   bool doAutoLayout;              // Whether to auto layout descriptors
   bool checkAutoLayoutCompatible; // Whether to comapre if auto layout descriptors is
                                   // same as specified pipeline layout


### PR DESCRIPTION
Many applications use the Vulkan scalar block layout feature.  To do offline compilation for those application, we will need a command line option to enable that feature.