### PR TITLE
Update unit tests gtest and gmock name

### DIFF
--- a/llpc/unittests/CMakeLists.txt
+++ b/llpc/unittests/CMakeLists.txt
@@ -39,7 +39,7 @@ find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
 
 # Find all the LLVM libraries necessary to use the LLVM components in gtest/gmock.
 llvm_map_components_to_libnames(llvm_testing_support_lib TestingSupport)
-set(LLVM_GTEST_LIBS gtest gtest_main ${llvm_testing_support_lib})
+set(LLVM_GTEST_LIBS llvm_gtest llvm_gtest_main ${llvm_testing_support_lib})
 if(LLVM_PTHREAD_LIB)
   list(APPEND LLVM_GTEST_LIBS pthread)
 endif()


### PR DESCRIPTION
Upstream llvm change to rename the included gtest and gmock so it doesn't clash
with a third-party installation means that our testing fails to compile.

Make the necessary changes for this to work.
Note: this may break unit testing until amd-gfx is fully merged.