### PR TITLE
Don't try reloc compilation with inline buffers

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -859,6 +859,13 @@ static bool isUnrelocatableResourceMappingRootNode(const ResourceMappingNode *no
         // The code to handle a compact descriptor cannot be easily patched, so relocatable shaders assume there are
         // no compact descriptors.
         return true;
+#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 50)
+      if (innerNode->type == ResourceMappingNodeType::InlineBuffer) {
+        // The code to handle an inline buffer cannot be easily patched, so relocatable shaders
+        // assume there are no inline buffers.
+        return true;
+      }
+#endif
     }
     break;
   }
@@ -869,6 +876,11 @@ static bool isUnrelocatableResourceMappingRootNode(const ResourceMappingNode *no
   case ResourceMappingNodeType::DescriptorBufferCompact:
     // Generic descriptors in the top level are not handled by the linker.
     return true;
+#if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 50)
+  case ResourceMappingNodeType::InlineBuffer:
+    // Loading from an inline buffer requires building a descriptor that is not handled by the linker.
+    return true;
+#endif
   default:
     break;
   }

--- a/llpc/test/shaderdb/general/PipelineCs_MultipleRootInlineBuffer.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_MultipleRootInlineBuffer.pipe
@@ -39,6 +39,16 @@
 ; SHADERTEST-LABEL: {{^//}} LLPC pipeline patching results
 ; END_SHADERTEST
 
+; Test the use of InlineBuffer with relocatable shaders.  This is currently not supported, and we
+; should fall back to full pipeline compilation.
+; BEGIN_RELOCTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% --enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | FileCheck -check-prefix=RELOCTEST %s
+; RELOCTEST-LABEL: {{^// LLPC}} calculated hash results (compute pipeline)
+; RELOCTEST-LABEL: {{^Warning:}} Relocatable shader compilation requested but not possible
+; RELOCTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; RELOCTEST: {{^=====}} AMDLLPC SUCCESS
+; END_RELOCTEST
+
 [Version]
 version = 46
 

--- a/llpc/test/shaderdb/general/PipelineCs_TestInlineConstDirect_lit.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_TestInlineConstDirect_lit.pipe
@@ -18,6 +18,16 @@
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
+; Test the use of InlineBuffer with relocatable shaders.  This is currently not supported, and we
+; should fall back to full pipeline compilation.
+; BEGIN_RELOCTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% --enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | FileCheck -check-prefix=RELOCTEST %s
+; RELOCTEST-LABEL: {{^// LLPC}} calculated hash results (compute pipeline)
+; RELOCTEST-LABEL: {{^Warning:}} Relocatable shader compilation requested but not possible
+; RELOCTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; RELOCTEST: {{^=====}} AMDLLPC SUCCESS
+; END_RELOCTEST
+
 [CsGlsl]
 #version 450
 


### PR DESCRIPTION
Inline buffers require a bit of special code that the reloc compilation
cannot know will be required until the user data nodes are available.
For now, it will be best if we just avoid reloc compilation when inline
buffers are used.  This allows a large number of VK CTS tests with pass.
We can revisit later if needed.
