### PR TITLE
Only set xnack attribute for a GPU that supports XNACK

### DIFF
--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -77,6 +77,7 @@ struct GpuProperty {
     unsigned sameSignedness : 1; // Whether the components of two vectors have the same signedness
     unsigned diffSignedness : 1; // Whether the components of two vectors have the diff signedness
   } supportIntegerDotFlag;       // The flag indicates the HW supports integer dot product
+  unsigned supportsXnack;        // GPU supports XNACK
 };
 
 // Contains flags for all of the hardware workarounds which affect pipeline compilation.

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -156,11 +156,12 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       targetFeatures += ",+cumode";
     }
 
-    if (m_pipelineState->getOptions().pageMigrationEnabled) {
-      // Enable xnack when page migration is enabled
-      targetFeatures += ",+xnack";
-    } else {
-      targetFeatures += ",-xnack";
+    if (m_pipelineState->getTargetInfo().getGpuProperty().supportsXnack) {
+      // Enable or disable xnack depending on whether page migration is enabled.
+      if (m_pipelineState->getOptions().pageMigrationEnabled)
+        targetFeatures += ",+xnack";
+      else
+        targetFeatures += ",-xnack";
     }
 
     // Set up denormal mode attributes.

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -210,6 +210,7 @@ static void setGfx8Info(TargetInfo *targetInfo) {
 static void setGfx800Info(TargetInfo *targetInfo) {
   setGfx8Info(targetInfo);
   targetInfo->getGpuProperty().numShaderEngines = 1;
+  targetInfo->getGpuProperty().supportsXnack = 1;
 }
 
 // gfx802/gfx805
@@ -256,6 +257,8 @@ static void setGfx9BaseInfo(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx9Info(TargetInfo *targetInfo) {
   setGfx9BaseInfo(targetInfo);
+
+  targetInfo->getGpuProperty().supportsXnack = 1;
 
   // TODO: Clean up code for all 1d texture patch
   targetInfo->getGpuWorkarounds().gfx9.treat1dImagesAs2d = 1;
@@ -314,6 +317,8 @@ static void setGfx10Info(TargetInfo *targetInfo) {
 static void setGfx1010Info(TargetInfo *targetInfo) {
   setGfx10Info(targetInfo);
 
+  targetInfo->getGpuProperty().supportsXnack = 1;
+
   targetInfo->getGpuWorkarounds().gfx10.waShaderInstPrefetch0 = 1;
   targetInfo->getGpuWorkarounds().gfx10.waDidtThrottleVmem = 1;
   targetInfo->getGpuWorkarounds().gfx10.waLdsVmemNotWaitingVmVsrc = 1;
@@ -330,6 +335,8 @@ static void setGfx1010Info(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx1011Info(TargetInfo *targetInfo) {
   setGfx10Info(targetInfo);
+
+  targetInfo->getGpuProperty().supportsXnack = 1;
 
   targetInfo->getGpuWorkarounds().gfx10.waShaderInstPrefetch0 = 1;
   targetInfo->getGpuWorkarounds().gfx10.waDidtThrottleVmem = 1;
@@ -353,6 +360,8 @@ static void setGfx1011Info(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx1012Info(TargetInfo *targetInfo) {
   setGfx10Info(targetInfo);
+
+  targetInfo->getGpuProperty().supportsXnack = 1;
 
   targetInfo->getGpuWorkarounds().gfx10.waShaderInstPrefetch0 = 1;
   targetInfo->getGpuWorkarounds().gfx10.waDidtThrottleVmem = 1;


### PR DESCRIPTION
Otherwise, LLVM outputs a warning to stderr that you can see when
running the compiler standalone.