### PR TITLE
Relax LGC lit test branch patterns

### DIFF
--- a/lgc/test/PackUnlinkVsGs.lgc
+++ b/lgc/test/PackUnlinkVsGs.lgc
@@ -6,13 +6,13 @@
 ; make sure the only ds_write instructions are for the VS output that are used by the GS, and that there are no others.
 ;
 ; CHECK-LABEL: _amdgpu_gs_main:
-; CHECK-NOT: {{^}}BB
+; CHECK-NOT: {{^[L\.]*}}BB
 ; CHECK-NOT: ds_write2_b32
 ; CHECK: ds_write2_b32 v{{[0-9]*}}, v{{[0-9]*}}, v{{[0-9]*}} offset1:1
 ; CHECK-NOT: ds_write2_b32
 ; CHECK: ds_write2_b32 v{{[0-9]*}}, v{{[0-9]*}}, v{{[0-9]*}} offset0:2 offset1:3
 ; CHECK-NOT: ds_write2_b32
-; CHECK: {{^}}BB
+; CHECK: {{^[L\.]*}}BB
 
 ; ModuleID = 'lgcPipeline'
 source_filename = "lgcPipeline"


### PR DESCRIPTION
LLVM backend can now generate local symbols for more branches (after D114273), so allow these in LGC lit test patterns.