### PR TITLE
Remove unconditional if condition

### DIFF
--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -381,15 +381,13 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
       compileInfo.shaderModuleDatas.push_back(shaderModuleData);
       compileInfo.stageMask |= shaderStageToMask(pipelineState->stages[stage].stage);
 
-      if (spvDisassembleSpirv) {
-        unsigned binSize = pipelineState->stages[stage].dataSize;
-        unsigned textSize = binSize * 10 + 1024;
-        LLPC_OUTS("\nSPIR-V disassembly for " << getShaderStageName(pipelineState->stages[stage].stage)
-                                              << " shader module:\n");
-        std::vector<char> spvText(textSize);
-        spvDisassembleSpirv(binSize, shaderModuleData.spirvBin.pCode, textSize, spvText.data());
-        LLPC_OUTS(spvText.data() << "\n");
-      }
+      unsigned binSize = pipelineState->stages[stage].dataSize;
+      unsigned textSize = binSize * 10 + 1024;
+      LLPC_OUTS("\nSPIR-V disassembly for " << getShaderStageName(pipelineState->stages[stage].stage)
+                                            << " shader module:\n");
+      std::vector<char> spvText(textSize);
+      spvDisassembleSpirv(binSize, shaderModuleData.spirvBin.pCode, textSize, spvText.data());
+      LLPC_OUTS(spvText.data() << "\n");
     }
   }
 


### PR DESCRIPTION
Now that we link with spvgen statically, comparing any spvgen pointers to null is redundant.

This fixes an internal clang build warning-as-error.