### PR TITLE
Fix typos

### DIFF
--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -106,7 +106,7 @@ bool LegacyBuilderReplayer::runOnModule(Module &module) {
 //
 // @param [in/out] module : LLVM module to be run on
 // @param [in/out] analysisManager : Analysis manager to use for this transformation
-// @returns : The preverved analyses (The Analyses that are still valid after this pass)
+// @returns : The preserved analyses (The Analyses that are still valid after this pass)
 PreservedAnalyses BuilderReplayer::run(Module &module, ModuleAnalysisManager &analysisManager) {
   PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
   runImpl(module, pipelineState);

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -92,7 +92,7 @@ bool LegacyPatchNullFragShader::runOnModule(Module &module) {
 //
 // @param [in/out] module : LLVM module to be run on
 // @param [in/out] analysisManager : Analysis manager to use for this transformation
-// @returns : The preverved analyses (The Analyses that are still valid after this pass)
+// @returns : The preserved analyses (The Analyses that are still valid after this pass)
 PreservedAnalyses PatchNullFragShader::run(Module &module, ModuleAnalysisManager &analysisManager) {
   PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
   if (runImpl(module, pipelineState))

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1611,7 +1611,7 @@ bool LegacyPipelineStateClearer::runOnModule(Module &module) {
 //
 // @param [in/out] module : IR module
 // @param [in/out] analysisManager : Analysis manager to use for this transformation
-// @returns : The preverved analyses (The Analyses that are still valid after this pass)
+// @returns : The preserved analyses (The Analyses that are still valid after this pass)
 PreservedAnalyses PipelineStateClearer::run(Module &module, ModuleAnalysisManager &analysisManager) {
   PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
   runImpl(module, pipelineState);


### PR DESCRIPTION
The patch to setup the new pass manager infrastructure for the middle-end passes introduced some typos. This patch fixes them.