### PR TITLE
Allow parallel pipeline/shader compilation

### DIFF
--- a/llpc/test/shaderdb/error_reporting/MultipleThreadsVerboseOutput.spvasm
+++ b/llpc/test/shaderdb/error_reporting/MultipleThreadsVerboseOutput.spvasm
@@ -1,0 +1,19 @@
+; Check that an error is produced when we request to use multiple threads and verbose output.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip --num-threads=2 -v %s \
+; RUN:   | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Verbose output is not available when compiling with multiple threads
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1  "main"
+         %2 = OpTypeVoid
+         %3 = OpTypeFunction %2
+         %1 = OpFunction %2 None %3
+         %4 = OpLabel
+              OpReturn
+              OpFunctionEnd

--- a/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
@@ -1,12 +1,20 @@
 ; Check that an error is produced when the same shader stage is provided twice.
 
-; BEGIN_SHADERTEST
+; BEGIN_SHADERTEST_ST
 ; RUN: not amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s %s \
-; RUN:   | FileCheck --check-prefix=SHADERTEST %s
+; RUN:   | FileCheck --check-prefix=SHADERTEST_ST %s
 ;
-; SHADERTEST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (vertex)
-; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
-; END_SHADERTEST
+; SHADERTEST_ST-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (vertex)
+; SHADERTEST_ST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_ST
+
+; BEGIN_SHADERTEST_MT
+; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip --num-threads=2 %s %s \
+; RUN:   | FileCheck --check-prefix=SHADERTEST_MT %s
+;
+; SHADERTEST_MT-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (vertex)
+; SHADERTEST_MT-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST_MT
 
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/llpc/test/shaderdb/multiple_inputs/ParallelPipelineCompilation.multi-input
+++ b/llpc/test/shaderdb/multiple_inputs/ParallelPipelineCompilation.multi-input
@@ -1,0 +1,39 @@
+; Check that we can compile pipelines in parallel.
+
+; BEGIN_SHADERTEST_1
+; Use fewer threads than the number of inputs.
+; RUN: amdllpc -spvgen-dir=%spvgendir% --num-threads=2 \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe
+; END_SHADERTEST_1
+
+; BEGIN_SHADERTEST_2
+; Request more theads than the number of inputs.
+; RUN: amdllpc -spvgen-dir=%spvgendir% --num-threads=8 \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe
+; END_SHADERTEST_2
+
+; BEGIN_SHADERTEST_3
+; Large number of inputs. Use all available CPUs.
+; RUN: amdllpc -spvgen-dir=%spvgendir% --num-threads=0 \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs1Fs2.pipe \
+; RUN:   %S/test_inputs/PipelineVsFs_ConstantData_Vs2Fs1.pipe
+; END_SHADERTEST_3

--- a/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
+++ b/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
@@ -21,18 +21,30 @@
 ; SHADERTEST_FS-LABEL: {{^=====}} AMDLLPC SUCCESS =====
 ; END_SHADERTES_FS
 
-; BEGIN_SHADERTEST_BOTH
+; BEGIN_SHADERTEST_BOTH_ST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s,main_vs %s,main_fs \
-; RUN:   | FileCheck --check-prefix=SHADERTEST_BOTH %s
+; RUN:   | FileCheck --check-prefix=SHADERTEST_BOTH_ST %s
 ;
-; SHADERTEST_BOTH-LABEL: {{^//}} LLPC final pipeline module info
-; SHADERTEST_BOTH:       define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless
-; SHADERTEST_BOTH:       define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main
-; SHADERTEST_BOTH-LABEL: {{^//}} LLPC final ELF info
-; SHADERTEST_BOTH-LABEL: _amdgpu_vs_main_fetchless:
-; SHADERTEST_BOTH-LABEL: _amdgpu_ps_main:
-; SHADERTEST_BOTH-LABEL: {{^=====}} AMDLLPC SUCCESS =====
-; END_SHADERTES_BOTH
+; SHADERTEST_BOTH_ST-LABEL: {{^//}} LLPC final pipeline module info
+; SHADERTEST_BOTH_ST:       define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless
+; SHADERTEST_BOTH_ST:       define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main
+; SHADERTEST_BOTH_ST-LABEL: {{^//}} LLPC final ELF info
+; SHADERTEST_BOTH_ST-LABEL: _amdgpu_vs_main_fetchless:
+; SHADERTEST_BOTH_ST-LABEL: _amdgpu_ps_main:
+; SHADERTEST_BOTH_ST-LABEL: {{^=====}} AMDLLPC SUCCESS =====
+; END_SHADERTES_BOTH_ST
+
+; BEGIN_SHADERTEST_BOTH_MT
+; This test uses llvm-objdump instead of verbose output, as it is not allowed to mix multi-threaded
+; compilation with verbose output.
+;
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s,main_vs %s,main_fs --num-threads=2 -o %t.both.elf
+; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.both.elf \
+; RUN:   | FileCheck --check-prefix=SHADERTEST_BOTH_MT %s
+;
+; SHADERTEST_BOTH_MT-LABEL: <_amdgpu_vs_main_fetchless>:
+; SHADERTEST_BOTH_MT-LABEL: <_amdgpu_ps_main>:
+; END_SHADERTES_BOTH_MT
 
 ; SPIR-V
 ; Version: 1.5

--- a/llpc/test/shaderdb/relocatable_shaders/VsGs_Reloc.spvasm
+++ b/llpc/test/shaderdb/relocatable_shaders/VsGs_Reloc.spvasm
@@ -1,22 +1,36 @@
 ; Check that we can compile Vertex and Geometry stages together, without having to provide a .pipe file.
 
-; BEGIN_SHADERTEST
+; BEGIN_SHADERTEST_ST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf %gfxip %s,main_vs %s,main_gs -v \
-; RUN:   | FileCheck -check-prefix=SHADERTEST %s
+; RUN:   | FileCheck -check-prefix=SHADERTEST_ST %s
 ;
-; SHADERTEST:       {{^}}Building pipeline with relocatable shader elf.
-; SHADERTEST-LABEL: {{^}}.AMDGPU.disasm
-; SHADERTEST:       {{^}}_amdgpu_gs_main:
-; SHADERTEST:       {{^}}_amdgpu_vs_main:
-; SHADERTEST-LABEL: {{^}} PalMetadata
-; SHADERTEST-LABEL: .hardware_stages
-; SHADERTEST-LABEL: .gs:
-; SHADERTEST-LABEL: .entry_point: _amdgpu_gs_main
-; SHADERTEST-LABEL: .vs:
-; SHADERTEST-LABEL: .entry_point: _amdgpu_vs_main
-; SHADERTEST-LABEL: .type: Gs
-; SHADERTEST-LABEL: {{^}}===== AMDLLPC SUCCESS =====
-; END_SHADERTEST
+; SHADERTEST_ST:       {{^}}Building pipeline with relocatable shader elf.
+; SHADERTEST_ST-LABEL: {{^}}.AMDGPU.disasm
+; SHADERTEST_ST:       {{^}}_amdgpu_gs_main:
+; SHADERTEST_ST:       {{^}}_amdgpu_vs_main:
+; SHADERTEST_ST-LABEL: {{^}} PalMetadata
+; SHADERTEST_ST-LABEL: .hardware_stages
+; SHADERTEST_ST-LABEL: .gs:
+; SHADERTEST_ST-LABEL: .entry_point: _amdgpu_gs_main
+; SHADERTEST_ST-LABEL: .vs:
+; SHADERTEST_ST-LABEL: .entry_point: _amdgpu_vs_main
+; SHADERTEST_ST-LABEL: .type: Gs
+; SHADERTEST_ST-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+; END_SHADERTEST_ST
+
+; BEGIN_SHADERTEST_MT
+; This test uses llvm-objdump instead of verbose output, as it is not allowed to mix multi-threaded
+; compilation with verbose output.
+;
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf %gfxip %s,main_vs %s,main_gs \
+; RUN:   --num-threads=2 -o %t.mt.elf
+; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.mt.elf \
+; RUN:   | FileCheck -check-prefix=SHADERTEST_MT %s
+;
+; SHADERTEST_MT-LABEL: <_amdgpu_gs_main>:
+; SHADERTEST_MT-LABEL: <_amdgpu_vs_main>:
+; END_SHADERTEST_MT
+
 
 ; SPIR-V
 ; Version: 1.5

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -72,6 +72,7 @@ struct ShaderModuleData {
   Llpc::ShaderModuleBuildInfo shaderInfo; // Info to build shader modules
   Llpc::ShaderModuleBuildOut shaderOut;   // Output of building shader modules
   void *shaderBuf;                        // Allocation buffer of building shader modules
+  bool disableDoAutoLayout;               // Indicates whether to disable auto layout of descriptors
 };
 
 // Represents a single compilation context of a pipeline or a group of shaders.
@@ -123,8 +124,8 @@ llvm::Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, 
                                  bool unlinked, bool ignoreColorAttachmentFormats);
 
 // Processes and compiles multiple shader stage input files.
-llvm::Error processInputStages(ICompiler *compiler, CompileInfo &compileInfo, llvm::ArrayRef<InputSpec> inputSpecs,
-                               bool validateSpirv);
+llvm::Error processInputStages(CompileInfo &compileInfo, llvm::ArrayRef<InputSpec> inputSpecs, bool validateSpirv,
+                               unsigned numThreads);
 
 } // namespace StandaloneCompiler
 } // namespace Llpc


### PR DESCRIPTION
Parallel compilation is controlled by the `--num-threads` flag.
We default to single-threaded compilation.

The main goal is to excercise the threading in the compiler without
having to run the full ICD on a machine with a GPU. With the thread
sanitizer being enabled in our public CI, we hope that this will catch
most of the potential synchronization issues in LLPC.

Parallel compilation and verbose output are disallowed because of
LLVM's ostream not being thread safe. Even if this wasn't the case,
verbose logs would be interleaved and not very useful.

Refactor stage processing such that `ShaderModuleData` mergin happens
at the end.