### PR TITLE
Don't use a table lookup in ShaderInputs::getSpecialUserDataName

### DIFF
--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -159,10 +159,10 @@ public:
   // Static methods called any time
 
   // Get name of a special user data value, one of the UserDataMapping values
-  static const char *getSpecialUserDataName(unsigned kind);
-  static const char *getSpecialUserDataName(UserDataMapping kind) {
-    return getSpecialUserDataName(static_cast<unsigned>(kind));
+  static const char *getSpecialUserDataName(unsigned kind) {
+    return getSpecialUserDataName(static_cast<UserDataMapping>(kind));
   }
+  static const char *getSpecialUserDataName(UserDataMapping kind);
 
   // Get IR type of a particular shader input
   static llvm::Type *getInputType(ShaderInput inputKind, const LgcContext &lgcContext);

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -43,38 +43,35 @@ using namespace llvm;
 // Get name of a special user data value, one of the UserDataMapping values
 //
 // @param kind : The kind of special user data, a UserDataMapping enum value
-const char *ShaderInputs::getSpecialUserDataName(unsigned kind) {
-  static const char *names[] = {
-      "GlobalTable",
-      "PerShaderTable",
-      "SpillTable",
-      "BaseVertex",
-      "BaseInstance",
-      "DrawIndex",
-      "Workgroup",
-      "",
-      "",
-      "",
-      "EsGsLdsSize",
-      "ViewId",
-      "StreamOutTable",
-      "",
-      "",
-      "VertexBufferTable",
-      "",
-      "NggCullingData",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-      "",
-  };
-  unsigned idx = kind - static_cast<unsigned>(UserDataMapping::GlobalTable);
-  return ArrayRef<const char *>(names)[idx];
+const char *ShaderInputs::getSpecialUserDataName(UserDataMapping kind) {
+  switch (kind) {
+  case UserDataMapping::GlobalTable:
+    return "GlobalTable";
+  case UserDataMapping::PerShaderTable:
+    return "PerShaderTable";
+  case UserDataMapping::SpillTable:
+    return "SpillTable";
+  case UserDataMapping::BaseVertex:
+    return "BaseVertex";
+  case UserDataMapping::BaseInstance:
+    return "BaseInstance";
+  case UserDataMapping::DrawIndex:
+    return "DrawIndex";
+  case UserDataMapping::Workgroup:
+    return "Workgroup";
+  case UserDataMapping::EsGsLdsSize:
+    return "EsGsLdsSize";
+  case UserDataMapping::ViewId:
+    return "ViewId";
+  case UserDataMapping::StreamOutTable:
+    return "StreamOutTable";
+  case UserDataMapping::VertexBufferTable:
+    return "VertexBufferTable";
+  case UserDataMapping::NggCullingData:
+    return "NggCullingData";
+  default:
+    return "";
+  }
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The previous method was dangerous, because the array elements must have been kept in sync with the enum definition, without  an easy way to validate it at compile time.