### PR TITLE
Fix DiscardToDemoteTransformations test for SPIR-V 1.6

### DIFF
--- a/llpc/test/shaderdb/general/DiscardToDemoteTransformations.frag
+++ b/llpc/test/shaderdb/general/DiscardToDemoteTransformations.frag
@@ -5,7 +5,7 @@
 // RUN:   | tee %t.disabled | FileCheck %s --check-prefix=DISABLED
 //
 // DISABLED-LABEL: {{^}}SPIR-V disassembly:
-// DISABLED:       {{^}} OpKill
+// DISABLED:       {{^}} {{OpKill|OpTerminateInvocation}}
 // DISABLED:             OpImageSampleImplicitLod
 // DISABLED-LABEL: {{^}}// LLPC SPIR-V lowering results
 // DISABLED:       call void (...) @lgc.create.kill()
@@ -23,7 +23,7 @@
 // RUN:   | tee %t.enabled | FileCheck %s --check-prefix=ENABLED
 //
 // ENABLED-LABEL: {{^}}SPIR-V disassembly:
-// ENABLED:       {{^}} OpKill
+// ENABLED:       {{^}} {{OpKill|OpTerminateInvocation}}
 // ENABLED:             OpImageSampleImplicitLod
 // ENABLED-LABEL: {{^}}// LLPC SPIR-V lowering results
 // ENABLED:       call void (...) @lgc.create.kill()


### PR DESCRIPTION
This test relied on `discard` being compiled to OpKill. In SPIR-V 1.6 it
is compiled to OpTerminateInvocation instead. Change the test to accept
either opcode.