### PR TITLE
Fix timer profile tests

### DIFF
--- a/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
@@ -1,22 +1,24 @@
 ; Check that timer profile and pipeline info printing works for pipe inputs.
 
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile 2>&1 \
-; RUN:   | FileCheck %s
-; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER_HASH:]]{{$}}
-; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER_HASH]]
-; CHECK-NOT:   {{^}} LLPC ShaderModule
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile >%t.stdout 2>%t.stderr \
+; RUN:   && cat %t.stdout %t.stderr | FileCheck %s
 ;
+; Check stdout.
 ; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
 ; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
 ;
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+;
+; Check stderr.
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER_HASH:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER_HASH]]
+; CHECK-NOT:   {{^}} LLPC ShaderModule
 ;
 ; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}
 ; CHECK:       {{^}} Total Execution Time:
 ; CHECK:       {{^}} LLPC 0x[[#PIPE_HASH]]{{$}}
 ; CHECK:       {{^}} Total Execution Time:
-;
-; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 
 [CsGlsl]
 #version 450

--- a/llpc/test/shaderdb/general/VertexTimerProfileTest.spvasm
+++ b/llpc/test/shaderdb/general/VertexTimerProfileTest.spvasm
@@ -1,22 +1,24 @@
 ; Check that timer profile and pipeline info printing works with shader inputs.
 
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile 2>&1 \
-; RUN:   | FileCheck %s
-; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER:]]{{$}}
-; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER]]
-; CHECK-NOT:   {{^}} LLPC ShaderModule
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile >%t.stdout 2>%t.stderr \
+; RUN:   && cat %t.stdout %t.stderr | FileCheck %s
 ;
+; Check stdout.
 ; CHECK:       {{^}}SPIR-V disassembly for [[INPUT:.+\.spvasm]]{{$}}
 ; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
 ;
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+;
+; Check stderr.
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER]]
+; CHECK-NOT:   {{^}} LLPC ShaderModule
 ;
 ; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}
 ; CHECK:       {{^}} Total Execution Time:
 ; CHECK:       {{^}} LLPC 0x[[#PIPE_HASH]]{{$}}
 ; CHECK:       {{^}} Total Execution Time:
-;
-; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 
                OpCapability Shader
                OpMemoryModel Logical GLSL450

--- a/llpc/test/shaderdb/general/VsFsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/VsFsTimerProfileTest.pipe
@@ -1,23 +1,25 @@
 ; Check that timer profile and pipeline info printing works for pipe inputs.
 
-; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile 2>&1 \
-; RUN:   | FileCheck %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s --enable-timer-profile >%t.stdout 2>%t.stderr \
+; RUN:   && cat %t.stdout %t.stderr | FileCheck %s
+;
+; Check stdout.
+; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+;
+; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+;
+; Check stderr.
 ; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER1:]]{{$}}
 ; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER1]]
 ; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER2:]]{{$}}
 ; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER2]]
 ;
-; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
-; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
-;
-; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-;
 ; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}
 ; CHECK:       {{^}} Total Execution Time:
 ; CHECK:       {{^}} LLPC 0x[[#PIPE_HASH]]{{$}}
 ; CHECK:       {{^}} Total Execution Time:
-;
-; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 
 [VsGlsl]
 #version 450 core


### PR DESCRIPTION
Ensure that we always try to match stdout and stderr in the same order,
insted of relying on unstable interleaving.