### PR TITLE
Fix --emit-* and --filetype=asm options with part pipeline compilation

### DIFF
--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -148,6 +148,10 @@ public:
   void addInputElf(MemoryBufferRef inputElf) override final { addInputElf(inputElf, /*addAtStart=*/true); }
   void addInputElf(MemoryBufferRef inputElf, bool addAtStart);
 
+  // Check whether we have FS input mappings, and thus whether we're doing part-pipeline compilation of the
+  // pre-FS part of the pipeline.
+  bool haveFsInputMappings() override final;
+
   // Get a representation of the fragment shader input mappings from the PAL metadata of ELF input(s) added so far.
   // This is used by the caller in a part-pipeline compilation scheme to include the FS input mappings in the
   // hash for the non-FS part of the pipeline.
@@ -279,6 +283,13 @@ void ElfLinkerImpl::addInputElf(MemoryBufferRef inputElf, bool addAtStart) {
   readIsaName(*elfInput.objectFile);
   mergePalMetadataFromElf(*elfInput.objectFile, false);
   m_elfInputs.insert(addAtStart ? m_elfInputs.begin() : m_elfInputs.end(), std::move(elfInput));
+}
+
+// =====================================================================================================================
+// Check whether we have FS input mappings, and thus whether we're doing part-pipeline compilation of the
+// pre-FS part of the pipeline.
+bool ElfLinkerImpl::haveFsInputMappings() {
+  return m_pipelineState->getPalMetadata()->haveFsInputMappings();
 }
 
 // =====================================================================================================================

--- a/lgc/interface/lgc/ElfLinker.h
+++ b/lgc/interface/lgc/ElfLinker.h
@@ -53,6 +53,10 @@ public:
   // Add another input ELF to the link, in addition to the ones that were added when the ElfLinker was constructed.
   virtual void addInputElf(llvm::MemoryBufferRef inputElf) = 0;
 
+  // Check whether we have FS input mappings, and thus whether we're doing part-pipeline compilation of the
+  // pre-FS part of the pipeline.
+  virtual bool haveFsInputMappings() = 0;
+
   // Get a representation of the fragment shader input mappings from the PAL metadata of ELF input(s) added so far.
   // This is used by the caller in a part-pipeline compilation scheme to include the FS input mappings in the
   // hash for the non-FS part of the pipeline.


### PR DESCRIPTION
Using options to emit textual output (`--emit-llvm`, `--emit-llvm-bc`, `--emit-lgc` and `--filetype=asm`) with the new part pipeline compilation scheme, introduced by https://github.com/GPUOpen-Drivers/llpc/pull/1704, currently causes a crash.
This patch fix these options by generating a single file with the concatenation of the textual output of each part with a separator string.