### PR TITLE
Add mesh shader support: Register new mesh shader built-ins

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -220,6 +220,8 @@ Type *Builder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
     a4f32,
     af32,
     ai32,
+    av2i32,
+    av3i32,
     f32,
     i1,
     i32,
@@ -255,9 +257,15 @@ Type *Builder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
   // For ClipDistance and CullDistance, the shader determines the array size.
   case TypeCode::af32:
     return ArrayType::get(getFloatTy(), arraySize);
-  // For SampleMask, the shader determines the array size.
+  // For SampleMask and PrimitivePointIndices, the shader determines the array size.
   case TypeCode::ai32:
     return ArrayType::get(getInt32Ty(), arraySize);
+  // For PrimitiveLineIndices, the shader determines the array size.
+  case TypeCode::av2i32:
+    return ArrayType::get(FixedVectorType::get(getInt32Ty(), 2), arraySize);
+  // For PrimitiveTriangleIndices, the shader determines the array size.
+  case TypeCode::av3i32:
+    return ArrayType::get(FixedVectorType::get(getInt32Ty(), 3), arraySize);
   case TypeCode::f32:
     return getFloatTy();
   case TypeCode::i1:

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -105,5 +105,9 @@ BUILTIN(ViewIndex, 4440, N, VHDGP, i32)                  // View index
 BUILTIN(ViewportIndex, 10, MVDG, P, i32)                 // Viewport index
 BUILTIN(WorkgroupId, 26, N, TMC, v3i32)                  // ID of global workgroup
 BUILTIN(WorkgroupSize, 25, N, TMC, v3i32)                // Size of global workgroup
+BUILTIN(CullPrimitive, 5299, N, M, i1)                   // Whether primitive should be culled
+BUILTIN(PrimitivePointIndices, 5294, N, M, ai32)         // Array of indices of the vertices making up the points
+BUILTIN(PrimitiveLineIndices, 5295, N, M, av2i32)        // Array of indices of the vertices making up the lines
+BUILTIN(PrimitiveTriangleIndices, 5296, N, M, av3i32)    // Array of indices of the vertices making up the triangles
 
 // Reserved LGC internal built-ins


### PR DESCRIPTION
There are 4 new built-ins: CullPrimitive, PrimitivePointIndices,
PrimitiveLineIndices, PrimitiveTriangleIndices.