### PR TITLE
Enable the new pass manager by default for the middle-end passes

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -162,8 +162,8 @@ opt<bool> FatalLlvmErrors("fatal-llvm-errors", cl::desc("Make all LLVM errors fa
 // -new-pass-manager: Use LLVM's new pass manager (experimental)
 opt<unsigned> NewPassManager("new-pass-manager",
                              cl::desc("0 - Legacy pass manager, 1 - New pass manager front-end, 2 - New pass manager "
-                                      "front-end and middle-end (experimental)"),
-                             init(1));
+                                      "front-end and middle-end"),
+                             init(2));
 
 extern opt<bool> EnableOuts;
 


### PR DESCRIPTION
This is finally the patch enabling the new pass manager by default for the middle-end passes (It is already enabled for the front-end passes). I ran preliminary performance tests and didn't identify any obvious regression. There is also a small improvement in compile time (~1.2%).