### PR TITLE
Derive array/matrix stride when it is missing but is requested

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -102,7 +102,8 @@ public:
   bool transShaderDecoration(SPIRVValue *, Value *);
   bool checkContains64BitType(SPIRVType *bt);
   Constant *buildShaderInOutMetadata(SPIRVType *bt, ShaderInOutDecorate &inOutDec, Type *&metaTy);
-  Constant *buildShaderBlockMetadata(SPIRVType *bt, ShaderBlockDecorate &blockDec, Type *&mdTy);
+  Constant *buildShaderBlockMetadata(SPIRVType *bt, ShaderBlockDecorate &blockDec, Type *&mdTy,
+                                     bool deriveStride = false);
   unsigned calcShaderBlockSize(SPIRVType *bt, unsigned blockSize, unsigned matrixStride, bool isRowMajor);
   Value *transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb);
   Value *flushDenorm(Value *val);

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -65,10 +65,12 @@ public:
 
   SPIRVType *getArrayElementType() const;
   uint64_t getArrayLength() const;
+  unsigned getDerivedArrayStride() const;
   unsigned getBitWidth() const;
   unsigned getFloatBitWidth() const;
-  SPIRVType *getFunctionReturnType() const;
   unsigned getIntegerBitWidth() const;
+  unsigned getSizeInBytes() const;
+  SPIRVType *getFunctionReturnType() const;
   SPIRVType *getPointerElementType() const;
   SPIRVStorageClassKind getPointerStorageClass() const;
   SPIRVType *getStructMemberType(size_t) const;
@@ -77,6 +79,7 @@ public:
   SPIRVType *getVectorComponentType() const;
   SPIRVWord getMatrixColumnCount() const;
   SPIRVType *getMatrixColumnType() const;
+  unsigned getDerivedMatrixStride() const;
   SPIRVType *getCompositeElementType(size_t) const;
   SPIRVWord getCompositeElementCount() const;
 


### PR DESCRIPTION
This is for future use. When array/matrix stride is missing, we can try
to derive it. This is because certain categories of blocks could meet
such conditions. They don't specify ArrayStride and MatrixStride but
expect the data layout is decided by compiler.

Change-Id: I7824a622a3ca0adeb1da78c9d538cf7f4dd43430