### PR TITLE
Disable opaque pointer support

### DIFF
--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -113,6 +113,9 @@ static bool isIsaText(StringRef data) {
 int main(int argc, char **argv) {
   const char *progName = sys::path::filename(argv[0]).data();
   LLVMContext context;
+  // Temporarily disable opaque pointers (llvm is making opaque the default).
+  // TODO: Remove this once work complete on transition to opaque pointers.
+  context.setOpaquePointers(false);
   LgcContext::initialize();
 
   // Set our category on options that we want to show in -help, and hide other options.

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -65,6 +65,9 @@ namespace Llpc {
 // @param gfxIp : Graphics IP version info
 Context::Context(GfxIpVersion gfxIp) : LLVMContext(), m_gfxIp(gfxIp) {
   reset();
+  // Temporarily disable opaque pointers (llvm is making opaque the default).
+  // TODO: Remove this once work complete on transition to opaque pointers.
+  setOpaquePointers(false);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
LLVM is moving to opaque pointers as the default.
Temporarily disable this until opaque pointer support is enabled in llpc and
lgc.