### PR TITLE
Break up and modularize `buildPipeline`

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -299,6 +299,7 @@ add_library(llpc_standalone_compiler
     tool/llpcAutoLayout.cpp
     tool/llpcCompilationUtils.cpp
     tool/llpcInputUtils.cpp
+    tool/llpcPipelineBuilder.cpp
 )
 add_dependencies(llpc_standalone_compiler llpc)
 

--- a/llpc/tool/Makefile.apicompilerllpctool
+++ b/llpc/tool/Makefile.apicompilerllpctool
@@ -46,7 +46,8 @@ CPPFILES +=                   \
     amdllpc.cpp               \
     llpcAutoLayout.cpp        \
     llpcCompilationUtils.cpp  \
-    llpcInputUtils.cpp
+    llpcInputUtils.cpp        \
+    llpcPipelineBuilder.cpp
 
 EXE_TARGET = amdllpc
 

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -56,8 +56,8 @@
 
 #include "llpc.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include <vector>
 
 namespace Llpc {
 namespace StandaloneCompiler {
@@ -73,17 +73,17 @@ struct ShaderModuleData {
 
 // Represents global compilation info of LLPC standalone tool (as tool context).
 struct CompileInfo {
-  Llpc::GfxIpVersion gfxIp;                                            // Graphics IP version info
-  VkFlags stageMask;                                                   // Shader stage mask
-  std::vector<StandaloneCompiler::ShaderModuleData> shaderModuleDatas; // ShaderModule Data
-  Llpc::GraphicsPipelineBuildInfo gfxPipelineInfo;                     // Info to build graphics pipeline
-  Llpc::GraphicsPipelineBuildOut gfxPipelineOut;                       // Output of building graphics pipeline
-  Llpc::ComputePipelineBuildInfo compPipelineInfo;                     // Info to build compute pipeline
-  Llpc::ComputePipelineBuildOut compPipelineOut;                       // Output of building compute pipeline
-  void *pipelineBuf;                                                   // Allocation buffer of building pipeline
-  void *pipelineInfoFile;                                              // VFX-style file containing pipeline info
-  const char *fileNames;                                               // Names of input shader source files
-  std::string entryTarget;                                             // Name of the entry target function.
+  Llpc::GfxIpVersion gfxIp;                                                  // Graphics IP version info
+  VkFlags stageMask;                                                         // Shader stage mask
+  llvm::SmallVector<StandaloneCompiler::ShaderModuleData> shaderModuleDatas; // ShaderModule Data
+  Llpc::GraphicsPipelineBuildInfo gfxPipelineInfo;                           // Info to build graphics pipeline
+  Llpc::GraphicsPipelineBuildOut gfxPipelineOut;                             // Output of building graphics pipeline
+  Llpc::ComputePipelineBuildInfo compPipelineInfo;                           // Info to build compute pipeline
+  Llpc::ComputePipelineBuildOut compPipelineOut;                             // Output of building compute pipeline
+  void *pipelineBuf;                                                         // Allocation buffer of building pipeline
+  void *pipelineInfoFile;                                                    // VFX-style file containing pipeline info
+  llvm::SmallVector<std::string> fileNames;                                  // Names of input shader source files
+  std::string entryTarget;                                                   // Name of the entry target function
   bool unlinked;                  // Whether to generate unlinked shader/part-pipeline ELF
   bool relocatableShaderElf;      // Whether to enable relocatable shader compilation
   bool scalarBlockLayout;         // Whether to enable scalar block layout
@@ -112,10 +112,6 @@ Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileI
 // Builds shader module based on the specified SPIR-V binary.
 Result buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
 
-// Builds pipeline and does linking.
-Result buildPipeline(ICompiler *compiler, CompileInfo *compileInfo,
-                     llvm::Optional<Vkgc::PipelineDumpOptions> pipelineDumpOptions, bool timePasses);
-
 // Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
 Result outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile, llvm::StringRef firstInFile);
 
@@ -125,7 +121,7 @@ Result processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const
 
 // Processes and compiles multiple shader stage input files.
 Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, llvm::ArrayRef<std::string> inFiles,
-                          bool validateSpirv, std::string &fileNames);
+                          bool validateSpirv, llvm::SmallVectorImpl<std::string> &fileNames);
 
 } // namespace StandaloneCompiler
 } // namespace Llpc

--- a/llpc/tool/llpcPipelineBuilder.cpp
+++ b/llpc/tool/llpcPipelineBuilder.cpp
@@ -1,0 +1,270 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2016-2021 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcCompilationUtils.cpp
+ * @brief LLPC source file: contains the implementation LLPC pipeline compilation logic for standalone LLPC compilers.
+ ***********************************************************************************************************************
+ */
+#ifdef WIN_OS
+// NOTE: Disable Windows-defined min()/max() because we use STL-defined std::min()/std::max() in LLPC.
+#define NOMINMAX
+#endif
+
+#include "llpcPipelineBuilder.h"
+#include "llpcAutoLayout.h"
+#include "llpcDebug.h"
+#include "llpcInputUtils.h"
+#include "vkgcUtil.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/StringExtras.h"
+
+using namespace llvm;
+using namespace Vkgc;
+
+namespace Llpc {
+namespace StandaloneCompiler {
+
+// =====================================================================================================================
+// Returns true iff the compiled pipeline is a graphics pipeline.
+//
+// @returns : True if the compiled pipeline is a graphics pipeline, false if compute.
+bool PipelineBuilder::isGraphicsPipeline() const {
+  return (m_compileInfo.stageMask & (shaderStageToMask(ShaderStageCompute) - 1)) != 0;
+}
+
+// =====================================================================================================================
+// Builds pipeline using the provided build info and performs linking.
+//
+// @returns : Result::Success on success, other status on failure.
+Result PipelineBuilder::build() {
+  BinaryData pipeline = {};
+  const bool isGraphics = isGraphicsPipeline();
+  if (isGraphics) {
+    Result result = buildGraphicsPipeline(pipeline);
+    if (result != Result::Success)
+      return result;
+  } else {
+    Result result = buildComputePipeline(pipeline);
+    if (result != Result::Success)
+      return result;
+  }
+
+  return decodePipelineBinary(&pipeline, &m_compileInfo, isGraphics);
+}
+
+// =====================================================================================================================
+// Build the graphics pipeline.
+//
+// @param [in/out] outBinaryData : The compiled pipeline. The caller must value-initialize this parameter.
+// @returns : Result::Success on success, other status on failure.
+Result PipelineBuilder::buildGraphicsPipeline(BinaryData &outBinaryData) {
+  GraphicsPipelineBuildInfo *pipelineInfo = &m_compileInfo.gfxPipelineInfo;
+  GraphicsPipelineBuildOut *pipelineOut = &m_compileInfo.gfxPipelineOut;
+
+  // Fill pipeline shader info.
+  PipelineShaderInfo *shaderInfos[ShaderStageGfxCount] = {
+      &pipelineInfo->vs, &pipelineInfo->tcs, &pipelineInfo->tes, &pipelineInfo->gs, &pipelineInfo->fs,
+  };
+
+  ResourceMappingNodeMap nodeSets;
+  unsigned pushConstSize = 0;
+  for (StandaloneCompiler::ShaderModuleData &moduleData : m_compileInfo.shaderModuleDatas) {
+    const ShaderStage stage = moduleData.shaderStage;
+    PipelineShaderInfo *shaderInfo = shaderInfos[stage];
+    const ShaderModuleBuildOut *shaderOut = &moduleData.shaderOut;
+
+    // If entry target is not specified, use the one from command line option.
+    if (!shaderInfo->pEntryTarget)
+      shaderInfo->pEntryTarget = m_compileInfo.entryTarget.c_str();
+
+    shaderInfo->pModuleData = shaderOut->pModuleData;
+    shaderInfo->entryStage = stage;
+
+    // If not compiling from pipeline, lay out user data now.
+    if (m_compileInfo.doAutoLayout)
+      doAutoLayoutDesc(stage, moduleData.spirvBin, pipelineInfo, shaderInfo, nodeSets, pushConstSize,
+                       /*autoLayoutDesc = */ m_compileInfo.autoLayoutDesc);
+  }
+
+  if (m_compileInfo.doAutoLayout)
+    buildTopLevelMapping(m_compileInfo.stageMask, nodeSets, pushConstSize, &pipelineInfo->resourceMapping,
+                         m_compileInfo.autoLayoutDesc);
+
+  pipelineInfo->pInstance = nullptr; // Placeholder, unused.
+  pipelineInfo->pUserData = &m_compileInfo.pipelineBuf;
+  pipelineInfo->pfnOutputAlloc = allocateBuffer;
+  pipelineInfo->unlinked = m_compileInfo.unlinked;
+
+  // NOTE: If number of patch control points is not specified, we set it to 3.
+  if (pipelineInfo->iaState.patchControlPoints == 0)
+    pipelineInfo->iaState.patchControlPoints = 3;
+
+  pipelineInfo->options.robustBufferAccess = m_compileInfo.robustBufferAccess;
+  pipelineInfo->options.enableRelocatableShaderElf = m_compileInfo.relocatableShaderElf;
+  pipelineInfo->options.scalarBlockLayout = m_compileInfo.scalarBlockLayout;
+  pipelineInfo->options.enableScratchAccessBoundsChecks = m_compileInfo.scratchAccessBoundsChecks;
+
+  PipelineBuildInfo localPipelineInfo = {};
+  localPipelineInfo.pGraphicsInfo = pipelineInfo;
+  void *pipelineDumpHandle = runPreBuildActions(localPipelineInfo);
+  auto onExit = make_scope_exit([&] { runPostBuildActions(pipelineDumpHandle, outBinaryData); });
+
+  Result result = m_compiler.BuildGraphicsPipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
+  if (result != Result::Success)
+    return result;
+
+  outBinaryData = pipelineOut->pipelineBin;
+  return Result::Success;
+}
+
+// =====================================================================================================================
+// Build the compute pipeline.
+//
+// @param [in/out] outBinaryData : The compiled pipeline. The caller must value-initialize this parameter.
+// @returns : Result::Success on success, other status on failure.
+Result PipelineBuilder::buildComputePipeline(BinaryData &outBinaryData) {
+  assert(m_compileInfo.shaderModuleDatas.size() == 1);
+  assert(m_compileInfo.shaderModuleDatas[0].shaderStage == ShaderStageCompute);
+
+  ComputePipelineBuildInfo *pipelineInfo = &m_compileInfo.compPipelineInfo;
+  ComputePipelineBuildOut *pipelineOut = &m_compileInfo.compPipelineOut;
+
+  PipelineShaderInfo *shaderInfo = &pipelineInfo->cs;
+  const ShaderModuleBuildOut *shaderOut = &m_compileInfo.shaderModuleDatas[0].shaderOut;
+
+  // If entry target is not specified, use the one from command line option.
+  if (!shaderInfo->pEntryTarget)
+    shaderInfo->pEntryTarget = m_compileInfo.entryTarget.c_str();
+
+  shaderInfo->entryStage = ShaderStageCompute;
+  shaderInfo->pModuleData = shaderOut->pModuleData;
+
+  // If not compiling from pipeline, lay out user data now.
+  if (m_compileInfo.doAutoLayout) {
+    ResourceMappingNodeMap nodeSets;
+    unsigned pushConstSize = 0;
+    doAutoLayoutDesc(ShaderStageCompute, m_compileInfo.shaderModuleDatas[0].spirvBin, nullptr, shaderInfo, nodeSets,
+                     pushConstSize, /*autoLayoutDesc =*/m_compileInfo.autoLayoutDesc);
+
+    buildTopLevelMapping(ShaderStageComputeBit, nodeSets, pushConstSize, &pipelineInfo->resourceMapping,
+                         m_compileInfo.autoLayoutDesc);
+  }
+
+  pipelineInfo->pInstance = nullptr; // Placeholder, unused.
+  pipelineInfo->pUserData = &m_compileInfo.pipelineBuf;
+  pipelineInfo->pfnOutputAlloc = allocateBuffer;
+  pipelineInfo->unlinked = m_compileInfo.unlinked;
+  pipelineInfo->options.robustBufferAccess = m_compileInfo.robustBufferAccess;
+  pipelineInfo->options.enableRelocatableShaderElf = m_compileInfo.relocatableShaderElf;
+  pipelineInfo->options.scalarBlockLayout = m_compileInfo.scalarBlockLayout;
+  pipelineInfo->options.enableScratchAccessBoundsChecks = m_compileInfo.scratchAccessBoundsChecks;
+
+  PipelineBuildInfo localPipelineInfo = {};
+  localPipelineInfo.pComputeInfo = pipelineInfo;
+  void *pipelineDumpHandle = runPreBuildActions(localPipelineInfo);
+  auto onExit = make_scope_exit([&] { runPostBuildActions(pipelineDumpHandle, outBinaryData); });
+
+  Result result = m_compiler.BuildComputePipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
+  if (result != Result::Success)
+    return result;
+
+  outBinaryData = pipelineOut->pipelineBin;
+  return Result::Success;
+}
+
+// =====================================================================================================================
+// Runs pre-compilation actions: starts a pipeline dump (if requested) and prints pipeline info (if requested).
+// The caller must call `runPostBuildActions` after calling this function to perform the necessary cleanup.
+//
+// @param buildInfo : Build info of the pipeline.
+// @returns : Handle to the started pipeline dump, nullptr if pipeline dump was not started.
+void *PipelineBuilder::runPreBuildActions(PipelineBuildInfo buildInfo) {
+  void *pipelineDumpHandle = nullptr;
+  if (shouldDumpPipelines())
+    pipelineDumpHandle = IPipelineDumper::BeginPipelineDump(m_dumpOptions.getPointer(), buildInfo);
+
+  if (m_printPipelineInfo)
+    printPipelineInfo(buildInfo);
+
+  return pipelineDumpHandle;
+}
+
+// =====================================================================================================================
+// Runs post-compilation actions: finalizes the pipeline dump, if started. Must be called after `runPreBuildActions`.
+//
+// @param pipelineDumpHandle : Handle to the started pipeline dump.
+// @param pipeline : The compiled pipeline.
+void PipelineBuilder::runPostBuildActions(void *pipelineDumpHandle, BinaryData pipeline) {
+  if (!pipelineDumpHandle)
+    return;
+
+  if (pipeline.pCode)
+    IPipelineDumper::DumpPipelineBinary(pipelineDumpHandle, m_compileInfo.gfxIp, &pipeline);
+
+  IPipelineDumper::EndPipelineDump(pipelineDumpHandle);
+}
+
+// =====================================================================================================================
+// Prints pipeline dump hash code and filenames. Can be called before pipeline compilation.
+//
+// @param buildInfo : Build info of the pipeline.
+void PipelineBuilder::printPipelineInfo(PipelineBuildInfo buildInfo) {
+  uint64_t hash = 0;
+  if (isGraphicsPipeline())
+    hash = IPipelineDumper::GetPipelineHash(buildInfo.pGraphicsInfo);
+  else
+    hash = IPipelineDumper::GetPipelineHash(buildInfo.pComputeInfo);
+
+  LLPC_OUTS("LLPC PipelineHash: " << format("0x%016" PRIX64, hash) << " Files: " << join(m_compileInfo.fileNames, " ")
+                                  << "\n");
+}
+
+} // namespace StandaloneCompiler
+} // namespace Llpc

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -1,0 +1,86 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcPipelineBuilder.h
+ * @brief LLPC header file: pipeline compilation logic for standalone LLPC compilers.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcCompilationUtils.h"
+#include "vkgcDefs.h"
+#include "llvm/ADT/Optional.h"
+
+namespace Llpc {
+namespace StandaloneCompiler {
+
+// Performs pipeline compilation. Dumps compiled pipelines when requested.
+class PipelineBuilder {
+public:
+  // Creates a PipelineBuilder.
+  //
+  // @param compiler : LLPC compiler object.
+  // @param [in/out] compileInfo : Compilation info of LLPC standalone tool. This will be modified by `build()`.
+  // @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when llvm::None is passed.
+  // @param printPipelineInfo : Whether to print pipeline info (hash, filenames) before compilation.
+  PipelineBuilder(ICompiler &compiler, CompileInfo &compileInfo, llvm::Optional<Vkgc::PipelineDumpOptions> dumpOptions,
+                  bool printPipelineInfo)
+      : m_compiler(compiler), m_compileInfo(compileInfo), m_dumpOptions(std::move(dumpOptions)),
+        m_printPipelineInfo(printPipelineInfo) {}
+
+  // Compiles the pipeline and performs linking.
+  LLPC_NODISCARD Result build();
+
+  // Returns true iff the compiled pipeline is a graphics pipeline.
+  LLPC_NODISCARD bool isGraphicsPipeline() const;
+
+private:
+  // Returns true iff pipeline dumps are requested.
+  LLPC_NODISCARD bool shouldDumpPipelines() const { return m_dumpOptions.hasValue(); }
+
+  // Builds graphics pipeline and does linking.
+  LLPC_NODISCARD Result buildGraphicsPipeline(Vkgc::BinaryData &outPipeline);
+
+  // Builds compute pipeline and does linking.
+  LLPC_NODISCARD Result buildComputePipeline(Vkgc::BinaryData &outPipeline);
+
+  // Runs optional pre-build code (pipeline dumping, pipeline info printing).
+  LLPC_NODISCARD void *runPreBuildActions(Vkgc::PipelineBuildInfo buildInfo);
+
+  // Runs post-build cleanup code. Must be called after `runPrebuildActions`.
+  void runPostBuildActions(void *pipelineDumpHandle, Vkgc::BinaryData pipeline);
+
+  // Prints pipeline dump hash code and filenames.
+  void printPipelineInfo(Vkgc::PipelineBuildInfo buildInfo);
+
+  ICompiler &m_compiler;
+  CompileInfo &m_compileInfo;
+  llvm::Optional<Vkgc::PipelineDumpOptions> m_dumpOptions = llvm::None;
+  bool m_printPipelineInfo = false;
+};
+
+} // namespace StandaloneCompiler
+} // namespace Llpc


### PR DESCRIPTION
This is in preparation to support multi-stage shader compilation (e.g., vertex + tess)
without `.pipe` files.

-  Refactor `buildPipeline`. Move it into its own file and split the logic into smaller functions.
-  Reduce code duplication.
-  Fix a memory leak when compilation fails after a pipeline dump has been started.
-  Do not eagerly format input filenames.