### PR TITLE
Refine the per-vertex input variable

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -477,6 +477,11 @@ public:
                                       llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
                                       llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
 
+  // Create a read of (part of) a perVertex input value.
+  llvm::Value *CreateReadPerVertexInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
+                                        llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
+                                        llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
+
   // Create a read of (part of) a user output value.
   llvm::Value *CreateReadGenericOutput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
                                        llvm::Value *elemIdx, unsigned locationCount, InOutInfo outputInfo,

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -160,6 +160,8 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "buffer.ptrdiff";
   case Opcode::ReadGenericInput:
     return "read.generic.input";
+  case Opcode::ReadPerVertexInput:
+    return "read.pervertex.input";
   case Opcode::ReadGenericOutput:
     return "read.generic.output";
   case Opcode::WriteGenericOutput:
@@ -1384,6 +1386,35 @@ Value *BuilderRecorder::CreateReadGenericInput(Type *resultTy, unsigned location
 }
 
 // =====================================================================================================================
+// Create a read of (part of) a perVertex input value, passed from the previous shader stage.
+//
+// @param resultTy : Type of value to read
+// @param location : Base location (row) of input
+// @param locationOffset : Variable location offset; must be within locationCount
+// @param elemIdx : Element index in vector. (This is the SPIR-V "component", except that it is half the component for
+// 64-bit elements.)
+// @param locationCount : Count of locations taken by the input
+// @param inputInfo : Extra input info (FS interp info)
+// @param vertexIndex : Vertex index, for each vertex, it is unique. the range is 0-2, up to three vertices per
+// primitive; for FS custom interpolated input: auxiliary interpolation value;
+// @param instName : Name to give instruction(s)
+// @returns Value of input
+Value *BuilderRecorder::CreateReadPerVertexInput(Type *resultTy, unsigned location, Value *locationOffset,
+                                                 Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
+                                                 Value *vertexIndex, const Twine &instName) {
+  return record(Opcode::ReadPerVertexInput, resultTy,
+                {
+                    getInt32(location),
+                    locationOffset,
+                    elemIdx,
+                    getInt32(locationCount),
+                    getInt32(inputInfo.getData()),
+                    vertexIndex,
+                },
+                instName);
+}
+
+// =====================================================================================================================
 // Create a read of (part of) a user output value, the last written value in the same shader stage.
 //
 // @param resultTy : Type of value to read
@@ -2079,6 +2110,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::ReadBuiltInOutput:
     case Opcode::ReadGenericInput:
     case Opcode::ReadGenericOutput:
+    case Opcode::ReadPerVertexInput:
       // Functions that only read memory.
       func->addFnAttr(Attribute::ReadOnly);
       // Must be marked as returning for DCE.

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -613,6 +613,17 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
                                              isa<UndefValue>(args[5]) ? nullptr : &*args[5]); // Vertex index
   }
 
+  case BuilderRecorder::Opcode::ReadPerVertexInput: {
+    InOutInfo inputInfo(cast<ConstantInt>(args[4])->getZExtValue());
+    return m_builder->CreateReadPerVertexInput(call->getType(),                                // Result type
+                                               cast<ConstantInt>(args[0])->getZExtValue(),     // Location
+                                               args[1],                                        // Location offset
+                                               isa<UndefValue>(args[2]) ? nullptr : &*args[2], // Element index
+                                               cast<ConstantInt>(args[3])->getZExtValue(),     // Location count
+                                               inputInfo,                                      // Input info
+                                               args[5]);                                       // Vertex index
+  }
+
   case BuilderRecorder::Opcode::ReadGenericOutput: {
     InOutInfo outputInfo(cast<ConstantInt>(args[4])->getZExtValue());
     return m_builder->CreateReadGenericOutput(call->getType(),                                 // Result type

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -66,6 +66,150 @@ Value *InOutBuilder::CreateReadGenericInput(Type *resultTy, unsigned location, V
 }
 
 // =====================================================================================================================
+// Create a read of (part of) a perVertex input value, passed from the previous shader stage.
+// The result type is as specified by pResultTy, a scalar or vector type with no more than four elements.
+// A "location" contains four "components", each of which can contain a 16- or 32-bit scalar value. A
+// 64-bit scalar value takes two components.
+//
+// @param resultTy : Type of value to read
+// @param location : Base location (row) of input
+// @param locationOffset : Variable location offset; must be within locationCount
+// @param elemIdx : Element index in vector. (This is the SPIR-V "component", except that it is half the component for
+// 64-bit elements.)
+// @param locationCount : Count of locations taken by the input
+// @param inputInfo : Extra input info (FS interp info)
+// @param vertexIndex : Vertex index, for each vertex, it is unique. the range is 0-2, up to three vertices per
+// primitive; for FS custom interpolated input: auxiliary interpolation value;
+// @param instName : Name to give instruction(s)
+// @returns Value of input
+Value *InOutBuilder::CreateReadPerVertexInput(Type *resultTy, unsigned location, Value *locationOffset, Value *elemIdx,
+                                              unsigned locationCount, InOutInfo inputInfo, Value *vertexIndex,
+                                              const Twine &instName) {
+  assert(!resultTy->isAggregateType());
+  assert(inputInfo.getInterpMode() == InOutInfo::InterpModeCustom);
+  assert(m_shaderStage == ShaderStageFragment);
+
+  // Fold constant pLocationOffset into location.
+  if (auto constLocOffset = dyn_cast<ConstantInt>(locationOffset)) {
+    location += constLocOffset->getZExtValue();
+    locationOffset = getInt32(0);
+    locationCount = divideCeil(resultTy->getPrimitiveSizeInBits(), 128);
+  }
+
+  // Mark the usage of the input/output.
+  markGenericInputOutputUsage(false, location, locationCount, inputInfo, vertexIndex);
+
+  // Fixing the order
+  bool parity = false;
+  Value *odd = nullptr;
+  Value *even = nullptr;
+
+  auto primType = getPipelineState()->getPrimitiveType();
+  switch (primType) {
+  case PrimitiveType::Point:
+    break;
+  case PrimitiveType::Line_List:
+  case PrimitiveType::Line_Strip:
+    break;
+  case PrimitiveType::Triangle_List: {
+    switch (cast<ConstantInt>(vertexIndex)->getZExtValue()) {
+    case 0: {
+      vertexIndex = getInt32(2);
+      break;
+    }
+    case 1: {
+      vertexIndex = getInt32(0);
+      break;
+    }
+    case 2: {
+      vertexIndex = getInt32(1);
+      break;
+    }
+    }
+    break;
+  }
+  case PrimitiveType::Triangle_Strip:
+  case PrimitiveType::Triangle_Fan:
+  case PrimitiveType::Triangle_Strip_Adjacency: {
+    switch (cast<ConstantInt>(vertexIndex)->getZExtValue()) {
+    case 0: {
+      odd = getInt32(2);
+      even = vertexIndex;
+      break;
+    }
+    case 1: {
+      odd = getInt32(0);
+      even = vertexIndex;
+      break;
+    }
+    case 2: {
+      odd = getInt32(1);
+      even = vertexIndex;
+      break;
+    }
+    }
+    parity = true;
+    break;
+  }
+  case PrimitiveType::Triangle_List_Adjacency: {
+    switch (cast<ConstantInt>(vertexIndex)->getZExtValue()) {
+    case 0: {
+      odd = getInt32(1);
+      even = vertexIndex;
+      break;
+    }
+    case 1: {
+      odd = getInt32(2);
+      even = vertexIndex;
+      break;
+    }
+    case 2: {
+      odd = getInt32(0);
+      even = vertexIndex;
+      break;
+    }
+    }
+    parity = true;
+    break;
+  }
+  default:
+    llvm_unreachable("Unable to get vertices per primitive!");
+    break;
+  }
+
+  auto readInput = [&](Value *vertexIndex) {
+    std::string callName = lgcName::InputImportInterpolant;
+    SmallVector<Value *, 5> args({
+        getInt32(location),
+        locationOffset,
+        elemIdx,
+        getInt32(inputInfo.getInterpMode()),
+        vertexIndex,
+    });
+    addTypeMangling(resultTy, args, callName);
+    return emitCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn}, &*GetInsertPoint());
+  };
+
+  Value *result = nullptr;
+  if (parity) {
+    // Odd
+    auto oddRes = readInput(odd);
+    // Even
+    auto evenRes = readInput(even);
+
+    auto primtiveId = readBuiltIn(false, BuiltInPrimitiveId, {}, nullptr, nullptr, "");
+    auto evenV = CreateSRem(primtiveId, getInt32(2));
+    Value *con = CreateICmpEQ(evenV, getInt32(0));
+    result = CreateSelect(con, evenRes, oddRes);
+  } else {
+    result = readInput(vertexIndex);
+  }
+
+  result->setName(instName);
+  return result;
+}
+
+// =====================================================================================================================
 // Create a read of (part of) a generic (user) output value, returning the value last written in this shader stage.
 // The result type is as specified by pResultTy, a scalar or vector type with no more than four elements.
 // A "location" can contain up to a 4-vector of 16- or 32-bit components, or up to a 2-vector of
@@ -481,30 +625,6 @@ Value *InOutBuilder::modifyAuxInterpValue(Value *auxInterpValue, InOutInfo input
     }
   } else {
     assert(inputInfo.getInterpMode() == InOutInfo::InterpModeCustom);
-    if (inputInfo.isPerVertex()) {
-      unsigned vertsPerPrim = getPipelineState()->getVerticesPerPrimitive();
-      switch (vertsPerPrim) {
-      case 1:
-        // Points
-        break;
-      case 2:
-        // Lines
-        break;
-      case 3: {
-        // Triangles
-        // V0 ==> Attr_indx2
-        // V1 ==> Attr_indx0
-        // V2 ==> Attr_indx1
-        // just satisfies (idx + 2)%3.
-        Value *T = CreateAdd(getInt32(2), auxInterpValue);
-        auxInterpValue = CreateSRem(T, getInt32(3));
-        break;
-      }
-      default:
-        llvm_unreachable("Should never be called!");
-        break;
-      }
-    }
   }
   return auxInterpValue;
 }
@@ -1278,9 +1398,11 @@ void InOutBuilder::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySiz
       break;
     case BuiltInBaryCoord:
       usage.fs.baryCoord = true;
+      usage.fs.primitiveId = true;
       break;
     case BuiltInBaryCoordNoPerspKHR:
       usage.fs.baryCoordNoPerspKHR = true;
+      usage.fs.primitiveId = true;
       break;
 
     // Internal built-ins.

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -156,6 +156,7 @@ public:
     // Input/output
     ReadGenericInput,
     ReadGenericOutput,
+    ReadPerVertexInput,
     WriteGenericOutput,
     WriteXfbOutput,
     ReadBuiltInInput,
@@ -468,6 +469,11 @@ public:
   // Create a write of (part of) a built-in output value.
   llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn, InOutInfo outputInfo,
                                               llvm::Value *vertexIndex, llvm::Value *index) override final;
+
+  // Create a read of (part of) a pervertex input value.
+  llvm::Value *CreateReadPerVertexInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,
+                                        llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
+                                        llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Miscellaneous operations

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -333,6 +333,9 @@ public:
   // Get the count of vertices per primitive
   unsigned getVerticesPerPrimitive();
 
+  // Get the primitive type
+  PrimitiveType getPrimitiveType();
+
   // -----------------------------------------------------------------------------------------------------------------
   // Utility methods
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -250,11 +250,16 @@ struct ResourceNode {
 // Primitive type.
 enum class PrimitiveType : unsigned {
   Point = 0,
-  Line = 1,
-  Triangle = 2,
-  Rect = 3,
-  Quad = 4,
-  Patch = 5,
+  Line_List = 1,
+  Line_Strip = 2,
+  Triangle_List = 3,
+  Triangle_Strip = 4,
+  Triangle_Fan = 5,
+  Triangle_List_Adjacency = 6,
+  Triangle_Strip_Adjacency = 7,
+  Rect = 8,
+  Quad = 9,
+  Patch = 10,
 };
 
 // Data format of vertex buffer entry. For ones that exist in GFX9 hardware, these match the hardware

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1522,14 +1522,25 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
   } else {
     // Without tessellation
     const auto primType = m_pipelineState->getInputAssemblyState().primitiveType;
-    if (primType == PrimitiveType::Point)
+    switch (primType) {
+    case PrimitiveType::Point:
       gsOutputPrimitiveType = POINTLIST;
-    else if (primType == PrimitiveType::Line)
+      break;
+    case PrimitiveType::Line_List:
+    case PrimitiveType::Line_Strip:
       gsOutputPrimitiveType = LINESTRIP;
-    else if (primType == PrimitiveType::Triangle)
+      break;
+    case PrimitiveType::Triangle_List:
+    case PrimitiveType::Triangle_Strip:
+    case PrimitiveType::Triangle_Fan:
+    case PrimitiveType::Triangle_List_Adjacency:
+    case PrimitiveType::Triangle_Strip_Adjacency:
       gsOutputPrimitiveType = TRISTRIP;
-    else
+      break;
+    default:
       llvm_unreachable("Should never be called!");
+      break;
+    }
   }
 
   // TODO: Multiple output streams are not supported.

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2584,35 +2584,79 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
     builder.SetInsertPoint(insertPos);
     auto iCoord = builder.CreateExtractElement(iJCoord, uint64_t(0));
     auto jCoord = builder.CreateExtractElement(iJCoord, 1);
-    unsigned vertsPerPrim = m_pipelineState->getVerticesPerPrimitive();
-    switch (vertsPerPrim) {
-    case 1: {
+    auto primType = m_pipelineState->getPrimitiveType();
+    switch (primType) {
+    case PrimitiveType::Point: {
       // Points
-      input = builder.CreateInsertElement(input, ConstantFP::get(Type::getFloatTy(*m_context), 1.0), uint64_t(0));
-      input = builder.CreateInsertElement(input, ConstantFP::get(Type::getFloatTy(*m_context), 0.0), 1);
-      input = builder.CreateInsertElement(input, ConstantFP::get(Type::getFloatTy(*m_context), 0.0), 2);
+      input = builder.CreateInsertElement(input, ConstantFP::get(builder.getFloatTy(), 1.0), uint64_t(0));
+      input = builder.CreateInsertElement(input, ConstantFP::get(builder.getFloatTy(), 0.0), 1);
+      input = builder.CreateInsertElement(input, ConstantFP::get(builder.getFloatTy(), 0.0), 2);
       break;
     }
-    case 2: {
+    case PrimitiveType::Line_List:
+    case PrimitiveType::Line_Strip: {
       // Lines
       // The weight of vertex0 is (1 - i - j), the weight of vertex1 is (i + j).
-      auto kCoord = builder.CreateFSub(ConstantFP::get(Type::getFloatTy(*m_context), 1.0), iCoord);
+      auto kCoord = builder.CreateFSub(ConstantFP::get(builder.getFloatTy(), 1.0), iCoord);
       kCoord = builder.CreateFSub(kCoord, jCoord);
       jCoord = builder.CreateFAdd(iCoord, jCoord);
       input = builder.CreateInsertElement(input, kCoord, uint64_t(0));
       input = builder.CreateInsertElement(input, jCoord, 1);
+      input = builder.CreateInsertElement(input, ConstantFP::get(builder.getFloatTy(), 0.0), 2);
       break;
     }
-    case 3: {
+    case PrimitiveType::Triangle_List: {
       // Triangles
       // V0 ==> Attr_indx2
       // V1 ==> Attr_indx0
       // V2 ==> Attr_indx1
-      auto kCoord = builder.CreateFSub(ConstantFP::get(Type::getFloatTy(*m_context), 1.0), iCoord);
+      auto kCoord = builder.CreateFSub(ConstantFP::get(builder.getFloatTy(), 1.0), iCoord);
       kCoord = builder.CreateFSub(kCoord, jCoord);
       input = builder.CreateInsertElement(input, iCoord, uint64_t(2));
       input = builder.CreateInsertElement(input, jCoord, uint64_t(0));
       input = builder.CreateInsertElement(input, kCoord, uint64_t(1));
+      break;
+    }
+    case PrimitiveType::Triangle_Strip:
+    case PrimitiveType::Triangle_Fan:
+    case PrimitiveType::Triangle_Strip_Adjacency: {
+      // Odd
+      auto kCoord = builder.CreateFSub(ConstantFP::get(builder.getFloatTy(), 1.0), iCoord);
+      kCoord = builder.CreateFSub(kCoord, jCoord);
+      Value *odd = UndefValue::get(inputTy);
+      odd = builder.CreateInsertElement(odd, iCoord, uint64_t(2));
+      odd = builder.CreateInsertElement(odd, jCoord, uint64_t(0));
+      odd = builder.CreateInsertElement(odd, kCoord, uint64_t(1));
+      // Even
+      Value *even = UndefValue::get(inputTy);
+      even = builder.CreateInsertElement(even, iCoord, uint64_t(1));
+      even = builder.CreateInsertElement(even, jCoord, uint64_t(2));
+      even = builder.CreateInsertElement(even, kCoord, uint64_t(0));
+
+      auto primitiveId = patchFsBuiltInInputImport(builder.getInt32Ty(), BuiltInPrimitiveId, nullptr, insertPos);
+      auto evenV = builder.CreateSRem(primitiveId, builder.getInt32(2));
+      Value *con = builder.CreateICmpEQ(evenV, builder.getInt32(0));
+      input = builder.CreateSelect(con, even, odd);
+      break;
+    }
+    case PrimitiveType::Triangle_List_Adjacency: {
+      // Odd
+      auto kCoord = builder.CreateFSub(ConstantFP::get(builder.getFloatTy(), 1.0), iCoord);
+      kCoord = builder.CreateFSub(kCoord, jCoord);
+      Value *odd = UndefValue::get(inputTy);
+      odd = builder.CreateInsertElement(odd, iCoord, uint64_t(0));
+      odd = builder.CreateInsertElement(odd, jCoord, uint64_t(1));
+      odd = builder.CreateInsertElement(odd, kCoord, uint64_t(2));
+      // Even
+      Value *even = UndefValue::get(inputTy);
+      even = builder.CreateInsertElement(even, iCoord, uint64_t(1));
+      even = builder.CreateInsertElement(even, jCoord, uint64_t(2));
+      even = builder.CreateInsertElement(even, kCoord, uint64_t(0));
+
+      auto primitiveId = patchFsBuiltInInputImport(builder.getInt32Ty(), BuiltInPrimitiveId, nullptr, insertPos);
+      auto evenV = builder.CreateSRem(primitiveId, builder.getInt32(2));
+      Value *con = builder.CreateICmpEQ(evenV, builder.getInt32(0));
+      input = builder.CreateSelect(con, even, odd);
       break;
     }
     default: {

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -369,7 +369,7 @@ bool PatchResourceCollect::canUseNggCulling(Module *module) {
         return false;
     } else {
       // Check primitive type specified in pipeline state
-      if (primType == PrimitiveType::Point || primType == PrimitiveType::Line)
+      if (primType < PrimitiveType::Triangle_List)
         return false;
     }
   }
@@ -1273,7 +1273,16 @@ void PatchResourceCollect::clearInactiveBuiltInInput() {
     if (builtInUsage.fs.pointCoord && m_activeInputBuiltIns.find(BuiltInPointCoord) == m_activeInputBuiltIns.end())
       builtInUsage.fs.pointCoord = false;
 
-    if (builtInUsage.fs.primitiveId && m_activeInputBuiltIns.find(BuiltInPrimitiveId) == m_activeInputBuiltIns.end())
+    if (builtInUsage.fs.baryCoord && m_activeInputBuiltIns.find(BuiltInBaryCoord) == m_activeInputBuiltIns.end())
+      builtInUsage.fs.baryCoord = false;
+
+    if (builtInUsage.fs.baryCoordNoPerspKHR &&
+        m_activeInputBuiltIns.find(BuiltInBaryCoordNoPerspKHR) == m_activeInputBuiltIns.end())
+      builtInUsage.fs.baryCoordNoPerspKHR = false;
+
+    // BaryCoord depends on PrimitiveID
+    if (builtInUsage.fs.primitiveId && !(builtInUsage.fs.baryCoordNoPerspKHR || builtInUsage.fs.baryCoord) &&
+        m_activeInputBuiltIns.find(BuiltInPrimitiveId) == m_activeInputBuiltIns.end())
       builtInUsage.fs.primitiveId = false;
 
     if (builtInUsage.fs.sampleId && m_activeInputBuiltIns.find(BuiltInSampleId) == m_activeInputBuiltIns.end())
@@ -1331,13 +1340,6 @@ void PatchResourceCollect::clearInactiveBuiltInInput() {
     if (builtInUsage.fs.baryCoordPullModel &&
         m_activeInputBuiltIns.find(BuiltInBaryCoordPullModel) == m_activeInputBuiltIns.end())
       builtInUsage.fs.baryCoordPullModel = false;
-
-    if (builtInUsage.fs.baryCoord && m_activeInputBuiltIns.find(BuiltInBaryCoord) == m_activeInputBuiltIns.end())
-      builtInUsage.fs.baryCoord = false;
-
-    if (builtInUsage.fs.baryCoordNoPerspKHR &&
-        m_activeInputBuiltIns.find(BuiltInBaryCoordNoPerspKHR) == m_activeInputBuiltIns.end())
-      builtInUsage.fs.baryCoordNoPerspKHR = false;
   }
 }
 

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -628,17 +628,27 @@ void PipelineContext::setGraphicsStateInPipeline(Pipeline *pipeline) const {
     inputAssemblyState.primitiveType = PrimitiveType::Point;
     break;
   case VK_PRIMITIVE_TOPOLOGY_LINE_LIST:
-  case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
   case VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY:
+    inputAssemblyState.primitiveType = PrimitiveType::Line_List;
+    break;
+  case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP:
   case VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY:
-    inputAssemblyState.primitiveType = PrimitiveType::Line;
+    inputAssemblyState.primitiveType = PrimitiveType::Line_Strip;
     break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_List;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_Strip;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_Fan;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY:
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_List_Adjacency;
+    break;
   case VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY:
-    inputAssemblyState.primitiveType = PrimitiveType::Triangle;
+    inputAssemblyState.primitiveType = PrimitiveType::Triangle_Strip_Adjacency;
     break;
   case VK_PRIMITIVE_TOPOLOGY_PATCH_LIST:
     inputAssemblyState.primitiveType = PrimitiveType::Patch;

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -78,7 +78,7 @@ private:
   llvm::Value *addCallInstForInOutImport(llvm::Type *inOutTy, unsigned addrSpace, llvm::Constant *inOutMeta,
                                          llvm::Value *startLoc, unsigned maxLocOffset, llvm::Value *compIdx,
                                          llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,
-                                         llvm::Instruction *insertPos);
+                                         bool isPerVertexDimension, llvm::Instruction *insertPos);
 
   void addCallInstForOutputExport(llvm::Value *outputValue, llvm::Constant *outputMeta, llvm::Value *locOffset,
                                   unsigned maxLocOffset, unsigned xfbOffsetAdjust, unsigned xfbBufferAdjust,

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -507,6 +507,7 @@ union ShaderInOutMetadata {
                                   //   occupied byte count of an element)
     // byte 10~11
     uint64_t XfbExtraOffset : 16; // Transform feedback extra offset
+    uint64_t PerVertexDimension : 1; // Whether this is the per-vertex dimension (outermost) for an array
   };
   uint64_t U64All[2];
 };


### PR DESCRIPTION
Add OpCode::ReadPerVertexInput and separate per-vertex input variable from
Opcode::ReadGenericInput, when Replaying we can handle it alone.
Subdivision primitive type, For different type, we have different order
for per-vertex input.