### PR TITLE
Use CallInst.arg_size()

### DIFF
--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -203,7 +203,7 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     m_builder->clearFastMathFlags();
 
   // Get the args.
-  auto args = ArrayRef<Use>(&call->getOperandList()[0], call->getNumArgOperands());
+  auto args = ArrayRef<Use>(&call->getOperandList()[0], call->arg_size());
 
   switch (opcode) {
   case BuilderRecorder::Opcode::Nop:

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -701,7 +701,7 @@ void LowerFragColorExport::collectExportInfoForBuiltinOutput(Function *module, B
       if (callInst->getFunction() != module)
         continue;
 
-      Value *output = callInst->getOperand(callInst->getNumArgOperands() - 1); // Last argument
+      Value *output = callInst->getOperand(callInst->arg_size() - 1); // Last argument
       unsigned builtInId = cast<ConstantInt>(callInst->getOperand(0))->getZExtValue();
       switch (builtInId) {
       case BuiltInFragDepth: {

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3186,7 +3186,7 @@ Function *NggPrimShader::mutateGs(Module *module) {
         assert(call);
         m_builder->SetInsertPoint(call);
 
-        assert(call->getNumArgOperands() == 4);
+        assert(call->arg_size() == 4);
         const unsigned location = cast<ConstantInt>(call->getOperand(0))->getZExtValue();
         const unsigned compIdx = cast<ConstantInt>(call->getOperand(1))->getZExtValue();
         const unsigned streamId = cast<ConstantInt>(call->getOperand(2))->getZExtValue();
@@ -3331,7 +3331,7 @@ Function *NggPrimShader::mutateCopyShader(Module *module) {
 
         m_builder->SetInsertPoint(call);
 
-        assert(call->getNumArgOperands() == 2);
+        assert(call->arg_size() == 2);
         const unsigned location = cast<ConstantInt>(call->getOperand(0))->getZExtValue();
         const unsigned streamId = cast<ConstantInt>(call->getOperand(1))->getZExtValue();
         assert(streamId < MaxGsStreams);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -360,8 +360,8 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
         if (!callInst || callInst->getParent()->getParent() != gsEntryPoint)
           continue;
 
-        assert(callInst->getNumArgOperands() == 4);
-        Value *output = callInst->getOperand(callInst->getNumArgOperands() - 1); // Last argument
+        assert(callInst->arg_size() == 4);
+        Value *output = callInst->getOperand(callInst->arg_size() - 1); // Last argument
         auto outputTy = output->getType();
 
         InOutLocationInfo origLocInfo;

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -690,7 +690,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
           if (inst && inst->getFunction() == &func) {
             Value *replacementVal = arg;
             auto call = dyn_cast<CallInst>(inst);
-            if (call->getNumArgOperands() >= 2) {
+            if (call->arg_size() >= 2) {
               // There is a second operand, used by ShaderInputs::getSpecialUserDataAsPoint to indicate that we
               // need to extend the loaded 32-bit value to a 64-bit pointer, using either PC or the provided
               // high half.
@@ -816,7 +816,7 @@ void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *>
       // inputs), plus the original args on the call.
       SmallVector<Type *, 20> argTys;
       SmallVector<Value *, 20> args;
-      for (unsigned idx = 0; idx != call->getNumArgOperands(); ++idx) {
+      for (unsigned idx = 0; idx != call->arg_size(); ++idx) {
         argTys.push_back(call->getArgOperand(idx)->getType());
         args.push_back(call->getArgOperand(idx));
       }
@@ -846,7 +846,7 @@ void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *>
       // Mark sgpr arguments as inreg
       for (unsigned idx = 0; idx != shaderInputTys.size(); ++idx) {
         if ((inRegMask >> idx) & 1)
-          newCall->addParamAttr(idx + call->getNumArgOperands(), Attribute::InReg);
+          newCall->addParamAttr(idx + call->arg_size(), Attribute::InReg);
       }
 
       // Replace and erase the old one.

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -500,10 +500,10 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         // Builtin Call has different number of operands
         Value *elemIdx = nullptr;
         Value *vertexIdx = nullptr;
-        if (callInst.getNumArgOperands() > 1)
+        if (callInst.arg_size() > 1)
           elemIdx = isDontCareValue(callInst.getOperand(1)) ? nullptr : callInst.getOperand(1);
 
-        if (callInst.getNumArgOperands() > 2)
+        if (callInst.arg_size() > 2)
           vertexIdx = isDontCareValue(callInst.getOperand(2)) ? nullptr : callInst.getOperand(2);
 
         input = patchTcsBuiltInInputImport(inputTy, builtInId, elemIdx, vertexIdx, &callInst);
@@ -513,10 +513,10 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         // Builtin Call has different number of operands
         Value *elemIdx = nullptr;
         Value *vertexIdx = nullptr;
-        if (callInst.getNumArgOperands() > 1)
+        if (callInst.arg_size() > 1)
           elemIdx = isDontCareValue(callInst.getOperand(1)) ? nullptr : callInst.getOperand(1);
 
-        if (callInst.getNumArgOperands() > 2)
+        if (callInst.arg_size() > 2)
           vertexIdx = isDontCareValue(callInst.getOperand(2)) ? nullptr : callInst.getOperand(2);
         input = patchTesBuiltInInputImport(inputTy, builtInId, elemIdx, vertexIdx, &callInst);
         break;
@@ -524,7 +524,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       case ShaderStageGeometry: {
         // Builtin Call has different number of operands
         Value *vertexIdx = nullptr;
-        if (callInst.getNumArgOperands() > 1)
+        if (callInst.arg_size() > 1)
           vertexIdx = isDontCareValue(callInst.getOperand(1)) ? nullptr : callInst.getOperand(1);
 
         input = patchGsBuiltInInputImport(inputTy, builtInId, vertexIdx, &callInst);
@@ -532,7 +532,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       }
       case ShaderStageFragment: {
         Value *sampleId = nullptr;
-        if (callInst.getNumArgOperands() >= 2)
+        if (callInst.arg_size() >= 2)
           sampleId = callInst.getArgOperand(1);
         input = patchFsBuiltInInputImport(inputTy, builtInId, sampleId, &callInst);
         break;
@@ -620,7 +620,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
 
       switch (m_shaderStage) {
       case ShaderStageTessControl: {
-        assert(callInst.getNumArgOperands() == 4);
+        assert(callInst.arg_size() == 4);
 
         if (!elemIdx) {
           elemIdx = callInst.getOperand(2);
@@ -634,7 +634,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         break;
       }
       case ShaderStageTessEval: {
-        assert(callInst.getNumArgOperands() == 4);
+        assert(callInst.arg_size() == 4);
 
         auto elemIdx = callInst.getOperand(2);
         assert(isDontCareValue(elemIdx) == false);
@@ -645,7 +645,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         break;
       }
       case ShaderStageGeometry: {
-        assert(callInst.getNumArgOperands() == 3);
+        assert(callInst.arg_size() == 3);
         if (!elemIdx)
           elemIdx = cast<ConstantInt>(callInst.getOperand(1));
 
@@ -669,13 +669,13 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         Value *auxInterpValue = nullptr;
 
         if (isGenericInputImport) {
-          assert(callInst.getNumArgOperands() == 4);
+          assert(callInst.arg_size() == 4);
 
           interpMode = cast<ConstantInt>(callInst.getOperand(2))->getZExtValue();
           interpLoc = cast<ConstantInt>(callInst.getOperand(3))->getZExtValue();
         } else {
           assert(isInterpolantInputImport);
-          assert(callInst.getNumArgOperands() == 5);
+          assert(callInst.arg_size() == 5);
 
           interpMode = cast<ConstantInt>(callInst.getOperand(3))->getZExtValue();
           interpLoc = InOutInfo::InterpLocUnknown;
@@ -717,7 +717,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
     if (isBuiltInOutputImport) {
       const unsigned builtInId = value;
 
-      assert(callInst.getNumArgOperands() == 3);
+      assert(callInst.arg_size() == 3);
       Value *elemIdx = isDontCareValue(callInst.getOperand(1)) ? nullptr : callInst.getOperand(1);
       Value *vertexIdx = isDontCareValue(callInst.getOperand(2)) ? nullptr : callInst.getOperand(2);
 
@@ -748,7 +748,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       }
       assert(loc != InvalidValue);
 
-      assert(callInst.getNumArgOperands() == 4);
+      assert(callInst.arg_size() == 4);
       auto elemIdx = callInst.getOperand(2);
       assert(isDontCareValue(elemIdx) == false);
       auto vertexIdx = isDontCareValue(callInst.getOperand(3)) ? nullptr : callInst.getOperand(3);
@@ -761,7 +761,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
     // Output exports
     assert(isOutput);
 
-    Value *output = callInst.getOperand(callInst.getNumArgOperands() - 1); // Last argument
+    Value *output = callInst.getOperand(callInst.arg_size() - 1); // Last argument
 
     // Generic value (location or SPIR-V built-in ID or XFB buffer ID)
     unsigned value = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
@@ -815,7 +815,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         break;
       }
       case ShaderStageTessControl: {
-        assert(callInst.getNumArgOperands() == 4);
+        assert(callInst.arg_size() == 4);
         Value *elemIdx = isDontCareValue(callInst.getOperand(1)) ? nullptr : callInst.getOperand(1);
         Value *vertexIdx = isDontCareValue(callInst.getOperand(2)) ? nullptr : callInst.getOperand(2);
 
@@ -919,14 +919,14 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
 
         switch (m_shaderStage) {
         case ShaderStageVertex: {
-          assert(callInst.getNumArgOperands() == 3);
+          assert(callInst.arg_size() == 3);
           if (elemIdx == InvalidValue)
             elemIdx = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
           patchVsGenericOutputExport(output, loc, elemIdx, &callInst);
           break;
         }
         case ShaderStageTessControl: {
-          assert(callInst.getNumArgOperands() == 5);
+          assert(callInst.arg_size() == 5);
 
           auto elemIdx = callInst.getOperand(2);
           assert(isDontCareValue(elemIdx) == false);
@@ -937,14 +937,14 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           break;
         }
         case ShaderStageTessEval: {
-          assert(callInst.getNumArgOperands() == 3);
+          assert(callInst.arg_size() == 3);
           if (elemIdx == InvalidValue)
             elemIdx = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
           patchTesGenericOutputExport(output, loc, elemIdx, &callInst);
           break;
         }
         case ShaderStageGeometry: {
-          assert(callInst.getNumArgOperands() == 4);
+          assert(callInst.arg_size() == 4);
           if (elemIdx == InvalidValue)
             elemIdx = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
           const unsigned streamId = cast<ConstantInt>(callInst.getOperand(2))->getZExtValue();
@@ -952,7 +952,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           break;
         }
         case ShaderStageFragment: {
-          assert(callInst.getNumArgOperands() == 3);
+          assert(callInst.arg_size() == 3);
           llvm_unreachable("Fragment shader export should have been handled by the LowerFragColorExport pass");
           break;
         }

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -385,7 +385,7 @@ bool PatchResourceCollect::canUseNggCulling(Module *module) {
   assert(posCall); // Position export must exist
 
   // Check position value, disable NGG culling if it is constant
-  auto posValue = posCall->getArgOperand(posCall->getNumArgOperands() - 1); // Last argument is position value
+  auto posValue = posCall->getArgOperand(posCall->arg_size() - 1); // Last argument is position value
   if (isa<Constant>(posValue))
     return false;
 
@@ -1084,7 +1084,7 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
     unsigned builtInId = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
     m_importedOutputBuiltIns.insert(builtInId);
   } else if (mangledName.startswith(lgcName::OutputExportGeneric)) {
-    auto outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
+    auto outputValue = callInst.getArgOperand(callInst.arg_size() - 1);
     if (m_shaderStage != ShaderStageFragment && isa<UndefValue>(outputValue)) {
       // NOTE: If an output value of vertex processing stages is undefined, we can safely drop it and remove the output
       // export call.
@@ -1114,7 +1114,7 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
     // NOTE: If an output value is undefined, we can safely drop it and remove the output export call.
     // Currently, do this for geometry shader.
     if (m_shaderStage == ShaderStageGeometry) {
-      auto outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
+      auto outputValue = callInst.getArgOperand(callInst.arg_size() - 1);
       if (isa<UndefValue>(outputValue))
         m_deadCalls.push_back(&callInst);
       else {
@@ -1123,7 +1123,7 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
       }
     }
   } else if (mangledName.startswith(lgcName::OutputExportXfb)) {
-    auto outputValue = callInst.getArgOperand(callInst.getNumArgOperands() - 1);
+    auto outputValue = callInst.getArgOperand(callInst.arg_size() - 1);
     if (isa<UndefValue>(outputValue)) {
       // NOTE: If an output value is undefined, we can safely drop it and remove the transform feedback output export
       // call.
@@ -2478,7 +2478,7 @@ void PatchResourceCollect::updateInputLocInfoMapWithPack() {
   // Fill inputLocInfoMap of {TCS, GS, FS} for the packable calls
   unsigned newLocIdx = 0;
   for (auto call : packableCalls) {
-    const bool isInterpolant = isFs && call->getNumArgOperands() == 5;
+    const bool isInterpolant = isFs && call->arg_size() == 5;
     unsigned locOffset = 0;
     unsigned compIdxArgIdx = 1;
     if (isInterpolant || isTcs) {
@@ -2755,7 +2755,7 @@ void PatchResourceCollect::scalarizeForInOutPacking(Module *module) {
         ShaderStage shaderStage = m_pipelineShaders->getShaderStage(call->getFunction());
         if (m_pipelineState->canPackOutput(shaderStage)) {
           // We have a use in VS/TES/GS. See if it needs scalarizing. The output value is always the final argument.
-          Type *valueTy = call->getArgOperand(call->getNumArgOperands() - 1)->getType();
+          Type *valueTy = call->getArgOperand(call->arg_size() - 1)->getType();
           if (isa<VectorType>(valueTy) || valueTy->getPrimitiveSizeInBits() == 64)
             outputCalls.push_back(call);
         }
@@ -2789,7 +2789,7 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
   //      @llpc.input.import.interpolant.%Type%(i32 location, i32 locOffset, i32 elemIdx,
   //                                            i32 interpMode, <2 x float> | i32 auxInterpValue)
   SmallVector<Value *, 5> args;
-  for (unsigned i = 0, end = call->getNumArgOperands(); i != end; ++i)
+  for (unsigned i = 0, end = call->arg_size(); i != end; ++i)
     args.push_back(call->getArgOperand(i));
 
   const auto shaderStage = m_pipelineShaders->getShaderStage(call->getFunction());
@@ -2901,11 +2901,11 @@ void PatchResourceCollect::scalarizeGenericOutput(CallInst *call) {
   // TES: @llpc.output.export.generic.%Type%(i32 location, i32 elemIdx, %Type% outputValue)
   // GS:  @llpc.output.export.generic.%Type%(i32 location, i32 elemIdx, i32 streamId, %Type% outputValue)
   SmallVector<Value *, 5> args;
-  for (unsigned i = 0, end = call->getNumArgOperands(); i != end; ++i)
+  for (unsigned i = 0, end = call->arg_size(); i != end; ++i)
     args.push_back(call->getArgOperand(i));
 
   static const unsigned ElemIdxArgIdx = 1;
-  unsigned valArgIdx = call->getNumArgOperands() - 1;
+  unsigned valArgIdx = call->arg_size() - 1;
   unsigned elemIdx = cast<ConstantInt>(args[ElemIdxArgIdx])->getZExtValue();
   Value *outputVal = call->getArgOperand(valArgIdx);
   Type *elementTy = outputVal->getType();
@@ -2978,7 +2978,7 @@ void InOutLocationInfoMapManager::deserializeMap(ArrayRef<std::pair<unsigned, un
 // @param resUsage : The resource usage reference
 void InOutLocationInfoMapManager::addSpan(CallInst *call, ShaderStage shaderStage, bool requireDword) {
   const bool isFs = shaderStage == ShaderStageFragment;
-  const bool isInterpolant = isFs && call->getNumArgOperands() == 5;
+  const bool isInterpolant = isFs && call->arg_size() == 5;
   unsigned locOffset = 0;
   unsigned compIdxArgIdx = 1;
   if (isInterpolant || shaderStage == ShaderStageTessControl) {

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -861,7 +861,7 @@ void SpirvLowerGlobal::lowerOutput() {
   // Replace the Emit(Stream)Vertex calls with builder code.
   for (auto emitCall : m_emitCalls) {
     unsigned emitStreamId =
-        emitCall->getNumArgOperands() != 0 ? cast<ConstantInt>(emitCall->getArgOperand(0))->getZExtValue() : 0;
+        emitCall->arg_size() != 0 ? cast<ConstantInt>(emitCall->getArgOperand(0))->getZExtValue() : 0;
     m_builder->SetInsertPoint(emitCall);
     m_builder->CreateEmitVertex(emitStreamId);
     emitCall->eraseFromParent();

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -451,7 +451,7 @@ void SpirvLowerMathFloatOp::visitCallInst(CallInst &callInst) {
     Value *valueWritten = nullptr;
     if (calleeName.startswith("lgc.output.export.builtin.")) {
       builtIn = cast<ConstantInt>(callInst.getOperand(0))->getZExtValue();
-      valueWritten = callInst.getOperand(callInst.getNumArgOperands() - 1);
+      valueWritten = callInst.getOperand(callInst.arg_size() - 1);
     } else if (calleeName.startswith("lgc.create.write.builtin")) {
       builtIn = cast<ConstantInt>(callInst.getOperand(1))->getZExtValue();
       valueWritten = callInst.getOperand(0);

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -332,7 +332,7 @@ Value *SpirvLowerResourceCollect::findCallAndGetIndexValue(Module &module, CallI
         CallInst *const call = dyn_cast<CallInst>(useIt->getUser());
 
         // Get the args.
-        auto args = ArrayRef<Use>(&call->getOperandList()[0], call->getNumArgOperands());
+        auto args = ArrayRef<Use>(&call->getOperandList()[0], call->arg_size());
 
         if (args[0] == targetCall)
           return args[1];
@@ -370,7 +370,7 @@ void SpirvLowerResourceCollect::visitCalls(Module &module) {
       CallInst *const call = dyn_cast<CallInst>(useIt->getUser());
 
       // Get the args.
-      auto args = ArrayRef<Use>(&call->getOperandList()[0], call->getNumArgOperands());
+      auto args = ArrayRef<Use>(&call->getOperandList()[0], call->arg_size());
 
       ResourceMappingNodeType nodeType = ResourceMappingNodeType::Unknown;
       if (opcode == BuilderRecorder::Opcode::GetDescPtr)


### PR DESCRIPTION
Use arg_size() instead of getNumArgOperands(), as the latter
has been removed from API in llvm@3e1c787b3160.