### PR TITLE
Enable early fragment test

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 50
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -71,6 +71,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     50.2 | Add the member dsState to GraphicsPipelineBuildInfo                                                   |
 //  |     50.1 | Add the member word4 and word5 to SamplerYCbCrConversionMetaData                                      |
 //  |     50.0 | Removed the member 'enableOpt' of ShaderModuleOptions                                                 |
 //  |     49.1 | Added enableEarlyCompile to GraphicsPipelineBuildInfo                                                 |
@@ -747,6 +748,9 @@ struct GraphicsPipelineBuildInfo {
   /// Create info of vertex input state
   const VkPipelineVertexInputStateCreateInfo *pVertexInput;
 
+  // Depth/stencil state
+  VkPipelineDepthStencilStateCreateInfo dsState;
+
   struct {
     VkPrimitiveTopology topology; ///< Primitive topology
     unsigned patchControlPoints;  ///< Number of control points per patch (valid when the topology is
@@ -783,7 +787,6 @@ struct GraphicsPipelineBuildInfo {
     bool depthBiasEnable; ///< Whether to bias fragment depth values
 #endif
   } rsState; ///< Rasterizer State
-
   struct {
     bool alphaToCoverageEnable; ///< Enable alpha to coverage
     bool dualSourceBlendEnable; ///< Blend state bound at draw time will use a dual source blend mode

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -154,6 +154,9 @@ public:
   // Set graphics state (input-assembly, viewport, rasterizer).
   void setGraphicsState(const InputAssemblyState &iaState, const RasterizerState &rsState) override final;
 
+  // Set depth/stencil state
+  void setDepthStencilState(const DepthStencilState &dsState) override final;
+
   // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache for the given version of LLPC.
   void set128BitCacheHash(const Hash128 &finalizedCacheHash, const llvm::VersionTuple &version) override final;
 
@@ -259,6 +262,7 @@ public:
   unsigned getDeviceIndex() const { return m_deviceIndex; }
   const InputAssemblyState &getInputAssemblyState() const { return m_inputAssemblyState; }
   const RasterizerState &getRasterizerState() const { return m_rasterizerState; }
+  const DepthStencilState &getDepthStencilState() const { return m_depthStencilState; }
 
   // Determine whether to use off-chip tessellation mode
   bool isTessOffChip();
@@ -474,6 +478,7 @@ private:
   ColorExportState m_colorExportState = {};                                    // Color export state
   InputAssemblyState m_inputAssemblyState = {};                                // Input-assembly state
   RasterizerState m_rasterizerState = {};                                      // Rasterizer state
+  DepthStencilState m_depthStencilState = {};                                  // Depth/stencil state
   std::unique_ptr<ResourceUsage> m_resourceUsage[ShaderStageCompute + 1] = {}; // Per-shader ResourceUsage
   std::unique_ptr<InterfaceData> m_interfaceData[ShaderStageCompute + 1] = {}; // Per-shader InterfaceData
   PalMetadata *m_palMetadata = nullptr;                                        // PAL metadata object

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -381,6 +381,15 @@ struct RasterizerState {
   unsigned usrClipPlaneMask;        // Mask to indicate the enabled user defined clip planes
 };
 
+// Struct to pass to depth/stencil state
+struct DepthStencilState {
+  bool depthTestEnable;           // Whether enable depth test
+  unsigned depthCompareOp;        // Depth compare operation
+  bool stencilTestEnable;         // Whether enable stencil test
+  unsigned stencilCompareOpFront; // Stencil compare operation for front face
+  unsigned stencilCompareOpBack;  // Stencil compare operation for back face
+};
+
 // =====================================================================================================================
 // Structs for setting shader modes, e.g. Builder::SetCommonShaderMode
 
@@ -470,7 +479,7 @@ struct GeometryShaderMode {
   unsigned outputVertices;          // Max number of vertices the shader will emit in one invocation
 };
 
-// Kind of conservative depth
+// Kind of conservative depth/stencil
 enum class ConservativeDepth : unsigned { Any, LessEqual, GreaterEqual };
 
 // Struct to pass to SetFragmentShaderMode.
@@ -481,7 +490,10 @@ struct FragmentShaderMode {
   unsigned pixelCenterInteger;
   unsigned earlyFragmentTests;
   unsigned postDepthCoverage;
+  unsigned earlyAndLatFragmentTests;
   ConservativeDepth conservativeDepth;
+  ConservativeDepth conservativeStencilFront;
+  ConservativeDepth conservativeStencilBack;
 };
 
 // Struct to pass to SetComputeShaderMode.
@@ -563,6 +575,9 @@ public:
   // Set graphics state (input-assembly, rasterizer).
   // The front-end should zero-initialize each struct with "= {}" in case future changes add new fields.
   virtual void setGraphicsState(const InputAssemblyState &iaState, const RasterizerState &rsState) = 0;
+
+  // Set depth/stencil state
+  virtual void setDepthStencilState(const DepthStencilState &dsState) = 0;
 
   // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache for the given version of LLPC.
   virtual void set128BitCacheHash(const Hash128 &finalizedCacheHash, const llvm::VersionTuple &version) = 0;

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -890,9 +890,49 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_CNTDWN_ENABLE, true);
   SET_REG_FIELD(&pConfig->psRegs, PA_SC_MODE_CNTL_1, FORCE_EOV_REZ_ENABLE, true);
 
+  auto depthStencilState = m_pipelineState->getDepthStencilState();
+  bool enableEarlyTests = fragmentMode.earlyFragmentTests;
+  if (!enableEarlyTests && fragmentMode.earlyAndLatFragmentTests && depthStencilState.stencilTestEnable) {
+    bool enableStencilFrontTest = false;
+    bool enableStencilBackTest = false;
+    // Never/always - enable early z
+    if (depthStencilState.stencilCompareOpFront == REF_NEVER || depthStencilState.stencilCompareOpFront == REF_ALWAYS)
+      enableStencilFrontTest = true;
+    // LessEqual
+    else if (fragmentMode.conservativeStencilFront == ConservativeDepth::LessEqual) {
+      if (depthStencilState.stencilCompareOpFront == REF_LEQUAL || depthStencilState.stencilCompareOpFront == REF_LESS)
+        enableStencilFrontTest = true;
+    } else if (fragmentMode.conservativeStencilFront == ConservativeDepth::GreaterEqual) {
+      if (depthStencilState.stencilCompareOpFront == REF_GEQUAL ||
+          depthStencilState.stencilCompareOpFront == REF_GREATER)
+        enableStencilFrontTest = true;
+    } else {
+      // Unchanged
+      if (depthStencilState.stencilCompareOpFront == REF_EQUAL ||
+          depthStencilState.stencilCompareOpFront == REF_NOTEQUAL)
+        enableStencilFrontTest = true;
+    }
+
+    if (depthStencilState.stencilCompareOpBack == REF_NEVER || depthStencilState.stencilCompareOpBack == REF_ALWAYS)
+      enableStencilBackTest = true;
+    else if (fragmentMode.conservativeStencilBack == ConservativeDepth::LessEqual) {
+      if (depthStencilState.stencilCompareOpBack == REF_LEQUAL || depthStencilState.stencilCompareOpBack == REF_EQUAL)
+        enableStencilBackTest = true;
+    } else if (fragmentMode.conservativeStencilBack == ConservativeDepth::GreaterEqual) {
+      if (depthStencilState.stencilCompareOpBack == REF_GEQUAL || depthStencilState.stencilCompareOpBack == REF_GREATER)
+        enableStencilBackTest = true;
+    } else {
+      // Unchanged
+      if (depthStencilState.stencilCompareOpBack == REF_EQUAL || depthStencilState.stencilCompareOpBack == REF_NOTEQUAL)
+        enableStencilFrontTest = true;
+    }
+
+    enableEarlyTests = (enableStencilBackTest && enableStencilFrontTest);
+  }
+
   ZOrder zOrder = LATE_Z;
   bool execOnHeirFail = false;
-  if (fragmentMode.earlyFragmentTests)
+  if (enableEarlyTests)
     zOrder = EARLY_Z_THEN_LATE_Z;
   else if (resUsage->resourceWrite) {
     zOrder = LATE_Z;
@@ -908,7 +948,7 @@ void ConfigBuilder::buildPsRegConfig(ShaderStage shaderStage, T *pConfig) {
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, STENCIL_TEST_VAL_EXPORT_ENABLE, builtInUsage.fragStencilRef);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, MASK_EXPORT_ENABLE, builtInUsage.sampleMask);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, ALPHA_TO_MASK_DISABLE, builtInUsage.sampleMask);
-  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, fragmentMode.earlyFragmentTests);
+  SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, DEPTH_BEFORE_SHADER, enableEarlyTests);
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_NOOP,
                 (fragmentMode.earlyFragmentTests && resUsage->resourceWrite));
   SET_REG_FIELD(&pConfig->psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1048,6 +1048,14 @@ void PipelineState::setGraphicsState(const InputAssemblyState &iaState, const Ra
 }
 
 // =====================================================================================================================
+// Set depth/stencil state.
+//
+// @param dsState : Depth/stencil state
+void PipelineState::setDepthStencilState(const DepthStencilState &dsState) {
+  m_depthStencilState = dsState;
+}
+
+// =====================================================================================================================
 // Set the finalized 128-bit cache hash that is used to find this pipeline in the cache.
 //
 // @param finalizedCacheHash: The 128-bit hash value.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -689,6 +689,20 @@ void PipelineContext::setGraphicsStateInPipeline(Pipeline *pipeline) const {
   rasterizerState.usrClipPlaneMask = inputRsState.usrClipPlaneMask;
 
   pipeline->setGraphicsState(inputAssemblyState, rasterizerState);
+
+  const auto &inputDsState = static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->dsState;
+  DepthStencilState depthStencilState = {};
+  if (inputDsState.depthTestEnable) {
+    depthStencilState.depthTestEnable = inputDsState.depthTestEnable;
+    depthStencilState.depthCompareOp = inputDsState.depthCompareOp;
+  }
+  if (inputDsState.stencilTestEnable) {
+    depthStencilState.stencilTestEnable = inputDsState.stencilTestEnable;
+    depthStencilState.stencilCompareOpFront = inputDsState.front.compareOp;
+    depthStencilState.stencilCompareOpBack = inputDsState.back.compareOp;
+  }
+
+  pipeline->setDepthStencilState(depthStencilState);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
According to the pipeline state and specific shader executionModel, we
can choose whether to turn on early z.
when pipeline state and shader execute model is coherent, we can eanble early z.