### PR TITLE
Add mesh shader support: Rename vertexIndex to vertexOrPrimitiveIndex

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -494,7 +494,7 @@ public:
   // Create a write of (part of) a user output value.
   llvm::Instruction *CreateWriteGenericOutput(llvm::Value *valueToWrite, unsigned location, llvm::Value *locationOffset,
                                               llvm::Value *elemIdx, unsigned locationCount, InOutInfo outputInfo,
-                                              llvm::Value *vertexIndex) override final;
+                                              llvm::Value *vertexOrPrimitiveIndex) override final;
 
   // Create a write to an XFB (transform feedback / streamout) buffer.
   llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
@@ -511,7 +511,7 @@ public:
 
   // Create a write of (part of) a built-in output value.
   llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn, InOutInfo outputInfo,
-                                              llvm::Value *vertexIndex, llvm::Value *index) override final;
+                                              llvm::Value *vertexOrPrimitiveIndex, llvm::Value *index) override final;
 
   // Create a read from (part of) a task payload.
   llvm::Value *CreateReadTaskPayload(llvm::Type *resultTy, llvm::Value *byteOffset,

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1478,10 +1478,11 @@ Value *BuilderRecorder::CreateReadGenericOutput(Type *resultTy, unsigned locatio
 // 64-bit elements.)
 // @param locationCount : Count of locations taken by the output. Ignored if pLocationOffset is const
 // @param outputInfo : Extra output info (GS stream ID, FS integer signedness)
-// @param vertexIndex : For TCS per-vertex output: vertex index; else nullptr
+// @param vertexOrPrimitiveIndex : For TCS/mesh shader per-vertex output: vertex index; for mesh shader per-primitive
+//                                 output: primitive index; else nullptr
 Instruction *BuilderRecorder::CreateWriteGenericOutput(Value *valueToWrite, unsigned location, Value *locationOffset,
                                                        Value *elemIdx, unsigned locationCount, InOutInfo outputInfo,
-                                                       Value *vertexIndex) {
+                                                       Value *vertexOrPrimitiveIndex) {
   return record(Opcode::WriteGenericOutput, nullptr,
                 {
                     valueToWrite,
@@ -1490,7 +1491,7 @@ Instruction *BuilderRecorder::CreateWriteGenericOutput(Value *valueToWrite, unsi
                     elemIdx,
                     getInt32(locationCount),
                     getInt32(outputInfo.getData()),
-                    vertexIndex ? vertexIndex : UndefValue::get(getInt32Ty()),
+                    vertexOrPrimitiveIndex ? vertexOrPrimitiveIndex : UndefValue::get(getInt32Ty()),
                 },
                 "");
 }
@@ -1578,16 +1579,17 @@ Value *BuilderRecorder::CreateReadBuiltInOutput(BuiltInKind builtIn, InOutInfo o
 // @param valueToWrite : Value to write
 // @param builtIn : Built-in kind, one of the BuiltIn* constants
 // @param outputInfo : Extra output info (shader-defined array length; GS stream id)
-// @param vertexIndex : For TCS per-vertex output: vertex index, else nullptr
+// @param vertexOrPrimitiveIndex : For TCS/mesh shader per-vertex output: vertex index; for mesh shader per-primitive
+//                                 output: primitive index; else nullptr
 // @param index : Array or vector index to access part of an input, else nullptr
 Instruction *BuilderRecorder::CreateWriteBuiltInOutput(Value *valueToWrite, BuiltInKind builtIn, InOutInfo outputInfo,
-                                                       Value *vertexIndex, Value *index) {
+                                                       Value *vertexOrPrimitiveIndex, Value *index) {
   return record(Opcode::WriteBuiltInOutput, nullptr,
                 {
                     valueToWrite,
                     getInt32(builtIn),
                     getInt32(outputInfo.getData()),
-                    vertexIndex ? vertexIndex : UndefValue::get(getInt32Ty()),
+                    vertexOrPrimitiveIndex ? vertexOrPrimitiveIndex : UndefValue::get(getInt32Ty()),
                     index ? index : UndefValue::get(getInt32Ty()),
                 },
                 "");

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -448,7 +448,7 @@ public:
   // Create a write of (part of) a user output value.
   llvm::Instruction *CreateWriteGenericOutput(llvm::Value *valueToWrite, unsigned location, llvm::Value *locationOffset,
                                               llvm::Value *elemIdx, unsigned locationCount, InOutInfo outputInfo,
-                                              llvm::Value *vertexIndex) override final;
+                                              llvm::Value *vertexOrPrimitiveIndex) override final;
 
   // Create a write to an XFB (transform feedback / streamout) buffer.
   llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
@@ -465,7 +465,7 @@ public:
 
   // Create a write of (part of) a built-in output value.
   llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn, InOutInfo outputInfo,
-                                              llvm::Value *vertexIndex, llvm::Value *index) override final;
+                                              llvm::Value *vertexOrPrimitiveIndex, llvm::Value *index) override final;
 
   // Create a read of (part of) a pervertex input value.
   llvm::Value *CreateReadPerVertexInput(llvm::Type *resultTy, unsigned location, llvm::Value *locationOffset,

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1158,11 +1158,12 @@ public:
   // 64-bit elements.)
   // @param locationCount : Count of locations taken by the output. Ignored if pLocationOffset is const
   // @param outputInfo : Extra output info (GS stream ID, FS integer signedness)
-  // @param vertexIndex : For TCS per-vertex output: vertex index; else nullptr
+  // @param vertexOrPrimitiveIndex : For TCS/mesh shader per-vertex output: vertex index; for mesh shader per-primitive
+  //                                 output: primitive index; else nullptr
   virtual llvm::Instruction *CreateWriteGenericOutput(llvm::Value *valueToWrite, unsigned location,
                                                       llvm::Value *locationOffset, llvm::Value *elemIdx,
                                                       unsigned locationCount, InOutInfo outputInfo,
-                                                      llvm::Value *vertexIndex) = 0;
+                                                      llvm::Value *vertexOrPrimitiveIndex) = 0;
 
   // Create a write to an XFB (transform feedback / streamout) buffer.
   // The value to write must be a scalar or vector type with no more than four elements.
@@ -1231,10 +1232,11 @@ public:
   // @param valueToWrite : Value to write
   // @param builtIn : Built-in kind, one of the BuiltIn* constants
   // @param outputInfo : Extra output info (shader-defined array length; GS stream id)
-  // @param vertexIndex : For TCS per-vertex output: vertex index, else nullptr
+  // @param vertexOrPrimitiveIndex : For TCS/mesh shader per-vertex output: vertex index; for mesh shader per-primitive
+  //                                 output: primitive index; else nullptr
   // @param index : For TCS: array or vector index to access part of an output, else nullptr
   virtual llvm::Instruction *CreateWriteBuiltInOutput(llvm::Value *valueToWrite, BuiltInKind builtIn,
-                                                      InOutInfo outputInfo, llvm::Value *vertexIndex,
+                                                      InOutInfo outputInfo, llvm::Value *vertexOrPrimitiveIndex,
                                                       llvm::Value *index) = 0;
 
   // Create a read of (part of) a task payload.


### PR DESCRIPTION
In the builder methods 'CreateWriteGenericOutput' and
'CreateWriteBuiltInOutput', they have a parameter 'vertexIndex' for TCS
output to represent the outermost dimension as vertex indexing. Now, the
two methods will be used by mesh shader. And mesh shader introduces
per-primitive outputs which need this parameter and the semantics are
similar. Rename it to 'vertexOrPrimitiveIndex' to accommodate this
change.