### PR TITLE
[CI] Revert "Add code coverage steps to CI."

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -35,22 +35,12 @@ jobs:
           git clone https://github.com/${GITHUB_REPOSITORY}.git .
           git fetch origin +${GITHUB_SHA}:${GITHUB_REF} --update-head-ok
           git checkout ${GITHUB_SHA}
-      - name: Setup Google Cloud SDK
-        if: contains(matrix.feature-set, '+coverage') && github.repository == 'GPUOpen-Drivers/llpc'
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          version: '290.0.1'
-          service_account_email: ${{ secrets.GCR_USER }}
-          service_account_key: ${{ secrets.GCR_KEY }}
-          export_default_credentials: true
       - name: Generate Docker base image tag string
         run: |
           CONFIG_LOWER=$(echo "${{ matrix.config }}" | tr "[:upper:]" "[:lower:]")
           FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
           TAG=$(printf "${{ matrix.image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER")
           echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
-          CONFIG_TAG=$(printf "%s%s" "$CONFIG_LOWER" "$FEATURES_LOWER")
-          echo "CONFIG_TAG=$CONFIG_TAG" | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
@@ -59,19 +49,4 @@ jobs:
                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"
-                            --build-arg FEATURES="${{ matrix.feature-set }}"
                             --tag llpc/ci-shaderdb
-      - name: Copy code coverage report to host and upload to GCS
-        if: contains(matrix.feature-set, '+coverage') && github.event.pull_request.number && github.repository == 'GPUOpen-Drivers/llpc'
-        run: |
-          docker run -v "$HOME:/host" llpc/ci-shaderdb 'bash' '-c' 'cp -r /vulkandriver/coverage_report /host/'
-          sudo chown -R runner $HOME/coverage_report
-          gsutil -m cp -r "$HOME/coverage_report/*" "gs://amdvlk-llpc-github-ci-artifacts-public/coverage_${CONFIG_TAG}_${GITHUB_SHA}/"
-      - name: Add comment with code coverage report link
-        if: contains(matrix.feature-set, '+coverage') && github.event.pull_request.number && github.repository == 'GPUOpen-Drivers/llpc'
-        uses: peter-evans/create-or-update-comment@v1.4.5
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            The LLPC code coverage report is available at https://storage.googleapis.com/amdvlk-llpc-github-ci-artifacts-public/coverage_${{ env.CONFIG_TAG }}_${{ github.sha }}/index.html.
-            Configuration: ${{ env.CONFIG_TAG }}.

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -6,7 +6,6 @@
 #                   --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                           \
 #                   --build-arg LLPC_REPO_REF=<GIT_REF>                                       \
 #                   --build-arg LLPC_REPO_SHA=<GIT_SHA>                                       \
-#                   --build-arg FEATURES="+coverage"                                          \
 #                   --tag llpc-ci/llpc
 #
 # Required arguments:
@@ -14,7 +13,6 @@
 # - LLPC_REPO_NAME: Name of the llpc repository to clone
 # - LLPC_REPO_REF: ref name to checkout
 # - LLPC_REPO_SHA: SHA of the commit to checkout
-# - FEATURES: A '+'-separated set of features to enable such as code coverage ('+coverage')
 #
 
 # Resume build from the specified image.
@@ -24,7 +22,6 @@ FROM "$AMDVLK_IMAGE"
 ARG LLPC_REPO_NAME
 ARG LLPC_REPO_REF
 ARG LLPC_REPO_SHA
-ARG FEATURES
 
 # Use bash instead of sh in this docker file.
 SHELL ["/bin/bash", "-c"]
@@ -46,8 +43,3 @@ RUN source /vulkandriver/env.sh \
 RUN source /vulkandriver/env.sh \
     && cmake --build . --target check-amdllpc check-amdllpc-units -- -v \
     && cmake --build . --target check-lgc check-lgc-units -- -v
-
-# Generate code coverage report for LLPC.
-RUN if echo "$FEATURES" | grep -q "+coverage" ; then \
-      /vulkandriver/generate-coverage-report.sh; \
-    fi


### PR DESCRIPTION
The PR workflows don't seem able to access secrets since they come from forks. I will look into alternative methods to support this.

This reverts commit 9666f53b6f9d5031fa8fed27b3c0b3477946d483.