### PR TITLE
Add nodiscard annotations to `llpcCompilationUtils.h`

### DIFF
--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -100,28 +100,30 @@ void *VKAPI_CALL allocateBuffer(void *instance, void *userData, size_t size);
 void cleanupCompileInfo(CompileInfo *compileInfo);
 
 // GLSL compiler, compiles GLSL source text file (input) to SPIR-V binary file (output).
-Result compileGlsl(const std::string &inFilename, ShaderStage *stage, std::string &outFilename,
-                   const std::string &defaultEntryTarget);
+LLPC_NODISCARD Result compileGlsl(const std::string &inFilename, ShaderStage *stage, std::string &outFilename,
+                                  const std::string &defaultEntryTarget);
 
 // SPIR-V assembler, converts SPIR-V assembly text file (input) to SPIR-V binary file (output).
-Result assembleSpirv(const std::string &inFilename, std::string &outFilename);
+LLPC_NODISCARD Result assembleSpirv(const std::string &inFilename, std::string &outFilename);
 
 // Decodes the binary after building a pipeline and outputs the decoded info.
-Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileInfo, bool isGraphics);
+LLPC_NODISCARD Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileInfo, bool isGraphics);
 
 // Builds shader module based on the specified SPIR-V binary.
-Result buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
+LLPC_NODISCARD Result buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
 
 // Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
-Result outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile, llvm::StringRef firstInFile);
+LLPC_NODISCARD Result outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile,
+                                llvm::StringRef firstInFile);
 
 // Processes and compiles one pipeline input file.
-Result processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const std::string &inFile, bool unlinked,
-                            bool ignoreColorAttachmentFormats);
+LLPC_NODISCARD Result processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const std::string &inFile,
+                                           bool unlinked, bool ignoreColorAttachmentFormats);
 
 // Processes and compiles multiple shader stage input files.
-Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo, llvm::ArrayRef<std::string> inFiles,
-                          bool validateSpirv, llvm::SmallVectorImpl<std::string> &fileNames);
+LLPC_NODISCARD Result processInputStages(ICompiler *compiler, CompileInfo &compileInfo,
+                                         llvm::ArrayRef<std::string> inFiles, bool validateSpirv,
+                                         llvm::SmallVectorImpl<std::string> &fileNames);
 
 } // namespace StandaloneCompiler
 } // namespace Llpc


### PR DESCRIPTION
Functions returning `Result` should have their results checked:
https://github.com/GPUOpen-Drivers/llpc/blob/dev/docs/CodingStandards.md#result-handling.