### PR TITLE
Refine the property in GpuProperty for integer dot product

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -93,14 +93,22 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
   Value *scalar = nullptr;
   Type *outputTy = accumulator->getType();
 
+  // The component of Vector 2 can be signed or unsigned
+  const bool isSigned = (flags & FirstVectorSigned);
+  // The mixed signed/unsigned is that component of Vector 1 is treated as signed and component of Vector 2 is treated
+  // as unsigned.
+  const bool isMixed = (flags == FirstVectorSigned);
+
   const unsigned compBitWidth = inputTy->getScalarSizeInBits();
-  bool hasHwNativeSupport =
-      (getPipelineState()->getTargetInfo().getGpuProperty().hasIntegerDot && (compBitWidth == 8 || compBitWidth == 16));
-  const bool isSigned = (flags & lgc::Builder::FirstVectorSigned);
-  const bool isMixed = (flags == lgc::Builder::FirstVectorSigned);
-  // The mixed mode "First vector is signed and secont vector is unsigned" is not supported
-  if (hasHwNativeSupport && isMixed)
-    hasHwNativeSupport = false;
+  assert(compBitWidth >= 8 && compBitWidth <= 64);
+
+  auto &supportIntegerDotFlag = getPipelineState()->getTargetInfo().getGpuProperty().supportIntegerDotFlag;
+  // Check if the component bitwidth of vectors and the signedness of component of vecotrs are both supppored by HW.
+  const bool isSupportCompBitwidth = (supportIntegerDotFlag.compBitwidth16 && compBitWidth == 16) ||
+                                     (supportIntegerDotFlag.compBitwidth8 && compBitWidth == 8);
+  const bool isSupportSignedness =
+      isMixed ? supportIntegerDotFlag.diffSignedness : supportIntegerDotFlag.sameSignedness;
+  const bool hasHwNativeSupport = isSupportCompBitwidth && isSupportSignedness;
 
   // NOTE: For opcodes with an accumulator, the spec said "If any of the multiplications or additions, with the
   // exception of the final accumulation, overflow or underflow, the result of the instruction is undefined". For

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -70,9 +70,13 @@ struct GpuProperty {
   unsigned tessFactorBufferSizePerSe; // Size of the tessellation-factor buffer per SE, in dwords.
   bool supportShaderPowerProfiling;   // Hardware supports Shader Profiling for Power
   bool supportSpiPrefPriority;        // Hardware supports SPI shader preference priority
-  bool hasIntegerDot;                 // Hardware supports interger dot product where two vectors are same signedness
-  bool hasMixedIntegerDot; // Hardware supports interger dot product where first vector is signed and second vector is
-                           // unsigned
+  struct {
+    unsigned compBitwidth16 : 1; // Whether the vector is 16-bit component
+    unsigned compBitwidth8 : 1;  // Whether the vector is 8-bit component
+    unsigned compBitwidth4 : 1;  // Whether the vector is 4-bit component
+    unsigned sameSignedness : 1; // Whether the components of two vectors have the same signedness
+    unsigned diffSignedness : 1; // Whether the components of two vectors have the diff signedness
+  } supportIntegerDotFlag;       // The flag indicates the HW supports integer dot product
 };
 
 // Contains flags for all of the hardware workarounds which affect pipeline compilation.

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -199,8 +199,11 @@ public:
   virtual llvm::Value *CreateDotProduct(llvm::Value *const vector1, llvm::Value *const vector2,
                                         const llvm::Twine &instName = "") = 0;
 
-  // Bit settings in flags argument for integer dot product
-  enum { FirstVectorSigned = 1, SecondVectorSigned = 2 };
+  // Bit settings for integer dot product
+  enum : unsigned {
+    FirstVectorSigned = 1, // The components of the first vector are signed
+    SecondVectorSigned,    // The components of the second vector are signed
+  };
 
   // Create code to calculate the dot product of two integer vectors, with optional accumulator, using hardware support
   // where available.

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -278,7 +278,11 @@ static void setGfx900Info(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx906Info(TargetInfo *targetInfo) {
   setGfx9Info(targetInfo);
-  targetInfo->getGpuProperty().hasIntegerDot = true;
+
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth16 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth8 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth4 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.sameSignedness = true;
 }
 
 // gfx10
@@ -337,7 +341,10 @@ static void setGfx1011Info(TargetInfo *targetInfo) {
   targetInfo->getGpuWorkarounds().gfx10.waWarFpAtomicDenormHazard = 1;
   targetInfo->getGpuWorkarounds().gfx10.waNggCullingNoEmptySubgroups = 1;
   targetInfo->getGpuWorkarounds().gfx10.waFixBadImageDescriptor = 1;
-  targetInfo->getGpuProperty().hasIntegerDot = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth16 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth8 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth4 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.sameSignedness = true;
 }
 
 // gfx1012
@@ -358,7 +365,10 @@ static void setGfx1012Info(TargetInfo *targetInfo) {
   targetInfo->getGpuWorkarounds().gfx10.waWarFpAtomicDenormHazard = 1;
   targetInfo->getGpuWorkarounds().gfx10.waNggDisabled = 1;
   targetInfo->getGpuWorkarounds().gfx10.waFixBadImageDescriptor = 1;
-  targetInfo->getGpuProperty().hasIntegerDot = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth16 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth8 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth4 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.sameSignedness = true;
 }
 
 // gfx103
@@ -367,7 +377,10 @@ static void setGfx1012Info(TargetInfo *targetInfo) {
 static void setGfx103Info(TargetInfo *targetInfo) {
   // Hardware workarounds for GFX10.3 based GPU's:
   targetInfo->getGpuWorkarounds().gfx10.waAdjustDepthImportVrs = 1;
-  targetInfo->getGpuProperty().hasIntegerDot = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth16 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth8 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.compBitwidth4 = true;
+  targetInfo->getGpuProperty().supportIntegerDotFlag.sameSignedness = true;
 }
 
 // gfx1030


### PR DESCRIPTION
This change is to make the decision of HW supported integer dot product
more scalable. So the original two boolean members -
`GpuProperty::hasIntegerDot` and `GpuProperty::hasMixedIntegerDot` are
replaced by one integer member - `GpuProperty::supportIntegerDotFlag`,
which can include all HW supported properties, such as the component
bitwidth of a vector and both signedness of the two vectors.