### PR TITLE
Guard breaking PAL interface change

### DIFF
--- a/llpc/util/llpcElfWriter.cpp
+++ b/llpc/util/llpcElfWriter.cpp
@@ -303,6 +303,7 @@ void ElfWriter<Elf>::mergeMetaNote(Context *pContext, const ElfNote *pNote1, con
   pipelineHash[0] = destDocument.getNode(pContext->getPipelineHashCode());
   pipelineHash[1] = destDocument.getNode(pContext->getPipelineHashCode());
 
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 723
   // Update .ps_sample_mask
   // NOTE: We need to erase the node if the cached ELF has it but we actually don't need it.
   auto srcPsSampleMask = srcPipeline.getMap(true).find(StringRef(PalAbi::PipelineMetadataKey::PsSampleMask));
@@ -311,6 +312,7 @@ void ElfWriter<Elf>::mergeMetaNote(Context *pContext, const ElfNote *pNote1, con
     destPipeline.getMap(true)[PalAbi::PipelineMetadataKey::PsSampleMask] = srcPsSampleMask->second;
   else if (destPsSampleMask != destPipeline.getMap(true).end())
     destPipeline.getMap(true).erase(destPsSampleMask);
+#endif
 
   // List of fragment shader related registers.
   static const unsigned PsRegNumbers[] = {


### PR DESCRIPTION
The field `PalAbi::PipelineMetadataKey::PsSampleMask` is only present in PAL since version 723.