### PR TITLE
Setup infrastructure to port the middle-end passes to the NPM

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -29,8 +29,8 @@
  ***********************************************************************************************************************
  */
 #include "BuilderImpl.h"
-#include "BuilderRecorder.h"
 #include "lgc/LgcContext.h"
+#include "lgc/builder/BuilderRecorder.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/ShaderModes.h"
 #include "lgc/state/TargetInfo.h"

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -28,7 +28,7 @@
  * @brief LLPC source file: BuilderRecorder implementation
  ***********************************************************************************************************************
  */
-#include "BuilderRecorder.h"
+#include "lgc/builder/BuilderRecorder.h"
 #include "lgc/LgcContext.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PipelineState.h"

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -40,7 +40,7 @@ namespace llvm {
 class ModulePass;
 class PassRegistry;
 
-void initializeBuilderReplayerPass(PassRegistry &);
+void initializeLegacyBuilderReplayerPass(PassRegistry &);
 
 } // namespace llvm
 
@@ -588,6 +588,6 @@ private:
 };
 
 // Create BuilderReplayer pass
-llvm::ModulePass *createBuilderReplayer(Pipeline *pipeline);
+llvm::ModulePass *createLegacyBuilderReplayer(Pipeline *pipeline);
 
 } // namespace lgc

--- a/lgc/include/lgc/builder/BuilderReplayer.h
+++ b/lgc/include/lgc/builder/BuilderReplayer.h
@@ -1,0 +1,44 @@
+/*
+************************************************************************************************************************
+*
+*  Copyright (C) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
+*
+***********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  BuilderReplayer.h
+ * @brief LLPC header file: contains declaration of class lgc::BuilderReplayer
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/builder/BuilderRecorder.h"
+#include "llvm/IR/PassManager.h"
+
+namespace lgc {
+
+// =====================================================================================================================
+// Pass to replay Builder calls recorded by BuilderRecorder
+class BuilderReplayer final : public BuilderRecorderMetadataKinds, public llvm::PassInfoMixin<BuilderReplayer> {
+public:
+  BuilderReplayer(Pipeline *pipeline);
+
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+
+  bool runImpl(llvm::Module &module, PipelineState *pipelineState);
+
+  static llvm::StringRef name() { return "Replay LLPC builder calls"; }
+
+private:
+  void replayCall(unsigned opcode, llvm::CallInst *call);
+
+  llvm::Value *processCall(unsigned opcode, llvm::CallInst *call);
+
+  std::unique_ptr<Builder> m_builder;                       // The LLPC builder that the builder
+                                                            //  calls are being replayed on.
+  std::map<llvm::Function *, ShaderStage> m_shaderStageMap; // Map function -> shader stage
+  llvm::Function *m_enclosingFunc = nullptr;                // Last function written with current
+                                                            //  shader stage
+};
+
+} // namespace lgc

--- a/lgc/include/lgc/state/PipelineShaders.h
+++ b/lgc/include/lgc/state/PipelineShaders.h
@@ -38,10 +38,10 @@ namespace lgc {
 
 // =====================================================================================================================
 // Simple analysis pass that finds the shaders in the pipeline module
-class PipelineShaders : public llvm::ModulePass {
+class LegacyPipelineShaders : public llvm::ModulePass {
 public:
   static char ID;
-  PipelineShaders() : llvm::ModulePass(ID) {}
+  LegacyPipelineShaders() : llvm::ModulePass(ID) {}
 
   bool runOnModule(llvm::Module &module) override;
 
@@ -52,13 +52,13 @@ public:
   ShaderStage getShaderStage(const llvm::Function *func) const;
 
 private:
-  PipelineShaders(const PipelineShaders &) = delete;
-  PipelineShaders &operator=(const PipelineShaders &) = delete;
+  LegacyPipelineShaders(const LegacyPipelineShaders &) = delete;
+  LegacyPipelineShaders &operator=(const LegacyPipelineShaders &) = delete;
 
   llvm::Function *m_entryPoints[ShaderStageCountInternal];       // The entry-point for each shader stage.
   std::map<const llvm::Function *, ShaderStage> m_entryPointMap; // Map from shader entry-point to shader stage.
 };
 
-llvm::ModulePass *createPipelineShaders();
+llvm::ModulePass *createLegacyPipelineShaders();
 
 } // namespace lgc

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -38,6 +38,7 @@
 #include "lgc/state/ShaderStage.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include <map>
 
@@ -49,9 +50,9 @@ class NamedMDNode;
 class PassRegistry;
 class Timer;
 
-void initializePipelineShadersPass(PassRegistry &);
-void initializePipelineStateClearerPass(PassRegistry &);
-void initializePipelineStateWrapperPass(PassRegistry &);
+void initializeLegacyPipelineShadersPass(PassRegistry &);
+void initializeLegacyPipelineStateClearerPass(PassRegistry &);
+void initializeLegacyPipelineStateWrapperPass(PassRegistry &);
 
 } // namespace llvm
 
@@ -62,15 +63,15 @@ class PalMetadata;
 class PipelineState;
 class TargetInfo;
 
-llvm::ModulePass *createPipelineStateClearer();
+llvm::ModulePass *createLegacyPipelineStateClearer();
 
 // Initialize passes in state directory
 //
 // @param passRegistry : Pass registry
 inline static void initializeStatePasses(llvm::PassRegistry &passRegistry) {
-  initializePipelineShadersPass(passRegistry);
-  initializePipelineStateClearerPass(passRegistry);
-  initializePipelineStateWrapperPass(passRegistry);
+  initializeLegacyPipelineShadersPass(passRegistry);
+  initializeLegacyPipelineStateClearerPass(passRegistry);
+  initializeLegacyPipelineStateWrapperPass(passRegistry);
 }
 
 // =====================================================================================================================
@@ -165,7 +166,8 @@ public:
 
   // Generate pipeline module
   bool generate(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
-                CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers) override final;
+                CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers,
+                bool newPassManager) override final;
 
   // Create an ELF linker object for linking unlinked shader/part-pipeline ELFs into a pipeline ELF using the
   // pipeline state
@@ -418,6 +420,17 @@ public:
   }
 
 private:
+  // NOTE: These two functions are temporarily used to generate pipeline modules
+  // with and without using the new pass manager. Once the switch to the new pass
+  // manager is done, these functions will be removed and we'll use a single
+  // generate function.
+  // Generate pipeline module
+  void generateWithNewPassManager(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
+                                  CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers);
+  // Generate pipeline module
+  void generateWithLegacyPassManager(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
+                                     CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers);
+
   // Read shaderStageMask from IR
   void readShaderStageMask(llvm::Module *module);
 
@@ -489,10 +502,37 @@ private:
 };
 
 // =====================================================================================================================
-// Wrapper pass for the pipeline state in the middle-end
-class PipelineStateWrapper : public llvm::ImmutablePass {
+// PipelineStateWrapper analysis result
+class PipelineStateWrapperResult {
 public:
-  PipelineStateWrapper(LgcContext *builderContext = nullptr);
+  PipelineStateWrapperResult(PipelineState *pipelineState);
+  PipelineState *getPipelineState() { return m_pipelineState; }
+
+private:
+  PipelineState *m_pipelineState = nullptr;
+};
+
+// =====================================================================================================================
+// Wrapper pass for the pipeline state in the middle-end
+class PipelineStateWrapper : public llvm::AnalysisInfoMixin<PipelineStateWrapper> {
+public:
+  using Result = PipelineStateWrapperResult;
+  PipelineStateWrapper(LgcContext *builderContext);
+  PipelineStateWrapper(PipelineState *pipelineState);
+  Result run(llvm::Module &module, llvm::ModuleAnalysisManager &);
+  static llvm::AnalysisKey Key; // NOLINT
+
+private:
+  LgcContext *m_builderContext = nullptr;                  // LgcContext for allocating PipelineState
+  PipelineState *m_pipelineState = nullptr;                // Cached pipeline state
+  std::unique_ptr<PipelineState> m_allocatedPipelineState; // Pipeline state allocated by this pass
+};
+
+// =====================================================================================================================
+// Wrapper pass for the pipeline state in the middle-end
+class LegacyPipelineStateWrapper : public llvm::ImmutablePass {
+public:
+  LegacyPipelineStateWrapper(LgcContext *builderContext = nullptr);
 
   bool doFinalization(llvm::Module &module) override;
 
@@ -508,6 +548,16 @@ private:
   LgcContext *m_builderContext = nullptr;              // LgcContext for allocating PipelineState
   PipelineState *m_pipelineState = nullptr;                // Cached pipeline state
   std::unique_ptr<PipelineState> m_allocatedPipelineState; // Pipeline state allocated by this pass
+};
+
+// =====================================================================================================================
+// Pass to clear pipeline state out of the IR
+class PipelineStateClearer : public llvm::PassInfoMixin<PipelineStateClearer> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+  bool runImpl(llvm::Module &module, PipelineState *pipelineState);
+
+  static llvm::StringRef name() { return "LLPC pipeline state clearer"; }
 };
 
 } // namespace lgc

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -52,7 +52,10 @@ public:
   static PassManager *Create();
   virtual ~PassManager() {}
   template <typename PassBuilderT> bool registerFunctionAnalysis(PassBuilderT &&PassBuilder) {
-    return functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));
+    return m_functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));
+  }
+  template <typename PassBuilderT> bool registerModuleAnalysis(PassBuilderT &&passBuilder) {
+    return m_moduleAnalysisManager.registerPass(std::forward<PassBuilderT>(passBuilder));
   }
   // Register a pass to identify it with a short name in the pass manager
   virtual void registerPass(llvm::StringRef passName, llvm::StringRef className) = 0;
@@ -60,7 +63,8 @@ public:
   virtual void setPassIndex(unsigned *passIndex) = 0;
 
 protected:
-  llvm::FunctionAnalysisManager functionAnalysisManager;
+  llvm::FunctionAnalysisManager m_functionAnalysisManager;
+  llvm::ModuleAnalysisManager m_moduleAnalysisManager;
 };
 
 } // namespace lgc

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -665,13 +665,16 @@ public:
   //                 timers[1]: LLVM optimizations
   //                 timers[2]: codegen
   // @param otherElf : Optional ELF for the other part-pipeline when compiling an unlinked part-pipeline ELF.
+  // @param newPassManager : Whether to use the new pass manager or not
   // @returns : True for success.
   //           False if irLink asked for an "unlinked" shader or part-pipeline, and there is some reason why the
   //           module cannot be compiled that way.  The client typically then does a whole-pipeline compilation
   //           instead. The client can call getLastError() to get a textual representation of the error, for
   //           use in logging or in error reporting in a command-line utility.
+  // NOTE: The newPassManager argument will be removed once the switch to the new pass manager is completed.
   virtual bool generate(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
-                        CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers) = 0;
+                        CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers,
+                        bool newPassManager) = 0;
 
   // Create an ELF linker object for linking unlinked shader or part-pipeline ELFs into a pipeline ELF using
   // the pipeline state. This needs to be deleted after use.

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -65,8 +65,8 @@ public:
   LowerFragColorExport &operator=(const LowerFragColorExport &) = delete;
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
   }
 
   virtual bool runOnModule(Module &module) override;
@@ -449,10 +449,10 @@ ModulePass *lgc::createLowerFragColorExport() {
 // @param [in/out] module : Module
 bool LowerFragColorExport::runOnModule(Module &module) {
   m_context = &module.getContext();
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   m_resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment);
 
-  auto pipelineShaders = &getAnalysis<PipelineShaders>();
+  auto pipelineShaders = &getAnalysis<LegacyPipelineShaders>();
   Function *fragEntryPoint = pipelineShaders->getEntryPoint(ShaderStageFragment);
   if (!fragEntryPoint)
     return false;

--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -124,7 +124,7 @@ NggLdsManager::NggLdsManager(Module *module, PipelineState *pipelineState, IRBui
   //
   // Create global variable modeling LDS
   //
-  m_lds = Patch::getLdsVariable(m_pipelineState, module);
+  m_lds = LegacyPatch::getLdsVariable(m_pipelineState, module);
 
   memset(&m_ldsRegionStart, InvalidValue, sizeof(m_ldsRegionStart)); // Initialized to invalid value (0xFFFFFFFF)
 

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -30,7 +30,10 @@
  */
 #include "lgc/patch/Patch.h"
 #include "PatchCheckShaderCache.h"
+#include "PatchNullFragShader.h"
 #include "lgc/LgcContext.h"
+#include "lgc/PassManager.h"
+#include "lgc/builder/BuilderReplayer.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 #include "lgc/util/Debug.h"
@@ -77,11 +80,42 @@ namespace lgc {
 //
 // @param pipelineState : Pipeline state
 // @param [in/out] passMgr : Pass manager to add passes to
+// @param patchTimer : Timer to time patch passes with, nullptr if not timing
+// @param optTimer : Timer to time LLVM optimization passes with, nullptr if not timing
+// @param checkShaderCacheDunc : Callback function to check shader cache
+void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, bool addReplayerPass, Timer *patchTimer,
+                      Timer *optTimer, Pipeline::CheckShaderCacheFunc checkShaderCacheFunc) {
+  // Start timer for patching passes.
+  if (patchTimer)
+    LgcContext::createAndAddStartStopTimer(passMgr, patchTimer, true);
+
+  // If using BuilderRecorder rather than BuilderImpl, replay the Builder calls now
+  if (addReplayerPass)
+    passMgr.addPass(BuilderReplayer(pipelineState));
+
+  if (raw_ostream *outs = getLgcOuts()) {
+    passMgr.addPass(PrintModulePass(*outs,
+                                    "===============================================================================\n"
+                                    "// LLPC pipeline before-patching results\n"));
+  }
+
+  // Build null fragment shader if necessary
+  passMgr.addPass(PatchNullFragShader());
+
+  // NOTE: The new pass manager is not fully implemented yet. We should add all
+  // the other patching passes here.
+}
+
+// =====================================================================================================================
+// Add whole-pipeline patch passes to pass manager
+//
+// @param pipelineState : Pipeline state
+// @param [in/out] passMgr : Pass manager to add passes to
 // @param replayerPass : BuilderReplayer pass, or nullptr if not needed
 // @param patchTimer : Timer to time patch passes with, nullptr if not timing
 // @param optTimer : Timer to time LLVM optimization passes with, nullptr if not timing
-void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr, ModulePass *replayerPass,
-                      Timer *patchTimer, Timer *optTimer, Pipeline::CheckShaderCacheFunc checkShaderCacheFunc)
+void LegacyPatch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr, ModulePass *replayerPass,
+                            Timer *patchTimer, Timer *optTimer, Pipeline::CheckShaderCacheFunc checkShaderCacheFunc)
 // Callback function to check shader cache
 {
   // Start timer for patching passes.
@@ -99,7 +133,7 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   }
 
   // Build null fragment shader if necessary
-  passMgr.add(createPatchNullFragShader());
+  passMgr.add(createLegacyPatchNullFragShader());
 
   // Patch resource collecting, remove inactive resources (should be the first preliminary pass)
   passMgr.add(createPatchResourceCollect());
@@ -215,7 +249,7 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
 // Add optimization passes to pass manager
 //
 // @param [in/out] passMgr : Pass manager to add passes to
-void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
+void LegacyPatch::addOptimizationPasses(legacy::PassManager &passMgr) {
   LLPC_OUTS("PassManager optimization level = " << cl::OptLevel << "\n");
 
   passMgr.add(createForceFunctionAttrsLegacyPass());

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -71,7 +71,7 @@ PatchBufferOp::PatchBufferOp() : FunctionPass(ID) {
 // @param [out] analysisUsage : The analysis usage.
 void PatchBufferOp::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
   analysisUsage.addRequired<LegacyDivergenceAnalysis>();
-  analysisUsage.addRequired<PipelineStateWrapper>();
+  analysisUsage.addRequired<LegacyPipelineStateWrapper>();
   analysisUsage.addRequired<TargetTransformInfoWrapperPass>();
   analysisUsage.addPreserved<TargetTransformInfoWrapperPass>();
 }
@@ -83,7 +83,7 @@ void PatchBufferOp::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
 bool PatchBufferOp::runOnFunction(Function &function) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Buffer-Op\n");
 
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(function.getParent());
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(function.getParent());
   m_context = &function.getContext();
   m_builder = std::make_unique<IRBuilder<>>(*m_context);
 

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -72,7 +72,7 @@ static void streamMapEntries(MapType &map, raw_ostream &stream) {
 } // namespace
 
 // =====================================================================================================================
-PatchCheckShaderCache::PatchCheckShaderCache() : Patch(ID) {
+PatchCheckShaderCache::PatchCheckShaderCache() : LegacyPatch(ID) {
 }
 
 // =====================================================================================================================
@@ -87,11 +87,11 @@ bool PatchCheckShaderCache::runOnModule(Module &module) {
     return false;
   }
 
-  Patch::init(&module);
+  LegacyPatch::init(&module);
 
   std::string inOutUsageStreams[ShaderStageGfxCount];
   ArrayRef<uint8_t> inOutUsageValues[ShaderStageGfxCount];
-  PipelineState *pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  PipelineState *pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   auto stageMask = pipelineState->getShaderStageMask();
 
   // Build input/output layout hash per shader stage

--- a/lgc/patch/PatchCheckShaderCache.h
+++ b/lgc/patch/PatchCheckShaderCache.h
@@ -38,13 +38,13 @@ namespace lgc {
 
 // =====================================================================================================================
 // Represents the pass of LLVM patching operations for checking shader cache
-class PatchCheckShaderCache : public Patch {
+class PatchCheckShaderCache : public LegacyPatch {
 public:
   PatchCheckShaderCache();
 
   void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
   }
 
   virtual bool runOnModule(llvm::Module &module) override;

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -60,16 +60,16 @@ namespace lgc {
 
 // =====================================================================================================================
 // Pass to generate copy shader if required
-class PatchCopyShader : public Patch {
+class PatchCopyShader : public LegacyPatch {
 public:
   static char ID;
-  PatchCopyShader() : Patch(ID) {}
+  PatchCopyShader() : LegacyPatch(ID) {}
 
   bool runOnModule(Module &module) override;
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
     // Pass does not preserve PipelineShaders as it adds a new shader.
   }
 
@@ -117,9 +117,9 @@ ModulePass *lgc::createPatchCopyShader() {
 bool PatchCopyShader::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Copy-Shader\n");
 
-  Patch::init(&module);
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
-  auto pipelineShaders = &getAnalysis<PipelineShaders>();
+  LegacyPatch::init(&module);
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
+  auto pipelineShaders = &getAnalysis<LegacyPipelineShaders>();
   auto gsEntryPoint = pipelineShaders->getEntryPoint(ShaderStageGeometry);
   if (!gsEntryPoint) {
     // No geometry shader -- copy shader not required.
@@ -245,7 +245,7 @@ bool PatchCopyShader::runOnModule(Module &module) {
   }
 
   if (m_pipelineState->isGsOnChip())
-    m_lds = Patch::getLdsVariable(m_pipelineState, &module);
+    m_lds = LegacyPatch::getLdsVariable(m_pipelineState, &module);
   else
     m_gsVsRingBufDesc = loadGsVsRingBufferDescriptor(builder);
 

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -89,15 +89,15 @@ namespace {
 
 // =====================================================================================================================
 // The entry-point mutation pass
-class PatchEntryPointMutate : public Patch {
+class PatchEntryPointMutate : public LegacyPatch {
 public:
   PatchEntryPointMutate();
   PatchEntryPointMutate(const PatchEntryPointMutate &) = delete;
   PatchEntryPointMutate &operator=(const PatchEntryPointMutate &) = delete;
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
     // Does not preserve PipelineShaders because it replaces the entrypoints.
   }
 
@@ -226,7 +226,7 @@ ModulePass *lgc::createPatchEntryPointMutate() {
 }
 
 // =====================================================================================================================
-PatchEntryPointMutate::PatchEntryPointMutate() : Patch(ID), m_hasTs(false), m_hasGs(false) {
+PatchEntryPointMutate::PatchEntryPointMutate() : LegacyPatch(ID), m_hasTs(false), m_hasGs(false) {
 }
 
 // =====================================================================================================================
@@ -236,9 +236,9 @@ PatchEntryPointMutate::PatchEntryPointMutate() : Patch(ID), m_hasTs(false), m_ha
 bool PatchEntryPointMutate::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Entry-Point-Mutate\n");
 
-  Patch::init(&module);
+  LegacyPatch::init(&module);
 
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
 
   const unsigned stageMask = m_pipelineState->getShaderStageMask();
   m_hasTs = (stageMask & (shaderStageToMask(ShaderStageTessControl) | shaderStageToMask(ShaderStageTessEval))) != 0;
@@ -254,7 +254,7 @@ bool PatchEntryPointMutate::runOnModule(Module &module) {
 
   if (m_pipelineState->isGraphics()) {
     // Process each shader in turn, but not the copy shader.
-    auto pipelineShaders = &getAnalysis<PipelineShaders>();
+    auto pipelineShaders = &getAnalysis<LegacyPipelineShaders>();
     for (unsigned shaderStage = ShaderStageVertex; shaderStage < ShaderStageNativeStageCount; ++shaderStage) {
       m_entryPoint = pipelineShaders->getEntryPoint(static_cast<ShaderStage>(shaderStage));
       if (m_entryPoint) {

--- a/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/patch/PatchInOutImportExport.h
@@ -43,16 +43,16 @@ namespace lgc {
 
 // =====================================================================================================================
 // Represents the pass of LLVM patching opertions for input import and output export.
-class PatchInOutImportExport : public Patch {
+class PatchInOutImportExport : public LegacyPatch {
 public:
   PatchInOutImportExport();
   ~PatchInOutImportExport();
 
   void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
     analysisUsage.addRequired<llvm::PostDominatorTreeWrapperPass>();
-    analysisUsage.addPreserved<PipelineShaders>();
+    analysisUsage.addPreserved<LegacyPipelineShaders>();
   }
 
   bool runOnModule(llvm::Module &module) override;

--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -49,13 +49,13 @@ namespace lgc {
 
 // =====================================================================================================================
 // Represents the pass of setting up the value for workgroup global variables.
-class PatchInitializeWorkgroupMemory final : public Patch {
+class PatchInitializeWorkgroupMemory final : public LegacyPatch {
 public:
   PatchInitializeWorkgroupMemory();
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineShaders>();
-    analysisUsage.addRequired<PipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
   }
 
   virtual bool runOnModule(Module &module) override;
@@ -84,7 +84,7 @@ ModulePass *createPatchInitializeWorkgroupMemory() {
 }
 
 // =====================================================================================================================
-PatchInitializeWorkgroupMemory::PatchInitializeWorkgroupMemory() : Patch(ID) {
+PatchInitializeWorkgroupMemory::PatchInitializeWorkgroupMemory() : LegacyPatch(ID) {
 }
 
 // =====================================================================================================================
@@ -94,7 +94,7 @@ PatchInitializeWorkgroupMemory::PatchInitializeWorkgroupMemory() : Patch(ID) {
 bool PatchInitializeWorkgroupMemory::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Initialize-Workgroup-Memory\n");
 
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   // This pass works on compute shader.
   if (!m_pipelineState->hasShaderStage(ShaderStageCompute))
     return false;
@@ -111,9 +111,9 @@ bool PatchInitializeWorkgroupMemory::runOnModule(Module &module) {
   if (workgroupGlobals.empty())
     return false;
 
-  Patch::init(&module);
+  LegacyPatch::init(&module);
   m_shaderStage = ShaderStageCompute;
-  m_entryPoint = (&getAnalysis<PipelineShaders>())->getEntryPoint(static_cast<ShaderStage>(m_shaderStage));
+  m_entryPoint = (&getAnalysis<LegacyPipelineShaders>())->getEntryPoint(static_cast<ShaderStage>(m_shaderStage));
   BuilderBase builder(*m_context);
   Instruction *insertPos = &*m_entryPoint->front().getFirstInsertionPt();
   builder.SetInsertPoint(insertPos);

--- a/lgc/patch/PatchLlvmIrInclusion.cpp
+++ b/lgc/patch/PatchLlvmIrInclusion.cpp
@@ -50,7 +50,7 @@ ModulePass *createPatchLlvmIrInclusion() {
 }
 
 // =====================================================================================================================
-PatchLlvmIrInclusion::PatchLlvmIrInclusion() : Patch(ID) {
+PatchLlvmIrInclusion::PatchLlvmIrInclusion() : LegacyPatch(ID) {
 }
 
 // =====================================================================================================================
@@ -61,7 +61,7 @@ PatchLlvmIrInclusion::PatchLlvmIrInclusion() : Patch(ID) {
 //
 // @param [in/out] module : LLVM module to be run on
 bool PatchLlvmIrInclusion::runOnModule(Module &module) {
-  Patch::init(&module);
+  LegacyPatch::init(&module);
 
   std::string moduleStr;
   raw_string_ostream llvmIr(moduleStr);

--- a/lgc/patch/PatchLlvmIrInclusion.h
+++ b/lgc/patch/PatchLlvmIrInclusion.h
@@ -36,7 +36,7 @@ namespace lgc {
 
 // =====================================================================================================================
 // Represents the pass of LLVM patch operations of including LLVM IR as a separate section in the ELF binary.
-class PatchLlvmIrInclusion : public Patch {
+class PatchLlvmIrInclusion : public LegacyPatch {
 public:
   PatchLlvmIrInclusion();
 

--- a/lgc/patch/PatchLoadScalarizer.cpp
+++ b/lgc/patch/PatchLoadScalarizer.cpp
@@ -63,9 +63,9 @@ PatchLoadScalarizer::PatchLoadScalarizer() : FunctionPass(ID) {
 //
 // @param [out] analysisUsage : The analysis usage.
 void PatchLoadScalarizer::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
-  analysisUsage.addRequired<PipelineStateWrapper>();
-  analysisUsage.addRequired<PipelineShaders>();
-  analysisUsage.addPreserved<PipelineShaders>();
+  analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+  analysisUsage.addRequired<LegacyPipelineShaders>();
+  analysisUsage.addPreserved<LegacyPipelineShaders>();
 }
 
 // =====================================================================================================================
@@ -75,8 +75,8 @@ void PatchLoadScalarizer::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
 bool PatchLoadScalarizer::runOnFunction(Function &function) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Load-Scalarizer-Opt\n");
 
-  auto pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(function.getParent());
-  auto pipelineShaders = &getAnalysis<PipelineShaders>();
+  auto pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(function.getParent());
+  auto pipelineShaders = &getAnalysis<LegacyPipelineShaders>();
   auto shaderStage = pipelineShaders->getShaderStage(&function);
 
   // If the function is not a valid shader stage, or the optimization is disabled, bail.

--- a/lgc/patch/PatchLoopMetadata.cpp
+++ b/lgc/patch/PatchLoopMetadata.cpp
@@ -55,7 +55,7 @@ public:
   static char ID; // ID of this pass
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
   }
 
   MDNode *updateMetadata(MDNode *loopId, ArrayRef<StringRef> prefixesToRemove, Metadata *addMetadata, bool conditional);
@@ -137,16 +137,16 @@ bool PatchLoopMetadata::runOnLoop(Loop *loop, LPPassManager &loopPassMgr) {
 
   Module *module = loop->getHeader()->getModule();
   Function *func = loop->getHeader()->getFirstNonPHI()->getFunction();
-  PipelineState *m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(module);
+  PipelineState *mPipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(module);
   m_context = &loop->getHeader()->getContext();
 
-  m_gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
+  m_gfxIp = mPipelineState->getTargetInfo().getGfxIpVersion();
   bool changed = false;
 
   ShaderStage stage = getShaderStage(func);
   if (stage == ShaderStageInvalid)
     return false;
-  if (auto shaderOptions = &m_pipelineState->getShaderOptions(stage)) {
+  if (auto shaderOptions = &mPipelineState->getShaderOptions(stage)) {
     m_disableLoopUnroll = shaderOptions->disableLoopUnroll;
     m_forceLoopUnrollCount = shaderOptions->forceLoopUnrollCount;
     m_disableLicmThreshold = shaderOptions->disableLicmThreshold;

--- a/lgc/patch/PatchNullFragShader.h
+++ b/lgc/patch/PatchNullFragShader.h
@@ -1,0 +1,30 @@
+/*
+************************************************************************************************************************
+*
+*  Copyright (C) 2021 Advanced Micro Devices, Inc. All rights reserved.
+*
+***********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchNullFragShader.h
+ * @brief LLPC header file: contains declaration of class lgc::PatchNullFragShader.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/patch/Patch.h"
+
+namespace lgc {
+
+// =====================================================================================================================
+// Pass to generate null fragment shader if required
+class PatchNullFragShader : public Patch, public llvm::PassInfoMixin<PatchNullFragShader> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+
+  bool runImpl(llvm::Module &module, PipelineState *pipelineState);
+
+  static llvm::StringRef name() { return "Patch LLVM for null fragment shader generation"; }
+};
+
+} // namespace lgc

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -48,16 +48,17 @@ namespace lgc {
 
 // =====================================================================================================================
 // Pass to prepare the pipeline ABI
-class PatchPreparePipelineAbi final : public Patch {
+class PatchPreparePipelineAbi final : public LegacyPatch {
 public:
   static char ID;
-  PatchPreparePipelineAbi(bool onlySetCallingConvs = false) : Patch(ID), m_onlySetCallingConvs(onlySetCallingConvs) {}
+  PatchPreparePipelineAbi(bool onlySetCallingConvs = false)
+      : LegacyPatch(ID), m_onlySetCallingConvs(onlySetCallingConvs) {}
 
   bool runOnModule(Module &module) override;
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
   }
 
 private:
@@ -77,7 +78,7 @@ private:
   void addAbiMetadata(Module &module);
 
   PipelineState *m_pipelineState;     // Pipeline state
-  PipelineShaders *m_pipelineShaders; // API shaders in the pipeline
+  LegacyPipelineShaders *m_pipelineShaders; // API shaders in the pipeline
 
   bool m_hasVs;  // Whether the pipeline has vertex shader
   bool m_hasTcs; // Whether the pipeline has tessellation control shader
@@ -108,10 +109,10 @@ ModulePass *lgc::createPatchPreparePipelineAbi(bool onlySetCallingConvs) {
 bool PatchPreparePipelineAbi::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Prepare-Pipeline-Abi\n");
 
-  Patch::init(&module);
+  LegacyPatch::init(&module);
 
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
-  m_pipelineShaders = &getAnalysis<PipelineShaders>();
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
+  m_pipelineShaders = &getAnalysis<LegacyPipelineShaders>();
 
   m_hasVs = m_pipelineState->hasShaderStage(ShaderStageVertex);
   m_hasTcs = m_pipelineState->hasShaderStage(ShaderStageTessControl);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -67,7 +67,7 @@ ModulePass *createPatchResourceCollect() {
 }
 
 // =====================================================================================================================
-PatchResourceCollect::PatchResourceCollect() : Patch(ID), m_resUsage(nullptr) {
+PatchResourceCollect::PatchResourceCollect() : LegacyPatch(ID), m_resUsage(nullptr) {
 }
 
 // =====================================================================================================================
@@ -77,9 +77,9 @@ PatchResourceCollect::PatchResourceCollect() : Patch(ID), m_resUsage(nullptr) {
 bool PatchResourceCollect::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Resource-Collect\n");
 
-  Patch::init(&module);
-  m_pipelineShaders = &getAnalysis<PipelineShaders>();
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  LegacyPatch::init(&module);
+  m_pipelineShaders = &getAnalysis<LegacyPipelineShaders>();
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
 
   // This pass processes a missing fragment shader using FS input packing information passed into LGC
   // from the separate compile of the FS.

--- a/lgc/patch/PatchResourceCollect.h
+++ b/lgc/patch/PatchResourceCollect.h
@@ -43,14 +43,14 @@ typedef std::map<InOutLocationInfo, InOutLocationInfo> InOutLocationInfoMap;
 
 // =====================================================================================================================
 // Represents the pass of LLVM patching opertions for resource collecting
-class PatchResourceCollect : public Patch, public llvm::InstVisitor<PatchResourceCollect> {
+class PatchResourceCollect : public LegacyPatch, public llvm::InstVisitor<PatchResourceCollect> {
 public:
   PatchResourceCollect();
 
   void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
-    analysisUsage.addRequired<PipelineShaders>();
-    analysisUsage.addPreserved<PipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
+    analysisUsage.addPreserved<LegacyPipelineShaders>();
   }
 
   virtual bool runOnModule(llvm::Module &module) override;
@@ -96,7 +96,7 @@ private:
   void scalarizeGenericInput(llvm::CallInst *call);
   void scalarizeGenericOutput(llvm::CallInst *call);
 
-  PipelineShaders *m_pipelineShaders; // Pipeline shaders
+  LegacyPipelineShaders *m_pipelineShaders; // Pipeline shaders
   PipelineState *m_pipelineState;     // Pipeline state
 
   std::vector<llvm::CallInst *> m_deadCalls; // Dead calls

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -43,13 +43,13 @@ namespace lgc {
 
 // =====================================================================================================================
 // Pass to set up target features on shader entry-points
-class PatchSetupTargetFeatures : public Patch {
+class PatchSetupTargetFeatures : public LegacyPatch {
 public:
   static char ID;
-  PatchSetupTargetFeatures() : Patch(ID) {}
+  PatchSetupTargetFeatures() : LegacyPatch(ID) {}
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
   }
 
   bool runOnModule(Module &module) override;
@@ -80,9 +80,9 @@ ModulePass *lgc::createPatchSetupTargetFeatures() {
 bool PatchSetupTargetFeatures::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Setup-Target-Features\n");
 
-  Patch::init(&module);
+  LegacyPatch::init(&module);
 
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   setupTargetFeatures(&module);
 
   return true; // Modified the module.

--- a/lgc/patch/PatchWaveSizeAdjust.cpp
+++ b/lgc/patch/PatchWaveSizeAdjust.cpp
@@ -51,8 +51,8 @@ public:
   PatchWaveSizeAdjust();
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineShaders>();
-    analysisUsage.addRequired<PipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineShaders>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
     analysisUsage.setPreservesAll();
   }
 
@@ -92,7 +92,7 @@ PatchWaveSizeAdjust::PatchWaveSizeAdjust() : ModulePass(ID) {
 bool PatchWaveSizeAdjust::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Running the pass of adjusting wave size heuristic\n");
 
-  auto pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  auto pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   for (int stageIdx = 0; stageIdx < ShaderStageCount; ++stageIdx) {
     ShaderStage shaderStage = static_cast<ShaderStage>(stageIdx);
     if (pipelineState->hasShaderStage(shaderStage)) {

--- a/lgc/patch/PatchWorkarounds.cpp
+++ b/lgc/patch/PatchWorkarounds.cpp
@@ -56,7 +56,7 @@ ModulePass *createPatchWorkarounds() {
   return new PatchWorkarounds();
 }
 
-PatchWorkarounds::PatchWorkarounds() : Patch(ID) {
+PatchWorkarounds::PatchWorkarounds() : LegacyPatch(ID) {
 }
 
 // =====================================================================================================================
@@ -66,9 +66,9 @@ PatchWorkarounds::PatchWorkarounds() : Patch(ID) {
 bool PatchWorkarounds::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Workarounds\n");
 
-  Patch::init(&module);
+  LegacyPatch::init(&module);
 
-  m_pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  m_pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   m_builder = std::make_unique<IRBuilder<>>(*m_context);
   m_processed.clear();
 
@@ -222,9 +222,9 @@ void PatchWorkarounds::processImageDescWorkaround(CallInst &callInst, bool isLas
 //
 // @param [out] analysisUsage : The analysis usage.
 void PatchWorkarounds::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
-  analysisUsage.addRequired<PipelineStateWrapper>();
-  analysisUsage.addRequired<PipelineShaders>();
-  analysisUsage.addPreserved<PipelineShaders>();
+  analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+  analysisUsage.addRequired<LegacyPipelineShaders>();
+  analysisUsage.addPreserved<LegacyPipelineShaders>();
 }
 
 } // namespace lgc

--- a/lgc/patch/PatchWorkarounds.h
+++ b/lgc/patch/PatchWorkarounds.h
@@ -46,7 +46,7 @@ namespace lgc {
 //   require a fix so the hardware will ignore this difference (actually an app error, but common enough to require
 //   handling)
 //
-class PatchWorkarounds final : public Patch {
+class PatchWorkarounds final : public LegacyPatch {
 public:
   PatchWorkarounds();
 

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -48,7 +48,7 @@ using namespace lgc;
 //
 // @param pipelineState : Pipeline state
 // @param pipelineShaders : API shaders in the pipeline
-ShaderMerger::ShaderMerger(PipelineState *pipelineState, PipelineShaders *pipelineShaders)
+ShaderMerger::ShaderMerger(PipelineState *pipelineState, LegacyPipelineShaders *pipelineShaders)
     : m_pipelineState(pipelineState), m_context(&pipelineState->getContext()),
       m_gfxIp(pipelineState->getTargetInfo().getGfxIpVersion()) {
   assert(m_gfxIp.major >= 9);

--- a/lgc/patch/ShaderMerger.h
+++ b/lgc/patch/ShaderMerger.h
@@ -77,7 +77,7 @@ enum EsGsSpecialSysValue {
 // Represents the manager doing shader merge operations.
 class ShaderMerger {
 public:
-  ShaderMerger(PipelineState *pipelineState, PipelineShaders *pipelineShaders);
+  ShaderMerger(PipelineState *pipelineState, LegacyPipelineShaders *pipelineShaders);
 
   llvm::Function *generateLsHsEntryPoint(llvm::Function *lsEntryPoint, llvm::Function *hsEntryPoint);
   llvm::Function *generateEsGsEntryPoint(llvm::Function *esEntryPoint, llvm::Function *gsEntryPoint);

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -82,7 +82,7 @@ public:
   LowerVertexFetch &operator=(const LowerVertexFetch &) = delete;
 
   void getAnalysisUsage(AnalysisUsage &analysisUsage) const override {
-    analysisUsage.addRequired<PipelineStateWrapper>();
+    analysisUsage.addRequired<LegacyPipelineStateWrapper>();
   }
 
   virtual bool runOnModule(Module &module) override;
@@ -363,7 +363,7 @@ ModulePass *lgc::createLowerVertexFetch() {
 //
 // @param [in/out] module : Module
 bool LowerVertexFetch::runOnModule(Module &module) {
-  PipelineState *pipelineState = getAnalysis<PipelineStateWrapper>().getPipelineState(&module);
+  PipelineState *pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
   std::unique_ptr<VertexFetch> vertexFetch(VertexFetch::create(pipelineState->getLgcContext()));
 
   // Gather vertex fetch calls. We can assume they're all in one function, the vertex shader.

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -72,7 +72,7 @@ using namespace lgc;
 using namespace llvm;
 
 namespace llvm {
-void initializeBuilderReplayerPass(PassRegistry &);
+void initializeLegacyBuilderReplayerPass(PassRegistry &);
 } // namespace llvm
 
 static codegen::RegisterCodeGenFlags CGF;
@@ -151,7 +151,7 @@ void LgcContext::initialize() {
   // Initialize LGC passes so they can be referenced by -stop-before etc.
   initializeUtilPasses(passRegistry);
   initializeStatePasses(passRegistry);
-  initializeBuilderReplayerPass(passRegistry);
+  initializeLegacyBuilderReplayerPass(passRegistry);
   initializePatchPasses(passRegistry);
 
   // Initialize some command-line option defaults.

--- a/lgc/state/PipelineShaders.cpp
+++ b/lgc/state/PipelineShaders.cpp
@@ -39,12 +39,12 @@
 using namespace lgc;
 using namespace llvm;
 
-char PipelineShaders::ID = 0;
+char LegacyPipelineShaders::ID = 0;
 
 // =====================================================================================================================
 // Create an instance of the pass.
-ModulePass *createPipelineShaders() {
-  return new PipelineShaders();
+ModulePass *createLegacyPipelineShaders() {
+  return new LegacyPipelineShaders();
 }
 
 // =====================================================================================================================
@@ -54,7 +54,7 @@ ModulePass *createPipelineShaders() {
 // and it has metadata giving the SPIR-V execution model.
 //
 // @param [in/out] module : LLVM module to be run on
-bool PipelineShaders::runOnModule(Module &module) {
+bool LegacyPipelineShaders::runOnModule(Module &module) {
   LLVM_DEBUG(dbgs() << "Run the pass Pipeline-Shaders\n");
 
   m_entryPointMap.clear();
@@ -78,7 +78,7 @@ bool PipelineShaders::runOnModule(Module &module) {
 // Get the shader for a particular API shader stage, or nullptr if none
 //
 // @param shaderStage : Shader stage
-Function *PipelineShaders::getEntryPoint(ShaderStage shaderStage) const {
+Function *LegacyPipelineShaders::getEntryPoint(ShaderStage shaderStage) const {
   assert((unsigned)shaderStage < ShaderStageCountInternal);
   return m_entryPoints[shaderStage];
 }
@@ -87,7 +87,7 @@ Function *PipelineShaders::getEntryPoint(ShaderStage shaderStage) const {
 // Get the ABI shader stage for a particular function, or ShaderStageInvalid if not a shader entrypoint.
 //
 // @param func : Function to look up
-ShaderStage PipelineShaders::getShaderStage(const Function *func) const {
+ShaderStage LegacyPipelineShaders::getShaderStage(const Function *func) const {
   auto entryMapIt = m_entryPointMap.find(func);
   if (entryMapIt == m_entryPointMap.end())
     return ShaderStageInvalid;
@@ -96,4 +96,4 @@ ShaderStage PipelineShaders::getShaderStage(const Function *func) const {
 
 // =====================================================================================================================
 // Initializes the pass
-INITIALIZE_PASS(PipelineShaders, DEBUG_TYPE, "LLVM pass for getting pipeline shaders", false, true)
+INITIALIZE_PASS(LegacyPipelineShaders, DEBUG_TYPE, "LLVM pass for getting pipeline shaders", false, true)

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -324,7 +324,7 @@ int main(int argc, char **argv) {
         }
       } else {
         // Run the middle-end compiler.
-        if (!pipeline->generate(std::move(module), outStream, nullptr, {}))
+        if (!pipeline->generate(std::move(module), outStream, nullptr, {}, false))
           err = pipeline->getLastError();
       }
 

--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -94,7 +94,6 @@ public:
   void registerPass(StringRef passName, StringRef className) override;
   void run(Module &module) override;
   void setPassIndex(unsigned *passIndex) override { m_passIndex = passIndex; }
-
 private:
   void registerCallbacks();
 
@@ -102,7 +101,6 @@ private:
 
   LoopAnalysisManager loopAnalysisManager;               // Loop analysis manager used when running the passes.
   CGSCCAnalysisManager cgsccAnalysisManager;             // CGSCC analysis manager used when running the passes.
-  ModuleAnalysisManager moduleAnalysisManager;           // Module analysis manager used when running the passes.
   PassInstrumentationCallbacks instrumentationCallbacks; // Instrumentation callbacks ran when running the passes.
   PrintIRInstrumentation instrumentationPrintIR; // Print IR instrumentation, to print IR before/after the passes.
   VerifyInstrumentation instrumentationVerify;   // Verify instrumentation, run module verifier after each pass.
@@ -197,15 +195,15 @@ void PassManagerImpl::run(Module &module) {
   // analyses are added beforehand.
   if (!initialized) {
     PassBuilder passBuilder(nullptr, PipelineTuningOptions(), None, &instrumentationCallbacks);
-    passBuilder.registerModuleAnalyses(moduleAnalysisManager);
+    passBuilder.registerModuleAnalyses(m_moduleAnalysisManager);
     passBuilder.registerCGSCCAnalyses(cgsccAnalysisManager);
-    passBuilder.registerFunctionAnalyses(functionAnalysisManager);
+    passBuilder.registerFunctionAnalyses(m_functionAnalysisManager);
     passBuilder.registerLoopAnalyses(loopAnalysisManager);
-    passBuilder.crossRegisterProxies(loopAnalysisManager, functionAnalysisManager, cgsccAnalysisManager,
-                                     moduleAnalysisManager);
+    passBuilder.crossRegisterProxies(loopAnalysisManager, m_functionAnalysisManager, cgsccAnalysisManager,
+                                     m_moduleAnalysisManager);
     initialized = true;
   }
-  ModulePassManager::run(module, moduleAnalysisManager);
+  ModulePassManager::run(module, m_moduleAnalysisManager);
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1207,7 +1207,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
           timerProfiler.getTimer(TimerCodeGen),
       };
 
-      pipeline->generate(std::move(pipelineModule), elfStream, checkShaderCacheFunc, timers);
+      pipeline->generate(std::move(pipelineModule), elfStream, checkShaderCacheFunc, timers, cl::NewPassManager == 2);
       result = Result::Success;
     }
 #if LLPC_ENABLE_EXCEPTION

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -36,7 +36,7 @@
 #include <algorithm>
 // TODO: Fix the code in this file so it does not break the builder abstraction. It should
 // not be including files directly in the LGC directory tree like this.
-#include "../../lgc/builder/BuilderRecorder.h"
+#include "../../lgc/include/lgc/builder/BuilderRecorder.h"
 #include "llpcContext.h"
 #include "llpcSpirvLowerResourceCollect.h"
 


### PR DESCRIPTION
This patch is bigger but very similar to the one I posted to setup the infrastructure for the frontend passes. This is an NFC patch, the new pass manager is disabled by default for the middle-end passes and will still be disabled by default after #1419 is merged.