### PR TITLE
Add task shader support: Add new methods in LGC builder

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -513,6 +513,14 @@ public:
   llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn, InOutInfo outputInfo,
                                               llvm::Value *vertexIndex, llvm::Value *index) override final;
 
+  // Create a read from (part of) a task payload.
+  llvm::Value *CreateReadTaskPayload(llvm::Type *resultTy, llvm::Value *byteOffset,
+                                     const llvm::Twine &instName = "") override final;
+
+  // Create a write to (part of) a task payload.
+  llvm::Instruction *CreateWriteTaskPayload(llvm::Value *valueToWrite, llvm::Value *byteOffset,
+                                            const llvm::Twine &instName = "") override final;
+
 private:
   InOutBuilder() = delete;
   InOutBuilder(const InOutBuilder &) = delete;
@@ -691,6 +699,11 @@ public:
 
   // Create a helper invocation query. Only allowed in a fragment shader.
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName) override final;
+
+  // In the task shader, emit the current values of all per-task output variables to the current task output by
+  // specifying the group count XYZ of the launched child mesh tasks.
+  llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, llvm::Value *groupCountZ,
+                                         const llvm::Twine &instName) override final;
 
 private:
   MiscBuilder() = delete;

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -686,6 +686,16 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
                                                isa<UndefValue>(args[4]) ? nullptr : &*args[4]); // Index
   }
 
+  case BuilderRecorder::Opcode::ReadTaskPayload: {
+    return m_builder->CreateReadTaskPayload(call->getType(), // Result type
+                                            args[0]);        // Byte offset within the payload structure
+  }
+
+  case BuilderRecorder::Opcode::WriteTaskPayload: {
+    return m_builder->CreateWriteTaskPayload(args[0],  // Value to write
+                                             args[1]); // Byte offset within the payload structure
+  }
+
   // Replayer implementations of MiscBuilder methods
   case BuilderRecorder::Opcode::EmitVertex: {
     return m_builder->CreateEmitVertex(cast<ConstantInt>(args[0])->getZExtValue());
@@ -711,6 +721,9 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   }
   case BuilderRecorder::Opcode::IsHelperInvocation: {
     return m_builder->CreateIsHelperInvocation();
+  }
+  case BuilderRecorder::Opcode::EmitMeshTasks: {
+    return m_builder->CreateEmitMeshTasks(args[0], args[1], args[2]);
   }
   case BuilderRecorder::Opcode::TransposeMatrix: {
     return m_builder->CreateTransposeMatrix(args[0]);

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -117,6 +117,22 @@ Value *MiscBuilder::CreateIsHelperInvocation(const Twine &instName) {
 }
 
 // =====================================================================================================================
+// In the task shader, emit the current values of all per-task output variables to the current task output by
+// specifying the group count XYZ of the launched child mesh tasks.
+//
+// @param groupCountX : X dimension of the launched child mesh tasks
+// @param groupCountY : Y dimension of the launched child mesh tasks
+// @param groupCountZ : Z dimension of the launched child mesh tasks
+// @param instName : Name to give final instruction
+// @returns Instruction to emit mesh tasks
+Instruction *MiscBuilder::CreateEmitMeshTasks(Value *groupCountX, Value *groupCountY, Value *groupCountZ,
+                                              const llvm::Twine &instName) {
+  assert(m_shaderStage == ShaderStageTask); // Only valid for task shader
+  return emitCall(lgcName::MeshTaskEmitMeshTasks, getVoidTy(), {groupCountX, groupCountY, groupCountZ}, {},
+                  &*GetInsertPoint());
+}
+
+// =====================================================================================================================
 // Create a "readclock".
 //
 // @param realtime : Whether to read real-time clock counter

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -162,6 +162,8 @@ public:
     ReadBuiltInInput,
     ReadBuiltInOutput,
     WriteBuiltInOutput,
+    ReadTaskPayload,
+    WriteTaskPayload,
 
     // Matrix
     TransposeMatrix,
@@ -190,6 +192,7 @@ public:
     Derivative,
     DemoteToHelperInvocation,
     IsHelperInvocation,
+    EmitMeshTasks,
     GetWaveSize,
 
     // Subgroup
@@ -476,6 +479,14 @@ public:
                                         llvm::Value *elemIdx, unsigned locationCount, InOutInfo inputInfo,
                                         llvm::Value *vertexIndex, const llvm::Twine &instName = "") override final;
 
+  // Create a read of (part of) a task payload.
+  llvm::Value *CreateReadTaskPayload(llvm::Type *resultTy, llvm::Value *byteOffset,
+                                     const llvm::Twine &instName = "") override final;
+
+  // Create a write of (part of) a task payload.
+  llvm::Instruction *CreateWriteTaskPayload(llvm::Value *valueToWrite, llvm::Value *byteOffset,
+                                            const llvm::Twine &instName = "") override final;
+
   // -----------------------------------------------------------------------------------------------------------------
   // Miscellaneous operations
 
@@ -493,6 +504,8 @@ public:
   llvm::Instruction *CreateReadClock(bool realtime, const llvm::Twine &instName = "") override final;
   llvm::Instruction *CreateDemoteToHelperInvocation(const llvm::Twine &instName) override final;
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName) override final;
+  llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, llvm::Value *groupCountZ,
+                                         const llvm::Twine &instName) override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Builder methods implemented in MatrixBuilder

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -67,6 +67,10 @@ const static char TfBufferStore[] = "lgc.tfbuffer.store.";
 const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
 const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
 
+const static char MeshTaskReadTaskPayload[] = "lgc.mesh.task.read.task.payload";
+const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload";
+const static char MeshTaskEmitMeshTasks[] = "lgc.mesh.task.emit.mesh.tasks";
+
 // Get pointer to spill table (as pointer to i8)
 const static char SpillTable[] = "lgc.spill.table";
 // Get pointer to push constant (as pointer type indicated by the return type)

--- a/lgc/test/TaskShaderOps.lgc
+++ b/lgc/test/TaskShaderOps.lgc
@@ -1,0 +1,62 @@
+; Test that the operations of task shader are handled as expected.
+
+; RUN: lgc -mcpu=gfx1030 --emit-llvm -o=- - <%s | FileCheck --check-prefixes=CHECK %s
+
+; In this test case, we check if the operations of a task shader is correctly handled. Three operations
+; are ReadTaskPayload, WriteTaskPayload, EmitMeshTasks.
+;
+; CHECK-LABEL: lgc.shader.TASK.main
+; CHECK: call float @lgc.mesh.task.read.task.payload.f32.i32(i32 %{{[0-9]*}})
+; CHECK: call void @lgc.mesh.task.write.task.payload.i32.f32(i32 %{{[0-9]*}}, float %{{[0-9]*}})
+; CHECK: call void @lgc.mesh.task.emit.mesh.tasks(i32 3, i32 1, i32 1)
+
+; ModuleID = 'lgcPipeline'
+source_filename = "llpctask1"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn--amdpal"
+
+; Function Attrs: nounwind
+define dllexport spir_func void @lgc.shader.TASK.main() local_unnamed_addr #0 !lgc.shaderstage !7 {
+.entry:
+  %0 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 26, i32 0, i32 undef, i32 undef)
+  %__llpc_input_proxy_gl_WorkGroupID.0.vec.extract = extractelement <3 x i32> %0, i32 0
+  %1 = shl i32 %__llpc_input_proxy_gl_WorkGroupID.0.vec.extract, 3
+  %2 = or i32 %1, 4
+  %3 = call float (...) @lgc.create.read.task.payload.f32(i32 %2)
+  %4 = add i32 %1, 8
+  call void (...) @lgc.create.write.task.payload(float %3, i32 %4)
+  call void (...) @lgc.create.emit.mesh.tasks(i32 3, i32 1, i32 1)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @lgc.create.emit.mesh.tasks(...) local_unnamed_addr #0
+
+; Function Attrs: nounwind readonly willreturn
+declare <3 x i32> @lgc.create.read.builtin.input.v3i32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind readonly willreturn
+declare float @lgc.create.read.task.payload.f32(...) local_unnamed_addr #1
+
+; Function Attrs: nounwind
+declare void @lgc.create.write.task.payload(...) local_unnamed_addr #0
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly willreturn }
+
+!llpc.compute.mode = !{!0}
+!lgc.client = !{!1}
+!lgc.unlinked = !{!2}
+!lgc.options = !{!3}
+!lgc.options.TASK = !{!4}
+!lgc.input.assembly.state = !{!5}
+!amdgpu.pal.metadata.msgpack = !{!6}
+
+!0 = !{i32 32, i32 1, i32 1}
+!1 = !{!"Vulkan"}
+!2 = !{i32 1}
+!3 = !{i32 1931310406, i32 1408637002, i32 -1184926787, i32 1622008494, i32 1, i32 0, i32 0, i32 552, i32 0, i32 0, i32 1, i32 256, i32 256, i32 2}
+!4 = !{i32 -2080943554, i32 763869174, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 64, i32 0, i32 0, i32 3, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 20, i32 1800}
+!5 = !{i32 0, i32 3}
+!6 = !{!"\82\B0amdpal.pipelines\91\84\AA.registers\80\B0.spill_threshold\CE\FF\FF\FF\FF\B0.user_data_limit\00\AF.xgl_cache_info\82\B3.128_bit_cache_hash\92\CF\D2\9D\9C\FE\\\B1\0A\1C\CF\F6\0B\90\C8\8D\1Bu\BC\AD.llpc_version\A452.2\AEamdpal.version\92\02\03"}
+!7 = !{i32 0}


### PR DESCRIPTION
Add three new methods in LGC: CreateEmitMeshTasks,
CreateReadTaskPayload, CreateWriteTaskPayload. Those methods are used by
LLPC front-end in the future to perform the required operations in task
shader. They will be further lowered in later phases of LGC.