### PR TITLE
Test updates to deal with upstream LLVM change

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
@@ -7,7 +7,9 @@
 ; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
 ; SHADERTEST: {{^_amdgpu_cs_main:}}
 ; SHADERTEST-NEXT: BB0_0:
-; SHADERTEST-NEXT: s_mov_b32 {{s[0-9]*}}, descset_14@abs32@lo
+; SHADERTEST-NEXT: s_ashr_i32 {{s[0-9]*}}, descset_14@abs32@lo, 31
+; SHADERTEST-NEXT: s_getpc_b64
+; SHADERTEST-NEXT: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, descset_14@abs32@lo
 ; The spill threshold in this case is 47 because it will have to load the descriptor table pointer from the root table.
 ; SHADERTEST: .spill_threshold: 0x000000000000002F
 ; END_SHADERTEST
@@ -16,7 +18,9 @@
 ; BEGIN_SHADERTEST2
 ; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2: 0000000000000000 <_amdgpu_cs_main>:
-; SHADERTEST2-NEXT: s_mov_b32 {{s[0-9]*}}, 0xbc // 000000000000
+; SHADERTEST2-NEXT: s_ashr_i32 {{s[0-9]*}}, 0xbc, 31 // 000000000000
+; SHADERTEST2-NEXT: s_getpc_b64
+; SHADERTEST2-NEXT: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0xbc
 ; END_SHADERTEST2
 
 [Version]

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
@@ -7,7 +7,7 @@
 ; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
 ; SHADERTEST: {{^_amdgpu_cs_main:}}
 ; SHADERTEST-NEXT: BB0_0:
-; SHADERTEST-NEXT: s_mov_b32 {{s[0-9]*}}, descset_14@abs32@lo
+; SHADERTEST-NEXT: s_ashr_i32 {{s[0-9]*}}, descset_14@abs32@lo, 31
 ; The spill threshold in this case is 0 because it will have to load the descriptor from the root table.
 ; SHADERTEST: .spill_threshold: 0x0000000000000000
 ; END_SHADERTEST
@@ -17,7 +17,7 @@
 ; BEGIN_SHADERTEST2
 ; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2: 0000000000000000 <_amdgpu_cs_main>:
-; SHADERTEST2-NEXT: s_mov_b32 {{s[0-9]*}}, 0 // 000000000000
+; SHADERTEST2-NEXT: s_ashr_i32 {{s[0-9]*}}, 0, 31 // 000000000000
 ; END_SHADERTEST2
 
 [Version]

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_PushConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_PushConst.pipe
@@ -7,10 +7,9 @@
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
 ; This tries to match the sequence that loads the vector from the push constant.  This is the only 2 element load in the
 ; code.  The "4" is the offset of the push constant area in the root table.
-; SHADERTEST: s_mov_b32 [[r1:s[0-9]+]], 4 //
-; SHADERTEST: s_ashr_i32 s[[r2:[0-9]+]], [[r1]], 31
-; SHADERTEST: s_add_u32 s[[addr1:[0-9]+]], {{s[0-9]+}}, [[r1]]
-; SHADERTEST: s_addc_u32 s[[addr2:[0-9]+]], {{s[0-9]+}}, s[[r2]]
+; SHADERTEST: s_ashr_i32 s[[r1:[0-9]+]], 4, 31
+; SHADERTEST: s_add_u32 s[[addr1:[0-9]+]], {{s[0-9]+}}, 4
+; SHADERTEST: s_addc_u32 s[[addr2:[0-9]+]], {{s[0-9]+}}, s[[r1]]
 ; SHADERTEST: s_load_dwordx2 {{s\[[0-9]+:[0-9]+\]}}, {{s\[}}[[addr1]]:[[addr2]]{{\]}}, 0x0
 ; END_SHADERTEST
 


### PR DESCRIPTION
Upstream LLVM has had a couple of commits for aggressive constant folding. This
has resulted in needing some changes for tests with relocs.