### PR TITLE
Add a vkgc-headers library to make defines consistant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,23 @@ endif()
 ### Top-level VKGC Interface ###
 add_library(vkgc INTERFACE)
 
+### VKGC header-only library ###
+add_library(vkgc_headers INTERFACE)
+
+### Options that affect the headers ####################################################################################
+option(LLPC_ENABLE_SHADER_CACHE "Enable experimental shader cache" OFF)
+if(LLPC_ENABLE_SHADER_CACHE)
+    target_compile_definitions(vkgc_headers INTERFACE LLPC_ENABLE_SHADER_CACHE=1)
+endif()
+if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
+    target_compile_definitions(vkgc_headers INTERFACE LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION})
+endif()
+
+
+target_link_libraries(vkgc INTERFACE vkgc_headers)
+
 ### Expose header files ################################################################################################
-target_include_directories(vkgc
+target_include_directories(vkgc_headers
     INTERFACE
         ${PROJECT_SOURCE_DIR}/include
 )
@@ -86,6 +101,7 @@ endif()
 if(EXISTS ${XGL_SPVGEN_PATH})
     set(XGL_SPVGEN_BUILD_PATH ${CMAKE_BINARY_DIR}/spvgen)
     add_subdirectory(${XGL_SPVGEN_PATH} ${XGL_SPVGEN_BUILD_PATH} EXCLUDE_FROM_ALL)
+    target_link_libraries(spvgen_base vkgc_headers) # TODO Remove after added in spvgen
 endif()
 
 ### VKGC build LLPC ################################################################

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -136,20 +136,12 @@ endif()
 target_compile_definitions(llpc PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIAN_CPU)
 target_compile_definitions(llpc PRIVATE _SPIRV_LLVM_API)
 target_compile_definitions(llpc PRIVATE PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION})
-if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
-    target_compile_definitions(llpc PRIVATE LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION})
-endif()
 if(ICD_BUILD_LLPC)
     target_compile_definitions(llpc PRIVATE ICD_BUILD_LLPC)
 endif()
 
 if(VKI_AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS)
   target_compile_definitions(llpc PRIVATE VKI_AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS)
-endif()
-
-option(LLPC_ENABLE_SHADER_CACHE "Enable experimental shader cache" OFF)
-if(LLPC_ENABLE_SHADER_CACHE)
-    target_compile_definitions(llpc PRIVATE LLPC_ENABLE_SHADER_CACHE=1)
 endif()
 
 if(ICD_BUILD_LLPC)
@@ -172,7 +164,6 @@ target_include_directories(llpc
         ${PROJECT_SOURCE_DIR}/../lgc/interface
     PRIVATE
         ${PROJECT_SOURCE_DIR}/context
-        ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/lower
         ${PROJECT_SOURCE_DIR}/translator/include
         ${PROJECT_SOURCE_DIR}/translator/lib/SPIRV
@@ -282,6 +273,7 @@ endif()
 target_link_libraries(llpc PRIVATE dumper)
 target_link_libraries(llpc PRIVATE cwpack)
 target_link_libraries(llpc PRIVATE metrohash)
+target_link_libraries(llpc PRIVATE vkgc_headers)
 target_link_libraries(llpc PUBLIC
     khronos_vulkan_interface
     khronos_spirv_interface
@@ -318,7 +310,6 @@ target_compile_definitions(llpc_standalone_compiler PUBLIC
 )
 if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
     target_compile_definitions(llpc_standalone_compiler PUBLIC
-        LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION}
         PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION}
     )
 endif()
@@ -329,7 +320,6 @@ endif()
 
 target_include_directories(llpc_standalone_compiler PUBLIC
     ${PROJECT_SOURCE_DIR}/../imported/spirv
-    ${PROJECT_SOURCE_DIR}/../include
     ${PROJECT_SOURCE_DIR}/../tool/dumper
     ${PROJECT_SOURCE_DIR}/../util
     ${PROJECT_SOURCE_DIR}/context
@@ -386,6 +376,7 @@ target_link_libraries(llpc_standalone_compiler PUBLIC
     ${llvm_libs}
     metrohash
     vfx
+    vkgc_headers
 )
 if(UNIX)
     target_link_libraries(llpc_standalone_compiler PUBLIC dl)

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -30,7 +30,7 @@
  */
 #pragma once
 
-#include "../../include/vkgcDefs.h"
+#include "vkgcDefs.h"
 
 namespace Llpc {
 

--- a/tool/dumper/CMakeLists.txt
+++ b/tool/dumper/CMakeLists.txt
@@ -38,15 +38,13 @@ set_compiler_options(dumper ${DUMPER_ENABLE_WERROR})
 ### Defines/Includes/Sources ###########################################################################################
 target_compile_definitions(dumper PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIAN_CPU)
 target_compile_definitions(dumper PRIVATE PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION})
-if (LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
-    target_compile_definitions(dumper PRIVATE LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION})
-endif()
 if(ICD_BUILD_LLPC)
     target_compile_definitions(dumper PRIVATE ICD_BUILD_LLPC)
 endif()
 
 target_link_libraries(dumper PUBLIC metrohash)
 target_link_libraries(dumper PRIVATE cwpack)
+target_link_libraries(dumper PRIVATE vkgc_headers)
 target_link_libraries(dumper PRIVATE
     khronos_vulkan_interface
     khronos_spirv_interface
@@ -60,7 +58,6 @@ target_include_directories(dumper
     PUBLIC
         ${XGL_VKGC_PATH}/include
     PRIVATE
-        ${XGL_VKGC_PATH}/include
         ${XGL_PAL_PATH}/inc/core
         ${XGL_PAL_PATH}/inc/util
         ${LLVM_INCLUDE_DIRS}

--- a/tool/vfx/CMakeLists.txt
+++ b/tool/vfx/CMakeLists.txt
@@ -33,15 +33,6 @@ option(VFX_ENABLE_WERROR "Build ${PROJECT_NAME} with more errors" OFF)
 
 target_compile_definitions(vfx PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIAN_CPU)
 
-if(LLPC_CLIENT_INTERFACE_MAJOR_VERSION)
-    target_compile_definitions(vfx PRIVATE LLPC_CLIENT_INTERFACE_MAJOR_VERSION=${LLPC_CLIENT_INTERFACE_MAJOR_VERSION})
-    target_compile_definitions(vfx PRIVATE PAL_CLIENT_INTERFACE_MAJOR_VERSION=${PAL_CLIENT_INTERFACE_MAJOR_VERSION})
-endif()
-
-if(LLPC_ENABLE_SHADER_CACHE)
-    target_compile_definitions(vfx PRIVATE LLPC_ENABLE_SHADER_CACHE=1)
-endif()
-
 target_sources(vfx PRIVATE
     vfxParser.cpp
     vfxPipelineDoc.cpp
@@ -58,8 +49,6 @@ PUBLIC
     ${PROJECT_SOURCE_DIR}
 PRIVATE
     ${PROJECT_SOURCE_DIR}/../../imported/spirv
-    ${PROJECT_SOURCE_DIR}/../../include
 )
 
-target_link_libraries(vfx PRIVATE khronos_vulkan_interface)
-target_link_libraries(vfx PRIVATE khronos_spirv_interface)
+target_link_libraries(vfx PRIVATE vkgc_headers khronos_vulkan_interface khronos_spirv_interface)


### PR DESCRIPTION
Currently, defines like LLPC_CLIENT_INTERFACE_MAJOR_VERSION need to be
defined on every library that includes vkgcDefs.h. If it is not defined
to the same value on every linked library, hard to debug bugs will
appear because defined structs end up with different sizes.

To fix that, add an interface library in CMake called vkgc-headers that
only exposes the header file and the needed defines to get consistent
definitions.

Use this library instead of adding the include path directly.
Also add some temporary workaround to decouple the llpc change from the
spvgen change.

This should help fixing the failures in  #1774.