### PR TITLE
[CI] Fix bash escaping for clang-tidy

### DIFF
--- a/docker/llpc-clang-tidy.Dockerfile
+++ b/docker/llpc-clang-tidy.Dockerfile
@@ -55,7 +55,7 @@ RUN ln -s /vulkandriver/builds/ci-build/compile_commands.json \
         echo "Please run clang-tidy-diff on your changes and push again:"; \
         echo "    git diff origin/$LLPC_BASE_REF -U0 --no-color | ../llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -p1 -fix"; \
         echo ""; \
-        echo "To disable a lint, add `// NOLINT` at the end of the line."; \
+        echo "To disable a lint, add \`// NOLINT\` at the end of the line."; \
         echo ""; \
         echo "Diff:"; \
         cat not-tidy.diff; \


### PR DESCRIPTION
I just noticed that the NOLINT comment is missing in the output in failing runs like https://github.com/GPUOpen-Drivers/llpc/runs/4096860724?check_suite_focus=true.