### PR TITLE
Adding forceCsThreadidSwizzling for shader tuning

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -408,6 +408,7 @@ struct PipelineOptions {
                                    ///  the pipeline ELF.
   bool scalarBlockLayout;          ///< If set, allows scalar block layout of types.
   bool reconfigWorkgroupLayout;    ///< If set, allows automatic workgroup reconfigure to take place on compute shaders.
+  bool forceCsThreadIdSwizzling;   ///< Force rearranges threadId within group into blocks of 8*8 or 8*4.
   bool includeIr;                  ///< If set, the IR for all compiled shaders will be included in the pipeline ELF.
   bool robustBufferAccess;         ///< If set, out of bounds accesses to buffer or private array will be handled.
                                    ///  for now this option is used by LLPC shader and affects only the private array,

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -190,7 +190,7 @@ private:
 
   WorkgroupLayout calculateWorkgroupLayout();
   llvm::Value *reconfigWorkgroup(llvm::Value *localInvocationId, llvm::Instruction *insertPos);
-
+  llvm::Value *swizzleLocalInvocationIdIn8x4(llvm::Value *localInvocationId, llvm::Instruction *insertPos);
   void exportShadingRate(llvm::Value *shadingRate, llvm::Instruction *insertPos);
   llvm::Value *getShadingRate(llvm::Instruction *insertPos);
 

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -66,6 +66,7 @@ const static char OutputExportXfb[] = "lgc.output.export.xfb.";
 const static char TfBufferStore[] = "lgc.tfbuffer.store.";
 const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
 const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
+const static char SwizzleLocalInvocationId[] = "lgc.swizzle.local.invocation.id";
 
 const static char MeshTaskReadTaskPayload[] = "lgc.mesh.task.read.task.payload";
 const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload";

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -106,6 +106,7 @@ struct Options {
                                        //   in the pipeline ELF.
   unsigned reconfigWorkgroupLayout;    // If set, allows automatic workgroup reconfigure to take place on
                                        //   compute shaders.
+  bool forceCsThreadIdSwizzling;       // Force rearranges threadId within group into blocks of 8*8 or 8*4.
   unsigned includeIr;                  // If set, the IR for all compiled shaders will be included in the
                                        //   pipeline ELF.
   unsigned nggFlags;                   // Flags to control NGG (NggFlag* values ored together)

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -478,6 +478,19 @@ void PatchInOutImportExport::processShader() {
           reconfigCall->eraseFromParent();
         }
       }
+      // Different with above, this will force the threadID swizzle which will rearrange thread ID within a group into
+      // blocks of 8*4, not to reconfig workgroup automatically and will support to be swizzled in 8*4 block
+      // split.
+      if (func.isDeclaration() && func.getName().startswith(lgcName::SwizzleLocalInvocationId)) {
+        while (!func.use_empty()) {
+          CallInst *swizzleCall = cast<CallInst>(*func.user_begin());
+          Value *localInvocationId = swizzleCall->getArgOperand(0);
+
+          localInvocationId = swizzleLocalInvocationIdIn8x4(localInvocationId, swizzleCall);
+          swizzleCall->replaceAllUsesWith(localInvocationId);
+          swizzleCall->eraseFromParent();
+        }
+      }
     }
   }
 }
@@ -5434,6 +5447,73 @@ Value *PatchInOutImportExport::reconfigWorkgroup(Value *localInvocationId, Instr
   remappedId = InsertElementInst::Create(remappedId, newY, ConstantInt::get(int32Ty, 1), "", insertPos);
 
   return remappedId;
+}
+
+// =====================================================================================================================
+// This function adds instructions to swizzle thread ID inside a group.
+//
+// The data layout in TCP is typically 8 x something.
+// The typewriter style SIMD layout does not match well with the data layout,
+// which will potentially cause partial cache line read/write.
+//
+// In the case of 16x16 thread group size, wf32 SIMD will be created in eight 16x2 regions.
+// This function maps the eight 16x2 regions into eight 8x4 regions.
+//
+// Originally SIMDs cover 16x2 regions, after swizzling they cover 8x4 regions.
+//
+// @param localInvocationId : The original workgroup ID.
+// @param insertPos : Where to insert instructions.
+Value *PatchInOutImportExport::swizzleLocalInvocationIdIn8x4(Value *localInvocationId, Instruction *insertPos) {
+  IRBuilder<> builder(*m_context);
+  builder.SetInsertPoint(insertPos);
+  auto &mode = m_pipelineState->getShaderModes()->getComputeShaderMode();
+
+  const unsigned workgroupSizeX = mode.workgroupSizeX;
+  const unsigned workgroupSizeY = mode.workgroupSizeY;
+
+  if (workgroupSizeX < 16)
+    return localInvocationId;
+
+  if (workgroupSizeX % 8 != 0)
+    return localInvocationId;
+
+  if (workgroupSizeY % 4 != 0)
+    return localInvocationId;
+
+  if ((workgroupSizeX >= 16) && (workgroupSizeX % 8 == 0) && (workgroupSizeY % 4 == 0)) {
+    Value *threadIdInGroupX = builder.CreateExtractElement(localInvocationId, (uint64_t)0);
+    Value *threadIdInGroupY = builder.CreateExtractElement(localInvocationId, 1);
+    Value *threadIdInGroupZ = builder.CreateExtractElement(localInvocationId, 2);
+    const unsigned blockSizeX = 8;
+    const unsigned blockSizeY = 4;
+    const unsigned blockDimY = workgroupSizeY / 4; // How many blocks are split in Y level.
+
+    const unsigned blockSize = blockSizeX * blockSizeY; // 32 threads per-block
+
+    Value *linearId = builder.CreateMul(threadIdInGroupY, builder.getInt32(workgroupSizeX));
+    linearId = builder.CreateAdd(linearId, threadIdInGroupX);
+
+    Value *waveId = builder.CreateUDiv(linearId, builder.getInt32(blockSize));
+    Value *waveLinearId = builder.CreateURem(linearId, builder.getInt32(blockSize));
+    Value *blockOffsX = builder.CreateUDiv(waveId, builder.getInt32(blockDimY));
+    Value *blockOffsY = builder.CreateURem(waveId, builder.getInt32(blockDimY));
+
+    Value *blockThreadIdX = builder.CreateURem(waveLinearId, builder.getInt32(blockSizeX));
+    Value *blockThreadIdY = builder.CreateUDiv(waveLinearId, builder.getInt32(blockSizeX));
+
+    Value *newThreadIdInGroupX = builder.CreateMul(blockOffsX, builder.getInt32(blockSizeX));
+    newThreadIdInGroupX = builder.CreateAdd(newThreadIdInGroupX, blockThreadIdX);
+    Value *newThreadIdInGroupY = builder.CreateMul(blockOffsY, builder.getInt32(blockSizeY));
+    newThreadIdInGroupY = builder.CreateAdd(newThreadIdInGroupY, blockThreadIdY);
+
+    Value *newThreadIdInGroupZ = threadIdInGroupZ;
+    Value *newThreadIdInGroup = PoisonValue::get(FixedVectorType::get(builder.getInt32Ty(), 3));
+    newThreadIdInGroup = builder.CreateInsertElement(newThreadIdInGroup, newThreadIdInGroupX, uint64_t(0));
+    newThreadIdInGroup = builder.CreateInsertElement(newThreadIdInGroup, newThreadIdInGroupY, 1);
+    newThreadIdInGroup = builder.CreateInsertElement(newThreadIdInGroup, newThreadIdInGroupZ, 2);
+    return newThreadIdInGroup;
+  }
+  return localInvocationId;
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -272,6 +272,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
 
   options.includeDisassembly = (cl::EnablePipelineDump || EnableOuts() || getPipelineOptions()->includeDisassembly);
   options.reconfigWorkgroupLayout = getPipelineOptions()->reconfigWorkgroupLayout;
+  options.forceCsThreadIdSwizzling = getPipelineOptions()->forceCsThreadIdSwizzling;
   options.includeIr = (IncludeLlvmIr || getPipelineOptions()->includeIr);
 
   switch (getPipelineOptions()->shadowDescriptorTableUsage) {

--- a/llpc/test/shaderdb/core/LocalInvocationIdSwizzle.spvasm
+++ b/llpc/test/shaderdb/core/LocalInvocationIdSwizzle.spvasm
@@ -1,0 +1,108 @@
+; BEGIN_SWIZZLETEST
+; RUN: amdllpc -v %gfxip %s --force-compute-shader-thread-id-swizzling | FileCheck -check-prefix=SWIZZLETEST %s
+; SWIZZLETEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SWIZZLETEST: %{{[0-9]+}} = call <3 x i32> @lgc.swizzle.local.invocation.id(<3 x i32> %{{[0-9]+}})
+; SWIZZLETEST: AMDLLPC SUCCESS
+; END_SWIZZLETEST
+; BEGIN_NOTSWIZZLETEST
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=NOTSWIZZLETEST %s
+; NOTSWIZZLETEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; NOTSWIZZLETEST-NOT: lgc.swizzle.local.invocation.id
+; NOTSWIZZLETEST: AMDLLPC SUCCESS
+; END_NOTSWIZZLETEST
+
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+                OpCapability Shader
+                OpCapability VariablePointers
+                OpExtension "SPV_KHR_variable_pointers"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main" %wg_var %diff_var %lid_var %gid_var
+                OpExecutionMode %main LocalSize 16 4 1
+
+                OpDecorate %struct_17 Block
+                OpMemberDecorate %struct_17 0 Offset 0
+                OpDecorate %runtime_17 ArrayStride 68
+                OpDecorate %array_17 ArrayStride 4
+
+                OpDecorate %diff_var DescriptorSet 0
+                OpDecorate %diff_var Binding 0
+
+                OpDecorate %lid_var BuiltIn LocalInvocationId
+                OpDecorate %gid_var BuiltIn GlobalInvocationId
+
+        %void = OpTypeVoid
+        %bool = OpTypeBool
+         %int = OpTypeInt 32 1
+       %int_0 = OpConstant %int 0
+       %int_1 = OpConstant %int 1
+       %int_4 = OpConstant %int 4
+      %int_16 = OpConstant %int 16
+      %int_17 = OpConstant %int 17
+      %int_64 = OpConstant %int 64
+        %int3 = OpTypeVector %int 3
+
+%ptr_input_int3 = OpTypePointer Input %int3
+
+     %array_4 = OpTypeArray %int %int_4
+%array_array_4 = OpTypeArray %array_4 %int_16
+%ptr_array_array_4 = OpTypePointer Workgroup %array_array_4
+%ptr_array_4 = OpTypePointer Workgroup %array_4
+ %ptr_wg_int = OpTypePointer Workgroup %int
+
+    %array_17 = OpTypeArray %int %int_17
+  %runtime_17 = OpTypeRuntimeArray %array_17
+   %struct_17 = OpTypeStruct %runtime_17
+%ptr_struct_17 = OpTypePointer StorageBuffer %struct_17
+%ptr_array_17 = OpTypePointer StorageBuffer %array_17
+     %ptr_int = OpTypePointer StorageBuffer %int
+
+      %wg_var = OpVariable %ptr_array_array_4 Workgroup
+    %diff_var = OpVariable %ptr_struct_17 StorageBuffer
+     %lid_var = OpVariable %ptr_input_int3 Input
+     %gid_var = OpVariable %ptr_input_int3 Input
+
+     %void_fn = OpTypeFunction %void
+        %main = OpFunction %void None %void_fn
+       %entry = OpLabel
+         %gid = OpLoad %int3 %gid_var
+       %gid_x = OpCompositeExtract %int %gid 0
+       %gid_y = OpCompositeExtract %int %gid 1
+         %lid = OpLoad %int3 %lid_var
+       %lid_x = OpCompositeExtract %int %lid 0
+       %lid_y = OpCompositeExtract %int %lid 1
+ %array_gep_0 = OpAccessChain %ptr_array_4 %wg_var %int_0
+   %array_gep = OpAccessChain %ptr_array_4 %wg_var %lid_x
+  %lid_y_is_1 = OpIEqual %bool %lid_y %int_1
+                OpSelectionMerge %loop None
+                OpBranchConditional %lid_y_is_1 %then %loop
+
+        %then = OpLabel
+                ; Compute results for outer array
+  %large_diff = OpPtrDiff %int %array_gep %array_gep_0
+%large_diff_gep = OpAccessChain %ptr_int %diff_var %int_0 %gid_x %int_16
+                OpStore %large_diff_gep %large_diff
+                ;
+                OpBranch %loop
+
+        %loop = OpLabel
+           %i = OpPhi %int %int_0 %entry %int_0 %then %inc_i %loop
+       %inc_i = OpIAdd %int %i %int_1
+       %i_cmp = OpIEqual %bool %inc_i %int_4
+  %lid_offset = OpIMul %int %lid_y %int_4
+%out_gep_index = OpIAdd %int %i %lid_offset
+                ; Compute results for inner array
+     %ref_gep = OpAccessChain %ptr_wg_int %array_gep %lid_y
+     %cmp_gep = OpAccessChain %ptr_wg_int %array_gep %i
+        %diff = OpPtrDiff %int %ref_gep %cmp_gep
+    %diff_gep = OpAccessChain %ptr_int %diff_var %int_0 %gid_x %out_gep_index
+                OpStore %diff_gep %diff
+                ;
+                OpLoopMerge %exit %loop None
+                OpBranchConditional %i_cmp %exit %loop
+        %exit = OpLabel
+                OpReturn
+                OpFunctionEnd

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -230,6 +230,12 @@ cl::opt<bool> EnableScratchAccessBoundsChecks("enable-scratch-bounds-checks",
                                               cl::desc("Insert scratch access bounds checks on loads and stores"),
                                               cl::init(false));
 
+// -enable-forceCsThreadIdSwizzling: force cs thread id swizzling
+cl::opt<bool> ForceCsThreadIdSwizzling("force-compute-shader-thread-id-swizzling",
+                                              cl::desc("force compute shader thread-id swizzling"),
+                                              cl::init(false));
+
+
 // -filter-pipeline-dump-by-type: filter which kinds of pipeline should be disabled.
 cl::opt<unsigned> FilterPipelineDumpByType("filter-pipeline-dump-by-type",
                                            cl::desc("Filter which types of pipeline dump are disabled\n"
@@ -427,6 +433,7 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
   compileInfo->compPipelineInfo.options.optimizationLevel = CodeGenOpt::Level::Default;
 #endif
   compileInfo->gfxPipelineInfo.options.resourceLayoutScheme = LayoutScheme;
+  compileInfo->compPipelineInfo.options.forceCsThreadIdSwizzling = ForceCsThreadIdSwizzling;
 
   // Set NGG control settings
   if (ParsedGfxIp.major >= 10) {

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -132,6 +132,7 @@ Expected<BinaryData> ComputePipelineBuilder::buildComputePipeline() {
   pipelineInfo->options.enableRelocatableShaderElf = compileInfo.relocatableShaderElf;
   pipelineInfo->options.scalarBlockLayout = compileInfo.scalarBlockLayout;
   pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo.scratchAccessBoundsChecks;
+  pipelineInfo->options.forceCsThreadIdSwizzling = compileInfo.compPipelineInfo.options.forceCsThreadIdSwizzling;
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
   if (compileInfo.optimizationLevel.hasValue()) {
     pipelineInfo->options.optimizationLevel = compileInfo.optimizationLevel.getValue();

--- a/llpc/unittests/util/testPipelineDumper.cpp
+++ b/llpc/unittests/util/testPipelineDumper.cpp
@@ -279,6 +279,19 @@ TEST(PipelineDumperTest, TestOptimizationLevel1Compute) {
     runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
   }
 }
+
+// =====================================================================================================================
+// Test the forceCsthreadIdSwizzling option.
+
+TEST(PipelineDumperTest, TestForceCsThreadIdSwizzlingCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.forceCsThreadIdSwizzling = true;
+  };
+
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
 #endif
 
 } // namespace

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -692,6 +692,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
   dumpFile << "options.includeIr = " << options->includeIr << "\n";
   dumpFile << "options.robustBufferAccess = " << options->robustBufferAccess << "\n";
   dumpFile << "options.reconfigWorkgroupLayout = " << options->reconfigWorkgroupLayout << "\n";
+  dumpFile << "options.forceCsThreadIdSwizzling = " << options->forceCsThreadIdSwizzling << "\n";
   dumpFile << "options.shadowDescriptorTableUsage = " << options->shadowDescriptorTableUsage << "\n";
   dumpFile << "options.shadowDescriptorTablePtrHigh = " << options->shadowDescriptorTablePtrHigh << "\n";
   dumpFile << "options.extendedRobustness.robustBufferAccess = " << options->extendedRobustness.robustBufferAccess
@@ -1095,6 +1096,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
   hasher->Update(options->includeIr);
   hasher->Update(options->robustBufferAccess);
   hasher->Update(options->reconfigWorkgroupLayout);
+  hasher->Update(options->forceCsThreadIdSwizzling);
   hasher->Update(options->enableRelocatableShaderElf);
   hasher->Update(options->disableImageResourceCheck);
   hasher->Update(options->enableScratchAccessBoundsChecks);

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -343,6 +343,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceCsThreadIdSwizzling, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
@@ -360,7 +361,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 11;
+  static const unsigned MemberCount = 12;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
This option will be set under vulkan optimization.
Originally SIMDs cover 16x2 regions, if open the switch, swizzling they cover 8x4 regions.
Default value for this option is false.