### PR TITLE
Add amber tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,10 @@ if(ICD_BUILD_LLPC)
 
     add_subdirectory(llpc ${PROJECT_BINARY_DIR}/llpc)
 
+    if(LLPC_BUILD_TESTS OR LLPC_BUILD_LIT)
+        add_subdirectory(test)
+    endif()
+
     # Export the LLVM and spvgen build paths so that they are available in XGL,
     # when this is not an LLPC standalone build.
     if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -107,4 +111,3 @@ if(ICD_BUILD_LLPC)
 
     target_link_libraries(vkgc INTERFACE llpc)
 endif()
-

--- a/llpc/docs/amdllpc.md
+++ b/llpc/docs/amdllpc.md
@@ -11,6 +11,11 @@ or
 cmake --build xgl/builds/Release64 --target check-lgc check-lgc-units check-amdllpc check-amdllpc-units
 ```
 
+LLPC also contains amber tests that need an actual GPU to run. See the [test directory](../../test/) for more information.
+```
+cmake --build xgl/builds/Release64 --target check-amber
+```
+
 Building the `check-amdllpc` target also builds spvgen.so.
 If the spvgen.so build fails with an error like this:
 ```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,4 +23,28 @@
  #
  #######################################################################################################################
 
-add_subdirectory(../llpc/test ${CMAKE_CURRENT_BINARY_DIR})
+find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
+  COMPONENTS Interpreter)
+
+list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm")
+include(LLVMConfig)
+
+# required by lit.site.cfg.py.in.
+set(LLPC_AMBER_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(LLPC_AMBER_TEST_ICD_NAME ${CMAKE_BINARY_DIR}/icd/amdvlk${TARGET_ARCHITECTURE_BITS}${CMAKE_SHARED_LIBRARY_SUFFIX})
+# required by configure_lit_site_cfg.
+set(LLVM_LIT_OUTPUT_DIR ${LLVM_TOOLS_BINARY_DIR})
+# Main config for shaderdb tests.
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+add_lit_testsuite(check-amber "Running the llpc amber regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${exclude_from_check_all}
+  DEPENDS
+    FileCheck count not xgl
+)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,19 @@
+# Tests
+
+This repository contains amber scripts to test changes and protect from
+regressions.
+
+## Amber
+
+The `check-amber` CMake target runs the amber scripts in this directory and
+checks the CHECK lines against the dumped pipelines for each script.
+
+The `run_amber.py` script runs all amber scripts inside the `amber` directory
+without checking the FileCheck lines with dumps.
+This needs a GPU with a working Vulkan driver and amber inside the `PATH`.
+The Vulkan driver can be set e.g. via `VK_ICD_FILENAMES`.
+
+The [amber readme](https://github.com/google/amber) has instructions and
+examples on how to write amber scripts. It also contains a
+[specification](https://github.com/google/amber/blob/main/docs/amber_script.md)
+of the script format.

--- a/test/amber/a16.amber
+++ b/test/amber/a16.amber
@@ -1,0 +1,140 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO Remove the not once this is fixed in LLVM
+# RUN: not run_amber_test.py --icd %icd %s | FileCheck %s
+# REQUIRES: gfx10+
+
+# Test a16 image samples with bias. The bias needs to be converted to 16 bit.
+
+DEVICE_EXTENSION VK_KHR_shader_float16_int8
+
+SHADER vertex vert_shader_mipclear PASSTHROUGH
+
+SHADER vertex vert_shader_lod GLSL
+#version 430
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+
+layout(location = 0) in vec3 position_in;
+layout(location = 0) out vec2 position_out;
+layout(location = 1) out float vert_i;
+layout(set = 0, binding = 0) uniform highp sampler2D tex;
+
+void main() {
+  gl_Position = vec4(position_in, 1.0);
+  position_out = gl_Position.xy;
+  vert_i = gl_VertexIndex % 4;
+}
+END
+
+SHADER fragment frag_shader GLSL
+#version 430
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+
+layout(location = 0) in vec2 position_in;
+layout(location = 1) in float vert_i;
+layout(location = 0) out vec4 color_out;
+layout(set = 0, binding = 0) uniform highp sampler2D tex;
+
+void main() {
+// CHECK: image_sample_b {{.*}} a16
+  vec2 pos = (position_in + vec2(1.0)) / 2.0;
+  float vi = round(vert_i); // Round to integer to get striped pattern
+  // Convert address and bias to f16 to generate an a16 sample.
+  color_out = vec4(texture(tex, vec2(f16vec2(pos)), float(float16_t(vi))));
+  // Render the texture, run with `amber <file> -i image.png` to view.
+  //color_out = vec4(textureLod(tex, pos, 0));
+}
+END
+
+SHADER fragment frag_passthrough_shader GLSL
+#version 430
+
+layout(location = 0) in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+void main() {
+  color_out = color_in;
+}
+END
+
+BUFFER texture FORMAT B8G8R8A8_UNORM MIP_LEVELS 4
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+SAMPLER sampler MAX_LOD 4.0
+
+PIPELINE graphics mipclear_pipeline0
+  ATTACH vert_shader_mipclear
+  ATTACH frag_passthrough_shader
+  BIND BUFFER texture AS color LOCATION 0 BASE_MIP_LEVEL 0
+  FRAMEBUFFER_SIZE 512 512
+END
+
+PIPELINE graphics mipclear_pipeline1
+  ATTACH vert_shader_mipclear
+  ATTACH frag_passthrough_shader
+  BIND BUFFER texture AS color LOCATION 0 BASE_MIP_LEVEL 1
+  FRAMEBUFFER_SIZE 256 256
+END
+
+PIPELINE graphics mipclear_pipeline2
+  ATTACH vert_shader_mipclear
+  ATTACH frag_passthrough_shader
+  BIND BUFFER texture AS color LOCATION 0 BASE_MIP_LEVEL 2
+  FRAMEBUFFER_SIZE 128 128
+END
+
+PIPELINE graphics mipclear_pipeline3
+  ATTACH vert_shader_mipclear
+  ATTACH frag_passthrough_shader
+  BIND BUFFER texture AS color LOCATION 0 BASE_MIP_LEVEL 3
+  FRAMEBUFFER_SIZE 64 64
+END
+
+PIPELINE graphics lod_pipeline
+  ATTACH vert_shader_lod
+  ATTACH frag_shader
+  BIND BUFFER texture AS combined_image_sampler SAMPLER sampler DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER framebuffer AS color LOCATION 0
+  FRAMEBUFFER_SIZE 512 512
+END
+
+# Clear all mip levels to different color.
+# The generated image has a striped pattern where the lower 3/4 are filled with color0,
+# the lower 3/4 of the upper 1/4 are filled with color1, etc. for color2 and 3.
+# On mip level 1, only stripes with color1, 2 and 3 are visible where color1 fills the lower 3/4.
+# Analogous for mip level 2 and 3 where 3 only consists of color3.
+CLEAR_COLOR mipclear_pipeline0 255 0 0 255
+CLEAR mipclear_pipeline0
+CLEAR_COLOR mipclear_pipeline1 0 255 0 255
+CLEAR mipclear_pipeline1
+CLEAR_COLOR mipclear_pipeline2 0 0 255 255
+CLEAR mipclear_pipeline2
+CLEAR_COLOR mipclear_pipeline3 255 255 0 255
+CLEAR mipclear_pipeline3
+
+CLEAR_COLOR lod_pipeline 0 0 0 255
+CLEAR lod_pipeline
+RUN lod_pipeline DRAW_RECT POS 0 0 SIZE 512 512
+
+# Rounding the vertex id in the fs generates diagonal stripes from the lower left corner into
+# the upper right corner.
+
+# Check corners of the frame buffer: each should have a color from a different mip level.
+# Sorted by vertex id 0, 1, 2, 3
+EXPECT framebuffer IDX 0   511 SIZE 1 1 EQ_RGBA 255 0   0   255
+# Check the bottom of the stripe, the top is color3 because the texture is striped at mip level 1
+EXPECT framebuffer IDX 200 511 SIZE 1 1 EQ_RGBA 0   255 0   255
+EXPECT framebuffer IDX 511 511 SIZE 1 1 EQ_RGBA 0   0   255 255
+EXPECT framebuffer IDX 511 0   SIZE 1 1 EQ_RGBA 255 255 0   255

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -1,0 +1,47 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+import sys
+import re
+import platform
+import subprocess
+
+import lit.util
+import lit.formats
+from lit.llvm import llvm_config
+from lit.llvm.subst import FindTool
+from lit.llvm.subst import ToolSubst
+
+# name: The name of this test suite.
+config.name = 'LLPC-AMBER'
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files. This is overriden
+# by individual lit.local.cfg files in the test subdirectories.
+config.suffixes = ['.amber']
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = []
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.llvm_obj_root, 'test')
+
+# TODO Set features for available gpu hardware. They can be queried with REQUIRES, etc.
+config.available_features.add('gfx10+')
+
+# Tweak the PATH to include the tools dir.
+llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+llvm_config.with_environment('PATH', config.test_source_root, append_path=True)
+# Contains the path for vulkan validation layers
+llvm_config.with_system_environment('XDG_DATA_DIRS')
+
+llvm_config.use_default_substitutions()

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -1,0 +1,25 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.python_executable = "@PYTHON_EXECUTABLE@"
+
+# Support substitution of the tools_dir with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@LLPC_AMBER_TEST_SOURCE_DIR@/lit.cfg.py")
+config.substitutions.append(('%icd', "@LLPC_AMBER_TEST_ICD_NAME@"))

--- a/test/run_amber.py
+++ b/test/run_amber.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import difflib
+import optparse
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+
+SUPPRESSIONS = {
+  "Darwin": [
+  ],
+  "Linux": [
+  ],
+  "Win": [
+  ]
+}
+
+DEBUGGER_CASES = [
+]
+
+DXC_CASES = [
+  "draw_triangle_list_hlsl.amber",
+  "relative_includes_hlsl.amber",
+  "debugger_hlsl_basic_compute.amber",
+  "debugger_hlsl_basic_fragment.amber",
+  "debugger_hlsl_basic_vertex.amber",
+  "debugger_hlsl_shadowed_vars.amber",
+  "debugger_hlsl_basic_fragment_with_legalization.amber",
+  "debugger_hlsl_basic_vertex_with_legalization.amber",
+  "debugger_hlsl_function_call.amber",
+  "debugger_hlsl_shadowed_vars.amber",
+]
+
+class TestCase:
+  def __init__(self, input_path, parse_only, use_dxc, test_debugger):
+    self.input_path = input_path
+    self.parse_only = parse_only
+    self.use_dxc = use_dxc
+    self.test_debugger = test_debugger
+
+    self.results = {}
+
+  def IsExpectedFail(self):
+    fail_re = re.compile('^.+[.]expect_fail[.][amber|vkscript]')
+    return fail_re.match(self.GetInputPath())
+
+  def IsSuppressed(self):
+    system = platform.system()
+
+    base = os.path.basename(self.input_path)
+    is_dxc_test = base in DXC_CASES
+    if not self.use_dxc and is_dxc_test:
+      return True
+
+    is_debugger_test = base in DEBUGGER_CASES
+    if not self.test_debugger and is_debugger_test:
+      return True
+
+    if system in SUPPRESSIONS.keys():
+      is_system_suppressed = base in SUPPRESSIONS[system]
+      return is_system_suppressed
+
+    return False
+
+  def IsParseOnly(self):
+    return self.parse_only
+
+  def GetInputPath(self):
+    return self.input_path
+
+  def GetResult(self, fmt):
+    return self.results[fmt]
+
+
+class TestRunner:
+  def RunTest(self, tc):
+    print("Testing {}".format(tc.GetInputPath()))
+
+    # Amber and SwiftShader both use the VK_DEBUGGER_PORT environment variable
+    # for specifying the Debug Adapter Protocol port number.
+    # This needs to be set before creating the Vulkan device.
+    # We remove this key from the enviroment if the test is not a debugger test
+    # so that full SPIR-V optimizations are preserved.
+    is_debugger_test = os.path.basename(tc.GetInputPath()) in DEBUGGER_CASES
+    if is_debugger_test:
+      os.environ["VK_DEBUGGER_PORT"] = "19020"
+    elif "VK_DEBUGGER_PORT" in os.environ:
+      del os.environ["VK_DEBUGGER_PORT"]
+
+    cmd = [self.options.test_prog_path, '-q']
+    if tc.IsParseOnly():
+      cmd += ['-p']
+    cmd += [tc.GetInputPath()]
+
+    try:
+      err = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+      if len(err) != 0 and not tc.IsExpectedFail() and not tc.IsSuppressed():
+        sys.stdout.write(err.decode('utf-8'))
+        return False
+
+    except Exception as e:
+      if not tc.IsExpectedFail() and not tc.IsSuppressed():
+        print("{}".format("".join(map(chr, bytearray(e.output)))))
+        print(e)
+      return False
+
+    return True
+
+
+  def RunTests(self):
+    for tc in self.test_cases:
+      result = self.RunTest(tc)
+
+      if tc.IsSuppressed():
+        self.suppressed.append(tc.GetInputPath())
+      else:
+        if not tc.IsExpectedFail() and not result:
+          self.failures.append(tc.GetInputPath())
+        elif tc.IsExpectedFail() and result:
+          print("Expected: " + tc.GetInputPath() + " to fail but passed.")
+          self.failures.append(tc.GetInputPath())
+
+  def SummarizeResults(self):
+    if len(self.failures) > 0:
+      self.failures.sort()
+
+      print('\nSummary of Failures:')
+      for failure in self.failures:
+        print(failure)
+
+    if len(self.suppressed) > 0:
+      self.suppressed.sort()
+
+      print('\nSummary of Suppressions:')
+      for suppression in self.suppressed:
+        print(suppression)
+
+    print('')
+    print('Test cases executed: {}'.format(len(self.test_cases)))
+    print('  Successes:  {}'.format((len(self.test_cases) - len(self.suppressed) - len(self.failures))))
+    print('  Failures:   {}'.format(len(self.failures)))
+    print('  Suppressed: {}'.format(len(self.suppressed)))
+    print('')
+
+
+  def Run(self):
+    base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+    usage = 'usage: %prog [options] (file)'
+    parser = optparse.OptionParser(usage=usage)
+    parser.add_option('--test-dir',
+                      default=os.path.join(os.path.dirname(__file__), 'amber'),
+                      help='path to directory containing test files')
+    parser.add_option('--test-prog-path', default=None,
+                      help='path to program to test')
+    parser.add_option('--parse-only',
+                      action="store_true", default=False,
+                      help='only parse test cases; do not execute')
+    parser.add_option('--use-dxc',
+                      action="store_true", default=False,
+                      help='Enable DXC tests')
+    parser.add_option('--test-debugger',
+                      action="store_true", default=False,
+                      help='Include debugger tests')
+
+    self.options, self.args = parser.parse_args()
+
+    if self.options.test_prog_path == None:
+      self.options.test_prog_path = 'amber'
+
+    input_file_re = re.compile('^.+[\.](amber|vkscript)')
+    self.test_cases = []
+
+    if self.args:
+      for filename in self.args:
+        input_path = os.path.join(self.options.test_dir, filename)
+        if not os.path.isfile(input_path):
+          print("Cannot find test file '{}'".format(filename))
+          return 1
+
+        self.test_cases.append(TestCase(input_path, self.options.parse_only,
+            self.options.use_dxc, self.options.test_debugger))
+
+    else:
+      for file_dir, _, filename_list in os.walk(self.options.test_dir):
+        for input_filename in filename_list:
+          if input_file_re.match(input_filename):
+            input_path = os.path.join(file_dir, input_filename)
+            if os.path.isfile(input_path):
+              self.test_cases.append(
+                  TestCase(input_path, self.options.parse_only,
+                      self.options.use_dxc, self.options.test_debugger))
+
+    self.failures = []
+    self.suppressed = []
+
+    self.RunTests()
+    self.SummarizeResults()
+
+    return len(self.failures) != 0
+
+def main():
+  runner = TestRunner()
+  return runner.Run()
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/test/run_amber_test.py
+++ b/test/run_amber_test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2020-2021 Advanced Micro Devices, Inc. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+#
+# Run an amber test and capture the generated pipelines. Print the pipelines to stdout, so they can be piped e.g. into
+# FileCheck.
+# Takes a .amber file as argument.
+# Run with e.g. ./run_amber_test.py --icd ../build/amdvlk64.so test.amber
+# Or with an installed driver: ./run_amber_test.py --icd /usr/lib/amdvlk64.so --icd-json /etc/vulkan/icd.d/amd_icd64.json test.amber
+
+import json
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+def main():
+  parser = argparse.ArgumentParser(description='Run an amber test and print generated pipelines to stdout')
+  parser.add_argument('--icd',
+                      help='Library that contains the Vulkan driver, e.g. amdvlk64.so')
+  parser.add_argument('--icd-json',
+                      help='JSON description of the Vulkan driver')
+  parser.add_argument('file',
+                      help='amber script to run')
+
+  args = parser.parse_args()
+
+  # Guess icd json filename to be amd_icd{64|32}.json near the amdvlk64.so
+  with open(args.icd_json or os.path.join(os.path.dirname(args.icd), "amd_icd" +
+      os.path.basename(args.icd).replace("amdvlk", "").replace(".so", "").replace(".dll", "") + ".json")) as f:
+    icd = json.load(f)
+  icd["ICD"]["library_path"] = args.icd
+
+  with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as icd_json_file:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      with open(os.path.join(tmp_dir, "amdVulkanSettings.cfg"), "w") as f:
+        f.write("ShaderCacheMode,0\n")
+        f.write("UsePalPipelineCaching,0\n")
+        f.write("EnableInternalPipelineCachingToDisk,0\n")
+        f.write("AllowVkPipelineCachingtoDisk,0\n")
+        f.write("HardAssert,0\n")
+        f.write("EnableLLPC,1\n")
+        f.write("EnablePipelineDump,1\n")
+
+      json.dump(icd, icd_json_file)
+      icd_json_file.flush()
+      os.environ["VK_ICD_FILENAMES"] = icd_json_file.name
+      os.environ["AMD_CONFIG_DIR"] = tmp_dir
+      os.environ["AMD_DEBUG_DIR"] = tmp_dir
+      os.environ["HOME"] = tmp_dir
+      dump_dir = os.path.join(tmp_dir, "spvPipeline")
+
+      # Run amber
+      cmd = ["amber"] + [args.file]
+      res = subprocess.run(cmd)
+
+      # Print pipeline dumps
+      for f in os.listdir(dump_dir):
+        if f.endswith(".pipe"):
+          print("Dump " + f)
+          with open(os.path.join(dump_dir, f)) as f:
+            print(f.read())
+
+      print("Dump End")
+
+  return res.returncode
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Add a folder with [amber](https://github.com/google/amber) scripts, so they can be run in CI for
regression testing.

Add a test for a16.
The test will currently fail, see [D111754](https://reviews.llvm.org/D111754).

Not sure what the license headers should look like, both files are from amber but I modified them.