### PR TITLE
[CI] Add nightly coverage build configurations

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -18,11 +18,20 @@ jobs:
         branch:         [dev]
         config:         [Release]
         assertions:     ["OFF", "ON"]
-        feature-set:    ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers"]
+        feature-set:    ["+gcc", "+clang", "+clang+shadercache", "+clang+sanitizers", "+clang+coverage", "+clang+shadercache+coverage"]
         generator:      [Ninja]
+        exclude:
+          - feature-set: "+clang"
+            assertions:  "OFF"
+          - feature-set: "+clang+shadercache"
+            assertions:  "ON"
+          - feature-set: "+clang+coverage"
+            assertions:  "ON"
+          - feature-set: "+clang+shadercache+coverage"
+            assertions:  "OFF"
     steps:
       - name: Free up disk space
-        if: contains(matrix.feature-set, '+sanitizers')
+        if: contains(matrix.feature-set, '+sanitizers') || contains(matrix.feature-set, '+coverage')
         run: |
           echo 'Before:' && df -h
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc
@@ -57,6 +66,10 @@ jobs:
                          --build-arg FEATURES="${{ matrix.feature-set }}" \
                          --build-arg GENERATOR="${{ matrix.generator }}" \
                          --tag "$IMAGE_TAG"
+      - name: Upload code coverage report
+        if: contains(matrix.feature-set, '+coverage')
+        run: |
+          gsutil -m cp -r /vulkandriver/coverage_report/* gs://amdvlk-llpc-github-ci-artifacts-public/coverage_${IMAGE_TAG}_${GITHUB_SHA}/
       - name: Push the new image
         run: |
           docker push "$IMAGE_TAG"

--- a/docker/generate-coverage-report.sh
+++ b/docker/generate-coverage-report.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Generates an HTML code coverage report using llvm-profdata (to merge raw profiles) and llvm-cov.
+# Assumes the profiles are under /vulkandriver, and writes to the output directory /vulkandriver/coverage_report.
+# Shared code between docker containers.
+set -e
+
+cd /vulkandriver
+
+# Merge raw profiles and delete them afterwards.
+llvm-profdata merge -sparse *.profraw -o code_coverage_profile.profdata
+rm *.profraw
+
+# Create HTML report. Ignore reporting coverage for files coming from LLVM as we are only interested in LLPC and would otherwise make the report very large.
+llvm-cov show -format=html -ignore-filename-regex='.*llvm.*' -instr-profile=code_coverage_profile.profdata builds/ci-build/compiler/llpc/amdllpc -o coverage_report


### PR DESCRIPTION
This PR adds two code coverage configurations to the nightly CI. A follow-up PR will integrate it with the per-PR CI.

Changes:
1) To keep the current maximum of 8 build configurations, the following configurations have been modified:

    - `+clang, assertions OFF` &rarr;  `+clang+coverage, assertions OFF`
    - `+clang+shadercache, assertions ON`  &rarr; `+clang+shadercache+coverage, assertions ON`.

    This makes sure we run code coverage for both configurations with and without shadercache and with and without assertions.

    The above change will also be made to XGL (https://github.com/GPUOpen-Drivers/xgl/blob/dev/.github/workflows/check-xgl-docker.yml) in a follow-up PR to allow it to pick up the new `+clang+coverage, assertions OFF` configuration that replaces the old `+clang, assertions OFF`.

2) For configurations that specify `+coverage`, the driver is built with Clang/LLVM's [source-based code coverage instrumentation](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) by using the compiler and linker flags `-fprofile-instr-generate -fcoverage-mapping`.

   I've changed how flags are handled in the docker script that generates the CMake command. Flags are now stored in an 
 Bash array, which should make it easier to handle flags with spaces in it (such as a collection of compiler flags).

3) When tests are run under a configuration that specifies `+coverage`, a new script `generate-coverage-report.sh` merges the raw profiles generated by running the tests and generates an HTML report limited to LLPC source files.

4) The report is uploaded to a public Google Cloud Storage bucket (`amdvlk-llpc-github-ci-artifacts-public`), storing it into a directory that uses the configuration string and the commit SHA as an identifier. The bucket is maintained by Google, and is read-only to the general public while write access is only granted to the CI bot and Google maintainers. 