### PR TITLE
Add unlinked shader stage build function

### DIFF
--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -102,6 +102,13 @@ public:
 
   virtual Result BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, ShaderModuleBuildOut *shaderOut);
 
+  virtual Result buildGraphicsShaderStage(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                          GraphicsPipelineBuildOut *pipelineOut, Vkgc::UnlinkedShaderStage stage,
+                                          void *pipelineDumpFile = nullptr);
+
+  virtual Result buildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                              GraphicsPipelineBuildOut *pipelineOut, const BinaryData *elfPackage);
+
   virtual unsigned ConvertColorBufferFormatToExportFormat(const ColorTarget *target,
                                                           const bool enableAlphaToCoverage) const;
 
@@ -166,6 +173,11 @@ private:
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo,
                                           const GraphicsPipelineBuildInfo *pipelineInfo);
   bool canUseRelocatableComputeShaderElf(const ComputePipelineBuildInfo *pipelineInfo);
+  Result buildUnlinkedShaderInternal(Context *context, llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo,
+                                     Vkgc::UnlinkedShaderStage stage, ElfPackage &elfPackage,
+                                     llvm::MutableArrayRef<CacheAccessInfo> stageCacheAccesses);
+  void dumpCompilerOptions(void *pipelineDumpFile);
+
   std::vector<std::string> m_options;           // Compilation options
   MetroHash::Hash m_optionHash;                 // Hash code of compilation options
   GfxIpVersion m_gfxIp;                         // Graphics IP version info

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -232,6 +232,29 @@ public:
   /// @returns : Result::Success if successful. Other return codes indicate failure.
   virtual Result BuildShaderModule(const ShaderModuleBuildInfo *pShaderInfo, ShaderModuleBuildOut *pShaderOut) = 0;
 
+  /// Build unlinked shader to ElfPackage with part pipeline info.
+  ///
+  /// @param [in]  pipelineInfo     : Info to build this shader module
+  /// @param [out] pipelineOut      : Output of building this shader module
+  /// @param [in]  stage            : Shader stage of needing to compile
+  /// @param [out] pipelineDumpFile : Handle of pipeline dump file
+  ///
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
+  virtual Result buildGraphicsShaderStage(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                          GraphicsPipelineBuildOut *pipelineOut, Vkgc::UnlinkedShaderStage stage,
+                                          void *pipelineDumpFile = nullptr) = 0;
+
+  /// Build the whole graphics pipeline. If missing elfPackage of a certain stage, we will build it first, and
+  /// link them to the full pipeline last.
+  ///
+  /// @param [in]  pipelineInfo : Info to build this shader module
+  /// @param [out] pipelineOut  : Output of building this shader module
+  /// @param [in]  elfPackage   : Early compiled elfPackage; it is an array which size is UnlinkedStageCount.
+  ///
+  /// @returns : Result::Success if successful. Other return codes indicate failure.
+  virtual Result buildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                              GraphicsPipelineBuildOut *pipelineOut, const BinaryData *elfPackage) = 0;
+
   /// Build graphics pipeline from the specified info.
   ///
   /// @param [in]  pPipelineInfo  Info to build this graphics pipeline


### PR DESCRIPTION
When shaders are as a library, we sometimes need to quickly link them. In
this case, we must to compile early and store ElfPackage, then link them
to a whole pipeline.