### PR TITLE
Pass context to AttrBuilder

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -793,7 +793,13 @@ void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *>
 // =====================================================================================================================
 // Set Attributes on new function
 void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 409358
+  // Old version of the code
   AttrBuilder builder;
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  AttrBuilder builder(entryPoint->getContext());
+#endif
   if (m_shaderStage == ShaderStageFragment) {
     auto &builtInUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->builtInUsage.fs;
     SpiPsInputAddr spiPsInputAddr = {};

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -103,7 +103,13 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       continue;
 
     std::string targetFeatures(globalFeatures);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 409358
+    // Old version of the code
     AttrBuilder builder;
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    AttrBuilder builder(module->getContext());
+#endif
 
     ShaderStage shaderStage = lgc::getShaderStage(&*func);
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5205,7 +5205,13 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *bf) {
 
     SPIRVWord maxOffset = 0;
     if (ba->hasDecorate(DecorationMaxByteOffset, 0, &maxOffset)) {
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 409358
+      // Old version of the code
       AttrBuilder builder;
+#else
+      // New version of the code (also handles unknown version, which we treat as latest)
+      AttrBuilder builder(*m_context);
+#endif
       builder.addDereferenceableAttr(maxOffset);
       i->addAttrs(builder);
     }


### PR DESCRIPTION
Since [D116599](https://reviews.llvm.org/D116599), upstream LLVM requires a Context in the AttrBuilder.