### PR TITLE
Clean up `inputUtils` unit tests

### DIFF
--- a/llpc/unittests/CMakeLists.txt
+++ b/llpc/unittests/CMakeLists.txt
@@ -38,7 +38,8 @@ find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
   COMPONENTS Interpreter)
 
 # Find all the LLVM libraries necessary to use the LLVM components in gtest/gmock.
-set(LLVM_GTEST_LIBS gtest gtest_main)
+llvm_map_components_to_libnames(llvm_testing_support_lib TestingSupport)
+set(LLVM_GTEST_LIBS gtest gtest_main ${llvm_testing_support_lib})
 if(LLVM_PTHREAD_LIB)
   list(APPEND LLVM_GTEST_LIBS pthread)
 endif()


### PR DESCRIPTION
Use `llvm::Succeeded` and `llvm::Failed` from the testing support library to check `llvm::Expected<T>` values instead of reinventing the wheel.