### PR TITLE
Use ShaderStageBit to replace the call shaderStageToMask()

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1178,9 +1178,8 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       };
 
   // Only enable per stage cache for full graphic pipeline
-  bool checkPerStageCache =
-      cl::EnablePerStageCache && context->isGraphics() && !buildingRelocatableElf &&
-      (context->getShaderStageMask() & (shaderStageToMask(ShaderStageVertex) | shaderStageToMask(ShaderStageFragment)));
+  bool checkPerStageCache = cl::EnablePerStageCache && context->isGraphics() && !buildingRelocatableElf &&
+                            (context->getShaderStageMask() & (ShaderStageVertexBit | ShaderStageFragmentBit));
   if (!checkPerStageCache)
     checkShaderCacheFunc = nullptr;
 
@@ -1213,7 +1212,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
   }
 
   if (result == Result::Success && fragmentShaderInfo && fragmentShaderInfo->options.updateDescInElf &&
-      (context->getShaderStageMask() & shaderStageToMask(ShaderStageFragment)))
+      (context->getShaderStageMask() & ShaderStageFragmentBit))
     graphicsShaderCacheChecker.updateRootUserDateOffset(pipelineElf);
 
   context->setDiagnosticHandler(nullptr);

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -51,7 +51,7 @@ public:
   virtual const void *getPipelineBuildInfo() const { return m_pipelineInfo; }
 
   // Gets the mask of active shader stages bound to this pipeline
-  virtual unsigned getShaderStageMask() const { return shaderStageToMask(ShaderStageCompute); }
+  virtual unsigned getShaderStageMask() const { return ShaderStageComputeBit; }
 
   // Sets the mask of active shader stages bound to this pipeline
   void setShaderStageMask(unsigned mask) { assert(mask == getShaderStageMask()); }

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -330,7 +330,7 @@ Error buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo) {
 // @param firstInFile : Name of first input file
 // @returns : `ErrorSuccess` on success, `ResultError` on failure
 Error outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile, StringRef firstInFile) {
-  const BinaryData &pipelineBin = (compileInfo->stageMask & shaderStageToMask(ShaderStageCompute))
+  const BinaryData &pipelineBin = (compileInfo->stageMask & ShaderStageComputeBit)
                                       ? compileInfo->compPipelineOut.pipelineBin
                                       : compileInfo->gfxPipelineOut.pipelineBin;
   SmallString<64> outFileName(suppliedOutFile);
@@ -413,7 +413,7 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
     }
   }
 
-  const bool isGraphics = (compileInfo.stageMask & shaderStageToMask(ShaderStageCompute)) == 0;
+  const bool isGraphics = (compileInfo.stageMask & ShaderStageComputeBit) == 0;
   for (unsigned i = 0; i < compileInfo.shaderModuleDatas.size(); ++i) {
     compileInfo.shaderModuleDatas[i].shaderInfo.options.pipelineOptions =
         isGraphics ? compileInfo.gfxPipelineInfo.options : compileInfo.compPipelineInfo.options;


### PR DESCRIPTION
When we know the shader stage, we can use the enumerants of ShaderStageBit.
This is more readable in LLPC front-end.

Change-Id: I9b63fff1f8156dc93179e292774452f6a63a5455