### PR TITLE
Set NoSignedZeros regardless of NoContraction decoration

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1029,7 +1029,7 @@ FastMathFlags SPIRVToLLVM::getFastMathFlags(SPIRVValue *bv) {
     if (!m_moduleUsage->useIsNan)
       fmf.setNoNaNs();
 
-    fmf.setNoSignedZeros(allowContract);
+    fmf.setNoSignedZeros();
   }
   return fmf;
 }


### PR DESCRIPTION
There is no reason for the SPIR-V NoContraction decoration to prevent us
from setting the LLVM NoSignedZeros fast math flag on an instruction.
Setting NoSignedZeros in more cases allows more optimizations like
0.0 * x --> 0.0 (assuming we have already set the NoNaNs flag).