### PR TITLE
[CI] Include coverage and tsan in nightly build configurations

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -17,8 +17,12 @@ jobs:
         image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
         branch:         [dev]
         config:         [Release]
-        feature-set:    ["+gcc", "+clang", "+clang+shadercache", "+clang+ubsan+asan",
-                         "+gcc+assertions", "+clang+assertions", "+clang+shadercache+assertions", "+clang+ubsan+asan+assertions"]
+        feature-set:    ["+gcc", "+gcc+assertions",
+                         "+clang", "+clang+coverage",
+                         "+clang+shadercache+coverage+assertions",
+                         "+clang+shadercache+ubsan+asan",
+                         "+clang+shadercache+ubsan+asan+assertions",
+                         "+clang+shadercache+tsan"]
         generator:      [Ninja]
     steps:
       - name: Free up disk space

--- a/.github/workflows/check-clang-tidy-llpc.yml
+++ b/.github/workflows/check-clang-tidy-llpc.yml
@@ -15,7 +15,7 @@ jobs:
           git checkout ${GITHUB_SHA}
       - name: Generate Docker base image tag string
         run: |
-          echo "IMAGE_TAG=gcr.io/stadia-open-source/amdvlk_release_clang_assertions:nightly" | tee -a $GITHUB_ENV
+          echo "IMAGE_TAG=gcr.io/stadia-open-source/amdvlk_release_clang:nightly" | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker


### PR DESCRIPTION
This is a change to the "nightly" configuration to introduce configurations that include coverage instrumentation and the thread sanitizer. 

Separate PRs will be sent to update XGL and LLPC's per-PR CI:
* XGL: https://github.com/GPUOpen-Drivers/xgl/pull/140
* LLPC: https://github.com/GPUOpen-Drivers/llpc/pull/1562