### PR TITLE
[CI] Free up more disk space on workflow runners

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Free up disk space
         run: |
           echo 'Before:' && df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc \
+                      /usr/lib/jvm /opt/hostedtoolcache/go /opt/hostedtoolcache/CodeQL /opt/az \
+                      /usr/share/swift /usr/local/.ghcup /usr/local/graalvm /usr/local/lib/node_modules
           echo 'After:' && df -h
       - name: Checkout LLPC
         run: |

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -27,7 +27,9 @@ jobs:
         if: contains(matrix.feature-set, '+ubsan') || contains(matrix.feature-set, '+asan') || contains(matrix.feature-set, '+tsan') || contains(matrix.feature-set, '+coverage')
         run: |
           echo 'Before:' && df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/hostedtoolcache/boost /opt/ghc \
+                      /usr/lib/jvm /opt/hostedtoolcache/go /opt/hostedtoolcache/CodeQL /opt/az \
+                      /usr/share/swift /usr/local/.ghcup /usr/local/graalvm /usr/local/lib/node_modules
           echo 'After:' && df -h
       - name: Checkout LLPC
         run: |


### PR DESCRIPTION
We ran into problems with builds running out of space. This PR removes a few unused folders and programs that take up disk space on the runner. We save about 10GB with these changes.

I checked that both the "Build AMDVLK" and the "Check LLPC" workflows still pass after the removal of these files.