### PR TITLE
Add glue shader for null frag shader.

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -135,6 +135,7 @@ target_sources(LLVMlgc PRIVATE
     elfLinker/ElfLinker.cpp
     elfLinker/FetchShader.cpp
     elfLinker/GlueShader.cpp
+    elfLinker/NullFragmentShader.cpp
     elfLinker/RelocHandler.cpp
 )
 

--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -32,6 +32,7 @@
 #include "GlueShader.h"
 #include "ColorExportShader.h"
 #include "FetchShader.h"
+#include "NullFragmentShader.h"
 #include "lgc/state/PassManagerCache.h"
 
 using namespace lgc;
@@ -69,4 +70,10 @@ std::unique_ptr<GlueShader> GlueShader::createFetchShader(PipelineState *pipelin
 std::unique_ptr<GlueShader> GlueShader::createColorExportShader(PipelineState *pipelineState,
                                                                 ArrayRef<ColorExportInfo> exports) {
   return std::make_unique<ColorExportShader>(pipelineState, exports);
+}
+
+// =====================================================================================================================
+// Create a null fragment shader object
+std::unique_ptr<GlueShader> GlueShader::createNullFragmentShader(PipelineState *pipelineState) {
+  return std::make_unique<NullFragmentShader>(pipelineState);
 }

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -53,6 +53,9 @@ public:
   static std::unique_ptr<GlueShader> createColorExportShader(PipelineState *pipelineState,
                                                              llvm::ArrayRef<ColorExportInfo> exports);
 
+  // Create a null fragment shader
+  static std::unique_ptr<GlueShader> createNullFragmentShader(PipelineState *pipelineState);
+
   // Get the string for this glue shader. This is some encoding or hash of the inputs to the create*Shader function
   // that the front-end client can use as a cache key to avoid compiling the same glue shader more than once.
   virtual llvm::StringRef getString() = 0;

--- a/lgc/elfLinker/NullFragmentShader.cpp
+++ b/lgc/elfLinker/NullFragmentShader.cpp
@@ -1,0 +1,74 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  NullFragmentShader.cpp
+ * @brief LGC source file: The class to generate the null fragment shader when linking.
+ ***********************************************************************************************************************
+ */
+
+#include "NullFragmentShader.h"
+#include "lgc/patch/FragColorExport.h"
+#include "lgc/patch/Patch.h"
+#include "lgc/state/TargetInfo.h"
+#include "llvm/Target/TargetMachine.h"
+
+using namespace lgc;
+using namespace llvm;
+
+// =====================================================================================================================
+// Generate the IR module for the null fragment shader
+//
+// @returns : The module containing the null fragment shader.
+Module *NullFragmentShader::generate() {
+  Module *module = generateEmptyModule();
+  Function *entryPoint = FragColorExport::generateNullFragmentShader(*module, getGlueShaderName());
+  addDummyExportIfNecessary(entryPoint);
+  return module;
+}
+
+// =====================================================================================================================
+// Adds a dummy export to the entry point if it is needed.
+//
+// @param [in/out] entryPoint : The function in which to add the dummy export.
+void NullFragmentShader::addDummyExportIfNecessary(Function *entryPoint) const {
+  if (m_lgcContext->getTargetInfo().getGfxIpVersion().major < 10) {
+    auto ret = cast<ReturnInst>(entryPoint->back().getTerminator());
+    BuilderBase builder(ret);
+    FragColorExport::addDummyExport(builder);
+  }
+}
+
+// =====================================================================================================================
+// Creates an empty module to be used for generating the null fragment shader.
+//
+// @returns : The new module.
+Module *NullFragmentShader::generateEmptyModule() const {
+  Module *module = new Module("nullFragmentShader", getContext());
+  TargetMachine *targetMachine = m_lgcContext->getTargetMachine();
+  module->setTargetTriple(targetMachine->getTargetTriple().getTriple());
+  module->setDataLayout(targetMachine->createDataLayout());
+  return module;
+}

--- a/lgc/elfLinker/NullFragmentShader.h
+++ b/lgc/elfLinker/NullFragmentShader.h
@@ -1,0 +1,75 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  NullFragmentShader.h
+ * @brief LGC header file: The class to generate the null fragment shader when linking.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "GlueShader.h"
+#include "lgc/state/PalMetadata.h"
+#include "lgc/state/PipelineState.h"
+
+namespace lgc {
+
+// =====================================================================================================================
+// The class to generate the null fragment shader when linking.
+class NullFragmentShader : public GlueShader {
+public:
+  NullFragmentShader(PipelineState *pipelineState) : GlueShader(pipelineState->getLgcContext()) {}
+
+  // Get the string for this glue shader. This is some encoding or hash of the inputs to the create*Shader function
+  // that the front-end client can use as a cache key to avoid compiling the same glue shader more than once.
+  llvm::StringRef getString() override { return "null"; }
+
+  // Get the symbol name of the main shader that this glue shader is prolog or epilog for.
+  llvm::StringRef getMainShaderName() override {
+    return getEntryPointName(llvm::CallingConv::AMDGPU_PS, /*isFetchlessVs=*/false);
+  }
+
+  // Get the symbol name of the glue shader.
+  llvm::StringRef getGlueShaderName() override {
+    return getEntryPointName(llvm::CallingConv::AMDGPU_PS, /*isFetchlessVs=*/false);
+  }
+
+  // Get whether this glue shader is a prolog (rather than epilog) for its main shader.
+  bool isProlog() override { return false; }
+
+  // Get the name of this glue shader.
+  llvm::StringRef getName() const override { return "null fragment shader"; }
+
+  // Update the entries in the PAL metadata that require both the pipeline state and export info.  So far, no entries
+  // seem to be needed for the null fragment shader.
+  void updatePalMetadata(PalMetadata &palMetadata) override {}
+
+protected:
+  llvm::Module *generate() override;
+  llvm::Module *generateEmptyModule() const;
+  void addDummyExportIfNecessary(llvm::Function *entryPoint) const;
+};
+
+} // namespace lgc

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -64,6 +64,9 @@ public:
                                   llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);
   static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
   static llvm::CallInst *addDummyExport(BuilderBase &builder);
+  static llvm::Function *generateNullFragmentShader(llvm::Module &module, llvm::StringRef entryPointName);
+  static llvm::Function *generateNullFragmentEntryPoint(llvm::Module &module, llvm::StringRef entryPointName);
+  static void generateNullFragmentShaderBody(llvm::Function *entryPoint);
 
 private:
   FragColorExport() = delete;

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -120,7 +120,7 @@ bool PatchNullFragShader::runImpl(Module &module, PipelineState *pipelineState) 
   if (hasFs || !pipelineState->isGraphics())
     return false;
 
-  generateNullFragmentShader(module);
+  FragColorExport::generateNullFragmentShader(module, lgcName::NullFsEntryPoint);
   updatePipelineState(pipelineState);
   return true;
 }
@@ -140,39 +140,6 @@ void PatchNullFragShader::updatePipelineState(PipelineState *pipelineState) cons
   origLocInfo.setLocation(0);
   auto &newOutLocInfo = resUsage->inOutUsage.outputLocInfoMap[origLocInfo];
   newOutLocInfo.setData(InvalidValue);
-}
-
-// =====================================================================================================================
-// Generate a new fragment shader that has the minimum code needed to make PAL happy.
-//
-// @param [in/out] module : The LLVM module in which to add the shader.
-void PatchNullFragShader::generateNullFragmentShader(Module &module) {
-  Function *entryPoint = generateNullFragmentEntryPoint(module);
-  generateNullFragmentShaderBody(entryPoint);
-}
-
-// =====================================================================================================================
-// Generate a new entry point for a null fragment shader.
-//
-// @param [in/out] module : The LLVM module in which to add the entry point.
-// @returns : The new entry point.
-Function *PatchNullFragShader::generateNullFragmentEntryPoint(Module &module) {
-  FunctionType *entryPointTy = FunctionType::get(Type::getVoidTy(module.getContext()), ArrayRef<Type *>(), false);
-  Function *entryPoint =
-      Function::Create(entryPointTy, GlobalValue::ExternalLinkage, lgcName::NullFsEntryPoint, &module);
-  entryPoint->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
-  setShaderStage(entryPoint, ShaderStageFragment);
-  return entryPoint;
-}
-
-// =====================================================================================================================
-// Generate the body of the null fragment shader.
-//
-// @param [in/out] entryPoint : The function in which the code will be inserted.
-void PatchNullFragShader::generateNullFragmentShaderBody(llvm::Function *entryPoint) {
-  BasicBlock *block = BasicBlock::Create(entryPoint->getContext(), "", entryPoint);
-  BuilderBase builder(block);
-  builder.CreateRetVoid();
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PatchNullFragShader.h
+++ b/lgc/patch/PatchNullFragShader.h
@@ -25,10 +25,7 @@ public:
   bool runImpl(llvm::Module &module, PipelineState *pipelineState);
 
   static llvm::StringRef name() { return "Patch LLVM for null fragment shader generation"; }
-  static void generateNullFragmentShader(llvm::Module &module);
   void updatePipelineState(PipelineState *pipelineState) const;
-  static llvm::Function *generateNullFragmentEntryPoint(llvm::Module &module);
-  static void generateNullFragmentShaderBody(llvm::Function *entryPoint);
 };
 
 } // namespace lgc

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -907,13 +907,6 @@ static bool hasUnrelocatableDescriptorNode(const ResourceMappingData *resourceMa
 // @param pipelineInfo : Pipeline info for the pipeline to be built
 bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineShaderInfo *> &shaderInfos,
                                                   const GraphicsPipelineBuildInfo *pipelineInfo) {
-  if (!pipelineInfo->unlinked) {
-    if (!shaderInfos[ShaderStageFragment] || !shaderInfos[ShaderStageFragment]->pModuleData) {
-      // TODO: Generate a null fragment shader when linking.
-      return false;
-    }
-  }
-
   // Check user data nodes for unsupported Descriptor types.
   if (hasUnrelocatableDescriptorNode(&pipelineInfo->resourceMapping))
     return false;

--- a/llpc/test/shaderdb/PipelineVsFs_NullFragmentShader.pipe
+++ b/llpc/test/shaderdb/PipelineVsFs_NullFragmentShader.pipe
@@ -14,14 +14,14 @@
 ; BEGIN_PAL_RELOC
 
 ; BEGIN_GEN_FULL
-; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=%gfxip -D -r %t.elf | FileCheck -check-prefix=GEN_FULL %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=%gfxip -D -r %t.elf | FileCheck -check-prefix=GEN_FULL %s
 ; Check that the PS is defined.  The body of the shader is not important since it should not be run.
 ; GEN_FULL-LABEL: <_amdgpu_ps_main>:
 ; GEN_FULL: s_endpgm
 ; END_GEN_FULL
 
 ; BEGIN_PAL_FULL
-; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | FileCheck -check-prefix=PAL_FULL %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s -v | FileCheck -check-prefix=PAL_FULL %s
 ; Make sure the DX_RASTERIZATION_KILL is set in the PAL_FULL metadata.
 ; PAL_FULL: PA_CL_CLIP_CNTL 0x0000000001400000
 ; BEGIN_PAL_FULL


### PR DESCRIPTION
When linking a pipeline that is missing the fragment shader, we need to
generate the null fragment shader.  This PR will get the linking code to
generate the null fragment shader when necessary.


This is built on top of #1539 since they will conflict.  I can rebase when that PR is merged.
