### PR TITLE
Use SPIRV-Headers canonical include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ add_library(khronos_spirv_interface INTERFACE)
 if(EXISTS ${SPIRV_HEADERS_PATH})
     target_include_directories(khronos_spirv_interface
         INTERFACE
-            ${SPIRV_HEADERS_PATH}/include/spirv
+            ${SPIRV_HEADERS_PATH}/include
             ${PROJECT_SOURCE_DIR}/include/khronos
     )
     if (NOT SPIRV_HEADERS_PATH_INTERNAL)
@@ -113,4 +113,3 @@ if(ICD_BUILD_LLPC)
 
     target_link_libraries(vkgc INTERFACE llpc)
 endif()
-

--- a/include/khronos/GLSL.std.450.h
+++ b/include/khronos/GLSL.std.450.h
@@ -32,7 +32,7 @@
 #pragma once
 
 #if EXTERNAL_SPIRV_HEADERS
-#include "unified1/GLSL.std.450.h"
+#include "spirv/unified1/GLSL.std.450.h"
 #else
 #include "spirv/GLSL.std.450.h"
 #endif

--- a/include/khronos/spirv.hpp
+++ b/include/khronos/spirv.hpp
@@ -32,10 +32,9 @@
 #pragma once
 
 #if EXTERNAL_SPIRV_HEADERS
-#include "unified1/spirv.hpp"
+#include "spirv/unified1/spirv.hpp"
 #else
 #include "spirv/spirv.hpp"
 #endif
 
 #include "devext/spv_amd_shader_early_and_late_fragment_tests.h"
-


### PR DESCRIPTION
The include path exported by SPIRV-Headers build files by default is
include/ (not include/spirv/). Using this path here allows downstream
builds with Bazel target dependencies to use EXTERNAL_SPIRV_HEADERS.