### PR TITLE
Add getDecorateString for the spirv

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -61,6 +61,10 @@ public:
   SPIRVDecorateGeneric(Op OC);
 
   SPIRVWord getLiteral(size_t) const;
+  const char *getLiteralString() const {
+    assert(!Literals.empty());
+    return reinterpret_cast<const char *>(Literals.data());
+  }
   Decoration getDecorateKind() const;
   size_t getLiteralCount() const;
   /// Compare for kind and literal only.

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -275,6 +275,14 @@ bool SPIRVEntry::hasDecorate(Decoration Kind, size_t Index,
   return true;
 }
 
+const char *SPIRVEntry::getDecorateString(Decoration kind) const {
+  DecorateMapType::const_iterator loc = Decorates.find(kind);
+  if (loc == Decorates.end())
+    return "";
+
+  return loc->second->getLiteralString();
+}
+
 // Check if an entry has Kind of member decoration at MemberIndex and get the
 // literal of the first decoration of such kind at Index.
 bool SPIRVEntry::hasMemberDecorate(SPIRVWord MemberIndex, Decoration Kind,

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -278,7 +278,7 @@ bool SPIRVEntry::hasDecorate(Decoration Kind, size_t Index,
 const char *SPIRVEntry::getDecorateString(Decoration kind) const {
   DecorateMapType::const_iterator loc = Decorates.find(kind);
   if (loc == Decorates.end())
-    return "";
+    return nullptr;
 
   return loc->second->getLiteralString();
 }

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -241,6 +241,7 @@ public:
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;
+  const char *getDecorateString(Decoration kind) const;
   bool hasMemberDecorate(SPIRVWord MemberIndex, Decoration Kind,
                          size_t Index = 0, SPIRVWord *Result = 0) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;


### PR DESCRIPTION
Our internal project need to use OpDecorateString, i add this
 function getDecorateString to decode the OpDecorateString
when presented in the spirv , in a hope we can reduce merge conflicts
when the whole or part of interal project code get upstreamed in the future.
