### PR TITLE
[LLPC] Add missing raw_ostream includes

### DIFF
--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
 


### PR DESCRIPTION
Refactoring in upstream LLVM to include what you use mean things
that were previously included transitively now need to be included
explicitly.