### PR TITLE
Fix a conversion issue from SpvGenStage to ShaderStage in VFX

### DIFF
--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -31,13 +31,6 @@
 #include "vfx.h"
 #include "vfxSection.h"
 
-#ifndef VFX_DISABLE_SPVGEN
-#if VFX_INSIDE_SPVGEN
-#define SH_EXPORTING
-#endif
-#include "spvgen.h"
-#endif
-
 #if VFX_SUPPORT_VK_PIPELINE
 #include "vfxPipelineDoc.h"
 #include "vfxVkSection.h"

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -62,6 +62,30 @@ StrToMemberAddr SectionSpecEntryItem::m_addrTable[SectionSpecEntryItem::MemberCo
 StrToMemberAddr SectionSpecInfo::m_addrTable[SectionSpecInfo::MemberCount];
 
 // =====================================================================================================================
+// A helper method to convert ShaderStage enumerant to corresponding SpvGenStage enumerant.
+//
+// @param shaderStage : Input ShaderStage enumerant
+static SpvGenStage shaderStageToSpvGenStage(ShaderStage shaderStage) {
+  switch (shaderStage) {
+  case ShaderStage::ShaderStageVertex:
+    return SpvGenStageVertex;
+  case ShaderStage::ShaderStageTessControl:
+    return SpvGenStageTessControl;
+  case ShaderStage::ShaderStageTessEval:
+    return SpvGenStageTessEvaluation;
+  case ShaderStage::ShaderStageGeometry:
+    return SpvGenStageGeometry;
+  case ShaderStage::ShaderStageFragment:
+    return SpvGenStageFragment;
+  case ShaderStage::ShaderStageCompute:
+    return SpvGenStageCompute;
+  default:
+    VFX_NEVER_CALLED();
+    return SpvGenStageInvalid;
+  }
+}
+
+// =====================================================================================================================
 // Dummy class used to initialize all static variables
 class ParserInit {
 public:
@@ -527,7 +551,7 @@ bool SectionShader::compileGlsl(const char *entryPoint, std::string *errorMsg) {
 
   const char *glslText = m_shaderSource.c_str();
   const char *fileName = m_fileName.c_str();
-  SpvGenStage stage = static_cast<SpvGenStage>(m_shaderStage);
+  SpvGenStage stage = shaderStageToSpvGenStage(m_shaderStage);
   void *program = nullptr;
   const char *log = nullptr;
 


### PR DESCRIPTION
Add a helper to do this conversion rather than using the static casting.
The enumerants are not identical after spvgen header is updated. 61 LIT
test failures are caused by this.

Change-Id: I03034a5a010eb0aba32b32abc35aafe5bcda93d4