### PR TITLE
Fix a call to DIBuilder::createExpression

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -750,7 +750,7 @@ DINode *SPIRVToLLVMDbgTran::transImportedEntry(const SPIRVExtInst *DebugInst) {
 
 MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Args = DebugInst->getArguments();
-  std::vector<int64_t> Ops;
+  std::vector<uint64_t> Ops;
   for (SPIRVId A : Args) {
     SPIRVExtInst *O = BM->get<SPIRVExtInst>(A);
     const SPIRVWordVec &Operands = O->getArguments();
@@ -760,7 +760,7 @@ MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
       Ops.push_back(Operands[I]);
     }
   }
-  ArrayRef<int64_t> Addr(Ops.data(), Ops.size());
+  ArrayRef<uint64_t> Addr(Ops.data(), Ops.size());
   return Builder.createExpression(Addr);
 }
 


### PR DESCRIPTION
Stop using the signed version of createExpression which was removed
from upstream LLVM by https://reviews.llvm.org/D116301.