### PR TITLE
Add missing includes of CommandLine.h

### DIFF
--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -35,6 +35,7 @@
 #include "lgc/state/PipelineState.h"
 #include "lgc/util/BuilderBase.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/Support/CommandLine.h"
 
 #define DEBUG_TYPE "lgc-patch-initialize-workgroup-memory"
 

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -43,6 +43,7 @@
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/CodeGen.h"
+#include "llvm/Support/CommandLine.h"
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 401324
 // Old version
 #include "llvm/Support/TargetRegistry.h"


### PR DESCRIPTION
This fixes compilation after this upstream LLVM commit, which cleaned up
various LLVM headers so we can no longer rely on CommandLine.h being
included implicitly:

ffe8720aa060 Reduce dependencies on llvm/BinaryFormat/Dwarf.h