### PR TITLE
Add the member word4 and word5 to SamplerYCbCrConversionMetaData

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 50
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -71,6 +71,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     50.1 | Add the member word4 and word5 to SamplerYCbCrConversionMetaData                                      |
 //  |     50.0 | Removed the member 'enableOpt' of ShaderModuleOptions                                                 |
 //  |     49.0 | Added DescriptorConstBuffer, DescriptorConstBufferCompact, DescriptorImage, DescriptorConstTexelBuffer|
 //  |          | to ResourceMappingNodeType                                                                            |
@@ -687,6 +688,22 @@ struct SamplerYCbCrConversionMetaData {
     };
     unsigned u32All;
   } word3;
+
+  union {
+    struct {
+      unsigned lumaWidth : 16;  ///< Actual width of luma plane
+      unsigned lumaHeight : 16; ///< Actual height of luma plane
+    };
+    unsigned u32All;
+  } word4;
+
+  union {
+    struct {
+      unsigned lumaDepth : 16; ///< Actual array slices of luma plane
+      unsigned : 16;
+    };
+    unsigned u32All;
+  } word5;
 };
 
 /// Represents info of a shader attached to a to-be-built pipeline.

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1189,7 +1189,7 @@ Value *BuilderRecorder::CreateImageSample(Type *resultTy, unsigned dim, unsigned
 // @param dim : Image dimension
 // @param flags : ImageFlag* flags
 // @param imageDescArray : Image descriptor, or array of up to three descriptors for multi-plane
-// @param convertingSamplerDesc : Converting sampler descriptor (constant v8i32)
+// @param convertingSamplerDesc : Converting sampler descriptor (constant v10i32)
 // @param address : Address and other arguments
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateImageSampleConvert(Type *resultTy, unsigned dim, unsigned flags, Value *imageDescArray,

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -729,7 +729,7 @@ Value *ImageBuilder::CreateImageSample(Type *resultTy, unsigned dim, unsigned fl
 // @param dim : Image dimension
 // @param flags : ImageFlag* flags
 // @param imageDescArray : Image descriptor, or array of up to three descriptors for multi-plane
-// @param convertingSamplerDesc : Converting sampler descriptor (v8i32)
+// @param convertingSamplerDesc : Converting sampler descriptor (v10i32)
 // @param address : Address and other arguments
 // @param instName : Name to give instruction(s)
 Value *ImageBuilder::CreateImageSampleConvert(Type *resultTy, unsigned dim, unsigned flags, Value *imageDescArray,
@@ -747,7 +747,7 @@ Value *ImageBuilder::CreateImageSampleConvert(Type *resultTy, unsigned dim, unsi
 // @param dim : Image dimension
 // @param flags : ImageFlag* flags
 // @param imageDescArray : Image descriptor, or array of up to three descriptors for multi-plane
-// @param convertingSamplerDesc : Converting sampler descriptor (v8i32)
+// @param convertingSamplerDesc : Converting sampler descriptor (v10i32)
 // @param address : Address and other arguments
 // @param instName : Name to give instruction(s)
 Value *ImageBuilder::CreateImageSampleConvertYCbCr(Type *resultTy, unsigned dim, unsigned flags, Value *imageDescArray,
@@ -768,6 +768,8 @@ Value *ImageBuilder::CreateImageSampleConvertYCbCr(Type *resultTy, unsigned dim,
   yCbCrMetaData.word1.u32All = getYCbCrMetaElement(5);
   yCbCrMetaData.word2.u32All = getYCbCrMetaElement(6);
   yCbCrMetaData.word3.u32All = getYCbCrMetaElement(7);
+  yCbCrMetaData.word4.u32All = getYCbCrMetaElement(8);
+  yCbCrMetaData.word5.u32All = getYCbCrMetaElement(9);
 
   // Only the first 4 dwords are sampler descriptor, we need to extract these values under any condition
   // Init sample descriptor for luma channel

--- a/lgc/builder/YCbCrConverter.h
+++ b/lgc/builder/YCbCrConverter.h
@@ -98,6 +98,22 @@ struct SamplerYCbCrConversionMetaData {
     };
     unsigned u32All;
   } word3;
+
+  union {
+    struct {
+      unsigned lumaWidth : 16;  ///< Actual width of luma plane
+      unsigned lumaHeight : 16; ///< Actual height of luma plane
+    };
+    unsigned u32All;
+  } word4;
+
+  union {
+    struct {
+      unsigned lumaDepth : 16; ///< Actual array slices of luma plane
+      unsigned : 16;
+    };
+    unsigned u32All;
+  } word5;
 };
 
 // Represents the type of sampler filter.

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -954,7 +954,7 @@ public:
   // @param dim : Image dimension
   // @param flags : ImageFlag* flags
   // @param imageDescArray : Image descriptor, or array of up to three descriptors for multi-plane
-  // @param convertingSamplerDesc : Converting sampler descriptor (constant v8i32)
+  // @param convertingSamplerDesc : Converting sampler descriptor (constant v10i32)
   // @param address : Address and other arguments
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateImageSampleConvert(llvm::Type *resultTy, unsigned dim, unsigned flags,

--- a/llpc/translator/include/LLVMSPIRVLib.h
+++ b/llpc/translator/include/LLVMSPIRVLib.h
@@ -86,9 +86,10 @@ typedef std::map<uint32_t, SPIRVSpecConstEntry> SPIRVSpecConstMap;
 struct ConvertingSampler {
   unsigned set;                    // Descriptor set
   unsigned binding;                // Binding
-  llvm::ArrayRef<uint32_t> values; // Values; 8 uint32_t per array entry
+  llvm::ArrayRef<uint32_t> values; // Values; 10 uint32_t per array entry
 };
-static const unsigned ConvertingSamplerDwordCount = 8;
+
+static const unsigned ConvertingSamplerDwordCount = 10;
 
 /// \brief Check if a string contains SPIR-V binary.
 bool IsSPIRVBinary(std::string &Img);

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -563,7 +563,9 @@ void PipelineDumper::dumpResourceMappingInfo(const ResourceMappingData* resource
             for (unsigned j = 0; j < staticDescriptorValue->arraySize; ++j) {
                 dumpFile << "descriptorRangeValue[" << i << "].uintData = ";
                 const unsigned descriptorSizeInDw =
-                    staticDescriptorValue->type == ResourceMappingNodeType::DescriptorYCbCrSampler ? 8 : 4;
+                    4 + (staticDescriptorValue->type == ResourceMappingNodeType::DescriptorYCbCrSampler
+                             ? (sizeof(SamplerYCbCrConversionMetaData) / 4)
+                             : 0);
 
                 for (unsigned k = 0; k < descriptorSizeInDw - 1; ++k)
                     dumpFile << staticDescriptorValue->pValue[k] << ", ";
@@ -1207,7 +1209,9 @@ void PipelineDumper::updateHashForResourceMappingInfo(const ResourceMappingData*
           // The hasher should be updated when the content changes, this is because YCbCrMetaData
           // is engaged in pipeline compiling.
           const unsigned descriptorSize =
-              staticDescriptorValue->type != ResourceMappingNodeType::DescriptorYCbCrSampler ? 16 : 32;
+              16 + (staticDescriptorValue->type != ResourceMappingNodeType::DescriptorYCbCrSampler
+                        ? 0
+                        : sizeof(SamplerYCbCrConversionMetaData));
 
           hasher->Update(reinterpret_cast<const uint8_t *>(staticDescriptorValue->pValue),
                          staticDescriptorValue->arraySize * descriptorSize);


### PR DESCRIPTION
This fix is used to support VK_EXT_ycbcr_image_arrays extension
implementation. Which is used to scale the coordinates for sampling image correctly.

And the more implemenatations for this extension will be added in later
commits.