### PR TITLE
Add replaceGlobal function and refactor postProcessExecutionModeId 

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -155,6 +155,26 @@ void SpirvLower::removeConstantExpr(Context *context, GlobalVariable *global) {
 }
 
 // =====================================================================================================================
+// Replace global variable with another global variable
+//
+// @param global : Replaced global variable
+// @param replaceGlobalglobal : Replacing global variable
+void SpirvLower::replaceGlobal(GlobalVariable *global, GlobalVariable *replaceGlobal) {
+  removeConstantExpr(m_context, global);
+  for (auto userIt = global->user_begin(); userIt != global->user_end();) {
+    User *user = *userIt++;
+    Instruction *inst = dyn_cast<Instruction>(user);
+    if (inst) {
+      m_builder->SetInsertPoint(inst);
+      Value *replacedValue = m_builder->CreateBitCast(replaceGlobal, global->getType());
+      user->replaceUsesOfWith(global, replacedValue);
+    }
+  }
+  global->dropAllReferences();
+  global->eraseFromParent();
+}
+
+// =====================================================================================================================
 // Add per-shader lowering passes to pass manager
 //
 // @param context : LLPC context

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -71,7 +71,7 @@ namespace Llpc {
 // Initialize passes for SPIR-V lowering
 //
 // @param passRegistry : Pass registry
-inline static void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
+inline void initializeLowerPasses(llvm::PassRegistry &passRegistry) {
   initializeLegacySpirvLowerAccessChainPass(passRegistry);
   initializeLegacySpirvLowerConstImmediateStorePass(passRegistry);
   initializeLegacySpirvLowerMathConstFoldingPass(passRegistry);
@@ -112,7 +112,7 @@ public:
 
   static void removeConstantExpr(Context *context, llvm::GlobalVariable *global);
   static void replaceConstWithInsts(Context *context, llvm::Constant *const constVal);
-  void replaceGlobal(llvm::GlobalVariable *global, llvm::GlobalVariable *replaceGlobal);
+  static void replaceGlobal(Context *context, llvm::GlobalVariable *original, llvm::GlobalVariable *replacement);
 
 protected:
   void init(llvm::Module *module);

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -112,6 +112,7 @@ public:
 
   static void removeConstantExpr(Context *context, llvm::GlobalVariable *global);
   static void replaceConstWithInsts(Context *context, llvm::Constant *const constVal);
+  void replaceGlobal(llvm::GlobalVariable *global, llvm::GlobalVariable *replaceGlobal);
 
 protected:
   void init(llvm::Module *module);

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -490,21 +490,23 @@ void SPIRVModuleImpl::postProcessExecutionModeId() {
   for (auto ExecModeId : ExecModeIdVec) {
     SPIRVExecutionModeId *E = static_cast<SPIRVExecutionModeId *>(ExecModeId);
     auto M = E->getExecutionMode();
+    auto tid = E->getTargetId();
+    auto ops = E->getOperands();
+    SPIRVExecutionMode *execMode = nullptr;
     switch (M) {
     case ExecutionModeLocalSizeId: {
-      auto TId = E->getTargetId();
-      auto Ops = E->getOperands();
-      auto WorkGroupSizeX = static_cast<SPIRVConstant *>(getEntry(Ops[0]));
-      auto WorkGroupSizeY = static_cast<SPIRVConstant *>(getEntry(Ops[1]));
-      auto WorkGroupSizeZ = static_cast<SPIRVConstant *>(getEntry(Ops[2]));
-      auto ExecMode =
-          add(new SPIRVExecutionMode(getEntry(TId), ExecutionModeLocalSize, WorkGroupSizeX->getZExtIntValue(),
-                                     WorkGroupSizeY->getZExtIntValue(), WorkGroupSizeZ->getZExtIntValue()));
-      static_cast<SPIRVFunction *>(getEntry(TId))->addExecutionMode(ExecMode);
+      auto workGroupSizeX = static_cast<SPIRVConstant *>(getEntry(ops[0]));
+      auto workGroupSizeY = static_cast<SPIRVConstant *>(getEntry(ops[1]));
+      auto workGroupSizeZ = static_cast<SPIRVConstant *>(getEntry(ops[2]));
+      execMode = add(new SPIRVExecutionMode(getEntry(tid), ExecutionModeLocalSize, workGroupSizeX->getZExtIntValue(),
+                                            workGroupSizeY->getZExtIntValue(), workGroupSizeZ->getZExtIntValue()));
+      break;
     }
     default:
       break;
     }
+    if (execMode)
+      static_cast<SPIRVFunction *>(getEntry(tid))->addExecutionMode(execMode);
   }
 }
 


### PR DESCRIPTION
1) Add replaceGlobal function to the Spirvlower class, two SpirvLower
    classes from internal project use this function, so put it into parent class.
2) Refactor the code and make space for the more exectionModes which internal project using
Try to reduce future merge conflicts when codes from two repos sync.