### PR TITLE
Make assemble spvasm to spv thread safe

### DIFF
--- a/llpc/util/llpcFile.cpp
+++ b/llpc/util/llpcFile.cpp
@@ -110,13 +110,7 @@ Result File::open(const char *filename, unsigned accessFlags) {
     }
 
     if (result == Result::Success) {
-#if defined(_WIN32)
-      // MS compilers provide fopen_s, which is supposedly "safer" than traditional fopen.
-      fopen_s(&m_fileHandle, filename, &fileMode[0]);
-#else
-      // Just use the traditional fopen.
       m_fileHandle = fopen(filename, &fileMode[0]);
-#endif
       if (!m_fileHandle)
         result = Result::ErrorUnknown;
     }


### PR DESCRIPTION
Assembling to an output file is now protected with a mutex. This is
required as assembling, outputting and recording the file as assembled
needs to be in a critical section.

Assembling the same file will only happen once.
Opening a file for reading on windows now uses fopen instead of fopen_s
which does not allow shareable (opening more than once). This is in
line with the Linux implementation.