### PR TITLE
[CI] Re-enable gcc configurations

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -17,7 +17,8 @@ jobs:
         host-os:             ["ubuntu-20.04"]
         image-template:      ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
         config:              [Release]
-        feature-set:         ["+clang", "+clang+coverage",
+        feature-set:         ["+gcc", "+gcc+assertions",
+                              "+clang", "+clang+coverage",
                               "+clang+shadercache+coverage+assertions",
                               "+clang+shadercache+ubsan+asan",
                               "+clang+shadercache+ubsan+asan+assertions",


### PR DESCRIPTION
Reenable gcc in the CI runners.

This reverts the second part of commit 7a811748f42afc9940c208053c89673f73968c32.
Fixes https://github.com/GPUOpen-Drivers/llpc/issues/1645

gcc image builds are passing again: https://github.com/GPUOpen-Drivers/llpc/actions/runs/1850119225