### PR TITLE
Fix up scalar block layout option test

### DIFF
--- a/llpc/test/shaderdb/ScalarBlockLayoutOptionTest.spvasm
+++ b/llpc/test/shaderdb/ScalarBlockLayoutOptionTest.spvasm
@@ -2,15 +2,29 @@
 ; option.
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --scalar-block-layout --enable-pipeline-dump --pipeline-dump-dir=%basename_t
-; RUN: FileCheck -check-prefix=SHADERTEST %s < %basename_t/*pipe
-; SHADERTEST: options.scalarBlockLayout = 1
+; Create a fresh directory for pipeline dump files.
+; RUN: mkdir -p %t/dump
+;
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --scalar-block-layout --enable-pipeline-dump --pipeline-dump-dir=%t/dump
+; RUN: FileCheck -check-prefix=SHADERTEST %s < %t/dump/*.pipe
+; SHADERTEST:     options.scalarBlockLayout = 1
+; SHADERTEST-NOT: options.scalarBlockLayout = 0
+;
+; Clean up.
+; RUN: rm -rf %t/dump
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST1
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --scalar-block-layout=false --enable-pipeline-dump --pipeline-dump-dir=%basename_t
-; RUN: FileCheck -check-prefix=SHADERTEST1 %s < %basename_t/*pipe
-; SHADERTEST1: options.scalarBlockLayout = 0
+; Create a fresh directory for pipeline dump files.
+; RUN: mkdir -p %t/dump1
+;
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --scalar-block-layout=false --enable-pipeline-dump --pipeline-dump-dir=%t/dump1
+; RUN: FileCheck -check-prefix=SHADERTEST1 %s < %t/dump1/*.pipe
+; SHADERTEST1:     options.scalarBlockLayout = 0
+; SHADERTEST1-NOT: options.scalarBlockLayout = 1
+;
+; Clean up.
+; RUN: rm -rf %t/dump1
 ; END_SHADERTEST1
 
                OpCapability Shader


### PR DESCRIPTION
-  Remove dumps at the end so that lit does not discover them as unknown test cases and fail.
-  Isolate pipline dumps from the two subtests by placing them in different directories.
-  Make sure that the other block layout option does not appear in the output pipe file.