### PR TITLE
Fix get incorrect shader wave size

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -278,6 +278,8 @@ public:
 
   // Gets wave size for the specified shader stage
   unsigned getShaderWaveSize(ShaderStage stage);
+  // Gets wave size for the merged shader stage
+  unsigned getMergedShaderWaveSize(ShaderStage stage);
   // Gets subgroup size for the specified shader stage
   unsigned getShaderSubgroupSize(ShaderStage stage);
 


### PR DESCRIPTION
When different wave sizes are mixed in merge shader or NGG mode, the
shader wave size should be re-calculated.