### PR TITLE
Rename BuiltInWaveId to BuiltInGsWaveId

### DIFF
--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -49,7 +49,7 @@ Instruction *MiscBuilder::CreateEmitVertex(unsigned streamId) {
   // Get GsWaveId
   std::string callName = lgcName::InputImportBuiltIn;
   callName += "GsWaveId.i32.i32";
-  Value *gsWaveId = emitCall(callName, getInt32Ty(), getInt32(BuiltInWaveId), {}, &*GetInsertPoint());
+  Value *gsWaveId = emitCall(callName, getInt32Ty(), getInt32(BuiltInGsWaveId), {}, &*GetInsertPoint());
 
   // Do the sendmsg.
   // [9:8] = stream, [5:4] = 2 (emit), [3:0] = 2 (GS)
@@ -67,7 +67,7 @@ Instruction *MiscBuilder::CreateEndPrimitive(unsigned streamId) {
   // Get GsWaveId
   std::string callName = lgcName::InputImportBuiltIn;
   callName += "GsWaveId.i32.i32";
-  Value *gsWaveId = emitCall(callName, getInt32Ty(), getInt32(BuiltInWaveId), {}, &*GetInsertPoint());
+  Value *gsWaveId = emitCall(callName, getInt32Ty(), getInt32(BuiltInGsWaveId), {}, &*GetInsertPoint());
 
   // Do the sendmsg.
   // [9:8] = stream, [5:4] = 1 (cut), [3:0] = 2 (GS)

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -47,7 +47,7 @@ static const BuiltInKind BuiltInInterpLinearCentroid = static_cast<BuiltInKind>(
 static const BuiltInKind BuiltInSamplePosOffset = static_cast<BuiltInKind>(0x10000007);
 static const BuiltInKind BuiltInNumSamples = static_cast<BuiltInKind>(0x10000008);
 static const BuiltInKind BuiltInSamplePatternIdx = static_cast<BuiltInKind>(0x10000009);
-static const BuiltInKind BuiltInWaveId = static_cast<BuiltInKind>(0x1000000A);
+static const BuiltInKind BuiltInGsWaveId = static_cast<BuiltInKind>(0x1000000A);
 
 // Names used for calls added to IR to represent various actions internally.
 namespace lgcName {

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -506,7 +506,7 @@ struct InterfaceData {
       // Geometry shader
       struct {
         unsigned gsVsOffset;                      // GS -> VS ring offset
-        unsigned waveId;                          // GS wave ID
+        unsigned gsWaveId;                        // GS wave ID
         unsigned esGsOffsets[MaxEsGsOffsetCount]; // ES -> GS ring offset
         unsigned primitiveId;                     // Primitive ID
         unsigned invocationId;                    // Invocation ID

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3176,7 +3176,7 @@ Function *NggPrimShader::mutateGs(Module *module) {
 
   // Initialize thread ID in subgroup
   auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageGeometry)->entryArgIdxs.gs;
-  auto waveId = getFunctionArgument(gsEntryPoint, entryArgIdxs.waveId);
+  auto waveId = getFunctionArgument(gsEntryPoint, entryArgIdxs.gsWaveId);
 
   auto threadIdInSubgroup = m_builder->CreateMul(waveId, m_builder->getInt32(waveSize));
   threadIdInSubgroup = m_builder->CreateAdd(threadIdInSubgroup, threadIdInWave);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1533,8 +1533,8 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
     }
 
     auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageGeometry)->entryArgIdxs.gs;
-    auto waveId = getFunctionArgument(m_entryPoint, entryArgIdxs.waveId);
-    Value *args[] = {ConstantInt::get(Type::getInt32Ty(*m_context), GsDone), waveId};
+    auto gsWaveId = getFunctionArgument(m_entryPoint, entryArgIdxs.gsWaveId);
+    Value *args[] = {ConstantInt::get(Type::getInt32Ty(*m_context), GsDone), gsWaveId};
 
     emitCall("llvm.amdgcn.s.sendmsg", Type::getVoidTy(*m_context), args, {}, insertPos);
   } else if (m_shaderStage == ShaderStageFragment) {
@@ -2292,8 +2292,8 @@ Value *PatchInOutImportExport::patchGsBuiltInInputImport(Type *inputTy, unsigned
     break;
   }
   // Handle internal-use built-ins
-  case BuiltInWaveId: {
-    input = getFunctionArgument(m_entryPoint, entryArgIdxs.waveId);
+  case BuiltInGsWaveId: {
+    input = getFunctionArgument(m_entryPoint, entryArgIdxs.gsWaveId);
     break;
   }
   default: {

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -420,7 +420,7 @@ static const ShaderInputDesc TcsSgprInputs[] = {
 // SGPRs: GS
 static const ShaderInputDesc GsSgprInputs[] = {
     {ShaderInput::GsVsOffset, offsetof(InterfaceData, entryArgIdxs.gs.gsVsOffset), true},
-    {ShaderInput::GsWaveId, offsetof(InterfaceData, entryArgIdxs.gs.waveId), true},
+    {ShaderInput::GsWaveId, offsetof(InterfaceData, entryArgIdxs.gs.gsWaveId), true},
 };
 
 // SGPRs: FS


### PR DESCRIPTION
GsWaveId is GS specific. It is not the same meaning as WaveId in semantics.
WaveId is a local concept to represent a wave in a thread group while
GsWaveId is a global one across thread groups.