### PR TITLE
Replace hard-coded rounding mode values

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -135,7 +135,7 @@ public:
   llvm::Value *CreateCubeFaceIndex(llvm::Value *coord, const llvm::Twine &instName = "") override final;
 
   // Create scalar or vector FP truncate operation with rounding mode.
-  llvm::Value *CreateFpTruncWithRounding(llvm::Value *value, llvm::Type *destTy, unsigned roundingMode,
+  llvm::Value *CreateFpTruncWithRounding(llvm::Value *value, llvm::Type *destTy, llvm::RoundingMode roundingMode,
                                          const llvm::Twine &instName = "") override final;
 
   // Create quantize operation.

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -830,9 +830,9 @@ Value *BuilderRecorder::CreateRefract(Value *i, Value *n, Value *eta, const Twin
 // @param destTy : Type to convert to
 // @param roundingMode : Rounding mode
 // @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreateFpTruncWithRounding(Value *value, Type *destTy, unsigned roundingMode,
+Value *BuilderRecorder::CreateFpTruncWithRounding(Value *value, Type *destTy, RoundingMode roundingMode,
                                                   const Twine &instName) {
-  return record(Opcode::FpTruncWithRounding, destTy, {value, getInt32(roundingMode)}, instName);
+  return record(Opcode::FpTruncWithRounding, destTy, {value, getInt32(static_cast<unsigned>(roundingMode))}, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -244,7 +244,7 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   }
 
   case BuilderRecorder::FpTruncWithRounding: {
-    auto roundingMode = static_cast<unsigned>(cast<ConstantInt>(args[1])->getZExtValue());
+    auto roundingMode = static_cast<RoundingMode>(cast<ConstantInt>(args[1])->getZExtValue());
     return m_builder->CreateFpTruncWithRounding(args[0], call->getType(), roundingMode);
   }
 

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -268,7 +268,7 @@ public:
   llvm::Value *CreateCubeFaceIndex(llvm::Value *coord, const llvm::Twine &instName = "") override final;
 
   // Create scalar or vector FP truncate operation with rounding mode.
-  llvm::Value *CreateFpTruncWithRounding(llvm::Value *value, llvm::Type *destTy, unsigned roundingMode,
+  llvm::Value *CreateFpTruncWithRounding(llvm::Value *value, llvm::Type *destTy, llvm::RoundingMode roundingMode,
                                          const llvm::Twine &instName = "") override final;
 
   // Create quantize operation.

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -305,8 +305,8 @@ public:
   // @param destTy : Type to convert to
   // @param roundingMode : Rounding mode
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateFpTruncWithRounding(llvm::Value *value, llvm::Type *destTy, unsigned roundingMode,
-                                                 const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateFpTruncWithRounding(llvm::Value *value, llvm::Type *destTy,
+                                                 llvm::RoundingMode roundingMode, const llvm::Twine &instName = "") = 0;
 
   // Create quantize operation: truncates float (or vector) value to a value that is representable by a half.
   //

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4670,28 +4670,21 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     if (val->getType()->getScalarType()->getPrimitiveSizeInBits() <= destTy->getScalarType()->getPrimitiveSizeInBits())
       return mapValue(bv, getBuilder()->CreateFPExt(val, destTy));
 
-    // TODO: use hardcoded values during namespace flux for llvm
-    // fp::RoundingMode RM = fp::rmDynamic;
-    unsigned rm = 0; // fp::rmDynamic
+    RoundingMode rm = RoundingMode::Dynamic;
     SPIRVFPRoundingModeKind rounding;
     if (bc->hasFPRoundingMode(&rounding)) {
       switch (rounding) {
       case FPRoundingModeRTE:
-        // TODO: use hardcoded values during namespace flux for llvm
-        // RM = fp::rmToNearest;
-        rm = 1;
+        rm = RoundingMode::NearestTiesToEven;
         break;
       case FPRoundingModeRTZ:
-        // RM = fp::rmTowardZero;
-        rm = 4;
+        rm = RoundingMode::TowardZero;
         break;
       case FPRoundingModeRTP:
-        // RM = fp::rmUpward;
-        rm = 3;
+        rm = RoundingMode::TowardPositive;
         break;
       case FPRoundingModeRTN:
-        // RM = fp::rmDownward;
-        rm = 2;
+        rm = RoundingMode::TowardNegative;
         break;
       default:
         llvm_unreachable("Should never be called!");


### PR DESCRIPTION
Previously rounding mode values used in LGC is hard-coded,
now we replace them with enum value RoundingMode defined by LLVM
in FloatingPointMode.h.