### PR TITLE
Don't hash immutable sampler data for reloc shaders

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1891,7 +1891,7 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
     PipelineDumper::updateHashForPipelineShaderInfo(stage, shaderInfo, true, &hasher, false);
     hasher.Update(pipelineInfo->iaState.deviceIndex);
 
-    PipelineDumper::updateHashForResourceMappingInfo(context->getResourceMapping(), &hasher, false, stage);
+    PipelineDumper::updateHashForResourceMappingInfo(context->getResourceMapping(), &hasher, stage);
 
     // Update input/output usage (provided by middle-end caller of this callback).
     hasher.Update(stageHashes[getLgcShaderStage(stage)].data(), stageHashes[getLgcShaderStage(stage)].size());

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ImmutableSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ImmutableSampler.pipe
@@ -9,6 +9,28 @@
 ; SHADERTEST: {{^=====}} AMDLLPC SUCCESS
 ; END_SHADERTEST
 
+// Test that the immutable sampler (descriptorRangeValue) does not affect the
+// hash for the relocatable shaders.
+
+; BEGIN_HASHTEST
+; Remove the immutable sampler from this file and store the result in another
+; file.
+; RUN: grep -v "descriptorRangeValue" %s > %t.pipe
+
+; Run amdllpc on the the two versions of the file an make sure the hashes for
+; vertex and fragment shader stages are the same for both.
+; RUN: amdllpc -spvgen-dir=%spvgendir% \
+; RUN:         -enable-relocatable-shader-elf \
+; RUN:         -v %gfxip %s %t.pipe | FileCheck -check-prefix=HASHTEST %s
+; HASHTEST-LABEL: {{^// LLPC}} calculated hash results (graphics pipeline)
+; HASHTEST-LABEL: Building pipeline with relocatable shader elf.
+; HASHTEST: Finalized hash for vertex stage cache lookup: [[vhash1:0x[0-9a-f]*]] [[vhash2:0x[0-9a-f]*]]
+; HASHTEST: Finalized hash for fragment stage cache lookup: [[fhash1:0x[0-9a-f]*]] [[fhash2:0x[0-9a-f]*]]
+; HASHTEST: Finalized hash for vertex stage cache lookup: [[vhash1]] [[vhash2]]
+; HASHTEST: Finalized hash for fragment stage cache lookup: [[fhash1]] [[fhash2]]
+; HASHTEST: {{^=====}} AMDLLPC SUCCESS
+; END_HASHTEST
+
 [VsGlsl]
 #version 450
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -895,7 +895,8 @@ MetroHash::Hash PipelineDumper::generateHashForGraphicsPipeline(const GraphicsPi
     break;
   }
 
-  updateHashForResourceMappingInfo(&pipeline->resourceMapping, &hasher, isRelocatableShader);
+  if (!isRelocatableShader)
+    updateHashForResourceMappingInfo(&pipeline->resourceMapping, &hasher);
 
   hasher.Update(pipeline->iaState.deviceIndex);
 
@@ -930,7 +931,8 @@ MetroHash::Hash PipelineDumper::generateHashForComputePipeline(const ComputePipe
 
   updateHashForPipelineShaderInfo(ShaderStageCompute, &pipeline->cs, isCacheHash, &hasher, isRelocatableShader);
 
-  updateHashForResourceMappingInfo(&pipeline->resourceMapping, &hasher, isRelocatableShader);
+  if (!isRelocatableShader)
+    updateHashForResourceMappingInfo(&pipeline->resourceMapping, &hasher);
 
   hasher.Update(pipeline->deviceIndex);
 
@@ -1197,10 +1199,9 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
 //
 // @param resourceMapping : Pipeline resource mapping data.
 // @param [in,out] hasher : Haher to generate hash code.
-// @param isRelocatableShader : TRUE if we are building relocatable shader.
 // @param stage : The stage for which we are building the hash. ShaderStageInvalid if building for the entire pipeline.
 void PipelineDumper::updateHashForResourceMappingInfo(const ResourceMappingData *pResourceMapping, MetroHash64 *hasher,
-                                                      bool isRelocatableShader, ShaderStage stage) {
+                                                      ShaderStage stage) {
   hasher->Update(pResourceMapping->staticDescriptorValueCount);
   if (pResourceMapping->staticDescriptorValueCount > 0) {
       for (unsigned i = 0; i < pResourceMapping->staticDescriptorValueCount; ++i) {
@@ -1229,7 +1230,6 @@ void PipelineDumper::updateHashForResourceMappingInfo(const ResourceMappingData 
       }
   }
 
-  if (!isRelocatableShader) {
     hasher->Update(pResourceMapping->userDataNodeCount);
     if (pResourceMapping->userDataNodeCount > 0) {
       for (unsigned i = 0; i < pResourceMapping->userDataNodeCount; ++i) {
@@ -1241,7 +1241,6 @@ void PipelineDumper::updateHashForResourceMappingInfo(const ResourceMappingData 
         }
       }
     }
-  }
 }
 
 // =====================================================================================================================

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -79,7 +79,7 @@ public:
                                               MetroHash64 *hasher, bool isRelocatableShader);
 
   static void updateHashForResourceMappingInfo(const ResourceMappingData *pResourceMapping, MetroHash64 *hasher,
-                                               bool isRelocatableShader, ShaderStage stage = ShaderStageInvalid);
+                                               ShaderStage stage = ShaderStageInvalid);
 
   static void updateHashForVertexInputState(const VkPipelineVertexInputStateCreateInfo *vertexInput,
                                             bool dynamicVertexStride, MetroHash64 *hasher);


### PR DESCRIPTION
The immutable sampler data is not added to the pipeline when doing
relocatable shaders, so it is not needed in the cache hash.
