### PR TITLE
Fix `-Wswitch` warnings. NFC.

### DIFF
--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1148,36 +1148,36 @@ unsigned PipelineState::getMergedShaderWaveSize(ShaderStage stage) {
   switch (stage) {
   case ShaderStageVertex:
     if (hasShaderStage(ShaderStageTessControl)) {
-      waveSize = std::max(waveSize, m_waveSize[ShaderStageTessControl]);
-    } else if (hasShaderStage(ShaderStageGeometry)) {
-      waveSize = std::max(waveSize, m_waveSize[ShaderStageGeometry]);
+      return std::max(waveSize, m_waveSize[ShaderStageTessControl]);
     }
-    break;
+    if (hasShaderStage(ShaderStageGeometry)) {
+      return std::max(waveSize, m_waveSize[ShaderStageGeometry]);
+    }
+    return waveSize;
 
   case ShaderStageTessControl:
-    waveSize = std::max(waveSize, m_waveSize[ShaderStageVertex]);
-    break;
+    return std::max(waveSize, m_waveSize[ShaderStageVertex]);
 
   case ShaderStageTessEval:
     if (hasShaderStage(ShaderStageGeometry)) {
-      waveSize = std::max(waveSize, m_waveSize[ShaderStageGeometry]);
+      return std::max(waveSize, m_waveSize[ShaderStageGeometry]);
     }
-    break;
+    return waveSize;
 
   case ShaderStageGeometry:
     if (!hasShaderStage(ShaderStageGeometry)) {
       // NGG, no geometry
-      waveSize =
-          std::max(waveSize, m_waveSize[hasShaderStage(ShaderStageTessEval) ? ShaderStageTessEval : ShaderStageVertex]);
-    } else if (hasShaderStage(ShaderStageTessEval)) {
-      waveSize = std::max(waveSize, m_waveSize[ShaderStageTessEval]);
-    } else {
-      waveSize = std::max(waveSize, m_waveSize[ShaderStageVertex]);
+      return std::max(waveSize,
+                      m_waveSize[hasShaderStage(ShaderStageTessEval) ? ShaderStageTessEval : ShaderStageVertex]);
     }
-    break;
-  }
+    if (hasShaderStage(ShaderStageTessEval)) {
+      return std::max(waveSize, m_waveSize[ShaderStageTessEval]);
+    }
+    return std::max(waveSize, m_waveSize[ShaderStageVertex]);
 
-  return waveSize;
+  default:
+    return waveSize;
+  }
 }
 
 unsigned PipelineState::getShaderSubgroupSize(ShaderStage stage) {

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -89,10 +89,10 @@ ShaderStage convertToShaderStage(unsigned execModel) {
     return ShaderStageCompute;
   case spv::ExecutionModelCopyShader:
     return ShaderStageCopyShader;
+  default:
+    llvm_unreachable("Unknown execution model");
+    return ShaderStageInvalid;
   }
-
-  llvm_unreachable("Should never be called!");
-  return ShaderStageInvalid;
 }
 
 // =====================================================================================================================
@@ -115,10 +115,10 @@ spv::ExecutionModel convertToExecModel(ShaderStage shaderStage) {
     return spv::ExecutionModelGLCompute;
   case ShaderStageCopyShader:
     return spv::ExecutionModelCopyShader;
+  default:
+    llvm_unreachable("Unknown shader stage");
+    return spv::ExecutionModelMax;
   }
-
-  llvm_unreachable("Should never be called!");
-  return spv::ExecutionModelMax;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Add default cases to some switch statements to silence internal compiler warnings.