### PR TITLE
Emplace dump options before setting

### DIFF
--- a/llpc/test/shaderdb/PipelineDumpTest.spvasm
+++ b/llpc/test/shaderdb/PipelineDumpTest.spvasm
@@ -1,0 +1,17 @@
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-pipeline-dump --pipeline-dump-dir=%basename_t
+; RUN: ls %basename_t/*pipe
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main"
+         %12 = OpTypeVoid
+         %21 = OpTypeFunction %12
+          %1 = OpFunction %12 None %21
+         %66 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -702,6 +702,7 @@ static Result processPipeline(ICompiler *compiler, ArrayRef<std::string> inFiles
     if (result == Result::Success && ToLink) {
       Optional<PipelineDumpOptions> dumpOptions = None;
       if (cl::EnablePipelineDump) {
+        dumpOptions.emplace();
         dumpOptions->pDumpDir = cl::PipelineDumpDir.c_str();
         dumpOptions->filterPipelineDumpByType = cl::FilterPipelineDumpByType;
         dumpOptions->filterPipelineDumpByHash = cl::FilterPipelineDumpByHash;


### PR DESCRIPTION
The pipeline dump options in amdllpc are currently set, in an "Optional" struct.  For that to be valid, the object first had to be allocated.  This is causing amdllpc to never dump the pipeline.