### PR TITLE
Fix the pipeline options hashing

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1933,20 +1933,14 @@ void Compiler::buildShaderCacheHash(Context *context, unsigned stageMask, ArrayR
 
   // Add additional pipeline state to final hasher
   if (stageMask & getLgcShaderStageMask(ShaderStageFragment)) {
-    // Add pipeline options to fragment hash
-    fragmentHasher.Update(pipelineOptions->includeDisassembly);
-    fragmentHasher.Update(pipelineOptions->scalarBlockLayout);
-    fragmentHasher.Update(pipelineOptions->reconfigWorkgroupLayout);
-    fragmentHasher.Update(pipelineOptions->includeIr);
-    fragmentHasher.Update(pipelineOptions->robustBufferAccess);
-    fragmentHasher.Update(pipelineOptions->extendedRobustness.robustBufferAccess);
-    fragmentHasher.Update(pipelineOptions->extendedRobustness.robustImageAccess);
-    fragmentHasher.Update(pipelineOptions->extendedRobustness.nullDescriptor);
+    PipelineDumper::updateHashForPipelineOptions(pipelineOptions, &fragmentHasher, true, false, UnlinkedStageFragment);
     PipelineDumper::updateHashForFragmentState(pipelineInfo, &fragmentHasher, false);
     fragmentHasher.Finalize(fragmentHash->bytes);
   }
 
   if (stageMask & ~getLgcShaderStageMask(ShaderStageFragment)) {
+    PipelineDumper::updateHashForPipelineOptions(pipelineOptions, &nonFragmentHasher, true, false,
+                                                 UnlinkedStageVertexProcess);
     PipelineDumper::updateHashForNonFragmentState(pipelineInfo, true, &nonFragmentHasher, false);
     nonFragmentHasher.Finalize(nonFragmentHash->bytes);
   }

--- a/llpc/unittests/util/CMakeLists.txt
+++ b/llpc/unittests/util/CMakeLists.txt
@@ -26,6 +26,7 @@
 add_llpc_unittest(LlpcUtilTests
   testError.cpp
   testMetroHash.cpp
+  testPipelineDumper.cpp
   testThreading.cpp
   testUtil.cpp
 )

--- a/llpc/unittests/util/testPipelineDumper.cpp
+++ b/llpc/unittests/util/testPipelineDumper.cpp
@@ -1,0 +1,230 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Google LLC. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "vkgcPipelineDumper.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <memory>
+
+using namespace Vkgc;
+using namespace llvm;
+
+namespace Llpc {
+namespace {
+
+using PipelineDumperTest = ::testing::Test;
+
+// The parameters to run a pipeline options test.
+struct GenerateHashParams {
+  bool isCacheHash;
+  bool isRelocatableShader;
+  UnlinkedShaderStage unlinkedShaderStage;
+};
+
+// The function type used to pass the function that given the expected result from a pipeline options tests.
+using HashModifiedFunc = std::function<bool(const GenerateHashParams &params)>;
+
+// The function type used to modify the compute pipeline build info for a pipeline options test.
+using ModifyComputeBuildInfo = std::function<void(ComputePipelineBuildInfo *)>;
+
+// The function type used to modify the graphics pipeline build info for a pipeline options test.
+using ModifyGraphicsBuildInfo = std::function<void(GraphicsPipelineBuildInfo *)>;
+
+// =====================================================================================================================
+// Runs a graphics pipeline options hash test.  The test will follow these steps:
+//
+// 1) Get the hash for a default graphics pipeline build info using `params`.
+// 2) Modify the build info using `modifyBuildInfoFunc`.
+// 3) Get the hash for the modified build info using `params`.
+// 4) The test passes if hashes are equal exactly when expected, and unequal otherwise.
+//
+// @param params : The parameters other than the build info to pass to
+// `PipelineDumper::generateHashForGraphicsPipeline`.
+// @param modifyBuildInfoFunc : A function that will modify the build info in some way.
+// @param expectHashesToBeEqual : The expected result of comparing the hashes of the original buildinfo and the modified
+// one.
+void runGraphicsPipelineOptionsHashTest(GenerateHashParams params, const ModifyGraphicsBuildInfo &modifyBuildInfoFunc,
+                                        bool expectHashesToBeEqual) {
+  auto buildInfo = std::make_unique<GraphicsPipelineBuildInfo>();
+  auto originalHash = PipelineDumper::generateHashForGraphicsPipeline(
+      buildInfo.get(), params.isCacheHash, params.isRelocatableShader, params.unlinkedShaderStage);
+
+  modifyBuildInfoFunc(buildInfo.get());
+  auto modifiedHash = PipelineDumper::generateHashForGraphicsPipeline(
+      buildInfo.get(), params.isCacheHash, params.isRelocatableShader, params.unlinkedShaderStage);
+  if (expectHashesToBeEqual) {
+    EXPECT_EQ(originalHash, modifiedHash);
+  } else {
+    EXPECT_NE(originalHash, modifiedHash);
+  }
+}
+
+// =====================================================================================================================
+// Runs a graphics pipeline options hash test on all possible values for the GenerateHashParams.
+//
+// @param modifyBuildInfoFunc : A function that will modify the build info in some way.
+// @param expectHashToBeEqual : A function that returns whether or not the change make by `modifyBuildInfoFunc` will
+// modify the hash for the given set of GenerateHashParameters.
+void runGraphicsPipelineVariations(const ModifyGraphicsBuildInfo &modifyBuildInfo,
+                                   const HashModifiedFunc &expectHashToBeEqual) {
+  for (auto unlinkedShaderStage : {UnlinkedStageVertexProcess, UnlinkedStageFragment, UnlinkedStageCount}) {
+    for (bool isCacheHash : {false, true}) {
+      for (bool isRelocatableShader : {false, true}) {
+        GenerateHashParams params = {isCacheHash, isRelocatableShader, unlinkedShaderStage};
+        runGraphicsPipelineOptionsHashTest(params, modifyBuildInfo, expectHashToBeEqual(params));
+      }
+    }
+  }
+}
+
+// =====================================================================================================================
+// Runs a compute pipeline options hash test.  The test will follow these steps:
+//
+// 1) Get the hash for a default compute pipeline build info using `params`.
+// 2) Modify the build info using `modifyBuildInfoFunc`.
+// 3) Get the hash for the modified build info using `params`.
+// 4) The test passes if hashes are equal exactly when expected, and unequal otherwise.
+//
+// @param params : The parameters other than the build info to pass to
+// `PipelineDumper::generateHashForGraphicsPipeline`.
+// @param modifyBuildInfoFunc : A function that will modify the build info in some way.
+// @param expectHashesToBeEqual : The expected result of comparing the hashes of the original buildinfo and the modified
+// one.
+void runComputePipelineOptionsHashTest(GenerateHashParams params, const ModifyComputeBuildInfo &modifyBuildInfoFunc,
+                                       bool expectHashesToBeEqual) {
+  auto buildInfo = std::make_unique<ComputePipelineBuildInfo>();
+  auto originalHash =
+      PipelineDumper::generateHashForComputePipeline(buildInfo.get(), params.isCacheHash, params.isRelocatableShader);
+
+  modifyBuildInfoFunc(buildInfo.get());
+  auto modifiedHash =
+      PipelineDumper::generateHashForComputePipeline(buildInfo.get(), params.isCacheHash, params.isRelocatableShader);
+  if (expectHashesToBeEqual) {
+    EXPECT_EQ(originalHash, modifiedHash);
+  } else {
+    EXPECT_NE(originalHash, modifiedHash);
+  }
+}
+
+// =====================================================================================================================
+// Runs a compute pipeline options hash test on all possible values for the GenerateHashParams.
+//
+// @param modifyBuildInfoFunc : A function that will modify the build info in some way.
+// @param expectHashToBeEqual : A function that returns whether or not the change make by `modifyBuildInfoFunc` will
+// modify the hash for the given set of GenerateHashParameters.
+void runComputePipelineVariations(const ModifyComputeBuildInfo &modifyBuildInfo,
+                                  const HashModifiedFunc &expectHashToBeEqual) {
+  UnlinkedShaderStage unlinkedShaderStage = UnlinkedStageCount;
+  for (bool isCacheHash : {false, true}) {
+    for (bool isRelocatableShader : {false, true}) {
+      GenerateHashParams params = {isCacheHash, isRelocatableShader, unlinkedShaderStage};
+      runComputePipelineOptionsHashTest(params, modifyBuildInfo, expectHashToBeEqual(params));
+    }
+  }
+}
+
+// =====================================================================================================================
+// Test the robustBufferAccess option.
+
+// cppcheck-suppress syntaxError
+TEST(PipelineDumperTest, TestRobustBufferAccessOptionGraphics) {
+  ModifyGraphicsBuildInfo modifyBuildInfo = [](GraphicsPipelineBuildInfo *buildInfo) {
+    buildInfo->options.robustBufferAccess = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &) { return false; };
+  runGraphicsPipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestRobustBufferAccessOptionCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.robustBufferAccess = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+// =====================================================================================================================
+// Test the includeDisassembly option.
+
+TEST(PipelineDumperTest, TestIncludeDisassemblyOptionGraphics) {
+  ModifyGraphicsBuildInfo modifyBuildInfo = [](GraphicsPipelineBuildInfo *buildInfo) {
+    buildInfo->options.includeDisassembly = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
+  runGraphicsPipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestIncludeDisassemblyOptionCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.includeDisassembly = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+// =====================================================================================================================
+// Test the enableInterpModePatch option.
+
+TEST(PipelineDumperTest, TestEnableInterpModePatchOptionGraphics) {
+  ModifyGraphicsBuildInfo modifyBuildInfo = [](GraphicsPipelineBuildInfo *buildInfo) {
+    buildInfo->options.enableInterpModePatch = true;
+  };
+
+  // This should only modify the fragment shader.
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) {
+    return params.unlinkedShaderStage == UnlinkedStageVertexProcess;
+  };
+  runGraphicsPipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestEnableInterpModePatchOptionCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.enableInterpModePatch = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return true; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+// =====================================================================================================================
+// Test the shadowDescriptorTableUsage option.
+
+TEST(PipelineDumperTest, TestShadowDescriptorTableUsageGraphics) {
+  ModifyGraphicsBuildInfo modifyBuildInfo = [](GraphicsPipelineBuildInfo *buildInfo) {
+    buildInfo->options.shadowDescriptorTableUsage = ShadowDescriptorTableUsage::Enable;
+  };
+
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return params.isRelocatableShader; };
+  runGraphicsPipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestShadowDescriptorTableUsageCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.shadowDescriptorTableUsage = ShadowDescriptorTableUsage::Enable;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return params.isRelocatableShader; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+} // namespace
+} // namespace Llpc

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -99,8 +99,8 @@ public:
   static void updateHashForFragmentState(const GraphicsPipelineBuildInfo *pipeline, MetroHash64 *hasher,
                                          bool isRelocatableShader);
 
-  static void updateHashForPipelineOptions(const PipelineOptions *options, MetroHash64 *hasher,
-                                           bool isRelocatableShader);
+  static void updateHashForPipelineOptions(const PipelineOptions *options, MetroHash64 *hasher, bool isCacheHash,
+                                           bool isRelocatableShader, UnlinkedShaderStage stage);
 
   // Get name of register, or "" if not known
   static const char *getRegisterNameString(unsigned regNumber);


### PR DESCRIPTION
There were what seem to be a few bugs in the hashing of the pipeline
options.  I believe these need to be fixed.

1. Some options were not being included in the hash under any
circumstaance.  They have been added.
1. Compute and graphics pipeline include the pipeline options in the
   hash under different circumstances.  Compute pipeline include it all
   of the time, but graphics pipelines only include it if the vertex
   processing stage is present and it is a cache hash.  Neither of these
   seem correct all of the time.  I've tried to include the options when
   I think they are needed.
1. I've added the framework for unit testing if the value of an options
   should modify the hash.  I've added testing from some options, but
   not all of them.  We can add more as needed.

