### PR TITLE
Revert "Avoid creating duplicate temporary `.spv` files in tests"

### DIFF
--- a/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
+++ b/llpc/test/shaderdb/error_reporting/SpirvDuplicateStage.spvasm
@@ -9,9 +9,7 @@
 ; END_SHADERTEST_ST
 
 ; BEGIN_SHADERTEST_MT
-; Copy the input shader so that we do not attempt to produce two temporary .spv files under the same location.
-; RUN: cp %s %t.copy.spvasm
-; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip --num-threads=2 %s %t.copy.spvasm \
+; RUN: not amdllpc -spvgen-dir=%spvgendir% %gfxip --num-threads=2 %s %s \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST_MT %s
 ;
 ; SHADERTEST_MT-LABEL: {{^}}ERROR: Result::ErrorInvalidShader: Duplicate shader stage (vertex)

--- a/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
+++ b/llpc/test/shaderdb/multiple_inputs/SpirvTwoEntryPoints.spvasm
@@ -38,9 +38,7 @@
 ; This test uses llvm-objdump instead of verbose output, as it is not allowed to mix multi-threaded
 ; compilation with verbose output.
 ;
-; Copy the input shader so that we do not produce two temporary .spv files under the same location.
-; RUN: cp %s %t.both_mt.spvasm
-; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s,main_vs %t.both_mt.spvasm,main_fs --num-threads=2 -o %t.both.elf
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s,main_vs %s,main_fs --num-threads=2 -o %t.both.elf
 ; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.both.elf \
 ; RUN:   | FileCheck --check-prefix=SHADERTEST_BOTH_MT %s
 ;


### PR DESCRIPTION
This reverts commit d73e39c2cd7cd7bb2dfd7392ba98a132d8b058e9.

Now that PR#1628 has been merged, this change can be reverted, and it would be
good to test that this does in fact now work consistently.