### PR TITLE
Enable early fragment test

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -783,6 +783,14 @@ struct GraphicsPipelineBuildInfo {
   } rsState; ///< Rasterizer State
 
   struct {
+    bool stencilTestEnable;    ///< Whether enable depth test
+    unsigned depthComp;        ///< Depth compare operation
+    bool depthTestEnable;      ///< Whether enable stencil test
+    unsigned stencilCompFront; ///< Stencil compare operation for front face
+    unsigned stencilCompBack;  ///< Stencil compare operation for back face
+  } dsState;                   ///< depth State
+
+  struct {
     bool alphaToCoverageEnable; ///< Enable alpha to coverage
     bool dualSourceBlendEnable; ///< Blend state bound at draw time will use a dual source blend mode
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -154,6 +154,9 @@ public:
   // Set graphics state (input-assembly, viewport, rasterizer).
   void setGraphicsState(const InputAssemblyState &iaState, const RasterizerState &rsState) override final;
 
+  // Set depth/stencil state
+  void setDepthStencilState(const DepthStencilState &dsState) override final;
+
   // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache for the given version of LLPC.
   void set128BitCacheHash(const Hash128 &finalizedCacheHash, const llvm::VersionTuple &version) override final;
 
@@ -259,6 +262,7 @@ public:
   unsigned getDeviceIndex() const { return m_deviceIndex; }
   const InputAssemblyState &getInputAssemblyState() const { return m_inputAssemblyState; }
   const RasterizerState &getRasterizerState() const { return m_rasterizerState; }
+  const DepthStencilState &getDepthStencilState() const { return m_depthStencilState; }
 
   // Determine whether to use off-chip tessellation mode
   bool isTessOffChip();
@@ -474,6 +478,7 @@ private:
   ColorExportState m_colorExportState = {};                                    // Color export state
   InputAssemblyState m_inputAssemblyState = {};                                // Input-assembly state
   RasterizerState m_rasterizerState = {};                                      // Rasterizer state
+  DepthStencilState m_depthStencilState = {};                                  // Depth/stencil state
   std::unique_ptr<ResourceUsage> m_resourceUsage[ShaderStageCompute + 1] = {}; // Per-shader ResourceUsage
   std::unique_ptr<InterfaceData> m_interfaceData[ShaderStageCompute + 1] = {}; // Per-shader InterfaceData
   PalMetadata *m_palMetadata = nullptr;                                        // PAL metadata object

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -381,6 +381,14 @@ struct RasterizerState {
   unsigned usrClipPlaneMask;        // Mask to indicate the enabled user defined clip planes
 };
 
+struct DepthStencilState {
+  bool depthTestEnable;      // Whether enable depth test
+  unsigned depthComp;        // Depth compare operation
+  bool stencilTestEnable;    // Whether enable stencil test
+  unsigned stencilCompFront; // Stencil compare operation for front face
+  unsigned stencilCompBack;  // Stencil compare operation for back face
+};
+
 // =====================================================================================================================
 // Structs for setting shader modes, e.g. Builder::SetCommonShaderMode
 
@@ -470,7 +478,7 @@ struct GeometryShaderMode {
   unsigned outputVertices;          // Max number of vertices the shader will emit in one invocation
 };
 
-// Kind of conservative depth
+// Kind of conservative depth/stencil
 enum class ConservativeDepth : unsigned { Any, LessEqual, GreaterEqual };
 
 // Struct to pass to SetFragmentShaderMode.
@@ -482,6 +490,8 @@ struct FragmentShaderMode {
   unsigned earlyFragmentTests;
   unsigned postDepthCoverage;
   ConservativeDepth conservativeDepth;
+  ConservativeDepth conservativeStencilFront;
+  ConservativeDepth conservativeStencilBack;
 };
 
 // Struct to pass to SetComputeShaderMode.
@@ -563,6 +573,9 @@ public:
   // Set graphics state (input-assembly, rasterizer).
   // The front-end should zero-initialize each struct with "= {}" in case future changes add new fields.
   virtual void setGraphicsState(const InputAssemblyState &iaState, const RasterizerState &rsState) = 0;
+
+  // Set depth/stencil state
+  virtual void setDepthStencilState(const DepthStencilState &dsState) = 0;
 
   // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache for the given version of LLPC.
   virtual void set128BitCacheHash(const Hash128 &finalizedCacheHash, const llvm::VersionTuple &version) = 0;

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -890,9 +890,35 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
   SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
 
+  bool enableEarlyTests = fragmentMode.earlyFragmentTests;
+  if (!enableEarlyTests) {
+    bool isEnableFront = false;
+    bool isEnableBack = false;
+    auto depthStencilState = m_pipelineState->getDepthStencilState();
+    if (fragmentMode.conservativeStencilFront == ConservativeDepth::LessEqual)
+      if (depthStencilState.stencilCompFront == REF_LEQUAL || depthStencilState.stencilCompFront == REF_LESS ||
+          depthStencilState.stencilCompFront == REF_EQUAL)
+        isEnableFront = true;
+      else if (fragmentMode.conservativeStencilFront == ConservativeDepth::GreaterEqual)
+        if (depthStencilState.stencilCompFront == REF_GEQUAL || depthStencilState.stencilCompFront == REF_GREATER ||
+            depthStencilState.stencilCompFront == REF_EQUAL)
+        isEnableFront = true;
+
+    if (fragmentMode.conservativeStencilBack == ConservativeDepth::LessEqual)
+      if (depthStencilState.stencilCompBack == REF_LEQUAL || depthStencilState.stencilCompBack == REF_LESS ||
+          depthStencilState.stencilCompBack == REF_EQUAL)
+        isEnableBack = true;
+      else if (fragmentMode.conservativeStencilBack == ConservativeDepth::GreaterEqual)
+        if (depthStencilState.stencilCompBack == REF_GEQUAL || depthStencilState.stencilCompBack == REF_GREATER ||
+            depthStencilState.stencilCompBack == REF_EQUAL)
+        isEnableBack = true;
+
+    enableEarlyTests = (isEnableBack && isEnableFront);
+  }
+
   ZOrder zOrder = LATE_Z;
   bool execOnHeirFail = false;
-  if (fragmentMode.earlyFragmentTests)
+  if (enableEarlyTests)
     zOrder = EARLY_Z_THEN_LATE_Z;
   else if (resUsage->resourceWrite) {
     zOrder = LATE_Z;
@@ -908,7 +934,7 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE, builtInUsage.sampleMask);
-  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
+  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, enableEarlyTests);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                 (fragmentMode.earlyFragmentTests && resUsage->resourceWrite));
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1803,9 +1803,35 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
   SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
 
+  bool enableEarlyTests = fragmentMode.earlyFragmentTests;
+  if (!enableEarlyTests) {
+    bool isEnableFront = false;
+    bool isEnableBack = false;
+    auto depthStencilState = m_pipelineState->getDepthStencilState();
+    if (fragmentMode.conservativeStencilFront == ConservativeDepth::LessEqual)
+      if (depthStencilState.stencilCompFront == REF_LEQUAL || depthStencilState.stencilCompFront == REF_LESS ||
+          depthStencilState.stencilCompFront == REF_EQUAL)
+        isEnableFront = true;
+      else if (fragmentMode.conservativeStencilFront == ConservativeDepth::GreaterEqual)
+        if (depthStencilState.stencilCompFront == REF_GEQUAL || depthStencilState.stencilCompFront == REF_GREATER ||
+            depthStencilState.stencilCompFront == REF_EQUAL)
+          isEnableFront = true;
+
+      if (fragmentMode.conservativeStencilBack == ConservativeDepth::LessEqual)
+        if (depthStencilState.stencilCompBack == REF_LEQUAL || depthStencilState.stencilCompBack == REF_LESS ||
+            depthStencilState.stencilCompBack == REF_EQUAL)
+          isEnableBack = true;
+      else if (fragmentMode.conservativeStencilBack == ConservativeDepth::GreaterEqual)
+        if (depthStencilState.stencilCompBack == REF_GEQUAL || depthStencilState.stencilCompBack == REF_GREATER ||
+            depthStencilState.stencilCompBack == REF_EQUAL)
+          isEnableBack = true;
+
+    enableEarlyTests = (isEnableBack && isEnableFront);
+  }
+
   ZOrder zOrder = LATE_Z;
   bool execOnHeirFail = false;
-  if (fragmentMode.earlyFragmentTests)
+  if (enableEarlyTests)
     zOrder = EARLY_Z_THEN_LATE_Z;
   else if (resUsage->resourceWrite) {
     zOrder = LATE_Z;
@@ -1827,7 +1853,7 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE, 0); // Set during pipeline finalization.
-  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
+  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, enableEarlyTests);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                 (fragmentMode.earlyFragmentTests && resUsage->resourceWrite));
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1048,6 +1048,14 @@ void PipelineState::setGraphicsState(const InputAssemblyState &iaState, const Ra
 }
 
 // =====================================================================================================================
+// Set depth/stencil state.
+//
+// @param dsState : Depth/stencil state
+void PipelineState::setDepthStencilState(const DepthStencilState &dsState) {
+  m_depthStencilState = dsState;
+}
+
+// =====================================================================================================================
 // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache.
 //
 // @param finalizedCacheHash: The 128-bit hash value.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -689,6 +689,20 @@ void PipelineContext::setGraphicsStateInPipeline(Pipeline *pipeline) const {
   rasterizerState.usrClipPlaneMask = inputRsState.usrClipPlaneMask;
 
   pipeline->setGraphicsState(inputAssemblyState, rasterizerState);
+
+  const auto &inputDsState = static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->dsState;
+  DepthStencilState depthStencilState = {};
+  if (inputDsState.depthTestEnable) {
+    depthStencilState.depthTestEnable = inputDsState.depthTestEnable;
+    depthStencilState.depthComp = inputDsState.depthComp;
+  }
+  if (inputDsState.stencilTestEnable) {
+    depthStencilState.stencilTestEnable = inputDsState.stencilTestEnable;
+    depthStencilState.stencilCompFront = inputDsState.stencilCompFront;
+    depthStencilState.stencilCompBack = inputDsState.stencilCompBack;
+  }
+
+  pipeline->setDepthStencilState(depthStencilState);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
According to the pipeline state and specific shader executionModel, we
can choose whether to turn on early z.
when pipeline state and shader execute model is coherent, we can enable early z.