### PR TITLE
Barycentric calculate

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -479,8 +479,33 @@ Value *InOutBuilder::modifyAuxInterpValue(Value *auxInterpValue, InOutInfo input
       else
         auxInterpValue = evalIjOffsetSmooth(auxInterpValue);
     }
-  } else
+  } else {
     assert(inputInfo.getInterpMode() == InOutInfo::InterpModeCustom);
+    if (inputInfo.isPerVertex()) {
+      unsigned vertsPerPrim = getPipelineState()->getVerticesPerPrimitive();
+      switch (vertsPerPrim) {
+      case 1:
+        // Points
+        break;
+      case 2:
+        // Lines
+        break;
+      case 3: {
+        // Triangles
+        // V0 ==> Attr_indx2
+        // V1 ==> Attr_indx0
+        // V2 ==> Attr_indx1
+        // just satisfies (idx + 2)%3.
+        Value *T = CreateAdd(getInt32(2), auxInterpValue);
+        auxInterpValue = CreateSRem(T, getInt32(3));
+        break;
+      }
+      default:
+        llvm_unreachable("Should never be called!");
+        break;
+      }
+    }
+  }
   return auxInterpValue;
 }
 
@@ -1248,6 +1273,12 @@ void InOutBuilder::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySiz
       break;
     case BuiltInBaryCoordPullModel:
       usage.fs.baryCoordPullModel = true;
+      break;
+    case BuiltInBaryCoord:
+      usage.fs.baryCoord = true;
+      break;
+    case BuiltInBaryCoordNoPerspKHR:
+      usage.fs.baryCoordNoPerspKHR = true;
       break;
 
     // Internal built-ins.

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -276,6 +276,9 @@ struct ResourceUsage {
         unsigned baryCoordSmoothCentroid : 1;  // Whether gl_BaryCoordSmoothCentroid is used (AMD extension)
         unsigned baryCoordSmoothSample : 1;    // Whether gl_BaryCoordSmoothSample is used (AMD extension)
         unsigned baryCoordPullModel : 1;       // Whether gl_BaryCoordPullModel is used (AMD extension)
+        unsigned baryCoord : 1;                // Whether gl_BaryCoordKHR is used
+        unsigned baryCoordNoPerspKHR : 1;      // Whether gl_BaryCoordNoPerspKHR is used, distinction from
+                                               // gl_BaryCoordNoPersp
         // Output
         unsigned fragDepth : 1;      // Whether gl_FragDepth is used
         unsigned sampleMask : 1;     // Whether gl_SampleMask[] is used

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -98,6 +98,9 @@ public:
   unsigned getArraySize() const { return m_data.bits.arraySize; }
   void setArraySize(unsigned arraySize) { m_data.bits.arraySize = arraySize; }
 
+  bool isPerVertex() const { return m_data.bits.perVertex; }
+  void setPerVertex(bool perVertex = true) { m_data.bits.perVertex = perVertex; }
+
 private:
   union {
     struct {
@@ -111,6 +114,7 @@ private:
       unsigned arraySize : 4;    // Built-in array input: shader-defined array size. Must be set for
                                  //    a read or write of ClipDistance or CullDistance that is of the
                                  //    whole array or of an element with a variable index.
+      unsigned perVertex : 1;    // FS input: adjust the index of the per-vertex input variable
     } bits;
     unsigned u32All;
   } m_data;

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -51,6 +51,8 @@
 //
 // If this file is included without the BUILTIN macro defined, then it declares the BuiltInKind enum.
 
+BUILTIN(BaryCoord, 5286, N, P, v3f32)                    // Perspective-interpolated (I,J,K) at pixel center
+BUILTIN(BaryCoordNoPerspKHR, 5287, N, P, v3f32)          // Linearly-interpolated (I,J,K) at pixel center
 BUILTIN(BaryCoordNoPersp, 4992, N, P, v2f32)             // Linearly-interpolated (I,J) at pixel center
 BUILTIN(BaryCoordNoPerspCentroid, 4993, N, P, v2f32)     // Linearly-interpolated (I,J) at pixel centroid
 BUILTIN(BaryCoordNoPerspSample, 4994, N, P, v2f32)       // Linearly-interpolated (I,J) at each covered sample

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1298,6 +1298,13 @@ void PatchResourceCollect::clearInactiveBuiltInInput() {
     if (builtInUsage.fs.baryCoordPullModel &&
         m_activeInputBuiltIns.find(BuiltInBaryCoordPullModel) == m_activeInputBuiltIns.end())
       builtInUsage.fs.baryCoordPullModel = false;
+
+    if (builtInUsage.fs.baryCoord && m_activeInputBuiltIns.find(BuiltInBaryCoord) == m_activeInputBuiltIns.end())
+      builtInUsage.fs.baryCoord = false;
+
+    if (builtInUsage.fs.baryCoordNoPerspKHR &&
+        m_activeInputBuiltIns.find(BuiltInBaryCoordNoPerspKHR) == m_activeInputBuiltIns.end())
+      builtInUsage.fs.baryCoordNoPerspKHR = false;
   }
 }
 


### PR DESCRIPTION
Add build-in variable to record barycentric weights vectors and
enable fragment inputs to read the raw per-vertex outputs.To keep
the attr_index aligned with barycentric values assigned to the vertex,
we need to adjust the index for triangle primitive.
