### PR TITLE
Support workgroup_memory_explicit_layout

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -243,7 +243,8 @@ void SpirvLower::registerPasses(lgc::PassManager &passMgr) {
 void SpirvLower::replaceGlobal(Context *context, GlobalVariable *original, GlobalVariable *replacement) {
   removeConstantExpr(context, original);
   Builder *builder = context->getBuilder();
-  for (User *user : original->users()) {
+  SmallVector<User *> users(original->users());
+  for (User *user : users) {
     Instruction *inst = cast<Instruction>(user);
     builder->SetInsertPoint(inst);
     Value *replacedValue = builder->CreateBitCast(replacement, original->getType());

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -72,6 +72,7 @@ private:
   void lowerInOutInPlace();
   void lowerBufferBlock();
   void lowerPushConsts();
+  void lowerAliasedVal();
 
   void cleanupReturnBlock();
 

--- a/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
+++ b/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
@@ -1,0 +1,111 @@
+; Test workgroup memory explicit layout. Workgroup variables can be declared in blocks, and then use the same
+; explicit layout decorations (e.g. Offset, ArrayStride) as other storage classes; All the Workgroup blocks share
+; the same underlying storage and either all or none of the variables must be explicitly laid out.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: @[[LDS0:[^ ]*]] = addrspace(3) global <{ [8 x i32] }> undef, align 16
+; SHADERTEST: @[[LDS1:[^ ]*]] = addrspace(3) global <{ [4 x i32] }> undef, align 16
+; SHADERTEST: @[[LDS2:[^ ]*]] = addrspace(3) global <{ [16 x i8], [4 x i32] }> undef, align 16
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 0), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 2), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 3), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, <{ [16 x i8], [4 x i32] }> addrspace(3)* @[[LDS2]], i32 0, i32 1, i32 0), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, <{ [16 x i8], [4 x i32] }> addrspace(3)* @[[LDS2]], i32 0, i32 1, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, <{ [16 x i8], [4 x i32] }> addrspace(3)* @[[LDS2]], i32 0, i32 1, i32 2), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, <{ [16 x i8], [4 x i32] }> addrspace(3)* @[[LDS2]], i32 0, i32 1, i32 3), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 0), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 1), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 2), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 3), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 4), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 5), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 6), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 7), align 4
+
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: @[[LDS:[^ ]*]] = local_unnamed_addr addrspace(3) global <{ [8 x i32] }> undef, align 16
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 0), align 16
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 2), align 8
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 3), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 4), align 16
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 5), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 6), align 8
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 7), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 0), align 16
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 1), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 2), align 8
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 3), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 4), align 16
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 5), align 4
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 6), align 8
+; index = 7 is optimized.
+
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 31
+; Schema: 0
+               OpCapability Shader
+               OpCapability WorkgroupMemoryExplicitLayoutKHR
+               OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %1 "main" %2 %3 %4 %5 %6 %7
+               OpExecutionMode %1 LocalSize 1 1 1
+               OpDecorate %_struct_8 Block
+               OpDecorate %_struct_9 Block
+               OpDecorate %_struct_10 Block
+               OpMemberDecorate %_struct_8 0 Offset 0
+               OpDecorate %_arr_uint_uint_32 ArrayStride 4
+               OpMemberDecorate %_struct_9 0 Offset 0
+               OpMemberDecorate %_struct_10 0 Offset 16
+               OpDecorate %_arr_uint_uint_16 ArrayStride 4
+               OpDecorate %2 DescriptorSet 0
+               OpDecorate %2 Binding 0
+               OpDecorate %3 DescriptorSet 0
+               OpDecorate %3 Binding 1
+               OpDecorate %4 DescriptorSet 0
+               OpDecorate %4 Binding 2
+               OpDecorate %5 Aliased
+               OpDecorate %6 Aliased
+               OpDecorate %7 Aliased
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_4 = OpConstant %uint 4
+     %uint_8 = OpConstant %uint 8
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+%_arr_uint_uint_32 = OpTypeArray %uint %uint_8
+%_arr_uint_uint_16 = OpTypeArray %uint %uint_4
+%_ptr_Workgroup__arr_uint_uint_16 = OpTypePointer Workgroup %_arr_uint_uint_16
+%_ptr_StorageBuffer__arr_uint_uint_16 = OpTypePointer StorageBuffer %_arr_uint_uint_16
+  %_struct_8 = OpTypeStruct %_arr_uint_uint_32
+  %_struct_9 = OpTypeStruct %_arr_uint_uint_16
+ %_struct_10 = OpTypeStruct %_arr_uint_uint_16
+%_ptr_StorageBuffer__struct_9 = OpTypePointer StorageBuffer %_struct_9
+%_ptr_StorageBuffer__struct_9_0 = OpTypePointer StorageBuffer %_struct_9
+%_ptr_StorageBuffer__struct_8 = OpTypePointer StorageBuffer %_struct_8
+%_ptr_Workgroup__struct_8 = OpTypePointer Workgroup %_struct_8
+%_ptr_Workgroup__struct_9 = OpTypePointer Workgroup %_struct_9
+%_ptr_Workgroup__struct_10 = OpTypePointer Workgroup %_struct_10
+          %5 = OpVariable %_ptr_Workgroup__struct_8 Workgroup
+          %6 = OpVariable %_ptr_Workgroup__struct_9 Workgroup
+          %7 = OpVariable %_ptr_Workgroup__struct_10 Workgroup
+          %2 = OpVariable %_ptr_StorageBuffer__struct_9 StorageBuffer
+          %3 = OpVariable %_ptr_StorageBuffer__struct_9_0 StorageBuffer
+          %4 = OpVariable %_ptr_StorageBuffer__struct_8 StorageBuffer
+          %1 = OpFunction %void None %19
+         %28 = OpLabel
+               OpCopyMemory %6 %2
+         %29 = OpAccessChain %_ptr_Workgroup__arr_uint_uint_16 %7 %uint_0
+         %30 = OpAccessChain %_ptr_StorageBuffer__arr_uint_uint_16 %3 %uint_0
+               OpCopyMemory %29 %30
+               OpCopyMemory %4 %5
+               OpReturn
+               OpFunctionEnd

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -216,6 +216,7 @@ const static char PushConst[] = "spirv.PushConst";
 const static char Resource[] = "spirv.Resource";
 const static char ExecutionModel[] = "spirv.ExecutionModel";
 const static char NonUniform[] = "spirv.NonUniform";
+const static char Lds[] = "spirv.Lds";
 } // namespace gSPIRVMD
 
 namespace gSPIRVName {

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -570,6 +570,9 @@ inline bool isValid(spv::Capability V) {
   case CapabilityDotProductInputAllKHR:
   case CapabilityDotProductInput4x8BitKHR:
   case CapabilityDotProductInput4x8BitPackedKHR:
+  case CapabilityWorkgroupMemoryExplicitLayoutKHR:
+  case CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR:
+  case CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR:
     return true;
   default:
     return false;

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -465,6 +465,9 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityDotProductInputAllKHR, "DotProductInputAllKHR");
   add(CapabilityDotProductInput4x8BitKHR, "DotProductInput4x8BitKHR");
   add(CapabilityDotProductInput4x8BitPackedKHR, "DotProductInput4x8BitPackedKHR");
+  add(CapabilityWorkgroupMemoryExplicitLayoutKHR, "WorkgroupMemoryExplicitLayoutKHR");
+  add(CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR, "WorkgroupMemoryExplicitLayout8BitAccessKHR");
+  add(CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR, "WorkgroupMemoryExplicitLayout16BitAccessKHR");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 


### PR DESCRIPTION
Workgroup variables can be declared in blocks, and then use the same explicit
layout decorations (e.g. Offset, ArrayStride) as other storage classes.All the
Workgroup blocks share the same underlying storage.