### PR TITLE
Enable reloc tess shaders

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -908,14 +908,9 @@ static bool hasUnrelocatableDescriptorNode(const ResourceMappingData *resourceMa
 bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineShaderInfo *> &shaderInfos,
                                                   const GraphicsPipelineBuildInfo *pipelineInfo) {
   if (!pipelineInfo->unlinked) {
-    for (unsigned stage = 0; stage < shaderInfos.size(); ++stage) {
-      if (stage != ShaderStageVertex && stage != ShaderStageFragment && stage != ShaderStageGeometry) {
-        if (shaderInfos[stage] && shaderInfos[stage]->pModuleData)
-          return false;
-      } else if (stage != ShaderStageGeometry && (!shaderInfos[stage] || !shaderInfos[stage]->pModuleData)) {
-        // TODO: Generate pass-through shaders when the fragment or vertex shaders are missing.
-        return false;
-      }
+    if (!shaderInfos[ShaderStageFragment] || !shaderInfos[ShaderStageFragment]->pModuleData) {
+      // TODO: Generate a null fragment shader when linking.
+      return false;
     }
   }
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineTess_RelocRemoveUnusedTcsOutputs.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineTess_RelocRemoveUnusedTcsOutputs.pipe
@@ -3,10 +3,11 @@
 ; RUN: amdllpc -spvgen-dir=%spvgendir% \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST-LABEL: // LLPC location input/output mapping results (TES shader)
-; SHADERTEST: (TES) Input:  loc = 2, comp = 0 =>  Mapped = 0, 0
-; SHADERTEST-LABEL: // LLPC location input/output mapping results (TCS shader)
-; SHADERTEST: (TCS) Output: loc = 2, comp = 0  =>  Mapped = 0, 0
+; SHADERTEST: {{^}}Building pipeline with relocatable shader elf.
+; SHADERTEST-LABEL: {{^}}// LLPC location input/output mapping results (TES shader)
+; SHADERTEST: {{^}}(TES) Input:  loc = 2, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST-LABEL: {{^}}// LLPC location input/output mapping results (TCS shader)
+; SHADERTEST: {{^}}(TCS) Output: loc = 2, comp = 0  =>  Mapped = 0, 0
 ; END_SHADERTEST
 
 [Version]


### PR DESCRIPTION
I believe we have fixed all of the issues that are stopping us for compiling reloctable tess shaders.  This commit will enable them.
