### PR TITLE
Stop using PointerType::getElementType

### DIFF
--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -91,7 +91,7 @@ void getTypeName(Type *ty, raw_ostream &nameStream) {
   for (;;) {
     if (auto pointerTy = dyn_cast<PointerType>(ty)) {
       nameStream << "p" << pointerTy->getAddressSpace();
-      ty = pointerTy->getElementType();
+      ty = pointerTy->getPointerElementType();
       continue;
     }
     if (auto arrayTy = dyn_cast<ArrayType>(ty)) {

--- a/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
+++ b/llpc/lower/llpcSpirvLowerConstImmediateStore.cpp
@@ -108,7 +108,7 @@ void SpirvLowerConstImmediateStore::processAllocaInsts(Function *func) {
   for (auto instIt = entryBlock->begin(), instItEnd = entryBlock->end(); instIt != instItEnd; ++instIt) {
     auto inst = &*instIt;
     if (auto allocaInst = dyn_cast<AllocaInst>(inst)) {
-      if (allocaInst->getType()->getElementType()->isAggregateType()) {
+      if (allocaInst->getAllocatedType()->isAggregateType()) {
         // Got an "alloca" instruction of aggregate type.
         auto storeInst = findSingleStore(allocaInst);
         if (storeInst && isa<Constant>(storeInst->getValueOperand())) {
@@ -175,7 +175,7 @@ StoreInst *SpirvLowerConstImmediateStore::findSingleStore(AllocaInst *allocaInst
 // @param storeInst : The single constant store into the "alloca"
 void SpirvLowerConstImmediateStore::convertAllocaToReadOnlyGlobal(StoreInst *storeInst) {
   auto allocaInst = cast<AllocaInst>(storeInst->getPointerOperand());
-  auto globalType = allocaInst->getType()->getElementType();
+  auto globalType = allocaInst->getAllocatedType();
   auto global = new GlobalVariable(*m_module, globalType,
                                    true, // isConstant
                                    GlobalValue::InternalLinkage, cast<Constant>(storeInst->getValueOperand()), "",

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5276,7 +5276,7 @@ static void printTypeName(Type *ty, raw_ostream &nameStream) {
   for (;;) {
     if (auto pointerTy = dyn_cast<PointerType>(ty)) {
       nameStream << "p" << pointerTy->getAddressSpace();
-      ty = pointerTy->getElementType();
+      ty = pointerTy->getPointerElementType();
       continue;
     }
     if (auto arrayTy = dyn_cast<ArrayType>(ty)) {


### PR DESCRIPTION
PointerType::getElementType will be deprecated in upstream LLVM patch
https://reviews.llvm.org/D117885, so use Type::getPointerElementType
instead.