### PR TITLE
Additional includes to handle latest llvm upstream

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -34,6 +34,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/PassManager.h"
 
 namespace lgc {
 

--- a/lgc/include/lgc/patch/PatchLlvmIrInclusion.h
+++ b/lgc/include/lgc/patch/PatchLlvmIrInclusion.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "lgc/patch/Patch.h"
+#include "llvm/IR/PassManager.h"
 
 namespace lgc {
 

--- a/lgc/include/lgc/patch/PatchWorkarounds.h
+++ b/lgc/include/lgc/patch/PatchWorkarounds.h
@@ -34,6 +34,7 @@
 #include "lgc/util/Internal.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/Value.h"
 #include "llvm/Pass.h"
 

--- a/lgc/patch/PatchNullFragShader.h
+++ b/lgc/patch/PatchNullFragShader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "lgc/patch/Patch.h"
+#include "llvm/IR/PassManager.h"
 
 namespace lgc {
 


### PR DESCRIPTION
LLVM change https://reviews.llvm.org/D120659 removes some unnecessary includes

Adding the now required includes to cope with this change in anticipation of merge