### PR TITLE
Fix namespace name CodeObjectMetadataKey to PalCodeObjectMetadataKey.

### DIFF
--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -284,8 +284,10 @@ void ElfWriter<Elf>::mergeMetaNote(Context *pContext, const ElfNote *pNote1, con
   if (srcNumIterpIt != srcPipeline.getMap(true).end())
     destPipeline.getMap(true)[PalAbi::PipelineMetadataKey::NumInterpolants] = srcNumIterpIt->second;
 #else
-  auto destPipeline = destDocument.getRoot().getMap(true)[Util::Abi::CodeObjectMetadataKey::Pipelines].getArray(true)[0];
-  auto srcPipeline = srcDocument.getRoot().getMap(true)[Util::Abi::CodeObjectMetadataKey::Pipelines].getArray(true)[0];
+  auto destPipeline =
+      destDocument.getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0];
+  auto srcPipeline =
+      srcDocument.getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0];
 
   // Copy .num_interpolants
   auto srcNumIterpIt = srcPipeline.getMap(true).find(StringRef(Util::Abi::PipelineMetadataKey::NumInterpolants));


### PR DESCRIPTION
The class `CodeObjectMetadataKey` does not exist. The correct name is `PalCodeObjectMetadataKey`.