### PR TITLE
Add a debug option that prints (all) LLVM options

### DIFF
--- a/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
+++ b/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
@@ -1,0 +1,28 @@
+; Check that we can print LLVM CLI options overridden by LLPC.
+
+; 1. Check that only the overridden options gets printed with `--print-options`.
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s --robust-buffer-access --print-options \
+; RUN:   | FileCheck %s --check-prefix=OVERRIDDEN --match-full-lines
+;
+; OVERRIDDEN-LABEL: --robust-buffer-access = 1 (default: 0)
+; OVERRIDDEN-NOT:   --scalar-block-layout = {{.*}}
+; OVERRIDDEN-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
+
+; 2. Check that all options gets printed with `--print-all-options`.
+; RUN: amdllpc -spvgen-dir=%spvgendir% %gfxip %s --robust-buffer-access --print-all-options \
+; RUN:   | FileCheck %s --check-prefix=ALL --match-full-lines
+;
+; ALL-LABEL: --robust-buffer-access = 1 (default: 0)
+; ALL-LABEL: --scalar-block-layout = {{.*}}
+; ALL-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
+
+
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %1 "main"
+         %12 = OpTypeVoid
+         %21 = OpTypeFunction %12
+          %1 = OpFunction %12 None %21
+         %66 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -360,6 +360,13 @@ static Result init(int argc, char *argv[], ICompiler *&compiler) {
   if (result != Result::Success)
     return result;
 
+  // Debug utility that prints all LLVM option values. This is activated by passing:
+  // `--print-options`     -- prints all LLVM options with non-default values, or
+  // `--print-all-options` -- prints all LLVM options and their values.
+  //
+  // We call this after compiler initialization to account for any flags overridden by LLPC.
+  cl::PrintOptionValues();
+
   if (SpvGenDir != "" && !InitSpvGen(SpvGenDir.c_str())) {
     // -spvgen-dir option: preload spvgen from the given directory
     LLPC_ERRS("Failed to load SPVGEN from specified directory\n");


### PR DESCRIPTION
This is so that we can easily check what are all the LLVM CLI options
overridden by LLPC.