### PR TITLE
Use in-memory binary for glsl and spvasm intermediate binary spv

### DIFF
--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -103,12 +103,12 @@ void *VKAPI_CALL allocateBuffer(void *instance, void *userData, size_t size);
 // Performs cleanup work for LLPC standalone compiler.
 void cleanupCompileInfo(CompileInfo *compileInfo);
 
-// GLSL compiler, compiles GLSL source text file (input) to SPIR-V binary file (output).
-llvm::Expected<std::string> compileGlsl(const std::string &inFilename, ShaderStage *stage,
-                                        const std::string &defaultEntryTarget);
+// GLSL compiler, compiles GLSL source text file (input) to SPIR-V BinaryData object (output).
+llvm::Expected<BinaryData> compileGlsl(const std::string &inFilename, ShaderStage *stage,
+                                       const std::string &defaultEntryTarget);
 
-// SPIR-V assembler, converts SPIR-V assembly text file (input) to SPIR-V binary file (output).
-llvm::Expected<std::string> assembleSpirv(const std::string &inFilename);
+// SPIR-V assembler, converts SPIR-V assembly text file (input) to SPIR-V BinaryData object (output).
+llvm::Expected<BinaryData> assembleSpirv(const std::string &inFilename);
 
 // Decodes the binary after building a pipeline and outputs the decoded info.
 LLPC_NODISCARD Result decodePipelineBinary(const BinaryData *pipelineBin, CompileInfo *compileInfo);

--- a/llpc/util/llpcFile.cpp
+++ b/llpc/util/llpcFile.cpp
@@ -110,13 +110,7 @@ Result File::open(const char *filename, unsigned accessFlags) {
     }
 
     if (result == Result::Success) {
-#if defined(_WIN32)
-      // MS compilers provide fopen_s, which is supposedly "safer" than traditional fopen.
-      fopen_s(&m_fileHandle, filename, &fileMode[0]);
-#else
-      // Just use the traditional fopen.
       m_fileHandle = fopen(filename, &fileMode[0]);
-#endif
       if (!m_fileHandle)
         result = Result::ErrorUnknown;
     }


### PR DESCRIPTION
Outputting a binary form spv file isn't required by the amdllpc tool. Move to
using an in-memory binary object instead. This should also result in a slight
speed-up as fewer file writes are required (and it is thread safe).

Also update fopen_s to use standard fopen as per Linux implementation to avoid
problems with multiple threads attempting to read the same file on Windows.