### PR TITLE
Fix misspelled check directives

### DIFF
--- a/llpc/test/shaderdb/object/ObjInput_TestVsBuiltIn_lit.vert
+++ b/llpc/test/shaderdb/object/ObjInput_TestVsBuiltIn_lit.vert
@@ -11,7 +11,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST-DAG: call i32 @lgc.special.user.data.BaseInstance(i32 268435460)
-; SHADERTEST-DAG: call i32 @lgc.shader.input.VertexId(i32 15)
+; SHADERTEST-DAG: call i32 @lgc.shader.input.VertexId(i32 17)
 ; SHADERTEST-DAG: call i32 @lgc.special.user.data.BaseVertex(i32 268435459)
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/object/ObjInput_TestVsBuiltIn_lit.vert
+++ b/llpc/test/shaderdb/object/ObjInput_TestVsBuiltIn_lit.vert
@@ -10,9 +10,9 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST_DAG: call i32 @lgc.special.user.data.BaseInstance(i32 268435460)
-; SHADERTEST_DAG: call i32 @lgc.shader.input.VertexId(i32 15)
-; SHADERTEST_DAG: call i32 @lgc.special.user.data.BaseVertex(i32 268435459)
+; SHADERTEST-DAG: call i32 @lgc.special.user.data.BaseInstance(i32 268435460)
+; SHADERTEST-DAG: call i32 @lgc.shader.input.VertexId(i32 15)
+; SHADERTEST-DAG: call i32 @lgc.special.user.data.BaseVertex(i32 268435459)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Since https://reviews.llvm.org/D125604, FileCheck considers these
misspelled directives an error.