### PR TITLE
Fix input error reporting format in amdllpc

### DIFF
--- a/llpc/test/lit.cfg.py
+++ b/llpc/test/lit.cfg.py
@@ -71,6 +71,6 @@ config.substitutions.append(('%spvgendir%', config.spvgen_dir))
 
 tool_dirs = [config.llvm_tools_dir, config.amdllpc_dir]
 
-tools = ['amdllpc', 'llvm-objdump', 'llvm-readelf']
+tools = ['amdllpc', 'llvm-objdump', 'llvm-readelf', 'not', 'count']
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/llpc/test/shaderdb/multiple_inputs/cli_bad_inputs.multi-input
+++ b/llpc/test/shaderdb/multiple_inputs/cli_bad_inputs.multi-input
@@ -1,0 +1,11 @@
+; Negative tests to make sure that amdllpc reports errors when invalid inputs are passed.
+
+; Check that mixing .pipe and shader inputs is not allowed.
+; BEGIN_SHADERTEST_1
+; RUN: not amdllpc -spvgen-dir=%spvgendir% -v \
+; RUN:      %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:      %S/test_inputs/Fs1.frag \
+; RUN: | FileCheck -check-prefix=SHADERTEST_1 %s
+; SHADERTEST_1-LABEL: {{^}}ERROR: Mixing .pipe and shader inputs is not allowed
+; SHADERTEST_1-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_1

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -799,8 +799,7 @@ int main(int argc, char *argv[]) {
 
   auto inputGroupsOrErr = groupInputFiles(expandedInputFiles);
   if (Error err = inputGroupsOrErr.takeError()) {
-    LLPC_ERRS(err);
-    consumeError(std::move(err));
+    reportError(std::move(err));
     result = Result::ErrorInvalidValue;
     return onFailure();
   }

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -32,6 +32,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
@@ -81,6 +82,15 @@ bool EnableOuts() {
 // Gets the value of option "allow-err".
 bool EnableErrs() {
   return cl::EnableErrs;
+}
+
+// =====================================================================================================================
+// Prints the error message in `err` to LLPC_ERRS and consumes the error.
+//
+// @param err : The error to handle.
+void reportError(Error &&err) {
+  // For details on llvm error handling, see https://llvm.org/docs/ProgrammersManual.html#recoverable-errors.
+  handleAllErrors(std::move(err), [](const ErrorInfoBase &baseError) { LLPC_ERRS(baseError.message() << "\n"); });
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -50,15 +50,14 @@
   while (false)
 
 namespace llvm {
-class raw_ostream;
-}
-namespace llvm {
 class raw_fd_ostream;
-}
+class raw_ostream;
+class Error;
+} // namespace llvm
 
 namespace MetroHash {
 struct Hash;
-};
+} // namespace MetroHash
 
 namespace Llpc {
 
@@ -67,6 +66,9 @@ bool EnableOuts();
 
 // Gets the value of option "enable-errs"
 bool EnableErrs();
+
+// Prints the error to LLPC_ERRS and consumes it.
+void reportError(llvm::Error &&err);
 
 // Redirects the output of logs, It affects the behavior of llvm::outs(), dbgs() and errs().
 void redirectLogOutput(bool restoreToDefault, unsigned optionCount, const char *const *options);


### PR DESCRIPTION
Add a negative LIT test for mixing .pipe and shader inputs.

Depends on https://github.com/GPUOpen-Drivers/llpc/pull/1443 which needs to be merged first.