### PR TITLE
Introduce `ResultError` to support `Result`-based `llvm::Error`s

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -237,6 +237,7 @@ if(ICD_BUILD_LLPC)
         util/llpcCacheAccessor.cpp
         util/llpcDebug.cpp
         util/llpcElfWriter.cpp
+        util/llpcError.cpp
         util/llpcFile.cpp
         util/llpcShaderModuleHelper.cpp
         util/llpcTimerProfiler.cpp

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -36,6 +36,7 @@
 #include "llpcContext.h"
 #include "llpcDebug.h"
 #include "llpcElfWriter.h"
+#include "llpcError.h"
 #include "llpcFile.h"
 #include "llpcGraphicsContext.h"
 #include "llpcShaderModuleHelper.h"

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -29,6 +29,7 @@
 ***********************************************************************************************************************
 */
 #include "llpcShaderCache.h"
+#include "llpcError.h"
 #include "llpcFile.h"
 #include "vkgcUtil.h"
 #include "llvm/ADT/StringExtras.h"

--- a/llpc/context/llpcShaderCacheManager.cpp
+++ b/llpc/context/llpcShaderCacheManager.cpp
@@ -29,6 +29,7 @@
 ***********************************************************************************************************************
 */
 #include "llpcShaderCacheManager.h"
+#include "llpcError.h"
 
 #define DEBUG_TYPE "llpc-shader-cache-manager"
 

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -36,6 +36,7 @@
 #include "llpc.h"
 #include "llpcCompilationUtils.h"
 #include "llpcDebug.h"
+#include "llpcError.h"
 #include "llpcFile.h"
 #include "llpcInputUtils.h"
 #include "llpcPipelineBuilder.h"

--- a/llpc/unittests/standaloneCompiler/CMakeLists.txt
+++ b/llpc/unittests/standaloneCompiler/CMakeLists.txt
@@ -26,6 +26,7 @@
 add_llpc_unittest(LlpcStandaloneCompilerTests
   testInputUtils.cpp
   testMetroHash.cpp
+  testResultError.cpp
   testShaderCache.cpp
 )
 

--- a/llpc/unittests/standaloneCompiler/testResultError.cpp
+++ b/llpc/unittests/standaloneCompiler/testResultError.cpp
@@ -1,0 +1,109 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "llpcError.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <system_error>
+
+using namespace llvm;
+using Vkgc::Result;
+
+namespace Llpc {
+namespace {
+
+using ::testing::StrEq;
+
+// cppcheck-suppress syntaxError
+TEST(ResultErrorTest, PlaceholderPass) {
+  EXPECT_TRUE(true);
+}
+
+TEST(ResultErrorTest, ResultErrorCodeSuccess) {
+  std::error_code err = resultToErrorCode(Result::Success);
+  EXPECT_FALSE(static_cast<bool>(err)) << err;
+  EXPECT_EQ(err.value(), 0);
+  EXPECT_THAT(err.category().name(), StrEq("Vkgc::Result"));
+  EXPECT_THAT(err.message(), StrEq("Success"));
+}
+
+TEST(ResultErrorTest, ResultErrorCodeFailure) {
+  std::error_code err = resultToErrorCode(Result::ErrorInvalidShader);
+  EXPECT_TRUE(static_cast<bool>(err)) << err;
+  EXPECT_EQ(err.value(), static_cast<int>(Result::ErrorInvalidShader));
+  EXPECT_THAT(err.category().name(), StrEq("Vkgc::Result"));
+  EXPECT_THAT(err.message(), StrEq("ErrorInvalidShader"));
+}
+
+TEST(ResultErrorTest, ResultErrorEmptyMessage) {
+  Error err = createResultError(Result::NotFound);
+  ASSERT_TRUE(err.isA<ResultError>());
+  std::string errorMessage;
+  raw_string_ostream os(errorMessage);
+  os << err;
+  os.flush();
+  EXPECT_THAT(errorMessage, StrEq("Result::NotFound"));
+
+  auto remainingErrors = handleErrors(
+      std::move(err), [](const ResultError &resultError) { EXPECT_EQ(resultError.getResult(), Result::NotFound); });
+  EXPECT_THAT_ERROR(std::move(remainingErrors), Succeeded());
+}
+
+TEST(ResultErrorTest, ResultErrorCustomMessage) {
+  Error err = createResultError(Result::ErrorUnavailable, "My message");
+  ASSERT_TRUE(err.isA<ResultError>());
+  EXPECT_THAT_ERROR(std::move(err), FailedWithMessage(StrEq("Result::ErrorUnavailable: My message")));
+}
+
+TEST(ResultErrorTest, ErrorToResultSuccess) {
+  Error err = Error::success();
+  EXPECT_EQ(errorToResult(std::move(err)), Result::Success);
+}
+
+TEST(ResultErrorTest, ErrorToResultFailure) {
+  Error err = createResultError(Result::NotFound);
+  EXPECT_EQ(errorToResult(std::move(err)), Result::NotFound);
+}
+
+Expected<int> mayFail(int value) {
+  if (value == 0)
+    return createResultError(Result::ErrorInvalidValue, "Zero passed");
+  return value;
+}
+
+TEST(ResultErrorTest, ExpectedResult) {
+  auto valueOrErr = mayFail(42);
+  ASSERT_THAT_EXPECTED(valueOrErr, Succeeded());
+  EXPECT_EQ(*valueOrErr, 42);
+
+  valueOrErr = mayFail(0);
+  EXPECT_THAT_EXPECTED(valueOrErr, FailedWithMessage(StrEq("Result::ErrorInvalidValue: Zero passed")));
+}
+
+} // namespace
+} // namespace Llpc

--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -31,6 +31,7 @@
  */
 #include "llpcCacheAccessor.h"
 #include "llpcContext.h"
+#include "llpcError.h"
 
 #define DEBUG_TYPE "llpc-cache-accessor"
 

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -85,15 +85,6 @@ bool EnableErrs() {
 }
 
 // =====================================================================================================================
-// Prints the error message in `err` to LLPC_ERRS and consumes the error.
-//
-// @param err : The error to handle.
-void reportError(Error &&err) {
-  // For details on llvm error handling, see https://llvm.org/docs/ProgrammersManual.html#recoverable-errors.
-  handleAllErrors(std::move(err), [](const ErrorInfoBase &baseError) { LLPC_ERRS(baseError.message() << "\n"); });
-}
-
-// =====================================================================================================================
 // Redirects the output of logs. It affects the behavior of llvm::outs(), dbgs() and errs().
 //
 // NOTE: This function redirects log output by modify the underlying static raw_fd_ostream object in outs() and errs().

--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -49,10 +49,6 @@
     }                                                                                                                  \
   while (false)
 
-namespace llvm {
-class Error;
-} // namespace llvm
-
 namespace MetroHash {
 struct Hash;
 } // namespace MetroHash
@@ -64,9 +60,6 @@ bool EnableOuts();
 
 // Gets the value of option "enable-errs"
 bool EnableErrs();
-
-// Prints the error to LLPC_ERRS and consumes it.
-void reportError(llvm::Error &&err);
 
 // Redirects the output of logs, It affects the behavior of llvm::outs(), dbgs() and errs().
 void redirectLogOutput(bool restoreToDefault, unsigned optionCount, const char *const *options);

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -30,6 +30,7 @@
  */
 #include "llpcElfWriter.h"
 #include "llpcContext.h"
+#include "llpcError.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 #include <algorithm>

--- a/llpc/util/llpcError.cpp
+++ b/llpc/util/llpcError.cpp
@@ -1,0 +1,135 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcError.cpp
+ * @brief LLPC source file: contains implementation of LLPC error handling utilities
+ ***********************************************************************************************************************
+ */
+#include "llpcError.h"
+#include "llpc.h"
+#include "llpcDebug.h"
+#include <cassert>
+#include <system_error>
+
+using namespace llvm;
+
+namespace Llpc {
+
+// =====================================================================================================================
+// Handles passed `result` and checks if it is a Success. Prints `errorMessage` if not.
+//
+// @param result : Result to check
+// @param errorMessage : Optional error message to print on failure
+void mustSucceed(Result result, const Twine &errorMessage) {
+  if (result == Result::Success)
+    return;
+
+  if (errorMessage.isTriviallyEmpty())
+    LLPC_ERRS("Unhandled error result\n");
+  else
+    LLPC_ERRS("Unhandled error result: " << errorMessage << "\n");
+
+  assert(false && "Result is not Success");
+}
+
+// =====================================================================================================================
+// Prints the error message in `err` to LLPC_ERRS and consumes the error.
+//
+// @param err : The error to handle
+void reportError(Error &&err) {
+  // For details on llvm error handling, see https://llvm.org/docs/ProgrammersManual.html#recoverable-errors.
+  handleAllErrors(std::move(err), [](const ErrorInfoBase &baseError) { LLPC_ERRS(baseError.message() << "\n"); });
+}
+
+char ResultError::ID = 0;
+
+namespace {
+// Make `Vkgc::Result` compatible with `std::error_category`. Because `Result` does not clearly map to the `std::errc`
+// codes, we create a custom error category. We need this because `llvm::Error` expects custom error values to be
+// convertible to `std::error_code`.
+// See https://en.cppreference.com/w/cpp/error/error_category for C++ error-handling details.
+struct ResultErrorCategory : std::error_category {
+  const char *name() const noexcept override { return "Vkgc::Result"; }
+
+  std::string message(int errorValue) const override {
+    const Result result = static_cast<Result>(errorValue);
+    switch (result) {
+    case Result::ErrorInvalidPointer:
+      return "ErrorInvalidPointer";
+    case Result::ErrorInvalidShader:
+      return "ErrorInvalidShader";
+    case Result::ErrorInvalidValue:
+      return "ErrorInvalidValue";
+    case Result::ErrorOutOfMemory:
+      return "ErrorOutOfMemory";
+    case Result::ErrorUnavailable:
+      return "ErrorUnavailable";
+    case Result::ErrorUnknown:
+      return "ErrorUnknown";
+    case Result::Delayed:
+      return "Delayed";
+    case Result::NotFound:
+      return "NotFound";
+    case Result::NotReady:
+      return "NotReady";
+    case Result::Unsupported:
+      return "Unsupported";
+    case Result::Success:
+      return "Success";
+    default:
+      llvm_unreachable("Invalid Result code");
+      return "Invalid Result code";
+    }
+  }
+};
+} // namespace
+
+// =====================================================================================================================
+// Converts a `Result` to a `std::error_code` with a custom error category.
+//
+// @param result : The `Result` value to convert
+// @returns : A new `std::error_code` with the `ResultErrorCategory` error category.
+std::error_code resultToErrorCode(Result result) {
+  static ResultErrorCategory GlobalCategoryId{};
+  return {static_cast<int>(result), GlobalCategoryId};
+}
+
+// =====================================================================================================================
+// Extracts the `Result` value from the given `ResultError`.
+//
+// @param err : The error to handle. This must be either a `ResultError` or `llvm::ErrorSuccess`.
+// @returns : `Result::Success` on `llvm::ErrorSuccess` or the underlying `Result` value in case of `ResultError`.
+Result errorToResult(Error &&err) {
+  if (!err)
+    return Result::Success;
+
+  assert(err.isA<ResultError>() && "Not a ResultError");
+  Result result = Result::ErrorUnknown;
+  handleAllErrors(std::move(err), [&result](const ResultError &err) { result = err.getResult(); });
+  return result;
+}
+
+} // namespace Llpc

--- a/llpc/util/llpcError.h
+++ b/llpc/util/llpcError.h
@@ -1,0 +1,126 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcError.h
+ * @brief LLPC header file: contains the definition of LLPC error handling utilities
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "vkgcDefs.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Error.h"
+#include <cassert>
+
+namespace Llpc {
+
+// Handles passed `result` and checks if it is a Success. Prints `errorMessage` if not.
+void mustSucceed(Vkgc::Result result, const llvm::Twine &errorMessage = {});
+
+// Prints the error to LLPC_ERRS and consumes it.
+void reportError(llvm::Error &&err);
+
+// Converts a `Vkgc::Result` to `std::error_code` with a custom error category.
+LLPC_NODISCARD std::error_code resultToErrorCode(Vkgc::Result result);
+
+// A custom LLPC Error class that holds a `Vkgc::Result` and, optionally, and error message.
+// ResultError work with the standard LLVM error handling utilities, including:
+// *  `llvm::Expected<T>` -- holds either a value or an Error.
+// *  `llvm::Error` -- typed-erased error class. You can create one with `createResultError(result, message)`.
+// *  `llvm::handleErrors`, `llvm::cantFail`, `llvm::errorToBool`, and other error handling functions.
+//
+// See https://llvm.org/docs/ProgrammersManual.html#recoverable-errors for LLVM error handling details.
+//
+// Usage sample:
+// ```c++
+// Expected<size_t> getFileSize(StringRef path) {
+//   if (exists(path))
+//     return file_size(path);
+//   return createResultError(Result::NotFound, Twine("File ") + path + " does not exist");
+// }
+//
+// // An internal LLPC function.
+// Expected<BinaryData> readSpirvFile(StringRef path) {
+//   auto sizeOrErr = getFileSize(path);
+//   if (Error err = sizeOrErr.takeError())
+//     return std::move(err); // Let the caller decide how to handle this error.
+//   BinaryData spv = {};
+//   spv.size = *sizeOrErr;
+//   ...
+//   return spv;
+// }
+//
+// // A public function exposed to XGL.
+// Result getCacheSize(size_t *outSize) {
+//   auto sizeOrErr = getFileSize(m_cacheFile);
+//   if (Error err = sizeOrErr.takeError())
+//     return errorToResult(std::move(err)); // We do not return LLVM errors to XGL.
+//   *outSize = *sizeOrErr;
+//   return Result::Success;
+// }
+// ```
+class LLPC_NODISCARD ResultError : public llvm::ErrorInfo<ResultError> {
+public:
+  // Creates a new `ResultError` with a non-Success `Result` value and an optional error message.
+  ResultError(Vkgc::Result result, const llvm::Twine &errorMessage = {})
+      : m_message(errorMessage.str()), m_result(result) {
+    assert(m_result != Vkgc::Result::Success && "Result::Success is not an error");
+  }
+
+  void log(llvm::raw_ostream &os) const override {
+    os << "Result::" << convertToErrorCode().message();
+    if (!m_message.empty())
+      os << ": " << m_message;
+  }
+
+  LLPC_NODISCARD std::error_code convertToErrorCode() const override { return resultToErrorCode(m_result); }
+
+  LLPC_NODISCARD const std::string &getMessage() const { return m_message; }
+  LLPC_NODISCARD Vkgc::Result getResult() const { return m_result; }
+
+  // Globally unique ID to register this Error type. Required by `llvm::ErrorInfo::classID`.
+  static char ID; // NOLINT
+
+private:
+  std::string m_message;
+  Vkgc::Result m_result = Vkgc::Result::ErrorUnknown;
+};
+
+// =====================================================================================================================
+// Creates an `llvm::Error` containing a `ResultError`.
+//
+// @param result : Non-Success Result value
+// @param errorMessage : Optional error message
+// @returns : New `llvm::Error` containing a `ResultError(result, errorMessage)`
+inline llvm::Error createResultError(Vkgc::Result result, const llvm::Twine &errorMessage = {}) {
+  return llvm::make_error<ResultError>(result, errorMessage);
+}
+
+// Extracts the `Result` value from the given `ResultError`. Assumes that `err` is either a `ResultError` or
+// `llvm::ErrorSuccess`.
+LLPC_NODISCARD Vkgc::Result errorToResult(llvm::Error &&err);
+
+} // namespace Llpc

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -45,23 +45,6 @@ using namespace Vkgc;
 namespace Llpc {
 
 // =====================================================================================================================
-// Handles passed `result` and checks if it is a Success. Prints `errorMessage` if not.
-//
-// @param result : Result to check
-// @param errorMessage : Optional error message to print on failure
-void mustSucceed(Result result, const Twine &errorMessage) {
-  if (result == Result::Success)
-    return;
-
-  if (errorMessage.isTriviallyEmpty())
-    LLPC_ERRS("Unhandled error result\n");
-  else
-    LLPC_ERRS("Unhandled error result: " << errorMessage << "\n");
-
-  assert(false && "Result is not Success");
-}
-
-// =====================================================================================================================
 // Gets the name string of shader stage.
 //
 // @param shaderStage : Shader stage

--- a/llpc/util/llpcUtil.h
+++ b/llpc/util/llpcUtil.h
@@ -25,8 +25,7 @@
 /**
  ***********************************************************************************************************************
  * @file  llpcUtil.h
- * @brief LLPC header file: contains the definition of LLPC internal types and utility functions
- * (independent of LLVM use).
+ * @brief LLPC header file: contains the definition of LLPC internal types and utility functions.
  ***********************************************************************************************************************
  */
 #pragma once
@@ -62,9 +61,6 @@ spv::ExecutionModel convertToExecModel(ShaderStage shaderStage);
 
 // Convert SPIR-V execution model to the shader stage
 ShaderStage convertToShaderStage(unsigned execModel);
-
-// Handles passed `result` and checks if it is a Success. Prints `errorMessage` if not.
-void mustSucceed(Vkgc::Result result, const llvm::Twine &errorMessage = "");
 
 // =====================================================================================================================
 // Gets module ID according to the index


### PR DESCRIPTION
Introduce a new class `Llpc::ResultError` that implements a `Result`-based
`llvm::Error` type. This is primarily to support returning either error results
or values with `llvm::Expected<T>`.

Also implement the necessary utility functions, and move some existing ones to the
new header.

I also considered using `llvm::StringError` directly, but this did not work well as
some `Vkgc::Result` values do not map well to any `std::errc` error codes, and it was
difficult to convert back to `Vkgc::Result`, which many existing APIs expect.

See the mailing list thread `[RFC] Improving LLPC Result checking` for the proposal
details.