### PR TITLE
Handle unchecked returned results

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -1142,8 +1142,11 @@ private:
   void Put() {
     if (!m_pCache)
       return;
-    if (m_mustPopulate)
-      m_pCache->SetValue(m_rawHandle, false, nullptr, 0);
+    if (m_mustPopulate) {
+      Result result = m_pCache->SetValue(m_rawHandle, false, nullptr, 0);
+      assert(result == Result::Success);
+      (void)result;
+    }
     m_pCache->ReleaseEntry(m_rawHandle);
     m_pCache = nullptr;
     m_rawHandle = nullptr;

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -570,8 +570,8 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
       result = Result::Unsupported;
     }
     if (result == Result::Success) {
-      ShaderModuleHelper::collectInfoFromSpirvBinary(&shaderInfo->shaderBin, &moduleDataEx.common.usage, entryNames,
-                                                     &debugInfoSize);
+      result = ShaderModuleHelper::collectInfoFromSpirvBinary(&shaderInfo->shaderBin, &moduleDataEx.common.usage,
+                                                              entryNames, &debugInfoSize);
     }
     moduleDataEx.common.binCode.codeSize = shaderInfo->shaderBin.codeSize;
     if (trimDebugInfo)
@@ -1768,7 +1768,7 @@ Result Compiler::CreateShaderCache(const ShaderCacheCreateInfo *pCreateInfo, ISh
   if ((result == Result::Success) &&
       ((cl::ShaderCacheMode == ShaderCacheEnableRuntime) || (cl::ShaderCacheMode == ShaderCacheEnableOnDisk)) &&
       (pCreateInfo->initialDataSize > 0)) {
-    m_shaderCache->Merge(1, const_cast<const IShaderCache **>(ppShaderCache));
+    result = m_shaderCache->Merge(1, const_cast<const IShaderCache **>(ppShaderCache));
   }
 
   return result;

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -152,7 +152,7 @@ private:
 
   Result loadCacheFromFile();
   void resetCacheFile();
-  void addShaderToFile(const ShaderIndex *index);
+  Result addShaderToFile(const ShaderIndex *index);
 
   void *getCacheSpace(size_t numBytes);
 

--- a/llpc/context/llpcShaderCacheManager.cpp
+++ b/llpc/context/llpcShaderCacheManager.cpp
@@ -73,7 +73,9 @@ ShaderCachePtr ShaderCacheManager::getShaderCacheObject(const ShaderCacheCreateI
   if (cacheIt == endIt) {
     shaderCache = std::make_shared<ShaderCache>();
     m_shaderCaches.push_back(shaderCache);
-    shaderCache->init(createInfo, auxCreateInfo);
+    Result result = shaderCache->init(createInfo, auxCreateInfo);
+    assert(result == Result::Success);
+    (void)result;
   }
 
   return shaderCache;

--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -178,14 +178,19 @@ bool CacheAccessor::lookUpInShaderCache(const MetroHash::Hash &hash, bool alloca
 void CacheAccessor::setElfInCache(BinaryData elf) {
   if (m_shaderCacheEntryState == ShaderEntryState::Compiling && m_shaderCacheEntry) {
     updateShaderCache(elf);
-    m_shaderCache->retrieveShader(m_shaderCacheEntry, &m_elf.pCode, &m_elf.codeSize);
+    Result result = m_shaderCache->retrieveShader(m_shaderCacheEntry, &m_elf.pCode, &m_elf.codeSize);
+    (void)result;
     m_shaderCacheEntryState = ShaderEntryState::Ready;
   }
 
   if (!m_cacheEntry.IsEmpty()) {
+    m_cacheResult = Result::ErrorUnknown;
     if (elf.pCode) {
-      m_cacheEntry.SetValue(true, elf.pCode, elf.codeSize);
-      m_cacheEntry.GetValueZeroCopy(&m_elf.pCode, &m_elf.codeSize);
+      Result result = m_cacheEntry.SetValue(true, elf.pCode, elf.codeSize);
+      assert(result == Result::Success);
+      result = m_cacheEntry.GetValueZeroCopy(&m_elf.pCode, &m_elf.codeSize);
+      assert(result == Result::Success);
+      (void)result;
     }
     Vkgc::EntryHandle::ReleaseHandle(std::move(m_cacheEntry));
     m_cacheResult = elf.pCode ? Result::Success : Result::ErrorUnknown;

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -1043,7 +1043,7 @@ void ElfWriter<Elf>::processRelocSection(const ElfReader<Elf> &reader, size_t no
   auto nonFragmentRelocSecIndex = GetSectionIndex(RelocName);
 
   reader.getSectionDataBySectionIndex(fragmentRelocSecIndex, &fragmentRelocSection);
-  getSectionDataBySectionIndex(nonFragmentRelocSecIndex, &nonFragmentRelocSection);
+  Result result = getSectionDataBySectionIndex(nonFragmentRelocSecIndex, &nonFragmentRelocSection);
 
   bool isFragmentRelocUsedInPs = false;
 
@@ -1066,7 +1066,9 @@ void ElfWriter<Elf>::processRelocSection(const ElfReader<Elf> &reader, size_t no
     m_relocSecIdx = m_sections.size() - 1;
     m_map[RelocName] = m_relocSecIdx;
     nonFragmentRelocSecIndex = m_relocSecIdx;
-    getSectionDataBySectionIndex(nonFragmentRelocSecIndex, &nonFragmentRelocSection);
+    result = getSectionDataBySectionIndex(nonFragmentRelocSecIndex, &nonFragmentRelocSection);
+    assert(result == Result::Success);
+    (void)result;
   }
 
   // Merge reloc section.
@@ -1200,7 +1202,6 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
   auto fragmentCodesize = pFragmentElf->codeSize;
   auto result = reader.ReadFromBuffer(pFragmentElf->pCode, &fragmentCodesize);
   assert(result == Result::Success);
-  (void(result)); // unused
 
   // Merge GPU ISA code
   const ElfSectionBuffer<Elf64::SectionHeader> *nonFragmentTextSection = nullptr;
@@ -1213,7 +1214,8 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
   reader.getSectionDataBySectionIndex(fragmentTextSecIndex, &fragmentTextSection);
   reader.GetSymbolsBySectionIndex(fragmentTextSecIndex, fragmentSymbols);
 
-  getSectionDataBySectionIndex(nonFragmentSecIndex, &nonFragmentTextSection);
+  result = getSectionDataBySectionIndex(nonFragmentSecIndex, &nonFragmentTextSection);
+  assert(result == Result::Success);
   GetSymbolsBySectionIndex(nonFragmentSecIndex, nonFragmentSymbols);
   ElfSymbol *fragmentIsaSymbol = nullptr;
   ElfSymbol *nonFragmentIsaSymbol = nullptr;
@@ -1277,7 +1279,7 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
   ElfSectionBuffer<Elf64::SectionHeader> *fragmentDisassemblySection = nullptr;
   const ElfSectionBuffer<Elf64::SectionHeader> *nonFragmentDisassemblySection = nullptr;
   reader.getSectionDataBySectionIndex(fragmentDisassemblySecIndex, &fragmentDisassemblySection);
-  getSectionDataBySectionIndex(nonFragmentDisassemblySecIndex, &nonFragmentDisassemblySection);
+  result = getSectionDataBySectionIndex(nonFragmentDisassemblySecIndex, &nonFragmentDisassemblySection);
   if (nonFragmentDisassemblySection) {
     assert(fragmentDisassemblySection);
     // NOTE: We have to replace last character with null terminator and restore it afterwards. Otherwise, the
@@ -1315,7 +1317,8 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
   auto fragmentLlvmIrSecIndex = reader.GetSectionIndex(llvmIrSectionName.c_str());
   auto nonFragmentLlvmIrSecIndex = GetSectionIndex(llvmIrSectionName.c_str());
   reader.getSectionDataBySectionIndex(fragmentLlvmIrSecIndex, &fragmentLlvmIrSection);
-  getSectionDataBySectionIndex(nonFragmentLlvmIrSecIndex, &nonFragmentLlvmIrSection);
+  result = getSectionDataBySectionIndex(nonFragmentLlvmIrSecIndex, &nonFragmentLlvmIrSection);
+  (void)result;
 
   if (nonFragmentLlvmIrSection) {
     assert(fragmentLlvmIrSection);


### PR DESCRIPTION
The unchecked retruned results cause compiling warning. Results should
either be checked or the return type should be changed.
Fixes: issue #1474