### PR TITLE
Add missing map includes

### DIFF
--- a/lgc/include/lgc/builder/BuilderReplayer.h
+++ b/lgc/include/lgc/builder/BuilderReplayer.h
@@ -32,6 +32,7 @@
 
 #include "lgc/builder/BuilderRecorder.h"
 #include "llvm/IR/PassManager.h"
+#include <map>
 
 namespace lgc {
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -33,6 +33,7 @@
 #include "lgc/state/Defs.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/util/Internal.h"
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/llpc/translator/include/LLVMSPIRVLib.h
+++ b/llpc/translator/include/LLVMSPIRVLib.h
@@ -41,9 +41,10 @@
 #ifndef LLVM_SUPPORT_SPIRV_H
 #define LLVM_SUPPORT_SPIRV_H
 
-#include <string>
-#include <iostream>
 #include "spirvExt.h"
+#include <iostream>
+#include <map>
+#include <string>
 
 namespace llvm {
 // llvm::Pass initialization functions need to be declared before inclusion of


### PR DESCRIPTION
Upstream llvm removed the map include somewhere, leading to compilation
failures here. Add the includes to fix them.