### PR TITLE
Forbid usage of unsupported --mcpu option

### DIFF
--- a/llpc/test/shaderdb/error_reporting/UnsupportedMCPUOption.ll
+++ b/llpc/test/shaderdb/error_reporting/UnsupportedMCPUOption.ll
@@ -1,0 +1,12 @@
+; Check that an error is produced when the --mcpu flag is used with amdllpc.
+
+; BEGIN_SHADERTEST
+; RUN: not amdllpc --mcpu=10.3.0 %s | FileCheck --check-prefix=SHADERTEST %s
+;
+; SHADERTEST-LABEL: {{^}}ERROR: Option --mcpu is not supported in amdllpc, use --gfxip instead!
+; SHADERTEST-LABEL: {{^}}===== AMDLLPC FAILED =====
+; END_SHADERTEST
+
+define i32 @foo(i32 %x) {
+  ret i32 %x
+}

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -45,6 +45,7 @@
 #include "spvgen.h"
 #include "lgc/LgcContext.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/CodeGen/CommandFlags.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/PrettyStackTrace.h"
@@ -371,6 +372,11 @@ static Result init(int argc, char *argv[], ICompiler *&compiler) {
   Result result = ICompiler::Create(ParsedGfxIp, argc, argv, &compiler);
   if (result != Result::Success)
     return result;
+
+  if (!llvm::codegen::getMCPU().empty()) {
+    LLPC_ERRS("Option --mcpu is not supported in amdllpc, use --gfxip instead!\n");
+    return Result::Unsupported;
+  }
 
   // Debug utility that prints all LLVM option values. This is activated by passing:
   // `--print-options`     -- prints all LLVM options with non-default values, or

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -79,6 +79,11 @@ using namespace Vkgc;
 namespace {
 // Represents options of the amdllpc standalone tool.
 // -gfxip: graphics IP version
+// NOTE: This object is not actually used to parse anything or provide access to
+// the gfx version. Its only purpose is to ensure the "--gfxip" option is included
+// in the --help output and that it is not rejected as unknown option by the main parser.
+// Parsing "--gfxip" instead is done in the init(..) function,
+// before calling ICompiler::Create, which invokes the cl::opt parsing.
 cl::opt<std::string> GfxIp("gfxip", cl::desc("Graphics IP version"), cl::value_desc("major.minor.step"),
                            cl::init("8.0.2"));
 


### PR DESCRIPTION
Inherited from LLVM, `amdllpc` accepts a command-line option
`--mcpu`, which for other tools (e.g. `llc`, `lgc`, `opt`, etc.) defines
the target processor.

However, amdllpc uses the option `--gfxip` instead.

Before this change, amdllpc silently ignored `--mcpu`.
Now, instead an error is raised if `--mcpu` is specified.

This change affects the stand-alone version of `amdllpc` only.

Also add a documenting comment on a only seemingly unused variable. 