### PR TITLE
Turn unused result warnings into errors on Clang/gcc

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -27,6 +27,7 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
             -Werror=unused-variable
             -Wunused-function
             -Werror=unused-function
+            -Werror=unused-result  # Error out on unused results of functions marked with LLPC_NODISCARD
         )
 
         target_compile_options("${PROJECT_NAME}" PRIVATE $<$<COMPILE_LANGUAGE:CXX>:


### PR DESCRIPTION
This is the last part of the proposal 1. from `[RFC] Improving LLPC Result checking`.

Now that all results are handled (https://github.com/GPUOpen-Drivers/llpc/pull/1500),
turn unused variable result into errors so that we don't regress.

Issue: https://github.com/GPUOpen-Drivers/llpc/issues/1474