### PR TITLE
Fix clang-tidy const member case

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,8 +20,9 @@ CheckOptions:
   - { key: readability-identifier-naming.GlobalVariableCase, value: CamelCase }
   - { key: readability-identifier-naming.GlobalVariableRemovePrefixes, value: 'p,b,pfn,g_,g_p' }
   - { key: readability-identifier-naming.ConstantMemberIgnoredRegexp, value: 'mm.*' }
-  - { key: readability-identifier-naming.ConstantMemberCase, value: CamelCase }
-  - { key: readability-identifier-naming.ConstantMemberPrefix, value: '' }
+  - { key: readability-identifier-naming.ConstantMemberCase, value: camelBack }
+  - { key: readability-identifier-naming.ConstantMemberRemovePrefixes, value: 'p,b,pfn,m_p,m_b' }
+  - { key: readability-identifier-naming.ConstantMemberPrefix, value: m_ }
   - { key: readability-identifier-naming.PublicMemberCase, value: camelBack }
   - { key: readability-identifier-naming.PublicMemberIgnoredRegexp, value: '^pSymName$' }
   - { key: readability-identifier-naming.PublicMemberPrefix, value: '' }

--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -166,14 +166,14 @@ private:
   // Does *not* automatically lock/unlock on construction/destruction.
   class CacheMapLock {
   public:
-    CacheMapLock(ShaderCache &sc, bool readOnlyLock) : m_sc(sc), ReadOnlyLock(readOnlyLock) {}
+    CacheMapLock(ShaderCache &sc, bool readOnlyLock) : m_sc(sc), m_readOnlyLock(readOnlyLock) {}
 
-    void lock() { m_sc.lockCacheMap(ReadOnlyLock); }
-    void unlock() { m_sc.unlockCacheMap(ReadOnlyLock); }
+    void lock() { m_sc.lockCacheMap(m_readOnlyLock); }
+    void unlock() { m_sc.unlockCacheMap(m_readOnlyLock); }
 
   private:
     ShaderCache &m_sc;
-    const bool ReadOnlyLock;
+    const bool m_readOnlyLock;
   };
 
   // Returns a new lock object that satisfies `BasicLockable`. It can be used with `std::condition_variable_any`.


### PR DESCRIPTION
Private, const members should have a m_ prefix,
only private, static, const members do not have the m_ prefix.

Fixes #1494.