### PR TITLE
[CI] Add code coverage report upload steps

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -30,6 +30,14 @@ jobs:
           echo 'Before:' && df -h
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc
           echo 'After:' && df -h
+      - name: Setup Google Cloud SDK
+        if: contains(matrix.feature-set, '+coverage') && github.repository == 'GPUOpen-Drivers/llpc' && secrets.GCR_KEY
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          service_account_email: ${{ secrets.GCR_USER }}
+          service_account_key: ${{ secrets.GCR_KEY }}
+          export_default_credentials: true
       - name: Checkout LLPC
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
@@ -41,6 +49,8 @@ jobs:
           FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
           TAG=$(printf "${{ matrix.image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER")
           echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
+          CONFIG_TAG=$(printf "%s%s" "$CONFIG_LOWER" "$FEATURES_LOWER")
+          echo "CONFIG_TAG=$CONFIG_TAG" | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
@@ -49,4 +59,19 @@ jobs:
                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"
+                            --build-arg FEATURES="${{ matrix.feature-set }}"
                             --tag llpc/ci-shaderdb
+      - name: Copy code coverage report to host and upload to GCS
+        if: contains(matrix.feature-set, '+coverage') && github.event.pull_request.number && github.repository == 'GPUOpen-Drivers/llpc' && secrets.GCR_KEY
+        run: |
+          docker run -v "$HOME:/host" llpc/ci-shaderdb 'bash' '-c' 'cp -r /vulkandriver/coverage_report /host/'
+          sudo chown -R runner $HOME/coverage_report
+          gsutil -m cp -r "$HOME/coverage_report/*" "gs://amdvlk-llpc-github-ci-artifacts-public/coverage_${CONFIG_TAG}_${GITHUB_SHA}/"
+      - name: Add comment with code coverage report link
+        if: contains(matrix.feature-set, '+coverage') && github.event.pull_request.number && github.repository == 'GPUOpen-Drivers/llpc' && secrets.GCR_KEY
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            The LLPC code coverage report is available at https://storage.cloud.google.com/amdvlk-llpc-github-ci-artifacts-public/coverage_${{ env.CONFIG_TAG }}_${{ github.sha }}/index.html.
+            Configuration: ${{ env.CONFIG_TAG }}.

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -6,6 +6,7 @@
 #                   --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                           \
 #                   --build-arg LLPC_REPO_REF=<GIT_REF>                                       \
 #                   --build-arg LLPC_REPO_SHA=<GIT_SHA>                                       \
+#                   --build-arg FEATURES="+coverage"                                          \
 #                   --tag llpc-ci/llpc
 #
 # Required arguments:
@@ -13,6 +14,7 @@
 # - LLPC_REPO_NAME: Name of the llpc repository to clone
 # - LLPC_REPO_REF: ref name to checkout
 # - LLPC_REPO_SHA: SHA of the commit to checkout
+# - FEATURES: A '+'-separated set of features to enable such as code coverage ('+coverage')
 #
 
 # Resume build from the specified image.
@@ -22,6 +24,7 @@ FROM "$AMDVLK_IMAGE"
 ARG LLPC_REPO_NAME
 ARG LLPC_REPO_REF
 ARG LLPC_REPO_SHA
+ARG FEATURES
 
 # Use bash instead of sh in this docker file.
 SHELL ["/bin/bash", "-c"]
@@ -43,3 +46,8 @@ RUN source /vulkandriver/env.sh \
 RUN source /vulkandriver/env.sh \
     && cmake --build . --target check-amdllpc check-amdllpc-units -- -v \
     && cmake --build . --target check-lgc check-lgc-units -- -v
+
+# Generate code coverage report for LLPC.
+RUN if echo "$FEATURES" | grep -q "+coverage" ; then \
+      /vulkandriver/generate-coverage-report.sh; \
+    fi


### PR DESCRIPTION
Add code coverage reports to pull request CI. When the CI runs configurations with code coverage (`+coverage`) enabled, a code coverage report is generated and uploaded to a public Google Cloud Storage [bucket](https://storage.cloud.google.com/amdvlk-llpc-github-ci-artifacts-public/) for inspection. The link to the code coverage report is then posted to the pull request by the CI bot.

The Google Cloud Storage bucket has been configured so that it's read-only by the public and write access is only granted to the CI bot.

This should be tested by force-pushing when https://github.com/GPUOpen-Drivers/llpc/pull/1599 is merged and the nightly images have been updated.