### PR TITLE
Add tests for barycentric

### DIFF
--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_line_list.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_line_list.pipe
@@ -1,0 +1,154 @@
+// This test tests barycentric coordinate when topology is VK_PRIMITIVE_TOPOLOGY_LINE_LIST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
+; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32(i32 5286)
+
+// barycentric coordinate: (1 - i - j, i + j, 0)
+; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,
+; SHADERTEST: %[[jCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 1
+; SHADERTEST: %[[iCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 0
+; SHADERTEST: %[[subICoord:[0-9]*]] = fsub float 1.000000e+00, %[[iCoord]]
+; SHADERTEST: fsub float %[[subICoord]], %[[jCoord]]
+; SHADERTEST: fadd float %[[iCoord]], %[[jCoord]]
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 52
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main" %9 %12 %20 %31
+               OpDecorate %9 Location 0
+               OpDecorate %12 Location 1
+               OpMemberDecorate %_struct_18 0 BuiltIn Position
+               OpMemberDecorate %_struct_18 1 BuiltIn PointSize
+               OpMemberDecorate %_struct_18 2 BuiltIn ClipDistance
+               OpMemberDecorate %_struct_18 3 BuiltIn CullDistance
+               OpDecorate %_struct_18 Block
+               OpMemberDecorate %_struct_24 0 ColMajor
+               OpMemberDecorate %_struct_24 0 Offset 0
+               OpMemberDecorate %_struct_24 0 MatrixStride 16
+               OpDecorate %_struct_24 Block
+               OpDecorate %31 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+          %9 = OpVariable %_ptr_Output_v3float Output
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %12 = OpVariable %_ptr_Input_v4float Input
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+ %_struct_18 = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output__struct_18 = OpTypePointer Output %_struct_18
+         %20 = OpVariable %_ptr_Output__struct_18 Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%mat4v4float = OpTypeMatrix %v4float 4
+ %_struct_24 = OpTypeStruct %mat4v4float
+%_ptr_PushConstant__struct_24 = OpTypePointer PushConstant %_struct_24
+         %26 = OpVariable %_ptr_PushConstant__struct_24 PushConstant
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+         %31 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %int_1 = OpConstant %int 1
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v4float %12
+         %14 = OpVectorShuffle %v3float %13 %13 0 1 2
+               OpStore %9 %14
+         %28 = OpAccessChain %_ptr_PushConstant_mat4v4float %26 %int_0
+         %29 = OpLoad %mat4v4float %28
+         %30 = OpTranspose %mat4v4float %29
+         %32 = OpLoad %v4float %31
+         %33 = OpMatrixTimesVector %v4float %30 %32
+         %35 = OpAccessChain %_ptr_Output_v4float %20 %int_0
+               OpStore %35 %33
+         %39 = OpAccessChain %_ptr_Output_float %20 %int_1
+               OpStore %39 %float_1
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %9 %12
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %9 Location 0
+               OpDecorate %12 BuiltIn BaryCoordKHR
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %9 = OpVariable %_ptr_Output_v4float Output
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+         %12 = OpVariable %_ptr_Input_v3float Input
+    %float_1 = OpConstant %float 1
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v3float %12
+         %15 = OpCompositeExtract %float %13 0
+         %16 = OpCompositeExtract %float %13 1
+         %17 = OpCompositeExtract %float %13 2
+         %18 = OpCompositeConstruct %v4float %15 %16 %17 %float_1
+               OpStore %9 %18
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 66
+userDataNode[0].type = PushConst
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 16
+userDataNode[0].set = 0xFFFFFFFF
+userDataNode[0].binding = 0
+userDataNode[1].visibility = 4
+userDataNode[1].type = StreamOutTableVaPtr
+userDataNode[1].offsetInDwords = 17
+userDataNode[1].sizeInDwords = 1
+userDataNode[2].visibility = 2
+userDataNode[2].type = IndirectUserDataVaPtr
+userDataNode[2].offsetInDwords = 18
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST
+provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+nggState.enableNgg = 1
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 32
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[1].offset = 16

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
@@ -1,0 +1,161 @@
+// This test tests barycentric coordinate when topology is VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
+; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32(i32 5286)
+
+// barycentric coordinate: (i ,j , 1 - i - j).
+// Triangle_Fan depends the parity of primitive.
+; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,
+; SHADERTEST: %[[jCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 1
+; SHADERTEST: %[[iCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 0
+; SHADERTEST: %[[subICoord:[0-9]*]] = fsub float 1.000000e+00, %[[iCoord]]
+; SHADERTEST: %[[kCoord:[0-9]*]] = fsub float %[[subICoord]], %[[jCoord]]
+; SHADERTEST: %[[P:[0-9]*]] = call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
+; SHADERTEST: %[[primID:[0-9]*]] = bitcast float %[[P]] to i32
+; SHADERTEST: %[[and:[0-9]*]] = and i32 %[[primID]], 1
+; SHADERTEST: %[[even:[0-9]*]] = icmp eq i32 %[[and]], 0
+; SHADERTEST: select i1 %[[even]], float %[[kCoord]], float %[[jCoord]]
+; SHADERTEST: select i1 %[[even]], float %[[iCoord]], float %[[kCoord]]
+; SHADERTEST: select i1 %[[even]], float %[[jCoord]], float %[[iCoord]]
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 52
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main" %9 %12 %20 %31
+               OpDecorate %9 Location 0
+               OpDecorate %12 Location 1
+               OpMemberDecorate %_struct_18 0 BuiltIn Position
+               OpMemberDecorate %_struct_18 1 BuiltIn PointSize
+               OpMemberDecorate %_struct_18 2 BuiltIn ClipDistance
+               OpMemberDecorate %_struct_18 3 BuiltIn CullDistance
+               OpDecorate %_struct_18 Block
+               OpMemberDecorate %_struct_24 0 ColMajor
+               OpMemberDecorate %_struct_24 0 Offset 0
+               OpMemberDecorate %_struct_24 0 MatrixStride 16
+               OpDecorate %_struct_24 Block
+               OpDecorate %31 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+          %9 = OpVariable %_ptr_Output_v3float Output
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %12 = OpVariable %_ptr_Input_v4float Input
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+ %_struct_18 = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output__struct_18 = OpTypePointer Output %_struct_18
+         %20 = OpVariable %_ptr_Output__struct_18 Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%mat4v4float = OpTypeMatrix %v4float 4
+ %_struct_24 = OpTypeStruct %mat4v4float
+%_ptr_PushConstant__struct_24 = OpTypePointer PushConstant %_struct_24
+         %26 = OpVariable %_ptr_PushConstant__struct_24 PushConstant
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+         %31 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %int_1 = OpConstant %int 1
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v4float %12
+         %14 = OpVectorShuffle %v3float %13 %13 0 1 2
+               OpStore %9 %14
+         %28 = OpAccessChain %_ptr_PushConstant_mat4v4float %26 %int_0
+         %29 = OpLoad %mat4v4float %28
+         %30 = OpTranspose %mat4v4float %29
+         %32 = OpLoad %v4float %31
+         %33 = OpMatrixTimesVector %v4float %30 %32
+         %35 = OpAccessChain %_ptr_Output_v4float %20 %int_0
+               OpStore %35 %33
+         %39 = OpAccessChain %_ptr_Output_float %20 %int_1
+               OpStore %39 %float_1
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %9 %12
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %9 Location 0
+               OpDecorate %12 BuiltIn BaryCoordKHR
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %9 = OpVariable %_ptr_Output_v4float Output
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+         %12 = OpVariable %_ptr_Input_v3float Input
+    %float_1 = OpConstant %float 1
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v3float %12
+         %15 = OpCompositeExtract %float %13 0
+         %16 = OpCompositeExtract %float %13 1
+         %17 = OpCompositeExtract %float %13 2
+         %18 = OpCompositeConstruct %v4float %15 %16 %17 %float_1
+               OpStore %9 %18
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 66
+userDataNode[0].type = PushConst
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 16
+userDataNode[0].set = 0xFFFFFFFF
+userDataNode[0].binding = 0
+userDataNode[1].visibility = 4
+userDataNode[1].type = StreamOutTableVaPtr
+userDataNode[1].offsetInDwords = 17
+userDataNode[1].sizeInDwords = 1
+userDataNode[2].visibility = 2
+userDataNode[2].type = IndirectUserDataVaPtr
+userDataNode[2].offsetInDwords = 18
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN
+provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+nggState.enableNgg = 1
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 32
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[1].offset = 16

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_list.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_list.pipe
@@ -1,0 +1,153 @@
+// This test tests barycentric coordinate when topology is VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
+; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32(i32 5286)
+
+// barycentric coordinate: (i ,j , 1 - i - j)
+; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,
+; SHADERTEST: %[[jCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 1
+; SHADERTEST: %[[iCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 0
+; SHADERTEST: %[[subICoord:[0-9]*]] = fsub float 1.000000e+00, %[[iCoord]]
+; SHADERTEST: fsub float %[[subICoord]], %[[jCoord]]
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 52
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main" %9 %12 %20 %31
+               OpDecorate %9 Location 0
+               OpDecorate %12 Location 1
+               OpMemberDecorate %_struct_18 0 BuiltIn Position
+               OpMemberDecorate %_struct_18 1 BuiltIn PointSize
+               OpMemberDecorate %_struct_18 2 BuiltIn ClipDistance
+               OpMemberDecorate %_struct_18 3 BuiltIn CullDistance
+               OpDecorate %_struct_18 Block
+               OpMemberDecorate %_struct_24 0 ColMajor
+               OpMemberDecorate %_struct_24 0 Offset 0
+               OpMemberDecorate %_struct_24 0 MatrixStride 16
+               OpDecorate %_struct_24 Block
+               OpDecorate %31 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+          %9 = OpVariable %_ptr_Output_v3float Output
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %12 = OpVariable %_ptr_Input_v4float Input
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+ %_struct_18 = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output__struct_18 = OpTypePointer Output %_struct_18
+         %20 = OpVariable %_ptr_Output__struct_18 Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%mat4v4float = OpTypeMatrix %v4float 4
+ %_struct_24 = OpTypeStruct %mat4v4float
+%_ptr_PushConstant__struct_24 = OpTypePointer PushConstant %_struct_24
+         %26 = OpVariable %_ptr_PushConstant__struct_24 PushConstant
+%_ptr_PushConstant_mat4v4float = OpTypePointer PushConstant %mat4v4float
+         %31 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %int_1 = OpConstant %int 1
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v4float %12
+         %14 = OpVectorShuffle %v3float %13 %13 0 1 2
+               OpStore %9 %14
+         %28 = OpAccessChain %_ptr_PushConstant_mat4v4float %26 %int_0
+         %29 = OpLoad %mat4v4float %28
+         %30 = OpTranspose %mat4v4float %29
+         %32 = OpLoad %v4float %31
+         %33 = OpMatrixTimesVector %v4float %30 %32
+         %35 = OpAccessChain %_ptr_Output_v4float %20 %int_0
+               OpStore %35 %33
+         %39 = OpAccessChain %_ptr_Output_float %20 %int_1
+               OpStore %39 %float_1
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+               OpCapability Shader
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %9 %12
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %9 Location 0
+               OpDecorate %12 BuiltIn BaryCoordKHR
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %9 = OpVariable %_ptr_Output_v4float Output
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+         %12 = OpVariable %_ptr_Input_v3float Input
+    %float_1 = OpConstant %float 1
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %13 = OpLoad %v3float %12
+         %15 = OpCompositeExtract %float %13 0
+         %16 = OpCompositeExtract %float %13 1
+         %17 = OpCompositeExtract %float %13 2
+         %18 = OpCompositeConstruct %v4float %15 %16 %17 %float_1
+               OpStore %9 %18
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 66
+userDataNode[0].type = PushConst
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 16
+userDataNode[0].set = 0xFFFFFFFF
+userDataNode[0].binding = 0
+userDataNode[1].visibility = 4
+userDataNode[1].type = StreamOutTableVaPtr
+userDataNode[1].offsetInDwords = 17
+userDataNode[1].sizeInDwords = 1
+userDataNode[2].visibility = 2
+userDataNode[2].type = IndirectUserDataVaPtr
+userDataNode[2].offsetInDwords = 18
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+nggState.enableNgg = 1
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 32
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[1].offset = 16

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestPervertexVariable.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestPervertexVariable.pipe
@@ -1,0 +1,165 @@
+// This test tests pervertex variable, the input variable is 2-dim array, we must load value for each vertex,
+// the index is 0-2.
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: %{{[0-9]*}} = call float {{.*}} @lgc.create.read.pervertex.input.f32(i32 0, i32 0, i32 0, i32 0, i32 195, i32 0)
+; SHADERTEST: %{{[0-9]*}} = call float {{.*}} @lgc.create.read.pervertex.input.f32(i32 0, i32 1, i32 0, i32 0, i32 195, i32 0)
+; SHADERTEST: %{{[0-9]*}} = call float {{.*}} @lgc.create.read.pervertex.input.f32(i32 0, i32 0, i32 0, i32 0, i32 195, i32 1)
+; SHADERTEST: %{{[0-9]*}} = call float {{.*}} @lgc.create.read.pervertex.input.f32(i32 0, i32 1, i32 0, i32 0, i32 195, i32 1)
+; SHADERTEST: %{{[0-9]*}} = call float {{.*}} @lgc.create.read.pervertex.input.f32(i32 0, i32 0, i32 0, i32 0, i32 195, i32 2)
+; SHADERTEST: %{{[0-9]*}} = call float {{.*}} @lgc.create.read.pervertex.input.f32(i32 0, i32 1, i32 0, i32 0, i32 195, i32 2)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+
+[Version]
+version = 52
+
+[VsSpirv]
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %4 "main" %gl_VertexIndex %19 %30 %36
+               OpDecorate %gl_VertexIndex BuiltIn VertexIndex
+               OpDecorate %19 Location 0
+               OpMemberDecorate %_struct_28 0 BuiltIn Position
+               OpMemberDecorate %_struct_28 1 BuiltIn PointSize
+               OpDecorate %_struct_28 Block
+               OpDecorate %36 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Input_int = OpTypePointer Input %int
+%gl_VertexIndex = OpVariable %_ptr_Input_int Input
+      %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_arr_float_uint_2 = OpTypeArray %float %uint_2
+%_ptr_Output__arr_float_uint_2 = OpTypePointer Output %_arr_float_uint_2
+         %19 = OpVariable %_ptr_Output__arr_float_uint_2 Output
+    %float_3 = OpConstant %float 3
+    %v4float = OpTypeVector %float 4
+ %_struct_28 = OpTypeStruct %v4float %float
+%_ptr_Output__struct_28 = OpTypePointer Output %_struct_28
+         %30 = OpVariable %_ptr_Output__struct_28 Output
+    %float_1 = OpConstant %float 1
+%_ptr_Output_float = OpTypePointer Output %float
+      %int_0 = OpConstant %int 0
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+         %36 = OpVariable %_ptr_Input_v4float Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+          %8 = OpVariable %_ptr_Function_int Function
+         %11 = OpLoad %int %gl_VertexIndex
+         %13 = OpIAdd %int %11 %int_1
+               OpStore %8 %13
+         %20 = OpLoad %int %8
+         %21 = OpConvertSToF %float %20
+         %23 = OpLoad %int %8
+         %24 = OpConvertSToF %float %23
+         %25 = OpFMul %float %float_3 %24
+         %26 = OpCompositeConstruct %_arr_float_uint_2 %21 %25
+               OpStore %19 %26
+         %33 = OpAccessChain %_ptr_Output_float %30 %int_1
+               OpStore %33 %float_1
+         %37 = OpLoad %v4float %36
+         %39 = OpAccessChain %_ptr_Output_v4float %30 %int_0
+               OpStore %39 %37
+               OpReturn
+               OpFunctionEnd
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+	       OpCapability Shader
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %15 %40
+               OpExecutionMode %4 OriginUpperLeft
+               OpDecorate %15 Location 0
+               OpDecorate %15 PerVertexKHR
+               OpDecorate %40 Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+%_arr_float_uint_2 = OpTypeArray %float %uint_2
+     %uint_3 = OpConstant %uint 3
+%_arr__arr_float_uint_2_uint_3 = OpTypeArray %_arr_float_uint_2 %uint_3
+%_ptr_Input__arr__arr_float_uint_2_uint_3 = OpTypePointer Input %_arr__arr_float_uint_2_uint_3
+         %15 = OpVariable %_ptr_Input__arr__arr_float_uint_2_uint_3 Input
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Input_float = OpTypePointer Input %float
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+         %40 = OpVariable %_ptr_Output_v4float Output
+    %float_1 = OpConstant %float 1
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+          %8 = OpVariable %_ptr_Function_float Function
+         %25 = OpVariable %_ptr_Function_float Function
+         %31 = OpVariable %_ptr_Function_float Function
+         %19 = OpAccessChain %_ptr_Input_float %15 %int_0 %int_0
+         %20 = OpLoad %float %19
+         %22 = OpAccessChain %_ptr_Input_float %15 %int_0 %int_1
+         %23 = OpLoad %float %22
+         %24 = OpFAdd %float %20 %23
+               OpStore %8 %24
+         %26 = OpAccessChain %_ptr_Input_float %15 %int_1 %int_0
+         %27 = OpLoad %float %26
+         %28 = OpAccessChain %_ptr_Input_float %15 %int_1 %int_1
+         %29 = OpLoad %float %28
+         %30 = OpFAdd %float %27 %29
+               OpStore %25 %30
+         %33 = OpAccessChain %_ptr_Input_float %15 %int_2 %int_0
+         %34 = OpLoad %float %33
+         %35 = OpAccessChain %_ptr_Input_float %15 %int_2 %int_1
+         %36 = OpLoad %float %35
+         %37 = OpFAdd %float %34 %36
+               OpStore %31 %37
+         %41 = OpLoad %float %8
+         %42 = OpLoad %float %25
+         %43 = OpLoad %float %31
+         %45 = OpCompositeConstruct %v4float %41 %42 %43 %float_1
+               OpStore %40 %45
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 4
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 2
+userDataNode[1].type = IndirectUserDataVaPtr
+userDataNode[1].offsetInDwords = 2
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+


### PR DESCRIPTION
Add four tests for barycentric. Three tests is for baryCoord, the shader
is the same, different topology will match different instructions; the other
is for testing pervertex input data.