### PR TITLE
Fix check-amdllpc with assertions enabled

### DIFF
--- a/llpc/test/shaderdb/general/PipelineVsFs_VsAndFsWithData.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_VsAndFsWithData.pipe
@@ -1,6 +1,6 @@
 ; Test that constant data in the vertex shader is handled correctly.
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -d -j .text -j .rodata -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: <_amdgpu_vs_main>:
 ; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[vs_data_sym:[.a-z]*]]
@@ -40,7 +40,7 @@
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -d -j .text -j .rodata -r %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2-LABEL: <_amdgpu_vs_main>:
 ; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .rodata

--- a/llpc/test/shaderdb/multiple_inputs/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe
+++ b/llpc/test/shaderdb/multiple_inputs/test_inputs/PipelineVsFs_ConstantData_Vs1Fs1.pipe
@@ -1,7 +1,7 @@
 ; Test that constant data in the vertex shader is handled correctly.
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t_0.elf %gfxip %s
-; RUN: llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t_0.elf | FileCheck -check-prefix=SHADERTEST %s
+; RUN: llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -d -j .text -j .rodata -r %t_0.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: <_amdgpu_vs_main>:
 ; SHADERTEST: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST-NEXT: R_AMDGPU_REL32_LO    [[vs_data_sym:[.a-z]*]]
@@ -42,7 +42,7 @@
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -o %t_01.elf %gfxip %s
-; RUN: llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -D -r %t_01.elf | FileCheck -check-prefix=SHADERTEST2 %s
+; RUN: llvm-objdump --arch=amdgcn --disassemble-zeroes --mcpu=gfx900 -d -j .text -j .rodata -r %t_01.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2-LABEL: <_amdgpu_vs_main>:
 ; SHADERTEST2: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 4
 ; SHADERTEST2-NEXT: R_AMDGPU_REL32_LO    .rodata


### PR DESCRIPTION
llvm-objdump -D disassembles all sections, even .note, which contains
junk that caused the AMDGPU disassembler to fail some assertions. Work
around this by disassembling only the sections that are necessary for
the test to pass (even though this includes .rodata which does not
contain code).