### PR TITLE
Add shader option to move spilling to LDS

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 53
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 3
+#define LLPC_INTERFACE_MINOR_VERSION 4
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     53.4 | Add ldsSpillLimitDwords shader option                                                                 |
 //  |     53.3 | Add disableFastMathFlags shader option, plus support for this and fastMathFlags in pipeline files     |
 //  |     53.2 | Add resourceLayoutScheme to PipelineOptions                                                           |
 //  |     53.1 | Add PartPipelineStage enum for part-pipeline mode                                                     |
@@ -662,6 +663,9 @@ struct PipelineShaderOptions {
 
   /// Disable fast math flags mask (0 = nothing disabled).
   unsigned disableFastMathFlags;
+
+  /// Maximum amount of LDS space to be used for spilling.
+  unsigned ldsSpillLimitDwords;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -196,6 +196,9 @@ struct ShaderOptions {
   // Threshold to use for loops with DontUnroll hint. 0 to use llvm.loop.unroll.disable metadata.
   unsigned dontUnrollHintThreshold;
 
+  // Maximum amount of LDS space to be used for spilling.
+  unsigned ldsSpillLimitDwords;
+
   ShaderOptions() {
     // The memory representation of this struct gets written into LLVM metadata. To prevent uninitialized values from
     // being written, we force everything to 0, including alignment gaps.

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -882,6 +882,12 @@ void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
     builder.addAttribute("amdgpu-unroll-threshold", "700");
   }
 
+  if (shaderOptions->ldsSpillLimitDwords != 0) {
+    // Sanity check: LDS spilling is only supported in Fragment and Compute.
+    if (m_shaderStage == ShaderStageFragment || m_shaderStage == ShaderStageCompute)
+      builder.addAttribute("amdgpu-lds-spill-limit-dwords", std::to_string(shaderOptions->ldsSpillLimitDwords));
+  }
+
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396807
   // Old version of the code
   AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -130,6 +130,11 @@ static cl::opt<int> DontUnrollHintThreshold("dontunroll-hint-threshold",
                                             cl::desc("loop unroll threshold to use for loops with DontUnroll hint"),
                                             cl::init(0));
 
+// -lds-spill-limit-dwords: Maximum amount of LDS space to be used for spilling. The value of 0 disables LDS spilling.
+static cl::opt<unsigned> LdsSpillLimitDwords("lds-spill-limit-dwords",
+                                             cl::desc("Maximum amount of LDS space to be used for spilling"),
+                                             cl::init(0));
+
 namespace Llpc {
 
 // =====================================================================================================================
@@ -439,6 +444,11 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
       shaderOptions.dontUnrollHintThreshold = shaderInfo->options.dontUnrollHintThreshold;
     else
       shaderOptions.dontUnrollHintThreshold = DontUnrollHintThreshold;
+    if (shaderInfo->options.ldsSpillLimitDwords > 0)
+      shaderOptions.ldsSpillLimitDwords = shaderInfo->options.ldsSpillLimitDwords;
+    else
+      shaderOptions.ldsSpillLimitDwords = LdsSpillLimitDwords;
+
     pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);
   }
 }

--- a/llpc/test/shaderdb/general/PipelineCs_LdsSpillLimitDwordsOption.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_LdsSpillLimitDwordsOption.pipe
@@ -1,0 +1,20 @@
+; Check that ldsSpillLimitDwords shader option gets propagated to the backend as amdgpu-lds-spill-limit-dwords attribute.
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
+; SHADERTEST: "amdgpu-lds-spill-limit-dwords"="1024"
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[CsGlsl]
+#version 450
+
+layout(local_size_x = 2, local_size_y = 3) in;
+void main()
+{
+}
+
+[CsInfo]
+entryPoint = main
+options.ldsSpillLimitDwords = 1024

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -540,6 +540,7 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.dontUnrollHintThreshold = " << shaderInfo->options.dontUnrollHintThreshold << "\n";
   dumpFile << "options.fastMathFlags = " << shaderInfo->options.fastMathFlags << "\n";
   dumpFile << "options.disableFastMathFlags = " << shaderInfo->options.disableFastMathFlags << "\n";
+  dumpFile << "options.ldsSpillLimitDwords = " << shaderInfo->options.ldsSpillLimitDwords << "\n";
   dumpFile << "\n";
 }
 
@@ -1186,6 +1187,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.dontUnrollHintThreshold);
       hasher->Update(options.fastMathFlags);
       hasher->Update(options.disableFastMathFlags);
+      hasher->Update(options.ldsSpillLimitDwords);
     }
   }
 }

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -151,6 +151,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, ldsSpillLimitDwords, MemberTypeInt, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -159,7 +160,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 26;
+  static const unsigned MemberCount = 27;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Add a shader option ldsSpillLimitDwords option to move
(a part of) spilling from scratch to LDS.

The LDS memory up-to the limit specified can be used for spilling.

The option sets a new attribute amdgpu-lds-spill-limit-dwords
for the backend to handle - currently no-op.