### PR TITLE
lgc: Separate BuilderCommon and BuilderBase

### DIFF
--- a/lgc/builder/BuilderBase.cpp
+++ b/lgc/builder/BuilderBase.cpp
@@ -28,7 +28,7 @@
  * @brief LLPC source file: implementation of BuilderBase
  ***********************************************************************************************************************
  */
-#include "lgc/BuilderBase.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
 using namespace lgc;
@@ -43,8 +43,8 @@ using namespace llvm;
 // @param args : Arguments to pass to the callee
 // @param attribs : Function attributes
 // @param instName : Name to give instruction
-CallInst *BuilderBase::CreateNamedCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args,
-                                       ArrayRef<Attribute::AttrKind> attribs, const Twine &instName) {
+CallInst *BuilderCommon::CreateNamedCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args,
+                                         ArrayRef<Attribute::AttrKind> attribs, const Twine &instName) {
   Module *module = GetInsertBlock()->getParent()->getParent();
   Function *func = dyn_cast_or_null<Function>(module->getFunction(funcName));
   if (!func) {
@@ -104,4 +104,102 @@ Value *BuilderBase::CreateAddByteOffset(Value *pointer, Value *byteOffset, const
   }
 
   return CreateGEP(getInt8Ty(), pointer, byteOffset, instName);
+}
+
+// =====================================================================================================================
+// Create a map to i32 function. Many AMDGCN intrinsics only take i32's, so we need to massage input data into an i32
+// to allow us to call these intrinsics. This helper takes a function pointer, massage arguments, and passthrough
+// arguments and massages the mappedArgs into i32's before calling the function pointer. Note that all massage
+// arguments must have the same type.
+//
+// @param mapFunc : The function to call on each provided i32.
+// @param mappedArgs : The arguments to be massaged into i32's and passed to function.
+// @param passthroughArgs : The arguments to be passed through as is (no massaging).
+Value *BuilderBase::CreateMapToInt32(MapToInt32Func mapFunc, ArrayRef<Value *> mappedArgs,
+                                     ArrayRef<Value *> passthroughArgs) {
+  // We must have at least one argument to massage.
+  assert(mappedArgs.size() > 0);
+
+  Type *const type = mappedArgs[0]->getType();
+
+  // Check the massage types all match.
+  for (unsigned i = 1; i < mappedArgs.size(); i++)
+    assert(mappedArgs[i]->getType() == type);
+
+  if (mappedArgs[0]->getType()->isVectorTy()) {
+    // For vectors we extract each vector component and map them individually.
+    const unsigned compCount = cast<FixedVectorType>(type)->getNumElements();
+
+    SmallVector<Value *, 4> results;
+
+    for (unsigned i = 0; i < compCount; i++) {
+      SmallVector<Value *, 4> newMappedArgs;
+
+      for (Value *const mappedArg : mappedArgs)
+        newMappedArgs.push_back(CreateExtractElement(mappedArg, i));
+
+      results.push_back(CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs));
+    }
+
+    Value *result = UndefValue::get(FixedVectorType::get(results[0]->getType(), compCount));
+
+    for (unsigned i = 0; i < compCount; i++)
+      result = CreateInsertElement(result, results[i], i);
+
+    return result;
+  } else if (type->isIntegerTy() && type->getIntegerBitWidth() == 1) {
+    SmallVector<Value *, 4> newMappedArgs;
+
+    for (Value *const mappedArg : mappedArgs)
+      newMappedArgs.push_back(CreateZExt(mappedArg, getInt32Ty()));
+
+    Value *const result = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
+    return CreateTrunc(result, getInt1Ty());
+  } else if (type->isIntegerTy() && type->getIntegerBitWidth() < 32) {
+    SmallVector<Value *, 4> newMappedArgs;
+
+    Type *const vectorType = FixedVectorType::get(type, type->getPrimitiveSizeInBits() == 16 ? 2 : 4);
+    Value *const undef = UndefValue::get(vectorType);
+
+    for (Value *const mappedArg : mappedArgs) {
+      Value *const newMappedArg = CreateInsertElement(undef, mappedArg, static_cast<uint64_t>(0));
+      newMappedArgs.push_back(CreateBitCast(newMappedArg, getInt32Ty()));
+    }
+
+    Value *const result = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
+    return CreateExtractElement(CreateBitCast(result, vectorType), static_cast<uint64_t>(0));
+  } else if (type->getPrimitiveSizeInBits() == 64) {
+    SmallVector<Value *, 4> castMappedArgs;
+
+    for (Value *const mappedArg : mappedArgs)
+      castMappedArgs.push_back(CreateBitCast(mappedArg, FixedVectorType::get(getInt32Ty(), 2)));
+
+    Value *result = UndefValue::get(castMappedArgs[0]->getType());
+
+    for (unsigned i = 0; i < 2; i++) {
+      SmallVector<Value *, 4> newMappedArgs;
+
+      for (Value *const castMappedArg : castMappedArgs)
+        newMappedArgs.push_back(CreateExtractElement(castMappedArg, i));
+
+      Value *const resultComp = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
+
+      result = CreateInsertElement(result, resultComp, i);
+    }
+
+    return CreateBitCast(result, type);
+  } else if (type->isFloatingPointTy()) {
+    SmallVector<Value *, 4> newMappedArgs;
+
+    for (Value *const mappedArg : mappedArgs)
+      newMappedArgs.push_back(CreateBitCast(mappedArg, getIntNTy(mappedArg->getType()->getPrimitiveSizeInBits())));
+
+    Value *const result = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
+    return CreateBitCast(result, type);
+  } else if (type->isIntegerTy(32))
+    return mapFunc(*this, mappedArgs, passthroughArgs);
+  else {
+    llvm_unreachable("Should never be called!");
+    return nullptr;
+  }
 }

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -32,6 +32,7 @@
 
 #include "lgc/Builder.h"
 #include "lgc/state/PipelineState.h"
+#include "lgc/util/BuilderBase.h"
 
 namespace lgc {
 
@@ -92,6 +93,21 @@ protected:
   // Create code to get the lane number within the wave. This depends on whether the shader is wave32 or wave64,
   // and thus on the shader stage it is used from.
   llvm::Value *CreateGetLaneNumber();
+
+  // Forwarding methods for methods in BuilderBase that BuilderImpl subclasses may need to access.
+  // We want these methods in BuilderBase to be accessible from anywhere in LGC, both BuilderImpl subclasses
+  // and later passes, but not from outside LGC. There is no possible class hierarchy to make that happen, without
+  // also making Builder methods visible from later passes in LGC, which we don't want.
+  llvm::Value *CreateRelocationConstant(const llvm::Twine &symbolName) {
+    return BuilderBase::get(*this).CreateRelocationConstant(symbolName);
+  }
+  llvm::Value *CreateAddByteOffset(llvm::Value *pointer, llvm::Value *byteOffset, const llvm::Twine &instName = "") {
+    return BuilderBase::get(*this).CreateAddByteOffset(pointer, byteOffset, instName);
+  }
+  llvm::Value *CreateMapToInt32(BuilderBase::MapToInt32Func mapFunc, llvm::ArrayRef<llvm::Value *> mappedArgs,
+                                llvm::ArrayRef<llvm::Value *> passthroughArgs) {
+    return BuilderBase::get(*this).CreateMapToInt32(mapFunc, mappedArgs, passthroughArgs);
+  }
 
   PipelineState *m_pipelineState = nullptr; // Pipeline state
 

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -879,7 +879,7 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
 
   case BuiltInNumWorkgroups: {
     // NumWorkgroups is a v3i32 loaded from an address pointed to by a special user data item.
-    Value *numWorkgroupPtr = ShaderInputs::getSpecialUserData(UserDataMapping::Workgroup, *this);
+    Value *numWorkgroupPtr = ShaderInputs::getSpecialUserData(UserDataMapping::Workgroup, BuilderBase::get(*this));
     LoadInst *load = CreateLoad(FixedVectorType::get(getInt32Ty(), 3), numWorkgroupPtr);
     load->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(getContext(), {}));
     return load;
@@ -887,11 +887,12 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
 
   case BuiltInWorkgroupId:
     // WorkgroupId is a v3i32 shader input (three SGPRs set up by hardware).
-    return ShaderInputs::getInput(ShaderInput::WorkgroupId, *this, *getLgcContext());
+    return ShaderInputs::getInput(ShaderInput::WorkgroupId, BuilderBase::get(*this), *getLgcContext());
 
   case BuiltInLocalInvocationId: {
     // LocalInvocationId is a v3i32 shader input (three VGPRs set up in hardware).
-    Value *localInvocationId = ShaderInputs::getInput(ShaderInput::LocalInvocationId, *this, *getLgcContext());
+    Value *localInvocationId =
+        ShaderInputs::getInput(ShaderInput::LocalInvocationId, BuilderBase::get(*this), *getLgcContext());
 
     // Unused dimensions need zero-initializing.
     if (shaderMode.workgroupSizeZ <= 1) {
@@ -964,17 +965,18 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
 // @param instName : Name to give instruction(s)
 // @returns : Value of input; nullptr if not handled here
 Value *InOutBuilder::readVsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
+  BuilderBase &builder = BuilderBase::get(*this);
   switch (builtIn) {
   case BuiltInBaseVertex:
-    return ShaderInputs::getSpecialUserData(UserDataMapping::BaseVertex, *this);
+    return ShaderInputs::getSpecialUserData(UserDataMapping::BaseVertex, builder);
   case BuiltInBaseInstance:
-    return ShaderInputs::getSpecialUserData(UserDataMapping::BaseInstance, *this);
+    return ShaderInputs::getSpecialUserData(UserDataMapping::BaseInstance, builder);
   case BuiltInDrawIndex:
-    return ShaderInputs::getSpecialUserData(UserDataMapping::DrawIndex, *this);
+    return ShaderInputs::getSpecialUserData(UserDataMapping::DrawIndex, builder);
   case BuiltInVertexIndex:
-    return ShaderInputs::getVertexIndex(*this, *getLgcContext());
+    return ShaderInputs::getVertexIndex(builder, *getLgcContext());
   case BuiltInInstanceIndex:
-    return ShaderInputs::getInstanceIndex(*this, *getLgcContext());
+    return ShaderInputs::getInstanceIndex(builder, *getLgcContext());
   default:
     // Not handled; caller will handle with lgc.input.import.builtin, which is then lowered in PatchInOutImportExport.
     return nullptr;

--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -29,7 +29,6 @@
  ***********************************************************************************************************************
  */
 #include "GlueShader.h"
-#include "lgc/BuilderBase.h"
 #include "lgc/patch/FragColorExport.h"
 #include "lgc/patch/ShaderInputs.h"
 #include "lgc/patch/VertexFetch.h"
@@ -38,6 +37,7 @@
 #include "lgc/state/ShaderStage.h"
 #include "lgc/state/TargetInfo.h"
 #include "lgc/util/AddressExtender.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -30,10 +30,10 @@
  */
 #pragma once
 
-#include "lgc/BuilderBase.h"
 #include "lgc/Pipeline.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PalMetadata.h"
+#include "lgc/util/BuilderBase.h"
 #include "lgc/util/Internal.h"
 
 namespace lgc {

--- a/lgc/include/lgc/util/BuilderBase.h
+++ b/lgc/include/lgc/util/BuilderBase.h
@@ -1,0 +1,82 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020-2021 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  BuilderBase.h
+ * @brief LLPC header file: declaration of BuilderBase
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/BuilderCommon.h"
+
+namespace lgc {
+
+// =====================================================================================================================
+// BuilderBase extends BuilderCommon, and provides some utility methods used within LGC.
+// Methods here can be used directly from a BuilderImpl subclass, such as InOutBuilder.
+// An LGC pass would have a BuilderCommon, and then use BuilderBase::get to turn it into a BuilderBase to
+// access the methods here.
+class BuilderBase : public BuilderCommon {
+public:
+  // Constructors
+  BuilderBase(llvm::LLVMContext &context) : BuilderCommon(context) {}
+  BuilderBase(llvm::BasicBlock *block) : BuilderCommon(block) {}
+  BuilderBase(llvm::Instruction *inst) : BuilderCommon(inst) {}
+
+  // Static method to use a BuilderCommon as a BuilderBase, relying on the fact that BuilderBase does not have
+  // any additional state. This is needed when code in one of the builder implementation classes, such as
+  // InOutBuilder, wants to use an LGC-internal method here in BuilderBase.
+  static BuilderBase &get(BuilderCommon &builder) { return *static_cast<BuilderBase *>(&builder); }
+
+  // Emits a amdgcn.reloc.constant intrinsic that represents an i32 relocatable value with the given symbol name
+  //
+  // @param symbolName : Name of the relocation symbol associated with this relocation
+  llvm::Value *CreateRelocationConstant(const llvm::Twine &symbolName);
+
+  // Generate an add of an offset to a byte pointer. This is provided to use in the case that the offset is,
+  // or might be, a relocatable value, as it implements a workaround to get more efficient code for the load
+  // that uses the offset pointer.
+  //
+  // @param pointer : Pointer to add to
+  // @param byteOffset : Byte offset to add
+  // @param instName : Name to give instruction
+  llvm::Value *CreateAddByteOffset(llvm::Value *pointer, llvm::Value *byteOffset, const llvm::Twine &instName = "");
+
+  // Type of function to pass to CreateMapToInt32
+  typedef llvm::function_ref<llvm::Value *(BuilderBase &builder, llvm::ArrayRef<llvm::Value *> mappedArgs,
+                                           llvm::ArrayRef<llvm::Value *> passthroughArgs)>
+      MapToInt32Func;
+
+  // Create a call that'll map the massage arguments to an i32 type (for functions that only take i32).
+  //
+  // @param mapFunc : Pointer to the function to call on each i32.
+  // @param mappedArgs : The arguments to massage into an i32 type.
+  // @param passthroughArgs : The arguments to pass-through without massaging.
+  llvm::Value *CreateMapToInt32(MapToInt32Func mapFunc, llvm::ArrayRef<llvm::Value *> mappedArgs,
+                                llvm::ArrayRef<llvm::Value *> passthroughArgs);
+};
+
+} // namespace lgc

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -30,7 +30,7 @@
  */
 #pragma once
 
-#include "lgc/BuilderBase.h"
+#include "lgc/BuilderCommon.h"
 #include "lgc/BuiltIns.h"
 #include "lgc/CommonDefs.h"
 #include "llvm/Support/AtomicOrdering.h"
@@ -125,7 +125,7 @@ private:
 // of IRBuilder<>, so the front-end can use its methods to create IR instructions at the set insertion
 // point. In addition it has its own Create* methods to create graphics-specific IR constructs.
 //
-class Builder : public BuilderBase {
+class Builder : public BuilderCommon {
 public:
   // The group arithmetic operations the builder can consume.
   // NOTE: We rely on casting this implicitly to an integer, so we cannot use an enum class.
@@ -1624,18 +1624,6 @@ protected:
   //
   // @param matrixType : The matrix type to tranpose
   llvm::Type *getTransposedMatrixTy(llvm::Type *const matrixType) const;
-
-  typedef std::function<llvm::Value *(Builder &builder, llvm::ArrayRef<llvm::Value *> mappedArgs,
-                                      llvm::ArrayRef<llvm::Value *> passthroughArgs)>
-      PFN_MapToInt32Func;
-
-  // Create a call that'll map the massage arguments to an i32 type (for functions that only take i32).
-  //
-  // @param mapFunc : Pointer to the function to call on each i32.
-  // @param mappedArgs : The arguments to massage into an i32 type.
-  // @param passthroughArgs : The arguments to pass-through without massaging.
-  llvm::Value *CreateMapToInt32(PFN_MapToInt32Func mapFunc, llvm::ArrayRef<llvm::Value *> mappedArgs,
-                                llvm::ArrayRef<llvm::Value *> passthroughArgs);
 
 private:
   Builder() = delete;

--- a/lgc/interface/lgc/BuilderCommon.h
+++ b/lgc/interface/lgc/BuilderCommon.h
@@ -24,8 +24,8 @@
  **********************************************************************************************************************/
 /**
  ***********************************************************************************************************************
- * @file  BuilderBase.h
- * @brief LLPC header file: declaration of BuilderBase
+ * @file  BuilderCommon.h
+ * @brief LLPC header file: declaration of BuilderCommon
  ***********************************************************************************************************************
  */
 #pragma once
@@ -35,16 +35,15 @@
 namespace lgc {
 
 // =====================================================================================================================
-// BuilderBase extends IRBuilder<>, and provides a few utility methods used in both the LLPC front-end and in LGC (the
-// LLPC middle-end). LGC code outside of Builder subclasses would use BuilderBase directly; LLPC front-end code gets
-// to use BuilderBase methods because it uses Builder, which inherits from BuilderBase.
-//
-class BuilderBase : public llvm::IRBuilder<> {
+// BuilderCommon extends IRBuilder<>, and provides a few utility methods used in both the LLPC front-end and in LGC
+// (the LLPC middle-end).
+// This class is used directly by passes in LGC.
+class BuilderCommon : public llvm::IRBuilder<> {
 public:
   // Constructors
-  BuilderBase(llvm::LLVMContext &context) : IRBuilder(context) {}
-  BuilderBase(llvm::BasicBlock *block) : IRBuilder(block) {}
-  BuilderBase(llvm::Instruction *inst) : IRBuilder(inst) {}
+  BuilderCommon(llvm::LLVMContext &context) : IRBuilder(context) {}
+  BuilderCommon(llvm::BasicBlock *block) : IRBuilder(block) {}
+  BuilderCommon(llvm::Instruction *inst) : IRBuilder(inst) {}
 
   // Create an LLVM function call to the named function. The callee is built automically based on return
   // type and its parameters.
@@ -56,20 +55,6 @@ public:
   // @param instName : Name to give instruction
   llvm::CallInst *CreateNamedCall(llvm::StringRef funcName, llvm::Type *retTy, llvm::ArrayRef<llvm::Value *> args,
                                   llvm::ArrayRef<llvm::Attribute::AttrKind> attribs, const llvm::Twine &instName = "");
-
-  // Emits a amdgcn.reloc.constant intrinsic that represents an i32 relocatable value with the given symbol name
-  //
-  // @param symbolName : Name of the relocation symbol associated with this relocation
-  llvm::Value *CreateRelocationConstant(const llvm::Twine &symbolName);
-
-  // Generate an add of an offset to a byte pointer. This is provided to use in the case that the offset is,
-  // or might be, a relocatable value, as it implements a workaround to get more efficient code for the load
-  // that uses the offset pointer.
-  //
-  // @param pointer : Pointer to add to
-  // @param byteOffset : Byte offset to add
-  // @param instName : Name to give instruction
-  llvm::Value *CreateAddByteOffset(llvm::Value *pointer, llvm::Value *byteOffset, const llvm::Twine &instName = "");
 };
 
 } // namespace lgc

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -29,7 +29,6 @@
  ***********************************************************************************************************************
  */
 #include "lgc/patch/FragColorExport.h"
-#include "lgc/BuilderBase.h"
 #include "lgc/LgcContext.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/IntrinsDefs.h"
@@ -38,6 +37,7 @@
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/ResourceUsage.h"
 #include "lgc/state/TargetInfo.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -28,13 +28,13 @@
  * @brief LLPC source file: contains declaration and implementation of class lgc::PatchCopyShader.
  ***********************************************************************************************************************
  */
-#include "lgc/BuilderBase.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
+#include "lgc/util/BuilderBase.h"
 #include "lgc/util/Internal.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -53,7 +53,6 @@
  ***********************************************************************************************************************
  */
 
-#include "lgc/BuilderBase.h"
 #include "lgc/LgcContext.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/patch/ShaderInputs.h"
@@ -64,6 +63,7 @@
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 #include "lgc/util/AddressExtender.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Support/CommandLine.h"

--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -29,11 +29,11 @@
  ***********************************************************************************************************************
  */
 
-#include "lgc/BuilderBase.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/patch/ShaderInputs.h"
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
 #define DEBUG_TYPE "lgc-patch-initialize-workgroup-memory"

--- a/lgc/patch/PatchReadFirstLane.cpp
+++ b/lgc/patch/PatchReadFirstLane.cpp
@@ -28,9 +28,9 @@
  * @brief LLPC source file: contains declaration and implementation of class lgc::PatchReadFirstLane.
  ***********************************************************************************************************************
  */
-#include "lgc/Builder.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/PipelineState.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/Analysis/LegacyDivergenceAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/Constants.h"

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -39,6 +39,7 @@
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
+#include "lgc/util/BuilderBase.h"
 #include "lgc/util/Debug.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"

--- a/lgc/patch/PatchWorkarounds.cpp
+++ b/lgc/patch/PatchWorkarounds.cpp
@@ -30,10 +30,10 @@
  */
 
 #include "PatchWorkarounds.h"
-#include "lgc/BuilderBase.h"
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -30,11 +30,11 @@
  ***********************************************************************************************************************
  */
 #include "lgc/patch/ShaderInputs.h"
-#include "lgc/BuilderBase.h"
 #include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/ResourceUsage.h"
 #include "lgc/state/TargetInfo.h"
+#include "lgc/util/BuilderBase.h"
 
 using namespace lgc;
 using namespace llvm;

--- a/lgc/patch/SystemValues.h
+++ b/lgc/patch/SystemValues.h
@@ -30,9 +30,9 @@
  */
 #pragma once
 
-#include "lgc/BuilderBase.h"
 #include "lgc/Pipeline.h"
 #include "lgc/state/Defs.h"
+#include "lgc/util/BuilderBase.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include <map>

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -29,7 +29,6 @@
  ***********************************************************************************************************************
  */
 #include "lgc/patch/VertexFetch.h"
-#include "lgc/BuilderBase.h"
 #include "lgc/LgcContext.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/patch/ShaderInputs.h"
@@ -37,6 +36,7 @@
 #include "lgc/state/PalMetadata.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
+#include "lgc/util/BuilderBase.h"
 #include "lgc/util/Internal.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -39,7 +39,7 @@
 #include <mach/mach_time.h>
 #endif
 
-#include "lgc/BuilderBase.h"
+#include "lgc/util/BuilderBase.h"
 #include "lgc/util/Internal.h"
 
 #define DEBUG_TYPE "lgc-internal"


### PR DESCRIPTION
BuilderBase is where we put methods for generating IR that are used in
both BuilderImpl subclasses (e.g. InOutBuilder) and in LGC passes.

The problem was that the class hierarchy (where Builder inherits from
BuilderBase and BuilderImplBase inherits from Builder) means that those
methods are visible to front-end code outside LGC. Those methods are not
intended to be used from there.

This commit moves BuilderBase out of the LGC interface and makes it no
longer the superclass of Builder. There is a new BuilderCommon class
occupying BuilderBase's former position in the hierarchy, containing
only CreateNamedCall(), which is legitimately used by both the LLPC
front-end and LGC.

To allow BuilderImpl subclasses such as InOutBuilder to access the
BuilderBase methods, I added a static method BuilderBase::get to static
cast a BuilderCommon into BuilderBase, and some forwarding methods in
BuilderImplBase for BuilderBase's methods.

Also I moved CreateMapToInt32 out of Builder and in to BuilderBase.