### PR TITLE
[CI] Re-enable gcc image configurations

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -17,7 +17,8 @@ jobs:
         image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
         branch:         [dev]
         config:         [Release]
-        feature-set:    ["+clang", "+clang+coverage",
+        feature-set:    ["+gcc", "+gcc+assertions",
+                         "+clang", "+clang+coverage",
                          "+clang+shadercache+coverage+assertions",
                          "+clang+shadercache+ubsan+asan",
                          "+clang+shadercache+ubsan+asan+assertions",


### PR DESCRIPTION
The gcc build should be fixed by D117537.
This only reenables the builds of the base images, not the ci checks.

This reverts a part of commit 7a811748f42afc9940c208053c89673f73968c32.