### PR TITLE
Break up and simplify `processPipeline`

### DIFF
--- a/llpc/test/shaderdb/error_reporting/UnknownExtension.multi-input
+++ b/llpc/test/shaderdb/error_reporting/UnknownExtension.multi-input
@@ -4,7 +4,8 @@
 ; RUN: not amdllpc -validate-spirv=true -spvgen-dir=%spvgendir% -v %gfxip %s \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: {{.*}}: Bad file extension; try -help
+; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}}.multi-input has an unknown extension;
+; SHADERTEST-SAME:  try -help to list supported input formats
 ; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
 ; END_SHADERTEST
 

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -415,225 +415,206 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
 }
 
 // =====================================================================================================================
-// Process one pipeline.
+// Process one pipeline input file.
 //
-// @param compiler : LLPC context
-// @param inFiles : Input filename(s)
+// @param compiler : LLPC compiler
+// @param inFile : Input filename
 // @returns : Result::Success on success, other status codes on failure
-static Result processPipeline(ICompiler *compiler, ArrayRef<std::string> inFiles) {
-  CompileInfo compileInfo = {};
-  compileInfo.unlinked = true;
-  compileInfo.doAutoLayout = true;
-  Result result = initCompileInfo(&compileInfo);
+static Result processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const std::string &inFile) {
+  const char *log = nullptr;
+  const bool vfxResult =
+      Vfx::vfxParseFile(inFile.c_str(), 0, nullptr, VfxDocTypePipeline, &compileInfo.pipelineInfoFile, &log);
+  if (!vfxResult) {
+    LLPC_ERRS("Failed to parse input file: " << inFile << "\n" << log << "\n");
+    return Result::ErrorInvalidShader;
+  }
 
-  std::string fileNames;
-  //
-  // Translate sources to SPIR-V binary
-  //
+  VfxPipelineStatePtr pipelineState = nullptr;
+  Vfx::vfxGetPipelineDoc(compileInfo.pipelineInfoFile, &pipelineState);
+
+  if (pipelineState->version != Vkgc::Version) {
+    LLPC_ERRS("Version incompatible, SPVGEN::Version = " << pipelineState->version
+                                                         << " AMDLLPC::Version = " << Vkgc::Version << "\n");
+    return Result::ErrorInvalidShader;
+  }
+
+  LLPC_OUTS("===============================================================================\n");
+  LLPC_OUTS("// Pipeline file info for " << inFile << " \n\n");
+
+  if (log && strlen(log) > 0)
+    LLPC_OUTS("Pipeline file parse warning:\n" << log << "\n");
+
+  compileInfo.compPipelineInfo = pipelineState->compPipelineInfo;
+  compileInfo.gfxPipelineInfo = pipelineState->gfxPipelineInfo;
+  if (IgnoreColorAttachmentFormats) {
+    // NOTE: When this option is enabled, we set color attachment format to
+    // R8G8B8A8_SRGB for color target 0. Also, for other color targets, if the
+    // formats are not UNDEFINED, we set them to R8G8B8A8_SRGB as well.
+    for (unsigned target = 0; target < MaxColorTargets; ++target) {
+      if (target == 0 || compileInfo.gfxPipelineInfo.cbState.target[target].format != VK_FORMAT_UNDEFINED)
+        compileInfo.gfxPipelineInfo.cbState.target[target].format = VK_FORMAT_R8G8B8A8_SRGB;
+    }
+  }
+
+  if (EnableOuts() && !InitSpvGen())
+    LLPC_OUTS("Failed to load SPVGEN -- cannot disassemble and validate SPIR-V\n");
+
+  for (unsigned stage = 0; stage < pipelineState->numStages; ++stage) {
+    if (pipelineState->stages[stage].dataSize > 0) {
+      StandaloneCompiler::ShaderModuleData shaderModuleData = {};
+      shaderModuleData.spirvBin.codeSize = pipelineState->stages[stage].dataSize;
+      shaderModuleData.spirvBin.pCode = pipelineState->stages[stage].pData;
+      shaderModuleData.shaderStage = pipelineState->stages[stage].stage;
+
+      compileInfo.shaderModuleDatas.push_back(shaderModuleData);
+      compileInfo.stageMask |= shaderStageToMask(pipelineState->stages[stage].stage);
+
+      if (spvDisassembleSpirv) {
+        unsigned binSize = pipelineState->stages[stage].dataSize;
+        unsigned textSize = binSize * 10 + 1024;
+        LLPC_OUTS("\nSPIR-V disassembly for " << getShaderStageName(pipelineState->stages[stage].stage)
+                                              << " shader module:\n");
+        SmallVector<char> spvText(textSize);
+        spvDisassembleSpirv(binSize, shaderModuleData.spirvBin.pCode, textSize, spvText.data());
+        LLPC_OUTS(spvText.data() << "\n");
+      }
+    }
+  }
+
+  const bool isGraphics = (compileInfo.stageMask & shaderStageToMask(ShaderStageCompute)) == 0;
+  for (unsigned i = 0; i < compileInfo.shaderModuleDatas.size(); ++i) {
+    compileInfo.shaderModuleDatas[i].shaderInfo.options.pipelineOptions =
+        isGraphics ? compileInfo.gfxPipelineInfo.options : compileInfo.compPipelineInfo.options;
+  }
+
+  // For a .pipe, build an "unlinked" shader/part-pipeline ELF if -unlinked is on.
+  compileInfo.unlinked = Unlinked;
+  compileInfo.doAutoLayout = false;
+  return Result::Success;
+}
+
+// =====================================================================================================================
+// Process multiple shader stage input files. Translates sources to SPIR-V binaries, if necessary.
+//
+// @param compiler : LLPC compiler
+// @param inFile : Input filenames
+// @param [out] filenames : Space-separated list of used input file names
+// @returns : Result::Success on success, other status codes on failure
+static Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, ArrayRef<std::string> inFiles,
+                                 std::string &fileNames) {
   for (const std::string &inFile : inFiles) {
-    if (result != Result::Success)
-      break;
-
     fileNames += inFile + " ";
+    Result result = Result::Success;
     std::string spvBinFile;
 
     if (isSpirvTextFile(inFile) || isSpirvBinaryFile(inFile)) {
-      // SPIR-V assembly text or SPIR-V binary
-      if (isSpirvTextFile(inFile))
+      // SPIR-V assembly text or SPIR-V binary.
+      if (isSpirvTextFile(inFile)) {
         result = assembleSpirv(inFile, spvBinFile);
-      else
+        if (result != Result::Success)
+          return result;
+      } else {
         spvBinFile = inFile;
+      }
 
       BinaryData spvBin = {};
+      Result result = getSpirvBinaryFromFile(spvBinFile, spvBin);
+      if (result != Result::Success)
+        return result;
 
-      if (result == Result::Success) {
-        result = getSpirvBinaryFromFile(spvBinFile, spvBin);
-
-        if (result == Result::Success) {
-          if (!InitSpvGen()) {
-            LLPC_OUTS("Failed to load SPVGEN -- no SPIR-V disassembler available\n");
-          } else {
-            // Disassemble SPIR-V code
-            unsigned textSize = spvBin.codeSize * 10 + 1024;
-            char *spvText = new char[textSize];
-            assert(spvText);
-            memset(spvText, 0, textSize);
-
-            LLPC_OUTS("\nSPIR-V disassembly for " << inFile << "\n");
-            spvDisassembleSpirv(spvBin.codeSize, spvBin.pCode, textSize, spvText);
-            LLPC_OUTS(spvText << "\n");
-
-            delete[] spvText;
-          }
-        }
+      if (!InitSpvGen()) {
+        LLPC_OUTS("Failed to load SPVGEN -- no SPIR-V disassembler available\n");
+      } else {
+        // Disassemble SPIR-V code
+        unsigned textSize = spvBin.codeSize * 10 + 1024;
+        SmallVector<char> spvText(textSize);
+        LLPC_OUTS("\nSPIR-V disassembly for " << inFile << "\n");
+        spvDisassembleSpirv(spvBin.codeSize, spvBin.pCode, textSize, spvText.data());
+        LLPC_OUTS(spvText.data() << "\n");
       }
 
-      if (result == Result::Success && ValidateSpirv) {
-        char log[1024] = {};
-        if (!InitSpvGen())
+      if (ValidateSpirv) {
+        if (!InitSpvGen()) {
           errs() << "Warning: Failed to load SPVGEN -- cannot validate SPIR-V\n";
-        else {
+        } else {
+          char log[1024] = {};
           if (!spvValidateSpirv(spvBin.codeSize, spvBin.pCode, sizeof(log), log)) {
             LLPC_ERRS("Fails to validate SPIR-V: \n" << log << "\n");
-            result = Result::ErrorInvalidShader;
+            return Result::ErrorInvalidShader;
           }
         }
       }
 
-      if (result == Result::Success) {
-        // NOTE: If the entry target is not specified, we set it to the one gotten from SPIR-V binary.
-        if (compileInfo.entryTarget.empty())
-          compileInfo.entryTarget = Vkgc::getEntryPointNameFromSpirvBinary(&spvBin);
+      // NOTE: If the entry target is not specified, we set it to the one gotten from SPIR-V binary.
+      if (compileInfo.entryTarget.empty())
+        compileInfo.entryTarget = Vkgc::getEntryPointNameFromSpirvBinary(&spvBin);
 
-        unsigned stageMask = ShaderModuleHelper::getStageMaskFromSpirvBinary(&spvBin, compileInfo.entryTarget.c_str());
+      unsigned stageMask = ShaderModuleHelper::getStageMaskFromSpirvBinary(&spvBin, compileInfo.entryTarget.c_str());
+      if ((stageMask & compileInfo.stageMask) != 0)
+        break;
 
-        if ((stageMask & compileInfo.stageMask) != 0)
-          break;
-        else if (stageMask != 0) {
-          for (unsigned stage = ShaderStageVertex; stage < ShaderStageCount; ++stage) {
-            if (stageMask & shaderStageToMask(static_cast<ShaderStage>(stage))) {
-              StandaloneCompiler::ShaderModuleData shaderModuleData = {};
-              shaderModuleData.shaderStage = static_cast<ShaderStage>(stage);
-              shaderModuleData.spirvBin = spvBin;
-              compileInfo.shaderModuleDatas.push_back(shaderModuleData);
-              compileInfo.stageMask |= shaderStageToMask(static_cast<ShaderStage>(stage));
-              break;
-            }
+      if (stageMask != 0) {
+        for (unsigned stage = ShaderStageVertex; stage < ShaderStageCount; ++stage) {
+          if (stageMask & shaderStageToMask(static_cast<ShaderStage>(stage))) {
+            StandaloneCompiler::ShaderModuleData shaderModuleData = {};
+            shaderModuleData.shaderStage = static_cast<ShaderStage>(stage);
+            shaderModuleData.spirvBin = spvBin;
+            compileInfo.shaderModuleDatas.push_back(shaderModuleData);
+            compileInfo.stageMask |= shaderStageToMask(static_cast<ShaderStage>(stage));
+            break;
           }
-        } else {
-          LLPC_ERRS(format("Fails to identify shader stages by entry-point \"%s\"\n", compileInfo.entryTarget.c_str()));
-          result = Result::ErrorUnavailable;
-        }
-      }
-
-    } else if (isPipelineInfoFile(inFile)) {
-      const char *log = nullptr;
-      bool vfxResult =
-          Vfx::vfxParseFile(inFile.c_str(), 0, nullptr, VfxDocTypePipeline, &compileInfo.pipelineInfoFile, &log);
-      if (vfxResult) {
-        VfxPipelineStatePtr pipelineState = nullptr;
-        Vfx::vfxGetPipelineDoc(compileInfo.pipelineInfoFile, &pipelineState);
-
-        if (pipelineState->version != Vkgc::Version) {
-          LLPC_ERRS("Version incompatible, SPVGEN::Version = " << pipelineState->version
-                                                               << " AMDLLPC::Version = " << Vkgc::Version << "\n");
-          result = Result::ErrorInvalidShader;
-        } else {
-          LLPC_OUTS("===============================================================================\n");
-          LLPC_OUTS("// Pipeline file info for " << inFile << " \n\n");
-
-          if (log && strlen(log) > 0) {
-            LLPC_OUTS("Pipeline file parse warning:\n" << log << "\n");
-          }
-
-          compileInfo.compPipelineInfo = pipelineState->compPipelineInfo;
-          compileInfo.gfxPipelineInfo = pipelineState->gfxPipelineInfo;
-          if (IgnoreColorAttachmentFormats) {
-            // NOTE: When this option is enabled, we set color attachment format to
-            // R8G8B8A8_SRGB for color target 0. Also, for other color targets, if the
-            // formats are not UNDEFINED, we set them to R8G8B8A8_SRGB as well.
-            for (unsigned target = 0; target < MaxColorTargets; ++target) {
-              if (target == 0 || compileInfo.gfxPipelineInfo.cbState.target[target].format != VK_FORMAT_UNDEFINED)
-                compileInfo.gfxPipelineInfo.cbState.target[target].format = VK_FORMAT_R8G8B8A8_SRGB;
-            }
-          }
-
-          if (EnableOuts() && !InitSpvGen()) {
-            LLPC_OUTS("Failed to load SPVGEN -- cannot disassemble and validate SPIR-V\n");
-          }
-
-          for (unsigned stage = 0; stage < pipelineState->numStages; ++stage) {
-            if (pipelineState->stages[stage].dataSize > 0) {
-              StandaloneCompiler::ShaderModuleData shaderModuleData = {};
-              shaderModuleData.spirvBin.codeSize = pipelineState->stages[stage].dataSize;
-              shaderModuleData.spirvBin.pCode = pipelineState->stages[stage].pData;
-              shaderModuleData.shaderStage = pipelineState->stages[stage].stage;
-
-              compileInfo.shaderModuleDatas.push_back(shaderModuleData);
-              compileInfo.stageMask |= shaderStageToMask(pipelineState->stages[stage].stage);
-
-              if (spvDisassembleSpirv) {
-                unsigned binSize = pipelineState->stages[stage].dataSize;
-                unsigned textSize = binSize * 10 + 1024;
-                char *spvText = new char[textSize];
-                assert(spvText);
-                memset(spvText, 0, textSize);
-                LLPC_OUTS("\nSPIR-V disassembly for " << getShaderStageName(pipelineState->stages[stage].stage)
-                                                      << " shader module:\n");
-                spvDisassembleSpirv(binSize, shaderModuleData.spirvBin.pCode, textSize, spvText);
-                LLPC_OUTS(spvText << "\n");
-                delete[] spvText;
-              }
-            }
-          }
-
-          bool isGraphics = (compileInfo.stageMask & shaderStageToMask(ShaderStageCompute)) == 0;
-          for (unsigned i = 0; i < compileInfo.shaderModuleDatas.size(); ++i) {
-            compileInfo.shaderModuleDatas[i].shaderInfo.options.pipelineOptions =
-                isGraphics ? compileInfo.gfxPipelineInfo.options : compileInfo.compPipelineInfo.options;
-          }
-
-          // For a .pipe, build an "unlinked" shader/part-pipeline ELF if -unlinked is on.
-          compileInfo.unlinked = Unlinked;
-          compileInfo.doAutoLayout = false;
-          break;
         }
       } else {
-        LLPC_ERRS("Failed to parse input file: " << inFile << "\n" << log << "\n");
-        result = Result::ErrorInvalidShader;
+        LLPC_ERRS(format("Fails to identify shader stages by entry-point \"%s\"\n", compileInfo.entryTarget.c_str()));
+        return Result::ErrorUnavailable;
       }
     } else if (isLlvmIrFile(inFile)) {
       LLVMContext context;
       SMDiagnostic errDiag;
 
-      // Load LLVM IR
+      // Load LLVM IR.
       std::unique_ptr<Module> module = parseAssemblyFile(inFile, errDiag, context, nullptr);
-      if (!module.get()) {
+      if (!module) {
         std::string errMsg;
         raw_string_ostream errStream(errMsg);
         errDiag.print(inFile.c_str(), errStream);
         LLPC_ERRS(errMsg);
-        result = Result::ErrorInvalidShader;
+        return Result::ErrorInvalidShader;
       }
 
-      // Verify LLVM module
+      // Verify LLVM module.
       std::string errMsg;
       raw_string_ostream errStream(errMsg);
-      if (result == Result::Success && verifyModule(*module.get(), &errStream)) {
+      if (verifyModule(*module.get(), &errStream)) {
         LLPC_ERRS("File " << inFile << " parsed, but fail to verify the module: " << errMsg << "\n");
-        result = Result::ErrorInvalidShader;
+        return Result::ErrorInvalidShader;
       }
 
-      // Check the shader stage of input module
-      ShaderStage shaderStage = ShaderStageInvalid;
-      if (result == Result::Success) {
-        shaderStage = getShaderStageFromModule(module.get());
-        if (shaderStage == ShaderStageInvalid) {
-          LLPC_ERRS("File " << inFile << ": Fail to determine shader stage\n");
-          result = Result::ErrorInvalidShader;
-        }
-
-        if (compileInfo.stageMask & shaderStageToMask(static_cast<ShaderStage>(shaderStage)))
-          break;
+      // Check the shader stage of input module.
+      ShaderStage shaderStage = getShaderStageFromModule(module.get());
+      if (shaderStage == ShaderStageInvalid) {
+        LLPC_ERRS("File " << inFile << ": Fail to determine shader stage\n");
+        return Result::ErrorInvalidShader;
       }
 
-      if (result == Result::Success) {
-        // Translate LLVM module to LLVM bitcode
-        SmallString<1024> bitcodeBuf;
-        raw_svector_ostream bitcodeStream(bitcodeBuf);
-        WriteBitcodeToFile(*module.get(), bitcodeStream);
-        void *code = new uint8_t[bitcodeBuf.size()];
-        memcpy(code, bitcodeBuf.data(), bitcodeBuf.size());
+      if (compileInfo.stageMask & shaderStageToMask(static_cast<ShaderStage>(shaderStage)))
+        break;
 
-        StandaloneCompiler::ShaderModuleData shaderModuledata = {};
-        shaderModuledata.spirvBin.codeSize = bitcodeBuf.size();
-        shaderModuledata.spirvBin.pCode = code;
-        shaderModuledata.shaderStage = shaderStage;
-        compileInfo.shaderModuleDatas.push_back(shaderModuledata);
-        compileInfo.stageMask |= shaderStageToMask(static_cast<ShaderStage>(shaderStage));
-        compileInfo.doAutoLayout = false;
-      }
-    } else {
+      // Translate LLVM module to LLVM bitcode.
+      SmallString<1024> bitcodeBuf;
+      raw_svector_ostream bitcodeStream(bitcodeBuf);
+      WriteBitcodeToFile(*module.get(), bitcodeStream);
+      void *code = new uint8_t[bitcodeBuf.size()];
+      memcpy(code, bitcodeBuf.data(), bitcodeBuf.size());
+
+      StandaloneCompiler::ShaderModuleData shaderModuledata = {};
+      shaderModuledata.spirvBin.codeSize = bitcodeBuf.size();
+      shaderModuledata.spirvBin.pCode = code;
+      shaderModuledata.shaderStage = shaderStage;
+      compileInfo.shaderModuleDatas.push_back(shaderModuledata);
+      compileInfo.stageMask |= shaderStageToMask(static_cast<ShaderStage>(shaderStage));
+      compileInfo.doAutoLayout = false;
+    } else if (isGlslShaderTextFile(inFile)) {
       // GLSL source text
 
       // NOTE: If the entry target is not specified, we set it to GLSL default ("main").
@@ -642,49 +623,84 @@ static Result processPipeline(ICompiler *compiler, ArrayRef<std::string> inFiles
 
       ShaderStage stage = ShaderStageInvalid;
       result = compileGlsl(inFile, &stage, spvBinFile, compileInfo.entryTarget);
-      if (result == Result::Success) {
-        if (compileInfo.stageMask & shaderStageToMask(static_cast<ShaderStage>(stage)))
-          break;
+      if (result != Result::Success)
+        return result;
 
-        compileInfo.stageMask |= shaderStageToMask(stage);
-        StandaloneCompiler::ShaderModuleData shaderModuleData = {};
-        result = getSpirvBinaryFromFile(spvBinFile, shaderModuleData.spirvBin);
-        shaderModuleData.shaderStage = stage;
-        compileInfo.shaderModuleDatas.push_back(shaderModuleData);
-      }
+      if (compileInfo.stageMask & shaderStageToMask(static_cast<ShaderStage>(stage)))
+        break;
+
+      compileInfo.stageMask |= shaderStageToMask(stage);
+      StandaloneCompiler::ShaderModuleData shaderModuleData = {};
+      result = getSpirvBinaryFromFile(spvBinFile, shaderModuleData.spirvBin);
+      shaderModuleData.shaderStage = stage;
+      compileInfo.shaderModuleDatas.push_back(shaderModuleData);
+    } else {
+      LLPC_ERRS("File " << inFile << " has an unknown extension; try -help to list supported input formats\n");
+      return Result::ErrorInvalidShader;
     }
+  }
+  return Result::Success;
+}
+
+// =====================================================================================================================
+// Process one pipeline. This can either be a single .pipe file or a set of shader stages.
+//
+// @param compiler : LLPC compiler
+// @param inFiles : Input filename(s)
+// @returns : Result::Success on success, other status codes on failure
+static Result processInputs(ICompiler *compiler, ArrayRef<std::string> inFiles) {
+  CompileInfo compileInfo = {};
+  compileInfo.unlinked = true;
+  compileInfo.doAutoLayout = true;
+
+  // Clean code that gets run automatically before returning.
+  auto onExit = make_scope_exit([&compileInfo] { cleanupCompileInfo(&compileInfo); });
+  Result result = initCompileInfo(&compileInfo);
+  if (result != Result::Success)
+    return result;
+
+  std::string fileNames;
+  if (inFiles.size() == 1 && isPipelineInfoFile(inFiles[0])) {
+    fileNames = inFiles[0] + " ";
+    result = processInputPipeline(compiler, compileInfo, inFiles[0]);
+    if (result != Result::Success)
+      return result;
+  } else {
+    result = processInputStages(compiler, compileInfo, inFiles, fileNames);
+    if (result != Result::Success)
+      return result;
   }
 
   //
   // Build shader modules
   //
-  if (result == Result::Success && compileInfo.stageMask != 0)
+  if (compileInfo.stageMask != 0) {
     result = buildShaderModules(compiler, &compileInfo);
+    if (result != Result::Success)
+      return result;
+  }
+
+  if (!ToLink)
+    return Result::Success;
 
   //
   // Build pipeline
   //
-  if (result == Result::Success && ToLink) {
-    Optional<PipelineDumpOptions> dumpOptions = None;
-    if (cl::EnablePipelineDump) {
-      dumpOptions.emplace();
-      dumpOptions->pDumpDir = cl::PipelineDumpDir.c_str();
-      dumpOptions->filterPipelineDumpByType = FilterPipelineDumpByType;
-      dumpOptions->filterPipelineDumpByHash = FilterPipelineDumpByHash;
-      dumpOptions->dumpDuplicatePipelines = DumpDuplicatePipelines;
-    }
-
-    compileInfo.fileNames = fileNames.c_str();
-    result = buildPipeline(compiler, &compileInfo, dumpOptions, TimePassesIsEnabled || cl::EnableTimerProfile);
-    if (result == Result::Success)
-      result = outputElf(&compileInfo, OutFile, inFiles[0]);
+  Optional<PipelineDumpOptions> dumpOptions = None;
+  if (cl::EnablePipelineDump) {
+    dumpOptions.emplace();
+    dumpOptions->pDumpDir = cl::PipelineDumpDir.c_str();
+    dumpOptions->filterPipelineDumpByType = FilterPipelineDumpByType;
+    dumpOptions->filterPipelineDumpByHash = FilterPipelineDumpByHash;
+    dumpOptions->dumpDuplicatePipelines = DumpDuplicatePipelines;
   }
-  //
-  // Clean up
-  //
-  cleanupCompileInfo(&compileInfo);
 
-  return result;
+  compileInfo.fileNames = fileNames.c_str();
+  result = buildPipeline(compiler, &compileInfo, dumpOptions, TimePassesIsEnabled || cl::EnableTimerProfile);
+  if (result != Result::Success)
+    return result;
+
+  return outputElf(&compileInfo, OutFile, inFiles[0]);
 }
 
 #ifdef WIN_OS
@@ -775,7 +791,7 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
   for (InputFilesGroup &inputGroup : *inputGroupsOrErr) {
-    result = processPipeline(compiler, inputGroup);
+    result = processInputs(compiler, inputGroup);
     if (result != Result::Success)
       return EXIT_FAILURE;
   }

--- a/llpc/tool/llpcInputUtils.cpp
+++ b/llpc/tool/llpcInputUtils.cpp
@@ -157,6 +157,15 @@ bool isSpirvBinaryFile(StringRef fileName) {
 }
 
 // =====================================================================================================================
+// Checks whether the specified file name represents a GLSL shader file (.vert, .frag, etc.).
+//
+// @param fileName : File path to check
+// @returns : true when fileName is an LLVM IR file
+bool isGlslShaderTextFile(llvm::StringRef fileName) {
+  return any_of(Ext::GlslShaders, [fileName](StringLiteral extension) { return fileName.endswith(extension); });
+}
+
+// =====================================================================================================================
 // Checks whether the specified file name represents an LLVM IR file (.ll).
 //
 // @param fileName : File path to check

--- a/llpc/tool/llpcInputUtils.h
+++ b/llpc/tool/llpcInputUtils.h
@@ -57,6 +57,8 @@ constexpr llvm::StringLiteral LlvmIr = ".ll";
 constexpr llvm::StringLiteral IsaText = ".s";
 constexpr llvm::StringLiteral IsaBin = ".elf";
 
+constexpr llvm::StringLiteral GlslShaders[] = {".vert", ".tesc", ".tese", ".geom", ".frag", ".comp"};
+
 } // namespace Ext
 
 // Returns true when the buffer is an ELF binary.
@@ -73,6 +75,9 @@ bool isSpirvTextFile(llvm::StringRef fileName);
 
 // Checks whether the specified file name represents a SPIR-V binary file (.spv).
 bool isSpirvBinaryFile(llvm::StringRef fileName);
+
+// Checks whether the specified file name represents a GLSL shader file (.vert, .frag, etc.).
+bool isGlslShaderTextFile(llvm::StringRef fileName);
 
 // Checks whether the specified file name represents an LLVM IR file (.ll).
 bool isLlvmIrFile(llvm::StringRef fileName);

--- a/llpc/unittests/standaloneCompiler/testInputUtils.cpp
+++ b/llpc/unittests/standaloneCompiler/testInputUtils.cpp
@@ -143,6 +143,34 @@ TEST(InputUtilsTest, IsSpirvBinaryFile) {
   EXPECT_FALSE(isSpirvBinaryFile(""));
 }
 
+TEST(InputUtilsTest, IsGlslShaderFile) {
+  // Based on https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/.
+  for (StringRef extension : {".vert", ".tesc", ".tese", ".geom", ".frag", ".comp"}) {
+    const std::string basename = "file" + extension.str();
+
+    // Good inputs.
+    EXPECT_TRUE(isGlslShaderTextFile(basename));
+    EXPECT_TRUE(isGlslShaderTextFile("/some/long/path/./test_" + basename));
+
+    // Bad inputs.
+    EXPECT_FALSE(isGlslShaderTextFile(basename + ".x"));
+    EXPECT_FALSE(isGlslShaderTextFile(StringRef(basename).drop_back(1)));
+  }
+
+  // Bad inputs.
+  EXPECT_FALSE(isGlslShaderTextFile("file.glsl"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.vs"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.vshader"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.fs"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.fragment"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.ps"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.pixel"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.spv"));
+  EXPECT_FALSE(isGlslShaderTextFile("file.spvasm"));
+  EXPECT_FALSE(isGlslShaderTextFile("file"));
+  EXPECT_FALSE(isGlslShaderTextFile(""));
+}
+
 TEST(InputUtilsTest, IsLlvmIrFile) {
   // Good inputs.
   EXPECT_TRUE(isLlvmIrFile("file.ll"));


### PR DESCRIPTION
-  Split the logic into smaller functions.
-  Use early returns to simplify control flow.
-  Use `llvm::ScopeExit` for cleanup code.
-  Use `vector<char>` instead of `new char[]`.

Depends on https://github.com/GPUOpen-Drivers/llpc/pull/1452 and https://github.com/GPUOpen-Drivers/llpc/pull/1458.

Has a soft dependency on additional tests in https://github.com/GPUOpen-Drivers/llpc/pull/1454 and https://github.com/GPUOpen-Drivers/llpc/pull/1456.