### PR TITLE
Fix flaky tests with leading zeros

### DIFF
--- a/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
@@ -5,13 +5,13 @@
 ;
 ; Check stdout.
 ; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
-; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%.16X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
 ;
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 ;
 ; Check stderr.
-; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER_HASH:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%.16X,SHADER_HASH:]]{{$}}
 ; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER_HASH]]
 ; CHECK-NOT:   {{^}} LLPC ShaderModule
 ;

--- a/llpc/test/shaderdb/general/DiscardToDemoteTransformations.frag
+++ b/llpc/test/shaderdb/general/DiscardToDemoteTransformations.frag
@@ -40,17 +40,17 @@
 // The hashes in the Elf note are currently expected to be the same.
 // RUN: cat %t.disabled %t.enabled | FileCheck %s --match-full-lines --check-prefix=HASH
 // HASH:      // LLPC calculated hash results (graphics pipeline)
-// HASH:      PIPE : 0x[[#%X,DIS_PIPE:]]
-// HASH-NEXT: FS   : 0x[[#%X,DIS_FS:]]
+// HASH:      PIPE : 0x[[#%.16X,DIS_PIPE:]]
+// HASH-NEXT: FS   : 0x[[#%.16X,DIS_FS:]]
 // HASH:      .xgl_cache_info: {
-// HASH-NEXT: .128_bit_cache_hash: [ 0x[[#%X,DIS_CACHE_1:]] 0x[[#%X,DIS_CACHE_2:]] ]
+// HASH-NEXT: .128_bit_cache_hash: [ 0x[[#%.16X,DIS_CACHE_1:]] 0x[[#%.16X,DIS_CACHE_2:]] ]
 // HASH:      ===== AMDLLPC SUCCESS =====
 //
 // HASH:      // LLPC calculated hash results (graphics pipeline)
 // HASH-NOT:  PIPE : 0x[[#DIS_PIPE]]
-// HASH:      PIPE : 0x[[#%X,EN_PIPE:]]
+// HASH:      PIPE : 0x[[#%.16X,EN_PIPE:]]
 // HASH-NOT:  FS   : 0x[[#DIS_FS]]
-// HASH-NEXT: FS   : 0x[[#%X,EN_FS:]]
+// HASH-NEXT: FS   : 0x[[#%.16X,EN_FS:]]
 // HASH:      .xgl_cache_info: {
 // HASH-NEXT: .128_bit_cache_hash: [ 0x[[#DIS_CACHE_1]] 0x[[#DIS_CACHE_2]] ]
 // HASH:      ===== AMDLLPC SUCCESS =====

--- a/llpc/test/shaderdb/general/VertexTimerProfileTest.spvasm
+++ b/llpc/test/shaderdb/general/VertexTimerProfileTest.spvasm
@@ -5,13 +5,13 @@
 ;
 ; Check stdout.
 ; CHECK:       {{^}}SPIR-V disassembly for [[INPUT:.+\.spvasm]]{{$}}
-; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%.16X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
 ;
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 ;
 ; Check stderr.
-; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%.16X,SHADER:]]{{$}}
 ; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER]]
 ; CHECK-NOT:   {{^}} LLPC ShaderModule
 ;

--- a/llpc/test/shaderdb/general/VsFsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/VsFsTimerProfileTest.pipe
@@ -5,15 +5,15 @@
 ;
 ; Check stdout.
 ; CHECK:       {{^//}} Pipeline file info for [[INPUT:.+\.pipe]] {{$}}
-; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
+; CHECK:       {{^}}LLPC PipelineHash: 0x[[#%.16X,PIPE_HASH:]] Files: [[INPUT]]{{$}}
 ;
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 ;
 ; Check stderr.
-; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER1:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%.16X,SHADER1:]]{{$}}
 ; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER1]]
-; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%X,SHADER2:]]{{$}}
+; CHECK:       {{^}} LLPC ShaderModule Phases 0x[[#%.16X,SHADER2:]]{{$}}
 ; CHECK:       {{^}} LLPC ShaderModule 0x[[#SHADER2]]
 ;
 ; CHECK:       {{^}} LLPC Phases 0x[[#PIPE_HASH]]{{$}}


### PR DESCRIPTION
If a matched hash ends up with a leading zero, FileCheck will only
match the number without leading zeros on further uses of that captured
value.

Specify the number of digits of the matched hashes to get passing tests
also with leading zeros in hashes.