### PR TITLE
Implement `lgc::enumRange` in terms of `llvm::enum_seq`. NFC.

### DIFF
--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -56,9 +56,13 @@ enum ShaderStage : unsigned {
   ShaderStageCountInternal,                 ///< Count of shader stages (internal-use)
 };
 
+} // namespace lgc
+namespace llvm {
 // Enable iteration over shader stages with `lgc::enumRange<lgc::ShaderStage>()`.
-LGC_DEFINE_ZERO_BASED_ITERABLE_ENUM(ShaderStage, ShaderStage::ShaderStageCountInternal);
+LGC_DEFINE_ZERO_BASED_ITERABLE_ENUM(lgc::ShaderStage, lgc::ShaderStage::ShaderStageCountInternal);
+} // namespace llvm
 
+namespace lgc {
 // Enumerates the function of a particular node in a shader's resource mapping graph. Also used as descriptor
 // type in Builder descriptor functions.
 enum class ResourceNodeType : unsigned {
@@ -83,8 +87,10 @@ enum class ResourceNodeType : unsigned {
   DescriptorReserved16,
   Count, ///< Count of resource mapping node types.
 };
-
-// Enable iteration over resource node type with `lgc::enumRange<ResourceNodeType>()`.
-LGC_DEFINE_DEFAULT_ITERABLE_ENUM(ResourceNodeType);
-
 } // namespace lgc
+
+namespace llvm {
+// Enable iteration over resource node type with `lgc::enumRange<ResourceNodeType>()`.
+LGC_DEFINE_DEFAULT_ITERABLE_ENUM(lgc::ResourceNodeType);
+
+} // namespace llvm

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -131,13 +131,13 @@ inline bool doesShaderStageExist(llvm::ArrayRef<const PipelineShaderInfo *> shad
 }
 } // namespace Llpc
 
-namespace lgc {
+namespace llvm {
 // Make Vkgc::UnlinkedShaderStage iterable using `lgc::enumRange<Vkgc::ShaderStage>()`.
 LGC_DEFINE_ZERO_BASED_ITERABLE_ENUM(Vkgc::ShaderStage, Vkgc::ShaderStageCountInternal);
 
 // Make Vkgc::UnlinkedShaderStage iterable using `lgc::enumRange<Vkgc::UnlinedShaderStage>()`.
 LGC_DEFINE_ZERO_BASED_ITERABLE_ENUM(Vkgc::UnlinkedShaderStage, Vkgc::UnlinkedStageCount);
-} // namespace lgc
+} // namespace llvm
 
 namespace Llpc {
 // Returns the range of all native ShaderStages.


### PR DESCRIPTION
Now that LLVM supports safe enum iteration with `llvm::enum_seq`: https://reviews.llvm.org/D107378,
use it to implement `lgc::enumRange`. This only simplifies the code and does not change the behavior.

This also fixes a bug with a dangling reference on reverse iteration, which LLPC never ran into.