### PR TITLE
Add pipelineType to the CompileInfo

### DIFF
--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -444,7 +444,8 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
   } else {
     if (Error err = processInputStages(compileInfo, inputSpecs, ValidateSpirv, NumThreads))
       return err;
-    compileInfo.pipelineType = isComputePipeline(compileInfo.stageMask) ? PipelineTypeCompute : PipelineTypeGraphics;
+    compileInfo.pipelineType =
+        isComputePipeline(compileInfo.stageMask) ? VfxPipelineTypeCompute : VfxPipelineTypeGraphics;
   }
 
   //
@@ -474,11 +475,7 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
   if (Error err = builder->build())
     return err;
 
-  if (compileInfo.pipelineType == PipelineTypeGraphics) {
-    return outputElf(compileInfo.gfxPipelineOut.pipelineBin, OutFile, firstInput.filename, 0);
-  } else {
-    return outputElf(compileInfo.compPipelineOut.pipelineBin, OutFile, firstInput.filename, 0);
-  }
+  return builder->outputElfs(OutFile, firstInput.filename);
 }
 
 #ifdef WIN_OS

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -475,7 +475,7 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
   if (Error err = builder->build())
     return err;
 
-  return builder->outputElfs(OutFile, firstInput.filename);
+  return builder->outputElfs(OutFile);
 }
 
 #ifdef WIN_OS

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -444,6 +444,7 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
   } else {
     if (Error err = processInputStages(compileInfo, inputSpecs, ValidateSpirv, NumThreads))
       return err;
+    compileInfo.pipelineType = isComputePipeline(compileInfo.stageMask) ? PipelineTypeCompute : PipelineTypeGraphics;
   }
 
   //
@@ -473,7 +474,11 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
   if (Error err = builder->build())
     return err;
 
-  return outputElf(&compileInfo, OutFile, firstInput.filename);
+  if (compileInfo.pipelineType == PipelineTypeGraphics) {
+    return outputElf(compileInfo.gfxPipelineOut.pipelineBin, OutFile, firstInput.filename, 0);
+  } else {
+    return outputElf(compileInfo.compPipelineOut.pipelineBin, OutFile, firstInput.filename, 0);
+  }
 }
 
 #ifdef WIN_OS

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -361,6 +361,8 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
 
   compileInfo.compPipelineInfo = pipelineState->compPipelineInfo;
   compileInfo.gfxPipelineInfo = pipelineState->gfxPipelineInfo;
+  compileInfo.pipelineType = pipelineState->pipelineType;
+
   if (ignoreColorAttachmentFormats) {
     // NOTE: When this option is enabled, we set color attachment format to
     // R8G8B8A8_SRGB for color target 0. Also, for other color targets, if the
@@ -374,7 +376,6 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
   if (EnableOuts() && !InitSpvGen())
     LLPC_OUTS("Failed to load SPVGEN -- cannot disassemble and validate SPIR-V\n");
 
-  compileInfo.pipelineType = pipelineState->pipelineType;
   for (unsigned stage = 0; stage < pipelineState->numStages; ++stage) {
     if (pipelineState->stages[stage].dataSize > 0) {
       StandaloneCompiler::ShaderModuleData shaderModuleData = {};

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -325,29 +325,6 @@ Error buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo) {
   return Error::success();
 }
 
-// =====================================================================================================================
-// Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
-//
-// @param pipelineBin : Output elf pipeline binary
-// @param suppliedOutFile : Name of the file to output ELF binary (specify "" to use base name of first input file with
-// appropriate extension; specify "-" to use stdout)
-// @param firstInFile : Name of first input file
-// @returns : `ErrorSuccess` on success, `ResultError` on failure
-Error outputElf(const BinaryData &pipelineBin, const std::string &suppliedOutFile, StringRef firstInFile) {
-  SmallString<64> outFileName(suppliedOutFile);
-  if (outFileName.empty()) {
-    // Detect the data type as we are unable to access the values of the options "-filetype" and "-emit-llvm".
-    StringLiteral ext = fileExtFromBinary(pipelineBin);
-    outFileName = sys::path::filename(firstInFile);
-    sys::path::replace_extension(outFileName, ext);
-  }
-  if (outFileName != "-" && index > 0) {
-    outFileName.append(".");
-    outFileName.append(utostr(index));
-  }
-
-  return writeFile(pipelineBin, outFileName);
-}
 
 // =====================================================================================================================
 // Process one pipeline input file.

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -397,9 +397,7 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
   if (EnableOuts() && !InitSpvGen())
     LLPC_OUTS("Failed to load SPVGEN -- cannot disassemble and validate SPIR-V\n");
 
-  assert(PipelineTypeGraphics == VfxPipelineTypeGraphics);
-  assert(PipelineTypeCompute == VfxPipelineTypeCompute);
-  compileInfo.pipelineType = static_cast<PipelineType>(pipelineState->pipelineType);
+  compileInfo.pipelineType = pipelineState->pipelineType;
   for (unsigned stage = 0; stage < pipelineState->numStages; ++stage) {
     if (pipelineState->stages[stage].dataSize > 0) {
       StandaloneCompiler::ShaderModuleData shaderModuleData = {};
@@ -422,7 +420,7 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
     }
   }
 
-  const bool isGraphics = compileInfo.pipelineType == PipelineTypeGraphics;
+  const bool isGraphics = compileInfo.pipelineType == VfxPipelineTypeGraphics;
   assert(!(isGraphics && isComputePipeline(compileInfo.stageMask)) && "Bad stage mask");
 
   for (unsigned i = 0; i < compileInfo.shaderModuleDatas.size(); ++i) {

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -56,6 +56,7 @@
 
 #include "llpc.h"
 #include "llpcInputUtils.h"
+#include "vfx.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -73,11 +74,6 @@ struct ShaderModuleData {
   Llpc::ShaderModuleBuildOut shaderOut;   // Output of building shader modules
   void *shaderBuf;                        // Allocation buffer of building shader modules
   bool disableDoAutoLayout;               // Indicates whether to disable auto layout of descriptors
-};
-
-enum PipelineType : unsigned {
-  PipelineTypeGraphics = 0, // Graphics pipeline type
-  PipelineTypeCompute,      // Compute pipeline type
 };
 
 // Represents a single compilation context of a pipeline or a group of shaders.
@@ -100,7 +96,7 @@ struct CompileInfo {
   bool autoLayoutDesc;            // Whether to automatically create descriptor layout based on resource usages
   bool robustBufferAccess;        // Whether to enable robust buffer access
   bool scratchAccessBoundsChecks; // Whether to enable scratch access bounds checks
-  PipelineType pipelineType;      // Pipeline type;
+  VfxPipelineType pipelineType;   // Pipeline type;
 };
 
 // Callback function to allocate buffer for building shader module and building pipeline.

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -75,6 +75,11 @@ struct ShaderModuleData {
   bool disableDoAutoLayout;               // Indicates whether to disable auto layout of descriptors
 };
 
+enum PipelineType : unsigned {
+  PipelineTypeGraphics = 0, // Graphics pipeline type
+  PipelineTypeCompute,      // Compute pipeline type
+};
+
 // Represents a single compilation context of a pipeline or a group of shaders.
 // This is only used by the standalone compiler tool.
 struct CompileInfo {
@@ -95,6 +100,7 @@ struct CompileInfo {
   bool autoLayoutDesc;            // Whether to automatically create descriptor layout based on resource usages
   bool robustBufferAccess;        // Whether to enable robust buffer access
   bool scratchAccessBoundsChecks; // Whether to enable scratch access bounds checks
+  PipelineType pipelineType;      // Pipeline type;
 };
 
 // Callback function to allocate buffer for building shader module and building pipeline.
@@ -117,7 +123,8 @@ LLPC_NODISCARD Result decodePipelineBinary(const BinaryData *pipelineBin, Compil
 llvm::Error buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
 
 // Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
-llvm::Error outputElf(CompileInfo *compileInfo, const std::string &suppliedOutFile, llvm::StringRef firstInFile);
+llvm::Error outputElf(const BinaryData &pipelineBin, const std::string &suppliedOutFile, llvm::StringRef firstInFile,
+                      unsigned index);
 
 // Processes and compiles one pipeline input file.
 llvm::Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const InputSpec &inputSpec,

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -96,7 +96,7 @@ struct CompileInfo {
   bool autoLayoutDesc;            // Whether to automatically create descriptor layout based on resource usages
   bool robustBufferAccess;        // Whether to enable robust buffer access
   bool scratchAccessBoundsChecks; // Whether to enable scratch access bounds checks
-  VfxPipelineType pipelineType;   // Pipeline type;
+  VfxPipelineType pipelineType;   // Pipeline type
 };
 
 // Callback function to allocate buffer for building shader module and building pipeline.
@@ -117,10 +117,6 @@ LLPC_NODISCARD Result decodePipelineBinary(const BinaryData *pipelineBin, Compil
 
 // Builds shader module based on the specified SPIR-V binary.
 llvm::Error buildShaderModules(ICompiler *compiler, CompileInfo *compileInfo);
-
-// Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
-llvm::Error outputElf(const BinaryData &pipelineBin, const std::string &suppliedOutFile, llvm::StringRef firstInFile,
-                      unsigned index);
 
 // Processes and compiles one pipeline input file.
 llvm::Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const InputSpec &inputSpec,

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -154,5 +154,16 @@ uint64_t ComputePipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildIn
   return IPipelineDumper::GetPipelineHash(buildInfo.pComputeInfo);
 }
 
+// =====================================================================================================================
+// Output LLPC resulting binaries
+//
+// @param suppliedOutFile : Name of the file to output ELF binary
+// @param firstInFile : Name of first input file
+// @returns : `llvm::ErrorSuccess` on success, `llpc::ResultError` on failure.
+Error ComputePipelineBuilder::outputElfs(const std::string &suppliedOutFile, StringRef firstInFile) {
+  CompileInfo &compileInfo = getCompileInfo();
+  return outputElf(compileInfo.compPipelineOut.pipelineBin, suppliedOutFile, firstInFile, 0);
+}
+
 } // namespace StandaloneCompiler
 } // namespace Llpc

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -158,11 +158,11 @@ uint64_t ComputePipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildIn
 // Output LLPC resulting binaries
 //
 // @param suppliedOutFile : Name of the file to output ELF binary
-// @param firstInFile : Name of first input file
 // @returns : `llvm::ErrorSuccess` on success, `llpc::ResultError` on failure.
-Error ComputePipelineBuilder::outputElfs(const std::string &suppliedOutFile, StringRef firstInFile) {
+Error ComputePipelineBuilder::outputElfs(const StringRef suppliedOutFile) {
   CompileInfo &compileInfo = getCompileInfo();
-  return outputElf(compileInfo.compPipelineOut.pipelineBin, suppliedOutFile, firstInFile, 0);
+  const InputSpec &firstInput = compileInfo.inputSpecs.front();
+  return outputElf(compileInfo.compPipelineOut.pipelineBin, suppliedOutFile, firstInput.filename, 0);
 }
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -162,7 +162,7 @@ uint64_t ComputePipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildIn
 Error ComputePipelineBuilder::outputElfs(const StringRef suppliedOutFile) {
   CompileInfo &compileInfo = getCompileInfo();
   const InputSpec &firstInput = compileInfo.inputSpecs.front();
-  return outputElf(compileInfo.compPipelineOut.pipelineBin, suppliedOutFile, firstInput.filename, 0);
+  return outputElf(compileInfo.compPipelineOut.pipelineBin, suppliedOutFile, firstInput.filename);
 }
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcComputePipelineBuilder.h
+++ b/llpc/tool/llpcComputePipelineBuilder.h
@@ -45,7 +45,7 @@ public:
 
   // Builds compute pipeline and does linking. Returns the pipeline Elf.
   llvm::Expected<Vkgc::BinaryData> buildComputePipeline();
-  llvm::Error outputElfs(const llvm::StringRef suppliedOutFile);
+  llvm::Error outputElfs(const llvm::StringRef suppliedOutFile) override;
 };
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcComputePipelineBuilder.h
+++ b/llpc/tool/llpcComputePipelineBuilder.h
@@ -45,6 +45,7 @@ public:
 
   // Builds compute pipeline and does linking. Returns the pipeline Elf.
   llvm::Expected<Vkgc::BinaryData> buildComputePipeline();
+  llvm::Error outputElfs(const std::string &suppliedOutFile, llvm::StringRef firstInFile);
 };
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcComputePipelineBuilder.h
+++ b/llpc/tool/llpcComputePipelineBuilder.h
@@ -45,7 +45,7 @@ public:
 
   // Builds compute pipeline and does linking. Returns the pipeline Elf.
   llvm::Expected<Vkgc::BinaryData> buildComputePipeline();
-  llvm::Error outputElfs(const std::string &suppliedOutFile, llvm::StringRef firstInFile);
+  llvm::Error outputElfs(const llvm::StringRef suppliedOutFile);
 };
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcGraphicsPipelineBuilder.cpp
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.cpp
@@ -175,7 +175,7 @@ uint64_t GraphicsPipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildI
 Error GraphicsPipelineBuilder::outputElfs(const StringRef suppliedOutFile) {
   CompileInfo &compileInfo = getCompileInfo();
   const InputSpec &firstInput = compileInfo.inputSpecs.front();
-  return outputElf(compileInfo.gfxPipelineOut.pipelineBin, suppliedOutFile, firstInput.filename, 0);
+  return outputElf(compileInfo.gfxPipelineOut.pipelineBin, suppliedOutFile, firstInput.filename);
 }
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcGraphicsPipelineBuilder.cpp
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.cpp
@@ -171,11 +171,11 @@ uint64_t GraphicsPipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildI
 // Output LLPC resulting binaries
 //
 // @param suppliedOutFile : Name of the file to output ELF binary
-// @param firstInFile : Name of first input file
 // @returns : `llvm::ErrorSuccess` on success, `llpc::ResultError` on failure.
-Error GraphicsPipelineBuilder::outputElfs(const std::string &suppliedOutFile, StringRef firstInFile) {
+Error GraphicsPipelineBuilder::outputElfs(const StringRef suppliedOutFile) {
   CompileInfo &compileInfo = getCompileInfo();
-  return outputElf(compileInfo.gfxPipelineOut.pipelineBin, suppliedOutFile, firstInFile, 0);
+  const InputSpec &firstInput = compileInfo.inputSpecs.front();
+  return outputElf(compileInfo.gfxPipelineOut.pipelineBin, suppliedOutFile, firstInput.filename, 0);
 }
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcGraphicsPipelineBuilder.cpp
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.cpp
@@ -167,5 +167,16 @@ uint64_t GraphicsPipelineBuilder::getPipelineHash(Vkgc::PipelineBuildInfo buildI
   return IPipelineDumper::GetPipelineHash(buildInfo.pGraphicsInfo);
 }
 
+// =====================================================================================================================
+// Output LLPC resulting binaries
+//
+// @param suppliedOutFile : Name of the file to output ELF binary
+// @param firstInFile : Name of first input file
+// @returns : `llvm::ErrorSuccess` on success, `llpc::ResultError` on failure.
+Error GraphicsPipelineBuilder::outputElfs(const std::string &suppliedOutFile, StringRef firstInFile) {
+  CompileInfo &compileInfo = getCompileInfo();
+  return outputElf(compileInfo.gfxPipelineOut.pipelineBin, suppliedOutFile, firstInFile, 0);
+}
+
 } // namespace StandaloneCompiler
 } // namespace Llpc

--- a/llpc/tool/llpcGraphicsPipelineBuilder.h
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.h
@@ -46,6 +46,7 @@ public:
 
   // Builds graphics pipeline and does linking. Returns the pipeline Elf.
   llvm::Expected<Vkgc::BinaryData> buildGraphicsPipeline();
+  llvm::Error outputElfs(const std::string &suppliedOutFile, llvm::StringRef firstInFile);
 };
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcGraphicsPipelineBuilder.h
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.h
@@ -46,7 +46,7 @@ public:
 
   // Builds graphics pipeline and does linking. Returns the pipeline Elf.
   llvm::Expected<Vkgc::BinaryData> buildGraphicsPipeline();
-  llvm::Error outputElfs(const std::string &suppliedOutFile, llvm::StringRef firstInFile);
+  llvm::Error outputElfs(const llvm::StringRef suppliedOutFile);
 };
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcGraphicsPipelineBuilder.h
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.h
@@ -46,7 +46,7 @@ public:
 
   // Builds graphics pipeline and does linking. Returns the pipeline Elf.
   llvm::Expected<Vkgc::BinaryData> buildGraphicsPipeline();
-  llvm::Error outputElfs(const llvm::StringRef suppliedOutFile);
+  llvm::Error outputElfs(const llvm::StringRef suppliedOutFile) override;
 };
 
 } // namespace StandaloneCompiler

--- a/llpc/tool/llpcPipelineBuilder.cpp
+++ b/llpc/tool/llpcPipelineBuilder.cpp
@@ -145,13 +145,14 @@ void PipelineBuilder::printPipelineInfo(PipelineBuildInfo buildInfo) {
 }
 
 // =====================================================================================================================
-// Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
+// Output LLPC single one elf ((ELF binary, ISA assembly text, or LLVM bitcode)) of pipeline binaries to the specified
+// target file.
 //
 // @param pipelineBin : Output elf pipeline binary
-// @param suppliedOutFile : Name of the file to output ELF binary (specify "" to use base name of first input file with
-// appropriate extension; specify "-" to use stdout)
+// @param suppliedOutFile : Name of the file to output ELF binary (specify "" to use the base name of first input file
+// with appropriate extension; specify "-" to use stdout)
 // @param firstInFile : Name of first input file
-// @param index : index of elf binaries
+// @param index : index of elf from pipeline binaries
 // @returns : `ErrorSuccess` on success, `ResultError` on failure
 Error PipelineBuilder::outputElf(const BinaryData &pipelineBin, const StringRef suppliedOutFile, StringRef firstInFile,
                                  unsigned index) {

--- a/llpc/tool/llpcPipelineBuilder.cpp
+++ b/llpc/tool/llpcPipelineBuilder.cpp
@@ -152,20 +152,15 @@ void PipelineBuilder::printPipelineInfo(PipelineBuildInfo buildInfo) {
 // @param suppliedOutFile : Name of the file to output ELF binary (specify "" to use the base name of first input file
 // with appropriate extension; specify "-" to use stdout)
 // @param firstInFile : Name of first input file
-// @param index : index of elf from pipeline binaries
 // @returns : `ErrorSuccess` on success, `ResultError` on failure
-Error PipelineBuilder::outputElf(const BinaryData &pipelineBin, const StringRef suppliedOutFile, StringRef firstInFile,
-                                 unsigned index) {
+Error PipelineBuilder::outputElf(const BinaryData &pipelineBin, const StringRef suppliedOutFile,
+                                 StringRef firstInFile) {
   SmallString<64> outFileName(suppliedOutFile);
   if (outFileName.empty()) {
     // Detect the data type as we are unable to access the values of the options "-filetype" and "-emit-llvm".
     StringLiteral ext = fileExtFromBinary(pipelineBin);
     outFileName = sys::path::filename(firstInFile);
     sys::path::replace_extension(outFileName, ext);
-  }
-  if (outFileName != "-" && index > 0) {
-    outFileName.append(".");
-    outFileName.append(utostr(index));
   }
 
   return writeFile(pipelineBin, outFileName);

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -75,8 +75,7 @@ public:
   // Output LLPC resulting binaries
   //
   // @param suppliedOutFile : Name of the file to output ELF binary
-  // @param firstInFile : Name of first input file
-  virtual llvm::Error outputElfs(const std::string &suppliedOutFile, llvm::StringRef firstInFile) = 0;
+  virtual llvm::Error outputElfs(const llvm::StringRef suppliedOutFile) = 0;
 
   // Calculates the hash of the compiled pipeline. This is used by `printPipelineInfo` to produce verbose logs.
   //
@@ -112,6 +111,11 @@ public:
 
   // Prints pipeline dump hash code and filenames.
   void printPipelineInfo(Vkgc::PipelineBuildInfo buildInfo);
+
+protected:
+  // Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
+  llvm::Error outputElf(const BinaryData &pipelineBin, const llvm::StringRef suppliedOutFile,
+                        llvm::StringRef firstInFile, unsigned index);
 
 private:
   ICompiler &m_compiler;

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -112,8 +112,8 @@ public:
   // Prints pipeline dump hash code and filenames.
   void printPipelineInfo(Vkgc::PipelineBuildInfo buildInfo);
 
-protected:
-  // Output LLPC resulting binary (ELF binary, ISA assembly text, or LLVM bitcode) to the specified target file.
+  // Output LLPC single one elf ((ELF binary, ISA assembly text, or LLVM bitcode)) of pipeline binaries to the specified
+  // target file.
   llvm::Error outputElf(const BinaryData &pipelineBin, const llvm::StringRef suppliedOutFile,
                         llvm::StringRef firstInFile, unsigned index);
 

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -72,6 +72,12 @@ public:
   // @returns : Calculated pipeline hash.
   virtual llvm::Error build() = 0;
 
+  // Output LLPC resulting binaries
+  //
+  // @param suppliedOutFile : Name of the file to output ELF binary
+  // @param firstInFile : Name of first input file
+  virtual llvm::Error outputElfs(const std::string &suppliedOutFile, llvm::StringRef firstInFile) = 0;
+
   // Calculates the hash of the compiled pipeline. This is used by `printPipelineInfo` to produce verbose logs.
   //
   // @param buildInfo : Pipeline build information.

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -115,7 +115,7 @@ public:
   // Output LLPC single one elf ((ELF binary, ISA assembly text, or LLVM bitcode)) of pipeline binaries to the specified
   // target file.
   llvm::Error outputElf(const BinaryData &pipelineBin, const llvm::StringRef suppliedOutFile,
-                        llvm::StringRef firstInFile, unsigned index);
+                        llvm::StringRef firstInFile);
 
 private:
   ICompiler &m_compiler;

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -558,8 +558,8 @@ typedef void *VfxRenderStatePtr;
 #if VFX_SUPPORT_VK_PIPELINE
 // =====================================================================================================================
 // Represents the kind of vkgc pipeline
-enum VfxPipelineType {
-  VfxPipelineTypeGraphics,
+enum VfxPipelineType : unsigned {
+  VfxPipelineTypeGraphics = 0,
   VfxPipelineTypeCompute,
 };
 


### PR DESCRIPTION
Our internal project has new pipeline type which can also have
compute/graphics shaders. so in some case using the shaderMask to decide
pipeline type could lead to errors.

Also refactor the outputElf to factor multiple elf binaries from "buildpipeline" function