### PR TITLE
[CI] Add Thread Sanitizer (+tsan) feature

### DIFF
--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -89,6 +89,9 @@ RUN EXTRA_COMPILER_FLAGS=() \
     && if echo "$FEATURES" | grep -q "+ubsan" ; then \
          SANITIZERS+=("Undefined"); \
        fi \
+    && if echo "$FEATURES" | grep -q "+tsan" ; then \
+         SANITIZERS+=("Thread"); \
+       fi \
     && if [ ${#SANITIZERS[@]} -ne 0 ]; then  \
          SANITIZERS_SEPARATED_LIST="${SANITIZERS[@]}"; \
          SANITIZERS_SEPARATED_LIST="${SANITIZERS_SEPARATED_LIST// /;}"; \


### PR DESCRIPTION
This add support for building the driver with Thread sanitizer. It does not enable it yet in our CI configurations.

Example `+clang+shadercache+tsan` run (on my fork): https://github.com/vettoreldaniele/llpc/runs/4356793043