### PR TITLE
Make helper invocations take part in subgroupQuad operations

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -453,7 +453,6 @@ struct ShaderModuleUsage {
   bool enableVarPtrStorageBuf; ///< Whether to enable "VariablePointerStorageBuffer" capability
   bool enableVarPtr;           ///< Whether to enable "VariablePointer" capability
   bool useSubgroupSize;        ///< Whether gl_SubgroupSize is used
-  bool useHelpInvocation;      ///< Whether fragment shader has helper-invocation for subgroup
   bool useSpecConstant;        ///< Whether specialization constant is used
   bool keepUnusedFunctions;    ///< Whether to keep unused function
   bool useIsNan;               ///< Whether IsNan is used

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -727,13 +727,13 @@ public:
   llvm::Value *CreateSubgroupElect(const llvm::Twine &instName) override final;
 
   // Create a subgroup all.
-  llvm::Value *CreateSubgroupAll(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupAll(llvm::Value *const value, const llvm::Twine &instName) override final;
 
   // Create a subgroup any
-  llvm::Value *CreateSubgroupAny(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupAny(llvm::Value *const value, const llvm::Twine &instName) override final;
 
   // Create a subgroup all equal.
-  llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, const llvm::Twine &instName) override final;
 
   // Create a subgroup broadcast.
   llvm::Value *CreateSubgroupBroadcast(llvm::Value *const value, llvm::Value *const index,
@@ -854,6 +854,7 @@ private:
 
   llvm::Value *createDsSwizzle(llvm::Value *const value, uint16_t dsPattern);
   llvm::Value *createWwm(llvm::Value *const value);
+  llvm::Value *createWqm(llvm::Value *const value);
   llvm::Value *createThreadMask();
   llvm::Value *createThreadMaskedSelect(llvm::Value *const threadMask, uint64_t andMask, llvm::Value *const value1,
                                         llvm::Value *const value2);

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1642,30 +1642,27 @@ Value *BuilderRecorder::CreateSubgroupElect(const Twine &instName) {
 // Create a subgroup all.
 //
 // @param value : The value to compare
-// @param wqm : Executed in WQM (whole quad mode)
 // @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreateSubgroupAll(Value *const value, bool wqm, const Twine &instName) {
-  return record(Opcode::SubgroupAll, getInt1Ty(), {value, getInt1(wqm)}, instName);
+Value *BuilderRecorder::CreateSubgroupAll(Value *const value, const Twine &instName) {
+  return record(Opcode::SubgroupAll, getInt1Ty(), {value}, instName);
 }
 
 // =====================================================================================================================
 // Create a subgroup any
 //
 // @param value : The value to compare
-// @param wqm : Executed in WQM (whole quad mode)
 // @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreateSubgroupAny(Value *const value, bool wqm, const Twine &instName) {
-  return record(Opcode::SubgroupAny, getInt1Ty(), {value, getInt1(wqm)}, instName);
+Value *BuilderRecorder::CreateSubgroupAny(Value *const value, const Twine &instName) {
+  return record(Opcode::SubgroupAny, getInt1Ty(), {value}, instName);
 }
 
 // =====================================================================================================================
 // Create a subgroup all equal.
 //
 // @param value : The value to compare
-// @param wqm : Executed in WQM (whole quad mode)
 // @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreateSubgroupAllEqual(Value *const value, bool wqm, const Twine &instName) {
-  return record(Opcode::SubgroupAllEqual, getInt1Ty(), {value, getInt1(wqm)}, instName);
+Value *BuilderRecorder::CreateSubgroupAllEqual(Value *const value, const Twine &instName) {
+  return record(Opcode::SubgroupAllEqual, getInt1Ty(), {value}, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -790,13 +790,13 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     return m_builder->CreateSubgroupElect();
   }
   case BuilderRecorder::Opcode::SubgroupAll: {
-    return m_builder->CreateSubgroupAll(args[0], cast<ConstantInt>(args[1])->getZExtValue() != 0);
+    return m_builder->CreateSubgroupAll(args[0]);
   }
   case BuilderRecorder::Opcode::SubgroupAny: {
-    return m_builder->CreateSubgroupAny(args[0], cast<ConstantInt>(args[1])->getZExtValue() != 0);
+    return m_builder->CreateSubgroupAny(args[0]);
   }
   case BuilderRecorder::Opcode::SubgroupAllEqual: {
-    return m_builder->CreateSubgroupAllEqual(args[0], cast<ConstantInt>(args[1])->getZExtValue() != 0);
+    return m_builder->CreateSubgroupAllEqual(args[0]);
   }
   case BuilderRecorder::Opcode::SubgroupBroadcast: {
     return m_builder->CreateSubgroupBroadcast(args[0], args[1]);

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -544,9 +544,9 @@ public:
   llvm::Value *CreateGetWaveSize(const llvm::Twine &instName) override final;
   llvm::Value *CreateGetSubgroupSize(const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupElect(const llvm::Twine &instName) override final;
-  llvm::Value *CreateSubgroupAll(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
-  llvm::Value *CreateSubgroupAny(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
-  llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, bool wqm, const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupAll(llvm::Value *const value, const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupAny(llvm::Value *const value, const llvm::Twine &instName) override final;
+  llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupBroadcast(llvm::Value *const value, llvm::Value *const index,
                                        const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupBroadcastWaterfall(llvm::Value *const value, llvm::Value *const index,

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1455,26 +1455,20 @@ public:
   // Create a subgroup all.
   //
   // @param value : The value to compare
-  // @param wqm : Executed in WQM (whole quad mode)
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateSubgroupAll(llvm::Value *const value, bool wqm = false,
-                                         const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateSubgroupAll(llvm::Value *const value, const llvm::Twine &instName = "") = 0;
 
   // Create a subgroup any
   //
   // @param value : The value to compare
-  // @param wqm : Executed in WQM (whole quad mode)
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateSubgroupAny(llvm::Value *const value, bool wqm = false,
-                                         const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateSubgroupAny(llvm::Value *const value, const llvm::Twine &instName = "") = 0;
 
   // Create a subgroup all equal.
   //
   // @param value : The value to compare
-  // @param wqm : Executed in WQM (whole quad mode)
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, bool wqm = false,
-                                              const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, const llvm::Twine &instName = "") = 0;
 
   // Create a subgroup broadcast.
   //

--- a/llpc/test/shaderdb/extensions/ExtSubgroupQuad_TestSubgroupQuadBroadcast.frag
+++ b/llpc/test/shaderdb/extensions/ExtSubgroupQuad_TestSubgroupQuadBroadcast.frag
@@ -1,0 +1,45 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
+; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.subgroup.quad.broadcast.f32
+; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.subgroup.quad.broadcast.f32
+; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.subgroup.quad.broadcast.f32
+; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.subgroup.quad.broadcast.f32
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450
+
+#extension GL_KHR_shader_subgroup_quad : require
+
+layout(binding = 0) readonly buffer Block0
+{
+    float alpha[];
+};
+
+layout(location = 0) out vec4 color;
+
+void main()
+{
+    ivec2 coord = ivec2(gl_FragCoord.xy);
+    float v = alpha[coord.y * 2 + coord.x];
+
+    vec4 lanes;
+    lanes.x = subgroupQuadBroadcast(v, 0u);
+    lanes.y = subgroupQuadBroadcast(v, 1u);
+    lanes.z = subgroupQuadBroadcast(v, 2u);
+    lanes.w = subgroupQuadBroadcast(v, 3u);
+
+    color = lanes;
+}

--- a/llpc/test/shaderdb/extensions/ExtSubgroupQuad_TestSubgroupQuadSwapDiagonal.frag
+++ b/llpc/test/shaderdb/extensions/ExtSubgroupQuad_TestSubgroupQuadSwapDiagonal.frag
@@ -1,0 +1,33 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
+; SHADERTEST: call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.subgroup.quad.swap.diagonal.v4f32
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450
+
+#extension GL_KHR_shader_subgroup_quad : require
+
+layout(location = 0) out vec4 result;
+
+layout(set = 0, binding = 4, std430) readonly buffer Buffer0
+{
+  vec4 data[];
+};
+
+void main (void)
+{
+  result = subgroupQuadSwapDiagonal(data[gl_SubgroupInvocationID]);
+}

--- a/llpc/test/shaderdb/extensions/ExtSubgroupQuad_TestSubgroupQuadSwapVertical.frag
+++ b/llpc/test/shaderdb/extensions/ExtSubgroupQuad_TestSubgroupQuadSwapVertical.frag
@@ -1,0 +1,33 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC.*}} SPIR-V lowering results
+; SHADERTEST: call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.subgroup.quad.swap.vertical.v4f32
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.mov.dpp.i32
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: call i32 @llvm.amdgcn.wqm
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450
+
+#extension GL_KHR_shader_subgroup_quad : require
+
+layout(location = 0) out vec4 result;
+
+layout(set = 0, binding = 4, std430) readonly buffer Buffer0
+{
+  vec4 data[];
+};
+
+void main (void)
+{
+  result = subgroupQuadSwapVertical(data[gl_SubgroupInvocationID]);
+}

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3197,7 +3197,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformAll>(SPIRV
   BasicBlock *const block = getBuilder()->GetInsertBlock();
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const predicate = transValue(spvOperands[1], func, block);
-  return getBuilder()->CreateSubgroupAll(predicate, m_moduleUsage->useHelpInvocation);
+  return getBuilder()->CreateSubgroupAll(predicate);
 }
 
 // =====================================================================================================================
@@ -3212,7 +3212,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformAny>(SPIRV
   BasicBlock *const block = getBuilder()->GetInsertBlock();
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const predicate = transValue(spvOperands[1], func, block);
-  return getBuilder()->CreateSubgroupAny(predicate, m_moduleUsage->useHelpInvocation);
+  return getBuilder()->CreateSubgroupAny(predicate);
 }
 
 // =====================================================================================================================
@@ -3227,7 +3227,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpGroupNonUniformAllEqual>(
   BasicBlock *const block = getBuilder()->GetInsertBlock();
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const value = transValue(spvOperands[1], func, block);
-  return getBuilder()->CreateSubgroupAllEqual(value, m_moduleUsage->useHelpInvocation);
+  return getBuilder()->CreateSubgroupAllEqual(value);
 }
 
 // =====================================================================================================================
@@ -3666,7 +3666,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpSubgroupAllKHR>(SPIRVValu
   BasicBlock *const block = getBuilder()->GetInsertBlock();
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const predicate = transValue(spvOperands[0], func, block);
-  return getBuilder()->CreateSubgroupAll(predicate, m_moduleUsage->useHelpInvocation);
+  return getBuilder()->CreateSubgroupAll(predicate);
 }
 
 // =====================================================================================================================
@@ -3680,7 +3680,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpSubgroupAnyKHR>(SPIRVValu
   BasicBlock *const block = getBuilder()->GetInsertBlock();
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const predicate = transValue(spvOperands[0], func, block);
-  return getBuilder()->CreateSubgroupAny(predicate, m_moduleUsage->useHelpInvocation);
+  return getBuilder()->CreateSubgroupAny(predicate);
 }
 
 // =====================================================================================================================
@@ -3694,7 +3694,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpSubgroupAllEqualKHR>(SPIR
   BasicBlock *const block = getBuilder()->GetInsertBlock();
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const value = transValue(spvOperands[0], func, block);
-  return getBuilder()->CreateSubgroupAllEqual(value, m_moduleUsage->useHelpInvocation);
+  return getBuilder()->CreateSubgroupAllEqual(value);
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -98,22 +98,6 @@ ShaderModuleUsage ShaderModuleHelper::getShaderModuleUsageInfo(const BinaryData 
       }
       break;
     }
-    case OpDPdx:
-    case OpDPdy:
-    case OpDPdxCoarse:
-    case OpDPdyCoarse:
-    case OpDPdxFine:
-    case OpDPdyFine:
-    case OpImageSampleImplicitLod:
-    case OpImageSampleDrefImplicitLod:
-    case OpImageSampleProjImplicitLod:
-    case OpImageSampleProjDrefImplicitLod:
-    case OpImageSparseSampleImplicitLod:
-    case OpImageSparseSampleProjDrefImplicitLod:
-    case OpImageSparseSampleProjImplicitLod: {
-      shaderModuleUsage.useHelpInvocation = true;
-      break;
-    }
     case OpSpecConstantTrue:
     case OpSpecConstantFalse:
     case OpSpecConstant:


### PR DESCRIPTION
Subgroup quad broadcasts should be marked as WQM because
helper invocations take part in subgroup operations if enabled.

This patch is free standing, but is intended to be paired with
LLVM D124981 to address a potential issue with Vulkan CTS test:
dEQP-VK.draw.renderpass.shader_invocation.helper_invocation