### PR TITLE
Remove unnecessary case branch of ShaderStageCompute

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -731,10 +731,6 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
                                           highHalf, &callInst);
         break;
       }
-      case ShaderStageCompute: {
-        llvm_unreachable("Should never be called!");
-        break;
-      }
       default: {
         llvm_unreachable("Should never be called!");
         break;
@@ -882,10 +878,6 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         patchCopyShaderBuiltInOutputExport(output, builtInId, &callInst);
         break;
       }
-      case ShaderStageCompute: {
-        llvm_unreachable("Should never be called!");
-        break;
-      }
       default: {
         llvm_unreachable("Should never be called!");
         break;
@@ -1002,10 +994,6 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         }
         case ShaderStageCopyShader: {
           patchCopyShaderGenericOutputExport(output, loc, &callInst);
-          break;
-        }
-        case ShaderStageCompute: {
-          llvm_unreachable("Should never be called!");
           break;
         }
         default: {


### PR DESCRIPTION
All stages that are not expected to be present are handled by the default
branch.

Change-Id: Idc1fb53408ff8622eed822dafcf59028f2121c62