### PR TITLE
[CI] Temporarily disable gcc configurations

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -17,8 +17,7 @@ jobs:
         image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
         branch:         [dev]
         config:         [Release]
-        feature-set:    ["+gcc", "+gcc+assertions",
-                         "+clang", "+clang+coverage",
+        feature-set:    ["+clang", "+clang+coverage",
                          "+clang+shadercache+coverage+assertions",
                          "+clang+shadercache+ubsan+asan",
                          "+clang+shadercache+ubsan+asan+assertions",

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -17,8 +17,7 @@ jobs:
         host-os:             ["ubuntu-20.04"]
         image-template:      ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
         config:              [Release]
-        feature-set:         ["+gcc", "+gcc+assertions",
-                              "+clang", "+clang+coverage",
+        feature-set:         ["+clang", "+clang+coverage",
                               "+clang+shadercache+coverage+assertions",
                               "+clang+shadercache+ubsan+asan",
                               "+clang+shadercache+ubsan+asan+assertions",


### PR DESCRIPTION
gcc builds are broken by updstream LLVM changes.
This should be reverted once LLVM cmake is fixed and the llvm-project
submodule is bumped.

Issue: https://github.com/GPUOpen-Drivers/llpc/issues/1645