### PR TITLE
Add task shader support: Add new class MeshTaskShader to process task/mesh shader

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -154,6 +154,7 @@ target_sources(LLVMlgc PRIVATE
     patch/Gfx6ConfigBuilder.cpp
     patch/Gfx9Chip.cpp
     patch/Gfx9ConfigBuilder.cpp
+    patch/MeshTaskShader.cpp
     patch/NggLdsManager.cpp
     patch/NggPrimShader.cpp
     patch/Patch.cpp

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1,0 +1,463 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  MeshTaskShader.cpp
+ * @brief LLPC source file: contains implementation of class lgc::MeshTaskShader.
+ ***********************************************************************************************************************
+ */
+#include "MeshTaskShader.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
+#define DEBUG_TYPE "lgc-mesh-task-shader"
+
+using namespace llvm;
+
+namespace lgc {
+
+// =====================================================================================================================
+// Constructor
+//
+// @param pipelineState : Pipeline state
+MeshTaskShader::MeshTaskShader(PipelineState *pipelineState)
+    : m_pipelineState(pipelineState), m_builder(std::make_unique<IRBuilder<>>(pipelineState->getContext())) {
+  assert(pipelineState->getTargetInfo().getGfxIpVersion() >= GfxIpVersion({10, 3})); // Must be GFX10.3+
+  m_pipelineSysValues.initialize(m_pipelineState);
+}
+
+// =====================================================================================================================
+// Destructor
+MeshTaskShader::~MeshTaskShader() {
+  m_pipelineSysValues.clear();
+}
+
+// =====================================================================================================================
+// Process the mesh/task shader lowering.
+//
+// @param taskEntryPoint : Entry-point of task shader (could be null)
+// @param meshEntryPoint : Entry-point of mesh shader (could be null)
+void MeshTaskShader::process(Function *taskEntryPoint, Function *meshEntryPoint) {
+  if (taskEntryPoint)
+    processTaskShader(taskEntryPoint);
+
+  if (meshEntryPoint)
+    processMeshShader(meshEntryPoint);
+}
+
+// =====================================================================================================================
+// Process task shader lowering.
+//
+// @param entryPoint : Entry-point of task shader
+void MeshTaskShader::processTaskShader(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask);
+
+  //
+  // NOTE: The processing is something like this:
+  //
+  // Task_Shader() {
+  //   Initialize thread/wave info
+  //
+  //   Task shader main body (from API shader, lower task payload read/write)
+  //
+  //   Barrier
+  //   if (threadIdInSubgroup == 0) {
+  //     Write data to mesh pipeline statistics buffer
+  //
+  //     Lower EmitMeshTasks, write data to task draw data ring buffer
+  //   }
+  // }
+  //
+  m_builder->SetInsertPoint(&*entryPoint->front().getFirstInsertionPt());
+  initWaveThreadInfo(entryPoint);
+
+  SmallVector<CallInst *, 8> removedCalls;
+
+  auto module = entryPoint->getParent();
+  for (auto &func : module->functions()) {
+    if (!func.isDeclaration())
+      continue; // Not targets
+
+    const bool isReadTaskPayload = func.getName().startswith(lgcName::MeshTaskReadTaskPayload);
+    const bool isWriteTaskPayload = func.getName().startswith(lgcName::MeshTaskWriteTaskPayload);
+    const bool isEmitMeshTasks = func.getName().startswith(lgcName::MeshTaskEmitMeshTasks);
+
+    if (isReadTaskPayload || isWriteTaskPayload || isEmitMeshTasks) {
+      for (auto user : func.users()) {
+        CallInst *const call = cast<CallInst>(user);
+
+        if (call->getFunction() != entryPoint)
+          continue; // Not belong to task shader
+
+        m_builder->SetInsertPoint(call);
+
+        if (isReadTaskPayload) {
+          // Read task payload
+          assert(call->arg_size() == 1);
+          auto byteOffset = call->getOperand(0);
+
+          auto readValue = readTaskPayload(entryPoint, call->getType(), byteOffset);
+          call->replaceAllUsesWith(readValue);
+          m_accessTaskPayload = true;
+        } else if (isWriteTaskPayload) {
+          // Write task payload
+          assert(call->arg_size() == 2);
+          auto byteOffset = call->getOperand(0);
+          auto writeValue = call->getOperand(1);
+
+          writeTaskPayload(entryPoint, writeValue, byteOffset);
+          m_accessTaskPayload = true;
+        } else {
+          // Emit mesh tasks
+          assert(isEmitMeshTasks);
+          assert(call->arg_size() == 3);
+          auto groupCountX = call->getOperand(0);
+          auto groupCountY = call->getOperand(1);
+          auto groupCountZ = call->getOperand(2);
+
+          emitTaskMeshs(entryPoint, groupCountX, groupCountY, groupCountZ);
+        }
+
+        removedCalls.push_back(call);
+      }
+    }
+  }
+
+  // Clear removed calls
+  for (auto call : removedCalls) {
+    call->dropAllReferences();
+    call->eraseFromParent();
+  }
+}
+
+// =====================================================================================================================
+// Process mesh shader lowering.
+//
+// @param entryPoint : Entry-point of mesh shader
+void MeshTaskShader::processMeshShader(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageMesh);
+
+  // TODO: Add mesh shader support.
+  llvm_unreachable("Not implemented!");
+}
+
+// =====================================================================================================================
+// Process the read of task payload.
+//
+// @param entryPoint : Entry-point of task shader
+// @param readTy : Type of value to read
+// @param byteOffset : Byte offset within the payload entry
+Value *MeshTaskShader::readTaskPayload(Function *entryPoint, Type *readTy, Value *byteOffset) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask);
+
+  auto payloadRingBufDesc = m_pipelineSysValues.get(entryPoint)->getTaskPayloadRingBufDesc();
+  auto payloadRingEntryOffset = getPayloadRingEntryOffset(entryPoint);
+
+  CoherentFlag coherent = {};
+  coherent.bits.glc = true;
+  coherent.bits.dlc = true;
+
+  return m_builder->CreateIntrinsic(
+      Intrinsic::amdgcn_raw_buffer_load, readTy,
+      {payloadRingBufDesc, byteOffset, payloadRingEntryOffset, m_builder->getInt32(coherent.u32All)});
+}
+
+// =====================================================================================================================
+// Process the write of task payload.
+//
+// @param entryPoint : Entry-point of task shader
+// @param writeValue : Value to write
+// @param byteOffset : Byte offset within the payload entry
+void MeshTaskShader::writeTaskPayload(Function *entryPoint, Value *writeValue, Value *byteOffset) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask);
+
+  auto payloadRingBufDesc = m_pipelineSysValues.get(entryPoint)->getTaskPayloadRingBufDesc();
+  auto payloadRingEntryOffset = getPayloadRingEntryOffset(entryPoint);
+
+  CoherentFlag coherent = {};
+  coherent.bits.glc = true;
+
+  m_builder->CreateIntrinsic(
+      Intrinsic::amdgcn_raw_buffer_store, writeValue->getType(),
+      {writeValue, payloadRingBufDesc, byteOffset, payloadRingEntryOffset, m_builder->getInt32(coherent.u32All)});
+}
+
+// =====================================================================================================================
+// Initialize the wave/thread info from the entry-point.
+//
+// @param entryPoint : Shader entry-point
+void MeshTaskShader::initWaveThreadInfo(Function *entryPoint) {
+  if (getShaderStage(entryPoint) == ShaderStageTask) {
+    // Task shader
+    auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageTask)->entryArgIdxs.task;
+
+    // waveId = dispatchInfo[24:20]
+    m_waveThreadInfo.waveIdInSubgroup = m_builder->CreateAnd(
+        m_builder->CreateLShr(getFunctionArgument(entryPoint, entryArgIdxs.multiDispatchInfo), 20), 0x1F);
+
+    const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageTask);
+
+    m_waveThreadInfo.threadIdInWave =
+        m_builder->CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {m_builder->getInt32(-1), m_builder->getInt32(0)});
+    if (waveSize == 64) {
+      m_waveThreadInfo.threadIdInWave = m_builder->CreateIntrinsic(
+          Intrinsic::amdgcn_mbcnt_hi, {}, {m_builder->getInt32(-1), m_waveThreadInfo.threadIdInWave});
+    }
+
+    m_waveThreadInfo.threadIdInSubgroup =
+        m_builder->CreateAdd(m_builder->CreateMul(m_waveThreadInfo.waveIdInSubgroup, m_builder->getInt32(waveSize)),
+                             m_waveThreadInfo.threadIdInWave);
+  } else {
+    // Mesh shader
+    assert(getShaderStage(entryPoint) == ShaderStageMesh);
+
+    // TODO: Add mesh shader support.
+    llvm_unreachable("Not implemented!");
+  }
+}
+
+// =====================================================================================================================
+// Get shader ring entry index of current workgroup from the entry-point.
+//
+// @param entryPoint : Shader entry-point
+// @returns : The shader ring entry index of current workgroup
+Value *MeshTaskShader::getShaderRingEntryIndex(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask); // Must be task shader
+
+  if (!m_shaderRingEntryIndex) {
+    // NOTE: The calculation of shader ring entry index should be done at the beginning of the entry block. And the
+    // value could be reused in subsequent operations.
+    auto savedInsertPoint = m_builder->saveIP();
+    m_builder->SetInsertPoint(&*entryPoint->getEntryBlock().getFirstInsertionPt());
+
+    auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageTask)->entryArgIdxs.task;
+
+    auto workgroupId = getFunctionArgument(entryPoint, entryArgIdxs.workgroupId);
+    auto dispatchDims = getFunctionArgument(entryPoint, entryArgIdxs.dispatchDims);
+
+    // flattenWorkgroupId = workgroupId.z * dispatchDims.x * dispatchDims.y +
+    //                      workgroupId.y * dispatchDims.x + workgroupId.x
+    //                    = (workgroupId.z * dispatchDims.y + workgroupId.y) * dispatchDims.x + workgroupId.x
+    auto flattenWorkgroupId = m_builder->CreateMul(m_builder->CreateExtractElement(workgroupId, 2),
+                                                   m_builder->CreateExtractElement(dispatchDims, 1));
+    flattenWorkgroupId = m_builder->CreateAdd(flattenWorkgroupId, m_builder->CreateExtractElement(workgroupId, 1));
+    flattenWorkgroupId = m_builder->CreateMul(flattenWorkgroupId,
+                                              m_builder->CreateExtractElement(dispatchDims, static_cast<uint64_t>(0)));
+    flattenWorkgroupId = m_builder->CreateAdd(flattenWorkgroupId,
+                                              m_builder->CreateExtractElement(workgroupId, static_cast<uint64_t>(0)));
+
+    auto baseRingEntryIndex = getFunctionArgument(entryPoint, entryArgIdxs.baseRingEntryIndex);
+    m_shaderRingEntryIndex = m_builder->CreateAdd(baseRingEntryIndex, flattenWorkgroupId);
+
+    m_builder->restoreIP(savedInsertPoint);
+  }
+
+  return m_shaderRingEntryIndex;
+}
+
+// =====================================================================================================================
+// Get the payload ring entry offset of current workgroup for task shader.
+//
+// @param entryPoint : Entry-point of task shader
+// @returns : The payload ring entry offset of current workgroup
+Value *MeshTaskShader::getPayloadRingEntryOffset(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask); // Must be task shader
+
+  if (!m_payloadRingEntryOffset) {
+    Value *ringEntryIndex = getShaderRingEntryIndex(entryPoint);
+    Value *payloadRingBufDesc = m_pipelineSysValues.get(entryPoint)->getTaskPayloadRingBufDesc();
+
+    // NUM_RECORDS = SQ_BUF_RSRC_WORD2[31:0]
+    Value *numPayloadRingEntries = m_builder->CreateUDiv(m_builder->CreateExtractElement(payloadRingBufDesc, 2),
+                                                         m_builder->getInt32(PayloadRingEntrySize));
+    // wrappedRingEntryIndex = ringEntryIndex % numRingEntries = ringEntryIndex & (numRingEntries - 1)
+    Value *wrappedRingEntryIndex =
+        m_builder->CreateAnd(ringEntryIndex, m_builder->CreateSub(numPayloadRingEntries, m_builder->getInt32(1)));
+    m_payloadRingEntryOffset = m_builder->CreateMul(wrappedRingEntryIndex, m_builder->getInt32(PayloadRingEntrySize));
+  }
+
+  return m_payloadRingEntryOffset;
+}
+
+// =====================================================================================================================
+// Get the draw data ring entry offset of current workgroup for task shader.
+//
+// @param entryPoint : Entry-point of task shader
+// @returns : The draw data ring entry offset of current workgroup
+Value *MeshTaskShader::getDrawDataRingEntryOffset(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask); // Must be task shader
+
+  if (!m_drawDataRingEntryOffset) {
+    Value *ringEntryIndex = getShaderRingEntryIndex(entryPoint);
+    Value *drawDataRingBufDesc = m_pipelineSysValues.get(entryPoint)->getTaskDrawDataRingBufDesc();
+
+    // NUM_RECORDS = SQ_BUF_RSRC_WORD2[31:0]
+    Value *numDrawDataRingEntries = m_builder->CreateUDiv(m_builder->CreateExtractElement(drawDataRingBufDesc, 2),
+                                                          m_builder->getInt32(DrawDataRingEntrySize));
+    // wrappedRingEntryIndex = ringEntryIndex % numRingEntries = ringEntryIndex & (numRingEntries - 1)
+    Value *wrappedRingEntryIndex =
+        m_builder->CreateAnd(ringEntryIndex, m_builder->CreateSub(numDrawDataRingEntries, m_builder->getInt32(1)));
+    m_drawDataRingEntryOffset = m_builder->CreateMul(wrappedRingEntryIndex, m_builder->getInt32(DrawDataRingEntrySize));
+  }
+
+  return m_drawDataRingEntryOffset;
+}
+
+// =====================================================================================================================
+// Get the draw data ready bit.
+//
+// @param entryPoint : Entry-point of task shader
+// @returns : Flag (i1 typed) indicating whether the draw data is ready for command processor (CP) to fetch.
+Value *MeshTaskShader::getDrawDataReadyBit(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask); // Must be task shader
+
+  if (!m_drawDataReadyBit) {
+    Value *ringEntryIndex = getShaderRingEntryIndex(entryPoint);
+    Value *drawDataRingBufDesc = m_pipelineSysValues.get(entryPoint)->getTaskDrawDataRingBufDesc();
+
+    // NUM_RECORDS = SQ_BUF_RSRC_WORD2[31:0]
+    Value *numDrawDataRingEntries = m_builder->CreateUDiv(m_builder->CreateExtractElement(drawDataRingBufDesc, 2),
+                                                          m_builder->getInt32(DrawDataRingEntrySize));
+    // readyBit = ringEntryIndex & numRingEnties != 0
+    m_drawDataReadyBit =
+        m_builder->CreateICmpNE(m_builder->CreateAnd(ringEntryIndex, numDrawDataRingEntries), m_builder->getInt32(0));
+  }
+
+  return m_drawDataReadyBit;
+}
+
+// =====================================================================================================================
+// Emit mesh tasks. Defines the dimension size of subsequent mesh shader workgroups to generate upon completion of the
+// task shader workgroup
+//
+// @param entryPoint : Entry-point of task shader
+// @param groupCountX : Number of local workgroups in X dimension for the launch of child mesh tasks
+// @param groupCountX : Number of local workgroups in Y dimension for the launch of child mesh tasks
+// @param groupCountX : Number of local workgroups in Z dimension for the launch of child mesh tasks
+void MeshTaskShader::emitTaskMeshs(Function *entryPoint, Value *groupCountX, Value *groupCountY, Value *groupCountZ) {
+  assert(getShaderStage(entryPoint) == ShaderStageTask); // Must be task shader
+
+  auto emitMeshsCall = m_builder->GetInsertPoint();
+
+  auto checkEmitMeshsBlock = m_builder->GetInsertBlock();
+  auto emitMeshsBlock = checkEmitMeshsBlock->splitBasicBlock(emitMeshsCall, ".emitMeshs");
+  auto endEmitMeshsBlock = emitMeshsBlock->splitBasicBlock(emitMeshsCall, ".endEmitMeshs");
+
+  // Modify ".checkEmitMeshs" block
+  {
+    m_builder->SetInsertPoint(checkEmitMeshsBlock->getTerminator());
+
+    if (m_accessTaskPayload) {
+      // Make sure the task payload read/write access is completed
+      m_builder->CreateFence(AtomicOrdering::Release, SyncScope::System);
+      m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_barrier, {}, {});
+    }
+
+    auto firstThreadInSubgroup = m_builder->CreateICmpEQ(m_waveThreadInfo.threadIdInSubgroup, m_builder->getInt32(0));
+    m_builder->CreateCondBr(firstThreadInSubgroup, emitMeshsBlock, endEmitMeshsBlock);
+    checkEmitMeshsBlock->getTerminator()->eraseFromParent(); // Remove old terminator
+  }
+
+  // Construct ".emitTaskMeshs" block
+  {
+    m_builder->SetInsertPoint(emitMeshsBlock->getTerminator());
+
+    //
+    // Collect task statistics info
+    //
+    auto &computeMode =
+        m_pipelineState->getShaderModes()->getComputeShaderMode(); // Task shader is actually a compute shader
+    const uint64_t numTaskThreads =
+        computeMode.workgroupSizeX * computeMode.workgroupSizeY * computeMode.workgroupSizeZ;
+
+    Value *meshPipeStatsBufPtr = m_pipelineSysValues.get(entryPoint)->getMeshPipeStatsBufPtr();
+    Value *meshPipeStatsBufEntryPtr = m_builder->CreateGEP(
+        m_builder->getInt8Ty(), meshPipeStatsBufPtr, m_builder->getInt32(offsetof(MeshPipeStatsEntry, numTaskThreads)));
+    meshPipeStatsBufEntryPtr = m_builder->CreateBitCast(meshPipeStatsBufEntryPtr,
+                                                        PointerType::get(m_builder->getInt64Ty(), ADDR_SPACE_GLOBAL));
+
+    // NOTE: LLVM backend will try to apply atomics optimization. But here, we only have one active thread to execute
+    // the global_atomic_add instruction. Thus, the optimization is completely unnecessary. To avoid this, we try to
+    // move the added value to VGPR to mark it as "divergent".
+    Value *valueToAdd = UndefValue::get(FixedVectorType::get(m_builder->getInt32Ty(), 2));
+    valueToAdd = m_builder->CreateInsertElement(valueToAdd, convertToDivergent(m_builder->getInt32(numTaskThreads)),
+                                                static_cast<uint64_t>(0));
+    valueToAdd =
+        m_builder->CreateInsertElement(valueToAdd, convertToDivergent(m_builder->getInt32(numTaskThreads >> 32)), 1);
+    valueToAdd = m_builder->CreateBitCast(valueToAdd, m_builder->getInt64Ty());
+
+    m_builder->CreateAtomicRMW(AtomicRMWInst::Add, meshPipeStatsBufEntryPtr, valueToAdd, MaybeAlign(),
+                               AtomicOrdering::Monotonic, SyncScope::System);
+
+    //
+    // Write draw data
+    //
+
+    // Set X dimension to 0 if any of X, Y, Z dimension is 0:
+    //   groupCountX = min(groupCountY, groupCountZ) == 0 ? 0 : groupCountX
+    auto minGroupCountYZ =
+        m_builder->CreateIntrinsic(Intrinsic::umin, groupCountY->getType(), {groupCountY, groupCountZ});
+    groupCountX = m_builder->CreateSelect(m_builder->CreateICmpEQ(minGroupCountYZ, m_builder->getInt32(0)),
+                                          m_builder->getInt32(0), groupCountX);
+
+    Value *drawDataRingBufDesc = m_pipelineSysValues.get(entryPoint)->getTaskDrawDataRingBufDesc();
+    Value *drawDataRingEntryOffset = getDrawDataRingEntryOffset(entryPoint);
+
+    // Draw data (<4 x i32>) = <groupCountX, groupCountY, groupCountZ, readyBit>
+    Value *drawData = UndefValue::get(FixedVectorType::get(m_builder->getInt32Ty(), 4));
+    drawData = m_builder->CreateInsertElement(drawData, groupCountX, static_cast<uint64_t>(0));
+    drawData = m_builder->CreateInsertElement(drawData, groupCountY, 1);
+    drawData = m_builder->CreateInsertElement(drawData, groupCountZ, 2);
+
+    Value *readyBit = getDrawDataReadyBit(entryPoint);
+    drawData = m_builder->CreateInsertElement(drawData, m_builder->CreateZExt(readyBit, m_builder->getInt32Ty()), 3);
+
+    m_builder->CreateIntrinsic(
+        Intrinsic::amdgcn_raw_buffer_store, drawData->getType(),
+        {drawData, drawDataRingBufDesc, m_builder->getInt32(0), drawDataRingEntryOffset, m_builder->getInt32(0)});
+  }
+
+  // Construct ".endEmitTaskMeshs" block
+  {
+    m_builder->SetInsertPoint(endEmitMeshsBlock->getTerminator());
+
+    // Currently, nothing to do
+  }
+}
+
+// =====================================================================================================================
+// Convert a i32 value to divergent one by inserting a "v_mov_b32" forcibly.
+//
+// @param value : Input i32 value
+// @returns : A new i32 value that is considered to be divergent
+Value *MeshTaskShader::convertToDivergent(Value *value) {
+  assert(value->getType() == m_builder->getInt32Ty()); // Must be i32 typed
+  auto inlineAsmTy = FunctionType::get(m_builder->getInt32Ty(), m_builder->getInt32Ty(), false);
+  auto inlineAsm = InlineAsm::get(inlineAsmTy, "v_mov_b32 $0, $1", "=v,0", true);
+  return m_builder->CreateCall(inlineAsm, value);
+}
+
+} // namespace lgc

--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -1,0 +1,96 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  MeshTaskShader.h
+ * @brief LLPC header file: contains declaration of class lgc::MeshTaskShader.
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "lgc/patch/SystemValues.h"
+#include "lgc/state/PipelineState.h"
+#include "lgc/state/TargetInfo.h"
+
+namespace lgc {
+
+// Represents the entry layout of mesh pipeline statistics buffer for a workgroup
+struct MeshPipeStatsEntry {
+  uint64_t numMeshThreads;
+  uint64_t numMeshPrimitives;
+  uint64_t numTaskThreads;
+};
+
+// =====================================================================================================================
+// Represents the handler of mesh/task shader.
+class MeshTaskShader {
+public:
+  MeshTaskShader(PipelineState *pipelineState);
+  ~MeshTaskShader();
+
+  void process(llvm::Function *taskEntryPoint, llvm::Function *meshEntryPoint);
+
+private:
+  void processTaskShader(llvm::Function *entryPoint);
+  void processMeshShader(llvm::Function *entryPoint);
+
+  llvm::Value *readTaskPayload(llvm::Function *entryPoint, llvm::Type *readTy, llvm::Value *byteOffset);
+  void writeTaskPayload(llvm::Function *entryPoint, llvm::Value *writeValue, llvm::Value *byteOffset);
+
+  void initWaveThreadInfo(llvm::Function *entryPoint);
+  llvm::Value *getShaderRingEntryIndex(llvm::Function *entryPoint);
+
+  llvm::Value *getPayloadRingEntryOffset(llvm::Function *entryPoint);
+  llvm::Value *getDrawDataRingEntryOffset(llvm::Function *entryPoint);
+  llvm::Value *getDrawDataReadyBit(llvm::Function *entryPoint);
+  void emitTaskMeshs(llvm::Function *entryPoint, llvm::Value *groupCountX, llvm::Value *groupCountY,
+                     llvm::Value *groupCountZ);
+
+  llvm::Value *convertToDivergent(llvm::Value *value);
+
+  static constexpr unsigned PayloadRingEntrySize = 16 * 1024; // 16K bytes per group
+  static constexpr unsigned DrawDataRingEntrySize = 16;       // 16 bytes per group
+
+  PipelineState *m_pipelineState = nullptr; // Pipeline state
+
+  PipelineSystemValues m_pipelineSysValues; // Cache of ShaderSystemValues objects, one per shader stage
+
+  std::unique_ptr<llvm::IRBuilder<>> m_builder; // LLVM IR builder
+
+  // The wave/thread info used for control shader branching
+  struct {
+    llvm::Value *waveIdInSubgroup;
+    llvm::Value *threadIdInWave;
+    llvm::Value *threadIdInSubgroup;
+  } m_waveThreadInfo = {};
+
+  bool m_accessTaskPayload = false;                 // Whether task shader has payload access operations
+  llvm::Value *m_shaderRingEntryIndex = nullptr;    // Shader ring entry index of current workgroup
+  llvm::Value *m_payloadRingEntryOffset = nullptr;  // Entry offset (in bytes) of the payload ring
+  llvm::Value *m_drawDataRingEntryOffset = nullptr; // Entry offset (in bytes) of the draw data ring
+  llvm::Value *m_drawDataReadyBit = nullptr;        // Flag indicating whether the draw data is ready for CP to fetch
+};
+
+} // namespace lgc

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -31,6 +31,7 @@
 #include "lgc/patch/PatchPreparePipelineAbi.h"
 #include "Gfx6ConfigBuilder.h"
 #include "Gfx9ConfigBuilder.h"
+#include "MeshTaskShader.h"
 #include "ShaderMerger.h"
 #include "lgc/state/PalMetadata.h"
 #include "llvm/Pass.h"
@@ -198,7 +199,10 @@ void PatchPreparePipelineAbi::mergeShaderAndSetCallingConvs(Module &module) {
 
   if (m_pipelineState->isGraphics()) {
     if (m_hasTask || m_hasMesh) {
-      // TODO: Add task/mesh shader processing.
+      auto taskEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTask);
+      auto meshEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageMesh);
+      MeshTaskShader meshTaskShader(m_pipelineState);
+      meshTaskShader.process(taskEntryPoint, meshEntryPoint);
       return;
     }
 

--- a/lgc/test/TaskShaderOps.lgc
+++ b/lgc/test/TaskShaderOps.lgc
@@ -1,14 +1,63 @@
 ; Test that the operations of task shader are handled as expected.
 
-; RUN: lgc -mcpu=gfx1030 --emit-llvm -o=- - <%s | FileCheck --check-prefixes=CHECK %s
+; RUN: lgc -mcpu=gfx1030 --emit-llvm -v -o=- - <%s | FileCheck --check-prefixes=CHECK %s
 
 ; In this test case, we check if the operations of a task shader is correctly handled. Three operations
 ; are ReadTaskPayload, WriteTaskPayload, EmitMeshTasks.
 ;
-; CHECK-LABEL: _amdgpu_cs_main
+; CHECK-LABEL: lgc.shader.TASK.main
 ; CHECK: call float @lgc.mesh.task.read.task.payload.f32.i32(i32 %{{[0-9]*}})
 ; CHECK: call void @lgc.mesh.task.write.task.payload.i32.f32(i32 %{{[0-9]*}}, float %{{[0-9]*}})
 ; CHECK: call void @lgc.mesh.task.emit.mesh.tasks(i32 3, i32 1, i32 1)
+;
+; CHECK-LABEL: _amdgpu_cs_main
+; CHECK: .entry:
+; CHECK-DAG: [[groupIdZ:%[0-9]*]] = extractelement <3 x i32> %WorkgroupId, i64 2
+; CHECK-DAG: [[dimY:%[0-9]*]] = extractelement <3 x i32> %meshTaskDispatchDims, i64 1
+; CHECK-NEXT: [[tempResult0:%[0-9]*]] = mul i32 [[groupIdZ]], [[dimY]]
+; CHECK-NEXT: [[groupIdY:%[0-9]*]] = extractelement <3 x i32> %WorkgroupId, i64 1
+; CHECK-NEXT: [[tempResult1:%[0-9]*]] = add i32 [[tempResult0]], [[groupIdY]]
+; CHECK-NEXT: [[dimX:%[0-9]*]] = extractelement <3 x i32> %meshTaskDispatchDims, i64 0
+; CHECK-NEXT: [[tempResult2:%[0-9]*]] = mul i32 [[tempResult1]], [[dimX]]
+; CHECK-NEXT: [[groupIdX:%[0-9]*]] = extractelement <3 x i32> %WorkgroupId, i64 0
+; CHECK-NEXT: [[flattenId:%[0-9]*]] = add i32 [[tempResult2]], [[groupIdX]]
+; CHECK-NEXT: [[entryIndex:%[0-9]*]] = add i32 %meshTaskRingIndex, [[flattenId]]
+; CHECK: [[payloadRingDescPtr:%[0-9]*]] = getelementptr <4 x i32>, <4 x i32> addrspace(4)* %{{[0-9]*}}, i32 13
+; CHECK-NEXT: [[payloadRingDesc:%[0-9]*]] = load <4 x i32>, <4 x i32> addrspace(4)* [[payloadRingDescPtr]], align 16
+; CHECK: [[drawDataRingDescPtr:%[0-9]*]] = getelementptr <4 x i32>, <4 x i32> addrspace(4)* %{{[0-9]*}}, i32 14
+; CHECK-NEXT: [[drawDataRingDesc:%[0-9]*]] = load <4 x i32>, <4 x i32> addrspace(4)* [[drawDataRingDescPtr]], align 16
+; CHECK: [[meshPipeStatsBufAddr2x32:%[0-9]*]] = insertelement <2 x i32> %{{[0-9]*}}, i32 %meshPipeStatsBuf, i32 0
+; CHECK-NEXT: [[meshPipeStatsBufAddr64:%[0-9]*]] = bitcast <2 x i32> [[meshPipeStatsBufAddr2x32]] to i64
+; CHECK-NEXT: [[meshPipeStatsBufAddr:%[0-9]*]] = inttoptr i64 [[meshPipeStatsBufAddr64]] to i8 addrspace(1)*
+; CHECK: [[ringSize:%[0-9]*]] = extractelement <4 x i32> [[payloadRingDesc]], i64 2
+; CHECK-NEXT: [[numEntries:%[0-9]*]] = udiv i32 [[ringSize]], 16384
+; CHECK-NEXT: [[wrapMask:%[0-9]*]] = sub i32 [[numEntries]], 1
+; CHECK-NEXT: [[wrappedEntryIndex:%[0-9]*]] = and i32 [[entryIndex]], [[wrapMask]]
+; CHECK-NEXT: [[entryOffset:%[0-9]*]] = mul i32 [[wrappedEntryIndex]], 16384
+; CHECK: %{{[0-9]*}} = call float @llvm.amdgcn.raw.buffer.load.f32(<4 x i32> [[payloadRingDesc]], i32 %{{[0-9]*}}, i32 [[entryOffset]], i32 5)
+; CHECK: call void @llvm.amdgcn.raw.buffer.store.f32(float %{{[0-9]*}}, <4 x i32> [[payloadRingDesc]], i32 %{{[0-9]*}}, i32 [[entryOffset]], i32 1)
+; CHECK: br i1 %{{[0-9]*}}, label %.emitMeshs, label %.endEmitMeshs
+;
+; CHECK: .emitMeshs:
+; CHECK-NEXT: [[numTaskThreadsPtr8:%[0-9]*]] = getelementptr i8, i8 addrspace(1)* [[meshPipeStatsBufAddr]], i32 16
+; CHECK-NEXT: [[numTaskThreadsPtr:%[0-9]*]] = bitcast i8 addrspace(1)* [[numTaskThreadsPtr8]] to i64 addrspace(1)*
+; CHECK: %{{[0-9]*}} = atomicrmw add i64 addrspace(1)* [[numTaskThreadsPtr]], i64 %{{[0-9]*}} monotonic, align 8
+; CHECK: [[ringSize:%[0-9]*]] = extractelement <4 x i32> [[drawDataRingDesc]], i64 2
+; CHECK-NEXT: [[numEntries:%[0-9]*]] = udiv i32 [[ringSize]], 16
+; CHECK-NEXT: [[wrapMask:%[0-9]*]] = sub i32 [[numEntries]], 1
+; CHECK-NEXT: [[wrappedEntryIndex:%[0-9]*]] = and i32 [[entryIndex]], [[wrapMask]]
+; CHECK-NEXT: [[entryOffset:%[0-9]*]] = mul i32 [[wrappedEntryIndex]], 16
+; CHECK: [[ringSize:%[0-9]*]] = extractelement <4 x i32> [[drawDataRingDesc]], i64 2
+; CHECK-NEXT: [[numEntries:%[0-9]*]] = udiv i32 [[ringSize]], 16
+; CHECK-NEXT: [[checkReadyBit:%[0-9]*]] = and i32 [[entryIndex]], [[numEntries]]
+; CHECK-NEXT: [[readyBit:%[0-9]*]] = icmp ne i32 [[checkReadyBit]], 0
+; CHECK-NEXT: [[readyBit32:%[0-9]*]] = zext i1 [[readyBit]] to i32
+; CHECK-NEXT: [[drawData:%[0-9]*]] = insertelement <4 x i32> %{{[0-9]*}}, i32 [[readyBit32]], i64 3
+; CHECK: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> [[drawData]], <4 x i32> [[drawDataRingDesc]], i32 0, i32 [[entryOffset]], i32 0)
+; CHECK-NEXT: br label %.endEmitMeshs
+;
+; CHECK: .endEmitMeshs:
+; CHECK-NEXT: ret void
 
 ; ModuleID = 'lgcPipeline'
 source_filename = "llpctask1"


### PR DESCRIPTION
Create a new class MeshTaskShader, responsible for handling task/mesh
shader lowering. For task shader, we only have two operations to
handle:
  Lower read/write task payload -> Read/write payload ring buffer
  Lower emit mesh tasks -> Write draw data ring buffer and statistics buffer

A task shader processing is something like this:

```
  Task_Shader() {
    Initialize thread/wave info

    Task shader main body (from API shader, lower task payload read/write)

    Barrier
      if (threadIdInSubgroup == 0) {
        Write data to mesh pipeline statistics buffer

        Lower EmitMeshTasks, write data to task draw data ring buffer
      }
    }
```