### PR TITLE
Fix missing merged Hs-Ls shader operations in NGG mode

### DIFF
--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -219,21 +219,21 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
           lgc::setShaderStage(esGsEntryPoint, ShaderStageGeometry);
         }
 
-        // This must be done after generating the EsGs entry point because it must appear first in the module.
-        if (m_hasTcs) {
-          auto lsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageVertex);
-          auto hsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTessControl);
-
-          if (hsEntryPoint) {
-            if (lsEntryPoint)
-              lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
-            auto lsHsEntryPoint = shaderMerger.generateLsHsEntryPoint(lsEntryPoint, hsEntryPoint);
-            lsHsEntryPoint->setCallingConv(CallingConv::AMDGPU_HS);
-            lgc::setShaderStage(lsHsEntryPoint, ShaderStageTessControl);
-          }
-        }
-
         setCallingConv(ShaderStageCopyShader, CallingConv::AMDGPU_VS);
+      }
+
+      // This must be done after generating the EsGs entry point because it must appear first in the module.
+      if (m_hasTcs) {
+        auto lsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageVertex);
+        auto hsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTessControl);
+
+        if (hsEntryPoint) {
+          if (lsEntryPoint)
+            lgc::setShaderStage(lsEntryPoint, ShaderStageTessControl);
+          auto lsHsEntryPoint = shaderMerger.generateLsHsEntryPoint(lsEntryPoint, hsEntryPoint);
+          lsHsEntryPoint->setCallingConv(CallingConv::AMDGPU_HS);
+          lgc::setShaderStage(lsHsEntryPoint, ShaderStageTessControl);
+        }
       }
     } else if (hasTs) {
       // TS-only pipeline


### PR DESCRIPTION
There are tessellation issues caused by a regression point 03d9e6cb.