### PR TITLE
Add invalid input amdllpc test

### DIFF
--- a/llpc/test/shaderdb/error_reporting/LlvmMissingShaderStage.ll
+++ b/llpc/test/shaderdb/error_reporting/LlvmMissingShaderStage.ll
@@ -1,0 +1,15 @@
+; Check that an error is produced when valid LLVM IR is passed but is not a shader.
+
+; BEGIN_SHADERTEST
+; DONT-RUN: not amdllpc -v %gfxip %s | FileCheck --check-prefix=SHADERTEST %s
+; Currently this test-case crashes instead of exiting gracefully. Do not run this test for now.
+; RUN: false
+; XFAIL: *
+;
+; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}}: Fail to determine shader stage
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+define i32 @foo(i32 %x) {
+  ret i32 %x
+}

--- a/llpc/test/shaderdb/error_reporting/LlvmVerificationFailure.ll
+++ b/llpc/test/shaderdb/error_reporting/LlvmVerificationFailure.ll
@@ -1,0 +1,14 @@
+; Check that an error is produced when parsable but invalid LLVM IR is passed.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -v %gfxip %s | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}} parsed, but fail to verify the module: Instruction does not dominate all uses!
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+define i32 @f1(i32 %x) {
+  %y = add i32 %z, 1
+  %z = add i32 %x, 1
+  ret i32 %y
+}

--- a/llpc/test/shaderdb/error_reporting/SpirvInvalidOpcode.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvInvalidOpcode.spvasm
@@ -1,0 +1,13 @@
+; Check that an error is produced when bad SPIR-V is passed and it is not possible to assemble it.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -validate-spirv=false -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck %s --check-prefix=SHADERTEST
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Fails to assemble SPIR-V:
+; SHADERTEST-LABEL: {{^}}error: {{[0-9]+}}: {{[0-9]+}}: Invalid Opcode name 'OpThisSpirvIsBad'
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+               OpCapability Shader
+               OpThisSpirvIsBad Please Fail

--- a/llpc/test/shaderdb/error_reporting/SpirvMissingEntryTarget.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvMissingEntryTarget.spvasm
@@ -1,0 +1,19 @@
+; Check that an error is produced when the specified entry target is not a SPIR-V entry point.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -entry-target=foo -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Fails to identify shader stages by entry-point "foo"
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1  "main"
+         %2 = OpTypeVoid
+         %3 = OpTypeFunction %2
+         %1 = OpFunction %2 None %3
+         %4 = OpLabel
+              OpReturn
+              OpFunctionEnd

--- a/llpc/test/shaderdb/error_reporting/SpirvValidationFailure.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvValidationFailure.spvasm
@@ -1,0 +1,25 @@
+; Check that an error is produced when invalid SPIR-V is passed and validation is enabled.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -validate-spirv=true -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Fails to validate SPIR-V:
+; SHADERTEST-LABEL: {{^}}error: {{[0-9]+}}: 2 Entry points cannot share the same name and ExecutionMode.
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1  "main"
+               OpEntryPoint Vertex %99 "main"
+         %2 = OpTypeVoid
+         %3 = OpTypeFunction %2
+         %1 = OpFunction %2 None %3
+         %4 = OpLabel
+              OpReturn
+              OpFunctionEnd
+        %99 = OpFunction %2 None %3
+         %5 = OpLabel
+              OpReturn
+              OpFunctionEnd

--- a/llpc/test/shaderdb/error_reporting/UnknownExtension.multi-input
+++ b/llpc/test/shaderdb/error_reporting/UnknownExtension.multi-input
@@ -1,0 +1,11 @@
+; Check that an error is produced when a file with unknown extensions is passed.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -validate-spirv=true -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: {{.*}}: Bad file extension; try -help
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+Nothing more to see here.


### PR DESCRIPTION
Make sure we have tests for the remaining failures in `processPipeline`.

This revealed one crash: amdllpc segfaults when the input is LLVM IR and
it cannot determine the shader stage. I did not fix that in this PR, I
plan to submit a fix separately.