### PR TITLE
Fix getting the code size for a shader module.

### DIFF
--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -446,7 +446,7 @@ BinaryData ShaderModuleHelper::getShaderCode(const ShaderModuleBuildInfo *shader
 unsigned ShaderModuleHelper::getCodeSize(const ShaderModuleBuildInfo *shaderInfo) {
   const BinaryData& shaderBinary = shaderInfo->shaderBin;
   bool trimDebugInfo = cl::TrimDebugInfo;
-  if (trimDebugInfo)
+  if (!trimDebugInfo)
     return shaderBinary.codeSize;
   return ShaderModuleHelper::trimSpirvDebugInfo(&shaderBinary, {});
 }


### PR DESCRIPTION
No new tests were added because this is fixing existing tests that are currently failing:

```
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugExpression.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugLexicalBlock.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypeArray.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypeEnum.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypeFunction.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypeInheritance.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypePointer.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypeQualifier.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypeVector.spvasm
  LLPC_SHADERTEST :: shaderdb/debug_info/DebugInfo_DebugTypedef.spvasm
```