### PR TITLE
[CI] Add code coverage upload workflow

### DIFF
--- a/.github/workflows/upload-coverage-report.yml
+++ b/.github/workflows/upload-coverage-report.yml
@@ -1,0 +1,53 @@
+name: Upload Coverage Report
+
+on:
+  workflow_run:
+    workflows:
+      - LLPC Docker CI
+    types:
+      - completed
+
+jobs:
+  retrieve-and-upload:
+    if: github.repository == 'GPUOpen-Drivers/llpc' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    name: "Configuration: ${{ matrix.config_tag }}"
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        config_tag:  ["release_clang_coverage", "release_clang_shadercache_coverage_assertions"]
+    steps:
+      - name: Download code coverage artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: check-amdllpc-docker.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: cov_report_${{ matrix.config_tag }}
+          path: "coverage_report/"
+      - name: Download PR number artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: check-amdllpc-docker.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr_num
+          path: "pr_num/"
+      - name: Read originating PR number from artifact
+        run: |
+          NUM=$(cat pr_num/pr_num.txt)
+          echo "PR_NUM=$NUM" | tee -a $GITHUB_ENV
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+      - name: Upload code coverage report to Google Cloud bucket
+        run: gsutil -m cp -r "coverage_report/*" "gs://amdvlk-llpc-github-ci-artifacts-public/coverage_${{ matrix.config_tag }}_${{ github.event.workflow_run.id }}/"
+      - name: Add comment with code coverage report link on originating PR
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        with:
+          issue-number: ${{ env.PR_NUM }}
+          body: |
+            The LLPC code coverage report is available at https://storage.googleapis.com/amdvlk-llpc-github-ci-artifacts-public/coverage_${{ matrix.config_tag }}_${{ github.event.workflow_run.id }}/index.html.
+            Configuration: ${{ matrix.config_tag }}.


### PR DESCRIPTION
This workflow is responsible for retrieving code coverage report artifacts created by pull request CI workflows, uploading them to Google Cloud Storage, and leaving a comment on the originating PR with a link to the code coverage report.

The advantage of having a separate workflow is that failures of this workflow will not impact pull requests.

The workflow is set up so that it runs automatically after a pull-request CI workflow. Since it accesses repository's secrets, it's only configured to run in the main GpuOpen-Drivers/llpc repository.

Example run: https://github.com/vettoreldaniele/llpc/actions/runs/1684053472 that left a comment in PR https://github.com/vettoreldaniele/llpc/pull/5.