### PR TITLE
[CI] Upload code coverage report as GitHub artifact.

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -41,12 +41,34 @@ jobs:
           FEATURES_LOWER=$(echo "${{ matrix.feature-set }}" | tr "+" "_")
           TAG=$(printf "${{ matrix.image-template }}" "$CONFIG_LOWER" "$FEATURES_LOWER")
           echo "IMAGE_TAG=$TAG" | tee -a $GITHUB_ENV
+          CONFIG_TAG=$(printf "%s%s" "$CONFIG_LOWER" "$FEATURES_LOWER")
+          echo "CONFIG_TAG=$CONFIG_TAG" | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
         run: docker build . --file docker/llpc.Dockerfile
-                            --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
-                            --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
-                            --build-arg LLPC_REPO_REF="${GITHUB_REF}"
-                            --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"
-                            --tag llpc/ci-shaderdb
+                             --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
+                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
+                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
+                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"
+                             --build-arg FEATURES="${{ matrix.feature-set }}"
+                             --tag llpc/ci-shaderdb
+      - name: Copy code coverage report to host and save PR number
+        if: contains(matrix.feature-set, '+coverage') && github.event.pull_request.number
+        run: |
+          docker run -v "$HOME:/host" llpc/ci-shaderdb 'bash' '-c' 'cp -r /vulkandriver/coverage_report /host/'
+          sudo chown -R runner $HOME/coverage_report
+          echo "COVERAGE_REPORT_FILES=$HOME/coverage_report/*" | tee -a $GITHUB_ENV
+          echo "${{ github.event.pull_request.number }}" > pr_num.txt
+      - name: Upload code coverage report as a GitHub artifact
+        if:  contains(matrix.feature-set, '+coverage') && github.event.pull_request.number
+        uses: actions/upload-artifact@v2
+        with:
+          name: cov_report_${{ env.CONFIG_TAG }}
+          path: ${{ env.COVERAGE_REPORT_FILES }}
+      - name: Upload the PR number as a GitHub artifact
+        if: contains(matrix.feature-set, '+coverage') && github.event.pull_request.number
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr_num
+          path: pr_num.txt

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -6,6 +6,7 @@
 #                   --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                           \
 #                   --build-arg LLPC_REPO_REF=<GIT_REF>                                       \
 #                   --build-arg LLPC_REPO_SHA=<GIT_SHA>                                       \
+#                   --build-arg FEATURES="+coverage"                                          \
 #                   --tag llpc-ci/llpc
 #
 # Required arguments:
@@ -13,6 +14,7 @@
 # - LLPC_REPO_NAME: Name of the llpc repository to clone
 # - LLPC_REPO_REF: ref name to checkout
 # - LLPC_REPO_SHA: SHA of the commit to checkout
+# - FEATURES: A '+'-separated set of features to enable such as code coverage ('+coverage')
 #
 
 # Resume build from the specified image.
@@ -22,6 +24,7 @@ FROM "$AMDVLK_IMAGE"
 ARG LLPC_REPO_NAME
 ARG LLPC_REPO_REF
 ARG LLPC_REPO_SHA
+ARG FEATURES
 
 # Use bash instead of sh in this docker file.
 SHELL ["/bin/bash", "-c"]
@@ -43,3 +46,8 @@ RUN source /vulkandriver/env.sh \
 RUN source /vulkandriver/env.sh \
     && cmake --build . --target check-amdllpc check-amdllpc-units -- -v \
     && cmake --build . --target check-lgc check-lgc-units -- -v
+
+# Generate code coverage report for LLPC.
+RUN if echo "$FEATURES" | grep -q "+coverage" ; then \
+      /vulkandriver/generate-coverage-report.sh; \
+    fi


### PR DESCRIPTION
Background: we are not able to access repository's secrets in CI triggered by a pull request from a fork, and therefore we are not able to upload code coverage reports to Google Cloud Storage since we can't authenticate. 

This change instead uploads code coverage reports as GitHub artifacts, accessible from the CI Summary page. For example, see the Artifacts section at this example run: https://github.com/vettoreldaniele/llpc/actions/runs/1678664668.

Note: I will follow-up with another PR that adds a separate workflow to retrieve these artifacts and upload them to Google Cloud Storage, along with adding a comment to the original PR with a link to the report (similar to how it would have worked if the previous PR https://github.com/GPUOpen-Drivers/llpc/pull/1619 worked). That workflow should have access to the repository's secrets according to GitHub's docs.