### PR TITLE
Fix -Werror -Wparentheses build failure.

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6883,7 +6883,7 @@ bool SPIRVToLLVM::transMetadata() {
           execModeMd.cs.LocalSizeX = em->getLiterals()[0];
           execModeMd.cs.LocalSizeY = em->getLiterals()[1];
           execModeMd.cs.LocalSizeZ = em->getLiterals()[2];
-        } else if (em = bf->getExecutionMode(ExecutionModeLocalSizeId)) {
+        } else if ((em = bf->getExecutionMode(ExecutionModeLocalSizeId))) {
           auto workGroupSizeX = static_cast<SPIRVConstant *>(m_bm->getValue(em->getLiterals()[0]));
           auto workGroupSizeY = static_cast<SPIRVConstant *>(m_bm->getValue(em->getLiterals()[1]));
           auto workGroupSizeZ = static_cast<SPIRVConstant *>(m_bm->getValue(em->getLiterals()[2]));


### PR DESCRIPTION
We build spvgen with `-Werror`.  Today's build failed with

```
llpc/llpc/translator/lib/SPIRV/SPIRVReader.cpp:6886:23: error: using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses]
        } else if (em = bf->getExecutionMode(ExecutionModeLocalSizeId)) {
                   ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
llpc/llpc/translator/lib/SPIRV/SPIRVReader.cpp:6886:23: note: place parentheses around the assignment to silence this warning
        } else if (em = bf->getExecutionMode(ExecutionModeLocalSizeId)) {
                      ^
                   (                                                  )
llpc/llpc/translator/lib/SPIRV/SPIRVReader.cpp:6886:23: note: use '==' to turn this assignment into an equality comparison
        } else if (em = bf->getExecutionMode(ExecutionModeLocalSizeId)) {
                      ^
                      ==
```

I don't know this code, but looking around, it seems like the assignment is the intended action here.