### PR TITLE
Use functions to query stages and stage masks

### DIFF
--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -108,7 +108,7 @@ llvm::Expected<std::string> compileGlsl(const std::string &inFilename, ShaderSta
 llvm::Expected<std::string> assembleSpirv(const std::string &inFilename);
 
 // Decodes the binary after building a pipeline and outputs the decoded info.
-LLPC_NODISCARD Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileInfo, bool isGraphics);
+LLPC_NODISCARD Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileInfo);
 
 // Builds shader module based on the specified SPIR-V binary.
 llvm::Error buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -54,9 +54,6 @@ public:
   // Compiles the pipeline and performs linking.
   LLPC_NODISCARD Result build();
 
-  // Returns true iff the compiled pipeline is a graphics pipeline.
-  LLPC_NODISCARD bool isGraphicsPipeline() const;
-
 private:
   // Returns true iff pipeline dumps are requested.
   LLPC_NODISCARD bool shouldDumpPipelines() const { return m_dumpOptions.hasValue(); }

--- a/llpc/unittests/util/CMakeLists.txt
+++ b/llpc/unittests/util/CMakeLists.txt
@@ -26,4 +26,5 @@
 add_llpc_unittest(LlpcUtilTests
   testError.cpp
   testMetroHash.cpp
+  testUtil.cpp
 )

--- a/llpc/unittests/util/testUtil.cpp
+++ b/llpc/unittests/util/testUtil.cpp
@@ -1,0 +1,190 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "llpcUtil.h"
+#include "vkgcDefs.h"
+#include "vkgcUtil.h"
+#include "lgc/EnumIterator.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using namespace Vkgc;
+using namespace llvm;
+
+using ::testing::ElementsAre;
+
+namespace Llpc {
+namespace {
+
+// cppcheck-suppress syntaxError
+TEST(UtilTest, PlaceholderPass) {
+  EXPECT_TRUE(true);
+}
+
+// cppcheck-suppress syntaxError
+TEST(UtilTest, ShaderStageToMaskSingleBit) {
+  EXPECT_EQ(shaderStageToMask(ShaderStage::ShaderStageVertex), ShaderStageBit::ShaderStageVertexBit);
+  EXPECT_EQ(shaderStageToMask(ShaderStage::ShaderStageTessControl), ShaderStageBit::ShaderStageTessControlBit);
+  EXPECT_EQ(shaderStageToMask(ShaderStage::ShaderStageTessEval), ShaderStageBit::ShaderStageTessEvalBit);
+  EXPECT_EQ(shaderStageToMask(ShaderStage::ShaderStageGeometry), ShaderStageBit::ShaderStageGeometryBit);
+  EXPECT_EQ(shaderStageToMask(ShaderStage::ShaderStageFragment), ShaderStageBit::ShaderStageFragmentBit);
+  EXPECT_EQ(shaderStageToMask(ShaderStage::ShaderStageCompute), ShaderStageBit::ShaderStageComputeBit);
+}
+
+TEST(UtilTest, IsStageInMaskEmpty) {
+  const unsigned emptyMask = 0;
+  for (ShaderStage stage : lgc::enumRange<ShaderStage>())
+    EXPECT_FALSE(isShaderStageInMask(stage, emptyMask));
+}
+
+TEST(UtilTest, IsStageInMaskStageToMask) {
+  for (ShaderStage stage : lgc::enumRange<ShaderStage>())
+    EXPECT_TRUE(isShaderStageInMask(stage, shaderStageToMask(stage)));
+}
+
+TEST(UtilTest, IsStageInMaskStageBit) {
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageVertex, ShaderStageBit::ShaderStageVertexBit));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageTessControl, ShaderStageBit::ShaderStageTessControlBit));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageTessEval, ShaderStageBit::ShaderStageTessEvalBit));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageGeometry, ShaderStageBit::ShaderStageGeometryBit));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageFragment, ShaderStageBit::ShaderStageFragmentBit));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageCompute, ShaderStageBit::ShaderStageComputeBit));
+
+  // Note: Copy shader is not a native shader stage, but we handle it regardless.
+  EXPECT_TRUE(
+      isShaderStageInMask(ShaderStage::ShaderStageCopyShader, shaderStageToMask(ShaderStage::ShaderStageCopyShader)));
+}
+
+TEST(UtilTest, IsStageInMaskAllGraphicsBit) {
+  const unsigned gfxMask = ShaderStageBit::ShaderStageAllGraphicsBit;
+  for (ShaderStage stage : gfxShaderStages())
+    EXPECT_TRUE(isShaderStageInMask(stage, gfxMask));
+
+  EXPECT_FALSE(isShaderStageInMask(ShaderStage::ShaderStageCompute, gfxMask));
+}
+
+TEST(UtilTest, IsStageInMaskMultiple) {
+  const unsigned mask = ShaderStageBit::ShaderStageVertexBit | ShaderStageBit::ShaderStageTessEvalBit |
+                        ShaderStageBit::ShaderStageFragmentBit;
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageVertex, mask));
+  EXPECT_FALSE(isShaderStageInMask(ShaderStage::ShaderStageTessControl, mask));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageTessEval, mask));
+  EXPECT_TRUE(isShaderStageInMask(ShaderStage::ShaderStageFragment, mask));
+  EXPECT_FALSE(isShaderStageInMask(ShaderStage::ShaderStageCompute, mask));
+}
+
+TEST(UtilTest, IsNativeStage) {
+  for (ShaderStage stage : nativeShaderStages())
+    EXPECT_TRUE(isNativeStage(stage));
+
+  EXPECT_FALSE(isNativeStage(ShaderStage::ShaderStageCopyShader));
+}
+
+TEST(UtilTest, IsGraphicsPipelineEmptyMask) {
+  const unsigned emptyMask = 0;
+  EXPECT_FALSE(isGraphicsPipeline(emptyMask));
+}
+
+TEST(UtilTest, IsGraphicsPipelineSingleBit) {
+  EXPECT_TRUE(isGraphicsPipeline(ShaderStageBit::ShaderStageVertexBit));
+  EXPECT_TRUE(isGraphicsPipeline(ShaderStageBit::ShaderStageTessControlBit));
+  EXPECT_TRUE(isGraphicsPipeline(ShaderStageBit::ShaderStageTessEvalBit));
+  EXPECT_TRUE(isGraphicsPipeline(ShaderStageBit::ShaderStageGeometryBit));
+  EXPECT_TRUE(isGraphicsPipeline(ShaderStageBit::ShaderStageFragmentBit));
+
+  EXPECT_FALSE(isGraphicsPipeline(ShaderStageBit::ShaderStageComputeBit));
+}
+
+TEST(UtilTest, IsGraphicsPipelineAllGraphics) {
+  EXPECT_TRUE(isGraphicsPipeline(ShaderStageBit::ShaderStageAllGraphicsBit));
+}
+
+TEST(UtilTest, IsGraphicsPipelineMultiple) {
+  const unsigned mask = ShaderStageBit::ShaderStageVertexBit | ShaderStageBit::ShaderStageTessEvalBit |
+                        ShaderStageBit::ShaderStageFragmentBit;
+  EXPECT_TRUE(isGraphicsPipeline(mask));
+
+  EXPECT_FALSE(isGraphicsPipeline(mask | ShaderStageBit::ShaderStageComputeBit));
+}
+
+TEST(UtilTest, IsComputePipelineEmptyMask) {
+  const unsigned emptyMask = 0;
+  EXPECT_FALSE(isComputePipeline(emptyMask));
+}
+
+TEST(UtilTest, IsComputePipelineSingleBit) {
+  EXPECT_TRUE(isComputePipeline(ShaderStageBit::ShaderStageComputeBit));
+
+  EXPECT_FALSE(isComputePipeline(ShaderStageBit::ShaderStageVertexBit));
+  EXPECT_FALSE(isComputePipeline(ShaderStageBit::ShaderStageTessControlBit));
+  EXPECT_FALSE(isComputePipeline(ShaderStageBit::ShaderStageTessEvalBit));
+  EXPECT_FALSE(isComputePipeline(ShaderStageBit::ShaderStageGeometryBit));
+  EXPECT_FALSE(isComputePipeline(ShaderStageBit::ShaderStageFragmentBit));
+}
+
+TEST(UtilTest, IsComputePipelineTwoStages) {
+  for (ShaderStage gfxStage : gfxShaderStages())
+    EXPECT_FALSE(isComputePipeline(shaderStageToMask(gfxStage) | ShaderStageBit::ShaderStageComputeBit));
+}
+
+TEST(UtilTest, MaskToShaderStagesEmpty) {
+  const auto stages = maskToShaderStages(0);
+  EXPECT_TRUE(stages.empty());
+}
+
+TEST(UtilTest, MaskToShaderStagesOneStage) {
+  EXPECT_THAT(maskToShaderStages(ShaderStageBit::ShaderStageVertexBit), ElementsAre(ShaderStage::ShaderStageVertex));
+  EXPECT_THAT(maskToShaderStages(ShaderStageBit::ShaderStageTessControlBit),
+              ElementsAre(ShaderStage::ShaderStageTessControl));
+  EXPECT_THAT(maskToShaderStages(ShaderStageBit::ShaderStageTessEvalBit),
+              ElementsAre(ShaderStage::ShaderStageTessEval));
+  EXPECT_THAT(maskToShaderStages(ShaderStageBit::ShaderStageGeometryBit),
+              ElementsAre(ShaderStage::ShaderStageGeometry));
+  EXPECT_THAT(maskToShaderStages(ShaderStageBit::ShaderStageFragmentBit),
+              ElementsAre(ShaderStage::ShaderStageFragment));
+  EXPECT_THAT(maskToShaderStages(ShaderStageBit::ShaderStageComputeBit), ElementsAre(ShaderStage::ShaderStageCompute));
+
+  // Note: Copy shader is not a native shader stage, but we handle it regardless.
+  EXPECT_THAT(maskToShaderStages(shaderStageToMask(ShaderStage::ShaderStageCopyShader)),
+              ElementsAre(ShaderStage::ShaderStageCopyShader));
+}
+
+TEST(UtilTest, MaskToShaderStagesAllGraphics) {
+  const auto stages = maskToShaderStages(ShaderStageBit::ShaderStageAllGraphicsBit);
+  EXPECT_THAT(stages, ElementsAre(ShaderStage::ShaderStageVertex, ShaderStage::ShaderStageTessControl,
+                                  ShaderStage::ShaderStageTessEval, ShaderStage::ShaderStageGeometry,
+                                  ShaderStage::ShaderStageFragment));
+}
+
+TEST(UtilTest, MaskToShaderStagesMultiple) {
+  const unsigned mask = ShaderStageBit::ShaderStageVertexBit | ShaderStageBit::ShaderStageTessEvalBit |
+                        ShaderStageBit::ShaderStageFragmentBit;
+  const auto stages = maskToShaderStages(mask);
+  EXPECT_THAT(stages, ElementsAre(ShaderStage::ShaderStageVertex, ShaderStage::ShaderStageTessEval,
+                                  ShaderStage::ShaderStageFragment));
+}
+
+} // namespace
+} // namespace Llpc

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -147,14 +147,12 @@ bool hasDataForUnlinkedShaderType(Vkgc::UnlinkedShaderStage type, ArrayRef<const
 unsigned getShaderStageMaskForType(Vkgc::UnlinkedShaderStage type) {
   switch (type) {
   case UnlinkedStageVertexProcess:
-    return shaderStageToMask(static_cast<ShaderStage>(ShaderStageVertex)) |
-           shaderStageToMask(static_cast<ShaderStage>(ShaderStageGeometry)) |
-           shaderStageToMask(static_cast<ShaderStage>(ShaderStageTessControl)) |
-           shaderStageToMask(static_cast<ShaderStage>(ShaderStageTessEval));
+    return ShaderStageBit::ShaderStageVertexBit | ShaderStageBit::ShaderStageTessControlBit |
+           ShaderStageBit::ShaderStageTessEvalBit | ShaderStageBit::ShaderStageGeometryBit;
   case UnlinkedStageFragment:
-    return shaderStageToMask(static_cast<ShaderStage>(ShaderStageFragment));
+    return ShaderStageBit::ShaderStageFragmentBit;
   case UnlinkedStageCompute:
-    return shaderStageToMask(static_cast<ShaderStage>(ShaderStageCompute));
+    return ShaderStageBit::ShaderStageComputeBit;
   default:
     return 0;
   }


### PR DESCRIPTION
This introduces new helper function to `llpcUtils.h` to replace bug-prone
and verbose manual bit manipulation.

The new functions should make it more immediately obvious what the intention
behind each check is. For example, there are some subtleties around what
to do with copy shader stages, which stages should be graphics vs. native, etc.
This PR attempts to make it clearer and more consistent; each new function
should have well-defined semantics, documented via unit tests.
    
Also, introduce a helper function to get all shader stages in a mask to make
loops more concise.