### PR TITLE
Add resource layout scheme

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 53
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -86,6 +86,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     53.2 | Add resourceLayoutScheme to PipelineOptions                                                           |
 //  |     53.1 | Add PartPipelineStage enum for part-pipeline mode                                                     |
 //  |     53.0 | Add optimizationLevel to PipelineOptions                                                              |
 //  |     52.3 | Add fastMathFlags to PipelineShaderOptions                                                            |
@@ -393,6 +394,16 @@ enum class ThreadGroupSwizzleMode : unsigned {
   Count
 };
 
+/// Represents mapping layout of the resources used in shaders
+enum class ResourceLayoutScheme : unsigned {
+  Compact = 0, ///< Compact scheme make full use of all the user data registers.
+  Indirect     ///< Fixed layout, push constant will be the sub node of DescriptorTableVaPtr
+               ///  In indirect scheme, The order of resources is like this:
+               ///  1. one user data entry for vertex buffer
+               ///  2. one user data entry for the push constant buffer
+               ///  3. descriptor set index for each set
+};
+
 /// Represents per pipeline options.
 struct PipelineOptions {
   bool includeDisassembly;         ///< If set, the disassembly for all compiled shaders will be included in
@@ -420,6 +431,7 @@ struct PipelineOptions {
   uint32_t optimizationLevel; ///< The higher the number the more optimizations will be performed.  Valid values are
                               ///< between 0 and 3.
 #endif
+  ResourceLayoutScheme resourceLayoutScheme; ///< Resource layout scheme
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -221,10 +221,31 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType descType, unsigned descSet
 // @param pushConstantsTy : Type of the push constants table that the returned pointer will point to
 // @param instName : Name to give instruction(s)
 Value *DescBuilder::CreateLoadPushConstantsPtr(Type *pushConstantsTy, const Twine &instName) {
+  Type *returnTy = pushConstantsTy->getPointerTo(ADDR_SPACE_CONST);
+  const bool isIndirect = getPipelineState()->getOptions().resourceLayoutScheme == ResourceLayoutScheme::Indirect;
+  if (isIndirect) {
+    // Push const is the sub node of DescriptorTableVaPtr.
+    if (m_pipelineState->getUserDataNodes().empty()) {
+      Value *highHalf = getInt32(HighAddrPc);
+      Value *descPtr = CreateNamedCall(
+          lgcName::DescriptorTableAddr, getInt8Ty()->getPointerTo(ADDR_SPACE_CONST),
+          {getInt32(unsigned(ResourceNodeType::PushConst)), getInt32(-1), getInt32(0), highHalf}, Attribute::ReadNone);
+      return CreateBitCast(descPtr, returnTy);
+    }
+
+    const ResourceNode *topNode = m_pipelineState->findPushConstantResourceNode();
+    assert(topNode);
+    const ResourceNode subNode = topNode->innerTable[0];
+    Value *highHalf = getInt32(HighAddrPc);
+    Value *descPtr = CreateNamedCall(
+        lgcName::DescriptorTableAddr, getInt8Ty()->getPointerTo(ADDR_SPACE_CONST),
+        {getInt32(unsigned(ResourceNodeType::PushConst)), getInt32(subNode.set), getInt32(subNode.binding), highHalf},
+        Attribute::ReadNone);
+    return CreateBitCast(descPtr, returnTy);
+  }
   // Get the push const pointer. If subsequent code only uses this with constant GEPs and loads,
   // then PatchEntryPointMutate might be able to "unspill" it so the code uses shader entry SGPRs
   // directly instead of loading from the spill table.
-  Type *returnTy = pushConstantsTy->getPointerTo(ADDR_SPACE_CONST);
   std::string callName = lgcName::PushConst;
   addTypeMangling(returnTy, {}, callName);
   return CreateNamedCall(callName, returnTy, {}, Attribute::ReadOnly, instName);

--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -89,6 +89,12 @@ enum class ResourceNodeType : unsigned {
   DescriptorReserved16,
   Count, ///< Count of resource mapping node types.
 };
+
+// Represents mapping layout of the resources used in shaders
+enum class ResourceLayoutScheme : unsigned {
+  Compact = 0, ///< Compact scheme make full use of all the user data registers.
+  Indirect     ///< Fixed layout, push constant will be the sub node of DescriptorTableVaPtr
+};
 } // namespace lgc
 
 namespace llvm {

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -127,6 +127,7 @@ struct Options {
   unsigned reserved1f;                // Reserved for future functionality
   unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
   unsigned pageMigrationEnabled;  // Enable page migration
+  ResourceLayoutScheme resourceLayoutScheme; // Resource layout scheme
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -728,8 +728,13 @@ void PipelineState::readUserDataNodes(Module *module) {
 // Returns the resource node for the push constant.
 const ResourceNode *PipelineState::findPushConstantResourceNode() const {
   for (const ResourceNode &node : getUserDataNodes()) {
-    if (node.type == ResourceNodeType::PushConst) {
+    if (node.type == ResourceNodeType::PushConst)
       return &node;
+    if (node.type == ResourceNodeType::DescriptorTableVaPtr) {
+      if (!node.innerTable.empty() && node.innerTable[0].type == ResourceNodeType::PushConst) {
+        assert(ResourceLayoutScheme::Indirect == m_options.resourceLayoutScheme);
+        return &node;
+      }
     }
   }
   return nullptr;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -334,6 +334,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
   options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
   options.enableInterpModePatch = getPipelineOptions()->enableInterpModePatch;
   options.pageMigrationEnabled = getPipelineOptions()->pageMigrationEnabled;
+  options.resourceLayoutScheme = static_cast<lgc::ResourceLayoutScheme>(getPipelineOptions()->resourceLayoutScheme);
 
   // Driver report full subgroup lanes for compute shader, here we just set fullSubgroups as default options
   options.fullSubgroups = true;

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
@@ -1,0 +1,97 @@
+; Check the resource layout mode. In "Indirect" mode, "PushConst" resource is not in root node.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: [[Desc:%[0-9]*]] = call [16 x i8] addrspace(4)* (...) @lgc.create.load.push.constants.ptr.p4a16i8()
+; SHADERTEST: [[Addr:%[0-9]*]] = bitcast [16 x i8] addrspace(4)* [[Desc]] to <4 x float> addrspace(4)*
+; SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, <4 x float> addrspace(4)* [[Addr]], align 16
+; SHADERTEST: call void (...) @lgc.create.write.generic.output(<4 x float> [[Value]], i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST: [[Desc:%[0-9]*]] = call i8 addrspace(4)* @lgc.descriptor.table.addr(i32 9, i32 -1, i32 0, i32 -1)
+; SHADERTEST: [[Addr1:%[0-9]*]] = bitcast i8 addrspace(4)* [[Desc]] to [16 x i8] addrspace(4)*
+; SHADERTEST: [[Addr2:%[0-9]*]] = bitcast [16 x i8] addrspace(4)* [[Addr1]] to <4 x float> addrspace(4)*
+; SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, <4 x float> addrspace(4)* [[Addr2]], align 16
+; SHADERTEST: call void @lgc.output.export.generic.i32.i32.v4f32(i32 0, i32 0, <4 x float> [[Value]])
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %{{[^,]*}}, i32 inreg %descTable1,
+; SHADERTEST: [[Addr0:%[0-9]*]] = zext i32 %descTable1 to i64
+; SHADERTEST: [[Addr1:%[0-9]*]] = or i64 %{{[0-9]*}}, [[Addr0]]
+; SHADERTEST: [[Addr2:%[0-9]*]] = inttoptr i64 [[Addr1]] to <4 x float> addrspace(4)*
+; SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, <4 x float> addrspace(4)* [[Addr2]], align 16
+; SHADERTEST: [[Value3:%[.a-zA-Z0-9]+]] = extractelement <4 x float> [[Value]], i64 3
+; SHADERTEST: [[Value2:%[.a-zA-Z0-9]+]] = extractelement <4 x float> [[Value]], i64 2
+; SHADERTEST: [[Value1:%[.a-zA-Z0-9]+]] = extractelement <4 x float> [[Value]], i64 1
+; SHADERTEST: [[Value0:%[.a-zA-Z0-9]+]] = extractelement <4 x float> [[Value]], i64 0
+; SHADERTEST: [[Color0:%[0-9]*]] = call <2 x half> @llvm.amdgcn.cvt.pkrtz(float [[Value0]], float [[Value1]])
+; SHADERTEST: [[Color1:%[0-9]*]] = call <2 x half> @llvm.amdgcn.cvt.pkrtz(float [[Value2]], float [[Value3]])
+; SHADERTEST: call void @llvm.amdgcn.exp.compr.v2f16(i32 immarg 0, i32 immarg 15, <2 x half> [[Color0]], <2 x half> [[Color1]], i1 immarg true, i1 immarg true)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+
+
+[Version]
+version = 52
+
+[VsGlsl]
+#version 450
+
+layout( location = 0 ) in vec4 app_position;
+
+void main() {
+  gl_Position = app_position;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+layout( location = 0 ) out vec4 frag_color;
+
+layout( push_constant ) uniform ColorBlock {
+  vec4 Color;
+} PushConstant;
+
+void main() {
+   frag_color = PushConstant.Color;
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 2
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 4
+userDataNode[1].visibility = 66
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = PushConst
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 4
+userDataNode[1].next[0].set = 0xFFFFFFFF
+userDataNode[1].next[0].binding = 0
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+options.resourceLayoutScheme = Indirect
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 12
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0

--- a/llpc/test/shaderdb/general/TestResourceLayoutScheme.frag
+++ b/llpc/test/shaderdb/general/TestResourceLayoutScheme.frag
@@ -1,0 +1,37 @@
+// Check the resource layout option '--resource-layout-scheme'
+
+// BEGIN_SHADERTEST
+// RUN: amdllpc -v %gfxip --resource-layout-scheme=indirect %s | FileCheck -check-prefix=SHADERTEST %s
+// SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+// SHADERTEST: [[Desc:%[0-9]*]] = call [16 x i8] addrspace(4)* (...) @lgc.create.load.push.constants.ptr.p4a16i8()
+// SHADERTEST: [[Addr:%[0-9]*]] = bitcast [16 x i8] addrspace(4)* [[Desc]] to <4 x float> addrspace(4)*
+// SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, <4 x float> addrspace(4)* [[Addr]], align 16
+// SHADERTEST: call void (...) @lgc.create.write.generic.output(<4 x float> [[Value]], i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
+
+// SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+// SHADERTEST: [[Desc:%[0-9]*]] = call i8 addrspace(4)* @lgc.descriptor.table.addr(i32 9, i32 -1, i32 0, i32 -1)
+// SHADERTEST: [[Addr1:%[0-9]*]] = bitcast i8 addrspace(4)* [[Desc]] to [16 x i8] addrspace(4)*
+// SHADERTEST: [[Addr2:%[0-9]*]] = bitcast [16 x i8] addrspace(4)* [[Addr1]] to <4 x float> addrspace(4)*
+// SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, <4 x float> addrspace(4)* [[Addr2]], align 16
+// SHADERTEST: call void @lgc.output.export.generic.i32.i32.v4f32(i32 0, i32 0, <4 x float> [[Value]])
+
+// SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+// SHADERTEST: define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %{{[^,]*}}, i32 inreg %descTable0,
+// SHADERTEST: [[Addr0:%[0-9]*]] = zext i32 %descTable0 to i64
+// SHADERTEST: [[Addr1:%[0-9]*]] = or i64 %{{[0-9]*}}, [[Addr0]]
+// SHADERTEST: [[Addr2:%[0-9]*]] = inttoptr i64 [[Addr1]] to <4 x float> addrspace(4)*
+// SHADERTEST: load <4 x float>, <4 x float> addrspace(4)* [[Addr2]], align 16
+// SHADERTEST: AMDLLPC SUCCESS
+// END_SHADERTEST
+
+#version 450
+
+layout( location = 0 ) out vec4 frag_color;
+
+layout( push_constant ) uniform ColorBlock {
+  vec4 Color;
+} PushConstant;
+
+void main() {
+   frag_color = PushConstant.Color;
+}

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -258,6 +258,12 @@ cl::opt<CodeGenOpt::Level> LlpcOptLevel("llpc-opt", cl::desc("The optimization l
                                                clEnumValN(CodeGenOpt::Default, "default", "default optimizations"),
                                                clEnumValN(CodeGenOpt::Aggressive, "fast", "fast execution time")));
 
+// -resource-layout-scheme: specifies the layout scheme of the resource
+cl::opt<ResourceLayoutScheme> LayoutScheme("resource-layout-scheme", cl::desc("The resource layout scheme:"),
+                                           cl::init(ResourceLayoutScheme::Compact),
+                                           values(clEnumValN(ResourceLayoutScheme::Compact, "compact", "make full use of user data registers"),
+                                                  clEnumValN(ResourceLayoutScheme::Indirect, "indirect", "fixed user data registers")));
+
 #ifdef WIN_OS
 // -assert-to-msgbox: pop message box when an assert is hit, only valid in Windows
 cl::opt<bool> AssertToMsgBox("assert-to-msgbox", cl::desc("Pop message box when assert is hit"));
@@ -413,6 +419,7 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
   compileInfo->gfxPipelineInfo.options.optimizationLevel = CodeGenOpt::Level::Default;
   compileInfo->compPipelineInfo.options.optimizationLevel = CodeGenOpt::Level::Default;
 #endif
+  compileInfo->gfxPipelineInfo.options.resourceLayoutScheme = LayoutScheme;
 
   // Set NGG control settings
   if (ParsedGfxIp.major >= 10) {

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -64,6 +64,7 @@ std::ostream &operator<<(std::ostream &out, DenormalMode denormalMode);
 std::ostream &operator<<(std::ostream &out, WaveBreakSize waveBreakSize);
 std::ostream &operator<<(std::ostream &out, ShadowDescriptorTableUsage shadowDescriptorTableUsage);
 std::ostream &operator<<(std::ostream &out, VkProvokingVertexModeEXT provokingVertexMode);
+std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout);
 
 template std::ostream &operator<<(std::ostream &out, ElfReader<Elf64> &reader);
 template raw_ostream &operator<<(raw_ostream &out, ElfReader<Elf64> &reader);
@@ -684,6 +685,7 @@ void PipelineDumper::dumpComputeStateInfo(const ComputePipelineBuildInfo *pipeli
 void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::ostream &dumpFile) {
   dumpFile << "options.includeDisassembly = " << options->includeDisassembly << "\n";
   dumpFile << "options.scalarBlockLayout = " << options->scalarBlockLayout << "\n";
+  dumpFile << "options.resourceLayoutScheme = " << options->resourceLayoutScheme << "\n";
   dumpFile << "options.includeIr = " << options->includeIr << "\n";
   dumpFile << "options.robustBufferAccess = " << options->robustBufferAccess << "\n";
   dumpFile << "options.reconfigWorkgroupLayout = " << options->reconfigWorkgroupLayout << "\n";
@@ -1093,6 +1095,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
   hasher->Update(options->enableRelocatableShaderElf);
   hasher->Update(options->disableImageResourceCheck);
   hasher->Update(options->enableScratchAccessBoundsChecks);
+  hasher->Update(options->resourceLayoutScheme);
 
   if (!isRelocatableShader) {
     hasher->Update(options->shadowDescriptorTableUsage);
@@ -2027,6 +2030,25 @@ std::ostream &operator<<(std::ostream &out, VkProvokingVertexModeEXT provokingVe
     llvm_unreachable("Should never be called!");
     break;
   }
+  return out << string;
+}
+
+// =====================================================================================================================
+// Translates enum "ResourceLayoutScheme" to string and output to ostream.
+//
+// @param [out] out : Output stream
+// @param ResourceLayoutScheme : Resource layout scheme
+std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout) {
+  const char *string = nullptr;
+  switch (layout) {
+    CASE_CLASSENUM_TO_STRING(ResourceLayoutScheme, Compact)
+    CASE_CLASSENUM_TO_STRING(ResourceLayoutScheme, Indirect)
+    break;
+  default:
+    llvm_unreachable("Should never be called!");
+    break;
+  }
+
   return out << string;
 }
 

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -94,6 +94,9 @@ public:
     ADD_CLASS_ENUM_MAP(DenormalMode, Auto)
     ADD_CLASS_ENUM_MAP(DenormalMode, FlushToZero)
     ADD_CLASS_ENUM_MAP(DenormalMode, Preserve)
+
+    ADD_CLASS_ENUM_MAP(ResourceLayoutScheme, Compact)
+    ADD_CLASS_ENUM_MAP(ResourceLayoutScheme, Indirect)
   }
 };
 

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -342,6 +342,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
 #endif
@@ -356,7 +357,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 10;
+  static const unsigned MemberCount = 11;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Indirect scheme is designed for the case that the pipeline layout only
contains part of information of the final executable pipeline. So that
user data is used in conservative way to make sure that this pipeline
layout is alaways compatiable with other layouts which may contain the
descriptor which is not known currently.

In indirect mode, the user data registers for various resources are
allocated in the following fashion:
 1. one user data entry for vertex buffer
 2. one user data entry for the push constant buffer
 3. descriptor set index for each set.