### PR TITLE
Add amdllpc spvgen loading tests

### DIFF
--- a/llpc/test/shaderdb/error_reporting/MissingSpvgen_Glsl.frag
+++ b/llpc/test/shaderdb/error_reporting/MissingSpvgen_Glsl.frag
@@ -1,0 +1,26 @@
+// Check that an error/warning is reported when no SPVGEN dir is provided or a wrong dir is passed.
+/*
+; BEGIN_SHADERTEST_1
+; RUN: not amdllpc -spvgen-dir=/spvgen/is/definitely/not/here -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_1 %s
+;
+; SHADERTEST_1-LABEL: {{^}}ERROR: Failed to load SPVGEN from specified directory
+; SHADERTEST_1-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_1
+
+; BEGIN_SHADERTEST_2
+; RUN: not amdllpc -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_2 %s
+;
+; SHADERTEST_2-LABEL: {{^}}ERROR: Failed to load SPVGEN -- cannot compile GLSL
+; SHADERTEST_2: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_2
+*/
+
+#version 460
+
+layout (location = 0) out vec4 fragColor;
+
+void main() {
+  fragColor = vec4(0);
+}

--- a/llpc/test/shaderdb/error_reporting/MissingSpvgen_PipeGlsl.pipe
+++ b/llpc/test/shaderdb/error_reporting/MissingSpvgen_PipeGlsl.pipe
@@ -1,0 +1,33 @@
+// Check that an error/warning is reported when no SPVGEN dir is provided or a wrong dir is passed.
+
+; BEGIN_SHADERTEST_1
+; RUN: not amdllpc -spvgen-dir=/spvgen/is/definitely/not/here -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_1 %s
+; SHADERTEST_1-LABEL: {{^}}ERROR: Failed to load SPVGEN from specified directory
+; SHADERTEST_1-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_1
+
+; BEGIN_SHADERTEST_2
+; RUN: not amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST_2 %s
+; SHADERTEST_2-LABEL: {{^}}ERROR: Failed to parse input file:
+; SHADERTEST_2-LABEL: {{^}}Parse error at line {{[0-9]+}}: Failed to load SPVGEN: cannot compile GLSL
+; SHADERTEST_2-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_2
+
+[VsGlsl]
+#version 460 core
+
+void main() {
+  gl_Position = vec4(0);
+}
+
+[VsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+patchControlPoints = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0

--- a/llpc/test/shaderdb/error_reporting/MissingSpvgen_PipeSpirv.pipe
+++ b/llpc/test/shaderdb/error_reporting/MissingSpvgen_PipeSpirv.pipe
@@ -1,0 +1,53 @@
+// Check that an error/warning is reported when no SPVGEN dir is provided or a wrong dir is passed.
+
+; BEGIN_SHADERTEST_1
+; RUN: not amdllpc -spvgen-dir=/spvgen/is/definitely/not/here -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_1 %s
+; SHADERTEST_1-LABEL: {{^}}ERROR: Failed to load SPVGEN from specified directory
+; SHADERTEST_1-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_1
+
+; BEGIN_SHADERTEST_2
+; RUN: not amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST_2 %s
+; SHADERTEST_2-LABEL: {{^}}ERROR: Failed to parse input file:
+; SHADERTEST_2-LABEL: {{^}}Parse error at line {{[0-9]+}}: Failed to load SPVGEN: cannot assemble SPIR-V assembler source
+; SHADERTEST_2-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_2
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %9
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %9 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %9 = OpVariable %_ptr_Output_v4float Output
+         %23 = OpUndef %v4float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %9 %23
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main

--- a/llpc/test/shaderdb/error_reporting/MissingSpvgen_Spirv.spvasm
+++ b/llpc/test/shaderdb/error_reporting/MissingSpvgen_Spirv.spvasm
@@ -1,0 +1,62 @@
+; Check that an error/warning is reported when no SPVGEN dir is provided or a wrong dir is passed.
+; Ensure that amdllpc only fails when SPVGEN is missing but we have to assemble SPIR-V.
+
+; BEGIN_SHADERTEST_1
+; RUN: not amdllpc -spvgen-dir=/spvgen/is/definitely/not/here -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_1 %s
+;
+; SHADERTEST_1-LABEL: {{^}}ERROR: Failed to load SPVGEN from specified directory
+; SHADERTEST_1-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_1
+
+; BEGIN_SHADERTEST_2
+; RUN: not amdllpc -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_2 %s
+;
+; SHADERTEST_2-LABEL: {{^}}ERROR: Failed to load SPVGEN -- cannot assemble SPIR-V assembler source
+; SHADERTEST_2-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_2
+
+; BEGIN_SHADERTEST_3
+; In this test, produce produce a .spv file which should only require SPVGEN for disassembly/validation.
+
+; Create a fresh directory for pipeline dump files.
+; RUN: mkdir -p %t/dump
+
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-pipeline-dump --pipeline-dump-dir=%t/dump \
+; RUN:   | FileCheck -check-prefix=COMPILE %s
+; COMPILE-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; COMPILE-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+; RUN: not amdllpc -spvgen-dir=/spvgen/is/definitely/not/here -v -validate-spirv=false %gfxip \
+; RUN:   %t/dump/*.spv | FileCheck -check-prefix=BAD_DIR %s
+;
+; BAD_DIR-LABEL: {{^}}ERROR: Failed to load SPVGEN from specified directory
+; BAD_DIR-LABEL: {{^}}===== AMDLLPC FAILED =====
+
+; RUN: amdllpc -v -validate-spirv=false %gfxip %t/dump/*.spv \
+; RUN:   | FileCheck -check-prefix=MISSING_DIR_NO_VALIDATE %s
+;
+; MISSING_DIR_NO_VALIDATE-LABEL: {{^}}Failed to load SPVGEN -- no SPIR-V disassembler available
+; MISSING_DIR_NO_VALIDATE-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+; RUN: amdllpc -v -validate-spirv=true %gfxip %t/dump/*.spv \
+; RUN:   | FileCheck -check-prefix=MISSING_DIR_VALIDATE %s
+;
+; MISSING_DIR_VALIDATE-LABEL:     {{^}}Failed to load SPVGEN -- no SPIR-V disassembler available
+; MISSING_DIR_VALIDATE-LABEL-NOT: {{^}}Warning: Failed to load SPVGEN -- cannot validate SPIR-V
+; MISSING_DIR_VALIDATE-LABEL:     {{^}}===== AMDLLPC SUCCESS =====
+
+; Cleanup.
+; RUN: rm -rf %t/dump
+; END_SHADERTEST_3
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main"
+         %2 = OpTypeVoid
+         %3 = OpTypeFunction %2
+         %1 = OpFunction %2 None %3
+         %4 = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
Make sure that we have tests for all failure modes and input types that depend on spvgen.

This is in preparation to refactor and simplify the pipeline/shader processing code in `amdllpc.cpp`.