### PR TITLE
Fix misleading indentation warning

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -547,10 +547,9 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
         destNode.type = ResourceNodeType::DescriptorBuffer;
       else
         destNode.type = static_cast<ResourceNodeType>(node.type);
-      // clang-format off
-        destNode.set = node.srdRange.set; // NOLINT
-        destNode.binding = node.srdRange.binding; // NOLINT
-      // clang-format on
+
+      destNode.set = node.srdRange.set;
+      destNode.binding = node.srdRange.binding;
       destNode.immutableValue = nullptr;
       destNode.immutableSize = 0;
       switch (node.type) {


### PR DESCRIPTION
In our internal build, we turn on warnings as errors, and so warning is
causing an error.

It will also make the code easier to read.  I had to look carefully to
know for sure that this was the correct behaviour.