### PR TITLE
Fix one issue of spvgen shader stages

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -210,6 +210,8 @@ enum ShaderStageBit : unsigned {
   ShaderStageGeometryBit = (1 << ShaderStageGeometry),       ///< Geometry shader bit
   ShaderStageFragmentBit = (1 << ShaderStageFragment),       ///< Fragment shader bit
   ShaderStageComputeBit = (1 << ShaderStageCompute),         ///< Compute shader bit
+  ShaderStageAllGraphicsBit = ShaderStageVertexBit | ShaderStageTessControlBit | ShaderStageTessEvalBit |
+                              ShaderStageGeometryBit | ShaderStageFragmentBit, ///< All graphics bits
 };
 
 /// Enumerates LLPC types of unlinked shader elf.

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -100,14 +100,23 @@ void cleanupCompileInfo(CompileInfo *compileInfo) {
 //
 // @param sourceLang : GLSL source language
 static ShaderStage sourceLangToShaderStage(SpvGenStage sourceLang) {
-  static_assert(SpvGenStageVertex == 0, "Unexpected value!");
-  static_assert(SpvGenStageTessControl == 1, "Unexpected value!");
-  static_assert(SpvGenStageTessEvaluation == 2, "Unexpected value!");
-  static_assert(SpvGenStageGeometry == 3, "Unexpected value!");
-  static_assert(SpvGenStageFragment == 4, "Unexpected value!");
-  static_assert(SpvGenStageCompute == 5, "Unexpected value!");
+  switch (sourceLang) {
+  case SpvGenStageVertex:
+    return ShaderStage::ShaderStageVertex;
+  case SpvGenStageTessControl:
+    return ShaderStage::ShaderStageTessControl;
+  case SpvGenStageTessEvaluation:
+    return ShaderStage::ShaderStageTessEval;
+  case SpvGenStageGeometry:
+    return ShaderStage::ShaderStageGeometry;
+  case SpvGenStageFragment:
+    return ShaderStage::ShaderStageFragment;
+  case SpvGenStageCompute:
+    return ShaderStage::ShaderStageCompute;
+  }
 
-  return static_cast<ShaderStage>(sourceLang);
+  llvm_unreachable("Unexpected shading language type!");
+  return ShaderStage::ShaderStageInvalid;
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -255,10 +255,8 @@ bool PipelineDocument::validate() {
     return false;
   }
 
-  const unsigned graphicsStageMask =
-      ((1 << SpvGenStageVertex) | (1 << SpvGenStageTessControl) | (1 << SpvGenStageTessEvaluation) |
-       (1 << SpvGenStageGeometry) | (1 << SpvGenStageFragment));
-  const unsigned computeStageMask = (1 << SpvGenStageCompute);
+  const unsigned graphicsStageMask = ShaderStageBit::ShaderStageAllGraphicsBit;
+  const unsigned computeStageMask = ShaderStageBit::ShaderStageComputeBit;
 
   if (((stageMask & graphicsStageMask) && (stageMask & computeStageMask))
   ) {


### PR DESCRIPTION
Rewrite the conversion from shading language type to shader stage
type. The static_cast is not safe.

Change-Id: Ieeb817318db3008617221e65cbef97a26a3e72d7