### PR TITLE
Handle input filenames with entrypoint for Windows

### DIFF
--- a/llpc/test/shaderdb/error_reporting/SpirvWildcardAndEntryPoint.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvWildcardAndEntryPoint.spvasm
@@ -1,0 +1,19 @@
+; Check that an error is produced when wildcards and entrypoint are specified
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -entry-target=foo -spvgen-dir=%spvgendir% -v %gfxip "%s*,bar" \
+; RUN:   | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Can't use wildcards as well as entrypoint
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1  "main"
+         %2 = OpTypeVoid
+         %3 = OpTypeFunction %2
+         %1 = OpFunction %2 None %3
+         %4 = OpLabel
+              OpReturn
+              OpFunctionEnd


### PR DESCRIPTION
Windows has different code to expand input filenames.
Modified to accept the optional entrypoint appended to the filename.