### PR TITLE
Refactor SPIRVGenFastMathFlags handling code

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -971,29 +971,30 @@ FastMathFlags SPIRVToLLVM::getFastMathFlags(SPIRVValue *bv) {
 
   // For floating-point operations, if "FastMath" is enabled, set the "FastMath"
   // flags on the handled instruction
-  if (SPIRVGenFastMathFlags & FastMathFlags::AllowReassoc)
-    fmf.setAllowReassoc();
+  if (SPIRVGenFastMathFlags) {
+    if (SPIRVGenFastMathFlags & FastMathFlags::AllowReassoc)
+      fmf.setAllowReassoc();
 
-  if (SPIRVGenFastMathFlags & FastMathFlags::NoNaNs)
-    fmf.setNoNaNs();
+    if (SPIRVGenFastMathFlags & FastMathFlags::NoNaNs)
+      fmf.setNoNaNs();
 
-  if (SPIRVGenFastMathFlags & FastMathFlags::NoInfs)
-    fmf.setNoInfs();
+    if (SPIRVGenFastMathFlags & FastMathFlags::NoInfs)
+      fmf.setNoInfs();
 
-  if (SPIRVGenFastMathFlags & FastMathFlags::NoSignedZeros)
-    fmf.setNoSignedZeros();
+    if (SPIRVGenFastMathFlags & FastMathFlags::NoSignedZeros)
+      fmf.setNoSignedZeros();
 
-  if (SPIRVGenFastMathFlags & FastMathFlags::AllowReciprocal)
-    fmf.setAllowReciprocal();
+    if (SPIRVGenFastMathFlags & FastMathFlags::AllowReciprocal)
+      fmf.setAllowReciprocal();
 
-  if (SPIRVGenFastMathFlags & FastMathFlags::AllowContract)
-    fmf.setAllowContract();
+    if (SPIRVGenFastMathFlags & FastMathFlags::AllowContract)
+      fmf.setAllowContract();
 
-  if (SPIRVGenFastMathFlags & FastMathFlags::ApproxFunc)
-    fmf.setApproxFunc();
+    if (SPIRVGenFastMathFlags & FastMathFlags::ApproxFunc)
+      fmf.setApproxFunc();
 
-  if (SPIRVGenFastMathFlags)
     return fmf;
+  }
 
   // Only do this for operations with floating point type.
   if (!bv->hasType())


### PR DESCRIPTION
This just makes it more obvious which parts of the code only apply
when SPIRVGenFastMathFlags is non-zero. No functional change.