### PR TITLE
Use full pipeline compilation for convert samplers

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -882,6 +882,14 @@ static bool isUnrelocatableResourceMappingRootNode(const ResourceMappingNode *no
 //
 // @param [in] resourceMapping : resource mapping data, containing user data nodes
 static bool hasUnrelocatableDescriptorNode(const ResourceMappingData *resourceMapping) {
+  auto descriptorRangeValues = ArrayRef<StaticDescriptorValue>(resourceMapping->pStaticDescriptorValues,
+                                                               resourceMapping->staticDescriptorValueCount);
+  for (const auto &range : descriptorRangeValues) {
+    if (range.type == ResourceMappingNodeType::DescriptorYCbCrSampler) {
+      return true;
+    }
+  }
+
   for (unsigned i = 0; i < resourceMapping->userDataNodeCount; ++i) {
     if (isUnrelocatableResourceMappingRootNode(&resourceMapping->pUserDataNodes[i].node))
       return true;

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ConvertingSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_ConvertingSampler.pipe
@@ -1,0 +1,52 @@
+; Check that a warning is printed when relocatable compilation is requested but not possible because of a DescriptorYCbCrSampler.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-relocatable-shader-elf -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} calculated hash results (compute pipeline)
+; SHADERTEST-LABEL: {{^Warning:}} Relocatable shader compilation requested but not possible
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: {{^=====}} AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 52
+
+[CsGlsl]
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std430) buffer _65_67
+{
+    vec4 _m0[];
+} _67;
+
+layout(set = 1, binding = 0) uniform sampler2D _58;
+
+void main()
+{
+    vec2 _37 = vec2(0.0, 0.0);
+    vec4 _54 = textureLod(_58, _37, 0.0);
+    _67._m0[0] = _54;
+}
+
+[CsInfo]
+entryPoint = main
+
+[ResourceMapping]
+descriptorRangeValue[0].visibility = 32
+descriptorRangeValue[0].type = DescriptorYCbCrSampler
+descriptorRangeValue[0].set = 1
+descriptorRangeValue[0].binding = 0
+descriptorRangeValue[0].arraySize = 1
+descriptorRangeValue[0].uintData = 2281730194, 0, 3288334336, 0, 131473672, 32626, 3607134728, 32597, 0, 0
+
+userDataNode[0].visibility = 32
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 2
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorYCbCrSampler
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 16
+userDataNode[0].next[0].set = 0x00000001
+userDataNode[0].next[0].binding = 0


### PR DESCRIPTION
The data in the descriptorRangeValues for the conver samplers is used
when translating the spir-v to llvm-ir.  This is too big of a change to
be able to handle as a relocatable shader for now.

We can look into handling it by moving that data to LGC and seeing what
we can do about it.
