### PR TITLE
Add task shader support: Add new system values for task shader

### DIFF
--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -61,7 +61,7 @@ class PipelineState;
 // =====================================================================================================================
 // Internal numbering for shader inputs
 enum class ShaderInput : unsigned {
-  // CS SGPRs
+  // TasK/CS SGPRs
   WorkgroupId,       // WorkgroupId (v3i32)
   MultiDispatchInfo, // Multiple dispatch info, include TG_SIZE and etc.
 
@@ -134,7 +134,7 @@ enum class ShaderInput : unsigned {
   SampleCoverage,       // Sample coverage
   FixedXY,              // Fixed X/Y
 
-  // CS VGPRs
+  // Task/CS VGPRs
   LocalInvocationId, // LocalInvocationId (v3i32)
 
   Count

--- a/lgc/include/lgc/patch/SystemValues.h
+++ b/lgc/include/lgc/patch/SystemValues.h
@@ -59,6 +59,12 @@ public:
   // Get the descriptor for tessellation factor (TF) buffer (TCS output)
   llvm::Value *getTessFactorBufDesc();
 
+  // Get the descriptor for task payload ring buffer (for task and mesh shader)
+  llvm::Value *getTaskPayloadRingBufDesc();
+
+  // Get the descriptor for task draw data ring buffer (for task and mesh shader)
+  llvm::Value *getTaskDrawDataRingBufDesc();
+
   // Extract value of primitive ID (TCS)
   llvm::Value *getPrimitiveId();
 
@@ -85,6 +91,9 @@ public:
 
   // Get global internal table pointer as pointer to i8.
   llvm::Instruction *getInternalGlobalTablePtr();
+
+  // Get the mesh pipeline statistics buffer pointer as pointer to i8
+  llvm::Value *getMeshPipeStatsBufPtr();
 
   // Load descriptor from driver table
   llvm::Instruction *loadDescFromDriverTable(unsigned tableOffset, BuilderBase &builder);
@@ -119,6 +128,8 @@ private:
   llvm::Value *m_esGsRingBufDesc = nullptr; // ES -> GS ring buffer descriptor (VS, TES, and GS)
   llvm::Value *m_tfBufDesc = nullptr;       // Descriptor for tessellation factor (TF) buffer (TCS)
   llvm::Value *m_offChipLdsDesc = nullptr;  // Descriptor for off-chip LDS buffer (TCS and TES)
+  llvm::Value *m_taskPayloadRingBufDesc = nullptr;  // Descriptor for task payload ring buffer (task and mesh shader)
+  llvm::Value *m_taskDrawDataRingBufDesc = nullptr; // Descriptor for task draw data ring buffer (task and mesh shader)
   llvm::SmallVector<llvm::Value *, MaxGsStreams>
       m_gsVsRingBufDescs; // GS -> VS ring buffer descriptor (GS out and copy shader in)
   llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufDescs; // Stream-out buffer descriptors
@@ -133,6 +144,7 @@ private:
   llvm::SmallVector<llvm::Value *, 8> m_descTablePtrs;       // Descriptor table pointers
   llvm::SmallVector<llvm::Value *, 8> m_shadowDescTablePtrs; // Shadow descriptor table pointers
   llvm::Instruction *m_internalGlobalTablePtr = nullptr;     // Internal global table pointer
+  llvm::Value *m_meshPipeStatsBufPtr = nullptr;              // Mesh pipeline statistics buffer pointer
   llvm::Value *m_internalPerShaderTablePtr = nullptr;        // Internal per shader table pointer
   llvm::Instruction *m_streamOutTablePtr = nullptr;          // Stream-out buffer table pointer
   llvm::Instruction *m_pc = nullptr; // Program counter as <2 x i32>

--- a/lgc/include/lgc/state/Abi.h
+++ b/lgc/include/lgc/state/Abi.h
@@ -51,6 +51,8 @@ static const unsigned SiDrvTableTfBufferOffs = 9;
 static const unsigned SiDrvTableHsBuffeR0Offs = 10;
 static const unsigned SiDrvTableOffChipParamCache = 11;
 static const unsigned SiDrvTableSamplepos = 12;
+static const unsigned SiDrvTableTaskPayloadRingOffs = 13;
+static const unsigned SiDrvTableTaskDrawDataRingOffs = 14;
 
 static const unsigned SiStreamoutTableOffs = 0;
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -458,6 +458,16 @@ struct InterfaceData {
   // Indices of the arguments in shader entry-point
   struct {
     union {
+      // Task shader
+      struct {
+        unsigned dispatchDims;       // Dispatch dimensions
+        unsigned baseRingEntryIndex; // Base entry index (first workgroup) of mesh/task shader ring for current dispatch
+        unsigned pipeStatsBuf;       // Pipeline statistics buffer
+        unsigned workgroupId;        // Workgroup ID
+        unsigned multiDispatchInfo;  // Multiple dispatch info
+        unsigned localInvocationId;  // Local invocation ID
+      } task;
+
       // Vertex shader
       struct {
         unsigned baseVertex;         // Base vertex

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1109,6 +1109,17 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       auto numWorkgroupsPtrTy = PointerType::get(FixedVectorType::get(builder.getInt32Ty(), 3), ADDR_SPACE_CONST);
       userDataArgs.push_back(UserDataArg(numWorkgroupsPtrTy, "numWorkgroupsPtr", UserDataMapping::Workgroup, nullptr));
     }
+  } else if (m_shaderStage == ShaderStageTask) {
+    auto taskIntfData = m_pipelineState->getShaderInterfaceData(ShaderStageTask);
+    specialUserDataArgs.push_back(UserDataArg(FixedVectorType::get(builder.getInt32Ty(), 3), "meshTaskDispatchDims",
+                                              UserDataMapping::MeshTaskDispatchDims,
+                                              &taskIntfData->entryArgIdxs.task.dispatchDims));
+    specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshTaskRingIndex",
+                                              UserDataMapping::MeshTaskRingIndex,
+                                              &taskIntfData->entryArgIdxs.task.baseRingEntryIndex));
+    specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshPipeStatsBuf",
+                                              UserDataMapping::MeshPipeStatsBuf,
+                                              &taskIntfData->entryArgIdxs.task.pipeStatsBuf));
   }
 
   // Allocate register for stream-out buffer table, to go before the user data node args (unlike all the ones

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -165,9 +165,8 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
     }
     if (func->getCallingConv() == CallingConv::AMDGPU_CS || func->getCallingConv() == CallingConv::AMDGPU_Gfx) {
       // Set the work group size
-      const auto &csBuiltInUsage = m_pipelineState->getShaderModes()->getComputeShaderMode();
-      unsigned flatWorkGroupSize =
-          csBuiltInUsage.workgroupSizeX * csBuiltInUsage.workgroupSizeY * csBuiltInUsage.workgroupSizeZ;
+      const auto &computeMode = m_pipelineState->getShaderModes()->getComputeShaderMode();
+      unsigned flatWorkGroupSize = computeMode.workgroupSizeX * computeMode.workgroupSizeY * computeMode.workgroupSizeZ;
       auto flatWorkGroupSizeString = std::to_string(flatWorkGroupSize);
       builder.addAttribute("amdgpu-flat-work-group-size", flatWorkGroupSizeString + "," + flatWorkGroupSizeString);
     }

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -364,6 +364,12 @@ struct ShaderInputDesc {
   bool always;           // True if this register is always added as an argument; false to check usage
 };
 
+// SGPRs: Task (identical to CS)
+static const ShaderInputDesc TaskSgprInputs[] = {
+    {ShaderInput::WorkgroupId, offsetof(InterfaceData, entryArgIdxs.task.workgroupId), true},
+    {ShaderInput::MultiDispatchInfo, offsetof(InterfaceData, entryArgIdxs.task.multiDispatchInfo), true},
+};
+
 // SGPRs: VS as hardware ES
 static const ShaderInputDesc VsAsEsSgprInputs[] = {
     {ShaderInput::EsGsOffset, offsetof(InterfaceData, entryArgIdxs.vs.esGsOffset), true},
@@ -418,6 +424,11 @@ static const ShaderInputDesc FsSgprInputs[] = {
 static const ShaderInputDesc CsSgprInputs[] = {
     {ShaderInput::WorkgroupId, 0, true},
     {ShaderInput::MultiDispatchInfo, 0, true},
+};
+
+// VGPRs: Task (identical to CS)
+static const ShaderInputDesc TaskVgprInputs[] = {
+    {ShaderInput::LocalInvocationId, offsetof(InterfaceData, entryArgIdxs.task.localInvocationId), true},
 };
 
 // VGPRs: VS
@@ -556,6 +567,10 @@ uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage
   ArrayRef<ShaderInputDesc> vgprInputDescs;
 
   switch (shaderStage) {
+  case ShaderStageTask:
+    sgprInputDescs = TaskSgprInputs;
+    vgprInputDescs = TaskVgprInputs;
+    break;
   case ShaderStageVertex:
     if (!hasTs) {
       if (hasGs)

--- a/lgc/test/TaskShaderEntryArgs.lgc
+++ b/lgc/test/TaskShaderEntryArgs.lgc
@@ -1,0 +1,39 @@
+; Test that the arguments of task shader entry-point are generated as expected.
+
+; RUN: lgc -mcpu=gfx1030 --emit-llvm -o=- - <%s | FileCheck --check-prefixes=CHECK %s
+
+; In this test case, we check if the arguments of an empty task shader is correctly generated. Three new
+; arguments should be present in order: meshTaskDispatchDims, meshTaskRingIndex, meshPipeStatsBuf.
+;
+; CHECK-LABEL: lgc.shader.TASK.main
+; CHECK: <3 x i32> inreg %meshTaskDispatchDims, i32 inreg %meshTaskRingIndex, i32 inreg %meshPipeStatsBuf
+
+; ModuleID = 'lgcPipeline'
+source_filename = "llpctask1"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.TASK.main() local_unnamed_addr #0 !lgc.shaderstage !7 {
+.entry:
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!llpc.compute.mode = !{!0}
+!lgc.client = !{!1}
+!lgc.unlinked = !{!2}
+!lgc.options = !{!3}
+!lgc.options.TASK = !{!4}
+!lgc.input.assembly.state = !{!5}
+!amdgpu.pal.metadata.msgpack = !{!6}
+
+!0 = !{i32 32, i32 1, i32 1}
+!1 = !{!"Vulkan"}
+!2 = !{i32 1}
+!3 = !{i32 312583037, i32 1996946094, i32 943896560, i32 -1535752756, i32 1, i32 0, i32 0, i32 552, i32 0, i32 0, i32 1, i32 256, i32 256, i32 2}
+!4 = !{i32 1993623129, i32 -1672542133, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 20, i32 1800}
+!5 = !{i32 0, i32 3}
+!6 = !{!"\82\B0amdpal.pipelines\91\84\AA.registers\80\B0.spill_threshold\CE\FF\FF\FF\FF\B0.user_data_limit\00\AF.xgl_cache_info\82\B3.128_bit_cache_hash\92\CF|'\00\E3\DA\D4\DE\CE\CF\1DA!\FE\839\C2\13\AD.llpc_version\A452.2\AEamdpal.version\92\02\03"}
+!7 = !{i32 0}


### PR DESCRIPTION
- The arguments of task shader are similar to those of CS, but some new
  arguments are added. They are dispatchDims, baseRingEntryIndex,
  pipeStatsBuf.
- Add new entries to global table: SiDrvTableTaskPayloadRingOffs,
  SiDrvTableTaskDrawDataRingOffs.
- Add new methods to handle the new arguments of task shader. They will
  be used to lower task shader operations, such as task payload
  read/write, mesh count emit.