### PR TITLE
Refine the per-vertex input variable

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -477,6 +477,11 @@ public:
                                       llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
                                       llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
 
+  // Create a read of (part of) a perVertex input value.
+  llvm::Value *CreateReadPerVertexInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
+                                        llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
+                                        llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
+
   // Create a read of (part of) a user output value.
   llvm::Value *CreateReadGenericOutput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
                                        llvm::Value *elemIdx, unsigned locationCount, InOutInfo outputInfo,

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -613,6 +613,17 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
                                              isa<UndefValue>(args[5]) ? nullptr : &*args[5]); // Vertex index
   }
 
+  case BuilderRecorder::Opcode::ReadPerVertexInput: {
+    InOutInfo inputInfo(cast<ConstantInt>(args[4])->getZExtValue());
+    return m_builder->CreateReadPerVertexInput(call->getType(),                                 // Result type
+                                               cast<ConstantInt>(args[0])->getZExtValue(),      // Location
+                                               args[1],                                         // Location offset
+                                               isa<UndefValue>(args[2]) ? nullptr : &*args[2],  // Element index
+                                               cast<ConstantInt>(args[3])->getZExtValue(),      // Location count
+                                               inputInfo,                                       // Input info
+                                               isa<UndefValue>(args[5]) ? nullptr : &*args[5]); // Vertex index
+  }
+
   case BuilderRecorder::Opcode::ReadGenericOutput: {
     InOutInfo outputInfo(cast<ConstantInt>(args[4])->getZExtValue());
     return m_builder->CreateReadGenericOutput(call->getType(),                                 // Result type

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -156,6 +156,7 @@ public:
     // Input/output
     ReadGenericInput,
     ReadGenericOutput,
+    ReadPerVertexInput,
     WriteGenericOutput,
     WriteXfbOutput,
     ReadBuiltInInput,
@@ -468,6 +469,11 @@ public:
   // Create a write of (part of) a built-in output value.
   llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn, InOutInfo outputInfo,
                                               llvm::Value *vertexIndex, llvm::Value *index) override final;
+
+  // Create a read of (part of) a pervertex input value.
+  llvm::Value *CreateReadPerVertexInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
+                                        llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
+                                        llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Miscellaneous operations

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -333,6 +333,9 @@ public:
   // Get the count of vertices per primitive
   unsigned getVerticesPerPrimitive();
 
+  // Get the primitive type
+  PrimitiveType getPrimitiveType();
+
   // -----------------------------------------------------------------------------------------------------------------
   // Utility methods
 

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -98,9 +98,6 @@ public:
   unsigned getArraySize() const { return m_data.bits.arraySize; }
   void setArraySize(unsigned arraySize) { m_data.bits.arraySize = arraySize; }
 
-  bool isPerVertex() const { return m_data.bits.perVertex; }
-  void setPerVertex(bool perVertex = true) { m_data.bits.perVertex = perVertex; }
-
 private:
   union {
     struct {
@@ -114,7 +111,6 @@ private:
       unsigned arraySize : 4;    // Built-in array input: shader-defined array size. Must be set for
                                  //    a read or write of ClipDistance or CullDistance that is of the
                                  //    whole array or of an element with a variable index.
-      unsigned perVertex : 1;    // FS input: adjust the index of the per-vertex input variable
     } bits;
     unsigned u32All;
   } m_data;
@@ -1091,6 +1087,29 @@ public:
   virtual llvm::Value *CreateReadGenericInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
                                               llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
                                               llvm::Value *vertexIndex, const llvm::Twine &instName = "") = 0;
+
+  // -----------------------------------------------------------------------------------------------------------------
+  // Shader input/output methods
+
+  // Create a read of (part of) a perVertex input value, passed from the previous shader stage.
+  // The result type is as specified by pResultTy, a scalar or vector type with no more than four elements.
+  // A "location" can contain up to a 4-vector of 16- or 32-bit components, or up to a 2-vector of
+  // 64-bit components. Two consecutive locations together can contain up to a 4-vector of 64-bit components.
+  // A non-constant pLocationOffset is currently only supported for TCS and TES, and for an FS custom-interpolated
+  // input.
+  //
+  // @param resultTy : Type of value to read
+  // @param location : Base location (row) of input
+  // @param locationOffset : Location offset; must be within locationCount if variable
+  // @param elemIdx : Element index in vector. (This is the SPIR-V "component", except that it is half the component for
+  // 64-bit elements.)
+  // @param locationCount : Count of locations taken by the input. Ignored if pLocationOffset is const
+  // @param inputInfo : Extra input info (FS interp info)
+  // @param vertexIndex : Vertex index (For FS custom interpolated input: auxiliary interpolation value)
+  // @param instName : Name to give instruction(s)
+  virtual llvm::Value *CreateReadPerVertexInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
+                                                llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
+                                                llvm::Value *vertexIndex, const llvm::Twine &instName = "") = 0;
 
   // Create a read of (part of) a generic (user) output value, returning the value last written in this shader stage.
   // The result type is as specified by pResultTy, a scalar or vector type with no more than four elements.

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -250,11 +250,16 @@ struct ResourceNode {
 // Primitive type.
 enum class PrimitiveType : unsigned {
   Point = 0,
-  Line = 1,
-  Triangle = 2,
-  Rect = 3,
-  Quad = 4,
-  Patch = 5,
+  Line_List = 1,
+  Line_Strip = 2,
+  Triangle_List = 3,
+  Triangle_Strip = 4,
+  Triangle_Fan = 5,
+  Triangle_List_Adjacency = 6,
+  Triangle_Strip_Adjacency = 7,
+  Rect = 8,
+  Quad = 9,
+  Patch = 10,
 };
 
 // Data format of vertex buffer entry. For ones that exist in GFX9 hardware, these match the hardware

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1522,14 +1522,25 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
   } else {
     // Without tessellation
     const auto primType = m_pipelineState->getInputAssemblyState().primitiveType;
-    if (primType == PrimitiveType::Point)
+    switch (primType) {
+    case PrimitiveType::Point:
       gsOutputPrimitiveType = POINTLIST;
-    else if (primType == PrimitiveType::Line)
+      break;
+    case PrimitiveType::Line_List:
+    case PrimitiveType::Line_Strip:
       gsOutputPrimitiveType = LINESTRIP;
-    else if (primType == PrimitiveType::Triangle)
+      break;
+    case PrimitiveType::Triangle_List:
+    case PrimitiveType::Triangle_Strip:
+    case PrimitiveType::Triangle_Fan:
+    case PrimitiveType::Triangle_List_Adjacency:
+    case PrimitiveType::Triangle_Strip_Adjacency:
       gsOutputPrimitiveType = TRISTRIP;
-    else
+      break;
+    default:
       llvm_unreachable("Should never be called!");
+      break;
+    }
   }
 
   // TODO: Multiple output streams are not supported.

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -337,7 +337,7 @@ bool PatchResourceCollect::canUseNggCulling(Module *module) {
         return false;
     } else {
       // Check primitive type specified in pipeline state
-      if (primType == PrimitiveType::Point || primType == PrimitiveType::Line)
+      if (primType < PrimitiveType::Triangle_List)
         return false;
     }
   }
@@ -1241,7 +1241,16 @@ void PatchResourceCollect::clearInactiveBuiltInInput() {
     if (builtInUsage.fs.pointCoord && m_activeInputBuiltIns.find(BuiltInPointCoord) == m_activeInputBuiltIns.end())
       builtInUsage.fs.pointCoord = false;
 
-    if (builtInUsage.fs.primitiveId && m_activeInputBuiltIns.find(BuiltInPrimitiveId) == m_activeInputBuiltIns.end())
+    if (builtInUsage.fs.baryCoord && m_activeInputBuiltIns.find(BuiltInBaryCoord) == m_activeInputBuiltIns.end())
+      builtInUsage.fs.baryCoord = false;
+
+    if (builtInUsage.fs.baryCoordNoPerspKHR &&
+        m_activeInputBuiltIns.find(BuiltInBaryCoordNoPerspKHR) == m_activeInputBuiltIns.end())
+      builtInUsage.fs.baryCoordNoPerspKHR = false;
+
+    // BaryCoord depends on PrimitiveID
+    if (builtInUsage.fs.primitiveId && !(builtInUsage.fs.baryCoordNoPerspKHR || builtInUsage.fs.baryCoord) &&
+        m_activeInputBuiltIns.find(BuiltInPrimitiveId) == m_activeInputBuiltIns.end())
       builtInUsage.fs.primitiveId = false;
 
     if (builtInUsage.fs.sampleId && m_activeInputBuiltIns.find(BuiltInSampleId) == m_activeInputBuiltIns.end())
@@ -1299,13 +1308,6 @@ void PatchResourceCollect::clearInactiveBuiltInInput() {
     if (builtInUsage.fs.baryCoordPullModel &&
         m_activeInputBuiltIns.find(BuiltInBaryCoordPullModel) == m_activeInputBuiltIns.end())
       builtInUsage.fs.baryCoordPullModel = false;
-
-    if (builtInUsage.fs.baryCoord && m_activeInputBuiltIns.find(BuiltInBaryCoord) == m_activeInputBuiltIns.end())
-      builtInUsage.fs.baryCoord = false;
-
-    if (builtInUsage.fs.baryCoordNoPerspKHR &&
-        m_activeInputBuiltIns.find(BuiltInBaryCoordNoPerspKHR) == m_activeInputBuiltIns.end())
-      builtInUsage.fs.baryCoordNoPerspKHR = false;
   }
 }
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1531,16 +1531,56 @@ unsigned PipelineState::getVerticesPerPrimitive() {
       return 3;
   } else {
     auto primType = getInputAssemblyState().primitiveType;
-    if (primType == PrimitiveType::Point)
+    switch (primType) {
+    case lgc::PrimitiveType::Point:
       return 1;
-    else if (primType == PrimitiveType::Line)
+    case lgc::PrimitiveType::Line_List:
+    case lgc::PrimitiveType::Line_Strip:
       return 2;
-    else if (primType == PrimitiveType::Triangle)
+    case lgc::PrimitiveType::Triangle_List:
+    case lgc::PrimitiveType::Triangle_Strip:
+    case lgc::PrimitiveType::Triangle_Fan:
+    case lgc::PrimitiveType::Triangle_List_Adjacency:
+    case lgc::PrimitiveType::Triangle_Strip_Adjacency:
       return 3;
+    default:
+      break;
+    }
   }
 
   llvm_unreachable("Unable to get vertices per primitive!");
   return 0;
+}
+
+// =====================================================================================================================
+// Get the primitive type. For GS, the type is for output primitive.
+PrimitiveType PipelineState::getPrimitiveType() {
+  if (hasShaderStage(ShaderStageGeometry)) {
+    const auto &geometryMode = getShaderModes()->getGeometryShaderMode();
+    switch (geometryMode.outputPrimitive) {
+    case OutputPrimitives::Points:
+      return PrimitiveType::Point;
+    case OutputPrimitives::LineStrip:
+      return PrimitiveType::Line_Strip;
+    case OutputPrimitives::TriangleStrip:
+      return PrimitiveType::Triangle_Strip;
+    default:
+      llvm_unreachable("Unexpected output primitive type!");
+    }
+  } else if (hasShaderStage(ShaderStageTessControl) || hasShaderStage(ShaderStageTessEval)) {
+    assert(getInputAssemblyState().primitiveType == PrimitiveType::Patch);
+    const auto &tessMode = getShaderModes()->getTessellationMode();
+    if (tessMode.pointMode)
+      return PrimitiveType::Point;
+    else if (tessMode.primitiveMode == PrimitiveMode::Isolines)
+      return PrimitiveType::Line_Strip;
+    else if (tessMode.primitiveMode == PrimitiveMode::Triangles)
+      return PrimitiveType::Triangle_Strip;
+  } else {
+    return getInputAssemblyState().primitiveType;
+  }
+  llvm_unreachable("Unable to get primitive type!");
+  return PrimitiveType::Triangle_Strip;
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -628,17 +628,27 @@ void PipelineContext::setGraphicsStateInPipeline(Pipeline *pipeline) const {
     inputAssemblyState.primitiveType = PrimitiveType::Point;
     break;
   case VK_PRIMITIVE_TOPOLOGY_LINE_LIST:
-  case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
   case VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY:
+    inputAssemblyState.primitiveType = PrimitiveType::Line_List;
+    break;
+  case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
   case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY:
-    inputAssemblyState.primitiveType = PrimitiveType::Line;
+    inputAssemblyState.primitiveType = PrimitiveType::Line_Strip;
     break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_List;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_Strip;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_Fan;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_List_Adjacency;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY:
-    inputAssemblyState.primitiveType = PrimitiveType::Triangle;
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_Strip_Adjacency;
     break;
   case VK_PRIMITIVE_TOPOLOGY_PATCH_LIST:
     inputAssemblyState.primitiveType = PrimitiveType::Patch;

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -339,7 +339,7 @@ void SpirvLowerGlobal::visitCallInst(CallInst &callInst) {
         auto inputMeta = mdconst::dyn_extract<Constant>(metaNode->getOperand(0));
 
         auto loadValue = addCallInstForInOutImport(inputTy, SPIRAS_Input, inputMeta, nullptr, 0, nullptr, nullptr,
-                                                   interpLoc, auxInterpValue, &callInst);
+                                                   interpLoc, auxInterpValue, false, &callInst);
 
         m_interpCalls.insert(&callInst);
         callInst.replaceAllUsesWith(loadValue);
@@ -441,12 +441,12 @@ void SpirvLowerGlobal::visitLoadInst(LoadInst &loadInst) {
       for (unsigned i = 0; i < elemCount; ++i) {
         Value *vertexIdx = ConstantInt::get(Type::getInt32Ty(*m_context), i);
         auto elemValue = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, nullptr, 0, nullptr, vertexIdx,
-                                                   InterpLocUnknown, nullptr, &loadInst);
+                                                   InterpLocUnknown, nullptr, false, &loadInst);
         loadValue = InsertValueInst::Create(loadValue, elemValue, {i}, "", &loadInst);
       }
     } else {
       loadValue = addCallInstForInOutImport(inOutTy, addrSpace, inOutMetaVal, nullptr, 0, nullptr, nullptr,
-                                            InterpLocUnknown, nullptr, &loadInst);
+                                            InterpLocUnknown, nullptr, false, &loadInst);
     }
   }
   m_loadInsts.insert(&loadInst);
@@ -577,7 +577,7 @@ void SpirvLowerGlobal::mapInputToProxy(GlobalVariable *input) {
 
   // Import input to proxy variable
   auto inputValue = addCallInstForInOutImport(inputTy, SPIRAS_Input, meta, nullptr, 0, nullptr, nullptr,
-                                              InterpLocUnknown, nullptr, &*insertPos);
+                                              InterpLocUnknown, nullptr, false, &*insertPos);
   new StoreInst(inputValue, proxy, &*insertPos);
 
   m_inputProxyMap[input] = proxy;
@@ -893,11 +893,12 @@ void SpirvLowerGlobal::lowerInOutInPlace() {
 // @param auxInterpValue : Auxiliary value of interpolation (valid for fragment shader) - Value is sample ID for
 // "InterpLocSample" - Value is offset from the center of the pixel for "InterpLocCenter" - Value is vertex no. (0 ~ 2)
 // for "InterpLocCustom"
+// @param isPerVertexDimension : Whether this is a per vertex variable
 // @param insertPos : Where to insert this call
 Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrSpace, Constant *inOutMetaVal,
                                                    Value *locOffset, unsigned maxLocOffset, Value *elemIdx,
                                                    Value *vertexIdx, unsigned interpLoc, Value *auxInterpValue,
-                                                   Instruction *insertPos) {
+                                                   bool isPerVertexDimension, Instruction *insertPos) {
   assert(addrSpace == SPIRAS_Input || (addrSpace == SPIRAS_Output && m_shaderStage == ShaderStageTessControl));
 
   Value *inOutValue = UndefValue::get(inOutTy);
@@ -938,7 +939,7 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
           // Handle array elements recursively
           vertexIdx = ConstantInt::get(Type::getInt32Ty(*m_context), idx);
           auto elem = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, nullptr, maxLocOffset, nullptr, vertexIdx,
-                                                interpLoc, auxInterpValue, insertPos);
+                                                interpLoc, auxInterpValue, false, insertPos);
           inOutValue = InsertValueInst::Create(inOutValue, elem, {idx}, "", insertPos);
         }
       } else {
@@ -966,7 +967,7 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
         for (unsigned idx = 0; idx < elemCount; ++idx) {
           vertexIdx = ConstantInt::get(Type::getInt32Ty(*m_context), idx);
           auto elem = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, locOffset, maxLocOffset, nullptr,
-                                                vertexIdx, InterpLocUnknown, nullptr, insertPos);
+                                                vertexIdx, InterpLocUnknown, nullptr, false, insertPos);
           inOutValue = InsertValueInst::Create(inOutValue, elem, {idx}, "", insertPos);
         }
       } else {
@@ -975,16 +976,23 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
           locOffset = ConstantInt::get(Type::getInt32Ty(*m_context), 0);
 
         for (unsigned idx = 0; idx < elemCount; ++idx) {
-          // Handle array elements recursively
-          // elemLocOffset = locOffset + stride * idx
-          Value *elemLocOffset = nullptr;
-          if (isa<ConstantInt>(locOffset))
-            elemLocOffset = m_builder->getInt32(cast<ConstantInt>(locOffset)->getZExtValue() + stride * idx);
-          else
-            elemLocOffset = BinaryOperator::CreateAdd(locOffset, m_builder->getInt32(stride * idx), "", insertPos);
+          Value *elem = nullptr;
+          if (inOutMeta.PerVertexDimension) {
+            assert(inOutMeta.InterpLoc == InterpLocCustom);
+            elem = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, nullptr, 0, nullptr, 0, inOutMeta.InterpLoc,
+                                             m_builder->getInt32(idx), true, insertPos);
+          } else {
+            // Handle array elements recursively
+            // elemLocOffset = locOffset + stride * idx
+            Value *elemLocOffset = nullptr;
+            if (isa<ConstantInt>(locOffset))
+              elemLocOffset = m_builder->getInt32(cast<ConstantInt>(locOffset)->getZExtValue() + stride * idx);
+            else
+              elemLocOffset = BinaryOperator::CreateAdd(locOffset, m_builder->getInt32(stride * idx), "", insertPos);
 
-          auto elem = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, elemLocOffset, maxLocOffset, elemIdx,
-                                                vertexIdx, InterpLocUnknown, nullptr, insertPos);
+            elem = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, elemLocOffset, maxLocOffset, elemIdx,
+                                             vertexIdx, interpLoc, auxInterpValue, isPerVertexDimension, insertPos);
+          }
           inOutValue = InsertValueInst::Create(inOutValue, elem, {idx}, "", insertPos);
         }
       }
@@ -1000,7 +1008,7 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
       auto memberMeta = cast<Constant>(inOutMetaVal->getOperand(memberIdx));
 
       auto member = addCallInstForInOutImport(memberTy, addrSpace, memberMeta, locOffset, maxLocOffset, nullptr,
-                                              vertexIdx, InterpLocUnknown, nullptr, insertPos);
+                                              vertexIdx, interpLoc, auxInterpValue, isPerVertexDimension, insertPos);
       inOutValue = InsertValueInst::Create(inOutValue, member, {memberIdx}, "", insertPos);
     }
   } else {
@@ -1065,8 +1073,12 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
           inOutInfo.setInterpLoc(interpLoc);
           inOutInfo.setInterpMode(inOutMeta.InterpMode);
         }
-        inOutValue = m_builder->CreateReadGenericInput(inOutTy, inOutMeta.Value, locOffset, elemIdx, maxLocOffset,
-                                                       inOutInfo, vertexIdx);
+        if (isPerVertexDimension)
+          inOutValue = m_builder->CreateReadPerVertexInput(inOutTy, inOutMeta.Value, locOffset, elemIdx, maxLocOffset,
+                                                           inOutInfo, vertexIdx);
+        else
+          inOutValue = m_builder->CreateReadGenericInput(inOutTy, inOutMeta.Value, locOffset, elemIdx, maxLocOffset,
+                                                         inOutInfo, vertexIdx);
       } else {
         inOutValue = m_builder->CreateReadGenericOutput(inOutTy, inOutMeta.Value, locOffset, elemIdx, maxLocOffset,
                                                         inOutInfo, vertexIdx);
@@ -1383,15 +1395,15 @@ Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrS
       loadTy = cast<VectorType>(inOutTy)->getElementType();
       compIdx = indexOperands[operandIdx];
       Value *compValue = addCallInstForInOutImport(loadTy, addrSpace, inOutMetaVal, locOffset, 0, compIdx, nullptr,
-                                                   interpLoc, auxInterpValue, insertPos);
+                                                   interpLoc, auxInterpValue, false, insertPos);
       return InsertElementInst::Create(inOutValue, compValue, compIdx, "", insertPos);
     } else
       return addCallInstForInOutImport(loadTy, addrSpace, inOutMetaVal, locOffset, 0, compIdx, nullptr, interpLoc,
-                                       auxInterpValue, insertPos);
+                                       auxInterpValue, false, insertPos);
   } else {
     // simple scalar type
     return addCallInstForInOutImport(inOutTy, addrSpace, inOutMetaVal, locOffset, 0, nullptr, nullptr, interpLoc,
-                                     auxInterpValue, insertPos);
+                                     auxInterpValue, false, insertPos);
   }
 
   llvm_unreachable("Should never be called!");
@@ -1435,7 +1447,7 @@ Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, cons
       assert(operandIdx == indexOperands.size() - 1);
       auto elemIdx = indexOperands[operandIdx];
       return addCallInstForInOutImport(elemTy, addrSpace, elemMeta, locOffset, inOutTy->getArrayNumElements(), elemIdx,
-                                       vertexIdx, interpLoc, auxInterpValue, insertPos);
+                                       vertexIdx, interpLoc, auxInterpValue, false, insertPos);
     } else {
       // NOTE: If the relative location offset is not specified, initialize it to 0.
       if (!locOffset)
@@ -1479,11 +1491,11 @@ Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, cons
     }
 
     return addCallInstForInOutImport(loadTy, addrSpace, inOutMetaVal, locOffset, maxLocOffset, compIdx, vertexIdx,
-                                     interpLoc, auxInterpValue, insertPos);
+                                     interpLoc, auxInterpValue, false, insertPos);
   } else {
     // simple scalar type
     return addCallInstForInOutImport(inOutTy, addrSpace, inOutMetaVal, locOffset, maxLocOffset, nullptr, vertexIdx,
-                                     interpLoc, auxInterpValue, insertPos);
+                                     interpLoc, auxInterpValue, false, insertPos);
   }
 
   llvm_unreachable("Should never be called!");

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -74,7 +74,7 @@ private:
   llvm::Value *addCallInstForInOutImport(llvm::Type *inOutTy, unsigned addrSpace, llvm::Constant *inOutMeta,
                                          llvm::Value *startLoc, unsigned maxLocOffset, llvm::Value *compIdx,
                                          llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,
-                                         llvm::Instruction *insertPos);
+                                         bool isPerVertexDimension, llvm::Instruction *insertPos);
 
   void addCallInstForOutputExport(llvm::Value *outputValue, llvm::Constant *outputMeta, llvm::Value *locOffset,
                                   unsigned maxLocOffset, unsigned xfbOffsetAdjust, unsigned xfbBufferAdjust,

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -507,6 +507,7 @@ union ShaderInOutMetadata {
                                   //   occupied byte count of an element)
     // byte 10~11
     uint64_t XfbExtraOffset : 16; // Transform feedback extra offset
+    uint64_t PerVertexDimension : 1; // Whether this is the per-vertex dimension (outermost) for an array
   };
   uint64_t U64All[2];
 };


### PR DESCRIPTION
Add OpCode::ReadPerVertexInput and separate per-vertex input variable from
Opcode::ReadGenericInput, when Replaying we can handle it alone.
Subdivision primitive type, For different type, we have different order
for per-vertex input.