### PR TITLE
Ignore SPIR-V DontInline function control

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5175,6 +5175,8 @@ template <class SourceTy, class FuncTy> bool SPIRVToLLVM::foreachFuncCtlMask(Sou
   // Cancel those masks if they are both present
   if ((fcm & FunctionControlInlineMask) && (fcm & FunctionControlDontInlineMask))
     fcm &= ~(FunctionControlInlineMask | FunctionControlDontInlineMask);
+  // Ignore DontInline because we rely on inlining everything.
+  fcm &= ~FunctionControlDontInlineMask;
   SPIRSPIRVFuncCtlMaskMap::foreach ([&](Attribute::AttrKind attr, SPIRVFunctionControlMaskKind mask) {
     if (fcm & mask)
       func(attr);


### PR DESCRIPTION
Don't translate SPIR-V DontInline to the LLVM noinline attribute,
because the rest of the compiler relies on everything being inlined.

This becomes a real problem when this upstream LLVM patch changes the
AlwaysInliner pass to respect the noinline attribute:

https://reviews.llvm.org/D119553 "[AlwaysInliner] Respect noinline call site attribute"