### PR TITLE
Add mesh shader support: Add a builder method 'SetMeshOutputs'

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -664,7 +664,12 @@ public:
   // In the task shader, emit the current values of all per-task output variables to the current task output by
   // specifying the group count XYZ of the launched child mesh tasks.
   llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, llvm::Value *groupCountZ,
-                                         const llvm::Twine &instName) override final;
+                                         const llvm::Twine &instName = "") override final;
+
+  // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
+  // emit upon completion.
+  llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount,
+                                          const llvm::Twine &instName = "") override final;
 
 private:
   MiscBuilder() = delete;

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -212,6 +212,8 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "is.helper.invocation";
   case Opcode::EmitMeshTasks:
     return "emit.mesh.tasks";
+  case Opcode::SetMeshOutputs:
+    return "set.mesh.outputs";
   case Opcode::ImageLoad:
     return "image.load";
   case Opcode::ImageLoadWithFmask:
@@ -902,8 +904,20 @@ Value *BuilderRecorder::CreateIsHelperInvocation(const Twine &instName) {
 // @param instName : Name to give final instruction
 // @returns Instruction to emit mesh tasks
 Instruction *BuilderRecorder::CreateEmitMeshTasks(Value *groupCountX, Value *groupCountY, Value *groupCountZ,
-                                                  const llvm::Twine &instName) {
+                                                  const Twine &instName) {
   return record(Opcode::EmitMeshTasks, nullptr, {groupCountX, groupCountY, groupCountZ}, instName);
+}
+
+// =====================================================================================================================
+// In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
+// emit upon completion.
+//
+// @param vertexCount : Actual output size of the vertices
+// @param primitiveCount : Actual output size of the primitives
+// @param instName : Name to give final instruction
+// @returns Instruction to set the actual size of mesh outputs
+Instruction *BuilderRecorder::CreateSetMeshOutputs(Value *vertexCount, Value *primitiveCount, const Twine &instName) {
+  return record(Opcode::SetMeshOutputs, nullptr, {vertexCount, primitiveCount}, instName);
 }
 
 // =====================================================================================================================
@@ -2103,6 +2117,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::ImageQuerySize:
     case Opcode::IsHelperInvocation:
     case Opcode::EmitMeshTasks:
+    case Opcode::SetMeshOutputs:
     case Opcode::Kill:
     case Opcode::ReadClock:
     case Opcode::WriteBuiltInOutput:

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -725,6 +725,9 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   case BuilderRecorder::Opcode::EmitMeshTasks: {
     return m_builder->CreateEmitMeshTasks(args[0], args[1], args[2]);
   }
+  case BuilderRecorder::Opcode::SetMeshOutputs: {
+    return m_builder->CreateSetMeshOutputs(args[0], args[1]);
+  }
   case BuilderRecorder::Opcode::TransposeMatrix: {
     return m_builder->CreateTransposeMatrix(args[0]);
   }

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -126,10 +126,23 @@ Value *MiscBuilder::CreateIsHelperInvocation(const Twine &instName) {
 // @param instName : Name to give final instruction
 // @returns Instruction to emit mesh tasks
 Instruction *MiscBuilder::CreateEmitMeshTasks(Value *groupCountX, Value *groupCountY, Value *groupCountZ,
-                                              const llvm::Twine &instName) {
+                                              const Twine &instName) {
   assert(m_shaderStage == ShaderStageTask); // Only valid for task shader
   return emitCall(lgcName::MeshTaskEmitMeshTasks, getVoidTy(), {groupCountX, groupCountY, groupCountZ}, {},
                   &*GetInsertPoint());
+}
+
+// =====================================================================================================================
+// In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
+// emit upon completion.
+//
+// @param vertexCount : Actual output size of the vertices
+// @param primitiveCount : Actual output size of the primitives
+// @param instName : Name to give final instruction
+// @returns Instruction to set the actual size of mesh outputs
+Instruction *MiscBuilder::CreateSetMeshOutputs(Value *vertexCount, Value *primitiveCount, const Twine &instName) {
+  assert(m_shaderStage == ShaderStageMesh); // Only valid for mesh shader
+  return emitCall(lgcName::MeshTaskSetMeshOutputs, getVoidTy(), {vertexCount, primitiveCount}, {}, &*GetInsertPoint());
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -185,6 +185,7 @@ public:
     DemoteToHelperInvocation,
     IsHelperInvocation,
     EmitMeshTasks,
+    SetMeshOutputs,
     GetWaveSize,
 
     // Subgroup
@@ -497,7 +498,9 @@ public:
   llvm::Instruction *CreateDemoteToHelperInvocation(const llvm::Twine &instName) override final;
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName) override final;
   llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, llvm::Value *groupCountZ,
-                                         const llvm::Twine &instName) override final;
+                                         const llvm::Twine &instName = "") override final;
+  llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount,
+                                          const llvm::Twine &instName = "") override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Builder methods implemented in MatrixBuilder

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -70,6 +70,7 @@ const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invoca
 const static char MeshTaskReadTaskPayload[] = "lgc.mesh.task.read.task.payload";
 const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload";
 const static char MeshTaskEmitMeshTasks[] = "lgc.mesh.task.emit.mesh.tasks";
+const static char MeshTaskSetMeshOutputs[] = "lgc.mesh.task.set.mesh.outputs";
 
 // Get pointer to spill table (as pointer to i8)
 const static char SpillTable[] = "lgc.spill.table";

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1371,6 +1371,16 @@ public:
   virtual llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, // NOLINT
                                                  llvm::Value *groupCountZ, const llvm::Twine &instName = "") = 0;
 
+  // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
+  // emit upon completion.
+  //
+  // @param vertexCount : Actual output size of the vertices
+  // @param primitiveCount : Actual output size of the primitives
+  // @param instName : Name to give final instruction
+  // @returns Instruction to set the actual size of mesh outputs
+  virtual llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount, // NOLINT
+                                                  const llvm::Twine &instName = "") = 0;
+
   // -----------------------------------------------------------------------------------------------------------------
   // Subgroup operations
 


### PR DESCRIPTION
This is used to set the actual output size of primitives and vertices
that the mesh shader will emit. It is called by LLPC frontend and will
be further lowered by mesh shader processing (not implemented yet).