### PR TITLE
lgc: Move some functions to BuilderBase

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -841,7 +841,6 @@ private:
   unsigned getShaderWaveSize();
   llvm::Value *createGroupArithmeticIdentity(GroupArithOp groupArithOp, llvm::Type *const type);
   llvm::Value *createGroupArithmeticOperation(GroupArithOp groupArithOp, llvm::Value *const x, llvm::Value *const y);
-  llvm::Value *createInlineAsmSideEffect(llvm::Value *const value);
   llvm::Value *createDppMov(llvm::Value *const value, DppCtrl dppCtrl, unsigned rowMask, unsigned bankMask,
                             bool boundCtrl);
   llvm::Value *createDppUpdate(llvm::Value *const origValue, llvm::Value *const updateValue, DppCtrl dppCtrl,
@@ -855,7 +854,6 @@ private:
 
   llvm::Value *createDsSwizzle(llvm::Value *const value, uint16_t dsPattern);
   llvm::Value *createWwm(llvm::Value *const value);
-  llvm::Value *createSetInactive(llvm::Value *const active, llvm::Value *const inactive);
   llvm::Value *createThreadMask();
   llvm::Value *createThreadMaskedSelect(llvm::Value *const threadMask, uint64_t andMask, llvm::Value *const value1,
                                         llvm::Value *const value2);

--- a/lgc/include/lgc/util/BuilderBase.h
+++ b/lgc/include/lgc/util/BuilderBase.h
@@ -77,6 +77,12 @@ public:
   // @param passthroughArgs : The arguments to pass-through without massaging.
   llvm::Value *CreateMapToInt32(MapToInt32Func mapFunc, llvm::ArrayRef<llvm::Value *> mappedArgs,
                                 llvm::ArrayRef<llvm::Value *> passthroughArgs);
+
+  // Create an inline assembly call to cause a side effect (used to work around miscompiles with convergent).
+  llvm::Value *CreateInlineAsmSideEffect(llvm::Value *const value);
+
+  // Create a call to set inactive. Both active and inactive should have the same type.
+  llvm::Value *CreateSetInactive(llvm::Value *const active, llvm::Value *const inactive);
 };
 
 } // namespace lgc


### PR DESCRIPTION
Move below functions to BuilderBase, so they can also be used in patch pass.
createInlineAsmSideEffect()
createSetInactive()