### PR TITLE
Fix interpolation-related IR verification failures

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1818,7 +1818,7 @@ Value *PatchInOutImportExport::patchFsGenericInputImport(Type *inputTy, unsigned
   if (compIdx)
     startChannel = cast<ConstantInt>(compIdx)->getZExtValue();
 
-  Value *loc;
+  Value *loc = nullptr;
   if (locOffset) {
     loc = ConstantInt::get(Type::getInt32Ty(*m_context), location + cast<ConstantInt>(locOffset)->getZExtValue());
     assert((startChannel + numChannels) <= 4);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1818,10 +1818,12 @@ Value *PatchInOutImportExport::patchFsGenericInputImport(Type *inputTy, unsigned
   if (compIdx)
     startChannel = cast<ConstantInt>(compIdx)->getZExtValue();
 
-  Value *loc = ConstantInt::get(Type::getInt32Ty(*m_context), location);
+  Value *loc;
   if (locOffset) {
-    loc = BinaryOperator::CreateAdd(loc, locOffset, "", insertPos);
+    loc = ConstantInt::get(Type::getInt32Ty(*m_context), location + cast<ConstantInt>(locOffset)->getZExtValue());
     assert((startChannel + numChannels) <= 4);
+  } else {
+    loc = ConstantInt::get(Type::getInt32Ty(*m_context), location);
   }
 
   for (unsigned i = startChannel; i < startChannel + numChannels; ++i) {

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DArray.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DArray.frag
@@ -13,7 +13,7 @@ void main()
 
 // BEGIN_SHADERTEST
 /*
-; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; RUN: amdllpc -verify-ir -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results


### PR DESCRIPTION
Previously the modified test would fail with:

immarg operand has non-immediate parameter
  %66 = add i32 3, 0
  %67 = call float @llvm.amdgcn.interp.p1(float %64, i32 immarg 0, i32 immarg %66, i32 %PrimMask) #3