### PR TITLE
Fix ELF symbol type for symbols added to linker output sections

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -920,7 +920,7 @@ void OutputSection::addSymbol(const object::ELFSymbolRef &elfSymRef, unsigned in
   ELF::Elf64_Sym newSym = {};
   newSym.st_name = m_linker->getStringIndex(name);
   newSym.setBinding(elfSymRef.getBinding());
-  newSym.setType(cantFail(elfSymRef.getType()));
+  newSym.setType(cantFail(elfSymRef.getELFType()));
   newSym.st_shndx = getIndex();
   newSym.st_value = cantFail(elfSymRef.getValue()) + inputSection.offset;
   newSym.st_size = elfSymRef.getSize();

--- a/lgc/test/PartPipeline.lgc
+++ b/lgc/test/PartPipeline.lgc
@@ -10,6 +10,8 @@
 ; Both the VS and FS have a symbol "table" in .rodata referred to by relocs in code;
 ; the linker appends the source ELF filename to the symbols to distinguish them.
 
+; CHECK: .type	_amdgpu_gs_main,@function
+; CHECK: .type	_amdgpu_ps_main,@function
 ; CHECK-LABEL: _amdgpu_gs_main:
 ; CHECK: .reloc {{.*}}, R_AMDGPU_REL32_LO, table.{{.*}}.vs.elf
 ; CHECK: .reloc {{.*}}, R_AMDGPU_REL32_HI, table.{{.*}}.vs.elf


### PR DESCRIPTION
Elf64_Sym::setType expects an ELF symbol type, but
ElfSymbolRef::getType returns a generic SymbolRef::Type.