### PR TITLE
Resource Layout scheme

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 53
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #if VFX_INSIDE_SPVGEN
@@ -86,6 +86,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     53.2 | Add resourceLayoutScheme to PipelineOptions                                                           |
 //  |     53.1 | Add PartPipelineStage enum for part-pipeline mode                                                     |
 //  |     53.0 | Add optimizationLevel to PipelineOptions                                                              |
 //  |     52.3 | Add fastMathFlags to PipelineShaderOptions                                                            |
@@ -393,6 +394,12 @@ enum class ThreadGroupSwizzleMode : unsigned {
   Count
 };
 
+/// Represents mapping layout of the resources used in shaders
+enum class ResourceLayoutScheme : unsigned {
+  Compact = 0, ///< Compact scheme make full use of all the user data registers.
+  Indirect     ///< Fixed layout, push constant will be the sub node of DescriptorTableVaPtr
+};
+
 /// Represents per pipeline options.
 struct PipelineOptions {
   bool includeDisassembly;         ///< If set, the disassembly for all compiled shaders will be included in
@@ -420,6 +427,7 @@ struct PipelineOptions {
   uint32_t optimizationLevel; ///< The higher the number the more optimizations will be performed.  Valid values are
                               ///< between 0 and 3.
 #endif
+  ResourceLayoutScheme resourceLayoutScheme; ///< Resource layout scheme
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -89,6 +89,12 @@ enum class ResourceNodeType : unsigned {
   DescriptorReserved16,
   Count, ///< Count of resource mapping node types.
 };
+
+// Represents mapping layout of the resources used in shaders
+enum class ResourceLayoutScheme : unsigned {
+  Compact = 0, ///< Compact scheme make full use of all the user data registers.
+  Indirect     ///< Fixed layout, push constant will be the sub node of DescriptorTableVaPtr
+};
 } // namespace lgc
 
 namespace llvm {

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -127,6 +127,7 @@ struct Options {
   unsigned reserved1f;                // Reserved for future functionality
   unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
   unsigned pageMigrationEnabled;  // Enable page migration
+  ResourceLayoutScheme resourceLayoutScheme; // Resource layout scheme
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -728,8 +728,13 @@ void PipelineState::readUserDataNodes(Module *module) {
 // Returns the resource node for the push constant.
 const ResourceNode *PipelineState::findPushConstantResourceNode() const {
   for (const ResourceNode &node : getUserDataNodes()) {
-    if (node.type == ResourceNodeType::PushConst) {
+    if (node.type == ResourceNodeType::PushConst)
       return &node;
+    if (node.type == ResourceNodeType::DescriptorTableVaPtr) {
+      if (!node.innerTable.empty() && node.innerTable[0].type == ResourceNodeType::PushConst) {
+        assert(ResourceLayoutScheme::Indirect == m_options.resourceLayoutScheme);
+        return &node;
+      }
     }
   }
   return nullptr;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -334,6 +334,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
   options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
   options.enableInterpModePatch = getPipelineOptions()->enableInterpModePatch;
   options.pageMigrationEnabled = getPipelineOptions()->pageMigrationEnabled;
+  options.resourceLayoutScheme = static_cast<lgc::ResourceLayoutScheme>(getPipelineOptions()->resourceLayoutScheme);
 
   // Driver report full subgroup lanes for compute shader, here we just set fullSubgroups as default options
   options.fullSubgroups = true;

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
@@ -1,0 +1,69 @@
+; Check the resource layout mode. In "Indirect" mode, "PushConst" resource is not in root node.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -spvgen-dir=%spvgendir% -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: call [16 x i8] addrspace(4)* (...) @lgc.create.load.push.constants.ptr.p4a16i8()
+; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
+; SHADERTEST: call i8 addrspace(4)* @lgc.descriptor.table.addr(i32 9, i32 -1, i32 0, i32 -1)
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 52
+
+[VsGlsl]
+#version 450
+
+layout( location = 0 ) in vec4 app_position;
+
+void main() {
+  gl_Position = app_position;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+layout( location = 0 ) out vec4 frag_color;
+
+layout( push_constant ) uniform ColorBlock {
+  vec4 Color;
+} PushConstant;
+
+void main() {
+   frag_color = PushConstant.Color;
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 2
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 4
+userDataNode[1].visibility = 66
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = PushConst
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 4
+userDataNode[1].next[0].set = 0xFFFFFFFF
+userDataNode[1].next[0].binding = 0
+
+[GraphicsPipelineState]
+options.resourceLayoutScheme = Indirect
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 12
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -64,6 +64,7 @@ std::ostream &operator<<(std::ostream &out, DenormalMode denormalMode);
 std::ostream &operator<<(std::ostream &out, WaveBreakSize waveBreakSize);
 std::ostream &operator<<(std::ostream &out, ShadowDescriptorTableUsage shadowDescriptorTableUsage);
 std::ostream &operator<<(std::ostream &out, VkProvokingVertexModeEXT provokingVertexMode);
+std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout);
 
 template std::ostream &operator<<(std::ostream &out, ElfReader<Elf64> &reader);
 template raw_ostream &operator<<(raw_ostream &out, ElfReader<Elf64> &reader);
@@ -684,6 +685,7 @@ void PipelineDumper::dumpComputeStateInfo(const ComputePipelineBuildInfo *pipeli
 void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::ostream &dumpFile) {
   dumpFile << "options.includeDisassembly = " << options->includeDisassembly << "\n";
   dumpFile << "options.scalarBlockLayout = " << options->scalarBlockLayout << "\n";
+  dumpFile << "options.resourceLayoutScheme = " << options->resourceLayoutScheme << "\n";
   dumpFile << "options.includeIr = " << options->includeIr << "\n";
   dumpFile << "options.robustBufferAccess = " << options->robustBufferAccess << "\n";
   dumpFile << "options.reconfigWorkgroupLayout = " << options->reconfigWorkgroupLayout << "\n";
@@ -2027,6 +2029,25 @@ std::ostream &operator<<(std::ostream &out, VkProvokingVertexModeEXT provokingVe
     llvm_unreachable("Should never be called!");
     break;
   }
+  return out << string;
+}
+
+// =====================================================================================================================
+// Translates enum "ResourceLayoutScheme" to string and output to ostream.
+//
+// @param [out] out : Output stream
+// @param ResourceLayoutScheme : Resource layout scheme
+std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout) {
+  const char *string = nullptr;
+  switch (layout) {
+    CASE_CLASSENUM_TO_STRING(ResourceLayoutScheme, Compact)
+    CASE_CLASSENUM_TO_STRING(ResourceLayoutScheme, Indirect)
+    break;
+  default:
+    llvm_unreachable("Should never be called!");
+    break;
+  }
+
   return out << string;
 }
 

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -94,6 +94,9 @@ public:
     ADD_CLASS_ENUM_MAP(DenormalMode, Auto)
     ADD_CLASS_ENUM_MAP(DenormalMode, FlushToZero)
     ADD_CLASS_ENUM_MAP(DenormalMode, Preserve)
+
+    ADD_CLASS_ENUM_MAP(ResourceLayoutScheme, Compact)
+    ADD_CLASS_ENUM_MAP(ResourceLayoutScheme, Indirect)
   }
 };
 

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -342,6 +342,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
 #endif
@@ -356,7 +357,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 10;
+  static const unsigned MemberCount = 11;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Indirect scheme is designed for the case that the pipeline layout only
contains part of information of the final executable pipeline. So that
user data is used in conservative way to make sure that this pipeline
layout is alaways compatiable with other layouts which may contain the
descriptor which is not known currently.

In indirect mode, the user data registers for various resources are
allocated in the following fashion:
 1. one user data entry for vertex buffer
 2. one user data entry for the push constant buffer
 3. descriptor set index for each set.