### PR TITLE
Clean up amdllpc error reporting

### DIFF
--- a/llpc/test/shaderdb/error_reporting/LlvmMissingShaderStage.ll
+++ b/llpc/test/shaderdb/error_reporting/LlvmMissingShaderStage.ll
@@ -1,12 +1,9 @@
 ; Check that an error is produced when valid LLVM IR is passed but is not a shader.
 
 ; BEGIN_SHADERTEST
-; DONT-RUN: not amdllpc -v %gfxip %s | FileCheck --check-prefix=SHADERTEST %s
-; Currently this test-case crashes instead of exiting gracefully. Do not run this test for now.
-; RUN: false
-; XFAIL: *
+; RUN: not amdllpc -v %gfxip %s | FileCheck --check-prefix=SHADERTEST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}}: Fail to determine shader stage
+; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}} parsed, but failed to determine shader stage
 ; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/error_reporting/LlvmVerificationFailure.ll
+++ b/llpc/test/shaderdb/error_reporting/LlvmVerificationFailure.ll
@@ -3,7 +3,8 @@
 ; BEGIN_SHADERTEST
 ; RUN: not amdllpc -v %gfxip %s | FileCheck --check-prefix=SHADERTEST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}} parsed, but fail to verify the module: Instruction does not dominate all uses!
+; SHADERTEST-LABEL: {{^}}ERROR: File {{.*}} parsed, but failed to verify the module:
+; SHADERTEST-SAME:  Instruction does not dominate all uses!
 ; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/error_reporting/SpirvMissingEntryTarget.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvMissingEntryTarget.spvasm
@@ -4,7 +4,7 @@
 ; RUN: not amdllpc -entry-target=foo -spvgen-dir=%spvgendir% -v %gfxip %s \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: Fails to identify shader stages by entry-point "foo"
+; SHADERTEST-LABEL: {{^}}ERROR: Failed to identify shader stages by entry-point "foo"
 ; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/error_reporting/SpirvValidationFailure.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvValidationFailure.spvasm
@@ -4,7 +4,7 @@
 ; RUN: not amdllpc -validate-spirv=true -spvgen-dir=%spvgendir% -v %gfxip %s \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: Fails to validate SPIR-V:
+; SHADERTEST-LABEL: {{^}}ERROR: Failed to validate SPIR-V:
 ; SHADERTEST-LABEL: {{^}}error: {{[0-9]+}}: 2 Entry points cannot share the same name and ExecutionMode.
 ; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
 ; END_SHADERTEST

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -547,7 +547,7 @@ static Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, 
         } else {
           char log[1024] = {};
           if (!spvValidateSpirv(spvBin.codeSize, spvBin.pCode, sizeof(log), log)) {
-            LLPC_ERRS("Fails to validate SPIR-V: \n" << log << "\n");
+            LLPC_ERRS("Failed to validate SPIR-V: \n" << log << "\n");
             return Result::ErrorInvalidShader;
           }
         }
@@ -573,7 +573,7 @@ static Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, 
           }
         }
       } else {
-        LLPC_ERRS(format("Fails to identify shader stages by entry-point \"%s\"\n", compileInfo.entryTarget.c_str()));
+        LLPC_ERRS(format("Failed to identify shader stages by entry-point \"%s\"\n", compileInfo.entryTarget.c_str()));
         return Result::ErrorUnavailable;
       }
     } else if (isLlvmIrFile(inFile)) {
@@ -586,6 +586,7 @@ static Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, 
         std::string errMsg;
         raw_string_ostream errStream(errMsg);
         errDiag.print(inFile.c_str(), errStream);
+        errStream.flush();
         LLPC_ERRS(errMsg);
         return Result::ErrorInvalidShader;
       }
@@ -594,14 +595,15 @@ static Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, 
       std::string errMsg;
       raw_string_ostream errStream(errMsg);
       if (verifyModule(*module.get(), &errStream)) {
-        LLPC_ERRS("File " << inFile << " parsed, but fail to verify the module: " << errMsg << "\n");
+        errStream.flush();
+        LLPC_ERRS("File " << inFile << " parsed, but failed to verify the module: " << errMsg << "\n");
         return Result::ErrorInvalidShader;
       }
 
       // Check the shader stage of input module.
       ShaderStage shaderStage = getShaderStageFromModule(module.get());
       if (shaderStage == ShaderStageInvalid) {
-        LLPC_ERRS("File " << inFile << ": Fail to determine shader stage\n");
+        LLPC_ERRS("File " << inFile << " parsed, but failed to determine shader stage\n");
         return Result::ErrorInvalidShader;
       }
 


### PR DESCRIPTION
- Make error messages more consistent.
- Un-XFAIL a passing test.
- Make sure to flush `raw_stream_ostream`s before printing.

Fixes: https://github.com/GPUOpen-Drivers/llpc/issues/1467