### PR TITLE
Handle ls vgpr input workaround in the fetch shader

### DIFF
--- a/lgc/elfLinker/FetchShader.h
+++ b/lgc/elfLinker/FetchShader.h
@@ -81,7 +81,9 @@ private:
   llvm::Value *getReplacementForInputBuiltIn(llvm::CallInst *call) const;
   llvm::Value *getReplacementForVertexIdBuiltIn(llvm::CallInst *call) const;
   llvm::Value *getReplacementForInstanceIdBuiltIn(llvm::CallInst *call) const;
-  llvm::Value *getVgprArgument(unsigned vgpr, llvm::Function *function) const;
+  llvm::Value *getVgprArgumentAsAnInt32(unsigned vgpr, llvm::Function *function) const;
+  llvm::Value *getVpgrArgument(unsigned vgpr, BuilderBase &builder) const;
+  bool mustFixLsVgprInput() const;
 
   // The information stored here is all that is needed to generate the fetch shader. We deliberately do not
   // have access to PipelineState, so we can hash the information here and let the front-end use it as the
@@ -91,6 +93,9 @@ private:
   llvm::SmallVector<const VertexInputDescription *, 8> m_fetchDescriptions;
   // The encoded or hashed (in some way) single string version of the above.
   std::string m_shaderString;
+
+  // True if the fetch shader must work around the hardware sometimes shifting the vgpr inputs by two.
+  bool m_fixLsVgprInput = false;
 };
 
 } // namespace lgc

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineGsTess_AllStagesReloc.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineGsTess_AllStagesReloc.pipe
@@ -1,7 +1,7 @@
-; Test a reloctable shader compilation with every shader stage and a vertex input.
+; Test a relocatable shader compilation with every shader stage and a vertex input.
 
 ; BEGIN_SHADERTEST
-; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | \
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf -gfxip=9 %s -v | \
 ; RUN: FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST: Building pipeline with relocatable shader elf.
 ; SHADERTEST: {{^//}} LLPC pipeline patching results
@@ -20,7 +20,37 @@
 ; SHADERTEST: define dllexport amdgpu_gs void @_amdgpu_gs_main({{.*}}, i32 {{%[0-9]*}})
 
 ; SHADERTEST: {{^//}} LLPC final pipeline module info
+
+; Test that the vertex input is correctly loaded.  For GFX9, if the HS has no vertecies, then the first two vgpr inputs are dropped.  This must be accounted for.
+; SHADERTEST: {{^//}} LGC glue shader results
+; Fist identify the vgpr input in the function parameters.  We want to make sure we get the vertex id and the vgpr 2 place before it.
+; SHADERTEST: define amdgpu_hs { {{.*}} } @_amdgpu_hs_main({{(i32 inreg %[a-zA-Z0-9]+, )+}}float [[vgpr0:%[a-zA-Z0-9]+]], float [[vgpr1:%[a-zA-Z0-9]+]], float %VertexId, float [[vgpr3:%[a-zA-Z0-9]+]], float [[vgpr4:%[a-zA-Z0-9]+]], float %InstanceId)
+;
+; Make sure that the code picks the vgpr that actually contains the vertex id by checking if the HS has any vertices.
+; SHADERTEST: [[hsVertexCount:%[0-9]+]] = and i32 %MergedWaveInfo, 65280
+; SHADERTEST: %IsNullHs = icmp eq i32 [[hsVertexCount]], 0
+; SHADERTEST: %VgprArgument = select i1 %IsNullHs, float [[vgpr0]], float %VertexId
+; SHADERTEST: [[vgprAsInt:%[0-9]+]] = bitcast float %VgprArgument to i32
+
+; Calculate the vertex index and load the data.
+; SHADERTEST: %VertexIndex = add i32 [[vgprAsInt]], %BaseVertex
+; SHADERTEST: @llvm.amdgcn.struct.tbuffer.load.v4i32(<4 x i32> {{%[0-9]+}}, i32 %VertexIndex,
+
 ; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf -gfxip=10.1 %s -v | \
+; RUN: FileCheck -check-prefix=SHADERTEST_GFX10 %s
+
+; Test that the vertex input is correctly loaded.  GFX10 does not have to issue mentioned above.  Make sure that %VertexId is used.
+; SHADERTEST_GFX10: {{^//}} LGC glue shader results
+; SHADERTEST_GFX10: define amdgpu_hs { {{.*}} } @_amdgpu_hs_main({{.*}}, float %VertexId
+; SHADERTEST_GFX10: [[vgprAsInt:%[0-9]+]] = bitcast float %VertexId to i32
+; SHADERTEST_GFX10: %VertexIndex = add i32 [[vgprAsInt]], %BaseVertex
+; SHADERTEST_GFX10: @llvm.amdgcn.struct.tbuffer.load.v4i32(<4 x i32> {{%[0-9]+}}, i32 %VertexIndex,
+
+; SHADERTEST_GFX10: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
 [Version]


### PR DESCRIPTION
There is a bug for gfx9 where the hardware places the vgpr input in
different registers depending on whether or not the HS shader has any
verticies.  This needs to be accounted for when fetching the vertex
inputs.

This is built on top of #1742.  Look at the latest commit only.