### PR TITLE
Add disableFastMathFlags mask shader option

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 53
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 2
+#define LLPC_INTERFACE_MINOR_VERSION 3
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     53.3 | Add disableFastMathFlags shader option, plus support for this and fastMathFlags in pipeline files     |
 //  |     53.2 | Add resourceLayoutScheme to PipelineOptions                                                           |
 //  |     53.1 | Add PartPipelineStage enum for part-pipeline mode                                                     |
 //  |     53.0 | Add optimizationLevel to PipelineOptions                                                              |
@@ -658,6 +659,9 @@ struct PipelineShaderOptions {
 
   /// The enabled fast math flags (0 = depends on input language).
   unsigned fastMathFlags;
+
+  /// Disable fast math flags mask (0 = nothing disabled).
+  unsigned disableFastMathFlags;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/llpc/test/shaderdb/gfx10/CheckFMFOptions_NoContract.pipe
+++ b/llpc/test/shaderdb/gfx10/CheckFMFOptions_NoContract.pipe
@@ -1,0 +1,122 @@
+// This test checks that setting disableFastMathFlags to 32 (1<<5 == AllowContract)
+// does actually stop contract (no fma instructions are formed).
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc %gfxip %s -v | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: _amdgpu_ps_main:
+; SHADERTEST: s_waitcnt
+; SHADERTEST:	v_mul_f32_e64 v[[ACC1:[0-9]*]], s{{[0-9]*}}, s{{[0-9]*}}
+; SHADERTEST-DAG:	v_mul_f32_e64 v[[ACC2:[0-9]*]], s{{[0-9]*}}, s{{[0-9]*}}
+; SHADERTEST-DAG:	v_add_f32_e32 v[[ACC1]], s{{[0-9]*}}, v[[ACC1]]
+; SHADERTEST-DAG:	v_add_f32_e32 v[[ACC2]], s{{[0-9]*}}, v[[ACC2]]
+; END_SHADERTEST
+
+// Test the same shader without the disableFastMathFlags
+
+; BEGIN_NODISABLETEST
+; Remove the disableFastMathFlags option
+; RUN: grep -v "options.disableFastMathFlags" %s > %t.pipe
+; RUN: amdllpc %gfxip %t.pipe -v | FileCheck -check-prefix=NODISABLETEST %s
+; NODISABLETEST-LABEL: _amdgpu_ps_main:
+; NODISABLETEST: s_waitcnt
+; NODISABLETEST:	v_mov_b32_e32 v[[ACC1:[0-9]*]], s6
+; NODISABLETEST-DAG: v_mov_b32_e32 v[[ACC2:[0-9]*]], s7
+; NODISABLETEST-DAG: v_fmac_f32_e64 v[[ACC1]], s{{[0-9]*}}, s{{[0-9]*}}
+; NODISABLETEST-DAG: v_fmac_f32_e64 v[[ACC2]], s{{[0-9]*}}, s{{[0-9]*}}
+; END_NODISABLETEST
+
+// Check the cache hash is different
+; BEGIN_HASHTEST
+; RUN: grep -v "options.disableFastMathFlags" %s > %t.pipe
+; RUN: amdllpc %gfxip -v %s %t.pipe | FileCheck -check-prefix=HASHTEST %s
+; HASHTEST-LABEL: LLPC final ELF info
+; HASHTEST: 128_bit_cache_hash: [ [[HASH1:0x[0-9a-fA-F]*]] [[HASH2:0x[0-9a-fA-F]*]] ]
+; HASHTEST-LABEL: LLPC final ELF info
+; HASHTEST: 128_bit_cache_hash: [
+; HASHTEST-NOT: [[HASH1]] [[HASH2]]
+; END_HASHTEST
+
+[FsGlsl]
+#version 450
+
+layout(binding = 0) uniform Uniforms
+{
+    float f1_1, f1_2, f1_3;
+    vec3 f3_1, f3_2, f3_3;
+};
+
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    float f1_0 = f1_1 * f1_2 + f1_3;
+
+    vec3 f3_0 = f3_1 * f3_2 + f3_3;
+
+    fragColor = (f3_0.x != f1_0) ? vec4(0.0) : vec4(1.0);
+}
+
+[FsInfo]
+entryPoint = main
+options.disableFastMathFlags = 32
+
+[ResourceMapping]
+userDataNode[0].visibility = 64
+userDataNode[0].type = DescriptorTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].next[0].type = DescriptorBuffer
+userDataNode[0].next[0].offsetInDwords = 0
+userDataNode[0].next[0].sizeInDwords = 4
+userDataNode[0].next[0].set = 0x00000000
+userDataNode[0].next[0].binding = 0
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST
+provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT
+patchControlPoints = 3
+deviceIndex = 0
+disableVertexReuse = 0
+switchWinding = 0
+enableMultiView = 0
+depthClipEnable = 0
+rasterizerDiscardEnable = 0
+perSampleShading = 0
+numSamples = 0
+pixelShaderSamples = 0
+samplePatternIdx = 0
+usrClipPlaneMask = 0
+alphaToCoverageEnable = 0
+dualSourceBlendEnable = 0
+colorBuffer[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+nggState.enableNgg = 1
+nggState.enableGsUse = 0
+nggState.forceCullingMode = 0
+nggState.compactMode = NggCompactDisable
+nggState.enableVertexReuse = 0
+nggState.enableBackfaceCulling = 1
+nggState.enableFrustumCulling = 0
+nggState.enableBoxFilterCulling = 0
+nggState.enableSphereCulling = 0
+nggState.enableSmallPrimFilter = 1
+nggState.enableCullDistanceCulling = 0
+nggState.backfaceExponent = 0
+nggState.subgroupSizing = Auto
+nggState.primsPerSubgroup = 256
+nggState.vertsPerSubgroup = 256
+dynamicVertexStride = 0
+enableUberFetchShader = 0
+enableEarlyCompile = 0
+options.includeDisassembly = 0
+options.scalarBlockLayout = 0
+options.includeIr = 0
+options.robustBufferAccess = 0
+options.reconfigWorkgroupLayout = 0
+options.shadowDescriptorTableUsage = Auto
+options.shadowDescriptorTablePtrHigh = 0
+options.extendedRobustness.robustBufferAccess = 0
+options.extendedRobustness.robustImageAccess = 0
+options.extendedRobustness.nullDescriptor = 0

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -538,6 +538,8 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.disableLicmThreshold = " << shaderInfo->options.disableLicmThreshold << "\n";
   dumpFile << "options.unrollHintThreshold = " << shaderInfo->options.unrollHintThreshold << "\n";
   dumpFile << "options.dontUnrollHintThreshold = " << shaderInfo->options.dontUnrollHintThreshold << "\n";
+  dumpFile << "options.fastMathFlags = " << shaderInfo->options.fastMathFlags << "\n";
+  dumpFile << "options.disableFastMathFlags = " << shaderInfo->options.disableFastMathFlags << "\n";
   dumpFile << "\n";
 }
 
@@ -1122,7 +1124,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
 // @param stage : Shader stage
 // @param shaderInfo : Shader info in specified shader stage
 // @param isCacheHash : TRUE if the hash is used by shader cache
-// @param [in/out] hasher : Haher to generate hash code
+// @param [in/out] hasher : Hasher to generate hash code
 // @param isRelocatableShader : TRUE if we are building relocatable shader
 void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const PipelineShaderInfo *shaderInfo,
                                                      bool isCacheHash, MetroHash64 *hasher, bool isRelocatableShader) {
@@ -1182,6 +1184,8 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.disableLicmThreshold);
       hasher->Update(options.unrollHintThreshold);
       hasher->Update(options.dontUnrollHintThreshold);
+      hasher->Update(options.fastMathFlags);
+      hasher->Update(options.disableFastMathFlags);
     }
   }
 }

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -149,6 +149,8 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicmThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollHintThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -157,7 +159,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 24;
+  static const unsigned MemberCount = 26;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Add a new shader option that can be used to disable fastMathFlags when
translating from spirv to llvm-ir.

In addition, the option is encoded in the .pipe file (as well as the previously
created fastMathFlags option).
The new option is preferred as it allows selective disabling of the fast math
flags after the fastMathFlags are calculated in the normal way. This is more
selective than the previous fastMathFlags option.