### PR TITLE
The early/late fragment test SPV codes are already defined in upstream SPIRV-Headers.

### DIFF
--- a/include/khronos/spirv.hpp
+++ b/include/khronos/spirv.hpp
@@ -35,7 +35,5 @@
 #include "spirv/unified1/spirv.hpp"
 #else
 #include "spirv/spirv.hpp"
-#endif
-
 #include "devext/spv_amd_shader_early_and_late_fragment_tests.h"
-
+#endif


### PR DESCRIPTION
This moves the inclusion of
spv_amd_shader_early_and_late_fragment_tests.h inside the #ifdef guard.