### PR TITLE
Fix tests for LLVM patch D98152

### DIFF
--- a/llpc/test/shaderdb/extensions/OpExtInst_TestSignInt_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestSignInt_lit.frag
@@ -23,13 +23,9 @@ void main()
 ; SHADERTEST: = call i32 (...) @lgc.create.ssign.i32(i32
 ; SHADERTEST: = call <3 x i32> (...) @lgc.create.ssign.v3i32(<3 x i32>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = icmp slt i32 %{{.*}}, 1
-; SHADERTEST: = select i1 %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST: = icmp slt i32 %{{.*}}, 1
-; SHADERTEST: = select i1 %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST: = icmp sgt i32 %{{.*}}, -1
-; SHADERTEST: = select i1 %{{.*}}, i32 %{{.*}}, i32 -1
-; SHADERTEST: = icmp sgt i32 %{{.*}}, -1
+; SHADERTEST: = icmp {{slt i32 %.*, 1|sgt i32 %.*, 0}}
+; SHADERTEST: = select i1 %{{.*}}, {{i32 %.*, i32 1|i32 1, i32 %.*}}
+; SHADERTEST: = icmp {{sgt i32 %.*, -1|sge i32 %.*, 0}}
 ; SHADERTEST: = select i1 %{{.*}}, i32 %{{.*}}, i32 -1
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestSignIvec4_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestSignIvec4_lit.frag
@@ -14,22 +14,10 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call <4 x i32> (...) @lgc.create.ssign.v4i32(<4 x i32>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: = icmp slt i32 %{{.*}}, 1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST-DAG: = icmp slt i32 %{{.*}}, 1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST-DAG: = icmp slt i32 %{{.*}}, 1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST-DAG: = icmp slt i32 %{{.*}}, 1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 1
-; SHADERTEST-DAG: = icmp sgt i32 %{{.*}}, -1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 -1
-; SHADERTEST-DAG: = icmp sgt i32 %{{.*}}, -1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 -1
-; SHADERTEST-DAG: = icmp sgt i32 %{{.*}}, -1
-; SHADERTEST-DAG: = select i1 %{{.*}}, i32 %{{.*}}, i32 -1
-; SHADERTEST-DAG: = icmp sgt i32 %{{.*}}, -1
-; SHADERTEST: = select i1 %{{.*}}, i32 %{{.*}}, i32 -1
+; SHADERTEST: = icmp {{slt i32 %.*, 1|sgt <4 x i32> %.*, zeroinitializer}}
+; SHADERTEST-DAG: = select {{i1 %.*, i32 %.*, i32 1|<4 x i1> %.*, <4 x i32> <i32 1, i32 1, i32 1, i32 1>, <4 x i32> %.*}}
+; SHADERTEST-DAG: = icmp {{sgt i32 %.*, -1|sge <4 x i32> %.*, zeroinitializer}}
+; SHADERTEST-DAG: = select {{i1 %.*, i32 %.*, i32 -1|<4 x i1> %.*, <4 x i32> %.*, <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Update test checks so that pass both before and after this upstream LLVM
patch:

D98152 [InstCombine] Canonicalize SPF to min/max intrinsics

The effect of the patch is to canonicalize some compare/select sequences
differently, and to not scalarize them.