### PR TITLE
Add unlinked shader stage build function

### DIFF
--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -108,6 +108,15 @@ public:
 
   virtual Result BuildComputePipeline(const ComputePipelineBuildInfo *pipelineInfo,
                                       ComputePipelineBuildOut *pipelineOut, void *pipelineDumpFile = nullptr);
+
+  virtual Result BuildGraphicsShaderStage(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                          GraphicsPipelineBuildOut *pipelineOut,
+                                          Vkgc::UnlinkedShaderStage stage, void *pPipelineDumpFile = nullptr);
+
+  virtual Result BuildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                              GraphicsPipelineBuildOut *pipelineOut, const BinaryData *pElfpackage,
+                                              void *pPipelineDumpFile = nullptr);
+
   Result buildGraphicsPipelineInternal(GraphicsContext *graphicsContext,
                                        llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
                                        bool buildingRelocatableElf, ElfPackage *pipelineElf,
@@ -158,6 +167,10 @@ private:
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo,
                                           const GraphicsPipelineBuildInfo *pipelineInfo);
   bool canUseRelocatableComputeShaderElf(const ComputePipelineBuildInfo *pipelineInfo);
+
+  Result buildUnlinkedShaderInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
+                                     Vkgc::UnlinkedShaderStage stage, ElfPackage &elfPackage,
+                                     llvm::MutableArrayRef<CacheAccessInfo> stageCacheAccesses);
 
   std::vector<std::string> m_options;           // Compilation options
   MetroHash::Hash m_optionHash;                 // Hash code of compilation options

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -232,6 +232,30 @@ public:
   /// @returns : Result::Success if successful. Other return codes indicate failure.
   virtual Result BuildShaderModule(const ShaderModuleBuildInfo *pShaderInfo, ShaderModuleBuildOut *pShaderOut) = 0;
 
+  /// Build shader from the specified info.
+  ///
+  /// @param [in]  pShaderInfo    Info to build this shader module
+  /// @param [out] pShaderOut : Output of building this shader module
+  /// @param [in]  stage          Shader stage of needing to compile
+  /// @param [out] pipelineDumpFile : Handle of pipeline dump file
+  ///
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
+  virtual Result BuildGraphicsShaderStage(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                          GraphicsPipelineBuildOut *pipelineOut,
+                                          Vkgc::UnlinkedShaderStage stage, void *pPipelineDumpFile = nullptr) = 0;
+
+  /// Build shader from the specified info.
+  ///
+  /// @param [in]  pShaderInfo    Info to build this shader module
+  /// @param [out] pShaderOut  : Output of building this shader module
+  /// @param [in]  pElfpackage    Early compiled elfPackage
+  /// @param [out] pipelineDumpFile : Handle of pipeline dump file
+  ///
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
+  virtual Result BuildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                              GraphicsPipelineBuildOut *pipelineOut, const BinaryData *pElfpackage,
+                                              void *pPipelineDumpFile = nullptr) = 0;
+
   /// Build graphics pipeline from the specified info.
   ///
   /// @param [in]  pPipelineInfo  Info to build this graphics pipeline


### PR DESCRIPTION
When shaders are as library, we sometimes need to fastly link them. In
this case,we must to compile early and store Elfpackage, then link them
to a whole pipeline.