### PR TITLE
Don't assert if pointers have no ArrayStride

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7667,8 +7667,7 @@ Constant *SPIRVToLLVM::buildShaderBlockMetadata(SPIRVType *bt, ShaderBlockDecora
     } else if (bt->isTypePointer()) {
       blockDec.IsMatrix = false;
       SPIRVWord arrayStride = 0;
-      if (!bt->hasDecorate(DecorationArrayStride, 0, &arrayStride))
-        llvm_unreachable("Missing array stride decoration");
+      bt->hasDecorate(DecorationArrayStride, 0, &arrayStride);
       stride = arrayStride;
       elemTy = bt->getPointerElementType();
       blockMd.IsPointer = true;


### PR DESCRIPTION
As far as I understand, OpTypeRuntimeArray is required to have an
ArrayStride but OpTypePointer is not, so we should not assert
that pointers have an ArrayStride decoration.

Fixes dEQP-VK.spirv_assembly.instruction.compute.physical_pointers.compute.reads_opcopyobject_two_buffers
with assertions on.