### PR TITLE
UNLINKED: Fix handling of multi-dword push constant load

### DIFF
--- a/lgc/include/lgc/patch/PatchEntryPointMutate.h
+++ b/lgc/include/lgc/patch/PatchEntryPointMutate.h
@@ -121,6 +121,9 @@ private:
   uint64_t generateEntryPointArgTys(ShaderInputs *shaderInputs, llvm::SmallVectorImpl<llvm::Type *> &argTys,
                                     llvm::SmallVectorImpl<std::string> &argNames, unsigned argOffset);
 
+  bool isSystemUserDataValue(unsigned userDataValue) const;
+  bool isUnlinkedDescriptorSetValue(unsigned value) const;
+
   void addSpecialUserDataArgs(llvm::SmallVectorImpl<UserDataArg> &userDataArgs,
                               llvm::SmallVectorImpl<UserDataArg> &specialUserDataArgs, llvm::IRBuilder<> &builder);
   void addUserDataArgs(llvm::SmallVectorImpl<UserDataArg> &userDataArgs, llvm::IRBuilder<> &builder);

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultiDwordPushConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultiDwordPushConst.pipe
@@ -1,0 +1,100 @@
+; Test that the offset to the push constant area is correct when there are is a multi-dword load.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -enable-relocatable-shader-elf -o %t.elf %gfxip %s -v | \
+; RUN: FileCheck -check-prefix=SHADERTEST %s
+
+; Check that the llvm-ir gets the push constant values from as a parameter.
+; SHADERTEST: // LLPC pipeline patching results
+; SHADERTEST: define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main({{.*}}, <2 x i32> inreg %pushConst2, {{.*}})
+; SHADERTEST: [[bc0:%[a-zA-Z0-9]+]] = bitcast <2 x i32> %pushConst2 to <2 x float>
+; SHADERTEST: [[pushConst0:%[.a-zA-Z0-9]+]] = extractelement <2 x float> [[bc0]], i64 0
+; SHADERTEST: [[bc1:%[a-zA-Z0-9]+]] = bitcast <2 x i32> %pushConst2 to <2 x float>
+; SHADERTEST: [[pushConst1:%[.a-zA-Z0-9]+]] = extractelement <2 x float> [[bc1]], i64 1
+; SHADERTEST: @llvm.amdgcn.image.gather4.lz.2d.sl_v4f32i32s.f32({{.*}}, float [[pushConst0]], float [[pushConst1]], {{.*}})
+
+; Check that those parameters are passed in as s2 and s3.
+; SHADERTEST-LABEL: _amdgpu_ps_main:
+; SHADERTEST-NEXT: BB0_0
+; SHADERTEST-NEXT: s_mov_b32 s0, 0
+; SHADERTEST-NEXT: v_mov_b32_e32 v0, 0
+; SHADERTEST-NEXT: v_mov_b32_e32 v5, s2
+; SHADERTEST-NEXT: v_mov_b32_e32 v6, s3
+; SHADERTEST: image_gather4_lz v[0:4], v[5:6]
+
+; Check that the PAL metadata will place the correct values in those registers.
+; SHADERTEST: SPI_SHADER_USER_DATA_PS_2                     0x0000000000000003
+; SHADERTEST: SPI_SHADER_USER_DATA_PS_3                     0x0000000000000004
+
+; END_SHADERTEST
+[Version]
+version = 52
+
+[VsGlsl]
+#version 450
+
+void main()
+{
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+; I cannot recompile the glsl produced by spirv-cross, so leaving it as spir-v.
+               OpCapability Shader
+               OpCapability SampledCubeArray
+               OpCapability ImageCubeArray
+               OpCapability SparseResidency
+               OpCapability StorageImageExtendedFormats
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %2 "main" %4
+               OpExecutionMode %2 OriginUpperLeft
+               OpDecorate %4 Location 0
+               OpDecorate %_struct_6 Block
+               OpMemberDecorate %_struct_6 0 Offset 8
+       %void = OpTypeVoid
+         %10 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+      %v4int = OpTypeVector %int 4
+  %_struct_6 = OpTypeStruct %v2float
+ %_struct_20 = OpTypeStruct %int %v4int
+%_ptr_Output_v4int = OpTypePointer Output %v4int
+%_ptr_PushConstant__struct_6 = OpTypePointer PushConstant %_struct_6
+%_ptr_PushConstant_v2float = OpTypePointer PushConstant %v2float
+         %31 = OpTypeImage %int 2D 0 0 0 1 R32i
+         %32 = OpTypeSampledImage %31
+          %4 = OpVariable %_ptr_Output_v4int Output
+          %7 = OpVariable %_ptr_PushConstant__struct_6 PushConstant
+      %int_0 = OpConstant %int 0
+         %86 = OpUndef %32
+          %2 = OpFunction %void None %10
+         %46 = OpLabel
+         %57 = OpAccessChain %_ptr_PushConstant_v2float %7 %int_0
+         %58 = OpLoad %v2float %57
+         %65 = OpImageSparseGather %_struct_20 %86 %58 %int_0
+         %70 = OpCompositeExtract %v4int %65 1
+               OpStore %4 %70
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 17
+userDataNode[0].type = PushConst
+userDataNode[0].offsetInDwords = 1
+userDataNode[0].sizeInDwords = 4
+userDataNode[0].set = 0xFFFFFFFF
+userDataNode[0].binding = 0
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R32_SINT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+


### PR DESCRIPTION
The current codes does not place the required push constant entries in the user data.  The special user data value used by unlinked shaders are truncated to a single dword.  The code then ends up getting a random value.
