### PR TITLE
Avoid creating duplicate temporary `.spv` files in tests

### DIFF
--- a/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
@@ -9,7 +9,9 @@
 ; END_SHADERTEST_ST
 
 ; BEGIN_SHADERTEST_MT
-; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip --num-threads=2 %s %s \
+; Copy the input shader so that we do not attempt to produce two temporary .spv files under the same location.
+; RUN: cp %s %t.copy.spvasm
+; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip --num-threads=2 %s %t.copy.spvasm \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST_MT %s
 ;
 ; SHADERTEST_MT-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (vertex)

--- a/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
+++ b/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
@@ -38,7 +38,9 @@
 ; This test uses llvm-objdump instead of verbose output, as it is not allowed to mix multi-threaded
 ; compilation with verbose output.
 ;
-; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s,main_vs %s,main_fs --num-threads=2 -o %t.both.elf
+; Copy the input shader so that we do not produce two temporary .spv files under the same location.
+; RUN: cp %s %t.both_mt.spvasm
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s,main_vs %t.both_mt.spvasm,main_fs --num-threads=2 -o %t.both.elf
 ; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.both.elf \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST_BOTH_MT %s
 ;


### PR DESCRIPTION
Currently, `amdllpc` produces temporary `.spv` files in a fixed location
relative to inputs. When assembling input SPIR-V in multiple threads, we
may end up writing to the same location twice, which makes the tests
flaky.

As a workaround, make sure all `.spvasm` test inputs used in
multi-threading tests have unique names.