### PR TITLE
Add support for scalarize waterfall descriptor loads.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     53.6 | Add scalarizeWaterfallLoads to PipelineShaderOptions                                                  |
 //  |     53.5 | Add forceCsThreadIdSwizzling for thread id swizzle in 8*4                                             |
 //  |     53.4 | Add ldsSpillLimitDwords shader option                                                                 |
 //  |     53.3 | Add disableFastMathFlags shader option, plus support for this and fastMathFlags in pipeline files     |
@@ -668,6 +669,9 @@ struct PipelineShaderOptions {
 
   /// Maximum amount of LDS space to be used for spilling.
   unsigned ldsSpillLimitDwords;
+
+  /// Attempt to scalarize waterfall descriptor loads.
+  bool scalarizeWaterfallLoads;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -323,6 +323,150 @@ BranchInst *BuilderImplBase::createIf(Value *condition, bool wantElse, const Twi
   return branch;
 }
 
+#if defined(LLVM_HAVE_BRANCH_AMD_GFX)
+// =====================================================================================================================
+// For a non-uniform input, try and trace back through a descriptor load to
+// find the non-uniform index used in it. If that fails, we just use the
+// operand value as the index.
+//
+// Note: this code has to cope with relocs as well, this is why we have to
+// have a worklist of instructions to trace back
+// through. Something like this:
+// %1 = call .... @lgc.descriptor.set(...)          ;; Known uniform base
+// %2 = call .... @llvm.amdgcn.reloc.constant(...)  ;; Known uniform reloc constant
+// %3 = ptrtoint ... %1 to i64
+// %4 = zext ... %2 to i64
+// %5 = add i64 %3, %4
+// %6 = inttoptr i64 %5 to ....
+// %7 = bitcast .... %6 to ....
+// %8 = getelementptr .... %7, i64 %offset
+//
+// As long as the base pointer %7 can be traced back to a descriptor set and
+// reloc we can infer that it is truly uniform and use the gep index as the waterfall index safely.
+//
+// @param nonUniformVal : Value representing non-uniform descriptor
+// @return : Value representing the non-uniform index
+static Value *traceNonUniformIndex(Value *nonUniformVal) {
+  auto load = dyn_cast<LoadInst>(nonUniformVal);
+  if (!load)
+    return nonUniformVal;
+
+  SmallVector<Value *, 2> worklist;
+  Value *base = load->getOperand(0);
+  Value *index = nullptr;
+
+  // Loop until a descriptor table reference or unexpected operation is reached.
+  // In the worst case this may visit all instructions in a function.
+  for (;;) {
+    if (auto bitcast = dyn_cast<BitCastInst>(base)) {
+      base = bitcast->getOperand(0);
+      continue;
+    }
+    if (auto gep = dyn_cast<GetElementPtrInst>(base)) {
+      if (gep->hasAllConstantIndices()) {
+        base = gep->getPointerOperand();
+        continue;
+      }
+      // Variable GEP, to provide the index for the waterfall.
+      if (index || gep->getNumIndices() != 1)
+        break;
+      index = *gep->idx_begin();
+      base = gep->getPointerOperand();
+      continue;
+    }
+    if (auto extract = dyn_cast<ExtractValueInst>(base)) {
+      if (extract->getIndices().size() == 1 && extract->getIndices()[0] == 0) {
+        base = extract->getAggregateOperand();
+        continue;
+      }
+      break;
+    }
+    if (auto insert = dyn_cast<InsertValueInst>(base)) {
+      if (insert->getIndices()[0] != 0) {
+        base = insert->getAggregateOperand();
+        continue;
+      }
+      if (insert->getIndices().size() == 1 && insert->getIndices()[0] == 0) {
+        base = insert->getInsertedValueOperand();
+        continue;
+      }
+      break;
+    }
+    if (auto intToPtr = dyn_cast<IntToPtrInst>(base)) {
+      base = intToPtr->getOperand(0);
+      continue;
+    }
+    if (auto ptrToInt = dyn_cast<PtrToIntInst>(base)) {
+      base = ptrToInt->getOperand(0);
+      continue;
+    }
+    if (auto zExt = dyn_cast<ZExtInst>(base)) {
+      base = zExt->getOperand(0);
+      continue;
+    }
+    if (auto call = dyn_cast<CallInst>(base)) {
+      if (index) {
+        if (auto calledFunc = call->getCalledFunction()) {
+          if (calledFunc->getName().startswith(lgcName::DescriptorTableAddr) ||
+              calledFunc->getName().startswith("llvm.amdgcn.reloc.constant")) {
+            if (!worklist.empty()) {
+              base = worklist.pop_back_val();
+              continue;
+            }
+            nonUniformVal = index;
+            break;
+          }
+        }
+      }
+    }
+    if (auto addInst = dyn_cast<Instruction>(base)) {
+      // In this case we have to trace back both operands
+      // Set one to base for continued processing and put the other onto the worklist
+      // Give up if the worklist already has an entry - too complicated
+      if (addInst->isBinaryOp() && addInst->getOpcode() == Instruction::BinaryOps::Add) {
+        if (!worklist.empty())
+          break;
+        base = addInst->getOperand(0);
+        worklist.push_back(addInst->getOperand(1));
+        continue;
+      }
+    }
+    break;
+  }
+
+  return nonUniformVal;
+}
+
+// =====================================================================================================================
+// Test whether two instructions are identical
+// or are the same operation on identical operands.
+// @param lhs : First instruction
+// @param rhs : Second instruction
+// @return Result of equally test
+static bool instructionsEqual(Instruction *lhs, Instruction *rhs) {
+  if (lhs->isIdenticalTo(rhs))
+    return true;
+
+  if (!lhs->isSameOperationAs(rhs))
+    return false;
+
+  for (unsigned idx = 0, end = lhs->getNumOperands(); idx != end; ++idx) {
+    Value *lhsVal = lhs->getOperand(idx);
+    Value *rhsVal = rhs->getOperand(idx);
+    if (lhsVal == rhsVal)
+      continue;
+    Instruction *lhsInst = dyn_cast<Instruction>(lhsVal);
+    Instruction *rhsInst = dyn_cast<Instruction>(rhsVal);
+    if (!lhsInst || !rhsInst)
+      return false;
+    if (!lhsInst->isIdenticalTo(rhsInst))
+      return false;
+  }
+
+  return true;
+}
+#endif // defined(LLVM_HAVE_BRANCH_AMD_GFX)
+
 // =====================================================================================================================
 // Create a waterfall loop containing the specified instruction.
 // This does not use the current insert point; new code is inserted before and after pNonUniformInst.
@@ -331,7 +475,7 @@ BranchInst *BuilderImplBase::createIf(Value *condition, bool wantElse, const Twi
 // @param operandIdxs : The operand index/indices for non-uniform inputs that need to be uniform
 // @param instName : Name to give instruction(s)
 Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, ArrayRef<unsigned> operandIdxs,
-                                                  const Twine &instName) {
+                                                  bool scalarizeDescriptorLoads, const Twine &instName) {
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)
 #warning[!amd-gfx] Waterfall feature disabled
   errs() << "Generating invalid waterfall loop code\n";
@@ -339,146 +483,93 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
 #else
   assert(operandIdxs.empty() == false);
 
-  // For each non-uniform input, try and trace back through a descriptor load to
-  // find the non-uniform index used in it. If that fails, we just use the
-  // operand value as the index.
-  //
-  // Note: this code has to cope with relocs as well, this is why we have to
-  // have a worklist of instructions to trace back
-  // through. Something like this:
-  // %1 = call .... @lgc.descriptor.set(...)          ;; Known uniform base
-  // %2 = call .... @llvm.amdgcn.reloc.constant(...)  ;; Known uniform reloc constant
-  // %3 = ptrtoint ... %1 to i64
-  // %4 = zext ... %2 to i64
-  // %5 = add i64 %3, %4
-  // %6 = inttoptr i64 %5 to ....
-  // %7 = bitcast .... %6 to ....
-  // %8 = getelementptr .... %7, i64 %offset
-  //
-  // As long as the base pointer %7 can be traced back to a descriptor set and
-  // reloc we can infer that it is truly uniform and use the gep index as the waterfall index safely
-  //
-
   SmallVector<Value *, 2> nonUniformIndices;
-  SmallVector<Value *, 2> worklist;
-
   for (unsigned operandIdx : operandIdxs) {
-    Value *nonUniformVal = nonUniformInst->getOperand(operandIdx);
-    if (auto load = dyn_cast<LoadInst>(nonUniformVal)) {
-      Value *base = load->getOperand(0);
-      Value *index = nullptr;
-      for (;;) {
-        if (auto bitcast = dyn_cast<BitCastInst>(base)) {
-          base = bitcast->getOperand(0);
-          continue;
-        }
-        if (auto gep = dyn_cast<GetElementPtrInst>(base)) {
-          if (gep->hasAllConstantIndices()) {
-            base = gep->getPointerOperand();
-            continue;
-          }
-          // Variable GEP, to provide the index for the waterfall.
-          if (index || gep->getNumIndices() != 1)
-            break;
-          index = *gep->idx_begin();
-          base = gep->getPointerOperand();
-          continue;
-        }
-        if (auto extract = dyn_cast<ExtractValueInst>(base)) {
-          if (extract->getIndices().size() == 1 && extract->getIndices()[0] == 0) {
-            base = extract->getAggregateOperand();
-            continue;
-          }
-          break;
-        }
-        if (auto insert = dyn_cast<InsertValueInst>(base)) {
-          if (insert->getIndices()[0] != 0) {
-            base = insert->getAggregateOperand();
-            continue;
-          }
-          if (insert->getIndices().size() == 1 && insert->getIndices()[0] == 0) {
-            base = insert->getInsertedValueOperand();
-            continue;
-          }
-          break;
-        }
-        if (auto intToPtr = dyn_cast<IntToPtrInst>(base)) {
-          base = intToPtr->getOperand(0);
-          continue;
-        }
-        if (auto ptrToInt = dyn_cast<PtrToIntInst>(base)) {
-          base = ptrToInt->getOperand(0);
-          continue;
-        }
-        if (auto zExt = dyn_cast<ZExtInst>(base)) {
-          base = zExt->getOperand(0);
-          continue;
-        }
-        if (auto call = dyn_cast<CallInst>(base)) {
-          if (index) {
-            if (auto calledFunc = call->getCalledFunction()) {
-              if (calledFunc->getName().startswith(lgcName::DescriptorTableAddr) ||
-                  calledFunc->getName().startswith("llvm.amdgcn.reloc.constant")) {
-                if (worklist.size()) {
-                  base = worklist.pop_back_val();
-                  continue;
-                }
-                nonUniformVal = index;
-                break;
-              }
-            }
-          }
-        }
-        if (auto addInst = dyn_cast<Instruction>(base)) {
-          // In this case we have to trace back both operands
-          // Set one to base for continued processing and put the other onto the worklist
-          // Give up if the worklist already has an entry - too complicated
-          if (addInst->isBinaryOp() && addInst->getOpcode() == Instruction::BinaryOps::Add) {
-            if (worklist.size())
-              break;
-            base = addInst->getOperand(0);
-            worklist.push_back(addInst->getOperand(1));
-            continue;
-          }
-        }
-        break;
-      }
-    }
-    nonUniformIndices.push_back(nonUniformVal);
+    Value *nonUniformIndex = traceNonUniformIndex(nonUniformInst->getOperand(operandIdx));
+    nonUniformIndices.push_back(nonUniformIndex);
   }
-
-  // Save Builder's insert point, and set it to insert new code just before pNonUniformInst.
-  auto savedInsertPoint = saveIP();
-  SetInsertPoint(nonUniformInst);
 
   // For any index that is 64 bit, change it back to 32 bit for comparison at the top of the
   // waterfall loop.
   for (Value *&nonUniformVal : nonUniformIndices) {
-    if (nonUniformVal->getType()->isIntegerTy(64))
-      nonUniformVal = CreateTrunc(nonUniformVal, getInt32Ty());
+    if (nonUniformVal->getType()->isIntegerTy(64)) {
+      auto sExt = dyn_cast<SExtInst>(nonUniformVal);
+      // 64-bit index may already be formed from extension of 32-bit value.
+      if (sExt && sExt->getOperand(0)->getType()->isIntegerTy(32)) {
+        nonUniformVal = sExt->getOperand(0);
+      } else {
+        nonUniformVal = CreateTrunc(nonUniformVal, getInt32Ty());
+      }
+    }
   }
 
-  // The first begin contains a null token for the previous token argument
-  Value *waterfallBegin = ConstantInt::get(getInt32Ty(), 0);
-  for (auto nonUniformVal : nonUniformIndices) {
-    // Start the waterfall loop using the waterfall index.
+  // Find first index instruction and check if index instructions are identical.
+  Instruction *firstIndexInst = nullptr;
+  bool identicalIndexes = true;
+  for (Value *nonUniformVal : nonUniformIndices) {
+    Instruction *nuInst = dyn_cast<Instruction>(nonUniformVal);
+    if (!nuInst || (firstIndexInst && !instructionsEqual(nuInst, firstIndexInst))) {
+      identicalIndexes = false;
+      break;
+    }
+    if (!firstIndexInst || nuInst->comesBefore(firstIndexInst))
+      firstIndexInst = nuInst;
+  }
+
+  // Save Builder's insert point
+  auto savedInsertPoint = saveIP();
+
+  Value *waterfallBegin;
+  if (scalarizeDescriptorLoads && firstIndexInst && identicalIndexes) {
+    // Attempt to scalarize descriptor loads.
+
+    // Begin waterfall loop just after shared index is computed.
+    // This places all dependent instructions within the waterfall loop, including descriptor loads.
+    auto nonUniformVal = cast<Value>(firstIndexInst);
+    SetInsertPoint(firstIndexInst->getNextNonDebugInstruction(false));
+    waterfallBegin = ConstantInt::get(getInt32Ty(), 0);
     waterfallBegin = CreateIntrinsic(Intrinsic::amdgcn_waterfall_begin, nonUniformVal->getType(),
                                      {waterfallBegin, nonUniformVal}, nullptr, instName);
-  }
 
-  // Scalarize each non-uniform operand of the instruction.
-  for (unsigned operandIdx : operandIdxs) {
-    Value *desc = nonUniformInst->getOperand(operandIdx);
-    auto descTy = desc->getType();
-    desc = CreateIntrinsic(Intrinsic::amdgcn_waterfall_readfirstlane, {descTy, descTy}, {waterfallBegin, desc}, nullptr,
-                           instName);
-    if (nonUniformInst->getType()->isVoidTy()) {
-      // The buffer/image operation we are waterfalling is a store with no return value. Use
-      // llvm.amdgcn.waterfall.last.use on the descriptor.
-      desc = CreateIntrinsic(Intrinsic::amdgcn_waterfall_last_use, descTy, {waterfallBegin, desc}, nullptr, instName);
+    // Scalarize shared index.
+    auto descTy = nonUniformVal->getType();
+    Value *desc = CreateIntrinsic(Intrinsic::amdgcn_waterfall_readfirstlane, {descTy, descTy},
+                                  {waterfallBegin, nonUniformVal}, nullptr, instName);
+
+    // Replace all references to shared index within the waterfall loop with scalarized index.
+    // Loads using scalarized index will become scalar loads.
+    for (Value *otherNonUniformVal : nonUniformIndices) {
+      otherNonUniformVal->replaceUsesWithIf(desc, [desc, waterfallBegin, nonUniformInst](Use &U) {
+        Instruction *userInst = cast<Instruction>(U.getUser());
+        return U.getUser() != waterfallBegin && U.getUser() != desc && userInst->comesBefore(nonUniformInst);
+      });
     }
-    // Replace the descriptor operand in the buffer/image operation.
-    nonUniformInst->setOperand(operandIdx, desc);
+  } else {
+    // Insert new code just before pNonUniformInst.
+    SetInsertPoint(nonUniformInst);
+
+    // The first begin contains a null token for the previous token argument
+    waterfallBegin = ConstantInt::get(getInt32Ty(), 0);
+    for (auto nonUniformVal : nonUniformIndices) {
+      // Start the waterfall loop using the waterfall index.
+      waterfallBegin = CreateIntrinsic(Intrinsic::amdgcn_waterfall_begin, nonUniformVal->getType(),
+                                       {waterfallBegin, nonUniformVal}, nullptr, instName);
+    }
+
+    // Scalarize each non-uniform operand of the instruction.
+    for (unsigned operandIdx : operandIdxs) {
+      Value *desc = nonUniformInst->getOperand(operandIdx);
+      auto descTy = desc->getType();
+      desc = CreateIntrinsic(Intrinsic::amdgcn_waterfall_readfirstlane, {descTy, descTy}, {waterfallBegin, desc},
+                             nullptr, instName);
+      if (nonUniformInst->getType()->isVoidTy()) {
+        // The buffer/image operation we are waterfalling is a store with no return value. Use
+        // llvm.amdgcn.waterfall.last.use on the descriptor.
+        desc = CreateIntrinsic(Intrinsic::amdgcn_waterfall_last_use, descTy, {waterfallBegin, desc}, nullptr, instName);
+      }
+      // Replace the descriptor operand in the buffer/image operation.
+      nonUniformInst->setOperand(operandIdx, desc);
+    }
   }
 
   Instruction *resultValue = nonUniformInst;

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -77,7 +77,7 @@ protected:
 
   // Create a waterfall loop containing the specified instruction.
   llvm::Instruction *createWaterfallLoop(llvm::Instruction *nonUniformInst, llvm::ArrayRef<unsigned> operandIdxs,
-                                         const llvm::Twine &instName = "");
+                                         bool scalarizeDescriptorLoads = false, const llvm::Twine &instName = "");
 
   // Helper method to scalarize a possibly vector unary operation
   llvm::Value *scalarize(llvm::Value *value, const std::function<llvm::Value *(llvm::Value *)> &callback);

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -509,7 +509,8 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
   // Add a waterfall loop if needed.
   Value *result = imageInst;
   if (flags & ImageFlagNonUniformImage)
-    result = createWaterfallLoop(imageInst, imageDescArgIndex);
+    result = createWaterfallLoop(imageInst, imageDescArgIndex,
+                                 getPipelineState()->getShaderOptions(m_shaderStage).scalarizeWaterfallLoads);
   else if (flags & ImageFlagEnforceReadFirstLaneImage)
     enforceReadFirstLane(imageInst, imageDescArgIndex);
 
@@ -701,7 +702,8 @@ Value *ImageBuilder::CreateImageStore(Value *texel, unsigned dim, unsigned flags
 
   // Add a waterfall loop if needed.
   if (flags & ImageFlagNonUniformImage)
-    createWaterfallLoop(imageStore, imageDescArgIndex);
+    createWaterfallLoop(imageStore, imageDescArgIndex,
+                        getPipelineState()->getShaderOptions(m_shaderStage).scalarizeWaterfallLoads);
   else if (flags & ImageFlagEnforceReadFirstLaneImage)
     enforceReadFirstLane(imageStore, imageDescArgIndex);
 
@@ -1182,7 +1184,8 @@ Value *ImageBuilder::CreateImageSampleGather(Type *resultTy, unsigned dim, unsig
     enforceReadFirstLane(imageOp, samplerDescArgIndex);
 
   if (!nonUniformArgIndexes.empty())
-    imageOp = createWaterfallLoop(imageOp, nonUniformArgIndexes);
+    imageOp = createWaterfallLoop(imageOp, nonUniformArgIndexes,
+                                  getPipelineState()->getShaderOptions(m_shaderStage).scalarizeWaterfallLoads);
   return imageOp;
 }
 
@@ -1288,7 +1291,8 @@ Value *ImageBuilder::CreateImageAtomicCommon(unsigned atomicOp, unsigned dim, un
         CreateIntrinsic(StructBufferAtomicIntrinsicTable[atomicOp], inputValue->getType(), args, nullptr, instName);
   }
   if (flags & ImageFlagNonUniformImage)
-    atomicInst = createWaterfallLoop(atomicInst, imageDescArgIndex);
+    atomicInst = createWaterfallLoop(atomicInst, imageDescArgIndex,
+                                     getPipelineState()->getShaderOptions(m_shaderStage).scalarizeWaterfallLoads);
   else if (flags & ImageFlagEnforceReadFirstLaneImage)
     enforceReadFirstLane(atomicInst, imageDescArgIndex);
 
@@ -1530,7 +1534,8 @@ Value *ImageBuilder::CreateImageGetLod(unsigned dim, unsigned flags, Value *imag
     enforceReadFirstLane(result, samplerDescArgIndex);
 
   if (!nonUniformArgIndexes.empty())
-    result = createWaterfallLoop(result, nonUniformArgIndexes);
+    result = createWaterfallLoop(result, nonUniformArgIndexes,
+                                 getPipelineState()->getShaderOptions(m_shaderStage).scalarizeWaterfallLoads);
 
   return result;
 }

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -200,6 +200,9 @@ struct ShaderOptions {
   // Maximum amount of LDS space to be used for spilling.
   unsigned ldsSpillLimitDwords;
 
+  // Attempt to scalarize waterfall descriptor loads.
+  bool scalarizeWaterfallLoads;
+
   ShaderOptions() {
     // The memory representation of this struct gets written into LLVM metadata. To prevent uninitialized values from
     // being written, we force everything to 0, including alignment gaps.

--- a/llpc/test/shaderdb/core/OpTypeSampledImage_TestWaterfallScalarize.frag
+++ b/llpc/test/shaderdb/core/OpTypeSampledImage_TestWaterfallScalarize.frag
@@ -1,0 +1,30 @@
+// Make sure that there is a single begin index
+// Make sure that there is a single waterfall.readfirstlane for the offset
+
+#version 450
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 0, binding = 7) uniform sampler2D _11[];
+
+layout(location = 0) out vec4 _3;
+layout(location = 3) flat in int _4;
+layout(location = 1) flat in vec2 _6;
+
+void main()
+{
+    int _12 = _4;
+    _3 = texture(_11[nonuniformEXT(_12)], _6);
+}
+
+// BEGIN_SHADERTEST
+//
+// RUN: amdllpc -scalarize-waterfall-descriptor-loads -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+// SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+// SHADERTEST: call i32 @llvm.amdgcn.waterfall.begin.i32
+// SHADERTEST-NOT: call i32 @llvm.amdgcn.waterfall.begin.i32
+// SHADERTEST: call i32 @llvm.amdgcn.waterfall.readfirstlane.i32.i32
+// SHADERTEST-NOT: call i32 @llvm.amdgcn.waterfall.readfirstlane.i32.i32
+// SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.waterfall.end.v4f32
+// SHADERTEST: AMDLLPC SUCCESS
+//
+// END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpTypeSampledImage_TestWaterfallScalarizeVgprLimit.frag
+++ b/llpc/test/shaderdb/core/OpTypeSampledImage_TestWaterfallScalarizeVgprLimit.frag
@@ -1,0 +1,30 @@
+// Make sure that there is a single begin index
+// Make sure that there is a single waterfall.readfirstlane for the offset
+
+#version 450
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 0, binding = 7) uniform sampler2D _11[];
+
+layout(location = 0) out vec4 _3;
+layout(location = 3) flat in int _4;
+layout(location = 1) flat in vec2 _6;
+
+void main()
+{
+    int _12 = _4;
+    _3 = texture(_11[nonuniformEXT(_12)], _6);
+}
+
+// BEGIN_SHADERTEST
+//
+// RUN: amdllpc -vgpr-limit=64 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+// SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+// SHADERTEST: call i32 @llvm.amdgcn.waterfall.begin.i32
+// SHADERTEST-NOT: call i32 @llvm.amdgcn.waterfall.begin.i32
+// SHADERTEST: call i32 @llvm.amdgcn.waterfall.readfirstlane.i32.i32
+// SHADERTEST-NOT: call i32 @llvm.amdgcn.waterfall.readfirstlane.i32.i32
+// SHADERTEST: call {{.*}} <4 x float> @llvm.amdgcn.waterfall.end.v4f32
+// SHADERTEST: AMDLLPC SUCCESS
+//
+// END_SHADERTEST

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -541,6 +541,7 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.fastMathFlags = " << shaderInfo->options.fastMathFlags << "\n";
   dumpFile << "options.disableFastMathFlags = " << shaderInfo->options.disableFastMathFlags << "\n";
   dumpFile << "options.ldsSpillLimitDwords = " << shaderInfo->options.ldsSpillLimitDwords << "\n";
+  dumpFile << "options.scalarizeWaterfallLoads = " << shaderInfo->options.scalarizeWaterfallLoads << "\n";
   dumpFile << "\n";
 }
 
@@ -1190,6 +1191,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.fastMathFlags);
       hasher->Update(options.disableFastMathFlags);
       hasher->Update(options.ldsSpillLimitDwords);
+      hasher->Update(options.scalarizeWaterfallLoads);
     }
   }
 }

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -152,6 +152,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, ldsSpillLimitDwords, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarizeWaterfallLoads, MemberTypeBool, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -160,7 +161,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 27;
+  static const unsigned MemberCount = 28;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Provide support for scalarizing waterfalled non-uniform descriptor
loads in limited circumstances.
This is an alternative to the current behaviour which scalarizes
access to a vector loaded outside the waterfall loop.

While using scalarized loads introduces memory access into each
loop iteration it significantly reduces VGPR pressure created by
the loop.
It also has the positive side effect of reducing the probability
that a s_waitcnt on the vmcnt is introduced into the waterfall loop
by the backend, as lgkmcnt is used for the loads instead.

In practice performance of the scalarized loads can be equivalent
to vector loads when there is medium to high commonality in the
non-uniform values.

Automatically enable this scalarization when a vgpr limit is set.
As this is where it will be most beneficial.

The limitation of this transform is that loads are only scalarized
when all non-uniform values have a common base/index.
This covers the majority of scenarios.
For a general purpose solution instruction would need to be heavily
reordered to ensure the correct parts occur inside/outside the
waterfall loop.