### PR TITLE
Relax test matches for llvm change

### DIFF
--- a/lgc/test/InOutPackingNonZeroBase.lgc
+++ b/lgc/test/InOutPackingNonZeroBase.lgc
@@ -42,11 +42,11 @@ define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc
   %a6 = shufflevector <3 x float> %a5, <3 x float> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 undef>
   %a7 = insertelement <4 x float> %a6, float 1.000000e+00, i32 3
 
-; CHECK: %[[e0:.+]] = extractelement <3 x float> %[[bitcast]], i32 0
+; CHECK: %[[e0:.+]] = extractelement <3 x float> %[[bitcast]], i{{32|64}} 0
 ; CHECK: %[[bitcast1:.+]] = bitcast <3 x i32> %[[input_load]] to <3 x float>
-; CHECK: %[[e1:.+]] = extractelement <3 x float> %[[bitcast1]], i32 1
+; CHECK: %[[e1:.+]] = extractelement <3 x float> %[[bitcast1]], i{{32|64}} 1
 ; CHECK: %[[bitcast2:.+]] = bitcast <3 x i32> %[[input_load]] to <3 x float>
-; CHECK: %[[e2:.+]] = extractelement <3 x float> %[[bitcast2]], i32 2
+; CHECK: %[[e2:.+]] = extractelement <3 x float> %[[bitcast2]], i{{32|64}} 2
 
   call void (...) @lgc.create.write.generic.output(<4 x float> %a7, i32 3, i32 0, i32 0, i32 0, i32 0, i32 undef)
   call void (...) @lgc.create.write.builtin.output(<4 x float> %a7, i32 0, i32 0, i32 undef, i32 undef)
@@ -68,8 +68,8 @@ define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !lgc
   %a2 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 16, i32 undef)
   %e = extractelement <4 x float> %a2, i32 3
 
-; CHECK-DAG: %[[i0:.+]] = extractelement <2 x float> %[[ps_input:.+]], i32 0
-; CHECK-DAG: %[[i1:.+]] = extractelement <2 x float> %[[ps_input]],    i32 1
+; CHECK-DAG: %[[i0:.+]] = extractelement <2 x float> %[[ps_input:.+]], i{{32|64}} 0
+; CHECK-DAG: %[[i1:.+]] = extractelement <2 x float> %[[ps_input]],    i{{32|64}} 1
 
   %a6 = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 3, i32 0, i32 0, i32 0, i32 16, i32 undef)
   %a7 = shufflevector <4 x float> %a6, <4 x float> undef, <3 x i32> <i32 0, i32 1, i32 2>

--- a/lgc/test/IntToPtrWithAdd.lgc
+++ b/lgc/test/IntToPtrWithAdd.lgc
@@ -10,22 +10,22 @@ define dllexport spir_func void @lgc.shader.VS.main(i64 %0, <4 x i32> addrspace(
 ; CHECK: IR Dump After Patch LLVM for peephole optimizations
 ; CHECK: [[INTTOPTR:%[0-9]+]] = inttoptr i64 %[[#]] to i32 addrspace(1)*
 ; CHECK: [[LOAD:%[0-9]+]] = load i32, i32 addrspace(1)* [[INTTOPTR]], align 4
-; CHECK: [[INSERTELEMENT:%[0-9]+]] = insertelement <4 x i32> undef, i32 [[LOAD]], i32 0
+; CHECK: [[INSERTELEMENT:%[0-9]+]] = insertelement <4 x i32> undef, i32 [[LOAD]], i{{32|64}} 0
 
 ; CHECK: [[INTTOPTR1:%[0-9]+]] = inttoptr i64 %[[#]] to i32 addrspace(1)*
 ; CHECK: [[GEP1:%[0-9]+]] = getelementptr i32, i32 addrspace(1)* [[INTTOPTR1]], i64 1
 ; CHECK: [[LOAD1:%[0-9]+]] = load i32, i32 addrspace(1)* [[GEP1]], align 4
-; CHECK: [[INSERTELEMENT1:%[0-9]+]] = insertelement <4 x i32> [[INSERTELEMENT]], i32 [[LOAD1]], i32 1
+; CHECK: [[INSERTELEMENT1:%[0-9]+]] = insertelement <4 x i32> [[INSERTELEMENT]], i32 [[LOAD1]], i{{32|64}} 1
 
 ; CHECK: [[INTTOPTR2:%[0-9]+]] = inttoptr i64 %[[#]] to i32 addrspace(1)*
 ; CHECK: [[GEP2:%[0-9]+]] = getelementptr i32, i32 addrspace(1)* [[INTTOPTR2]], i64 2
 ; CHECK: [[LOAD2:%[0-9]+]] = load i32, i32 addrspace(1)* [[GEP2]], align 4
-; CHECK: [[INSERTELEMENT2:%[0-9]+]] = insertelement <4 x i32> [[INSERTELEMENT1]], i32 [[LOAD2]], i32 2
+; CHECK: [[INSERTELEMENT2:%[0-9]+]] = insertelement <4 x i32> [[INSERTELEMENT1]], i32 [[LOAD2]], i{{32|64}} 2
 
 ; CHECK: [[INTTOPTR3:%[0-9]+]] = inttoptr i64 %[[#]] to i32 addrspace(1)*
 ; CHECK: [[GEP3:%[0-9]+]] = getelementptr i32, i32 addrspace(1)* [[INTTOPTR3]], i64 3
 ; CHECK: [[LOAD3:%[0-9]+]] = load i32, i32 addrspace(1)* [[GEP3]], align 4
-; CHECK: [[INSERTELEMENT3:%[0-9]+]] = insertelement <4 x i32> [[INSERTELEMENT2]], i32 [[LOAD3]], i32 3
+; CHECK: [[INSERTELEMENT3:%[0-9]+]] = insertelement <4 x i32> [[INSERTELEMENT2]], i32 [[LOAD3]], i{{32|64}} 3
 
 ; CHECK: store <4 x i32> [[INSERTELEMENT3]], <4 x i32> addrspace(1)* %[[#]], align 16
 .entry:

--- a/llpc/test/shaderdb/core/OpAccessChain_TestRowMajorBlockVectorExtract_lit.frag
+++ b/llpc/test/shaderdb/core/OpAccessChain_TestRowMajorBlockVectorExtract_lit.frag
@@ -43,13 +43,13 @@ void main()
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> undef, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i32 0
-; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> %{{[0-9]*}}, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i32 1
-; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> %{{[0-9]*}}, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i32 2
-; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> %{{[0-9]*}}, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i32 3
-; SHADERTEST: insertelement <3 x [3 x %{{[a-z.]*}}] addrspace(7)*> undef, [3 x %{{[a-z.]*}}] addrspace(7)* %{{[0-9]*}}, i32 0
-; SHADERTEST: insertelement <3 x [3 x %{{[a-z.]*}}] addrspace(7)*> %{{[0-9]*}}, [3 x %{{[a-z.]*}}] addrspace(7)* %{{[0-9]*}}, i32 1
-; SHADERTEST: insertelement <3 x [3 x %{{[a-z.]*}}] addrspace(7)*> %{{[0-9]*}}, [3 x %{{[a-z.]*}}] addrspace(7)* %{{[0-9]*}}, i32 2
+; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> undef, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 0
+; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> %{{[0-9]*}}, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 1
+; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> %{{[0-9]*}}, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 2
+; SHADERTEST: insertelement <4 x [4 x %{{[a-z0-9.]*}}] addrspace(7)*> %{{[0-9]*}}, [4 x %{{[a-z0-9.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 3
+; SHADERTEST: insertelement <3 x [3 x %{{[a-z.]*}}] addrspace(7)*> undef, [3 x %{{[a-z.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 0
+; SHADERTEST: insertelement <3 x [3 x %{{[a-z.]*}}] addrspace(7)*> %{{[0-9]*}}, [3 x %{{[a-z.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 1
+; SHADERTEST: insertelement <3 x [3 x %{{[a-z.]*}}] addrspace(7)*> %{{[0-9]*}}, [3 x %{{[a-z.]*}}] addrspace(7)* %{{[0-9]*}}, i{{32|64}} 2
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/core/OpSMod_TestInt_lit.frag
+++ b/llpc/test/shaderdb/core/OpSMod_TestInt_lit.frag
@@ -22,7 +22,7 @@ void main()
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: srem i32
-; SHADERTEST: insertelement <4 x float> <float {{undef|poison}}, float 2.000000e+00, float 0.000000e+00, float 1.000000e+00>, float %{{.*}}, i32 0
+; SHADERTEST: insertelement <4 x float> <float {{undef|poison}}, float 2.000000e+00, float 0.000000e+00, float 1.000000e+00>, float %{{.*}}, i{{32|64}} 0
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestPowVec4Const_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestPowVec4Const_lit.frag
@@ -23,9 +23,9 @@ void main()
 ; SHADERTEST: [[mul2:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
 ; SHADERTEST: [[mul3:%.i[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
 ; SHADERTEST-NOT: = call reassoc nnan nsz arcp contract afn float @llvm.pow.f32(float
-; SHADERTEST: [[val1:%[.0-9a-zA-Z]*]] = insertelement <4 x float> <float 1.200000e+01, float {{undef|poison}}, float {{undef|poison}}, float {{undef|poison}}>, float [[mul1]], i32 1
-; SHADERTEST: [[val2:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i32 2
-; SHADERTEST: [[val3:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i32 3
+; SHADERTEST: [[val1:%[.0-9a-zA-Z]*]] = insertelement <4 x float> <float 1.200000e+01, float {{undef|poison}}, float {{undef|poison}}, float {{undef|poison}}>, float [[mul1]], i{{32|64}} 1
+; SHADERTEST: [[val2:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i{{32|64}} 2
+; SHADERTEST: [[val3:%[.0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i{{32|64}} 3
 ; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } {{undef|poison}}, <4 x float> [[val3]], 0
 ; SHADERTEST: ret { <4 x float> } [[ret]]
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestRadiansVec4Const_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestRadiansVec4Const_lit.frag
@@ -17,14 +17,14 @@ void main()
 ; SHADERTEST: store float 0x3F9ACEEA00000000, float addrspace(5)* %{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float> %{{.*}}, <float {{undef|poison}}, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000, float 0x3F91DF46A0000000>
-; SHADERTEST: = insertelement <4 x float> %{{.*}}, float 0x3F9ACEEA00000000, i32 0
+; SHADERTEST: = insertelement <4 x float> %{{.*}}, float 0x3F9ACEEA00000000, i{{32|64}} 0
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: [[mul1:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: [[mul2:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
 ; SHADERTEST: [[mul3:%.i[0-9]*]] = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3F91DF46A0000000
-; SHADERTEST: [[val1:%.[0-9a-zA-Z]*]] = insertelement <4 x float> <float 0x3F9ACEEA00000000, float {{undef|poison}}, float {{undef|poison}}, float {{undef|poison}}>, float [[mul1]], i32 1
-; SHADERTEST: [[val2:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i32 2
-; SHADERTEST: [[val3:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i32 3
+; SHADERTEST: [[val1:%.[0-9a-zA-Z]*]] = insertelement <4 x float> <float 0x3F9ACEEA00000000, float {{undef|poison}}, float {{undef|poison}}, float {{undef|poison}}>, float [[mul1]], i{{32|64}} 1
+; SHADERTEST: [[val2:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val1]], float [[mul2]], i{{32|64}} 2
+; SHADERTEST: [[val3:%.[0-9a-zA-Z]*]] = insertelement <4 x float> [[val2]], float [[mul3]], i{{32|64}} 3
 ; SHADERTEST: [[ret:%[0-9]*]] = insertvalue { <4 x float> } {{undef|poison}}, <4 x float> [[val3]], 0
 ; SHADERTEST: ret { <4 x float> } [[ret]]
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -16,9 +16,9 @@
 ; SHADERTEST:  [[f0:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 0, i32 0, i32 immarg 116, i32 immarg 0)
 ; SHADERTEST:  [[f1:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 4, i32 0, i32 immarg 116, i32 immarg 0)
 ; SHADERTEST:  [[f2:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 8, i32 0, i32 immarg 116, i32 immarg 0)
-; SHADERTEST:  [[vectmp0:%.*]] = insertelement <4 x i32> <i32 {{undef|poison}}, i32 {{undef|poison}}, i32 {{undef|poison}}, i32 1065353216>, i32 [[f0]], i32 0
-; SHADERTEST:  [[vectmp1:%.*]] = insertelement <4 x i32> [[vectmp0]], i32 [[f1]], i32 1
-; SHADERTEST:  [[vecf:%.*]] = insertelement <4 x i32> [[vectmp1]], i32 [[f2]], i32 2
+; SHADERTEST:  [[vectmp0:%.*]] = insertelement <4 x i32> <i32 {{undef|poison}}, i32 {{undef|poison}}, i32 {{undef|poison}}, i32 1065353216>, i32 [[f0]], i{{32|64}} 0
+; SHADERTEST:  [[vectmp1:%.*]] = insertelement <4 x i32> [[vectmp0]], i32 [[f1]], i{{32|64}} 1
+; SHADERTEST:  [[vecf:%.*]] = insertelement <4 x i32> [[vectmp1]], i32 [[f2]], i{{32|64}} 2
 ; Check that the attribute is cast to float so that it will be placed in a VGPR
 ; SHADERTEST:  %vertex0.0 = bitcast <4 x i32> [[vecf]] to <4 x float>
 ; Check that the attribute is inserted into the return value, and returned.


### PR DESCRIPTION
Match i32 and i64 for insert/extractelement indices as upstream llvm
started to use i64 constants.