### PR TITLE
Propagate specified entry points to the shader compiler

### DIFF
--- a/llpc/test/shaderdb/error_reporting/GlslBadEntryPointName.frag
+++ b/llpc/test/shaderdb/error_reporting/GlslBadEntryPointName.frag
@@ -1,0 +1,17 @@
+/*
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip %s,mainFs \
+; RUN:   | FileCheck -check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: GLSL requires the entry point to be 'main':
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+*/
+
+#version 460
+
+layout(location = 0) out vec4 outColor;
+
+void mainFs() {
+  outColor = vec4(1.0, 1.0, 1.0, 1.0);
+}

--- a/llpc/test/shaderdb/error_reporting/GlslDuplicateStage.frag
+++ b/llpc/test/shaderdb/error_reporting/GlslDuplicateStage.frag
@@ -1,0 +1,18 @@
+// Check that an error is produced when the same shader stage is provided twice.
+/*
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -v %gfxip -spvgen-dir=%spvgendir% %s %s \
+; RUN:   | FileCheck -check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (fragment)
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+*/
+
+#version 460
+
+layout (location = 0) out vec4 fragColor;
+
+void main() {
+  fragColor = vec4(0);
+}

--- a/llpc/test/shaderdb/error_reporting/SpirvBadEntryPoint.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvBadEntryPoint.spvasm
@@ -1,7 +1,7 @@
-; Check that an error is produced when the specified entry target is not a SPIR-V entry point.
+; Check that an error is produced when the specified entry point is not a valid SPIR-V entry point in the input.
 
 ; BEGIN_SHADERTEST
-; RUN: not amdllpc -entry-target=foo -spvgen-dir=%spvgendir% -v %gfxip %s \
+; RUN: not amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s,foo \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST %s
 ;
 ; SHADERTEST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Failed to identify shader stages by entry-point "foo"

--- a/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
@@ -1,10 +1,10 @@
-; Check that an error is produced when wildcards and entrypoint are specified
+; Check that an error is produced when the same shader stage is provided twice.
 
 ; BEGIN_SHADERTEST
-; RUN: not amdllpc -spvgen-dir=%spvgendir% -v %gfxip "%s*,bar" \
+; RUN: not amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s %s \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: Can't use wildcards as well as entrypoint
+; SHADERTEST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (vertex)
 ; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/error_reporting/SpirvMissingEntryPoint.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvMissingEntryPoint.spvasm
@@ -1,7 +1,7 @@
 ; Check that an error is produced when the specified entry point is empty.
 
 ; BEGIN_SHADERTEST
-; RUN: not amdllpc -entry-target=foo -spvgen-dir=%spvgendir% -v %gfxip "%s," \
+; RUN: not amdllpc -spvgen-dir=%spvgendir% -v %gfxip "%s," \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST %s
 ;
 ; SHADERTEST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Expected entry point name after ','

--- a/llpc/test/shaderdb/multiple_inputs/GlslTwoStages.multi-input
+++ b/llpc/test/shaderdb/multiple_inputs/GlslTwoStages.multi-input
@@ -1,0 +1,16 @@
+; Check that two GLSL input shaders can be compiled into a single pipeline.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v \
+; RUN:      %S/test_inputs/Vs1.vert \
+; RUN:      %S/test_inputs/Fs1.frag \
+; RUN: | FileCheck -check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^//}} LLPC final pipeline module info
+; SHADERTEST:       define dllexport amdgpu_vs void @_amdgpu_vs_main
+; SHADERTEST:       define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main
+; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
+; SHADERTEST-LABEL: _amdgpu_vs_main:
+; SHADERTEST-LABEL: _amdgpu_ps_main:
+; SHADERTEST-LABEL: {{^=====}} AMDLLPC SUCCESS ====
+; END_SHADERTEST

--- a/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
+++ b/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
@@ -1,0 +1,108 @@
+; This file contains two entry points: one vertex stage and one fragment stage.
+; Check that amdllpc can compile them separately and together.
+
+; BEGIN_SHADERTEST_VS
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s,main_vs \
+; RUN:   | FileCheck --check-prefix=SHADERTEST_VS %s
+;
+; SHADERTEST_VS-LABEL: {{^//}} LLPC pipeline before-patching results
+; SHADERTEST_VS-LABEL: define dllexport spir_func void @lgc.shader.VS.main()
+; SHADERTEST_VS-NOT:   define dllexport spir_func void @lgc.shader.FS.main()
+; SHADERTEST_VS-LABEL: {{^=====}} AMDLLPC SUCCESS =====
+; END_SHADERTES_VS
+
+; BEGIN_SHADERTEST_FS
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s,main_fs \
+; RUN:   | FileCheck --check-prefix=SHADERTEST_FS %s
+;
+; SHADERTEST_FS-LABEL: {{^//}} LLPC pipeline before-patching results
+; SHADERTEST_FS-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
+; SHADERTEST_FS-NOT:   define dllexport spir_func void @lgc.shader.VS.main()
+; SHADERTEST_FS-LABEL: {{^=====}} AMDLLPC SUCCESS =====
+; END_SHADERTES_FS
+
+; BEGIN_SHADERTEST_BOTH
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s,main_vs %s,main_fs \
+; RUN:   | FileCheck --check-prefix=SHADERTEST_BOTH %s
+;
+; SHADERTEST_BOTH-LABEL: {{^//}} LLPC final pipeline module info
+; SHADERTEST_BOTH:       define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless
+; SHADERTEST_BOTH:       define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main
+; SHADERTEST_BOTH-LABEL: {{^//}} LLPC final ELF info
+; SHADERTEST_BOTH-LABEL: _amdgpu_vs_main_fetchless:
+; SHADERTEST_BOTH-LABEL: _amdgpu_ps_main:
+; SHADERTEST_BOTH-LABEL: {{^=====}} AMDLLPC SUCCESS =====
+; END_SHADERTES_BOTH
+
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos; 17
+; Bound: 34
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main_vs" %_ %pos %vertColor
+               OpEntryPoint Fragment %main_0 "main_fs" %fragColor
+               OpExecutionMode %main_0 OriginUpperLeft
+               OpSource GLSL 460
+               OpSource GLSL 460
+               OpName %main "main"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %_ ""
+               OpName %pos "pos"
+               OpName %vertColor "vertColor"
+               OpName %main_0 "main"
+               OpName %fragColor "fragColor"
+               OpModuleProcessed "Linked by SPIR-V Tools Linker"
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %pos Location 0
+               OpDecorate %vertColor Location 0
+               OpDecorate %fragColor Location 0
+       %void = OpTypeVoid
+         %10 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+        %pos = OpVariable %_ptr_Input_v3float Input
+    %float_0 = OpConstant %float 0
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %vertColor = OpVariable %_ptr_Output_v4float Output
+         %23 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+  %fragColor = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+         %25 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+       %main = OpFunction %void None %10
+         %26 = OpLabel
+         %27 = OpLoad %v3float %pos
+         %28 = OpCompositeExtract %float %27 0
+         %29 = OpCompositeExtract %float %27 1
+         %30 = OpCompositeExtract %float %27 2
+         %31 = OpCompositeConstruct %v4float %28 %29 %30 %float_0
+         %32 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %32 %31
+               OpStore %vertColor %23
+               OpReturn
+               OpFunctionEnd
+     %main_0 = OpFunction %void None %10
+         %33 = OpLabel
+               OpStore %fragColor %25
+               OpReturn
+               OpFunctionEnd

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -55,6 +55,7 @@
 #pragma once
 
 #include "llpc.h"
+#include "llpcInputUtils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -66,15 +67,18 @@ namespace StandaloneCompiler {
 // Represents the module info for a shader module.
 struct ShaderModuleData {
   Llpc::ShaderStage shaderStage;          // Shader stage
+  std::string entryPoint;                 // Shader entry point
   Llpc::BinaryData spirvBin;              // SPIR-V binary codes
   Llpc::ShaderModuleBuildInfo shaderInfo; // Info to build shader modules
   Llpc::ShaderModuleBuildOut shaderOut;   // Output of building shader modules
   void *shaderBuf;                        // Allocation buffer of building shader modules
 };
 
-// Represents global compilation info of LLPC standalone tool (as tool context).
+// Represents a single compilation context of a pipeline or a group of shaders.
+// This is only used by the standalone compiler tool.
 struct CompileInfo {
   Llpc::GfxIpVersion gfxIp;                                                  // Graphics IP version info
+  llvm::SmallVector<InputSpec> inputSpecs;                                   // Input shader specification
   VkFlags stageMask;                                                         // Shader stage mask
   llvm::SmallVector<StandaloneCompiler::ShaderModuleData> shaderModuleDatas; // ShaderModule Data
   Llpc::GraphicsPipelineBuildInfo gfxPipelineInfo;                           // Info to build graphics pipeline
@@ -83,8 +87,6 @@ struct CompileInfo {
   Llpc::ComputePipelineBuildOut compPipelineOut;                             // Output of building compute pipeline
   void *pipelineBuf;                                                         // Allocation buffer of building pipeline
   void *pipelineInfoFile;                                                    // VFX-style file containing pipeline info
-  llvm::SmallVector<std::string> fileNames;                                  // Names of input shader source files
-  std::string entryTarget;                                                   // Name of the entry target function
   bool unlinked;                  // Whether to generate unlinked shader/part-pipeline ELF
   bool relocatableShaderElf;      // Whether to enable relocatable shader compilation
   bool scalarBlockLayout;         // Whether to enable scalar block layout
@@ -117,12 +119,12 @@ llvm::Error buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
 llvm::Error outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile, llvm::StringRef firstInFile);
 
 // Processes and compiles one pipeline input file.
-llvm::Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const std::string &inFile,
+llvm::Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const InputSpec &inputSpec,
                                  bool unlinked, bool ignoreColorAttachmentFormats);
 
 // Processes and compiles multiple shader stage input files.
-llvm::Error processInputStages(ICompiler *compiler, CompileInfo &compileInfo, llvm::ArrayRef<std::string> inFiles,
-                               bool validateSpirv, llvm::SmallVectorImpl<std::string> &fileNames);
+llvm::Error processInputStages(ICompiler *compiler, CompileInfo &compileInfo, llvm::ArrayRef<InputSpec> inputSpecs,
+                               bool validateSpirv);
 
 } // namespace StandaloneCompiler
 } // namespace Llpc


### PR DESCRIPTION
Push per-input entry point down the standalone compiler.

Also:
-  Remove the now obsolete `-entry-target` option.
-  Fix a bug where non-'main' GLSL entry points would be accepted but
   result in empty SPIR-V functions. Disallow non-'main' entry point
   names when compiling GLSL to match glslang.
-  Refactor input stage processing. Introduce a helper function for
   each input kind.