### PR TITLE
Replace some getPointerElementType calls

### DIFF
--- a/lgc/include/lgc/patch/SystemValues.h
+++ b/lgc/include/lgc/patch/SystemValues.h
@@ -87,7 +87,7 @@ public:
   llvm::Value *getGsVsRingBufDesc(unsigned streamId);
 
   // Get pointers to emit counters (GS)
-  llvm::ArrayRef<llvm::Value *> getEmitCounterPtr();
+  std::pair<llvm::Type *, llvm::ArrayRef<llvm::Value *>> getEmitCounterPtr();
 
   // Get global internal table pointer as pointer to i8.
   llvm::Instruction *getInternalGlobalTablePtr();
@@ -109,7 +109,7 @@ public:
 
 private:
   // Get stream-out buffer table pointer
-  llvm::Instruction *getStreamOutTablePtr();
+  std::pair<llvm::Type *, llvm::Instruction *> getStreamOutTablePtr();
 
   // Make 64-bit pointer of specified type from 32-bit int, extending with the specified value, or PC if InvalidValue
   llvm::Instruction *makePointer(llvm::Value *lowValue, llvm::Type *ptrTy, unsigned highValue);

--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -369,8 +369,7 @@ void NggLdsManager::atomicOpWithLds(AtomicRMWInst::BinOp atomicOp, Value *atomic
   // from byte offset.
   ldsOffset = m_builder->CreateLShr(ldsOffset, 2);
 
-  Value *atomicPtr = m_builder->CreateGEP(m_lds->getType()->getScalarType()->getPointerElementType(), m_lds,
-                                          {m_builder->getInt32(0), ldsOffset});
+  Value *atomicPtr = m_builder->CreateGEP(m_lds->getValueType(), m_lds, {m_builder->getInt32(0), ldsOffset});
 
   auto atomicInst = m_builder->CreateAtomicRMW(atomicOp, atomicPtr, atomicValue, MaybeAlign(),
                                                AtomicOrdering::SequentiallyConsistent, SyncScope::System);

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -613,8 +613,8 @@ void PatchBufferOp::visitGetElementPtrInst(GetElementPtrInst &getElemPtrInst) {
   SmallVector<Value *, 8> indices(getElemPtrInst.idx_begin(), getElemPtrInst.idx_end());
 
   Value *newGetElemPtr = nullptr;
-  auto getElemPtrPtr = cast<GetElementPtrInst>(m_replacementMap[pointer].second);
-  auto getElemPtrEltTy = getElemPtrPtr->getResultElementType();
+  auto getElemPtrPtr = m_replacementMap[pointer].second;
+  auto getElemPtrEltTy = getElemPtrPtr->getType()->getScalarType()->getPointerElementType();
 
   if (getElemPtrInst.isInBounds())
     newGetElemPtr = m_builder->CreateInBoundsGEP(getElemPtrEltTy, getElemPtrPtr, indices);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -593,8 +593,7 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
     assert(m_lds);
 
     Value *ringOffset = calcGsVsRingOffsetForInput(location, 0, streamId, builder);
-    Value *loadPtr = builder.CreateGEP(m_lds->getType()->getScalarType()->getPointerElementType(), m_lds,
-                                       {builder.getInt32(0), ringOffset});
+    Value *loadPtr = builder.CreateGEP(m_lds->getValueType(), m_lds, {builder.getInt32(0), ringOffset});
     loadPtr = builder.CreateBitCast(loadPtr, PointerType::get(loadTy, m_lds->getType()->getPointerAddressSpace()));
 
     return builder.CreateAlignedLoad(loadTy, loadPtr, m_lds->getAlign());

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1034,8 +1034,9 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
 
       if (emitStream != InvalidValue) {
         // Increment emit vertex counter
-        auto emitCounterPtr = m_pipelineSysValues.get(m_entryPoint)->getEmitCounterPtr()[emitStream];
-        auto emitCounterTy = emitCounterPtr->getType()->getPointerElementType();
+        auto emitCounterPair = m_pipelineSysValues.get(m_entryPoint)->getEmitCounterPtr();
+        auto emitCounterTy = emitCounterPair.first;
+        auto emitCounterPtr = emitCounterPair.second[emitStream];
         Value *emitCounter = new LoadInst(emitCounterTy, emitCounterPtr, "", &callInst);
         emitCounter =
             BinaryOperator::CreateAdd(emitCounter, ConstantInt::get(Type::getInt32Ty(*m_context), 1), "", &callInst);
@@ -4110,8 +4111,9 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
     const auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(m_shaderStage)->entryArgIdxs;
     Value *gsVsOffset = getFunctionArgument(m_entryPoint, entryArgIdxs.gs.gsVsOffset);
 
-    auto emitCounterPtr = m_pipelineSysValues.get(m_entryPoint)->getEmitCounterPtr()[streamId];
-    auto emitCounterTy = emitCounterPtr->getType()->getPointerElementType();
+    auto emitCounterPair = m_pipelineSysValues.get(m_entryPoint)->getEmitCounterPtr();
+    auto emitCounterTy = emitCounterPair.first;
+    auto emitCounterPtr = emitCounterPair.second[streamId];
     auto emitCounter = new LoadInst(emitCounterTy, emitCounterPtr, "", insertPos);
 
     auto ringOffset = calcGsVsRingOffsetForOutput(location, compIdx, streamId, emitCounter, gsVsOffset, insertPos);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -3926,7 +3926,7 @@ void PatchInOutImportExport::storeValueToEsGsRing(Value *storeValue, unsigned lo
     if (m_pipelineState->isGsOnChip() || m_gfxIp.major >= 9) // ES -> GS ring is always on-chip on GFX9+
     {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
-      auto ldsType = m_lds->getType()->getPointerElementType();
+      auto ldsType = m_lds->getValueType();
       Value *storePtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       new StoreInst(storeValue, storePtr, false, m_lds->getAlign().getValue(), insertPos);
     } else {
@@ -3995,10 +3995,10 @@ Value *PatchInOutImportExport::loadValueFromEsGsRing(Type *loadTy, unsigned loca
     if (m_pipelineState->isGsOnChip() || m_gfxIp.major >= 9) // ES -> GS ring is always on-chip on GFX9
     {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
-      auto ldsType = m_lds->getType()->getPointerElementType();
-      Value *loadPtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
-      auto loadInst = new LoadInst(loadPtr->getType()->getPointerElementType(), loadPtr, "", false,
-                                   m_lds->getAlign().getValue(), insertPos);
+      auto ldsType = m_lds->getValueType();
+      auto *loadPtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
+      auto loadInst =
+          new LoadInst(loadPtr->getResultElementType(), loadPtr, "", false, m_lds->getAlign().getValue(), insertPos);
       loadValue = loadInst;
 
       if (bitWidth == 8)
@@ -4118,7 +4118,7 @@ void PatchInOutImportExport::storeValueToGsVsRing(Value *storeValue, unsigned lo
 
     if (m_pipelineState->isGsOnChip()) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ringOffset};
-      auto ldsType = m_lds->getType()->getPointerElementType();
+      auto ldsType = m_lds->getValueType();
       Value *storePtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       new StoreInst(storeValue, storePtr, false, m_lds->getAlign().getValue(), insertPos);
     } else {
@@ -4357,9 +4357,9 @@ Value *PatchInOutImportExport::readValueFromLds(bool isOutput, Type *readTy, Val
   {
     for (unsigned i = 0; i < numChannels; ++i) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ldsOffset};
-      auto ldsType = m_lds->getType()->getPointerElementType();
-      Value *loadPtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
-      auto loadTy = loadPtr->getType()->getPointerElementType();
+      auto ldsType = m_lds->getValueType();
+      auto *loadPtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
+      auto loadTy = loadPtr->getResultElementType();
       auto loadInst = new LoadInst(loadTy, loadPtr, "", false, m_lds->getAlign().getValue(), insertPos);
       loadValues[i] = loadInst;
 
@@ -4455,7 +4455,7 @@ void PatchInOutImportExport::writeValueToLds(Value *writeValue, Value *ldsOffset
   {
     for (unsigned i = 0; i < numChannels; ++i) {
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), ldsOffset};
-      auto ldsType = m_lds->getType()->getPointerElementType();
+      auto ldsType = m_lds->getValueType();
       Value *storePtr = GetElementPtrInst::Create(ldsType, m_lds, idxs, "", insertPos);
       new StoreInst(storeValues[i], storePtr, false, m_lds->getAlign().getValue(), insertPos);
 

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1694,8 +1694,8 @@ void SpirvLowerGlobal::lowerBufferBlock() {
     SmallVector<ReplaceInstsInfo> instructionsToReplace;
     for (Function *const func : funcsUsedIn) {
       // Check if our block is an array of blocks.
-      if (global.getType()->getPointerElementType()->isArrayTy()) {
-        Type *const elementType = global.getType()->getPointerElementType()->getArrayElementType();
+      if (global.getValueType()->isArrayTy()) {
+        Type *const elementType = global.getValueType()->getArrayElementType();
         Type *const blockType = elementType->getPointerTo(global.getAddressSpace());
 
         // We need to run over the users of the global, find the GEPs, and add a load for each.
@@ -1937,8 +1937,7 @@ void SpirvLowerGlobal::lowerAliasedVal() {
         return;
       const unsigned aliased = mdconst::dyn_extract<ConstantInt>(meta->getOperand(0))->getZExtValue();
       if (aliased) {
-        unsigned inBits = static_cast<unsigned>(
-            m_module->getDataLayout().getTypeSizeInBits(global.getType()->getPointerElementType()));
+        unsigned inBits = static_cast<unsigned>(m_module->getDataLayout().getTypeSizeInBits(global.getValueType()));
         if (inBits > maxInBits) {
           maxInBits = inBits;
           index = aliasedVals.size();
@@ -1994,7 +1993,7 @@ void SpirvLowerGlobal::lowerPushConsts() {
       Value *pushConstants = m_builder->CreateLoadPushConstantsPtr(pushConstantsType);
 
       auto addrSpace = pushConstants->getType()->getPointerAddressSpace();
-      Type *const castType = global.getType()->getPointerElementType()->getPointerTo(addrSpace);
+      Type *const castType = global.getValueType()->getPointerTo(addrSpace);
       pushConstants = m_builder->CreateBitCast(pushConstants, castType);
 
       SmallVector<Instruction *, 8> usesToReplace;
@@ -2078,7 +2077,7 @@ void SpirvLowerGlobal::interpolateInputElement(unsigned interpLoc, Value *auxInt
     new StoreInst(loadValue, interpPtr, &callInst);
 
     auto interpElemPtr = GetElementPtrInst::Create(inputTy, interpPtr, indexOperands, "", &callInst);
-    auto interpElemTy = interpElemPtr->getType()->getPointerElementType();
+    auto interpElemTy = interpElemPtr->getResultElementType();
 
     // Only get the value that the original getElemPtr points to
     auto interpElemValue = new LoadInst(interpElemTy, interpElemPtr, "", &callInst);

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -140,7 +140,7 @@ void SpirvLowerMemoryOp::visitExtractElementInst(ExtractElementInst &extractElem
       auto castPtr = new BitCastInst(loadPtr, castPtrTy, "", &extractElementInst);
       Value *idxs[] = {ConstantInt::get(Type::getInt32Ty(*m_context), 0), extractElementInst.getOperand(1)};
       auto elementPtr = GetElementPtrInst::Create(castTy, castPtr, idxs, "", &extractElementInst);
-      auto elementTy = elementPtr->getType()->getPointerElementType();
+      auto elementTy = elementPtr->getResultElementType();
       auto newLoad = new LoadInst(elementTy, elementPtr, "", &extractElementInst);
       extractElementInst.replaceAllUsesWith(newLoad);
 
@@ -225,7 +225,7 @@ bool SpirvLowerMemoryOp::needExpandDynamicIndex(GetElementPtrInst *getElemPtr, u
         operandIndex = i;
         needExpand = true;
 
-        auto indexedTy = getElemPtr->getIndexedType(ptrVal->getType()->getPointerElementType(), idxs);
+        auto indexedTy = getElemPtr->getIndexedType(getElemPtr->getSourceElementType(), idxs);
         if (indexedTy) {
           // Check the upper bound of dynamic index
           if (isa<ArrayType>(indexedTy)) {


### PR DESCRIPTION
getPointerElementType will go away once llvm switches to opaque
pointers, so start replacing some of the uses with alternatives.