### PR TITLE
Set BoundCtrl to true when using DPP for OpGroupNonUniformQuad*

### DIFF
--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -980,16 +980,16 @@ Value *SubgroupBuilder::CreateSubgroupQuadBroadcast(Value *const value, Value *c
 
   if (supportDpp()) {
     Value *compare = CreateICmpEQ(index, getIntN(indexBits, 0));
-    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm0000, 0xF, 0xF, false), result);
+    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm0000, 0xF, 0xF, true), result);
 
     compare = CreateICmpEQ(index, getIntN(indexBits, 1));
-    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm1111, 0xF, 0xF, false), result);
+    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm1111, 0xF, 0xF, true), result);
 
     compare = CreateICmpEQ(index, getIntN(indexBits, 2));
-    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm2222, 0xF, 0xF, false), result);
+    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm2222, 0xF, 0xF, true), result);
 
     compare = CreateICmpEQ(index, getIntN(indexBits, 3));
-    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm3333, 0xF, 0xF, false), result);
+    result = CreateSelect(compare, createDppMov(value, DppCtrl::DppQuadPerm3333, 0xF, 0xF, true), result);
   } else {
     Value *compare = CreateICmpEQ(index, getIntN(indexBits, 0));
     result = CreateSelect(compare, createDsSwizzle(value, getDsSwizzleQuadMode(0, 0, 0, 0)), result);
@@ -1014,7 +1014,7 @@ Value *SubgroupBuilder::CreateSubgroupQuadBroadcast(Value *const value, Value *c
 // @param instName : Name to give final instruction.
 Value *SubgroupBuilder::CreateSubgroupQuadSwapHorizontal(Value *const value, const Twine &instName) {
   if (supportDpp())
-    return createDppMov(value, DppCtrl::DppQuadPerm1032, 0xF, 0xF, false);
+    return createDppMov(value, DppCtrl::DppQuadPerm1032, 0xF, 0xF, true);
   else
     return createDsSwizzle(value, getDsSwizzleQuadMode(1, 0, 3, 2));
 }
@@ -1026,7 +1026,7 @@ Value *SubgroupBuilder::CreateSubgroupQuadSwapHorizontal(Value *const value, con
 // @param instName : Name to give final instruction.
 Value *SubgroupBuilder::CreateSubgroupQuadSwapVertical(Value *const value, const Twine &instName) {
   if (supportDpp())
-    return createDppMov(value, DppCtrl::DppQuadPerm2301, 0xF, 0xF, false);
+    return createDppMov(value, DppCtrl::DppQuadPerm2301, 0xF, 0xF, true);
   else
     return createDsSwizzle(value, getDsSwizzleQuadMode(2, 3, 0, 1));
 }
@@ -1038,7 +1038,7 @@ Value *SubgroupBuilder::CreateSubgroupQuadSwapVertical(Value *const value, const
 // @param instName : Name to give final instruction.
 Value *SubgroupBuilder::CreateSubgroupQuadSwapDiagonal(Value *const value, const Twine &instName) {
   if (supportDpp())
-    return createDppMov(value, DppCtrl::DppQuadPerm3210, 0xF, 0xF, false);
+    return createDppMov(value, DppCtrl::DppQuadPerm3210, 0xF, 0xF, true);
   else
     return createDsSwizzle(value, getDsSwizzleQuadMode(3, 2, 1, 0));
 }

--- a/llpc/test/shaderdb/core/OpGroupNonUniformQuadSwap.comp
+++ b/llpc/test/shaderdb/core/OpGroupNonUniformQuadSwap.comp
@@ -1,0 +1,19 @@
+// RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck %s
+
+// CHECK-LABEL: {{^}}// LLPC final ELF info
+// CHECK: v_max_f32_dpp {{.*}} quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0xf bound_ctrl:1
+// CHECK: v_min_f32_dpp {{.*}} quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xf bound_ctrl:1
+
+#version 450
+#extension GL_KHR_shader_subgroup_quad : require
+
+layout(set=0, binding=0) buffer Buf {
+  float h[32];
+} data;
+
+void main() {
+  float val = data.h[gl_SubgroupInvocationID];
+  val = max(val, subgroupQuadSwapHorizontal(val));
+  val = min(val, subgroupQuadSwapVertical(val));
+  data.h[gl_SubgroupInvocationID] = val;
+}


### PR DESCRIPTION
When generating LLVM IR for OpGroupNonUniformQuadBroadcast and
OpGroupNonUniformQuadSwap, set the BoundCtrl argument to the
llvm.amdgcn.mov.dpp intrinsic to true. The effect of this is that if a
write to an active lane depends on the value of an inactive lane, a zero
value will be written, instead of leaving the active lane unchanged. The
SPIR-V spec for these ops says that "if an active invocation reads Value
from an inactive invocation, the resulting value is undefined", so this
should not affect correctness.

This allows the LLVM backend to generate better code, because a
v_mov_b32_dpp instruction with BC=1 can easily be combined into a
following arithmetic instruction by propagating the BC=1 bit to the
combined instruction. With BC=0 it is much harder, and could probably
only be done if the compiler could prove that all active lanes only
read from other active lanes.