### PR TITLE
Test changes to enable merge of upstream changes in llvm

### DIFF
--- a/lgc/test/CsBuiltIns.lgc
+++ b/lgc/test/CsBuiltIns.lgc
@@ -136,9 +136,9 @@ attributes #0 = { nounwind }
 
 ; RUN: lgc -extract=5 -mcpu=gfx802 %s -o - | FileCheck --check-prefixes=CHECK5 %s
 ; CHECK5-LABEL: _amdgpu_cs_main:
-; CHECK5-DAG: v_mov_b32_e32 v0, s3
-; CHECK5-DAG: v_mov_b32_e32 v1, s4
-; CHECK5-DAG: v_mov_b32_e32 v2, s5
+; CHECK5-DAG: v_mov_b32_e32 v0, s{{[0-9]*}}
+; CHECK5-DAG: v_mov_b32_e32 v1, s{{[0-9]*}}
+; CHECK5-DAG: v_mov_b32_e32 v2, s{{[0-9]*}}
 ; CHECK5: buffer_store_dwordx3 v[0:2],
 ; rsrc2 bits 7,8,9 need to be set to enable the three WorkgroupId SGPRs
 ; CHECK5: COMPUTE_PGM_RSRC2): 0x{{[0-9a-f]*[7f][89a-f][0-9a-f]$}}

--- a/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
+++ b/llpc/test/shaderdb/PipelineCs_StrideReloc.pipe
@@ -1,5 +1,3 @@
-; XFAIL: *
-
 // This test case checks that stride relocation is generated correctly for array of textures.
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
@@ -8,7 +6,8 @@
   // Matching the texture index
 ; SHADERTEST-DAG: v_readfirstlane_b32 s[[TEXINDEX:[0-9]+]], v{{[0-9]+}} //{{.*}}
   // Check that correct stride value is multiplied onto the index
-; SHADERTEST-DAG: s_mul_i32 s{{[0-9]+}}, s[[TEXINDEX]], 48 //{{.*}}
+; SHADERTEST-DAG: s_add_i32 s[[TEXINDEX2:[0-9]+]], s[[TEXINDEX]], s{{[0-9]+}}
+; SHADERTEST-DAG: s_mul_i32 s{{[0-9]+}}, s[[TEXINDEX2]], 48 //{{.*}}
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST


### PR DESCRIPTION
A couple of simple test fixes.

Make CsBuiltIns.lgc tolerate different sgpr allocations

Re-enable PipelineCs_StrideReloc.pipe test:
This could have been changed back from XFAIL before, the upstream change
highlighted an issue as it accidentally started working again. Added fix so it
works before/after the change (as it should).