### PR TITLE
Remove an incorrect comment

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1982,7 +1982,6 @@ lgc::ShaderStage getLgcShaderStage(Llpc::ShaderStage stage) {
   case ShaderStageGeometry:
     return lgc::ShaderStageGeometry;
   case ShaderStageFragment:
-    // TODO: Will add mesh support in LGC
     return lgc::ShaderStageFragment;
   case ShaderStageCopyShader:
     return lgc::ShaderStageCopyShader;


### PR DESCRIPTION
The comment in getLgcShaderStage() mentioning mesh shader is mistakenly
added. Remove it.

Change-Id: I48c23e48dbdfd6860fe59f474c3838171d83794b