### PR TITLE
Add timer profile tests

### DIFF
--- a/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
@@ -1,0 +1,41 @@
+; Check that timer profile and pipeline info printing works for pipe inputs.
+
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile 2>&1 \
+; RUN:   | FileCheck %s
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER_HASH:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER_HASH]]
+; CHECK-NOT:   {{^}} LLPC ShaderModule
+;
+; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+;
+; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+;
+; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}
+; CHECK:       {{^}} Total Execution Time:
+; CHECK:       {{^}} LLPC 0x[[#PIPE_HASH]]{{$}}
+; CHECK:       {{^}} Total Execution Time:
+;
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+[CsGlsl]
+#version 450
+
+layout(binding = 0, std430) buffer OUT
+{
+    uvec4 o;
+};
+
+layout(binding = 1, std430) buffer IN
+{
+    uvec4 i;
+};
+
+layout(local_size_x = 2, local_size_y = 3) in;
+void main()
+{
+    o = i;
+}
+
+[CsInfo]
+entryPoint = main

--- a/llpc/test/shaderdb/general/VertexTimerProfileTest.spvasm
+++ b/llpc/test/shaderdb/general/VertexTimerProfileTest.spvasm
@@ -1,0 +1,29 @@
+; Check that timer profile and pipeline info printing works with shader inputs.
+
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile 2>&1 \
+; RUN:   | FileCheck %s
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER]]
+; CHECK-NOT:   {{^}} LLPC ShaderModule
+;
+; CHECK:       {{^}}SPIR-V disassembly for [[INPUT:.+\.spvasm]]{{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+;
+; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+;
+; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}
+; CHECK:       {{^}} Total Execution Time:
+; CHECK:       {{^}} LLPC 0x[[#PIPE_HASH]]{{$}}
+; CHECK:       {{^}} Total Execution Time:
+;
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main"
+         %12 = OpTypeVoid
+         %21 = OpTypeFunction %12
+          %1 = OpFunction %12 None %21
+         %66 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/general/VsFsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/VsFsTimerProfileTest.pipe
@@ -1,0 +1,42 @@
+; Check that timer profile and pipeline info printing works for pipe inputs.
+
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile 2>&1 \
+; RUN:   | FileCheck %s
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER1:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER1]]
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER2:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER2]]
+;
+; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+;
+; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+;
+; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}
+; CHECK:       {{^}} Total Execution Time:
+; CHECK:       {{^}} LLPC 0x[[#PIPE_HASH]]{{$}}
+; CHECK:       {{^}} Total Execution Time:
+;
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+[VsGlsl]
+#version 450 core
+
+void main()
+{
+    gl_Position = vec4(0);
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+layout(location = 0) out vec4 fragColor;
+void main()
+{
+    fragColor = vec4(1);
+}
+
+[FsInfo]
+entryPoint = main


### PR DESCRIPTION
Excercise pipeline info printing in `PipelineBuilder` ahead of the
refactoring in https://github.com/GPUOpen-Drivers/llpc/pull/1620.

Also check that pass timing statistics get printed.