### PR TITLE
Avoid creating redundant nodes in lgc-patch-entry-point-mutate

### DIFF
--- a/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -9,7 +9,7 @@
 ; SHADERTEST: load <2 x double>, <2 x double> addrspace(7)* %{{.*}}, align 16
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{.*}} = inttoptr i64 %{{.*}} to <4 x i32> addrspace(4)*
+; SHADERTEST: %{{.*}} = bitcast i8 addrspace(4)* %4 to <4 x i32> addrspace(4)*
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> <i32 {{undef|poison}}, i32 {{undef|poison}}, i32 -1, i32 151468>, i32 %{{.*}}, {{i32|i64}} 0
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, {{i32|i64}} 1
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{.*}}, i32 64, i32 0)

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
@@ -13,10 +13,11 @@
 ; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: _amdgpu_ps_main
 ; SHADERTEST1: s_getpc_b64 s[0:1]
+; SHADERTEST1: s_mov_b32 s1, 0xffff
 ; SHADERTEST1: s_cmp_eq_u32 1, 0
-; SHADERTEST1: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0xffff
+; SHADERTEST1: s_cselect_b64 [[addr:s\[[0-9]+:[0-9]+\]]],  s[{{[0-9]*:[0-9]*}}], s[0:1]
 ; SHADERTEST1: s_mov_b32 [[offset:s[0-9]*]], 48
-; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]
+; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], [[addr]], [[offset]]
 ; END_SHADERTEST
 
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
@@ -13,10 +13,11 @@
 ; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST1 %s
 ; SHADERTEST1-LABEL: _amdgpu_ps_main
 ; SHADERTEST1: s_getpc_b64 s[0:1]
+; SHADERTEST1: s_mov_b32 s1, 0xffff
 ; SHADERTEST1: s_cmp_eq_u32 1, 0
-; SHADERTEST1: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0xffff
+; SHADERTEST1: s_cselect_b64 [[addr:s\[[0-9]+:[0-9]+\]]],  s[{{[0-9]*:[0-9]*}}], s[0:1]
 ; SHADERTEST1: s_mov_b32 [[offset:s[0-9]*]], 16
-; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]
+; SHADERTEST1: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], [[addr]], [[offset]]
 ; END_SHADERTEST
 
 

--- a/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
+++ b/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
@@ -15,12 +15,13 @@ void main()
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST: s_getpc_b64 s[0:1]
+; SHADERTEST: s_mov_b32 s1, 0
+; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowdesctable
 ; SHADERTEST: s_cmp_eq_u32 0, 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowenabled
-; SHADERTEST: s_cselect_b32 s[[highAddr:[0-9]*]], s1, 0
-; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowdesctable
+; SHADERTEST: s_cselect_b64 [[addr:s\[[0-9]+:[0-9]+\]]], s[{{[0-9]*:[0-9]*}}], s[0:1]
 ; SHADERTEST: s_mov_b32 [[offset:s[0-9]*]], 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 doff_0_0_f
-; SHADERTEST: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s[{{[0-9]*}}:[[highAddr]]], [[offset]]
+; SHADERTEST: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], [[addr]], [[offset]]
 */
 // END_SHADERTEST


### PR DESCRIPTION
There is no need to create multiple address extension nodes for the
same address. Redundant nodes cause more work for subsequent passes.

Avoid creating redundant nodes by using a map.