### PR TITLE
Add mesh shader support: Add mesh shader mode

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -105,6 +105,14 @@ void Builder::setGeometryShaderMode(const GeometryShaderMode &geometryShaderMode
 }
 
 // =====================================================================================================================
+// Set the mesh shader mode
+//
+// @param meshShaderMode : Mesh shader mode
+void Builder::setMeshShaderMode(const MeshShaderMode &meshShaderMode) {
+  getShaderModes()->setMeshShaderMode(meshShaderMode);
+}
+
+// =====================================================================================================================
 // Set the fragment shader mode
 //
 // @param fragmentShaderMode : Fragment shader mode

--- a/lgc/include/lgc/state/ShaderModes.h
+++ b/lgc/include/lgc/state/ShaderModes.h
@@ -62,6 +62,12 @@ public:
   // Get the geometry shader mode
   const GeometryShaderMode &getGeometryShaderMode();
 
+  // Set the mesh shader mode
+  void setMeshShaderMode(const MeshShaderMode &inMode);
+
+  // Get the mesh shader mode
+  const MeshShaderMode &getMeshShaderMode();
+
   // Set the fragment shader mode
   void setFragmentShaderMode(const FragmentShaderMode &inMode);
 
@@ -96,6 +102,7 @@ private:
   CommonShaderMode m_commonShaderModes[ShaderStageCompute + 1] = {}; // Per-shader FP modes
   TessellationMode m_tessellationMode = {};                          // Tessellation mode
   GeometryShaderMode m_geometryShaderMode = {};                      // Geometry shader mode
+  MeshShaderMode m_meshShaderMode = {};                              // Mesh shader mode
   FragmentShaderMode m_fragmentShaderMode = {};                      // Fragment shader mode
   ComputeShaderMode m_computeShaderMode = {};                        // Compute shader mode (workgroup size)
 };

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -42,6 +42,7 @@ struct CommonShaderMode;
 struct ComputeShaderMode;
 struct FragmentShaderMode;
 struct GeometryShaderMode;
+struct MeshShaderMode;
 class Pipeline;
 class ShaderModes;
 struct TessellationMode;
@@ -173,6 +174,11 @@ public:
   // The client should always zero-initialize the struct before setting it up, in case future versions
   // add more fields. A local struct variable can be zero-initialized with " = {}".
   void setGeometryShaderMode(const GeometryShaderMode &geometryShaderMode);
+
+  // Set the mesh shader state.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  void setMeshShaderMode(const MeshShaderMode &meshShaderMode);
 
   // Set the fragment shader mode.
   // The client should always zero-initialize the struct before setting it up, in case future versions

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -481,8 +481,14 @@ struct TessellationMode {
 // Kind of GS input primitives.
 enum class InputPrimitives : unsigned { Points, Lines, LinesAdjacency, Triangles, TrianglesAdjacency };
 
-// Kind of GS output primitives
-enum class OutputPrimitives : unsigned { Points, LineStrip, TriangleStrip };
+// Kind of GS/mesh shader output primitives
+enum class OutputPrimitives : unsigned {
+  Points,       // GS or mesh shader
+  Lines,        // Mesh shader only
+  LineStrip,    // GS only
+  Triangles,    // Mesh shader only
+  TriangleStrip // GS only
+};
 
 // Struct to pass to SetGeometryShaderMode. The front-end should zero-initialize it with "= {}" in case
 // future changes add new fields.
@@ -493,6 +499,19 @@ struct GeometryShaderMode {
   OutputPrimitives outputPrimitive; // Kind of output primitives
   unsigned invocations;             // Number of times to invoke shader for each input primitive
   unsigned outputVertices;          // Max number of vertices the shader will emit in one invocation
+};
+
+// Struct to pass to MeshShaderMode. The front-end should zero-initialize it with "= {}" in case
+// future changes add new fields.
+// All fields are unsigned, even those that could be bool, because the way the state is written to and read
+// from IR metadata relies on that.
+struct MeshShaderMode {
+  OutputPrimitives outputPrimitive; // Kind of output primitives
+  unsigned outputVertices;          // Max number of vertices the shader will emit in the invocation group
+  unsigned outputPrimitives;        // Max number of primitives the shader will emit in the invocation group
+  unsigned workgroupSizeX;          // X dimension of workgroup size. 0 is taken to be 1
+  unsigned workgroupSizeY;          // Y dimension of workgroup size. 0 is taken to be 1
+  unsigned workgroupSizeZ;          // Z dimension of workgroup size. 0 is taken to be 1
 };
 
 // Kind of conservative depth/stencil

--- a/lgc/state/ShaderModes.cpp
+++ b/lgc/state/ShaderModes.cpp
@@ -127,6 +127,18 @@ const GeometryShaderMode &ShaderModes::getGeometryShaderMode() {
 }
 
 // =====================================================================================================================
+// Set the mesh shader mode
+void ShaderModes::setMeshShaderMode(const MeshShaderMode &inMode) {
+  m_meshShaderMode = inMode;
+}
+
+// =====================================================================================================================
+// Get the mesh shader mode
+const MeshShaderMode &ShaderModes::getMeshShaderMode() {
+  return m_meshShaderMode;
+}
+
+// =====================================================================================================================
 // Set the fragment shader mode
 void ShaderModes::setFragmentShaderMode(const FragmentShaderMode &inMode) {
   m_fragmentShaderMode = inMode;


### PR DESCRIPTION
Currently, we need to record such info for mesh shader:
- Output primitive type: points, lines, triangles
- Max number of vertices that will be emitted
- Max number of primitives that will be emitted
- Workgroup three dimensions (X, Y, Z) specified

The shader mode will be set in LLPC frontend in the future.