### PR TITLE
Handle remaining `Result`s

### DIFF
--- a/llpc/context/llpcShaderCache.h
+++ b/llpc/context/llpcShaderCache.h
@@ -122,37 +122,38 @@ public:
   ShaderCache();
   ~ShaderCache() override;
 
-  Result init(const ShaderCacheCreateInfo *createInfo, const ShaderCacheAuxCreateInfo *auxCreateInfo);
+  LLPC_NODISCARD Result init(const ShaderCacheCreateInfo *createInfo, const ShaderCacheAuxCreateInfo *auxCreateInfo);
   void Destroy() override;
 
-  Result Serialize(void *blob, size_t *size) override;
+  LLPC_NODISCARD Result Serialize(void *blob, size_t *size) override;
 
-  Result Merge(unsigned srcCacheCount, const IShaderCache **ppSrcCaches) override;
+  LLPC_NODISCARD Result Merge(unsigned srcCacheCount, const IShaderCache **ppSrcCaches) override;
 
-  ShaderEntryState findShader(MetroHash::Hash hash, bool allocateOnMiss, CacheEntryHandle *phEntry);
+  LLPC_NODISCARD ShaderEntryState findShader(MetroHash::Hash hash, bool allocateOnMiss, CacheEntryHandle *phEntry);
 
   void insertShader(CacheEntryHandle hEntry, const void *blob, size_t size);
 
   void resetShader(CacheEntryHandle hEntry);
 
-  Result retrieveShader(CacheEntryHandle hEntry, const void **ppBlob, size_t *size);
+  LLPC_NODISCARD Result retrieveShader(CacheEntryHandle hEntry, const void **ppBlob, size_t *size);
 
-  bool isCompatible(const ShaderCacheCreateInfo *createInfo, const ShaderCacheAuxCreateInfo *auxCreateInfo);
+  LLPC_NODISCARD bool isCompatible(const ShaderCacheCreateInfo *createInfo,
+                                   const ShaderCacheAuxCreateInfo *auxCreateInfo);
 
 private:
   ShaderCache(const ShaderCache &) = delete;
   ShaderCache &operator=(const ShaderCache &) = delete;
 
-  Result buildFileName(const char *executableName, const char *cacheFilePath, GfxIpVersion gfxIp,
-                       bool *cacheFileExists);
-  Result validateAndLoadHeader(const ShaderCacheSerializedHeader *header, size_t dataSourceSize);
-  Result loadCacheFromBlob(const void *initialData, size_t initialDataSize);
-  Result populateIndexMap(void *dataStart, size_t dataSize);
-  uint64_t calculateCrc(const uint8_t *data, size_t numBytes);
+  LLPC_NODISCARD Result buildFileName(const char *executableName, const char *cacheFilePath, GfxIpVersion gfxIp,
+                                      bool *cacheFileExists);
+  LLPC_NODISCARD Result validateAndLoadHeader(const ShaderCacheSerializedHeader *header, size_t dataSourceSize);
+  LLPC_NODISCARD Result loadCacheFromBlob(const void *initialData, size_t initialDataSize);
+  LLPC_NODISCARD Result populateIndexMap(void *dataStart, size_t dataSize);
+  LLPC_NODISCARD uint64_t calculateCrc(const uint8_t *data, size_t numBytes);
 
-  Result loadCacheFromFile();
+  LLPC_NODISCARD Result loadCacheFromFile();
   void resetCacheFile();
-  Result addShaderToFile(const ShaderIndex *index);
+  LLPC_NODISCARD Result addShaderToFile(const ShaderIndex *index);
 
   void *getCacheSpace(size_t numBytes);
 

--- a/llpc/unittests/standaloneCompiler/testShaderCache.cpp
+++ b/llpc/unittests/standaloneCompiler/testShaderCache.cpp
@@ -87,7 +87,8 @@ private:
 TEST_F(ShaderCacheTest, CreateEmpty) {
   ShaderCache &cache = getCache();
   size_t size = 0;
-  cache.Serialize(nullptr, &size);
+  Result result = cache.Serialize(nullptr, &size);
+  EXPECT_EQ(result, Result::Success);
   EXPECT_EQ(size, sizeof(ShaderCacheSerializedHeader));
 }
 
@@ -127,7 +128,8 @@ TEST_F(ShaderCacheTest, InsertOne) {
   EXPECT_THAT(charArrayFromBlob(blob, blobSize), ElementsAreArray(cacheEntry));
 
   size_t cacheSize = 0;
-  cache.Serialize(nullptr, &cacheSize);
+  result = cache.Serialize(nullptr, &cacheSize);
+  EXPECT_EQ(result, Result::Success);
   EXPECT_GE(cacheSize, sizeof(ShaderCacheSerializedHeader) + blobSize);
 }
 
@@ -164,7 +166,8 @@ TEST_F(ShaderCacheTest, InsertsShaders) {
   }
 
   size_t cacheSize = 0;
-  cache.Serialize(nullptr, &cacheSize);
+  Result result = cache.Serialize(nullptr, &cacheSize);
+  EXPECT_EQ(result, Result::Success);
   EXPECT_GE(cacheSize, sizeof(ShaderCacheSerializedHeader) + (numShaders * cacheEntry.size()));
 }
 
@@ -227,7 +230,8 @@ TEST_F(ShaderCacheTest, InsertsShadersMultithreaded) {
   }
 
   size_t cacheSize = 0;
-  cache.Serialize(nullptr, &cacheSize);
+  Result result = cache.Serialize(nullptr, &cacheSize);
+  EXPECT_EQ(result, Result::Success);
   EXPECT_GE(cacheSize, sizeof(ShaderCacheSerializedHeader) + (numShaders * cacheEntry.size()));
 }
 

--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -892,7 +892,9 @@ template <class Elf> void ElfWriter<Elf>::addRelocSymbols(const ElfReader<Elf> &
   SectionBuffer *inputRodataSection = nullptr;
   std::vector<ElfSymbol> inputRodataSymbols;
   auto inputRodataSecIndex = reader.GetSectionIndex(relocSym.secName);
-  reader.getSectionDataBySectionIndex(inputRodataSecIndex, &inputRodataSection);
+  Result result = reader.getSectionDataBySectionIndex(inputRodataSecIndex, &inputRodataSection);
+  assert(result == Result::Success || result == Result::ErrorInvalidValue);
+  (void)result;
   reader.GetSymbolsBySectionIndex(inputRodataSecIndex, inputRodataSymbols);
 
   SectionBuffer newSection = createNewSection(secName, inputRodataSection);
@@ -1044,8 +1046,10 @@ void ElfWriter<Elf>::processRelocSection(const ElfReader<Elf> &reader, size_t no
   auto fragmentRelocSecIndex = reader.GetSectionIndex(RelocName);
   auto nonFragmentRelocSecIndex = GetSectionIndex(RelocName);
 
-  reader.getSectionDataBySectionIndex(fragmentRelocSecIndex, &fragmentRelocSection);
-  Result result = getSectionDataBySectionIndex(nonFragmentRelocSecIndex, &nonFragmentRelocSection);
+  Result result = reader.getSectionDataBySectionIndex(fragmentRelocSecIndex, &fragmentRelocSection);
+  assert(result == Result::Success || result == Result::ErrorInvalidValue);
+  (void)result;
+  result = getSectionDataBySectionIndex(nonFragmentRelocSecIndex, &nonFragmentRelocSection);
   assert(result == Result::Success || result == Result::NotFound);
   (void)result;
 
@@ -1212,7 +1216,9 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
 
   auto fragmentTextSecIndex = reader.GetSectionIndex(TextName);
   auto nonFragmentSecIndex = GetSectionIndex(TextName);
-  reader.getSectionDataBySectionIndex(fragmentTextSecIndex, &fragmentTextSection);
+  Result result = reader.getSectionDataBySectionIndex(fragmentTextSecIndex, &fragmentTextSection);
+  assert(result == Result::Success || result == Result::ErrorInvalidValue);
+  (void)result;
   reader.GetSymbolsBySectionIndex(fragmentTextSecIndex, fragmentSymbols);
 
   mustSucceed(getSectionDataBySectionIndex(nonFragmentSecIndex, &nonFragmentTextSection));
@@ -1278,7 +1284,9 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
   auto nonFragmentDisassemblySecIndex = GetSectionIndex(Util::Abi::AmdGpuDisassemblyName);
   ElfSectionBuffer<Elf64::SectionHeader> *fragmentDisassemblySection = nullptr;
   const ElfSectionBuffer<Elf64::SectionHeader> *nonFragmentDisassemblySection = nullptr;
-  reader.getSectionDataBySectionIndex(fragmentDisassemblySecIndex, &fragmentDisassemblySection);
+  result = reader.getSectionDataBySectionIndex(fragmentDisassemblySecIndex, &fragmentDisassemblySection);
+  assert(result == Result::Success || result == Result::ErrorInvalidValue);
+  (void)result;
   mustSucceed(getSectionDataBySectionIndex(nonFragmentDisassemblySecIndex, &nonFragmentDisassemblySection));
   if (nonFragmentDisassemblySection) {
     assert(fragmentDisassemblySection);
@@ -1316,8 +1324,11 @@ void ElfWriter<Elf>::mergeElfBinary(Context *pContext, const BinaryData *pFragme
 
   auto fragmentLlvmIrSecIndex = reader.GetSectionIndex(llvmIrSectionName.c_str());
   auto nonFragmentLlvmIrSecIndex = GetSectionIndex(llvmIrSectionName.c_str());
-  reader.getSectionDataBySectionIndex(fragmentLlvmIrSecIndex, &fragmentLlvmIrSection);
-  Result result = getSectionDataBySectionIndex(nonFragmentLlvmIrSecIndex, &nonFragmentLlvmIrSection);
+  result = reader.getSectionDataBySectionIndex(fragmentLlvmIrSecIndex, &fragmentLlvmIrSection);
+  assert(result == Result::Success || result == Result::ErrorInvalidValue);
+  (void)result;
+
+  result = getSectionDataBySectionIndex(nonFragmentLlvmIrSecIndex, &nonFragmentLlvmIrSection);
   assert(result == Result::Success || result == Result::NotFound);
   (void)result;
 


### PR DESCRIPTION
Add missing nodiscard annotations and check the remaining `Result`s.

I did not change `llpcElfReader.h` because the the comments mentioned
not to change the API. I added it locally to confirm that I did not miss
anything.

After this PR, all function returning `Result` should have their result
checked. See the mailing list thread '[RFC] Improving LLPC Result checking'
for more details.