### PR TITLE
Refactor the tessellation factor store

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -164,8 +164,6 @@ private:
   llvm::Value *readValueFromLds(bool offChip, llvm::Type *readTy, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
   void writeValueToLds(bool offChip, llvm::Value *writeValue, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
 
-  llvm::Value *calcTessFactorOffset(bool isOuter, llvm::Value *elemIdx, llvm::Instruction *insertPos);
-
   void storeTessFactorToBuffer(llvm::ArrayRef<llvm::Value *> tessFactors, llvm::Value *tessFactorOffset,
                                llvm::Instruction *insertPos);
 
@@ -240,8 +238,8 @@ private:
   std::set<unsigned> m_expLocs; // The locations that already have an export instruction for the vertex shader.
   const std::array<unsigned char, 4> *m_buffFormats; // The format of MTBUF instructions for specified GFX
 
-  llvm::SmallVector<llvm::Instruction *, 4> m_tessLevelOuterInsts; // Collect the instructions of TessLevelOuter
-  llvm::SmallVector<llvm::Instruction *, 2> m_tessLevelInnerInsts; // Collect the instructions of TessLevelInner
+  llvm::Value *m_tessLevelOuterPtr = nullptr; // Correspond to "out float gl_TessLevelOuter[4]"
+  llvm::Value *m_tessLevelInnerPtr = nullptr; // Correspond to "out float gl_TessLevelInner[2]"
 };
 
 // =====================================================================================================================

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1790,9 +1790,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.perPatchBuiltInInputLocMap[BuiltInTessLevelOuter];
         inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelOuter] = mapLoc;
         availPerPatchOutMapLoc = std::max(availPerPatchOutMapLoc, mapLoc + 1);
-      } else if (builtInUsage.tcs.tessLevelOuter && m_importedOutputBuiltIns.count(BuiltInTessLevelOuter) > 0) {
-        // NOTE: We have to map gl_TessLevelOuter to generic per-patch output if it is used for output import.
-        inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelOuter] = availPerPatchOutMapLoc++;
       }
 
       if (nextBuiltInUsage.tessLevelInner) {
@@ -1801,9 +1798,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.perPatchBuiltInInputLocMap[BuiltInTessLevelInner];
         inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelInner] = mapLoc;
         availPerPatchOutMapLoc = std::max(availPerPatchOutMapLoc, mapLoc + 1);
-      } else if (builtInUsage.tcs.tessLevelInner && m_importedOutputBuiltIns.count(BuiltInTessLevelInner) > 0) {
-        // NOTE: We have to map gl_TessLevelInner to generic per-patch output if it is used for output import.
-        inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelInner] = availPerPatchOutMapLoc++;
       }
 
       // Revisit built-in outputs and map those unmapped to generic ones
@@ -1842,10 +1836,10 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
           ++availOutMapLoc;
       }
 
-      if (builtInUsage.tcs.tessLevelOuter && m_importedOutputBuiltIns.count(BuiltInTessLevelOuter) > 0)
+      if (builtInUsage.tcs.tessLevelOuter)
         inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelOuter] = availPerPatchOutMapLoc++;
 
-      if (builtInUsage.tcs.tessLevelInner && m_importedOutputBuiltIns.count(BuiltInTessLevelInner) > 0)
+      if (builtInUsage.tcs.tessLevelInner)
         inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelInner] = availPerPatchOutMapLoc++;
     }
 


### PR DESCRIPTION
1. Tessellation level is treated as uniform by a patch. We define two
   local variables to cache the values of gl_TessLevelOuter and
   gl_TessLevelInner. The read and write of them are performed on these
   two local variables without direct LDS or TF buffer operations.

2. Before the return of TCS main, we start to write tessellation factors
   to TF buffer and to LDS if TES reads those tessellation factors.