### PR TITLE
Fix issue on vlk_cts compute.opudotaccsatkhr.*_out32

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -134,7 +134,8 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
       if (compBitWidth == 8 || compBitWidth == 16) {
         scalar = CreateTrunc(scalar, getInt32Ty());
         accumulator = CreateTrunc(accumulator, getInt32Ty());
-        scalar = CreateNamedCall("llvm.sadd.sat.i32", getInt32Ty(), {scalar, accumulator}, {}, instName);
+        StringRef addIntrinsic = isSigned ? "llvm.sadd.sat.i32" : "llvm.uadd.sat.i32";
+        scalar = CreateNamedCall(addIntrinsic, getInt32Ty(), {scalar, accumulator}, {}, instName);
       } else {
         scalar = CreateAdd(scalar, accumulator);
       }
@@ -193,8 +194,10 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
               CreateIntrinsic(intrinsicDot2, {}, {input1, input2, intermediateRes, getInt1(false)}, nullptr, instName);
         }
         // Add a saturation add if required.
-        if (hasAccumulator)
-          scalar = CreateNamedCall("llvm.sadd.sat.i32", getInt32Ty(), {scalar, accumulator}, {}, instName);
+        if (hasAccumulator) {
+          StringRef addIntrinsic = isSigned ? "llvm.sadd.sat.i32" : "llvm.uadd.sat.i32";
+          scalar = CreateNamedCall(addIntrinsic, getInt32Ty(), {scalar, accumulator}, {}, instName);
+        }
       }
     }
   }

--- a/llpc/test/shaderdb/core/OpSDotAccSat_TestIVec.spvasm
+++ b/llpc/test/shaderdb/core/OpSDotAccSat_TestIVec.spvasm
@@ -1,0 +1,55 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i32 {{[0-9]+}}, i32 3)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+      %5 = OpConstant %int 88
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToS %v4int %15
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToS %v4int %18
+         %21 = OpSDotAccSatKHR %int %16 %19 %5
+         %22 = OpCompositeConstruct %v4int %21 %21 %21 %21
+               OpStore %c %22
+         %23 = OpLoad %v4int %c
+         %24 = OpConvertSToF %v4float %23
+               OpStore %color %24
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpSDotAccSat_TestIVec16bit.spvasm
+++ b/llpc/test/shaderdb/core/OpSDotAccSat_TestIVec16bit.spvasm
@@ -1,0 +1,63 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i16> %{{[0-9]+}}, <4 x i16> %{{[0-9]+}}, i32 {{[0-9]+}}, i32 3)
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST: %{{[0-9]+}} = call i32 @llvm.sadd.sat.i32(i32 %{{[0-9]+}}, i32 {{[0-9]+}})
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int16
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+        %int16 = OpTypeInt 16 1
+      %v4int16 = OpTypeVector %int16 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+      %5 = OpConstant %int 88
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToS %v4int %15
+         %17 = OpSConvert %v4int16 %16
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToS %v4int %18
+         %20 = OpSConvert %v4int16 %19
+         %21 = OpSDotAccSatKHR %int16 %17 %20 %5
+         %22 = OpSConvert %int %21
+         %23 = OpCompositeConstruct %v4int %22 %22 %22 %22
+               OpStore %c %23
+         %24 = OpLoad %v4int %c
+         %25 = OpConvertSToF %v4float %24
+               OpStore %color %25
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpSDot_TestIVec.spvasm
+++ b/llpc/test/shaderdb/core/OpSDot_TestIVec.spvasm
@@ -1,0 +1,54 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i32 0, i32 3)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToS %v4int %15
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToS %v4int %18
+         %20 = OpSDotKHR %int %16 %19
+         %21 = OpCompositeConstruct %v4int %20 %20 %20 %20
+               OpStore %c %21
+         %23 = OpLoad %v4int %c
+         %24 = OpConvertSToF %v4float %23
+               OpStore %color %24
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpSUDotAccSat_TestIUVec.spvasm
+++ b/llpc/test/shaderdb/core/OpSUDotAccSat_TestIUVec.spvasm
@@ -1,0 +1,57 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i32 {{[0-9]+}}, i32 1)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 0
+        %int2 = OpTypeInt 32 1
+      %v4int = OpTypeVector %int 4
+      %v4int2 = OpTypeVector %int2 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+      %5 = OpConstant %int 88
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToU %v4int %15
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToS %v4int2 %18
+         %21 = OpSUDotAccSatKHR %int %16 %19 %5
+         %22 = OpCompositeConstruct %v4int %21 %21 %21 %21
+               OpStore %c %22
+         %23 = OpLoad %v4int %c
+         %24 = OpConvertSToF %v4float %23
+               OpStore %color %24
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpSUDot_TestSIVec.spvasm
+++ b/llpc/test/shaderdb/core/OpSUDot_TestSIVec.spvasm
@@ -1,0 +1,56 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i32 0, i32 1)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+        %int2 = OpTypeInt 32 0
+      %v4int = OpTypeVector %int 4
+      %v4int2 = OpTypeVector %int2 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToS %v4int %15
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToU %v4int2 %18
+         %20 = OpSUDotKHR %int %16 %19
+         %21 = OpCompositeConstruct %v4int %20 %20 %20 %20
+               OpStore %c %21
+         %23 = OpLoad %v4int %c
+         %24 = OpConvertSToF %v4float %23
+               OpStore %color %24
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpUDotAccSat_TestUVec.spvasm
+++ b/llpc/test/shaderdb/core/OpUDotAccSat_TestUVec.spvasm
@@ -1,0 +1,55 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i32 {{[0-9]+}}, i32 0)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 0
+      %v4int = OpTypeVector %int 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+      %5 = OpConstant %int 88
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToU %v4int %15
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToU %v4int %18
+         %21 = OpUDotAccSatKHR %int %16 %19 %5
+         %22 = OpCompositeConstruct %v4int %21 %21 %21 %21
+               OpStore %c %22
+         %23 = OpLoad %v4int %c
+         %24 = OpConvertSToF %v4float %23
+               OpStore %color %24
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpUDotAccSat_TestUVec16bit.spvasm
+++ b/llpc/test/shaderdb/core/OpUDotAccSat_TestUVec16bit.spvasm
@@ -1,0 +1,63 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i16> %{{[0-9]+}}, <4 x i16> %{{[0-9]+}}, i32 {{[0-9]+}}, i32 0)
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST: %{{[0-9]+}} = call i32 @llvm.uadd.sat.i32(i32 %{{[0-9]+}}, i32 {{[0-9]+}})
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability Int16
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 0
+      %v4int = OpTypeVector %int 4
+        %int16 = OpTypeInt 16 0
+      %v4int16 = OpTypeVector %int16 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+      %5 = OpConstant %int 88
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToU %v4int %15
+         %17 = OpUConvert %v4int16 %16
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToU %v4int %18
+         %20 = OpSConvert %v4int16 %19
+         %21 = OpUDotAccSatKHR %int16 %17 %20 %5
+         %22 = OpUConvert %int %21
+         %23 = OpCompositeConstruct %v4int %22 %22 %22 %22
+               OpStore %c %23
+         %24 = OpLoad %v4int %c
+         %25 = OpConvertSToF %v4float %24
+               OpStore %color %25
+               OpReturn
+               OpFunctionEnd

--- a/llpc/test/shaderdb/core/OpUDot_TestUVec.spvasm
+++ b/llpc/test/shaderdb/core/OpUDot_TestUVec.spvasm
@@ -1,0 +1,54 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: %{{[0-9]+}} = call i32 (...) @lgc.create.integer.dot.product.i32(<4 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i32 0, i32 0)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+               OpCapability Shader
+               OpCapability DotProductKHR
+               OpExtension "SPV_KHR_integer_dot_product"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %a0 %b0 %color
+               OpExecutionMode %main OriginUpperLeft
+               OpName %main "main"
+               OpName %c "c"
+               OpName %a0 "a0"
+               OpName %b0 "b0"
+               OpName %color "color"
+               OpDecorate %a0 Location 0
+               OpDecorate %b0 Location 10
+               OpDecorate %color Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+        %int = OpTypeInt 32 0
+      %v4int = OpTypeVector %int 4
+%_ptr_Function_v4int = OpTypePointer Function %v4int
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %a0 = OpVariable %_ptr_Input_v4float Input
+         %b0 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+          %c = OpVariable %_ptr_Function_v4int Function
+         %15 = OpLoad %v4float %a0
+         %16 = OpConvertFToU %v4int %15
+         %18 = OpLoad %v4float %b0
+         %19 = OpConvertFToU %v4int %18
+         %20 = OpUDotKHR %int %16 %19
+         %21 = OpCompositeConstruct %v4int %20 %20 %20 %20
+               OpStore %c %21
+         %23 = OpLoad %v4int %c
+         %24 = OpConvertSToF %v4float %23
+               OpStore %color %24
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
This issue has been root-caused. It's due to incorrect using for LLVM intrinsic: "llvm.sadd.sat.i32", it should use llvm.uadd.sat when the operators are unsigned and llvm.sadd.sat.i32 when operators are signed.

Please refer the description as below:

The ‘llvm.sadd.sat’ family of intrinsic functions perform signed saturating addition on the 2 arguments.

The ‘llvm.uadd.sat’ family of intrinsic functions perform unsigned saturating addition on the 2 arguments.