### PR TITLE
UNLINKED: assume fragment does not use builtin inputs.

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1380,6 +1380,8 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           const auto &nextBuiltInUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->builtInUsage.fs;
 
           hasViewportIndexExport = nextBuiltInUsage.viewportIndex;
+        } else if (nextStage == ShaderStageInvalid) {
+          hasViewportIndexExport = false;
         }
 
         if (hasViewportIndexExport) {
@@ -1405,6 +1407,8 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           const auto &nextBuiltInUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->builtInUsage.fs;
 
           hasLayerExport = nextBuiltInUsage.layer || nextBuiltInUsage.viewIndex;
+        } else if (nextStage == ShaderStageInvalid) {
+          hasLayerExport = false;
         }
 
         if (hasLayerExport) {
@@ -5040,10 +5044,10 @@ void PatchInOutImportExport::addExportInstForGenericOutput(Value *output, unsign
 // @param insertPos : Where to insert the "exp" instruction
 void PatchInOutImportExport::addExportInstForBuiltInOutput(Value *output, unsigned builtInId, Instruction *insertPos) {
   // Check if the shader stage is valid to use "exp" instruction to export output
-  const auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
+  const auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage, true);
   const bool useExpInst = ((m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval ||
                             m_shaderStage == ShaderStageCopyShader) &&
-                           (nextStage == ShaderStageInvalid || nextStage == ShaderStageFragment));
+                           (nextStage == ShaderStageFragment));
   assert(useExpInst);
   (void(useExpInst)); // unused
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocMultiView.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_RelocMultiView.pipe
@@ -1,0 +1,64 @@
+; Test that the layer input is not output when multiview is enabled.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s
+; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: <_amdgpu_vs_main>:
+; SHADERTEST-NOT: exp param0
+; SHADERTEST: exp param0 off, off, off, off
+; SHADERTEST-NOT: exp param0
+; SHADERTEST: s_endpgm
+; END_SHADERTEST
+[Version]
+version = 52
+
+[VsGlsl]
+#version 450
+
+layout(location = 0) in vec4 _17;
+
+void main()
+{
+    gl_Position = _17;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+layout(location = 0) out vec4 _9;
+
+void main()
+{
+    _9 = vec4(0,0,0,0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 1
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 8
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+enableMultiView = 1
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 1
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0


### PR DESCRIPTION
There are a couple places were the vertex shader needs to know if the fragment shader uses certain builtin inputs so the vertex shader can make them available.  For unlinked shaders when the fragment shader is not available, we need to check the fragment inputs.
