### PR TITLE
Use source node set and binding

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -588,7 +588,7 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
           node.type != ResourceMappingNodeType::DescriptorYCbCrSampler)
         break;
 
-      auto it = immutableNodesMap.find(std::pair<unsigned, unsigned>(destNode.set, destNode.binding));
+      auto it = immutableNodesMap.find(std::pair<unsigned, unsigned>(node.srdRange.set, node.srdRange.binding));
       if (it != immutableNodesMap.end()) {
         // This set/binding is (or contains) an immutable value. The value can only be a sampler, so we
         // can assume it is four dwords.


### PR DESCRIPTION
Our internal project would change the destNode set and binding, so use
input node.srdRange.set and node.srdRange.binding instead. this change aims to
reduce future merge conflict in case internal change upstreams to github