### PR TITLE
Fix primitiveID

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -668,6 +668,10 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
         // Distribute primitive ID
         auto vertexId0 = CreateUBfe(m_nggFactor.primData, 0, 9);
         writePerThreadDataToLds(gsPrimitiveId, vertexId0, LdsRegionDistribPrimId);
+        auto vertexId1 = CreateUBfe(m_nggFactor.primData, 10, 9);
+        writePerThreadDataToLds(gsPrimitiveId, vertexId1, LdsRegionDistribPrimId);
+        auto vertexId2 = CreateUBfe(m_nggFactor.primData, 20, 9);
+        writePerThreadDataToLds(gsPrimitiveId, vertexId2, LdsRegionDistribPrimId);
 
         BranchInst::Create(endWritePrimIdBlock, writePrimIdBlock);
       }
@@ -969,9 +973,12 @@ void NggPrimShader::constructPrimShaderWithoutGs(Module *module) {
       //   ES_GS_OFFSET01[31:16] = vertexId1 (in dwords)
       //   ES_GS_OFFSET01[15:0]  = vertexId0 (in dwords)
 
-      // Use vertex0 as provoking vertex to distribute primitive ID
       auto vertexId0 = m_nggFactor.esGsOffset0;
       writePerThreadDataToLds(gsPrimitiveId, vertexId0, LdsRegionDistribPrimId);
+      auto vertexId1 = m_nggFactor.esGsOffset1;
+      writePerThreadDataToLds(gsPrimitiveId, vertexId1, LdsRegionDistribPrimId);
+      auto vertexId2 = m_nggFactor.esGsOffset2;
+      writePerThreadDataToLds(gsPrimitiveId, vertexId2, LdsRegionDistribPrimId);
 
       m_builder->CreateBr(endWritePrimIdBlock);
     }


### PR DESCRIPTION
Currently we are using vertex0 as provoking vertex to distribute primitive ID,
but when provoking vertex is last, we should use vertex2, at that time,
we will get dirty data, so we need to write correct value for each vertex, this
behavior is consistent with HW.