### PR TITLE
Refactor `PipelineBuilder` allow for future pipeline types. NFC.

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -299,6 +299,8 @@ if(ICD_BUILD_LLPC)
 add_library(llpc_standalone_compiler
     tool/llpcAutoLayout.cpp
     tool/llpcCompilationUtils.cpp
+    tool/llpcComputePipelineBuilder.cpp
+    tool/llpcGraphicsPipelineBuilder.cpp
     tool/llpcInputUtils.cpp
     tool/llpcPipelineBuilder.cpp
 )

--- a/llpc/tool/Makefile.apicompilerllpctool
+++ b/llpc/tool/Makefile.apicompilerllpctool
@@ -42,11 +42,13 @@ endif
 
 vpath %.cpp $(LLPC_DEPTH)/tool
 
-CPPFILES +=                   \
-    amdllpc.cpp               \
-    llpcAutoLayout.cpp        \
-    llpcCompilationUtils.cpp  \
-    llpcInputUtils.cpp        \
+CPPFILES +=                          \
+    amdllpc.cpp                      \
+    llpcAutoLayout.cpp               \
+    llpcCompilationUtils.cpp         \
+    llpcComputePipelineBuilder.cpp   \
+    llpcGraphicsPipelineBuilder.cpp  \
+    llpcInputUtils.cpp               \
     llpcPipelineBuilder.cpp
 
 EXE_TARGET = amdllpc

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -1,7 +1,7 @@
 /*
  ***********************************************************************************************************************
  *
- *  Copyright (c) 2016-2021 Advanced Micro Devices, Inc. All Rights Reserved.
+ *  Copyright (c) 2016-2022 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -461,10 +461,10 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
     dumpOptions->dumpDuplicatePipelines = DumpDuplicatePipelines;
   }
 
-  PipelineBuilder builder(*compiler, compileInfo, dumpOptions, TimePassesIsEnabled || cl::EnableTimerProfile);
-  result = builder.build();
-  if (result != Result::Success)
-    return createResultError(result, "Failed to build pipeline");
+  std::unique_ptr<PipelineBuilder> builder =
+      createPipelineBuilder(*compiler, compileInfo, dumpOptions, TimePassesIsEnabled || cl::EnableTimerProfile);
+  if (Error err = builder->build())
+    return err;
 
   return outputElf(&compileInfo, OutFile, firstInput.filename);
 }

--- a/llpc/tool/llpcComputePipelineBuilder.h
+++ b/llpc/tool/llpcComputePipelineBuilder.h
@@ -1,0 +1,51 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcComputePipelineBuilder.h
+ * @brief LLPC header file: compute pipeline compilation logic for standalone LLPC compilers.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcPipelineBuilder.h"
+
+namespace Llpc {
+namespace StandaloneCompiler {
+
+// Pipeline builder implementation for compute pipelines.
+class ComputePipelineBuilder : public PipelineBuilder {
+public:
+  using PipelineBuilder::PipelineBuilder;
+
+  llvm::Error build() override;
+  uint64_t getPipelineHash(Vkgc::PipelineBuildInfo buildInfo) override;
+
+  // Builds compute pipeline and does linking. Returns the pipeline Elf.
+  llvm::Expected<Vkgc::BinaryData> buildComputePipeline();
+};
+
+} // namespace StandaloneCompiler
+} // namespace Llpc

--- a/llpc/tool/llpcGraphicsPipelineBuilder.cpp
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.cpp
@@ -1,0 +1,171 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2016-2022 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2021-2022 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcGraphicsPipelineBuilder.cpp
+ * @brief LLPC source file: contains the implementation LLPC graphics pipeline compilation logic for standalone LLPC
+ *        compilers.
+ ***********************************************************************************************************************
+ */
+#ifdef WIN_OS
+// NOTE: Disable Windows-defined min()/max() because we use STL-defined std::min()/std::max() in LLPC.
+#define NOMINMAX
+#endif
+
+#include "llpcGraphicsPipelineBuilder.h"
+#include "llpcAutoLayout.h"
+#include "llpcCompilationUtils.h"
+#include "llpcUtil.h"
+#include "vkgcUtil.h"
+#include "llvm/ADT/ScopeExit.h"
+
+using namespace llvm;
+using namespace Vkgc;
+
+namespace Llpc {
+namespace StandaloneCompiler {
+
+// =====================================================================================================================
+// Builds pipeline using the provided build info and performs linking.
+//
+// @returns : `llvm::ErrorSuccess` on success, `llpc::ResultError` on failure.
+Error GraphicsPipelineBuilder::build() {
+  CompileInfo &compileInfo = getCompileInfo();
+
+  Expected<BinaryData> pipelineOrErr = buildGraphicsPipeline();
+  if (Error err = pipelineOrErr.takeError())
+    return err;
+
+  Result result = decodePipelineBinary(&*pipelineOrErr, &compileInfo);
+  if (result != Result::Success)
+    return createResultError(result, "Failed to decode pipeline");
+
+  return Error::success();
+}
+
+// =====================================================================================================================
+// Build the graphics pipeline.
+//
+// @returns : Pipeline binary data on success, `llpc::ResultError` on failure.
+Expected<BinaryData> GraphicsPipelineBuilder::buildGraphicsPipeline() {
+  CompileInfo &compileInfo = getCompileInfo();
+  GraphicsPipelineBuildInfo *pipelineInfo = &compileInfo.gfxPipelineInfo;
+  GraphicsPipelineBuildOut *pipelineOut = &compileInfo.gfxPipelineOut;
+
+  // Fill pipeline shader info.
+  // clang-format off
+  PipelineShaderInfo *shaderInfos[ShaderStageGfxCount] = {
+      &pipelineInfo->vs,
+      &pipelineInfo->tcs,
+      &pipelineInfo->tes,
+      &pipelineInfo->gs,
+      &pipelineInfo->fs,
+  };
+  // clang-format on
+  ResourceMappingNodeMap nodeSets;
+  unsigned pushConstSize = 0;
+  for (StandaloneCompiler::ShaderModuleData &moduleData : compileInfo.shaderModuleDatas) {
+    const ShaderStage stage = moduleData.shaderStage;
+    PipelineShaderInfo *shaderInfo = shaderInfos[stage];
+    const ShaderModuleBuildOut *shaderOut = &moduleData.shaderOut;
+
+    // If entry target is not specified, use the one from command line option.
+    if (!shaderInfo->pEntryTarget)
+      shaderInfo->pEntryTarget = moduleData.entryPoint.c_str();
+
+    shaderInfo->pModuleData = shaderOut->pModuleData;
+    shaderInfo->entryStage = stage;
+
+    // If not compiling from pipeline, lay out user data now.
+    if (compileInfo.doAutoLayout)
+      doAutoLayoutDesc(stage, moduleData.spirvBin, pipelineInfo, shaderInfo, nodeSets, pushConstSize,
+                       /*autoLayoutDesc = */ compileInfo.autoLayoutDesc);
+  }
+
+  if (compileInfo.doAutoLayout)
+    buildTopLevelMapping(compileInfo.stageMask, nodeSets, pushConstSize, &pipelineInfo->resourceMapping,
+                         compileInfo.autoLayoutDesc);
+
+  pipelineInfo->pInstance = nullptr; // Placeholder, unused.
+  pipelineInfo->pUserData = &compileInfo.pipelineBuf;
+  pipelineInfo->pfnOutputAlloc = allocateBuffer;
+  pipelineInfo->unlinked = compileInfo.unlinked;
+
+  // NOTE: If number of patch control points is not specified, we set it to 3.
+  if (pipelineInfo->iaState.patchControlPoints == 0)
+    pipelineInfo->iaState.patchControlPoints = 3;
+
+  pipelineInfo->options.robustBufferAccess = compileInfo.robustBufferAccess;
+  pipelineInfo->options.enableRelocatableShaderElf = compileInfo.relocatableShaderElf;
+  pipelineInfo->options.scalarBlockLayout = compileInfo.scalarBlockLayout;
+  pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo.scratchAccessBoundsChecks;
+
+  PipelineBuildInfo localPipelineInfo = {};
+  localPipelineInfo.pGraphicsInfo = pipelineInfo;
+  void *pipelineDumpHandle = runPreBuildActions(localPipelineInfo);
+  auto onExit = make_scope_exit([&] { runPostBuildActions(pipelineDumpHandle, {pipelineOut->pipelineBin}); });
+
+  Result result = getCompiler().BuildGraphicsPipeline(pipelineInfo, pipelineOut, pipelineDumpHandle);
+  if (result != Result::Success)
+    return createResultError(result, "Graphics pipeline compilation failed");
+
+  return pipelineOut->pipelineBin;
+}
+
+// =====================================================================================================================
+// Calculates the pipeline hash.
+//
+// @param buildInfo : Pipeline build info.
+// @returns : Calculated pipeline hash.
+uint64_t GraphicsPipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildInfo) {
+  return IPipelineDumper::GetPipelineHash(buildInfo.pGraphicsInfo);
+}
+
+} // namespace StandaloneCompiler
+} // namespace Llpc

--- a/llpc/tool/llpcGraphicsPipelineBuilder.h
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.h
@@ -1,0 +1,52 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcGraphicsPipelineBuilder.h
+ * @brief LLPC header file: graphics pipeline compilation logic for standalone LLPC compilers.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcPipelineBuilder.h"
+
+namespace Llpc {
+namespace StandaloneCompiler {
+
+// Pipeline builder implementation for graphics pipelines.
+class GraphicsPipelineBuilder : public PipelineBuilder {
+public:
+  using PipelineBuilder::PipelineBuilder;
+
+  llvm::Error build() override;
+
+  uint64_t getPipelineHash(Vkgc::PipelineBuildInfo buildInfo) override;
+
+  // Builds graphics pipeline and does linking. Returns the pipeline Elf.
+  llvm::Expected<Vkgc::BinaryData> buildGraphicsPipeline();
+};
+
+} // namespace StandaloneCompiler
+} // namespace Llpc

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -30,49 +30,84 @@
  */
 #pragma once
 
+#include "llpc.h"
 #include "llpcCompilationUtils.h"
+#include "llpcError.h"
 #include "vkgcDefs.h"
 #include "llvm/ADT/Optional.h"
+#include <memory>
 
 namespace Llpc {
 namespace StandaloneCompiler {
 
-// Performs pipeline compilation. Dumps compiled pipelines when requested.
+class PipelineBuilder;
+
+// Factory function that returns a `PipelineBuilder` appropriate for the given pipeline type (e.g., graphics, compute).
+std::unique_ptr<PipelineBuilder> createPipelineBuilder(ICompiler &compiler, CompileInfo &compileInfo,
+                                                       llvm::Optional<Vkgc::PipelineDumpOptions> dumpOptions,
+                                                       bool printPipelineInfo);
+
+// Base class for pipeline compilation. Dumps compiled pipelines when requested.
+//
+// Note: We make all key functions virtual to give experimental implementations maximum freedom.
 class PipelineBuilder {
 public:
-  // Creates a PipelineBuilder.
+  // Initializes PipelineBuilder. Use `createPipelineBuilder` to create concrete instances of this class.
   //
   // @param compiler : LLPC compiler object.
   // @param [in/out] compileInfo : Compilation info of LLPC standalone tool. This will be modified by `build()`.
-  // @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when llvm::None is passed.
+  // @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when `llvm::None` is passed.
   // @param printPipelineInfo : Whether to print pipeline info (hash, filenames) before compilation.
   PipelineBuilder(ICompiler &compiler, CompileInfo &compileInfo, llvm::Optional<Vkgc::PipelineDumpOptions> dumpOptions,
                   bool printPipelineInfo)
       : m_compiler(compiler), m_compileInfo(compileInfo), m_dumpOptions(std::move(dumpOptions)),
         m_printPipelineInfo(printPipelineInfo) {}
 
+  virtual ~PipelineBuilder() = default;
+
   // Compiles the pipeline and performs linking.
-  LLPC_NODISCARD Result build();
+  // The implementations should call `runPreBuildActions` before performing compilation with `m_compiler` and
+  // call `runPostBuildActions` after.
+  //
+  // @returns : Calculated pipeline hash.
+  virtual llvm::Error build() = 0;
 
-private:
+  // Calculates the hash of the compiled pipeline. This is used by `printPipelineInfo` to produce verbose logs.
+  //
+  // @param buildInfo : Pipeline build information.
+  // @returns : Calculated pipeline hash.
+  LLPC_NODISCARD virtual uint64_t getPipelineHash(Vkgc::PipelineBuildInfo buildInfo) = 0;
+
+  // Returns the compiler.
+  //
+  // @returns : Compiler handle.
+  ICompiler &getCompiler() { return m_compiler; }
+
+  // Returns the compile info.
+  //
+  // @returns : Compile info.
+  CompileInfo &getCompileInfo() { return m_compileInfo; }
+
+  // Returns the pipeline dump options.
+  //
+  // @returns : `PipelineDumpOptions` or `llpc::None` if pipeline dumps were not requested.
+  llvm::Optional<Vkgc::PipelineDumpOptions> &getDumpOptions() { return m_dumpOptions; }
+
   // Returns true iff pipeline dumps are requested.
+  //
+  // @returns : `true` is pipeline dumps were requested, `false` if not.
   LLPC_NODISCARD bool shouldDumpPipelines() const { return m_dumpOptions.hasValue(); }
-
-  // Builds graphics pipeline and does linking.
-  LLPC_NODISCARD Result buildGraphicsPipeline(Vkgc::BinaryData &outPipeline);
-
-  // Builds compute pipeline and does linking.
-  LLPC_NODISCARD Result buildComputePipeline(Vkgc::BinaryData &outPipeline);
 
   // Runs optional pre-build code (pipeline dumping, pipeline info printing).
   LLPC_NODISCARD void *runPreBuildActions(Vkgc::PipelineBuildInfo buildInfo);
 
   // Runs post-build cleanup code. Must be called after `runPrebuildActions`.
-  void runPostBuildActions(void *pipelineDumpHandle, llvm::SmallVector<BinaryData, 1> &pipelines);
+  void runPostBuildActions(void *pipelineDumpHandle, llvm::MutableArrayRef<BinaryData> pipelines);
 
   // Prints pipeline dump hash code and filenames.
   void printPipelineInfo(Vkgc::PipelineBuildInfo buildInfo);
 
+private:
   ICompiler &m_compiler;
   CompileInfo &m_compileInfo;
   llvm::Optional<Vkgc::PipelineDumpOptions> m_dumpOptions = llvm::None;


### PR DESCRIPTION
Make it easier to add support for new pipeline types without having
to modify the compilation logic for graphics and compute pipelines.
    
New pipeline types are supported by deriving from `PipelineBuilder`
and registering the new class in `createPipelineBuilder`.
    
Also return descriptive error results.