### PR TITLE
Fix viewIndex

### DIFF
--- a/llpc/test/shaderdb/general/PipelineGs_TestViewIndexAndLayer.pipe
+++ b/llpc/test/shaderdb/general/PipelineGs_TestViewIndexAndLayer.pipe
@@ -1,0 +1,123 @@
+// Test gl_ViewIndex when multi-view is disabled
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v --gfxip=10.3.0 %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: _amdgpu_vs_main:
+// gl_ViewIndex = 0
+; SHADERTEST: v_mov_b32_e32 v[[VIEWINDEX:[0-9]*]], 0
+// export gl_Layer
+; SHADERTEST: exp pos1 off, off, {{v[0-9]*}}, off done
+// export gl_ViewIndex
+; SHADERTEST: exp param1 v[[VIEWINDEX]], off, off, off
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 53
+
+[VsGlsl]
+#version 450
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 positionOut;
+layout( push_constant ) uniform constants
+{
+	vec4 scale;
+	vec4 offset;
+	vec4 color;
+	int layer;
+} pc;
+
+void main (void)
+{
+    positionOut = position * pc.scale + pc.offset;
+}
+
+[VsInfo]
+entryPoint = main
+
+[GsGlsl]
+#version 450
+layout(triangles) in;
+layout(triangle_strip, max_vertices = 3) out;
+layout(location = 0) in vec4 position[];
+layout(location = 0) out vec4 vsColor;
+
+layout( push_constant ) uniform constants
+{
+	vec4 scale;
+	vec4 offset;
+	vec4 color;
+	int layer;
+} pc;
+
+void main (void)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        gl_Position = position[i];
+        vsColor     = pc.color;
+        gl_Layer    = pc.layer;
+        EmitVertex();
+    }
+    EndPrimitive();
+}
+
+[GsInfo]
+entryPoint = main
+
+
+[FsGlsl]
+#version 450
+#extension GL_EXT_multiview : require
+
+layout(location = 0) in vec4 vsColor;
+layout(location = 0) out vec4 fsColor;
+
+void main (void)
+{
+    fsColor   = vsColor;
+    fsColor.z = 0.15f * gl_ViewIndex;
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 82
+userDataNode[0].type = PushConst
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 13
+userDataNode[0].set = 0xFFFFFFFF
+userDataNode[0].binding = 0
+userDataNode[1].visibility = 32
+userDataNode[1].type = StreamOutTableVaPtr
+userDataNode[1].offsetInDwords = 13
+userDataNode[1].sizeInDwords = 1
+userDataNode[2].visibility = 2
+userDataNode[2].type = IndirectUserDataVaPtr
+userDataNode[2].offsetInDwords = 14
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+enableMultiView = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+nggState.enableNgg = 0
+
+
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0


### PR DESCRIPTION
When we use gl_Layer/gl_ViewIndex in Fs, we must export them. currently,
we just handle them in vertex process stage or enabling mulit-view.