### PR TITLE
Remove more redundant passes

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -119,6 +119,9 @@ void Patch::addPasses(PipelineState *pipelineState, legacy::PassManager &passMgr
   // Lower fragment export operations.
   passMgr.add(createLowerFragColorExport());
 
+  // Run IPSCCP before EntryPointMutate to avoid adding unnecessary arguments to an entry point.
+  passMgr.add(createIPSCCPPass());
+
   // Patch entry-point mutation (should be done before external library link)
   passMgr.add(createPatchEntryPointMutate());
 
@@ -219,9 +222,7 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
   LLPC_OUTS("PassManager optimization level = " << cl::OptLevel << "\n");
 
   passMgr.add(createForceFunctionAttrsLegacyPass());
-  passMgr.add(createIPSCCPPass());
   passMgr.add(createInstructionCombiningPass(1));
-  passMgr.add(createInstSimplifyLegacyPass());
   passMgr.add(createCFGSimplificationPass());
   passMgr.add(createSROAPass());
   passMgr.add(createEarlyCSEPass(true));
@@ -231,7 +232,6 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
   passMgr.add(createAggressiveInstCombinerPass());
   passMgr.add(createInstructionCombiningPass(1));
   passMgr.add(createPatchPeepholeOpt());
-  passMgr.add(createInstSimplifyLegacyPass());
   passMgr.add(createCFGSimplificationPass());
   passMgr.add(createReassociatePass());
   passMgr.add(createLoopRotatePass());
@@ -250,7 +250,6 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
   passMgr.add(createInstructionCombiningPass(1));
   passMgr.add(createCorrelatedValuePropagationPass());
   passMgr.add(createAggressiveDCEPass());
-  passMgr.add(createCFGSimplificationPass());
   passMgr.add(createLoopRotatePass());
   passMgr.add(createCFGSimplificationPass(SimplifyCFGOptions()
                                               .bonusInstThreshold(1)
@@ -262,7 +261,6 @@ void Patch::addOptimizationPasses(legacy::PassManager &passMgr) {
   // uses DivergenceAnalysis
   passMgr.add(createPatchReadFirstLane());
   passMgr.add(createInstructionCombiningPass(1));
-  passMgr.add(createLICMPass());
   passMgr.add(createConstantMergePass());
   passMgr.add(createDivRemPairsPass());
   passMgr.add(createCFGSimplificationPass());

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -197,12 +197,10 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
   // It is required by SpirvLowerImageOp.
   passMgr.addPass(createModuleToFunctionPassAdaptor(SROA()));
   passMgr.addPass(GlobalOptPass());
-  passMgr.addPass(createModuleToFunctionPassAdaptor(PromotePass()));
   passMgr.addPass(createModuleToFunctionPassAdaptor(ADCEPass()));
   passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(2)));
   passMgr.addPass(createModuleToFunctionPassAdaptor(SimplifyCFGPass()));
   passMgr.addPass(createModuleToFunctionPassAdaptor(EarlyCSEPass()));
-  passMgr.addPass(IPSCCPPass());
 
   // Lower SPIR-V floating point optimisation
   passMgr.addPass(SpirvLowerMathFloatOp());
@@ -275,12 +273,10 @@ void LegacySpirvLower::addPasses(Context *context, ShaderStage stage, legacy::Pa
   // It is required by SpirvLowerImageOp.
   passMgr.add(createSROAPass());
   passMgr.add(createGlobalOptimizerPass());
-  passMgr.add(createPromoteMemoryToRegisterPass());
   passMgr.add(createAggressiveDCEPass());
   passMgr.add(createInstructionCombiningPass(2));
   passMgr.add(createCFGSimplificationPass());
   passMgr.add(createEarlyCSEPass());
-  passMgr.add(createIPSCCPPass());
 
   // Lower SPIR-V floating point optimisation
   passMgr.add(createLegacySpirvLowerMathFloatOp());


### PR DESCRIPTION
Remove duplicate passes if they do not matter. The patch
improves overall compilation time by ~ 1% on average.

The change includes removing:

* the second run of IPSCCP and LICM
* an instsimplify if run soon after instcombine that did the simplification already
* one simplifycfg
* a mem2reg if run soon after sroa that handled allocas already