### PR TITLE
Change pure virtual functions in PipelineContext to virutal functions

### DIFF
--- a/llpc/context/llpcComputeContext.cpp
+++ b/llpc/context/llpcComputeContext.cpp
@@ -62,9 +62,11 @@ const PipelineShaderInfo *ComputeContext::getPipelineShaderInfo(ShaderStage shad
 
 // =====================================================================================================================
 // Gets subgroup size usage
+//
+// @returns : Bitmask per stage, in the same order as defined in `Vkgc::ShaderStage`.
 unsigned ComputeContext::getSubgroupSizeUsage() const {
   const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(m_pipelineInfo->cs.pModuleData);
-  return moduleData->usage.useSubgroupSize << ShaderStageCompute;
+  return moduleData->usage.useSubgroupSize ? ShaderStageComputeBit : 0;
 }
 
 } // namespace Llpc

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -42,10 +42,8 @@ public:
                  MetroHash::Hash *cacheHash);
   virtual ~ComputeContext() {}
 
+  // Gets pipeline shader info of the specified shader stage
   virtual const PipelineShaderInfo *getPipelineShaderInfo(ShaderStage shaderStage) const;
-
-  // Checks whether the pipeline is graphics or compute
-  virtual bool isGraphics() const { return false; }
 
   // Gets pipeline build info
   virtual const void *getPipelineBuildInfo() const { return m_pipelineInfo; }
@@ -54,22 +52,16 @@ public:
   virtual unsigned getShaderStageMask() const { return ShaderStageComputeBit; }
 
   // Sets the mask of active shader stages bound to this pipeline
-  void setShaderStageMask(unsigned mask) { assert(mask == getShaderStageMask()); }
-
-  // Sets whether pre-rasterization part has a geometry shader
-  void setPreRasterHasGs(bool /*preRasterHasGs*/) { llvm_unreachable("Should never be called!"); }
-
-  // Gets whether pre-rasterization part has a geometry shader
-  bool getPreRasterHasGs() const { return false; };
+  void setShaderStageMask(unsigned mask) { assert(mask == ShaderStageComputeBit); }
 
   // Gets the count of active shader stages
   virtual unsigned getActiveShaderStageCount() const { return 1; }
 
-  // Gets subgroup size usage
-  virtual unsigned getSubgroupSizeUsage() const;
-
   // Gets per pipeline options
   virtual const PipelineOptions *getPipelineOptions() const { return &m_pipelineInfo->options; }
+
+  // Gets subgroup size usage
+  virtual unsigned getSubgroupSizeUsage() const;
 
 private:
   ComputeContext() = delete;

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -119,6 +119,8 @@ const PipelineShaderInfo *GraphicsContext::getPipelineShaderInfo(ShaderStage sha
 
 // =====================================================================================================================
 // Gets subgroup size usage
+//
+// @returns : Bitmask per stage, in the same order as defined in `Vkgc::ShaderStage`.
 unsigned GraphicsContext::getSubgroupSizeUsage() const {
   // clang-format off
   std::array<const PipelineShaderInfo *, ShaderStageGfxCount> shaderInfos = {

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -44,10 +44,11 @@ public:
                   MetroHash::Hash *cacheHash);
   virtual ~GraphicsContext();
 
-  virtual const PipelineShaderInfo *getPipelineShaderInfo(ShaderStage shaderStage) const;
-
   // Checks whether the pipeline is graphics or compute
   virtual bool isGraphics() const { return true; }
+
+  // Gets pipeline shader info of the specified shader stage
+  virtual const PipelineShaderInfo *getPipelineShaderInfo(ShaderStage shaderStage) const;
 
   // Gets pipeline build info
   virtual const void *getPipelineBuildInfo() const { return m_pipelineInfo; }
@@ -56,13 +57,13 @@ public:
   virtual unsigned getShaderStageMask() const { return m_stageMask; }
 
   // Sets the mask of active shader stages bound to this pipeline
-  void setShaderStageMask(unsigned mask) { m_stageMask = mask; }
+  virtual void setShaderStageMask(unsigned mask) { m_stageMask = mask; }
 
   // Sets whether pre-rasterization part has a geometry shader
-  void setPreRasterHasGs(bool preRasterHasGs) { m_preRasterHasGs = preRasterHasGs; }
+  virtual void setPreRasterHasGs(bool preRasterHasGs) { m_preRasterHasGs = preRasterHasGs; }
 
   // Gets whether pre-rasterization part has a geometry shader
-  bool getPreRasterHasGs() const { return m_preRasterHasGs; };
+  virtual bool getPreRasterHasGs() const { return m_preRasterHasGs; };
 
   // Gets the count of active shader stages
   virtual unsigned getActiveShaderStageCount() const { return m_activeStageCount; }

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -102,34 +102,37 @@ public:
   virtual ~PipelineContext();
 
   // Checks whether the pipeline is graphics or compute
-  virtual bool isGraphics() const = 0;
-
-  // Gets subgroup size usage denoting which stage uses features relevant to subgroup size.
-  // @returns : Bitmask per stage, in the same order as defined in `Vkgc::ShaderStage`.
-  virtual unsigned getSubgroupSizeUsage() const = 0;
+  virtual bool isGraphics() { return false; }
 
   // Gets pipeline shader info of the specified shader stage
-  virtual const PipelineShaderInfo *getPipelineShaderInfo(ShaderStage shaderStage) const = 0;
+  virtual const PipelineShaderInfo *getPipelineShaderInfo(ShaderStage shaderStage) { return nullptr; }
 
   // Gets pipeline build info
-  virtual const void *getPipelineBuildInfo() const = 0;
+  virtual const void *getPipelineBuildInfo() const { return nullptr; }
 
   // Gets the mask of active shader stages bound to this pipeline
-  virtual unsigned getShaderStageMask() const = 0;
+  virtual unsigned getShaderStageMask() const { return 0; }
 
   // Sets the mask of active shader stages bound to this pipeline
-  virtual void setShaderStageMask(unsigned mask) = 0;
+  virtual void setShaderStageMask(unsigned mask) {}
 
   // Sets whether pre-rasterization part has a geometry shader.
   // NOTE: Only applicable in the part pipeline compilation mode.
-  virtual void setPreRasterHasGs(bool preRasterHasGs) = 0;
+  virtual void setPreRasterHasGs(bool preRasterHasGs) {}
 
   // Gets whether pre-rasterization part has a geometry shader.
   // NOTE: Only applicable in the part pipeline compilation mode.
-  virtual bool getPreRasterHasGs() const = 0;
+  virtual bool getPreRasterHasGs() const { return false; }
 
   // Gets the count of active shader stages
-  virtual unsigned getActiveShaderStageCount() const = 0;
+  virtual unsigned getActiveShaderStageCount() const { return 0; }
+
+  // Gets per pipeline options
+  virtual const PipelineOptions *getPipelineOptions() const { return nullptr; }
+
+  // Gets subgroup size usage denoting which stage uses features relevant to subgroup size.
+  // @returns : Bitmask per stage, in the same order as defined in `Vkgc::ShaderStage`.
+  virtual unsigned getSubgroupSizeUsage() const { return 0; }
 
   static const char *getGpuNameAbbreviation(GfxIpVersion gfxIp);
 
@@ -160,10 +163,7 @@ public:
   // Sets the cache hash for the pipeline.  This is the hash that is used to do cache lookups.
   void setHashForCacheLookUp(MetroHash::Hash hash) { m_cacheHash = hash; }
 
-  virtual ShaderHash getShaderHashCode(ShaderStage stage) const;
-
-  // Gets per pipeline options
-  virtual const PipelineOptions *getPipelineOptions() const = 0;
+  ShaderHash getShaderHashCode(ShaderStage stage) const;
 
   // Set pipeline state in lgc::Pipeline object for middle-end, and (optionally) hash the state.
   void setPipelineState(lgc::Pipeline *pipeline, Util::MetroHash64 *hasher, bool unlinked) const;


### PR DESCRIPTION
We have several pure virtual functions in PipelineContext. Acutally,some
of them don't need to be redefined by derived classes. We can use the
default one in base class. This could make the derived classes look
tidy without involving useless ones.