### PR TITLE
Small refactoring of some tessellation implementation

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -161,9 +161,8 @@ private:
                                            llvm::Value *vertexIdx, llvm::Value *gsVsOffset,
                                            llvm::Instruction *insertPos);
 
-  llvm::Value *readValueFromLds(bool isOutput, llvm::Type *readTy, llvm::Value *ldsOffset,
-                                llvm::Instruction *insertPos);
-  void writeValueToLds(llvm::Value *writeValue, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
+  llvm::Value *readValueFromLds(bool offChip, llvm::Type *readTy, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
+  void writeValueToLds(bool offChip, llvm::Value *writeValue, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
 
   llvm::Value *calcTessFactorOffset(bool isOuter, llvm::Value *elemIdx, llvm::Instruction *insertPos);
 

--- a/lgc/patch/Gfx6Chip.h
+++ b/lgc/patch/Gfx6Chip.h
@@ -80,6 +80,9 @@ constexpr unsigned GsPrimsPerEsThread = 256;
 // Preferred number of GS threads per VS thread.
 constexpr unsigned GsThreadsPerVsThread = 2;
 
+// Preferred number of HS threads per subgroup.
+constexpr unsigned MaxHsThreadsPerSubgroup = 256;
+
 // Max size of primitives per subgroup for adjacency primitives or when GS instancing is used. This restriction is
 // applicable only when GS on-chip mode is used.
 constexpr unsigned GsOnChipMaxPrimsPerSubgroup = 128;

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -655,10 +655,15 @@ template <typename T> void ConfigBuilder::buildLsRegConfig(ShaderStage shaderSta
 
   const auto &calcFactor = m_pipelineState->getShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor;
 
-  unsigned ldsSizeInDwords =
-      calcFactor.onChip.patchConstStart + calcFactor.patchConstSize * calcFactor.patchCountPerThreadGroup;
-  if (m_pipelineState->isTessOffChip())
+  unsigned ldsSizeInDwords = 0;
+  if (m_pipelineState->isTessOffChip()) {
+    // LDS usage: input patches
     ldsSizeInDwords = calcFactor.inPatchSize * calcFactor.patchCountPerThreadGroup;
+  } else {
+    // LDS usage: input patches, output patches, and patch constants
+    ldsSizeInDwords =
+        calcFactor.onChip.patchConstStart + calcFactor.patchConstSize * calcFactor.patchCountPerThreadGroup;
+  }
 
   auto gpuWorkarounds = &m_pipelineState->getTargetInfo().getGpuWorkarounds();
 

--- a/lgc/patch/Gfx9Chip.h
+++ b/lgc/patch/Gfx9Chip.h
@@ -186,6 +186,9 @@ constexpr unsigned GsPrimsPerEsThread = 256;
 // Preferred number of GS threads per VS thread.
 constexpr unsigned GsThreadsPerVsThread = 2;
 
+// Preferred number of HS threads per subgroup.
+constexpr unsigned MaxHsThreadsPerSubgroup = 256;
+
 // Preferred number of GS threads per subgroup.
 constexpr unsigned MaxGsThreadsPerSubgroup = 256;
 

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1096,10 +1096,8 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   // NOTE: On GFX7+, granularity for the LDS_SIZE field is 128. The range is 0~128 which allocates 0 to 16K
   // dwords.
   const auto &calcFactor = tcsResUsage->inOutUsage.tcs.calcFactor;
-  unsigned ldsSizeInDwords =
-      calcFactor.onChip.patchConstStart + calcFactor.patchConstSize * calcFactor.patchCountPerThreadGroup;
-  if (m_pipelineState->isTessOffChip())
-    ldsSizeInDwords = calcFactor.inPatchSize * calcFactor.patchCountPerThreadGroup;
+  assert(m_pipelineState->isTessOffChip()); // Must be off-chip on GFX9+
+  unsigned ldsSizeInDwords = calcFactor.inPatchSize * calcFactor.patchCountPerThreadGroup;
 
   const unsigned ldsSizeDwordGranularity = 128u;
   const unsigned ldsSizeDwordGranularityShift = 7u;


### PR DESCRIPTION
- Add a parameter 'offChip' to functions 'readValueFromLds' and
  'writeValueToLds'. The callers should decide on-chip mode or off-chip
  mode. On-chip mode and off-chip mode are valid to TCS outputs and TES
 inputs only.

- Add new capabilities 'MaxHsThreadsPerSubgroup'. Even if the value is
  always 256. We should use it. The assumption that tessellation always
  has 4 wavs is not correct when wave32 mode is enabled. We actually
  invoke fewer HS thread.

- Make some changes to LDS usage of HS. The original codes and comments
  are copied from GFX6 config builder, which is vague to GFX9. Actually,
  GFX9 always uses off-chip mode and only vertex data from LS to HS
  occupy LDS space.