### PR TITLE
[CI] Add code coverage (+coverage) feature and report generation script

### DIFF
--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -94,6 +94,10 @@ RUN EXTRA_COMPILER_FLAGS=() \
          SANITIZERS_SEPARATED_LIST="${SANITIZERS_SEPARATED_LIST// /;}"; \
          EXTRA_FLAGS+=("-DXGL_USE_SANITIZER='${SANITIZERS_SEPARATED_LIST}'"); \
        fi \
+    && if echo "$FEATURES" | grep -q "+coverage" ; then \
+         EXTRA_COMPILER_FLAGS+=("-fprofile-instr-generate=/vulkandriver/profile%2m.profraw" "-fcoverage-mapping"); \
+         EXTRA_LINKER_FLAGS+=("-fprofile-instr-generate=/vulkandriver/profile%2m.profraw" "-fcoverage-mapping"); \
+       fi \
     && if echo "$FEATURES" | grep -q "+assertions" ; then \
          EXTRA_FLAGS+=("-DXGL_ENABLE_ASSERTIONS=ON"); \
        fi \

--- a/docker/generate-coverage-report.sh
+++ b/docker/generate-coverage-report.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Generates an HTML code coverage report using llvm-profdata (to merge raw profiles) and llvm-cov.
+# Assumes the profiles are under /vulkandriver, and writes to the output directory /vulkandriver/coverage_report.
+set -e
+
+cd /vulkandriver
+
+# Merge raw profiles and delete them afterwards.
+llvm-profdata merge -sparse *.profraw -o code_coverage_profile.profdata
+rm *.profraw
+
+# Create HTML report. Ignore reporting coverage for files coming from LLVM as we are only interested in LLPC
+# and would otherwise make the report very large.
+llvm-cov show -format=html -ignore-filename-regex='.*llvm.*' \
+         -instr-profile=code_coverage_profile.profdata builds/ci-build/compiler/llpc/amdllpc \
+         -o coverage_report

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -26,7 +26,8 @@ ARG LLPC_REPO_SHA
 # Use bash instead of sh in this docker file.
 SHELL ["/bin/bash", "-c"]
 
-COPY docker/update-llpc.sh /vulkandriver/
+# Copy helper scripts into container.
+COPY docker/*.sh /vulkandriver/
 
 # Sync the repos. Replace the base LLPC with a freshly checked-out one.
 RUN /vulkandriver/update-llpc.sh


### PR DESCRIPTION
Add code coverage build option to build AMDVLK with [code coverage instrumentation](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) enabled.

Also add a script to generate an HTML code coverage report for LLPC. The script has been committed with executable (755) permissions.