### PR TITLE
Enable clang tidy performance checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
  # Do not modify llpc.h, vkgcDefs.h, anything in the SPIRV library, or vfx.h, or anything in lgc/imported.
 HeaderFilterRegex: '.*/vfx/vfx..*\\.h|.*/dumper/vkgc.*\\.h|.*/util/vkgc.*\\.h|.*/lgc/include/.*\\.h|.*/context/llpc[^/]*\\.h|.*/util/llpc[^/]*\\.h|.*/lower/llpc[^/]*\\.h|.*/builder/llpc[^/]*\\.h|.*/patch.*/llpc[^/]*\\.h|.*/tool/[^/]*\\.h'
-Checks: '-*,clang-diagnostic-*,llvm-*,-llvm-include-order,-llvm-qualified-auto,-llvm-header-guard,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
+Checks: '-*,clang-diagnostic-*,llvm-*,-llvm-include-order,-llvm-qualified-auto,-llvm-header-guard,performance-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
 CheckOptions:
   - { key: readability-identifier-naming.ParameterCase, value: camelBack }
   - { key: readability-identifier-naming.ParameterRemovePrefixes, value: 'p,b,pfn' }


### PR DESCRIPTION
These include suggestions about redundant copies/moves, inefficient
vector/string operations, etc. You can find more details in the
clang-tidy documentation:
https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/performance-faster-string-find.html.

I ran these over the whole llpc directory and it made a few good
suggestions. I haven't seen it produce any annoying/wrong warnings.