### PR TITLE
Enforce result handling

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -65,6 +65,21 @@
 #define LLPC_ENABLE_SHADER_CACHE 0
 #endif
 
+/// LLPC_NODISCARD - Warns when function return value is discarded.
+//
+// We cannot use the 'nodiscard' attribute until we upgrade to C++17 or newer mode.
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::warn_unused_result)
+#define LLPC_NODISCARD [[clang::warn_unused_result]]
+#elif defined(__GNUC__) && __has_cpp_attribute(nodiscard)
+#define LLPC_NODISCARD [[nodiscard]]
+#else
+#define LLPC_NODISCARD
+#endif
+#else
+#define LLPC_NODISCARD
+#endif
+
 //
 // -------------------------------------------------------------------------------------------------------------------
 //  @page VersionHistory
@@ -957,7 +972,7 @@ public:
   ///   * NotFound: no existing entry was found. If \p allocateOnMiss is set, a new entry was
   ///               allocated and the caller must populate it via SetValue
   ///   * ErrorXxx: some internal error has occurred, no handle is returned
-  virtual Result GetEntry(HashId hash, bool allocateOnMiss, EntryHandle *pHandle) = 0;
+  LLPC_NODISCARD virtual Result GetEntry(HashId hash, bool allocateOnMiss, EntryHandle *pHandle) = 0;
 
   /// \brief Release ownership of a handle to a cache entry.
   ///
@@ -978,7 +993,7 @@ public:
   ///   * ErrorXxx: some internal error has occurred, or populating the cache was not successful
   ///               (e.g. due to a compiler error). The operation was semantically a no-op:
   ///               the entry is still not ready, and the caller must still release it via \ref PutEntry
-  virtual Result WaitForEntry(RawEntryHandle rawHandle) = 0;
+  LLPC_NODISCARD virtual Result WaitForEntry(RawEntryHandle rawHandle) = 0;
 
   /// \brief Retrieve the value contents of a cache entry.
   ///
@@ -992,7 +1007,7 @@ public:
   ///   * Success: operation completed successfully
   ///   * NotReady: the entry is not ready yet (waiting to be populated by another thread)
   ///   * ErrorXxx: some internal error has occurred. The operation was semantically a no-op.
-  virtual Result GetValue(RawEntryHandle rawHandle, void *pData, size_t *pDataLen) = 0;
+  LLPC_NODISCARD virtual Result GetValue(RawEntryHandle rawHandle, void *pData, size_t *pDataLen) = 0;
 
   /// \brief Zero-copy retrieval of the value contents of a cache entry.
   ///
@@ -1006,7 +1021,7 @@ public:
   ///                  \ref GetValue instead
   ///   * NotReady: the entry is not ready yet (waiting to be populated by another thread)
   ///   * ErrorXxx: some internal error has occurred. The operation was semantically a no-op.
-  virtual Result GetValueZeroCopy(RawEntryHandle rawHandle, const void **ppData, size_t *pDataLen) = 0;
+  LLPC_NODISCARD virtual Result GetValueZeroCopy(RawEntryHandle rawHandle, const void **ppData, size_t *pDataLen) = 0;
 
   /// \brief Populate the value contents of a cache entry.
   ///
@@ -1023,14 +1038,15 @@ public:
   ///   * Success: operation completed successfully
   ///   * ErrorXxx: some internal error has occurred. The caller must not call SetValue again,
   ///               but it must still release the handle via \ref PutEntry.
-  virtual Result SetValue(RawEntryHandle rawHandle, bool success, const void *pData, size_t dataLen) = 0;
+  LLPC_NODISCARD virtual Result SetValue(RawEntryHandle rawHandle, bool success, const void *pData, size_t dataLen) = 0;
 
   /// \brief Populate the value contents of a cache entry and release the handle.
   ///
   /// Semantics are identical to SetValue, except that the handle is guaranteed to be released.
   /// Doing this atomically can sometimes allow a more efficient implementation; the default
   /// implementation is trivial.
-  virtual Result ReleaseWithValue(RawEntryHandle rawHandle, bool success, const void *pData, size_t dataLen) {
+  LLPC_NODISCARD virtual Result ReleaseWithValue(RawEntryHandle rawHandle, bool success, const void *pData,
+                                                 size_t dataLen) {
     Result result = Result::ErrorUnknown;
     if (!rawHandle)
       return result;
@@ -1096,22 +1112,22 @@ public:
 
   // semantics of these methods are largely analogous to the above in ICache,
   // their implementation simply forwards to the m_pCache.
-  Result WaitForEntry() const {
+  LLPC_NODISCARD Result WaitForEntry() const {
     assert(m_pCache);
     return m_pCache->WaitForEntry(m_rawHandle);
   }
 
-  Result GetValue(void *pData, size_t *pDataLen) const {
+  LLPC_NODISCARD Result GetValue(void *pData, size_t *pDataLen) const {
     assert(m_pCache);
     return m_pCache->GetValue(m_rawHandle, pData, pDataLen);
   }
 
-  Result GetValueZeroCopy(const void **ppData, size_t *pDataLen) const {
+  LLPC_NODISCARD Result GetValueZeroCopy(const void **ppData, size_t *pDataLen) const {
     assert(m_pCache);
     return m_pCache->GetValueZeroCopy(m_rawHandle, ppData, pDataLen);
   }
 
-  Result SetValue(bool success, const void *pData, size_t dataLen) {
+  LLPC_NODISCARD Result SetValue(bool success, const void *pData, size_t dataLen) {
     assert(m_pCache);
     assert(m_mustPopulate);
     m_mustPopulate = false;

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -686,8 +686,10 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
       moduleDataExCopy->extra.fsOutInfoCount = fsOutInfos.size();
       if (fsOutInfos.size() > 0)
         memcpy(fsOutInfo, &fsOutInfos[0], fsOutInfos.size() * sizeof(FsOutInfo));
-      if (m_cache && allocateOnMiss && cacheResult == Result::NotFound)
-        cacheEntry.SetValue(true, moduleDataExCopy, allocSize);
+      if (m_cache && allocateOnMiss && cacheResult == Result::NotFound) {
+        mustSucceed(cacheEntry.SetValue(true, moduleDataExCopy, allocSize),
+                    "Failed to insert shader module into cache");
+      }
       if (cacheEntryState == ShaderEntryState::Compiling) {
         if (hEntry)
           m_shaderCache->insertShader(hEntry, moduleDataExCopy, allocSize);

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -363,8 +363,9 @@ Result ShaderCache::buildFileName(const char *executableName, const char *cacheF
 // Resets the contents of the cache file, assumes the shader cache has been locked for writes.
 void ShaderCache::resetCacheFile() {
   m_onDiskFile.close();
-  Result fileResult = m_onDiskFile.open(m_fileFullPath, (FileAccessRead | FileAccessWrite | FileAccessBinary));
-  assert(fileResult == Result::Success);
+  const unsigned accessFlags = FileAccessRead | FileAccessWrite | FileAccessBinary;
+  mustSucceed(m_onDiskFile.open(m_fileFullPath, accessFlags),
+              Twine("Failed to open shader cache file: ") + m_fileFullPath);
 
   ShaderCacheSerializedHeader header = {};
   header.headerSize = sizeof(ShaderCacheSerializedHeader);
@@ -372,9 +373,8 @@ void ShaderCache::resetCacheFile() {
   header.shaderDataEnd = header.headerSize;
   getBuildTime(&header.buildId);
 
-  fileResult = m_onDiskFile.write(&header, header.headerSize);
-  assert(fileResult == Result::Success);
-  (void)fileResult; // unused
+  mustSucceed(m_onDiskFile.write(&header, header.headerSize),
+              Twine("Failed to write shader cache file: ") + m_fileFullPath);
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcShaderCacheManager.cpp
+++ b/llpc/context/llpcShaderCacheManager.cpp
@@ -73,9 +73,7 @@ ShaderCachePtr ShaderCacheManager::getShaderCacheObject(const ShaderCacheCreateI
   if (cacheIt == endIt) {
     shaderCache = std::make_shared<ShaderCache>();
     m_shaderCaches.push_back(shaderCache);
-    Result result = shaderCache->init(createInfo, auxCreateInfo);
-    assert(result == Result::Success);
-    (void)result;
+    mustSucceed(shaderCache->init(createInfo, auxCreateInfo), "Failed to initialize shader cache");
   }
 
   return shaderCache;

--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -178,19 +178,16 @@ bool CacheAccessor::lookUpInShaderCache(const MetroHash::Hash &hash, bool alloca
 void CacheAccessor::setElfInCache(BinaryData elf) {
   if (m_shaderCacheEntryState == ShaderEntryState::Compiling && m_shaderCacheEntry) {
     updateShaderCache(elf);
-    Result result = m_shaderCache->retrieveShader(m_shaderCacheEntry, &m_elf.pCode, &m_elf.codeSize);
-    (void)result;
+    mustSucceed(m_shaderCache->retrieveShader(m_shaderCacheEntry, &m_elf.pCode, &m_elf.codeSize),
+                "Failed to retrieve shader");
     m_shaderCacheEntryState = ShaderEntryState::Ready;
   }
 
   if (!m_cacheEntry.IsEmpty()) {
     m_cacheResult = Result::ErrorUnknown;
     if (elf.pCode) {
-      Result result = m_cacheEntry.SetValue(true, elf.pCode, elf.codeSize);
-      assert(result == Result::Success);
-      result = m_cacheEntry.GetValueZeroCopy(&m_elf.pCode, &m_elf.codeSize);
-      assert(result == Result::Success);
-      (void)result;
+      mustSucceed(m_cacheEntry.SetValue(true, elf.pCode, elf.codeSize));
+      mustSucceed(m_cacheEntry.GetValueZeroCopy(&m_elf.pCode, &m_elf.codeSize));
     }
     Vkgc::EntryHandle::ReleaseHandle(std::move(m_cacheEntry));
     m_cacheResult = elf.pCode ? Result::Success : Result::ErrorUnknown;

--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -30,7 +30,7 @@
  */
 #pragma once
 
-#include <cstdint>
+#include "llvm/Support/raw_ostream.h"
 
 // Output error message
 #define LLPC_ERRS(_msg)                                                                                                \
@@ -50,8 +50,6 @@
   while (false)
 
 namespace llvm {
-class raw_fd_ostream;
-class raw_ostream;
 class Error;
 } // namespace llvm
 

--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "llpcUtil.h"
 #include "vkgcElfReader.h"
 
 // Forward declaration
@@ -75,9 +76,9 @@ public:
 
   static void updateMetaNote(Context *context, const ElfNote *note, ElfNote *newNote);
 
-  static size_t numRelocs(const SectionBuffer *relocSection);
+  LLPC_NODISCARD static size_t numRelocs(const SectionBuffer *relocSection);
 
-  static size_t getRelocPsStartPos(const SectionBuffer *relocSection, size_t psIsaOffset);
+  LLPC_NODISCARD static size_t getRelocPsStartPos(const SectionBuffer *relocSection, size_t psIsaOffset);
 
   SectionBuffer createNewSection(const char *sectionName, SectionBuffer *inputSection);
 
@@ -87,38 +88,38 @@ public:
 
   void addRelocSymbols(const ElfReader<Elf> &reader, ElfReloc inputRelocs);
 
-  uint32_t getRelocSymbolIndex(const char *inputSymbolName);
+  LLPC_NODISCARD uint32_t getRelocSymbolIndex(const char *inputSymbolName);
 
   void processRelocSection(const ElfReader<Elf> &reader, size_t nonFragmentPsIsaOffset, size_t fragmentPsIsaOffset);
 
-  Result ReadFromBuffer(const void *buffer, size_t bufSize);
-  Result copyFromReader(const ElfReader<Elf> &reader);
+  LLPC_NODISCARD Result ReadFromBuffer(const void *buffer, size_t bufSize);
+  LLPC_NODISCARD Result copyFromReader(const ElfReader<Elf> &reader);
 
   void updateElfBinary(Context *context, ElfPackage *pipelineElf);
 
   void mergeElfBinary(Context *context, const BinaryData *fragmentElf, ElfPackage *pipelineElf);
 
   // Gets the section index for the specified section name.
-  int GetSectionIndex(const char *name) const {
+  LLPC_NODISCARD int GetSectionIndex(const char *name) const {
     auto entry = m_map.find(name);
     return entry != m_map.end() ? entry->second : InvalidValue;
   }
 
   void setSection(unsigned secIndex, SectionBuffer *section);
 
-  ElfSymbol *getSymbol(const char *symbolName);
+  LLPC_NODISCARD ElfSymbol *getSymbol(const char *symbolName);
 
-  ElfNote getNote(uint32_t noteType);
+  LLPC_NODISCARD ElfNote getNote(uint32_t noteType);
 
   void setNote(ElfNote *note);
 
-  Result getSectionDataBySectionIndex(unsigned secIdx, const SectionBuffer **ppSectionData) const;
+  LLPC_NODISCARD Result getSectionDataBySectionIndex(unsigned secIdx, const SectionBuffer **ppSectionData) const;
 
-  Result getSectionData(const char *name, const void **ppData, size_t *dataLength) const;
+  LLPC_NODISCARD Result getSectionData(const char *name, const void **ppData, size_t *dataLength) const;
 
   void GetSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol *> &secSymbols);
 
-  Result getSectionTextShader(const char *name, const void **ppData, size_t *dataLength);
+  LLPC_NODISCARD Result getSectionTextShader(const char *name, const void **ppData, size_t *dataLength);
 
   void updateSymbolsBySectionIndex(unsigned secIdx, std::vector<ElfSymbol> &secSymbols);
 
@@ -130,7 +131,7 @@ private:
 
   static void mergeMapItem(llvm::msgpack::MapDocNode &destMap, llvm::msgpack::MapDocNode &srcMap, unsigned key);
 
-  size_t getRequiredBufferSizeBytes();
+  LLPC_NODISCARD size_t getRequiredBufferSizeBytes();
 
   void calcSectionHeaderOffset();
 

--- a/llpc/util/llpcFile.h
+++ b/llpc/util/llpcFile.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "llpc.h"
+#include "llpcUtil.h"
 #include <climits>
 #include <cstdio>
 
@@ -71,24 +72,24 @@ public:
   // Closes the file if it is still open.
   ~File() { close(); }
 
-  static size_t getFileSize(const char *filename);
-  static bool exists(const char *filename);
+  LLPC_NODISCARD static size_t getFileSize(const char *filename);
+  LLPC_NODISCARD static bool exists(const char *filename);
 
-  Result open(const char *filename, unsigned accessFlags);
+  LLPC_NODISCARD Result open(const char *filename, unsigned accessFlags);
   void close();
-  Result write(const void *buffer, size_t bufferSize);
-  Result read(void *buffer, size_t bufferSize, size_t *bytesRead);
-  Result readLine(void *buffer, size_t bufferSize, size_t *bytesRead);
-  Result printf(const char *formatStr, ...) const;
-  Result vPrintf(const char *formatStr, va_list argList);
-  Result flush() const;
+  LLPC_NODISCARD Result write(const void *buffer, size_t bufferSize);
+  LLPC_NODISCARD Result read(void *buffer, size_t bufferSize, size_t *bytesRead);
+  LLPC_NODISCARD Result readLine(void *buffer, size_t bufferSize, size_t *bytesRead);
+  LLPC_NODISCARD Result printf(const char *formatStr, ...) const;
+  LLPC_NODISCARD Result vPrintf(const char *formatStr, va_list argList);
+  LLPC_NODISCARD Result flush() const;
   void rewind();
   void seek(int offset, bool fromOrigin);
 
   // Returns true if the file is presently open.
-  bool isOpen() const { return (m_fileHandle); }
+  LLPC_NODISCARD bool isOpen() const { return (m_fileHandle); }
   // Gets handle of the file
-  const std::FILE *getHandle() const { return m_fileHandle; }
+  LLPC_NODISCARD const std::FILE *getHandle() const { return m_fileHandle; }
 
 private:
   std::FILE *m_fileHandle; // File handle

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -35,6 +35,7 @@
 #include "palPipelineAbi.h"
 #include "spirvExt.h"
 #include "vkgcElfReader.h"
+#include <cassert>
 
 using namespace llvm;
 using namespace Vkgc;
@@ -42,6 +43,23 @@ using namespace Vkgc;
 #define DEBUG_TYPE "llpc-util"
 
 namespace Llpc {
+
+// =====================================================================================================================
+// Handles passed `result` and checks if it is a Success. Prints `errorMessage` if not.
+//
+// @param result : Result to check
+// @param errorMessage : Optional error message to print on failure
+void mustSucceed(Result result, const Twine &errorMessage) {
+  if (result == Result::Success)
+    return;
+
+  if (errorMessage.isTriviallyEmpty())
+    LLPC_ERRS("Unhandled error result\n");
+  else
+    LLPC_ERRS("Unhandled error result: " << errorMessage << "\n");
+
+  assert(false && "Result is not Success");
+}
 
 // =====================================================================================================================
 // Gets the name string of shader stage.

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -39,6 +39,7 @@
 #include "lgc/EnumIterator.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Twine.h"
 
 namespace Llpc {
 
@@ -61,6 +62,9 @@ spv::ExecutionModel convertToExecModel(ShaderStage shaderStage);
 
 // Convert SPIR-V execution model to the shader stage
 ShaderStage convertToShaderStage(unsigned execModel);
+
+// Handles passed `result` and checks if it is a Success. Prints `errorMessage` if not.
+void mustSucceed(Vkgc::Result result, const llvm::Twine &errorMessage = "");
 
 // =====================================================================================================================
 // Gets module ID according to the index


### PR DESCRIPTION
This implements proposal 1. from `[RFC] Improving LLPC Result checking`.

-  Introduce a new macro `LLPC_NODISCARD` to warn about unused results.
-  Annotate function returning `Result` with the new attribute.
   Not all functions are covered by this PR.
-  Introduce a new function `mustSucceed` that ensures that returned results
   are `Success`.
-  Add a few checks missed by https://github.com/GPUOpen-Drivers/llpc/pull/1483.

This uncovered a few unhandled non-success results, see
https://github.com/GPUOpen-Drivers/llpc/issues/1468#issuecomment-963531203.

Issue: https://github.com/GPUOpen-Drivers/llpc/issues/1474, https://github.com/GPUOpen-Drivers/llpc/issues/1468,
https://github.com/GPUOpen-Drivers/llpc/issues/1469, https://github.com/GPUOpen-Drivers/llpc/issues/1470,
https://github.com/GPUOpen-Drivers/llpc/issues/1471, https://github.com/GPUOpen-Drivers/llpc/issues/1473.