### PR TITLE
Refactor tessellation factor store

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -237,9 +237,6 @@ private:
 
   std::set<unsigned> m_expLocs; // The locations that already have an export instruction for the vertex shader.
   const std::array<unsigned char, 4> *m_buffFormats; // The format of MTBUF instructions for specified GFX
-
-  llvm::Value *m_tessLevelOuterPtr = nullptr; // Correspond to "out float gl_TessLevelOuter[4]"
-  llvm::Value *m_tessLevelInnerPtr = nullptr; // Correspond to "out float gl_TessLevelInner[2]"
 };
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -147,6 +147,9 @@ static const unsigned MaxTransformFeedbackBuffers = 4;
 static const unsigned MaxGsStreams = 4;
 static_assert(MaxGsStreams == MaxTransformFeedbackBuffers, "Unexpected value!");
 
+// Maximum tess factors per patch
+static const unsigned MaxTessFactorsPerPatch = 6; // 4 outer factors + 2 inner factors
+
 // Internal resource table's virtual descriptor sets
 static const unsigned InternalResourceTable = 0x10000000;
 static const unsigned InternalPerShaderTable = 0x10000001;

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -346,6 +346,7 @@ struct ResourceUsage {
                                     // (in dword, correspond to "hsOutputBase")
           unsigned patchConstStart; // Offset into LDS where patch constants start (in dword,
                                     // correspond to "patchConstBase")
+          unsigned tessFactorStart; // Offset into LDS where tess factor start (in dword)
         } onChip;
 
         // Off-chip calculation factors
@@ -363,6 +364,8 @@ struct ResourceUsage {
 
         unsigned patchConstSize;   // Size of an output patch constants (in dword)
         unsigned tessFactorStride; // Size of tess factor stride (in dword)
+
+        unsigned tessOnChipLdsSize; // On-chip LDS size (exclude off-chip LDS buffer) (in dword)
 
       } calcFactor;
     } tcs = {};

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -654,16 +654,7 @@ template <typename T> void ConfigBuilder::buildLsRegConfig(ShaderStage shaderSta
   SET_REG_FIELD(&config->lsRegs, SPI_SHADER_PGM_RSRC2_LS, USER_SGPR, intfData->userDataCount);
 
   const auto &calcFactor = m_pipelineState->getShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor;
-
-  unsigned ldsSizeInDwords = 0;
-  if (m_pipelineState->isTessOffChip()) {
-    // LDS usage: input patches
-    ldsSizeInDwords = calcFactor.inPatchSize * calcFactor.patchCountPerThreadGroup;
-  } else {
-    // LDS usage: input patches, output patches, and patch constants
-    ldsSizeInDwords =
-        calcFactor.onChip.patchConstStart + calcFactor.patchConstSize * calcFactor.patchCountPerThreadGroup;
-  }
+  unsigned ldsSizeInDwords = calcFactor.tessOnChipLdsSize;
 
   auto gpuWorkarounds = &m_pipelineState->getTargetInfo().getGpuWorkarounds();
 

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1097,7 +1097,7 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   // dwords.
   const auto &calcFactor = tcsResUsage->inOutUsage.tcs.calcFactor;
   assert(m_pipelineState->isTessOffChip()); // Must be off-chip on GFX9+
-  unsigned ldsSizeInDwords = calcFactor.inPatchSize * calcFactor.patchCountPerThreadGroup;
+  unsigned ldsSizeInDwords = calcFactor.tessOnChipLdsSize;
 
   const unsigned ldsSizeDwordGranularity = 128u;
   const unsigned ldsSizeDwordGranularityShift = 7u;

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -52,6 +52,7 @@ ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
     calcFactor.offChip.patchConstStart = InvalidValue;
     calcFactor.onChip.outPatchStart = InvalidValue;
     calcFactor.onChip.patchConstStart = InvalidValue;
+    calcFactor.onChip.tessFactorStart = InvalidValue;
     calcFactor.outPatchSize = InvalidValue;
     calcFactor.patchConstSize = InvalidValue;
   } else if (shaderStage == ShaderStageGeometry) {

--- a/lgc/test/UnlinkedTessFetches.lgc
+++ b/lgc/test/UnlinkedTessFetches.lgc
@@ -31,10 +31,7 @@ declare void @lgc.create.write.generic.output(...) local_unnamed_addr #0
 ; Function Attrs: nounwind
 define dllexport spir_func void @lgc.shader.TCS.VkMain() local_unnamed_addr #0 !lgc.shaderstage !10 {
 .entry:
-  br label %0, !llvm.loop !11
-
-0:                                                ; preds = %0, %.entry
-  br label %0, !llvm.loop !12
+  ret void
 }
 
 ; Function Attrs: nounwind


### PR DESCRIPTION
Resort to on-chip LDS to store tess factors. We previously use
local variables. It is not true when the shader just writes tess
factors in some invocations (not all). The case is like this:

void main() {
  ...
  if (gl_InvocationID == N) {
    gl_TessLevelOuter[X] = ...
    ...
    gl_TessLevelInner[Y] = ...
  }
  ...
  return;
}

In such cases, fetching tess factors from local variables as output
proxies will lead to invalid values for some invocations. Finally, the
invalid values will overwrite valid tess factors in TF buffer.

Also, simplify the calcuation of on-chip LDS by adding a new field
'tessOnChipLdsSize'. And print more tessellation info in debug log.