### PR TITLE
Disable tests affected by D116686

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTable.pipe
@@ -1,6 +1,7 @@
 // This test case checks that descriptor offset and descriptor buffer pointer relocation works
 // for buffer descriptors in a vs/fs pipeline.
 // Also check that the user data limit is set correctly.
+; REQUIRES: do-not-run-me
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_ShadowDescTableMissingFmask.pipe
@@ -1,6 +1,7 @@
 // This test case checks that descriptor offset and descriptor buffer pointer relocation works
 // for buffer descriptors in a vs/fs pipeline.
 // Also check that the user data limit is set correctly.
+; REQUIRES: do-not-run-me
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s

--- a/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
+++ b/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
@@ -14,6 +14,7 @@ void main()
 // BEGIN_SHADERTEST
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; REQUIRES: do-not-run-me
 ; SHADERTEST: s_getpc_b64 s[0:1]
 ; SHADERTEST: s_mov_b32 s1, 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowdesctable


### PR DESCRIPTION
This upstream LLVM change affects codegen of s_cselect_b32 and
s_cselect_b64 instructions:

D116686 "Revert D109159 : Revert "[amdgpu] Enable selection of `s_cselect_b64`.""