### PR TITLE
Remove binding from push-constant test

### DIFF
--- a/llpc/test/shaderdb/object/ObjPushConstant_TestBasic_lit.frag
+++ b/llpc/test/shaderdb/object/ObjPushConstant_TestBasic_lit.frag
@@ -1,6 +1,6 @@
 #version 450
 
-layout(binding = 1, std140, push_constant) uniform PushConstant
+layout(std140, push_constant) uniform PushConstant
 {
    vec4 m1;
    vec4 m2;


### PR DESCRIPTION
binding is not required (and incorrect in the context of a push constant)

(Reopening as every approver except David is out of office)