### PR TITLE
Implement NPM middle-end pass registration and fix various NPM options

### DIFF
--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -129,6 +129,9 @@ public:
                         llvm::Timer *patchTimer, llvm::Timer *optTimer,
                         Pipeline::CheckShaderCacheFunc checkShaderCacheFunc, llvm::CodeGenOpt::Level optLevel);
 
+  // Register all the patching passes into the given pass manager
+  static void registerPasses(lgc::PassManager &passMgr);
+
   static llvm::GlobalVariable *getLdsVariable(PipelineState *pipelineState, llvm::Module *module);
 
 protected:

--- a/lgc/patch/PassRegistry.def
+++ b/lgc/patch/PassRegistry.def
@@ -1,0 +1,50 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PassRegistry.def
+ * @brief LLPC header file: used as the registry of LLPC patching passes
+ ***********************************************************************************************************************
+ */
+
+LLPC_PASS("lgc-patch-resource-collect", PatchResourceCollect())
+LLPC_PASS("lgc-patch-initialize-workgroup-memory", PatchInitializeWorkgroupMemory())
+LLPC_PASS("lgc-patch-in-out-import-export", PatchInOutImportExport())
+LLPC_PASS("lgc-patch-setup-target-features", PatchSetupTargetFeatures())
+LLPC_PASS("lgc-patch-copy-shader", PatchCopyShader())
+LLPC_PASS("lgc-patch-prepare-pipeline-abi", PatchPreparePipelineAbi())
+LLPC_PASS("lgc-patch-read-first-lane", PatchReadFirstLane())
+LLPC_PASS("lgc-patch-llvm-ir-inclusion", PatchLlvmIrInclusion())
+LLPC_PASS("lgc-patch-wave-size-adjust", PatchWaveSizeAdjust())
+LLPC_PASS("lgc-patch-peephole-opt", PatchPeepholeOpt())
+LLPC_PASS("lgc-patch-entry-point-mutate", PatchEntryPointMutate())
+LLPC_PASS("lgc-patch-check-shader-cache", PatchCheckShaderCache())
+LLPC_PASS("lgc-patch-loop-metadata", PatchLoopMetadata())
+LLPC_PASS("lgc-patch-buffer-op", PatchBufferOp())
+LLPC_PASS("lgc-patch-workarounds", PatchWorkarounds())
+LLPC_PASS("lgc-patch-load-scalarizer", PatchLoadScalarizer())
+LLPC_PASS("lgc-patch-null-frag-shader", PatchNullFragShader())
+
+#undef LLPC_PASS

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -242,6 +242,15 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
 }
 
 // =====================================================================================================================
+// Register all the patching passes into the given pass manager
+//
+// @param [in/out] passMgr : Pass manager
+void Patch::registerPasses(lgc::PassManager &passMgr) {
+#define LLPC_PASS(NAME, CLASS) passMgr.registerPass(NAME, decltype(CLASS)::name());
+#include "PassRegistry.def"
+}
+
+// =====================================================================================================================
 // Add whole-pipeline patch passes to pass manager
 //
 // @param pipelineState : Pipeline state

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -204,6 +204,7 @@ void PipelineState::generateWithNewPassManager(std::unique_ptr<Module> pipelineM
   // Set up "whole pipeline" passes, where we have a single module representing the whole pipeline.
   std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(getLgcContext()->getTargetMachine()));
   passMgr->setPassIndex(&passIndex);
+  Patch::registerPasses(*passMgr);
   passMgr->registerFunctionAnalysis([&] { return getLgcContext()->getTargetMachine()->getTargetIRAnalysis(); });
   passMgr->registerModuleAnalysis([&] { return PipelineShaders(); });
 

--- a/llpc/docs/AddingPasses.md
+++ b/llpc/docs/AddingPasses.md
@@ -31,4 +31,4 @@ This `PassRegistry.def` file is included in `llpcSpirvLower.cpp`, so you may nee
 
 ## Register a middle-end pass
 
-TODO: The new pass manager is currently unused for the middle-end passes.
+The process to register a middle-end pass is the same. The middle-end pass registry file is `lgc/patch/PassRegistry.def`.

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -226,7 +226,7 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 }
 
 // =====================================================================================================================
-// Register a pass to identify it with a short name in the pass manager
+// Register all the lowering passes into the given pass manager
 //
 // @param [in/out] passMgr : Pass manager
 void SpirvLower::registerPasses(lgc::PassManager &passMgr) {

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -59,7 +59,7 @@ public:
   void handleStoreInstGlobal(StoreInst &storeInst);
   void handleStoreInstGEP(GetElementPtrInst *const getElemPtr, StoreInst &storeInst);
 
-  static llvm::StringRef name() { return "Lower SPIR-V globals (global variables, inputs, and outputs"; }
+  static llvm::StringRef name() { return "Lower SPIR-V globals (global variables, inputs, and outputs)"; }
 
 private:
   void mapGlobalVariableToProxy(llvm::GlobalVariable *globalVar);


### PR DESCRIPTION
This patch fixes various command line options that are currently not working with the new pass manager:
  1. Implements the middle-end pass registration mechanism to enable the `--print-before`, `--print-after` and the other options based on pass names for the middle-end passes.
  2. Add the `--debug-pass-manager` option to verify the passes and print the list of executed passes, (similar to the `--debug-only=Arguments` which doesn't work with the new pass manager). This option has the same name as in the llvm tools.
  3. Add error when using `--dump-cfg-after` with the new pass manager. Implementing this option for the new pass manager is a bit tricky and the `-dot-cfg` pass can already be used for that. (e.g. `opt -dot-cfg file.ll`)
  4. Removed the `PrintIRInstrumentation` and `VerifyInstrumentation` instrumentations and use the `StandardInstrumentations` class to implement the options from 1. and 2. and the `--verify-ir` option