### PR TITLE
Fix OpImageQueryLod

### DIFF
--- a/llpc/test/shaderdb/core/OpImageQueryLod_TestTextureQueryLod_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQueryLod_TestTextureQueryLod_lit.frag
@@ -2,8 +2,6 @@
 
 layout(set = 0, binding = 0) uniform sampler1D          samp1D;
 layout(set = 1, binding = 0) uniform sampler2D          samp2D[4];
-layout(set = 0, binding = 1) uniform sampler2DShadow    samp2DShadow;
-layout(set = 2, binding = 0) uniform samplerCubeArray   sampCubeArray[4];
 layout(set = 3, binding = 0) uniform texture3D          tex3D;
 layout(set = 3, binding = 1) uniform sampler            samp;
 
@@ -18,8 +16,6 @@ void main()
 {
     vec2 f2 = textureQueryLod(samp1D, 1.0);
     f2 += textureQueryLod(samp2D[index], vec2(0.5));
-    f2 += textureQueryLod(samp2DShadow, vec2(0.4));
-    f2 += textureQueryLod(sampCubeArray[index], vec3(0.6));
     f2 += textureQueryLod(sampler3D(tex3D, samp), vec3(0.7));
 
     fragColor = vec4(f2, f2);
@@ -27,43 +23,50 @@ void main()
 // BEGIN_SHADERTEST
 /*
 ; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
-; SHADERTEST: <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 0, i32 0)
-; SHADERTEST: <4 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v4i32(i32 2, i32 0, i32 0)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 0, i32 512, {{.*}}, {{.*}}, float 1.000000e+00)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.derivative.f32(float 1.000000e+00, i1 false, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.derivative.f32(float 1.000000e+00, i1 true, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn float @llvm.fabs.f32(
-; SHADERTEST: <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 1, i32 0)
-; SHADERTEST: <4 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v4i32(i32 2, i32 1, i32 0)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 1, i32 384, {{.*}}, {{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.derivative.v2f32(<2 x float> <float 5.000000e-01, float 5.000000e-01>, i1 false, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.derivative.v2f32(<2 x float> <float 5.000000e-01, float 5.000000e-01>, i1 true, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> @llvm.fabs.v2f32(
-; SHADERTEST: <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 0, i32 1)
-; SHADERTEST: <4 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v4i32(i32 2, i32 0, i32 1)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 1, i32 512, {{.*}}, {{.*}}, <2 x float> <float 0x3FD99999A0000000, float 0x3FD99999A0000000>)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.derivative.v2f32(<2 x float> <float 0x3FD99999A0000000, float 0x3FD99999A0000000>, i1 false, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.derivative.v2f32(<2 x float> <float 0x3FD99999A0000000, float 0x3FD99999A0000000>, i1 true, i1 false)
-; SHADERTEST: <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 2, i32 0)
-; SHADERTEST: <4 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v4i32(i32 2, i32 2, i32 0)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 8, i32 384, {{.*}}, {{.*}}, <3 x float> <float 0x3FE3333340000000, float 0x3FE3333340000000, float 0x3FE3333340000000>)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.derivative.v3f32(<3 x float> <float 0x3FE3333340000000, float 0x3FE3333340000000, float 0x3FE3333340000000>, i1 false, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.derivative.v3f32(<3 x float> <float 0x3FE3333340000000, float 0x3FE3333340000000, float 0x3FE3333340000000>, i1 true, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <3 x float> @llvm.fabs.v3f32(
-; SHADERTEST: <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 3, i32 0)
-; SHADERTEST: <4 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v4i32(i32 2, i32 3, i32 1)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 2, i32 512, {{.*}}, {{.*}}, <3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.derivative.v3f32(<3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>, i1 false, i1 false)
-; SHADERTEST: call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.derivative.v3f32(<3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>, i1 true, i1 false)
+; SHADERTEST-LABEL: {{^// LLPC}}  SPIRV-to-LLVM translation results
+; 1D
+; SHADERTEST: [[LOD1:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 0, i32 512, {{.*}}, {{.*}}, float 1.000000e+00)
+; SHADERTEST: [[DPX:%[0-9]*]] = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.derivative.f32(float 1.000000e+00, i1 false, i1 true)
+; SHADERTEST: [[ABSDPX:%[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.fabs.f32(float [[DPX]])
+; SHADERTEST: [[DPY:%[0-9]*]] = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.derivative.f32(float 1.000000e+00, i1 true, i1 true)
+; SHADERTEST: [[ABSDPY:%[0-9]*]] = call reassoc nnan nsz arcp contract afn float @llvm.fabs.f32(float [[DPY]])
+; SHADERTEST: [[SUM:%[0-9]*]] = fadd reassoc nnan nsz arcp contract afn float [[ABSDPX]], [[ABSDPY]]
+; SHADERTEST: [[ZERO:%[0-9]*]] = fcmp reassoc nnan nsz arcp contract afn oeq float [[SUM]], 0.000000e+00
+; -FLT_MAX for LOD
+; SHADERTEST: [[LOD2:%[0-9]*]] = insertelement <2 x float> [[LOD1]], float 0xC7EFFFFFE0000000, i64 1
+; SHADERTEST: select reassoc nnan nsz arcp contract afn i1 [[ZERO]], <2 x float> [[LOD2]], <2 x float> [[LOD1]]
 
-; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: call {{.*}} <2 x float> @llvm.amdgcn.image.getlod.1d.v2f32.f32(i32 3, float 1.000000e+00,{{.*}},{{.*}}, i1 false, i32 0, i32 0)
-; SHADERTEST: call {{.*}} <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 5.000000e-01, float 5.000000e-01,{{.*}},{{.*}}, i1 false, i32 0, i32 0)
-; SHADERTEST: call {{.*}} <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0x3FD99999A0000000, float 0x3FD99999A0000000,{{.*}},{{.*}}, i1 false, i32 0, i32 0)
-; SHADERTEST: call {{.*}} <2 x float> @llvm.amdgcn.image.getlod.cube.v2f32.f32(i32 3,{{.*}},{{.*}},{{.*}},{{.*}},{{.*}}, i1 false, i32 0, i32 0)
-; SHADERTEST: call {{.*}} <2 x float> @llvm.amdgcn.image.getlod.3d.v2f32.f32(i32 3, float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000,{{.*}},{{.*}}, i1 false, i32 0, i32 0)
+; 2D
+; SHADERTEST: [[LOD1:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 1, i32 384, {{.*}}, {{.*}}, <2 x float> <float 5.000000e-01, float 5.000000e-01>)
+; SHADERTEST: [[DPX:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.derivative.v2f32(<2 x float> <float 5.000000e-01, float 5.000000e-01>, i1 false, i1 true)
+; SHADERTEST: [[ABSDPX:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[DPX]])
+; SHADERTEST: [[DPY:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.derivative.v2f32(<2 x float> <float 5.000000e-01, float 5.000000e-01>, i1 true, i1 true)
+; SHADERTEST: [[ABSDPY:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[DPY]])
+; SHADERTEST: [[SUM:%[0-9]*]] = fadd reassoc nnan nsz arcp contract afn <2 x float> [[ABSDPX]], [[ABSDPY]]
+; SHADERTEST: [[ZERO:%[0-9]*]] = fcmp reassoc nnan nsz arcp contract afn oeq <2 x float> [[SUM]], zeroinitializer
+; SHADERTEST: [[ZERO_X:%[0-9]*]] = extractelement <2 x i1> [[ZERO]], i64 0
+; SHADERTEST: [[CMP1:%[0-9]*]] = and i1 [[ZERO_X]], true
+; SHADERTEST: [[ZERO_Y:%[0-9]*]] = extractelement <2 x i1> [[ZERO]], i64 1
+; SHADERTEST: [[CMP2:%[0-9]*]] = and i1 [[ZERO_Y]], [[CMP1]]
+; SHADERTEST: [[LOD2:%[0-9]*]] = insertelement <2 x float> [[LOD1]], float 0xC7EFFFFFE0000000, i64 1
+; SHADERTEST: select reassoc nnan nsz arcp contract afn i1 [[CMP2]], <2 x float> [[LOD2]], <2 x float> [[LOD1]]
+
+; 3D
+; SHADERTEST: [[LOD1:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <2 x float> (...) @lgc.create.image.get.lod.v2f32(i32 2, i32 512, {{.*}}, {{.*}}, <3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>)
+; SHADERTEST: [[DPX:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.derivative.v3f32(<3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>, i1 false, i1 true)
+; SHADERTEST: [[ABSDPX:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.fabs.v3f32(<3 x float> [[DPX]])
+; SHADERTEST: [[DPY:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.derivative.v3f32(<3 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>, i1 true, i1 true)
+; SHADERTEST: [[ABSDPY:%[0-9]*]] = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.fabs.v3f32(<3 x float> [[DPY]])
+; SHADERTEST: [[SUM:%[0-9]*]] = fadd reassoc nnan nsz arcp contract afn <3 x float> [[ABSDPX]], [[ABSDPY]]
+; SHADERTEST: [[ZERO:%[0-9]*]] =  fcmp reassoc nnan nsz arcp contract afn oeq <3 x float> [[SUM]], zeroinitializer
+; SHADERTEST: [[ZERO_X:%[0-9]*]] = extractelement <3 x i1> [[ZERO]], i64 0
+; SHADERTEST: [[CMP1:%[0-9]*]] = and i1 [[ZERO_X]], true
+; SHADERTEST: [[ZERO_Y:%[0-9]*]] = extractelement <3 x i1> [[ZERO]], i64 1
+; SHADERTEST: [[CMP2:%[0-9]*]] = and i1 [[ZERO_Y]], [[CMP1]]
+; SHADERTEST: [[ZERO_Z:%[0-9]*]] = extractelement <3 x i1> [[ZERO]], i64 2
+; SHADERTEST: [[CMP3:%[0-9]*]] = and i1 [[ZERO_Z]], [[CMP2]]
+; SHADERTEST: [[LOD2:%[0-9]*]] = insertelement <2 x float> [[LOD1]], float 0xC7EFFFFFE0000000, i64 1
+; SHADERTEST: select reassoc nnan nsz arcp contract afn i1 [[CMP3]], <2 x float> [[LOD2]], <2 x float> [[LOD1]]
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6409,9 +6409,9 @@ Value *SPIRVToLLVM::transSPIRVImageQueryLodFromInst(SPIRVInstruction *bi, BasicB
   // Derivative operations are performed on the XY of UV coordinate respectively, if both of result
   // are zero, we will return -FLT_MAX for LOD.
   Value *absDpdx =
-      getBuilder()->CreateUnaryIntrinsic(Intrinsic::fabs, getBuilder()->CreateDerivative(coord, false, false));
+      getBuilder()->CreateUnaryIntrinsic(Intrinsic::fabs, getBuilder()->CreateDerivative(coord, false, true));
   Value *absDpdy =
-      getBuilder()->CreateUnaryIntrinsic(Intrinsic::fabs, getBuilder()->CreateDerivative(coord, true, false));
+      getBuilder()->CreateUnaryIntrinsic(Intrinsic::fabs, getBuilder()->CreateDerivative(coord, true, true));
   Value *absDdpxPlusDpdy = getBuilder()->CreateFAdd(absDpdx, absDpdy);
   Value *maybeZero = getBuilder()->CreateFCmpOEQ(absDdpxPlusDpdy, ConstantFP::get(coord->getType(), 0.0));
 


### PR DESCRIPTION
1. 'coarse' calculation is not precise enough,modify derivative to 'fine' calculation.
2. Refine the test.