### PR TITLE
Remove unused output for some unlinked shaders.

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -313,7 +313,7 @@ void InOutBuilder::markGenericInputOutputUsage(bool isOutput, unsigned location,
   if (!isOutput || m_shaderStage != ShaderStageGeometry) {
     bool keepAllLocations = false;
     if (getPipelineState()->isUnlinked()) {
-      if (m_shaderStage == ShaderStageVertex && isOutput)
+      if (isOutput && m_pipelineState->getNextShaderStage(m_shaderStage, true) == ShaderStageFragment)
         keepAllLocations = true;
       if (m_shaderStage == ShaderStageFragment && !isOutput)
         keepAllLocations = true;

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2270,7 +2270,7 @@ void PatchResourceCollect::clearUnusedOutput() {
   ShaderStage nextStage = m_pipelineState->getNextShaderStage(m_shaderStage, m_processMissingFs);
   auto &inOutUsage = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage;
   auto &outputLocInfoMap = inOutUsage.outputLocInfoMap;
-  if (!m_pipelineState->isUnlinked() && nextStage != ShaderStageInvalid) {
+  if (nextStage != ShaderStageInvalid) {
     // Collect the locations of TCS with dynamic indexing or as imported output
     DenseSet<unsigned> dynIndexedOrImportOutputLocs;
     if (m_shaderStage == ShaderStageTessControl) {

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1409,6 +1409,8 @@ void PipelineState::initializeInOutPackState() {
     for (ShaderStage stage : lgc::enumRange(ShaderStage::ShaderStageGfxCount)) {
       if ((m_stageMask & shaderStageToMask(stage)) == 0)
         continue;
+      if (stage == ShaderStageTessEval)
+        continue;
       ShaderStage preStage = getPrevShaderStage(stage);
       if (preStage == ShaderStageInvalid)
         continue;

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineTess_RelocRemoveUnusedTcsOutputs.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineTess_RelocRemoveUnusedTcsOutputs.pipe
@@ -1,0 +1,80 @@
+; Test that the TCS output at location 0 is removed, and that the mapping of the TES inputs and TCS outputs match.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% \
+; RUN:         -enable-relocatable-shader-elf \
+; RUN:         -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: // LLPC location input/output mapping results (TES shader)
+; SHADERTEST: (TES) Input:  loc = 2, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST-LABEL: // LLPC location input/output mapping results (TCS shader)
+; SHADERTEST: (TCS) Output: loc = 2, comp = 0  =>  Mapped = 0, 0
+; END_SHADERTEST
+
+[Version]
+version = 50
+
+[VsGlsl]
+#version 450
+
+void main()
+{
+    gl_Position = vec4(0.0);
+}
+
+[VsInfo]
+entryPoint = main
+
+[TcsGlsl]
+#version 450
+layout(vertices = 3) out;
+
+layout(location = 0) out vec2 _6[3];
+layout(location = 2) out float _7[3];
+
+void main()
+{
+    gl_out[gl_InvocationID].gl_Position = vec4(0.0);
+    _6[gl_InvocationID] = vec2(0.0);
+    _7[gl_InvocationID] = 0.0;
+}
+
+[TcsInfo]
+entryPoint = main
+
+[TesGlsl]
+#version 450
+layout(triangles) in;
+
+layout(location = 2) in float _7[];
+
+void main()
+{
+    float _30_unrolled[3];
+    for (int i = 0; i < int(3); i++)
+    {
+        _30_unrolled[i] = _7[i];
+    }
+    gl_Position = vec4(_30_unrolled[0], _30_unrolled[1], _30_unrolled[2], 1.0);
+}
+
+[TesInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+layout(early_fragment_tests) in;
+
+layout(location = 0) out vec4 _4;
+
+void main()
+{
+    _4 = vec4(1.0, 0.0, 0.0, 1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_SRGB
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0


### PR DESCRIPTION
The TES inputs and TCS outputs are not matching up when compiling to
unlinked shaders.  This is because the compiler is inconsistent on when
it will try to pack the inputs and outputs.  It is also inconsistent on
how unused TES inputs are mapped.  This change tries to make that this
consistent.

The idea behind this change is to always remove unused output of the
next stage is available, even if we are doing unlinked shaders.
