### PR TITLE
Fixed UserData metadata entries number calculation

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -965,9 +965,12 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
       *userDataArg.argIndex = argTys.size() + argOffset;
     unsigned dwordSize = userDataArg.argDwordSize;
     if (userDataArg.userDataValue != static_cast<unsigned>(UserDataMapping::Invalid)) {
+      // Most of user data metadata entries is 1 except root push descriptors
+      bool systemUserData = userDataArg.userDataValue >= static_cast<unsigned>(UserDataMapping::GlobalTable);
+      unsigned entriesNum = systemUserData ? 1 : dwordSize;
       m_pipelineState->getPalMetadata()->setUserDataEntry(m_shaderStage, userDataIdx, userDataArg.userDataValue,
-                                                          dwordSize);
-      if (userDataArg.userDataValue >= static_cast<unsigned>(UserDataMapping::GlobalTable)) {
+                                                          entriesNum);
+      if (systemUserData) {
         unsigned index = userDataArg.userDataValue - static_cast<unsigned>(UserDataMapping::GlobalTable);
         auto &specialUserData = getUserDataUsage(m_shaderStage)->specialUserData;
         if (index < specialUserData.size())

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -965,12 +965,12 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
       *userDataArg.argIndex = argTys.size() + argOffset;
     unsigned dwordSize = userDataArg.argDwordSize;
     if (userDataArg.userDataValue != static_cast<unsigned>(UserDataMapping::Invalid)) {
-      // Most of user data metadata entries is 1 except root push descriptors
-      bool systemUserData = userDataArg.userDataValue >= static_cast<unsigned>(UserDataMapping::GlobalTable);
-      unsigned entriesNum = systemUserData ? 1 : dwordSize;
+      // Most of user data metadata entries is 1 except for root push descriptors.
+      bool isSystemUserData = userDataArg.userDataValue >= static_cast<unsigned>(UserDataMapping::GlobalTable);
+      unsigned numEntries = isSystemUserData ? 1 : dwordSize;
       m_pipelineState->getPalMetadata()->setUserDataEntry(m_shaderStage, userDataIdx, userDataArg.userDataValue,
-                                                          entriesNum);
-      if (systemUserData) {
+                                                          numEntries);
+      if (isSystemUserData) {
         unsigned index = userDataArg.userDataValue - static_cast<unsigned>(UserDataMapping::GlobalTable);
         auto &specialUserData = getUserDataUsage(m_shaderStage)->specialUserData;
         if (index < specialUserData.size())

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -381,10 +381,6 @@ void PalMetadata::setUserDataEntry(ShaderStage stage, unsigned userDataIndex, un
   if (userDataValue < InterfaceData::MaxSpillTableSize && userDataValue + dwordCount > m_userDataLimit->getUInt())
     *m_userDataLimit = userDataValue + dwordCount;
 
-  // Although NumWorkgroupsPtr is a register pair, only the first word has a user data entry.
-  if (userDataValue == static_cast<unsigned>(UserDataMapping::Workgroup))
-    dwordCount = 1;
-
   // Write the register(s)
   userDataReg += userDataIndex;
   while (dwordCount--)


### PR DESCRIPTION
Most of user data metadata entries is 1 except descriptorSets and
PushConsts, it is wrong to calculate the meta entries based on the
entries data type dword size