### PR TITLE
Apply recommended clang-tidy fixes. NFC.

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -940,8 +940,8 @@ bool Compiler::canUseRelocatableGraphicsShaderElf(const ArrayRef<const PipelineS
   if (cl::RelocatableShaderElfLimit != -1) {
     if (m_relocatablePipelineCompilations >= cl::RelocatableShaderElfLimit)
       return false;
-    else
-      ++m_relocatablePipelineCompilations;
+
+    ++m_relocatablePipelineCompilations;
   }
   return true;
 }
@@ -965,8 +965,8 @@ bool Compiler::canUseRelocatableComputeShaderElf(const ComputePipelineBuildInfo 
   if (cl::RelocatableShaderElfLimit != -1) {
     if (m_relocatablePipelineCompilations >= cl::RelocatableShaderElfLimit)
       return false;
-    else
-      ++m_relocatablePipelineCompilations;
+
+    ++m_relocatablePipelineCompilations;
   }
   return true;
 }
@@ -1010,7 +1010,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
   if (shaderInfoEntry) {
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfoEntry->pModuleData);
     if (moduleData && moduleData->binType == BinaryType::LlvmBc)
-      pipelineModule.reset(context->loadLibrary(&moduleData->binCode).release());
+      pipelineModule = context->loadLibrary(&moduleData->binCode);
   }
 
   // If not IR input, run the per-shader passes, including SPIR-V translation, and then link the modules

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -180,16 +180,14 @@ ShaderHash PipelineContext::getShaderHashCode(ShaderStage stage) const {
 
   if (shaderInfo->options.clientHash.upper != 0 && shaderInfo->options.clientHash.lower != 0)
     return shaderInfo->options.clientHash;
-  else {
-    ShaderHash hash = {};
-    const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo->pModuleData);
+  ShaderHash hash = {};
+  const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo->pModuleData);
 
-    if (moduleData) {
-      hash.lower = MetroHash::compact64(reinterpret_cast<const MetroHash::Hash *>(&moduleData->hash));
-      hash.upper = 0;
-    }
-    return hash;
+  if (moduleData) {
+    hash.lower = MetroHash::compact64(reinterpret_cast<const MetroHash::Hash *>(&moduleData->hash));
+    hash.upper = 0;
   }
+  return hash;
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -72,7 +72,7 @@ public:
   LegacySpirvLowerMathConstFolding &operator=(const LegacySpirvLowerMathConstFolding &) = delete;
 
 private:
-  SpirvLowerMathConstFolding Impl;
+  SpirvLowerMathConstFolding m_impl;
 };
 
 // =====================================================================================================================
@@ -89,7 +89,7 @@ public:
   LegacySpirvLowerMathFloatOp &operator=(const LegacySpirvLowerMathFloatOp &) = delete;
 
 private:
-  SpirvLowerMathFloatOp Impl;
+  SpirvLowerMathFloatOp m_impl;
 };
 
 } // namespace Llpc
@@ -207,8 +207,8 @@ void SpirvLowerMath::disableFastMath(Value *value) {
 //
 // @param [in/out] module : LLVM module to be run on (empty on entry)
 bool LegacySpirvLowerMathConstFolding::runOnModule(Module &module) {
-  return Impl.runImpl(module, [&]() -> TargetLibraryInfo & {
-    return getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(*(Impl.getEntryPoint()));
+  return m_impl.runImpl(module, [&]() -> TargetLibraryInfo & {
+    return getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(*(m_impl.getEntryPoint()));
   });
 }
 
@@ -230,7 +230,8 @@ PreservedAnalyses SpirvLowerMathConstFolding::run(Module &module, ModuleAnalysis
 // Executes constant folding SPIR-V lowering pass on the specified LLVM module.
 //
 // @param [in/out] module : LLVM module to be run on
-bool SpirvLowerMathConstFolding::runImpl(Module &module, std::function<TargetLibraryInfo &()> getTargetLibraryInfo) {
+bool SpirvLowerMathConstFolding::runImpl(Module &module,
+                                         const std::function<TargetLibraryInfo &()> &getTargetLibraryInfo) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Math-Const-Folding\n");
 
   SpirvLowerMath::init(module);
@@ -319,7 +320,7 @@ bool SpirvLowerMathFloatOp::runImpl(Module &module) {
 //
 // @param [in/out] module : LLVM module to be run on (empty on entry)
 bool LegacySpirvLowerMathFloatOp::runOnModule(Module &module) {
-  return Impl.runImpl(module);
+  return m_impl.runImpl(module);
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerMath.h
+++ b/llpc/lower/llpcSpirvLowerMath.h
@@ -67,7 +67,7 @@ public:
   // needed because the passes for the legacy and new pass managers use different ways to
   // retrieve it. That also ensures the object is retrieved once the passes are properly
   // initialized. This can be removed once the switch to the new pass manager is completed.
-  bool runImpl(llvm::Module &module, std::function<llvm::TargetLibraryInfo &()> getTargetLibraryInfo);
+  bool runImpl(llvm::Module &module, const std::function<llvm::TargetLibraryInfo &()> &getTargetLibraryInfo);
 
   static llvm::StringRef name() { return "Lower SPIR-V math constant folding"; }
 

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -95,7 +95,7 @@ void SpirvLowerResourceCollect::collectResourceNodeData(const GlobalVariable *gl
     const std::string imageTypeName(imageType->getStructName());
     // Format of image opaque type: ...[.SampledImage.<date type><dim>]...
     if (imageTypeName.find(".SampledImage") != std::string::npos) {
-      auto pos = imageTypeName.find("_");
+      auto pos = imageTypeName.find('_');
       assert(pos != std::string::npos);
 
       ++pos;

--- a/llpc/tool/llpcPipelineBuilder.cpp
+++ b/llpc/tool/llpcPipelineBuilder.cpp
@@ -88,10 +88,10 @@ std::unique_ptr<PipelineBuilder> createPipelineBuilder(ICompiler &compiler, Comp
   assert(!(isGraphicsPipeline(stageMask) && isComputePipeline(stageMask)) && "Invalid stage mask");
 
   if (isGraphicsPipeline(stageMask))
-    return std::make_unique<GraphicsPipelineBuilder>(compiler, compileInfo, std::move(dumpOptions), printPipelineInfo);
+    return std::make_unique<GraphicsPipelineBuilder>(compiler, compileInfo, dumpOptions, printPipelineInfo);
 
   if (isComputePipeline(stageMask))
-    return std::make_unique<ComputePipelineBuilder>(compiler, compileInfo, std::move(dumpOptions), printPipelineInfo);
+    return std::make_unique<ComputePipelineBuilder>(compiler, compileInfo, dumpOptions, printPipelineInfo);
 
   llvm_unreachable("Unknown pipeline kind");
   return nullptr;

--- a/llpc/util/llpcFile.cpp
+++ b/llpc/util/llpcFile.cpp
@@ -202,7 +202,8 @@ Result File::readLine(void *buffer, size_t bufferSize, size_t *bytesReadOut) {
       if (c == '\n') {
         result = Result::Success;
         break;
-      } else if (c == EOF) {
+      }
+      if (c == EOF) {
         result = Result::ErrorUnknown;
         break;
       }

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -84,7 +84,7 @@ Result ShaderModuleHelper::collectInfoFromSpirvBinary(const BinaryData *spvBinCo
     }
     case OpExtension: {
       StringRef extName = reinterpret_cast<const char *>(&codePos[1]);
-      if ((extName == "SPV_AMD_shader_ballot") && (shaderModuleUsage->useSubgroupSize == false)) {
+      if ((extName == "SPV_AMD_shader_ballot") && (!shaderModuleUsage->useSubgroupSize)) {
         shaderModuleUsage->useSubgroupSize = true;
       }
       break;
@@ -159,7 +159,7 @@ Result ShaderModuleHelper::collectInfoFromSpirvBinary(const BinaryData *spvBinCo
   if (capabilities.find(CapabilityVariablePointers) != capabilities.end())
     shaderModuleUsage->enableVarPtr = true;
 
-  if ((shaderModuleUsage->useSubgroupSize == false) &&
+  if ((!shaderModuleUsage->useSubgroupSize) &&
       ((capabilities.count(CapabilityGroupNonUniform) > 0) || (capabilities.count(CapabilityGroupNonUniformVote) > 0) ||
        (capabilities.count(CapabilityGroupNonUniformArithmetic) > 0) ||
        (capabilities.count(CapabilityGroupNonUniformBallot) > 0) ||

--- a/llpc/util/llpcUtil.cpp
+++ b/llpc/util/llpcUtil.cpp
@@ -163,8 +163,8 @@ unsigned getShaderStageMaskForType(Vkgc::UnlinkedShaderStage type) {
 //
 // @param type : The unlinked shader type.
 const char *getUnlinkedShaderStageName(Vkgc::UnlinkedShaderStage type) {
-  static const char *names[] = {"vertex", "fragment", "compute", "unknown"};
-  return names[type];
+  static const char *Names[] = {"vertex", "fragment", "compute", "unknown"};
+  return Names[type];
 }
 
 } // namespace Llpc


### PR DESCRIPTION
Apply clang-tidy fixes to the `llpc` directory with `llpc/translator`
excluded.

This makes the codebase more consistent, disables warnings in my IDE,
and avoids some bugprone patterns (e.g., local `llvm::Twine` variables).