### PR TITLE
Add build option in amdllpc to link spvgen statically or dynamically

### DIFF
--- a/imported/spirv/spvgen.h
+++ b/imported/spirv/spvgen.h
@@ -240,11 +240,9 @@ void SH_IMPORT_EXPORT vfxPrintDoc(
 }
 #endif
 
-static inline bool InitSpvGen(
-    const char* pSpvGenDir = nullptr)
-{
-    return true;
-}
+bool InitSpvGen(const char* pSpvGenDir = nullptr);
+
+void FinalizeSpvgen();
 
 #else
 
@@ -390,6 +388,8 @@ DECL_EXPORT_FUNC(vfxGetPipelineDoc);
 DECL_EXPORT_FUNC(vfxPrintDoc);
 
 bool SPVAPI InitSpvGen(const char* pSpvGenDir = nullptr);
+
+void SPVAPI FinalizeSpvgen();
 
 #endif
 
@@ -552,6 +552,10 @@ bool SPVAPI InitSpvGen(
     }
     return success;
 }
+
+// =====================================================================================================================
+// Finalize spvgen; Clean up resource
+void SPVAPI FinalizeSpvgen() {}
 
 #endif
 

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -397,6 +397,8 @@ add_executable(amdllpc tool/amdllpc.cpp)
 add_dependencies(amdllpc llpc_standalone_compiler)
 target_link_libraries(amdllpc PRIVATE llpc_standalone_compiler)
 set_compiler_options(amdllpc ${LLPC_ENABLE_WERROR})
+add_compile_definitions(amdllpc PRIVATE SH_EXPORTING)
+target_link_libraries(amdllpc PRIVATE spvgen_static)
 
 endif()
 ### Add Subdirectories #################################################################################################

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -74,7 +74,6 @@
 #include <unordered_set>
 
 #ifdef LLPC_ENABLE_SPIRV_OPT
-#define SPVGEN_STATIC_LIB 1
 #include "spvgen.h"
 #endif
 

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -542,6 +542,8 @@ int main(int argc, char *argv[]) {
 
   // Cleanup code that gets run automatically before returning.
   auto onExit = make_scope_exit([compiler, &result] {
+    FinalizeSpvgen();
+
     if (compiler)
       compiler->Destroy();
 

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -75,10 +75,6 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 
-#ifndef LLPC_ENABLE_SPIRV_OPT
-#define SPVGEN_STATIC_LIB 1
-#endif
-
 #include "spvgen.h"
 #include "vfx.h"
 #include <cassert>

--- a/llpc/unittests/vfx/testVfxParser.cpp
+++ b/llpc/unittests/vfx/testVfxParser.cpp
@@ -30,9 +30,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#define SPVGEN_STATIC_LIB 1
-#include "spvgen.h"
-
 using namespace llvm;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;

--- a/tool/vfx/CMakeLists.txt
+++ b/tool/vfx/CMakeLists.txt
@@ -51,7 +51,7 @@ target_sources(vfx PRIVATE
     vfxVkSection.cpp
 )
 
-target_compile_definitions(vfx PRIVATE VFX_SUPPORT_VK_PIPELINE)
+target_compile_definitions(vfx PRIVATE VFX_SUPPORT_VK_PIPELINE SH_EXPORTING)
 
 target_include_directories(vfx
 PUBLIC
@@ -61,5 +61,6 @@ PRIVATE
     ${PROJECT_SOURCE_DIR}/../../include
 )
 
+target_link_libraries(vfx PRIVATE spvgen_static)
 target_link_libraries(vfx PRIVATE khronos_vulkan_interface)
 target_link_libraries(vfx PRIVATE khronos_spirv_interface)


### PR DESCRIPTION
Add an option 'USING_STATIC_SPVGEN' to handle amdllpc to link spvgen
dynamically or statically.