### PR TITLE
Add task shader support in LGC

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -59,6 +59,8 @@ enum PipelineType : unsigned {
   Tess,
   GsTess,
   NggTess,
+  Mesh,
+  TaskMesh,
 };
 
 // Hardware shader stage
@@ -142,30 +144,36 @@ static constexpr char HardwareMapping[] = ".hardware_mapping";
 
 // User data mapping for special user data values.
 enum class UserDataMapping : unsigned {
-  GlobalTable = 0x10000000,    // 32-bit pointer to GPU memory containing the global internal table.
-  PerShaderTable = 0x10000001, // 32-bit pointer to GPU memory containing the per-shader internal table.
-  SpillTable = 0x10000002,     // 32-bit pointer to GPU memory containing the user data spill table.  See User
-                               //  Data Spilling.
-  BaseVertex = 0x10000003,     // Vertex offset (32-bit unsigned integer). Only supported by the first stage in a
-                               //  graphics pipeline.
-  BaseInstance = 0x10000004,   // Instance offset (32-bit unsigned integer). Only supported by the first stage in
-                               //  a graphics pipeline.
-  DrawIndex = 0x10000005,      // Draw index (32-bit unsigned integer). Only supported by the first stage in a
-                               //  graphics pipeline.
-  Workgroup = 0x10000006,      // Thread group count (32-bit unsigned integer). Only supported by compute
-                               //  pipelines.
-  EsGsLdsSize = 0x1000000A,    // Indicates that PAL will program this user-SGPR to contain the amount of LDS
-                               //  space used for the ES/GS pseudo-ring-buffer for passing data between shader
-                               //  stages.
-  ViewId = 0x1000000B,         // View id (32-bit unsigned integer) identifies a view of graphic
-                               //  pipeline instancing.
-  StreamOutTable = 0x1000000C, // 32-bit pointer to GPU memory containing the stream out target SRD table.  This
-                               //  can only appear for one shader stage per pipeline.
-  VertexBufferTable = 0x1000000F, // 32-bit pointer to GPU memory containing the vertex buffer SRD table.  This can
-                                  //  only appear for one shader stage per pipeline.
-  NggCullingData = 0x10000011,    // 64-bit pointer to GPU memory containing the hardware register data needed by
-                                  //  some NGG pipelines to perform culling.  This value contains the address of the
-                                  //  first of two consecutive registers which provide the full GPU address.
+  GlobalTable = 0x10000000,          // 32-bit pointer to GPU memory containing the global internal table.
+  PerShaderTable = 0x10000001,       // 32-bit pointer to GPU memory containing the per-shader internal table.
+  SpillTable = 0x10000002,           // 32-bit pointer to GPU memory containing the user data spill table.  See User
+                                     //  Data Spilling.
+  BaseVertex = 0x10000003,           // Vertex offset (32-bit unsigned integer). Only supported by the first stage in a
+                                     //  graphics pipeline.
+  BaseInstance = 0x10000004,         // Instance offset (32-bit unsigned integer). Only supported by the first stage in
+                                     //  a graphics pipeline.
+  DrawIndex = 0x10000005,            // Draw index (32-bit unsigned integer). Only supported by the first stage in a
+                                     //  graphics pipeline.
+  Workgroup = 0x10000006,            // Thread group count (32-bit unsigned integer). Only supported by compute
+                                     //  pipelines.
+  EsGsLdsSize = 0x1000000A,          // Indicates that PAL will program this user-SGPR to contain the amount of LDS
+                                     //  space used for the ES/GS pseudo-ring-buffer for passing data between shader
+                                     //  stages.
+  ViewId = 0x1000000B,               // View id (32-bit unsigned integer) identifies a view of graphic
+                                     //  pipeline instancing.
+  StreamOutTable = 0x1000000C,       // 32-bit pointer to GPU memory containing the stream out target SRD table.  This
+                                     //  can only appear for one shader stage per pipeline.
+  VertexBufferTable = 0x1000000F,    // 32-bit pointer to GPU memory containing the vertex buffer SRD table.  This can
+                                     //  only appear for one shader stage per pipeline.
+  NggCullingData = 0x10000011,       // 64-bit pointer to GPU memory containing the hardware register data needed by
+                                     //  some NGG pipelines to perform culling.  This value contains the address of the
+                                     //  first of two consecutive registers which provide the full GPU address.
+  MeshTaskDispatchDims = 0x10000012, // Offset to three consecutive registers which indicate the number of
+                                     //  threadgroups dispatched in the X, Y, and Z dimensions.
+  MeshTaskRingIndex = 0x10000013,    // Index offset (32-bit unsigned integer). Indicates the index into the
+                                     //  Mesh/Task shader rings for the shader to consume.
+  MeshPipeStatsBuf = 0x10000014,     // 32-bit GPU virtual address of a buffer storing the shader-emulated mesh
+                                     //  pipeline stats query.
   // Values used in a user data PAL metadata register to be resolved at link time.
   // This is part of the "unlinked" ABI, so should arguably be in AbiUnlinked.h.
   DescriptorSet0 = 0x80000000,   // 32-bit pointer to the descriptor table for descriptor set 0: add N to this value

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -243,6 +243,12 @@ void ConfigBuilderBase::setPipelineType(Util::Abi::PipelineType value) {
   case Util::Abi::NggTess:
     typeStr = "NggTess";
     break;
+  case Util::Abi::Mesh:
+    typeStr = "Mesh";
+    break;
+  case Util::Abi::TaskMesh:
+    typeStr = "TaskMesh";
+    break;
   default:
     break;
   }


### PR DESCRIPTION
This change is to add task shader support in LGC

- Define new builder methods ReadTaskPayload, WriteTaskPayload,
  EmitMeshTasks to handle new task shader operations. In LLPC builder,
  those methods are not actually handled, just renamed. Their further
  lowering is in the class MeshTaskShader. We want to centralize the
  processing.

- Add new shader inputs for task shader. Compared with normal compute
  shader, task shader needs three additional user data inputs:
  MeshTaskDispatchDims, MeshTaskRingIndex, MeshPipeStatsBuf. These
  inputs are both added when we mutate entry-point and generate PAL ABI
  metadata.

- Create a new class MeshTaskShader, responsible for handling task/mesh
  shader lowering. For task shader, we only have two operations to
  handle:
    Lower read/write task payload -> Read/write payload ring buffer
    Lower emit mesh tasks -> Write draw data ring buffer and statistics
    buffer


  A task shader processing is something like this:
 
```
  Task_Shader() {
    Initialize thread/wave info

    Task shader main body (from API shader, lower task payload read/write)

    Barrier
    if (threadIdInSubgroup == 0) {
      Write data to mesh pipeline statistics buffer
      Lower EmitMeshTasks, write data to task draw data ring buffer
    }
  }
```

- Add new register config for task/mesh shader and task-mesh pipeline.
  We don't want to reuse the compute shader config and primitive shader
  config since task/mesh shader still have some difference register
  config and in the future more differences might be introduced by HW.