### PR TITLE
Add replaceGlobal function and refactor postProcessExecutionModeId

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -320,4 +320,21 @@ void SpirvLower::init(Module *module) {
   m_builder = m_context->getBuilder();
 }
 
+// =====================================================================================================================
+// Replace global variable with another global variable
+//
+// @param original : Replaced global variable
+// @param replacement : Replacing global variable
+void SpirvLower::replaceGlobal(GlobalVariable *original, GlobalVariable *replacement) {
+  removeConstantExpr(m_context, original);
+  for (User *user : original->users()) {
+    Instruction *inst = cast<Instruction>(user);
+    m_builder->SetInsertPoint(inst);
+    Value *replacedValue = m_builder->CreateBitCast(replacement, original->getType());
+    user->replaceUsesOfWith(original, replacedValue);
+  }
+  original->dropAllReferences();
+  original->eraseFromParent();
+}
+
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -112,6 +112,7 @@ public:
 
   static void removeConstantExpr(Context *context, llvm::GlobalVariable *global);
   static void replaceConstWithInsts(Context *context, llvm::Constant *const constVal);
+  void replaceGlobal(llvm::GlobalVariable *original, llvm::GlobalVariable *replacement);
 
 protected:
   void init(llvm::Module *module);


### PR DESCRIPTION
1.Add replaceGlobal function to the Spirvlower class, two SpirvLower
classes from internal project use this function, so put it into parent
class.
2.Refactor the code and make space for the more exectionModes which
internal project using
Try to reduce future merge conflicts when codes from two repos sync.