### PR TITLE
Refactor scratchBoundsChecksEnabled

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -245,6 +245,7 @@ private:
   const Vkgc::PipelineShaderOptions *m_shaderOptions;
   unsigned m_spirvOpMetaKindId;
   unsigned m_execModule;
+  bool m_scratchBoundsChecksEnabled;
 
   enum class LlvmMemOpType : uint8_t { IS_LOAD, IS_STORE };
   struct ScratchBoundsCheckData {


### PR DESCRIPTION
The coverage report shows that scratchBoundsChecksEnabled() is called
32.1k times, for many load and store instructions.

Move the call into the SPIRVToLLVM constructor so the call is executed
fewer times.