### PR TITLE
Fix a mistach issue of LLPC/LGC shader stage mask

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1120,7 +1120,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
         }
       }
     }
-    SmallVector<Module *, 5> modulesToLink;
+    SmallVector<Module *, ShaderStageGfxCount> modulesToLink;
     for (unsigned shaderIndex = 0; shaderIndex < shaderInfo.size() && result == Result::Success; ++shaderIndex) {
       // Per-shader SPIR-V lowering passes.
       const PipelineShaderInfo *shaderInfoEntry = shaderInfo[shaderIndex];
@@ -1238,7 +1238,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
 // shader stages that we don't want because there was a shader cache hit.
 //
 // @param module : Module
-// @param stageMask : Shader stage mask
+// @param stageMask : Shader stage mask (NOTE: This is a LGC shader stage mask passed by middle-end)
 // @param stageHashes : Per-stage hash of in/out usage
 // @param [out] stageCacheAccesses : Stage cache access info to fill out
 // @returns : Stage mask of the stages left to compile.
@@ -1251,11 +1251,11 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, const unsigned 
   Compiler::buildShaderCacheHash(m_context, stageMask, stageHashes, &fragmentHash, &nonFragmentHash);
   unsigned stagesLeftToCompile = stageMask;
 
-  if (stageMask & shaderStageToMask(ShaderStageFragment)) {
+  if (stageMask & getLgcShaderStageMask(ShaderStageFragment)) {
     m_fragmentCacheAccessor.emplace(m_context, fragmentHash, m_compiler->getInternalCaches());
     if (m_fragmentCacheAccessor->isInCache()) {
       // Remove fragment shader stages.
-      stagesLeftToCompile &= ~shaderStageToMask(ShaderStageFragment);
+      stagesLeftToCompile &= ~getLgcShaderStageMask(ShaderStageFragment);
       stageCacheAccesses[ShaderStageFragment] =
           m_fragmentCacheAccessor->hitInternalCache() ? CacheAccessInfo::InternalCacheHit : CacheAccessInfo::CacheHit;
     } else {
@@ -1263,12 +1263,12 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, const unsigned 
     }
   }
 
-  if (stageMask & ~shaderStageToMask(ShaderStageFragment)) {
+  if (stageMask & ~getLgcShaderStageMask(ShaderStageFragment)) {
     auto accessInfo = CacheAccessInfo::CacheNotChecked;
     m_nonFragmentCacheAccessor.emplace(m_context, nonFragmentHash, m_compiler->getInternalCaches());
     if (m_nonFragmentCacheAccessor->isInCache()) {
       // Remove non-fragment shader stages.
-      stagesLeftToCompile &= shaderStageToMask(ShaderStageFragment);
+      stagesLeftToCompile &= getLgcShaderStageMask(ShaderStageFragment);
       accessInfo = m_nonFragmentCacheAccessor->hitInternalCache() ? CacheAccessInfo::InternalCacheHit
                                                                   : CacheAccessInfo::CacheHit;
     } else {
@@ -1276,7 +1276,7 @@ unsigned GraphicsShaderCacheChecker::check(const Module *module, const unsigned 
     }
 
     for (ShaderStage stage : gfxShaderStages())
-      if (stage != ShaderStageFragment && (shaderStageToMask(stage) & stageMask))
+      if (stage != ShaderStageFragment && (getLgcShaderStageMask(stage) & stageMask))
         stageCacheAccesses[stage] = accessInfo;
   }
   return stagesLeftToCompile;
@@ -1425,7 +1425,7 @@ Result Compiler::BuildGraphicsPipeline(const GraphicsPipelineBuildInfo *pipeline
   Result result = Result::Success;
   BinaryData elfBin = {};
 
-  SmallVector<const PipelineShaderInfo *, 6> shaderInfo = {
+  SmallVector<const PipelineShaderInfo *, ShaderStageGfxCount> shaderInfo = {
       &pipelineInfo->vs, &pipelineInfo->tcs, &pipelineInfo->tes, &pipelineInfo->gs, &pipelineInfo->fs,
   };
 
@@ -1867,7 +1867,7 @@ void Compiler::releaseContext(Context *context) const {
 // Builds hash code from input context for per shader stage cache
 //
 // @param context : Acquired context
-// @param stageMask : Shader stage mask
+// @param stageMask : Shader stage mask (NOTE: This is a LGC shader stage mask passed by middle-end)
 // @param stageHashes : Per-stage hash of in/out usage
 // @param [out] fragmentHash : Hash code of fragment shader
 // @param [out] nonFragmentHash : Hash code of all non-fragment shader
@@ -1880,7 +1880,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
 
   // Build hash per shader stage
   for (ShaderStage stage : gfxShaderStages()) {
-    if ((stageMask & shaderStageToMask(stage)) == 0)
+    if ((stageMask & getLgcShaderStageMask(stage)) == 0)
       continue;
 
     auto shaderInfo = context->getPipelineShaderInfo(stage);
@@ -1893,7 +1893,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
     PipelineDumper::updateHashForResourceMappingInfo(context->getResourceMapping(), &hasher, false);
 
     // Update input/output usage (provided by middle-end caller of this callback).
-    hasher.Update(stageHashes[stage].data(), stageHashes[stage].size());
+    hasher.Update(stageHashes[getLgcShaderStage(stage)].data(), stageHashes[getLgcShaderStage(stage)].size());
 
     // Update vertex input state
     if (stage == ShaderStageVertex)
@@ -1912,7 +1912,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
   }
 
   // Add addtional pipeline state to final hasher
-  if (stageMask & shaderStageToMask(ShaderStageFragment)) {
+  if (stageMask & getLgcShaderStageMask(ShaderStageFragment)) {
     // Add pipeline options to fragment hash
     fragmentHasher.Update(pipelineOptions->includeDisassembly);
     fragmentHasher.Update(pipelineOptions->scalarBlockLayout);
@@ -1926,7 +1926,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
     fragmentHasher.Finalize(fragmentHash->bytes);
   }
 
-  if (stageMask & ~shaderStageToMask(ShaderStageFragment)) {
+  if (stageMask & ~getLgcShaderStageMask(ShaderStageFragment)) {
     PipelineDumper::updateHashForNonFragmentState(pipelineInfo, true, &nonFragmentHasher, false);
     nonFragmentHasher.Finalize(nonFragmentHash->bytes);
   }
@@ -1973,6 +1973,8 @@ bool Compiler::linkRelocatableShaderElf(ElfPackage *shaderElfs, ElfPackage *pipe
 
 // =====================================================================================================================
 // Convert front-end LLPC shader stage to middle-end LGC shader type
+//
+// @param stage : Front-end LLPC shader stage
 lgc::ShaderStage getLgcShaderStage(Llpc::ShaderStage stage) {
   switch (stage) {
   case ShaderStageCompute:
@@ -1991,6 +1993,14 @@ lgc::ShaderStage getLgcShaderStage(Llpc::ShaderStage stage) {
     llvm_unreachable("");
     return lgc::ShaderStageInvalid;
   }
+}
+
+// =====================================================================================================================
+// Convert front-end LLPC shader stage to middle-end LGC shader stage mask
+//
+// @param stage : Front-end LLPC shader stage
+unsigned getLgcShaderStageMask(ShaderStage stage) {
+  return (1 << getLgcShaderStage(stage));
 }
 
 } // namespace Llpc

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -174,4 +174,7 @@ private:
 // Convert front-end LLPC shader stage to middle-end LGC shader stage
 lgc::ShaderStage getLgcShaderStage(ShaderStage stage);
 
+// Convert front-end LLPC shader stage to middle-end LGC shader stage mask
+unsigned getLgcShaderStageMask(ShaderStage stage);
+
 } // namespace Llpc


### PR DESCRIPTION
The method GraphicsShaderCacheChecker::check() is called by the
middle-end pass PatchCheckShaderCache. However, the input stage
mask and the stage hashes are organized according to LGC shader stage
enumerant order. The order is not necessarily identical to that of
LLPC. We have to do conversion.

This issue is latent because we always have the same order. This
assumption is not ture if either LLPC or LGC introduces new stages
while the counterpart is not.

Change-Id: Id21a2053d752eea6ec4c97dc8ddb1c080ed4e0ca