### PR TITLE
Replace some getPointerElementType in SPIRVReader

### DIFF
--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -258,7 +258,7 @@ unsigned PatchInitializeWorkgroupMemory::getTypeSizeInDwords(Type *inputTy) {
     return dwordCount;
   }
   if (inputTy->isArrayTy()) {
-    const unsigned elemSize = getTypeSizeInDwords(inputTy->getContainedType(0));
+    const unsigned elemSize = getTypeSizeInDwords(inputTy->getArrayElementType());
     return inputTy->getArrayNumElements() * elemSize;
   } else {
     assert(inputTy->isStructTy());

--- a/lgc/util/Internal.cpp
+++ b/lgc/util/Internal.cpp
@@ -88,6 +88,11 @@ CallInst *emitCall(StringRef funcName, Type *retTy, ArrayRef<Value *> args, Arra
 // @param ty : Type to get mangle name
 // @param [in/out] nameStream : Stream to write the type name into
 void getTypeName(Type *ty, raw_ostream &nameStream) {
+  if (ty->isOpaquePointerTy()) {
+    nameStream << "p" << ty->getPointerAddressSpace();
+    return;
+  }
+
   for (;;) {
     if (auto pointerTy = dyn_cast<PointerType>(ty)) {
       nameStream << "p" << pointerTy->getAddressSpace();

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -109,7 +109,7 @@ private:
 
   // NOTE: Here we use list to store pairs of output proxy mappings. This is because we want output patching to be
   // "ordered" (resulting LLVM IR for the patching always be consistent).
-  std::list<std::pair<llvm::Value *, llvm::Value *>> m_outputProxyMap; // Proxy list for lowering outputs
+  std::list<std::pair<llvm::Value *, llvm::AllocaInst *>> m_outputProxyMap; // Proxy list for lowering outputs
 
   llvm::BasicBlock *m_retBlock; // The return block of entry point
 

--- a/llpc/lower/llpcSpirvLowerResourceCollect.cpp
+++ b/llpc/lower/llpcSpirvLowerResourceCollect.cpp
@@ -73,7 +73,7 @@ SpirvLowerResourceCollect::SpirvLowerResourceCollect(bool collectDetailUsage)
 //
 // @param global : Global variable to collect resource node data
 void SpirvLowerResourceCollect::collectResourceNodeData(const GlobalVariable *global) {
-  auto globalTy = global->getType()->getContainedType(0);
+  auto globalTy = global->getValueType();
 
   MDNode *metaNode = global->getMetadata(gSPIRVMD::Resource);
   auto descSet = mdconst::dyn_extract<ConstantInt>(metaNode->getOperand(0))->getZExtValue();
@@ -186,7 +186,7 @@ bool SpirvLowerResourceCollect::runOnModule(Module &module) {
     }
     case SPIRAS_Output: {
       // Only collect FS out info when requested.
-      Type *globalTy = global->getType()->getContainedType(0);
+      Type *globalTy = global->getValueType();
       if (!m_collectDetailUsage || !globalTy->isSingleValueType())
         break;
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -176,7 +176,7 @@ public:
   // Translate integer dot product to LLVM IR
   Value *transSPIRVIntegerDotProductFromInst(SPIRVInstruction *bi, BasicBlock *bb);
 
-  Value *createLaunderRowMajorMatrix(Value *const);
+  std::pair<Type *, Value *> createLaunderRowMajorMatrix(Type *const, Value *const);
   Value *addLoadInstRecursively(SPIRVType *const, Value *const, bool, bool, bool);
   void addStoreInstRecursively(SPIRVType *const, Value *const, Value *const, bool, bool, bool);
   Constant *buildConstStoreRecursively(SPIRVType *const, Type *const, Constant *const);


### PR DESCRIPTION
Use alternative means like the SPIRVType to get the type behind
pointers.

Also replace uses of getContainedType(0), which is a
getPointerElementType in disguise.

SPIRVReader still has more getPointerElementType uses that are more
difficult to replace, but I wanted to put this up so the work is not
duplicated.

cc @mariusz-sikora-at-amd