### PR TITLE
Update a16 amber test

### DIFF
--- a/test/amber/a16.amber
+++ b/test/amber/a16.amber
@@ -15,8 +15,7 @@
 
 # Modifications Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
-# TODO Remove the not once this is fixed in LLVM
-# RUN: not run_amber_test.py --icd %icd %s | FileCheck %s
+# RUN: run_amber_test.py --icd %icd %s | FileCheck %s
 # REQUIRES: gfx10+
 
 # Test a16 image samples with bias. The bias needs to be converted to 16 bit.


### PR DESCRIPTION
The a16 issue has been fixed in D116038, so the test is passing now.