### PR TITLE
Correct the ResouceMapping hash of the shader stage

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1890,7 +1890,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
     PipelineDumper::updateHashForPipelineShaderInfo(stage, shaderInfo, true, &hasher, false);
     hasher.Update(pipelineInfo->iaState.deviceIndex);
 
-    PipelineDumper::updateHashForResourceMappingInfo(context->getResourceMapping(), &hasher, false);
+    PipelineDumper::updateHashForResourceMappingInfo(context->getResourceMapping(), &hasher, false, stage);
 
     // Update input/output usage (provided by middle-end caller of this callback).
     hasher.Update(stageHashes[stage].data(), stageHashes[stage].size());

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -122,15 +122,6 @@ spv::ExecutionModel convertToExecModel(ShaderStage shaderStage) {
 }
 
 // =====================================================================================================================
-// Translates shader stage to corresponding stage mask.
-//
-// @param stage : Shader stage
-unsigned shaderStageToMask(ShaderStage stage) {
-  assert(stage < ShaderStageCount || stage == ShaderStageCopyShader);
-  return (1 << stage);
-}
-
-// =====================================================================================================================
 // Returns true if shaderInfo has the information required to compile an unlinked shader of the given type.
 //
 // @param type : The unlinked shader type.

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -54,9 +54,6 @@ static const unsigned DescSetMask = 0x000000FF;
 // Gets the name string of shader stage.
 const char *getShaderStageName(ShaderStage shaderStage);
 
-// Translates shader stage to corresponding stage mask.
-unsigned shaderStageToMask(ShaderStage stage);
-
 // Convert shader stage to the SPIR-V execution model
 spv::ExecutionModel convertToExecModel(ShaderStage shaderStage);
 

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -78,8 +78,8 @@ public:
   static void updateHashForPipelineShaderInfo(ShaderStage stage, const PipelineShaderInfo *shaderInfo, bool isCacheHash,
                                               MetroHash64 *hasher, bool isRelocatableShader);
 
-  static void updateHashForResourceMappingInfo(const ResourceMappingData* pResourceMapping,
-                                               MetroHash64 *hasher, bool isRelocatableShader);
+  static void updateHashForResourceMappingInfo(const ResourceMappingData *pResourceMapping, MetroHash64 *hasher,
+                                               bool isRelocatableShader, ShaderStage stage = ShaderStageInvalid);
 
   static void updateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo *vertexInput,
                                             bool dynamicVertexStride, MetroHash64 *hasher);

--- a/util/vkgcUtil.h
+++ b/util/vkgcUtil.h
@@ -96,4 +96,10 @@ inline const T *findVkStructInChain(VkStructureType type, const void *next) {
   return reinterpret_cast<const T *>(structHeader);
 }
 
+// Translates shader stage to corresponding stage mask.
+inline unsigned shaderStageToMask(ShaderStage stage) {
+  assert(stage < ShaderStageCount || stage == ShaderStageCopyShader);
+  return 1U << static_cast<unsigned>(stage);
+}
+
 } // namespace Vkgc


### PR DESCRIPTION
The ResouceMapping content should only be hashed when it is actually
used in the shader stage.

Change-Id: Ic4556f4e3c03bc0b1cff990e7f264126a5516cce