### PR TITLE
Correctly handle the DescSet relocation

### DIFF
--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -63,6 +63,12 @@ const static char DescriptorOffset[] = "doff_";
 //  * 1: descriptor pointer should be loaded from the spill table
 const static char DescriptorUseSpillTable[] = "dusespill_";
 
+// The offset in the root table of the descriptor table that contains the descriptor set.  The value is in bytes.
+// The format is: "descset_X" where:
+// * X is the descriptor set number
+//
+const static char DescriptorTableOffset[] = "descset_";
+
 // Descriptor stride is "dstride_X_Y" where:
 // * X is the descriptor set number
 // * Y is the binding number

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -640,7 +640,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
             } else {
               // Shader compilation. Use a relocation to get the descriptor
               // table offset for the descriptor set userDataIdx.
-              offset = builder.CreateRelocationConstant("descset_" + Twine(userDataIdx));
+              offset = builder.CreateRelocationConstant(reloc::DescriptorTableOffset + Twine(userDataIdx));
               namePrefix = "descSet";
             }
             Value *addr = builder.CreateGEP(builder.getInt8Ty(), spillTable, offset);

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
@@ -1,0 +1,347 @@
+; Test that the DescSet relocation is generated.  If this starts to fail we need to change the test to make sure it
+; is generated.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% \
+; RUN:         -enable-relocatable-shader-elf \
+; RUN:         -o %t.elf %gfxip %s %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
+; SHADERTEST: {{^_amdgpu_cs_main:}}
+; SHADERTEST-NEXT: BB0_0:
+; SHADERTEST-NEXT: s_mov_b32 {{s[0-9]*}}, descset_14@abs32@lo
+; The spill threshold in this case is 47 because it will have to load the descriptor table pointer from the root table.
+; SHADERTEST: .spill_threshold: 0x000000000000002F
+; END_SHADERTEST
+
+; Test that the relocation is correctly replaced.  The value comes from the user data nodes 20: 47*4 = 188 = 0xbc
+; BEGIN_SHADERTEST2
+; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; SHADERTEST2: 0000000000000000 <_amdgpu_cs_main>:
+; SHADERTEST2-NEXT: s_mov_b32 {{s[0-9]*}}, 0xbc // 000000000000
+; END_SHADERTEST2
+
+[Version]
+version = 52
+
+[CsSpirv]
+               OpCapability Shader
+               OpCapability SampledBuffer
+               OpCapability ImageBuffer
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %4 "main"
+               OpExecutionMode %4 LocalSize 1 1 1
+               OpMemberDecorate %_struct_92 0 Offset 0
+               OpDecorate %_struct_92 Block
+               OpDecorate %94 DescriptorSet 2
+               OpDecorate %94 Binding 0
+               OpMemberDecorate %_struct_102 0 Offset 0
+               OpDecorate %_struct_102 Block
+               OpDecorate %104 DescriptorSet 3
+               OpDecorate %104 Binding 2
+               OpDecorate %111 DescriptorSet 4
+               OpDecorate %111 Binding 1
+               OpMemberDecorate %_struct_139 0 Offset 0
+               OpDecorate %_struct_139 Block
+               OpDecorate %141 DescriptorSet 5
+               OpDecorate %141 Binding 2
+               OpMemberDecorate %_struct_149 0 Offset 0
+               OpDecorate %_struct_149 Block
+               OpDecorate %151 DescriptorSet 6
+               OpDecorate %151 Binding 0
+               OpDecorate %168 DescriptorSet 7
+               OpDecorate %168 Binding 2
+               OpDecorate %186 DescriptorSet 8
+               OpDecorate %186 Binding 1
+               OpDecorate %195 DescriptorSet 9
+               OpDecorate %195 Binding 0
+               OpDecorate %204 DescriptorSet 10
+               OpDecorate %204 Binding 5
+               OpDecorate %213 DescriptorSet 11
+               OpDecorate %213 Binding 0
+               OpDecorate %252 DescriptorSet 12
+               OpDecorate %252 Binding 3
+               OpDecorate %289 DescriptorSet 13
+               OpDecorate %289 Binding 4
+               OpDecorate %298 DescriptorSet 14
+               OpDecorate %298 Binding 0
+               OpDecorate %327 DescriptorSet 0
+               OpDecorate %327 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %28 = OpTypeImage %int Buffer 0 0 0 2 R32i
+%_ptr_UniformConstant_28 = OpTypePointer UniformConstant %28
+      %v4int = OpTypeVector %int 4
+%_ptr_Uniform_int = OpTypePointer Uniform %int
+         %71 = OpTypeImage %int Buffer 0 0 0 1 Unknown
+%_ptr_UniformConstant_71 = OpTypePointer UniformConstant %71
+ %_struct_92 = OpTypeStruct %int
+%_ptr_Uniform__struct_92 = OpTypePointer Uniform %_struct_92
+         %94 = OpVariable %_ptr_Uniform__struct_92 Uniform
+%_struct_102 = OpTypeStruct %int
+%_ptr_Uniform__struct_102 = OpTypePointer Uniform %_struct_102
+        %104 = OpVariable %_ptr_Uniform__struct_102 Uniform
+        %111 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+%_struct_139 = OpTypeStruct %int
+%_ptr_Uniform__struct_139 = OpTypePointer Uniform %_struct_139
+        %141 = OpVariable %_ptr_Uniform__struct_139 Uniform
+%_struct_149 = OpTypeStruct %int
+%_ptr_Uniform__struct_149 = OpTypePointer Uniform %_struct_149
+        %151 = OpVariable %_ptr_Uniform__struct_149 Uniform
+        %168 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %186 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %195 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %204 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %213 = OpVariable %_ptr_UniformConstant_28 UniformConstant
+        %252 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %289 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %298 = OpVariable %_ptr_UniformConstant_28 UniformConstant
+        %325 = OpTypeImage %int 2D 0 0 0 2 R32i
+%_ptr_UniformConstant_325 = OpTypePointer UniformConstant %325
+        %327 = OpVariable %_ptr_UniformConstant_325 UniformConstant
+      %v2int = OpTypeVector %int 2
+        %343 = OpUndef %325
+        %344 = OpUndef %v2int
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %95 = OpAccessChain %_ptr_Uniform_int %94 %int_0
+         %96 = OpLoad %int %95
+        %105 = OpAccessChain %_ptr_Uniform_int %104 %int_0
+        %106 = OpLoad %int %105
+        %112 = OpLoad %71 %111
+        %142 = OpAccessChain %_ptr_Uniform_int %141 %int_0
+        %143 = OpLoad %int %142
+        %152 = OpAccessChain %_ptr_Uniform_int %151 %int_0
+        %153 = OpLoad %int %152
+        %169 = OpLoad %71 %168
+        %187 = OpLoad %71 %186
+        %196 = OpLoad %71 %195
+        %205 = OpLoad %71 %204
+        %214 = OpLoad %28 %213
+        %253 = OpLoad %71 %252
+        %290 = OpLoad %71 %289
+        %299 = OpLoad %28 %298
+        %300 = OpImageRead %v4int %299 %int_0
+        %328 = OpLoad %325 %327
+               OpImageWrite %343 %344 %300
+               OpReturn
+               OpFunctionEnd
+
+
+[CsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 1
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 32
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = DescriptorImage
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 0x00000000
+userDataNode[1].next[0].binding = 0
+userDataNode[1].next[1].type = DescriptorTexelBuffer
+userDataNode[1].next[1].offsetInDwords = 8
+userDataNode[1].next[1].sizeInDwords = 4
+userDataNode[1].next[1].set = 0x00000000
+userDataNode[1].next[1].binding = 1
+userDataNode[1].next[2].type = DescriptorBuffer
+userDataNode[1].next[2].offsetInDwords = 12
+userDataNode[1].next[2].sizeInDwords = 4
+userDataNode[1].next[2].set = 0x00000000
+userDataNode[1].next[2].binding = 2
+userDataNode[2].visibility = 32
+userDataNode[2].type = DescriptorConstBuffer
+userDataNode[2].offsetInDwords = 2
+userDataNode[2].sizeInDwords = 4
+userDataNode[2].set = 0x00000001
+userDataNode[2].binding = 0
+userDataNode[3].visibility = 32
+userDataNode[3].type = DescriptorTableVaPtr
+userDataNode[3].offsetInDwords = 6
+userDataNode[3].sizeInDwords = 1
+userDataNode[3].next[0].type = DescriptorBuffer
+userDataNode[3].next[0].offsetInDwords = 0
+userDataNode[3].next[0].sizeInDwords = 4
+userDataNode[3].next[0].set = 0x00000001
+userDataNode[3].next[0].binding = 1
+userDataNode[3].next[1].type = DescriptorConstTexelBuffer
+userDataNode[3].next[1].offsetInDwords = 4
+userDataNode[3].next[1].sizeInDwords = 4
+userDataNode[3].next[1].set = 0x00000001
+userDataNode[3].next[1].binding = 3
+userDataNode[3].next[2].type = DescriptorConstBuffer
+userDataNode[3].next[2].offsetInDwords = 8
+userDataNode[3].next[2].sizeInDwords = 4
+userDataNode[3].next[2].set = 0x00000001
+userDataNode[3].next[2].binding = 5
+userDataNode[4].visibility = 32
+userDataNode[4].type = DescriptorConstBuffer
+userDataNode[4].offsetInDwords = 7
+userDataNode[4].sizeInDwords = 4
+userDataNode[4].set = 0x00000002
+userDataNode[4].binding = 0
+userDataNode[5].visibility = 32
+userDataNode[5].type = DescriptorConstBuffer
+userDataNode[5].offsetInDwords = 11
+userDataNode[5].sizeInDwords = 4
+userDataNode[5].set = 0x00000003
+userDataNode[5].binding = 2
+userDataNode[6].visibility = 32
+userDataNode[6].type = DescriptorTableVaPtr
+userDataNode[6].offsetInDwords = 15
+userDataNode[6].sizeInDwords = 1
+userDataNode[6].next[0].type = DescriptorConstTexelBuffer
+userDataNode[6].next[0].offsetInDwords = 0
+userDataNode[6].next[0].sizeInDwords = 4
+userDataNode[6].next[0].set = 0x00000004
+userDataNode[6].next[0].binding = 1
+userDataNode[6].next[1].type = DescriptorConstTexelBuffer
+userDataNode[6].next[1].offsetInDwords = 4
+userDataNode[6].next[1].sizeInDwords = 4
+userDataNode[6].next[1].set = 0x00000004
+userDataNode[6].next[1].binding = 3
+userDataNode[7].visibility = 32
+userDataNode[7].type = DescriptorConstBuffer
+userDataNode[7].offsetInDwords = 16
+userDataNode[7].sizeInDwords = 4
+userDataNode[7].set = 0x00000005
+userDataNode[7].binding = 0
+userDataNode[8].visibility = 32
+userDataNode[8].type = DescriptorConstBuffer
+userDataNode[8].offsetInDwords = 20
+userDataNode[8].sizeInDwords = 4
+userDataNode[8].set = 0x00000005
+userDataNode[8].binding = 2
+userDataNode[9].visibility = 32
+userDataNode[9].type = DescriptorConstBuffer
+userDataNode[9].offsetInDwords = 24
+userDataNode[9].sizeInDwords = 4
+userDataNode[9].set = 0x00000006
+userDataNode[9].binding = 0
+userDataNode[10].visibility = 32
+userDataNode[10].type = DescriptorTableVaPtr
+userDataNode[10].offsetInDwords = 28
+userDataNode[10].sizeInDwords = 1
+userDataNode[10].next[0].type = DescriptorConstTexelBuffer
+userDataNode[10].next[0].offsetInDwords = 0
+userDataNode[10].next[0].sizeInDwords = 4
+userDataNode[10].next[0].set = 0x00000007
+userDataNode[10].next[0].binding = 1
+userDataNode[10].next[1].type = DescriptorConstTexelBuffer
+userDataNode[10].next[1].offsetInDwords = 4
+userDataNode[10].next[1].sizeInDwords = 4
+userDataNode[10].next[1].set = 0x00000007
+userDataNode[10].next[1].binding = 2
+userDataNode[11].visibility = 32
+userDataNode[11].type = DescriptorTableVaPtr
+userDataNode[11].offsetInDwords = 29
+userDataNode[11].sizeInDwords = 1
+userDataNode[11].next[0].type = DescriptorConstTexelBuffer
+userDataNode[11].next[0].offsetInDwords = 0
+userDataNode[11].next[0].sizeInDwords = 4
+userDataNode[11].next[0].set = 0x00000008
+userDataNode[11].next[0].binding = 0
+userDataNode[11].next[1].type = DescriptorConstTexelBuffer
+userDataNode[11].next[1].offsetInDwords = 4
+userDataNode[11].next[1].sizeInDwords = 4
+userDataNode[11].next[1].set = 0x00000008
+userDataNode[11].next[1].binding = 1
+userDataNode[12].visibility = 32
+userDataNode[12].type = DescriptorTableVaPtr
+userDataNode[12].offsetInDwords = 30
+userDataNode[12].sizeInDwords = 1
+userDataNode[12].next[0].type = DescriptorConstTexelBuffer
+userDataNode[12].next[0].offsetInDwords = 0
+userDataNode[12].next[0].sizeInDwords = 4
+userDataNode[12].next[0].set = 0x00000009
+userDataNode[12].next[0].binding = 0
+userDataNode[13].visibility = 32
+userDataNode[13].type = DescriptorTableVaPtr
+userDataNode[13].offsetInDwords = 31
+userDataNode[13].sizeInDwords = 1
+userDataNode[13].next[0].type = DescriptorConstTexelBuffer
+userDataNode[13].next[0].offsetInDwords = 0
+userDataNode[13].next[0].sizeInDwords = 4
+userDataNode[13].next[0].set = 0x0000000A
+userDataNode[13].next[0].binding = 5
+userDataNode[14].visibility = 32
+userDataNode[14].type = DescriptorConstBuffer
+userDataNode[14].offsetInDwords = 32
+userDataNode[14].sizeInDwords = 4
+userDataNode[14].set = 0x0000000B
+userDataNode[14].binding = 1
+userDataNode[15].visibility = 32
+userDataNode[15].type = DescriptorTableVaPtr
+userDataNode[15].offsetInDwords = 36
+userDataNode[15].sizeInDwords = 1
+userDataNode[15].next[0].type = DescriptorTexelBuffer
+userDataNode[15].next[0].offsetInDwords = 0
+userDataNode[15].next[0].sizeInDwords = 4
+userDataNode[15].next[0].set = 0x0000000B
+userDataNode[15].next[0].binding = 0
+userDataNode[16].visibility = 32
+userDataNode[16].type = DescriptorConstBuffer
+userDataNode[16].offsetInDwords = 37
+userDataNode[16].sizeInDwords = 4
+userDataNode[16].set = 0x0000000C
+userDataNode[16].binding = 0
+userDataNode[17].visibility = 32
+userDataNode[17].type = DescriptorBuffer
+userDataNode[17].offsetInDwords = 41
+userDataNode[17].sizeInDwords = 4
+userDataNode[17].set = 0x0000000C
+userDataNode[17].binding = 1
+userDataNode[18].visibility = 32
+userDataNode[18].type = DescriptorTableVaPtr
+userDataNode[18].offsetInDwords = 45
+userDataNode[18].sizeInDwords = 1
+userDataNode[18].next[0].type = DescriptorConstTexelBuffer
+userDataNode[18].next[0].offsetInDwords = 0
+userDataNode[18].next[0].sizeInDwords = 4
+userDataNode[18].next[0].set = 0x0000000C
+userDataNode[18].next[0].binding = 3
+userDataNode[19].visibility = 32
+userDataNode[19].type = DescriptorTableVaPtr
+userDataNode[19].offsetInDwords = 46
+userDataNode[19].sizeInDwords = 1
+userDataNode[19].next[0].type = DescriptorBuffer
+userDataNode[19].next[0].offsetInDwords = 0
+userDataNode[19].next[0].sizeInDwords = 4
+userDataNode[19].next[0].set = 0x0000000D
+userDataNode[19].next[0].binding = 0
+userDataNode[19].next[1].type = DescriptorConstBuffer
+userDataNode[19].next[1].offsetInDwords = 4
+userDataNode[19].next[1].sizeInDwords = 4
+userDataNode[19].next[1].set = 0x0000000D
+userDataNode[19].next[1].binding = 1
+userDataNode[19].next[2].type = DescriptorConstTexelBuffer
+userDataNode[19].next[2].offsetInDwords = 8
+userDataNode[19].next[2].sizeInDwords = 4
+userDataNode[19].next[2].set = 0x0000000D
+userDataNode[19].next[2].binding = 3
+userDataNode[19].next[3].type = DescriptorConstTexelBuffer
+userDataNode[19].next[3].offsetInDwords = 12
+userDataNode[19].next[3].sizeInDwords = 4
+userDataNode[19].next[3].set = 0x0000000D
+userDataNode[19].next[3].binding = 4
+userDataNode[20].visibility = 32
+userDataNode[20].type = DescriptorTableVaPtr
+userDataNode[20].offsetInDwords = 47
+userDataNode[20].sizeInDwords = 1
+userDataNode[20].next[0].type = DescriptorTexelBuffer
+userDataNode[20].next[0].offsetInDwords = 0
+userDataNode[20].next[0].sizeInDwords = 4
+userDataNode[20].next[0].set = 0x0000000E
+userDataNode[20].next[0].binding = 0
+userDataNode[20].next[1].type = DescriptorConstTexelBuffer
+userDataNode[20].next[1].offsetInDwords = 4
+userDataNode[20].next[1].sizeInDwords = 4
+userDataNode[20].next[1].set = 0x0000000E
+userDataNode[20].next[1].binding = 3

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
@@ -1,0 +1,344 @@
+; Test that the DescSet relocation is generated.  If this starts to fail we need to change the test to make sure it
+; is generated.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% \
+; RUN:         -enable-relocatable-shader-elf \
+; RUN:         -o %t.elf %gfxip %s %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
+; SHADERTEST: {{^_amdgpu_cs_main:}}
+; SHADERTEST-NEXT: BB0_0:
+; SHADERTEST-NEXT: s_mov_b32 {{s[0-9]*}}, descset_14@abs32@lo
+; The spill threshold in this case is 0 because it will have to load the descriptor from the root table.
+; SHADERTEST: .spill_threshold: 0x0000000000000000
+; END_SHADERTEST
+
+; Test that the relocation is correctly replaced.  Since there is no descriptor table for descriptor 20, we expect a
+; value of 0.
+; BEGIN_SHADERTEST2
+; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; SHADERTEST2: 0000000000000000 <_amdgpu_cs_main>:
+; SHADERTEST2-NEXT: s_mov_b32 {{s[0-9]*}}, 0 // 000000000000
+; END_SHADERTEST2
+
+[Version]
+version = 52
+
+[CsSpirv]
+               OpCapability Shader
+               OpCapability SampledBuffer
+               OpCapability ImageBuffer
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %4 "main"
+               OpExecutionMode %4 LocalSize 1 1 1
+               OpMemberDecorate %_struct_92 0 Offset 0
+               OpDecorate %_struct_92 Block
+               OpDecorate %94 DescriptorSet 2
+               OpDecorate %94 Binding 0
+               OpMemberDecorate %_struct_102 0 Offset 0
+               OpDecorate %_struct_102 Block
+               OpDecorate %104 DescriptorSet 3
+               OpDecorate %104 Binding 2
+               OpDecorate %111 DescriptorSet 4
+               OpDecorate %111 Binding 1
+               OpMemberDecorate %_struct_139 0 Offset 0
+               OpDecorate %_struct_139 Block
+               OpDecorate %141 DescriptorSet 5
+               OpDecorate %141 Binding 2
+               OpMemberDecorate %_struct_149 0 Offset 0
+               OpDecorate %_struct_149 Block
+               OpDecorate %151 DescriptorSet 6
+               OpDecorate %151 Binding 0
+               OpDecorate %168 DescriptorSet 7
+               OpDecorate %168 Binding 2
+               OpDecorate %186 DescriptorSet 8
+               OpDecorate %186 Binding 1
+               OpDecorate %195 DescriptorSet 9
+               OpDecorate %195 Binding 0
+               OpDecorate %204 DescriptorSet 10
+               OpDecorate %204 Binding 5
+               OpDecorate %213 DescriptorSet 11
+               OpDecorate %213 Binding 0
+               OpDecorate %252 DescriptorSet 12
+               OpDecorate %252 Binding 3
+               OpDecorate %289 DescriptorSet 13
+               OpDecorate %289 Binding 4
+               OpDecorate %298 DescriptorSet 14
+               OpDecorate %298 Binding 0
+               OpDecorate %327 DescriptorSet 0
+               OpDecorate %327 Binding 0
+               OpMemberDecorate %UniformBufferObject 0 Offset 0
+               OpDecorate %UniformBufferObject Block
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+         %28 = OpTypeImage %int Buffer 0 0 0 2 R32i
+%_ptr_UniformConstant_28 = OpTypePointer UniformConstant %28
+      %v4int = OpTypeVector %int 4
+%_ptr_Uniform_int = OpTypePointer Uniform %int
+         %71 = OpTypeImage %int Buffer 0 0 0 1 Unknown
+%_ptr_UniformConstant_71 = OpTypePointer UniformConstant %71
+ %_struct_92 = OpTypeStruct %int
+%_ptr_Uniform__struct_92 = OpTypePointer Uniform %_struct_92
+         %94 = OpVariable %_ptr_Uniform__struct_92 Uniform
+%_struct_102 = OpTypeStruct %int
+%_ptr_Uniform__struct_102 = OpTypePointer Uniform %_struct_102
+        %104 = OpVariable %_ptr_Uniform__struct_102 Uniform
+        %111 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+%_struct_139 = OpTypeStruct %int
+%_ptr_Uniform__struct_139 = OpTypePointer Uniform %_struct_139
+        %141 = OpVariable %_ptr_Uniform__struct_139 Uniform
+%_struct_149 = OpTypeStruct %int
+%_ptr_Uniform__struct_149 = OpTypePointer Uniform %_struct_149
+%_ptr_Uniform_v4int = OpTypePointer Uniform %v4int
+        %151 = OpVariable %_ptr_Uniform__struct_149 Uniform
+        %168 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %186 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %195 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %204 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %213 = OpVariable %_ptr_UniformConstant_28 UniformConstant
+        %252 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+        %289 = OpVariable %_ptr_UniformConstant_71 UniformConstant
+%UniformBufferObject = OpTypeStruct %v4int
+%_ptr_Uniform_UniformBufferObject = OpTypePointer Uniform %UniformBufferObject
+        %298 = OpVariable %_ptr_Uniform_UniformBufferObject Uniform
+        %325 = OpTypeImage %int 2D 0 0 0 2 R32i
+%_ptr_UniformConstant_325 = OpTypePointer UniformConstant %325
+        %327 = OpVariable %_ptr_UniformConstant_325 UniformConstant
+      %v2int = OpTypeVector %int 2
+        %343 = OpUndef %325
+        %344 = OpUndef %v2int
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %95 = OpAccessChain %_ptr_Uniform_int %94 %int_0
+         %96 = OpLoad %int %95
+        %105 = OpAccessChain %_ptr_Uniform_int %104 %int_0
+        %106 = OpLoad %int %105
+        %112 = OpLoad %71 %111
+        %142 = OpAccessChain %_ptr_Uniform_int %141 %int_0
+        %143 = OpLoad %int %142
+        %152 = OpAccessChain %_ptr_Uniform_int %151 %int_0
+        %153 = OpLoad %int %152
+        %169 = OpLoad %71 %168
+        %187 = OpLoad %71 %186
+        %196 = OpLoad %71 %195
+        %205 = OpLoad %71 %204
+        %214 = OpLoad %28 %213
+        %253 = OpLoad %71 %252
+        %290 = OpLoad %71 %289
+        %299 = OpAccessChain %_ptr_Uniform_v4int %298 %int_0
+        %300 = OpLoad %v4int %299
+        %328 = OpLoad %325 %327
+               OpImageWrite %343 %344 %300
+               OpReturn
+               OpFunctionEnd
+
+
+[CsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 1
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 32
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = DescriptorImage
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 8
+userDataNode[1].next[0].set = 0x00000000
+userDataNode[1].next[0].binding = 0
+userDataNode[1].next[1].type = DescriptorTexelBuffer
+userDataNode[1].next[1].offsetInDwords = 8
+userDataNode[1].next[1].sizeInDwords = 4
+userDataNode[1].next[1].set = 0x00000000
+userDataNode[1].next[1].binding = 1
+userDataNode[1].next[2].type = DescriptorBuffer
+userDataNode[1].next[2].offsetInDwords = 12
+userDataNode[1].next[2].sizeInDwords = 4
+userDataNode[1].next[2].set = 0x00000000
+userDataNode[1].next[2].binding = 2
+userDataNode[2].visibility = 32
+userDataNode[2].type = DescriptorConstBuffer
+userDataNode[2].offsetInDwords = 2
+userDataNode[2].sizeInDwords = 4
+userDataNode[2].set = 0x00000001
+userDataNode[2].binding = 0
+userDataNode[3].visibility = 32
+userDataNode[3].type = DescriptorTableVaPtr
+userDataNode[3].offsetInDwords = 6
+userDataNode[3].sizeInDwords = 1
+userDataNode[3].next[0].type = DescriptorBuffer
+userDataNode[3].next[0].offsetInDwords = 0
+userDataNode[3].next[0].sizeInDwords = 4
+userDataNode[3].next[0].set = 0x00000001
+userDataNode[3].next[0].binding = 1
+userDataNode[3].next[1].type = DescriptorConstTexelBuffer
+userDataNode[3].next[1].offsetInDwords = 4
+userDataNode[3].next[1].sizeInDwords = 4
+userDataNode[3].next[1].set = 0x00000001
+userDataNode[3].next[1].binding = 3
+userDataNode[3].next[2].type = DescriptorConstBuffer
+userDataNode[3].next[2].offsetInDwords = 8
+userDataNode[3].next[2].sizeInDwords = 4
+userDataNode[3].next[2].set = 0x00000001
+userDataNode[3].next[2].binding = 5
+userDataNode[4].visibility = 32
+userDataNode[4].type = DescriptorConstBuffer
+userDataNode[4].offsetInDwords = 7
+userDataNode[4].sizeInDwords = 4
+userDataNode[4].set = 0x00000002
+userDataNode[4].binding = 0
+userDataNode[5].visibility = 32
+userDataNode[5].type = DescriptorConstBuffer
+userDataNode[5].offsetInDwords = 11
+userDataNode[5].sizeInDwords = 4
+userDataNode[5].set = 0x00000003
+userDataNode[5].binding = 2
+userDataNode[6].visibility = 32
+userDataNode[6].type = DescriptorTableVaPtr
+userDataNode[6].offsetInDwords = 15
+userDataNode[6].sizeInDwords = 1
+userDataNode[6].next[0].type = DescriptorConstTexelBuffer
+userDataNode[6].next[0].offsetInDwords = 0
+userDataNode[6].next[0].sizeInDwords = 4
+userDataNode[6].next[0].set = 0x00000004
+userDataNode[6].next[0].binding = 1
+userDataNode[6].next[1].type = DescriptorConstTexelBuffer
+userDataNode[6].next[1].offsetInDwords = 4
+userDataNode[6].next[1].sizeInDwords = 4
+userDataNode[6].next[1].set = 0x00000004
+userDataNode[6].next[1].binding = 3
+userDataNode[7].visibility = 32
+userDataNode[7].type = DescriptorConstBuffer
+userDataNode[7].offsetInDwords = 16
+userDataNode[7].sizeInDwords = 4
+userDataNode[7].set = 0x00000005
+userDataNode[7].binding = 0
+userDataNode[8].visibility = 32
+userDataNode[8].type = DescriptorConstBuffer
+userDataNode[8].offsetInDwords = 20
+userDataNode[8].sizeInDwords = 4
+userDataNode[8].set = 0x00000005
+userDataNode[8].binding = 2
+userDataNode[9].visibility = 32
+userDataNode[9].type = DescriptorConstBuffer
+userDataNode[9].offsetInDwords = 24
+userDataNode[9].sizeInDwords = 4
+userDataNode[9].set = 0x00000006
+userDataNode[9].binding = 0
+userDataNode[10].visibility = 32
+userDataNode[10].type = DescriptorTableVaPtr
+userDataNode[10].offsetInDwords = 28
+userDataNode[10].sizeInDwords = 1
+userDataNode[10].next[0].type = DescriptorConstTexelBuffer
+userDataNode[10].next[0].offsetInDwords = 0
+userDataNode[10].next[0].sizeInDwords = 4
+userDataNode[10].next[0].set = 0x00000007
+userDataNode[10].next[0].binding = 1
+userDataNode[10].next[1].type = DescriptorConstTexelBuffer
+userDataNode[10].next[1].offsetInDwords = 4
+userDataNode[10].next[1].sizeInDwords = 4
+userDataNode[10].next[1].set = 0x00000007
+userDataNode[10].next[1].binding = 2
+userDataNode[11].visibility = 32
+userDataNode[11].type = DescriptorTableVaPtr
+userDataNode[11].offsetInDwords = 29
+userDataNode[11].sizeInDwords = 1
+userDataNode[11].next[0].type = DescriptorConstTexelBuffer
+userDataNode[11].next[0].offsetInDwords = 0
+userDataNode[11].next[0].sizeInDwords = 4
+userDataNode[11].next[0].set = 0x00000008
+userDataNode[11].next[0].binding = 0
+userDataNode[11].next[1].type = DescriptorConstTexelBuffer
+userDataNode[11].next[1].offsetInDwords = 4
+userDataNode[11].next[1].sizeInDwords = 4
+userDataNode[11].next[1].set = 0x00000008
+userDataNode[11].next[1].binding = 1
+userDataNode[12].visibility = 32
+userDataNode[12].type = DescriptorTableVaPtr
+userDataNode[12].offsetInDwords = 30
+userDataNode[12].sizeInDwords = 1
+userDataNode[12].next[0].type = DescriptorConstTexelBuffer
+userDataNode[12].next[0].offsetInDwords = 0
+userDataNode[12].next[0].sizeInDwords = 4
+userDataNode[12].next[0].set = 0x00000009
+userDataNode[12].next[0].binding = 0
+userDataNode[13].visibility = 32
+userDataNode[13].type = DescriptorTableVaPtr
+userDataNode[13].offsetInDwords = 31
+userDataNode[13].sizeInDwords = 1
+userDataNode[13].next[0].type = DescriptorConstTexelBuffer
+userDataNode[13].next[0].offsetInDwords = 0
+userDataNode[13].next[0].sizeInDwords = 4
+userDataNode[13].next[0].set = 0x0000000A
+userDataNode[13].next[0].binding = 5
+userDataNode[14].visibility = 32
+userDataNode[14].type = DescriptorConstBuffer
+userDataNode[14].offsetInDwords = 32
+userDataNode[14].sizeInDwords = 4
+userDataNode[14].set = 0x0000000B
+userDataNode[14].binding = 1
+userDataNode[15].visibility = 32
+userDataNode[15].type = DescriptorTableVaPtr
+userDataNode[15].offsetInDwords = 36
+userDataNode[15].sizeInDwords = 1
+userDataNode[15].next[0].type = DescriptorTexelBuffer
+userDataNode[15].next[0].offsetInDwords = 0
+userDataNode[15].next[0].sizeInDwords = 4
+userDataNode[15].next[0].set = 0x0000000B
+userDataNode[15].next[0].binding = 0
+userDataNode[16].visibility = 32
+userDataNode[16].type = DescriptorConstBuffer
+userDataNode[16].offsetInDwords = 37
+userDataNode[16].sizeInDwords = 4
+userDataNode[16].set = 0x0000000C
+userDataNode[16].binding = 0
+userDataNode[17].visibility = 32
+userDataNode[17].type = DescriptorBuffer
+userDataNode[17].offsetInDwords = 41
+userDataNode[17].sizeInDwords = 4
+userDataNode[17].set = 0x0000000C
+userDataNode[17].binding = 1
+userDataNode[18].visibility = 32
+userDataNode[18].type = DescriptorTableVaPtr
+userDataNode[18].offsetInDwords = 45
+userDataNode[18].sizeInDwords = 1
+userDataNode[18].next[0].type = DescriptorConstTexelBuffer
+userDataNode[18].next[0].offsetInDwords = 0
+userDataNode[18].next[0].sizeInDwords = 4
+userDataNode[18].next[0].set = 0x0000000C
+userDataNode[18].next[0].binding = 3
+userDataNode[19].visibility = 32
+userDataNode[19].type = DescriptorTableVaPtr
+userDataNode[19].offsetInDwords = 46
+userDataNode[19].sizeInDwords = 1
+userDataNode[19].next[0].type = DescriptorBuffer
+userDataNode[19].next[0].offsetInDwords = 0
+userDataNode[19].next[0].sizeInDwords = 4
+userDataNode[19].next[0].set = 0x0000000D
+userDataNode[19].next[0].binding = 0
+userDataNode[19].next[1].type = DescriptorConstBuffer
+userDataNode[19].next[1].offsetInDwords = 4
+userDataNode[19].next[1].sizeInDwords = 4
+userDataNode[19].next[1].set = 0x0000000D
+userDataNode[19].next[1].binding = 1
+userDataNode[19].next[2].type = DescriptorConstTexelBuffer
+userDataNode[19].next[2].offsetInDwords = 8
+userDataNode[19].next[2].sizeInDwords = 4
+userDataNode[19].next[2].set = 0x0000000D
+userDataNode[19].next[2].binding = 3
+userDataNode[19].next[3].type = DescriptorConstTexelBuffer
+userDataNode[19].next[3].offsetInDwords = 12
+userDataNode[19].next[3].sizeInDwords = 4
+userDataNode[19].next[3].set = 0x0000000D
+userDataNode[19].next[3].binding = 4
+userDataNode[20].type = DescriptorConstBuffer
+userDataNode[20].offsetInDwords = 0
+userDataNode[20].sizeInDwords = 4
+userDataNode[20].set = 0x0000000E
+userDataNode[20].binding = 0


### PR DESCRIPTION
Code was added to generate a relocation for the off of the descriptor
table for a given descriptor set.  However, the code the replace the
relocation was not written.  I cannot remember why, but it was probably
because I could not create a test that actaully needed it.  The code
added and forgotten.  I have not found a case that will generate it.
I'm adding a test and adding the code to replace the relocation.
