### PR TITLE
Add task shader support: Add new built-in stage mask

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1647,29 +1647,30 @@ void InOutBuilder::markBuiltInOutputUsage(BuiltInKind builtIn, unsigned arraySiz
 unsigned InOutBuilder::getBuiltInValidMask(BuiltInKind builtIn, bool isOutput) {
   // See BuiltInDefs.h for an explanation of the letter codes.
   enum class StageValidMask : unsigned {
-    C = (1 << ShaderStageCompute),
-    D = (1 << ShaderStageTessEval),
-    H = (1 << ShaderStageTessControl),
-    HD = (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval),
-    HDG = (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) | (1 << ShaderStageGeometry),
-    HDGP = (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) | (1 << ShaderStageGeometry) |
-           (1 << ShaderStageFragment),
-    HG = (1 << ShaderStageTessControl) | (1 << ShaderStageGeometry),
-    MG = (1 << ShaderStageGeometry),
-    MVG = (1 << ShaderStageVertex) | (1 << ShaderStageGeometry),
-    MVDG = (1 << ShaderStageVertex) | (1 << ShaderStageTessEval) | (1 << ShaderStageGeometry),
-    MVHDG = (1 << ShaderStageVertex) | (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) |
-            (1 << ShaderStageGeometry),
+    C = shaderStageToMask(ShaderStageCompute),
+    D = shaderStageToMask(ShaderStageTessEval),
+    H = shaderStageToMask(ShaderStageTessControl),
+    HD = shaderStageToMask(ShaderStageTessControl, ShaderStageTessEval),
+    HDG = shaderStageToMask(ShaderStageTessControl, ShaderStageTessEval, ShaderStageGeometry),
+    HDGP = shaderStageToMask(ShaderStageTessControl, ShaderStageTessEval, ShaderStageGeometry, ShaderStageFragment),
+    HG = shaderStageToMask(ShaderStageTessControl, ShaderStageGeometry),
+    M = shaderStageToMask(ShaderStageMesh),
+    MG = shaderStageToMask(ShaderStageMesh, ShaderStageGeometry),
+    MVG = shaderStageToMask(ShaderStageMesh, ShaderStageVertex, ShaderStageGeometry),
+    MVDG = shaderStageToMask(ShaderStageMesh, ShaderStageVertex, ShaderStageTessEval, ShaderStageGeometry),
+    MVHDG = shaderStageToMask(ShaderStageMesh, ShaderStageVertex, ShaderStageTessControl, ShaderStageTessEval,
+                              ShaderStageGeometry),
     N = 0,
-    P = (1 << ShaderStageFragment),
-    TMC = (1 << ShaderStageCompute),
-    TMV = (1 << ShaderStageVertex),
-    TMVHDGPC = (1 << ShaderStageVertex) | (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) |
-               (1 << ShaderStageGeometry) | (1 << ShaderStageFragment) | (1 << ShaderStageCompute),
-    V = (1 << ShaderStageVertex),
-    VDG = (1 << ShaderStageVertex) | (1 << ShaderStageTessEval) | (1 << ShaderStageGeometry),
-    VHDGP = (1 << ShaderStageVertex) | (1 << ShaderStageTessControl) | (1 << ShaderStageTessEval) |
-            (1 << ShaderStageGeometry) | (1 << ShaderStageFragment),
+    P = shaderStageToMask(ShaderStageFragment),
+    T = shaderStageToMask(ShaderStageTask),
+    TMC = shaderStageToMask(ShaderStageTask, ShaderStageMesh, ShaderStageCompute),
+    TMV = shaderStageToMask(ShaderStageTask, ShaderStageMesh, ShaderStageVertex),
+    TMVHDGPC = shaderStageToMask(ShaderStageTask, ShaderStageMesh, ShaderStageVertex, ShaderStageTessControl,
+                                 ShaderStageTessEval, ShaderStageGeometry, ShaderStageFragment, ShaderStageCompute),
+    V = shaderStageToMask(ShaderStageVertex),
+    VDG = shaderStageToMask(ShaderStageVertex, ShaderStageTessEval, ShaderStageGeometry),
+    VHDGP = shaderStageToMask(ShaderStageVertex, ShaderStageTessControl, ShaderStageTessEval, ShaderStageGeometry,
+                              ShaderStageFragment),
   };
 
   unsigned validMask = 0;

--- a/lgc/include/lgc/state/ShaderStage.h
+++ b/lgc/include/lgc/state/ShaderStage.h
@@ -42,8 +42,14 @@ class Type;
 namespace lgc {
 
 // Translates shader stage to corresponding stage mask.
-static inline unsigned shaderStageToMask(ShaderStage stage) {
-  return 1U << static_cast<unsigned>(stage);
+constexpr unsigned shaderStageToMask() {
+  return 0; // To end the recursive call
+}
+
+template <typename Stage, typename... Stages>
+constexpr unsigned shaderStageToMask(Stage theStage, Stages... otherStages) {
+  static_assert(std::is_enum<Stage>::value, "Can only be used with ShaderStage enums");
+  return (1U << static_cast<unsigned>(theStage)) | shaderStageToMask(otherStages...);
 }
 
 // Set shader stage metadata on every defined function in a module

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -39,8 +39,8 @@
 // 5. the type of the built-in.
 //
 // A valid string in (3) and (4) is one or more characters from the following, in this order:
-//  T   task shader (placeholder; not implemented)
-//  M   mesh shader (placeholder; not implemented)
+//  T   task shader
+//  M   mesh shader
 //  V   vertex shader
 //  H   tessellation control (hull) shader
 //  D   tessellation evaluation (domain) shader
@@ -104,4 +104,4 @@ BUILTIN(VertexIndex, 42, N, V, i32)                      // Index of current ver
 BUILTIN(ViewIndex, 4440, N, VHDGP, i32)                  // View index
 BUILTIN(ViewportIndex, 10, MVDG, P, i32)                 // Viewport index
 BUILTIN(WorkgroupId, 26, N, TMC, v3i32)                  // ID of global workgroup
-BUILTIN(WorkgroupSize, 25, N, C, v3i32)                  // Size of global workgroup
+BUILTIN(WorkgroupSize, 25, N, TMC, v3i32)                // Size of global workgroup


### PR DESCRIPTION
Previously, the stage mask T and M are not defined because of the
missing shader stage. Now, we can add them.