### PR TITLE
[CI] Update LLVM toolchain to 11. Provide llvm-symbolizer.

### DIFF
--- a/.github/workflows/check-formatting-llpc.yml
+++ b/.github/workflows/check-formatting-llpc.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Setup environment
         run: |
-          sudo apt-get install -yqq clang-format-9
+          sudo apt-get install -yqq clang-format-11
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
@@ -19,7 +19,7 @@ jobs:
       - name: Run clang-format
         run: |
           git diff ${{ github.base_ref }} -U0 --no-color -- '**/*.cpp' '**/*.cc' '**/*.h' '**/*.hh' \
-            | clang-format-diff-9 -p1 >not-formatted.diff 2>&1
+            | clang-format-diff-11 -p1 >not-formatted.diff 2>&1
       - name: Check formatting
         run: |
           if ! grep -q '[^[:space:]]' not-formatted.diff ; then

--- a/docker/llpc-clang-tidy.Dockerfile
+++ b/docker/llpc-clang-tidy.Dockerfile
@@ -29,10 +29,6 @@ ARG LLPC_BASE_REF
 # Use bash instead of sh in this docker file.
 SHELL ["/bin/bash", "-c"]
 
-# TODO Remove once the base image is rebuilt
-RUN export DEBIAN_FRONTEND=noninteractive && export TZ=America/New_York \
-    && apt-get update \
-    && apt-get install -yqq --no-install-recommends clang-tidy-10
 COPY docker/update-llpc.sh /vulkandriver/
 
 RUN /vulkandriver/update-llpc.sh
@@ -46,8 +42,9 @@ RUN source /vulkandriver/env.sh \
 # Run clang-tidy. Detect failures by searching for a colon. An empty line or "No relevant changes found." signals success.
 WORKDIR /vulkandriver/drivers/llpc
 RUN ln -s /vulkandriver/builds/ci-build/compile_commands.json \
-    && git diff "origin/$LLPC_BASE_REF" -U0 | /vulkandriver/drivers/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py \
-        -p1 -j$(nproc) >not-tidy.diff \
+    && git diff "origin/$LLPC_BASE_REF" -U0 \
+         | /vulkandriver/drivers/llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py \
+             -p1 -j$(nproc) >not-tidy.diff \
     && if ! grep -q : not-tidy.diff ; then \
         echo "Clean code. Success."; \
     else \


### PR DESCRIPTION
-  Update all LLVM/clang tools to 11.
-  Cleanup tool installation code.
-  Use `clang -print-file-name` instead of hardcoding path to libclang_rt.
-  Provide llvm-symbolizer for pretty stack traces when amdllpc/lgc crash.

Fixes: https://github.com/GPUOpen-Drivers/llpc/issues/1448.