### PR TITLE
Refactor tess factor store function

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -164,11 +164,6 @@ private:
   llvm::Value *readValueFromLds(bool offChip, llvm::Type *readTy, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
   void writeValueToLds(bool offChip, llvm::Value *writeValue, llvm::Value *ldsOffset, llvm::Instruction *insertPos);
 
-  void storeTessFactorToBuffer(llvm::ArrayRef<llvm::Value *> tessFactors, llvm::Value *tessFactorOffset,
-                               llvm::Instruction *insertPos);
-
-  void createTessBufferStoreFunction(llvm::StringRef funcName, unsigned compCount, llvm::Type *tfValueTy);
-
   unsigned calcPatchCountPerThreadGroup(unsigned inVertexCount, unsigned inVertexStride, unsigned outVertexCount,
                                         unsigned outVertexStride, unsigned patchConstCount,
                                         unsigned tessFactorStride) const;
@@ -203,7 +198,7 @@ private:
   void exportVertexAttribs(llvm::Instruction *insertPos);
 
   void storeTessFactors();
-  void doTessFactorBufferStore(llvm::ArrayRef<llvm::Value *> outerTessFactors,
+  void storeTessFactorToBuffer(llvm::ArrayRef<llvm::Value *> outerTessFactors,
                                llvm::ArrayRef<llvm::Value *> innerTessFactors, llvm::Instruction *insertPos);
 
   GfxIpVersion m_gfxIp;                     // Graphics IP version info

--- a/llpc/test/shaderdb/general/PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe
+++ b/llpc/test/shaderdb/general/PipelineTcsTes_TestLocMapLoadBuiltInOutput.pipe
@@ -7,7 +7,7 @@
 ; SHADERTEST: Patch constant size: 0
 ; SHADERTEST: Patch constant total size: 0
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.raw.tbuffer.store.f32
+; SHADERTEST: call void @llvm.amdgcn.raw.tbuffer.store.v4f32
 ; SHADERTEST-NEXT: ret void
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST


### PR DESCRIPTION
Previously, we created a function to do tess factor store and called it
with inlining. This is not necessary. Currently, all tess factors are
obtained from LDS. The store fucntion could be largely simplified.
We merge all the operations.