### PR TITLE
Update OpFNegate test

### DIFF
--- a/llpc/test/shaderdb/core/OpFNegate_TestVec3_lit.frag
+++ b/llpc/test/shaderdb/core/OpFNegate_TestVec3_lit.frag
@@ -17,7 +17,6 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST-LABEL: {{^// LLPC}}  SPIR-V lowering results
 ; SHADERTEST: {{fsub|fneg}} reassoc nnan nsz arcp contract afn <3 x float> {{(<float -0.000000e\+00, float -0.000000e\+00, float -0.000000e\+00>, )?}}%
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
 ; SHADERTEST-COUNT-3: {{fsub|fneg}} reassoc nnan nsz arcp contract afn float {{(-0.000000e\+00, )?}}%


### PR DESCRIPTION
Do not check the IR after lowering to remove the dependency on
the instcombine, which can affect the pattern matching.

Instead check the IR after the translation, as it is done in
the other OpFNegate tests.