### PR TITLE
Remove SPIR-V 1.6+ assert

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -933,7 +933,9 @@ protected:
     assert(getTrueLabel()->isForward() || getTrueLabel()->isLabel());
     assert(getFalseLabel()->isForward() || getFalseLabel()->isLabel());
 #if SPV_VERSION >= 0x10600
-    assert(TrueLabelId != FalseLabelId);
+    // This requirement was added in 1.6, but we also need to accept SPIR-V
+    // from before that, so ignore violations.
+    // assert(TrueLabelId != FalseLabelId);
 #endif
   }
   SPIRVId ConditionId;


### PR DESCRIPTION
SPIR-V 1.6 added a requirement for OpBranchConditional.
As our compiler also accepts previous SPIR-V versions like SPIR-V 1.0,
the assert would could for correct code.
There does not seem to be a way to access the used SPIR-V version in the
validation function, so just ignore this requirement.

Fixes dEQP-VK.spirv_assembly.instruction.graphics.conditional_branch.same_labels_false_tesse
with assertions on.