### PR TITLE
Fix LGC tests after changes to the AMDGPU_Gfx calling convention.

### DIFF
--- a/lgc/test/CallLibFromCsPayload.lgc
+++ b/lgc/test/CallLibFromCsPayload.lgc
@@ -12,9 +12,9 @@ declare spir_func <10 x i32> @compute_library_func(<10 x i32>) #0
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spirv.ExecutionModel !7 !lgc.shaderstage !7 {
 ; CHECK: v_mov_b32_e32 v0, 42
-; CHECK: s_swappc_b64 s[30:31], s[26:27]
+; CHECK: s_swappc_b64 s[{{[0-9]+:[0-9]+}}], s[{{[0-9]+:[0-9]+}}]
 ; CHECK-NEXT: v_mov_b32_e32 v40, v0
-; CHECK-NEXT: buffer_store_dwordx4 v[40:43], off, s[36:39], 0
+; CHECK-NEXT: buffer_store_dwordx4 v[{{[0-9]+:[0-9]+}}], off, s[{{[0-9]+:[0-9]+}}], 0
 .entry:
   %0 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 2, i32 0, i32 2)
   %1 = call i8 addrspace(7)* (...) @lgc.create.load.buffer.desc.p7i8(i32 0, i32 0, i32 0, i32 2)

--- a/lgc/test/CsComputeLibraryPayload.lgc
+++ b/lgc/test/CsComputeLibraryPayload.lgc
@@ -13,15 +13,14 @@ define spir_func <10 x i32> @func(<10 x i32> %arg) local_unnamed_addr #0 !spirv.
 ; CHECK-LABEL: func:
 ; CHECK: s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT: s_waitcnt_vscnt null, 0x0
-; CHECK-NEXT: s_getpc_b64 s[4:5]
-; CHECK-NEXT: v_mov_b32_e32 v10, s20
-; CHECK-NEXT: s_mov_b32 s9, s5
-; CHECK-NEXT: v_mov_b32_e32 v11, s21
-; CHECK-NEXT: s_load_dwordx4 s[4:7], s[8:9], 0x0
-; CHECK-NEXT: v_mov_b32_e32 v12, s22
-; CHECK-NEXT: s_waitcnt lgkmcnt(0)
-; CHECK-NEXT: buffer_store_dwordx3 v[10:12], off, s[4:7], 0
-; CHECK-NEXT: s_waitcnt_vscnt null, 0x0
+; CHECK: s_getpc_b64 s[{{[0-9]+:[0-9]+}}]
+; CHECK: s_mov_b32 s9, s{{[0-9]+}}
+; CHECK-NEXT: v_mov_b32_e32 v{{[0-9]+}}, s{{[0-9]+}}
+; CHECK-NEXT: s_load_dwordx4 s[{{[0-9]+:[0-9]+}}], s[8:9], 0x0
+; CHECK: v_mov_b32_e32 v12, s{{[0-9]+}}
+; CHECK: s_waitcnt lgkmcnt(0)
+; CHECK-NEXT: buffer_store_dwordx3 v[{{[0-9]+:[0-9]+}}], off, s[{{[0-9]+:[0-9]+}}], 0
+; CHECK: s_waitcnt_vscnt null, 0x0
 ; CHECK-NEXT: s_setpc_b64 s[30:31]
 .entry:
   %id = call <3 x i32> @lgc.shader.input.LocalInvocationId(i32 0)


### PR DESCRIPTION
This patch aims to fix the LGC tests which are failing because of a
recent LLVM change 76cbe62262a3ccd0604599a1103ce5d38ac0164b.
Here, the AMDGPU_Gfx calling convention was changed so that some
SGPRs are now callee-save, the resulting ISA is different now.
The LGC tests are changed in a way so they work both with and
without the LLVM change.