### PR TITLE
Update spvgen header

### DIFF
--- a/imported/spirv/spvgen.h
+++ b/imported/spirv/spvgen.h
@@ -96,12 +96,20 @@ enum SpvSourceLanguage : uint32_t
 };
 enum SpvGenStage : uint32_t
 {
+    SpvGenStageTask,
     SpvGenStageVertex,
     SpvGenStageTessControl,
     SpvGenStageTessEvaluation,
     SpvGenStageGeometry,
+    SpvGenStageMesh,
     SpvGenStageFragment,
     SpvGenStageCompute,
+    SpvGenStageRayTracingRayGen,
+    SpvGenStageRayTracingIntersect,
+    SpvGenStageRayTracingAnyHit,
+    SpvGenStageRayTracingClosestHit,
+    SpvGenStageRayTracingMiss,
+    SpvGenStageRayTracingCallable,
     SpvGenStageCount,
     SpvGenStageInvalid = ~0u,
     SpvGenNativeStageCount = SpvGenStageCompute + 1,


### PR DESCRIPTION
The spvgen header is different from that in spvgen repo. Make sure they
are identical. In the future, spvgen should be placed under llpc/tool/.
Also, this change is to add the missing stages apart from traditional
stages which is supported by glslang repo.

Change-Id: I46eda3b6242f0e5fc82fbefee7caea18ca04adba