### PR TITLE
Fix clang-tidy remarks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
  # Do not modify llpc.h, vkgcDefs.h, anything in the SPIRV library, or vfx.h, or anything in lgc/imported.
 HeaderFilterRegex: '.*/vfx/vfx..*\\.h|.*/dumper/vkgc.*\\.h|.*/util/vkgc.*\\.h|.*/lgc/include/.*\\.h|.*/context/llpc[^/]*\\.h|.*/util/llpc[^/]*\\.h|.*/lower/llpc[^/]*\\.h|.*/builder/llpc[^/]*\\.h|.*/patch.*/llpc[^/]*\\.h|.*/tool/[^/]*\\.h'
-Checks: '-*,clang-diagnostic-*,llvm-*,-llvm-include-order,-llvm-qualified-auto,-llvm-header-guard,performance-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
+Checks: '-*,clang-analyzer-*,clang-diagnostic-*,-clang-analyzer-core.CallAndMessage,-clang-analyzer-core.DivideZero,-clang-analyzer-core.NonNullParamChecker,-clang-analyzer-core.NullDereference,-clang-analyzer-core.uninitialized.UndefReturn,-clang-analyzer-core.UndefinedBinaryOperatorResult,-clang-analyzer-optin.cplusplus.VirtualCall,llvm-*,-llvm-include-order,-llvm-qualified-auto,-llvm-header-guard,performance-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-simplify-boolean-expr,readability-redundant-nullptr-comparison,readability-redundant-parentheses,readability-declaration-inline-comment'
 CheckOptions:
   - { key: readability-identifier-naming.ParameterCase, value: camelBack }
   - { key: readability-identifier-naming.ParameterRemovePrefixes, value: 'p,b,pfn' }

--- a/lgc/builder/BuilderBase.cpp
+++ b/lgc/builder/BuilderBase.cpp
@@ -148,7 +148,8 @@ Value *BuilderBase::CreateMapToInt32(MapToInt32Func mapFunc, ArrayRef<Value *> m
       result = CreateInsertElement(result, results[i], i);
 
     return result;
-  } else if (type->isIntegerTy() && type->getIntegerBitWidth() == 1) {
+  }
+  if (type->isIntegerTy() && type->getIntegerBitWidth() == 1) {
     SmallVector<Value *, 4> newMappedArgs;
 
     for (Value *const mappedArg : mappedArgs)
@@ -156,7 +157,8 @@ Value *BuilderBase::CreateMapToInt32(MapToInt32Func mapFunc, ArrayRef<Value *> m
 
     Value *const result = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
     return CreateTrunc(result, getInt1Ty());
-  } else if (type->isIntegerTy() && type->getIntegerBitWidth() < 32) {
+  }
+  if (type->isIntegerTy() && type->getIntegerBitWidth() < 32) {
     SmallVector<Value *, 4> newMappedArgs;
 
     Type *const vectorType = FixedVectorType::get(type, type->getPrimitiveSizeInBits() == 16 ? 2 : 4);
@@ -169,7 +171,8 @@ Value *BuilderBase::CreateMapToInt32(MapToInt32Func mapFunc, ArrayRef<Value *> m
 
     Value *const result = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
     return CreateExtractElement(CreateBitCast(result, vectorType), static_cast<uint64_t>(0));
-  } else if (type->getPrimitiveSizeInBits() == 64) {
+  }
+  if (type->getPrimitiveSizeInBits() == 64) {
     SmallVector<Value *, 4> castMappedArgs;
 
     for (Value *const mappedArg : mappedArgs)
@@ -189,7 +192,8 @@ Value *BuilderBase::CreateMapToInt32(MapToInt32Func mapFunc, ArrayRef<Value *> m
     }
 
     return CreateBitCast(result, type);
-  } else if (type->isFloatingPointTy()) {
+  }
+  if (type->isFloatingPointTy()) {
     SmallVector<Value *, 4> newMappedArgs;
 
     for (Value *const mappedArg : mappedArgs)
@@ -197,12 +201,11 @@ Value *BuilderBase::CreateMapToInt32(MapToInt32Func mapFunc, ArrayRef<Value *> m
 
     Value *const result = CreateMapToInt32(mapFunc, newMappedArgs, passthroughArgs);
     return CreateBitCast(result, type);
-  } else if (type->isIntegerTy(32))
-    return mapFunc(*this, mappedArgs, passthroughArgs);
-  else {
-    llvm_unreachable("Should never be called!");
-    return nullptr;
   }
+  if (type->isIntegerTy(32))
+    return mapFunc(*this, mappedArgs, passthroughArgs);
+  llvm_unreachable("Should never be called!");
+  return nullptr;
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -168,8 +168,8 @@ Value *BuilderImplBase::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
       if (compCount == 2) {
         scalar = CreateIntrinsic(intrinsicDot2, {}, {input1, input2, accumulator, clamp}, nullptr, instName);
       } else {
-        Value *intermediateRes = getInt32(0);
-        scalar = getInt32(0);
+        Value *intermediateRes = nullptr;
+        scalar = nullptr;
         if (compCount == 3) {
           // Split <3xi16> up with an integer multiplication, a 16-bit integer dot product
           Value *w1 = CreateExtractElement(input1, 2);

--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -525,7 +525,7 @@ Instruction *BuilderImplBase::createWaterfallLoop(Instruction *nonUniformInst, A
 //
 // @param value : Input value
 // @param callback : Callback function
-Value *BuilderImplBase::scalarize(Value *value, std::function<Value *(Value *)> callback) {
+Value *BuilderImplBase::scalarize(Value *value, const std::function<Value *(Value *)> &callback) {
   if (auto vecTy = dyn_cast<FixedVectorType>(value->getType())) {
     Value *result0 = callback(CreateExtractElement(value, uint64_t(0)));
     Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
@@ -544,7 +544,7 @@ Value *BuilderImplBase::scalarize(Value *value, std::function<Value *(Value *)> 
 //
 // @param value : Input value
 // @param callback : Callback function
-Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Value *)> callback) {
+Value *BuilderImplBase::scalarizeInPairs(Value *value, const std::function<Value *(Value *)> &callback) {
   if (auto vecTy = dyn_cast<FixedVectorType>(value->getType())) {
     Value *inComps = CreateShuffleVector(value, value, ArrayRef<int>{0, 1});
     Value *resultComps = callback(inComps);
@@ -579,7 +579,8 @@ Value *BuilderImplBase::scalarizeInPairs(Value *value, std::function<Value *(Val
 // @param value0 : Input value 0
 // @param value1 : Input value 1
 // @param callback : Callback function
-Value *BuilderImplBase::scalarize(Value *value0, Value *value1, std::function<Value *(Value *, Value *)> callback) {
+Value *BuilderImplBase::scalarize(Value *value0, Value *value1,
+                                  const std::function<Value *(Value *, Value *)> &callback) {
   if (auto vecTy = dyn_cast<FixedVectorType>(value0->getType())) {
     Value *result0 = callback(CreateExtractElement(value0, uint64_t(0)), CreateExtractElement(value1, uint64_t(0)));
     Value *result = UndefValue::get(FixedVectorType::get(result0->getType(), vecTy->getNumElements()));
@@ -602,7 +603,7 @@ Value *BuilderImplBase::scalarize(Value *value0, Value *value1, std::function<Va
 // @param value2 : Input value 2
 // @param callback : Callback function
 Value *BuilderImplBase::scalarize(Value *value0, Value *value1, Value *value2,
-                                  std::function<Value *(Value *, Value *, Value *)> callback) {
+                                  const std::function<Value *(Value *, Value *, Value *)> &callback) {
   if (auto vecTy = dyn_cast<FixedVectorType>(value0->getType())) {
     Value *result0 = callback(CreateExtractElement(value0, uint64_t(0)), CreateExtractElement(value1, uint64_t(0)),
                               CreateExtractElement(value2, uint64_t(0)));

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -80,18 +80,18 @@ protected:
                                          const llvm::Twine &instName = "");
 
   // Helper method to scalarize a possibly vector unary operation
-  llvm::Value *scalarize(llvm::Value *value, std::function<llvm::Value *(llvm::Value *)> callback);
+  llvm::Value *scalarize(llvm::Value *value, const std::function<llvm::Value *(llvm::Value *)> &callback);
 
   // Helper method to scalarize in pairs a possibly vector unary operation.
-  llvm::Value *scalarizeInPairs(llvm::Value *value, std::function<llvm::Value *(llvm::Value *)> callback);
+  llvm::Value *scalarizeInPairs(llvm::Value *value, const std::function<llvm::Value *(llvm::Value *)> &callback);
 
   // Helper method to scalarize a possibly vector binary operation
   llvm::Value *scalarize(llvm::Value *value0, llvm::Value *value1,
-                         std::function<llvm::Value *(llvm::Value *, llvm::Value *)> callback);
+                         const std::function<llvm::Value *(llvm::Value *, llvm::Value *)> &callback);
 
   // Helper method to scalarize a possibly vector trinary operation
   llvm::Value *scalarize(llvm::Value *value0, llvm::Value *value1, llvm::Value *value2,
-                         std::function<llvm::Value *(llvm::Value *, llvm::Value *, llvm::Value *)> callback);
+                         const std::function<llvm::Value *(llvm::Value *, llvm::Value *, llvm::Value *)> &callback);
 
   // Create code to get the lane number within the wave. This depends on whether the shader is wave32 or wave64,
   // and thus on the shader stage it is used from.

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -542,7 +542,6 @@ Value *ImageBuilder::CreateImageLoad(Type *resultTy, unsigned dim, unsigned flag
       result = CreateInsertValue(CreateInsertValue(UndefValue::get(intrinsicDataTy), texel, uint64_t(0)),
                                  CreateExtractValue(result, 1), 1);
     } else {
-      intrinsicDataTy = origTexelTy;
       result = texel;
     }
   }

--- a/lgc/builder/YCbCrConverter.cpp
+++ b/lgc/builder/YCbCrConverter.cpp
@@ -349,19 +349,16 @@ void YCbCrConverter::genImgDescChroma() {
   SqImgRsrcRegHandler proxySqRsrcRegHelper(m_builder, m_imgDescLuma, m_gfxIp);
 
   Value *width = nullptr;
-  Value *height = nullptr;
-
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 52
   if ((m_metaData.word5.lumaDepth > 1) && (m_metaData.word1.planes > 1)) {
     width = ConstantInt::get(m_builder->getInt32Ty(), m_metaData.word4.lumaWidth);
-    height = ConstantInt::get(m_builder->getInt32Ty(), m_metaData.word4.lumaHeight);
     m_width = ConstantFP::get(m_builder->getFloatTy(), m_metaData.word4.lumaWidth);
     m_height = ConstantFP::get(m_builder->getFloatTy(), m_metaData.word4.lumaHeight);
   } else
 #endif
   {
     width = proxySqRsrcRegHelper.getReg(SqRsrcRegs::Width);
-    height = proxySqRsrcRegHelper.getReg(SqRsrcRegs::Height);
+    Value *height = proxySqRsrcRegHelper.getReg(SqRsrcRegs::Height);
     m_width = m_builder->CreateUIToFP(width, m_builder->getFloatTy());
     m_height = m_builder->CreateUIToFP(height, m_builder->getFloatTy());
   }

--- a/lgc/disassembler/Disassembler.cpp
+++ b/lgc/disassembler/Disassembler.cpp
@@ -444,10 +444,9 @@ void ObjDisassembler::tryDisassembleSection(ELFSectionRef sectionRef, unsigned s
 
     // Got a disassemblable instruction.
     // First output any non-disassemblable data up to this point.
-    if (lastOffset != offset) {
+    if (lastOffset != offset)
       outputData(outputting, lastOffset, contents.slice(lastOffset, offset), relocs);
-      lastOffset = offset;
-    }
+
     // Output reloc.
     outputRelocs(outputting, offset, inst.bytes.size(), relocs);
 

--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -684,9 +684,7 @@ bool ElfLinkerImpl::getRelocValue(object::RelocationRef reloc, uint64_t &value) 
   StringRef name = cantFail(reloc.getSymbol()->getName());
 
   // Handle the special case relocs from pipeline state
-  if (m_relocHandler.getValue(name, value))
-    return true;
-  return false;
+  return m_relocHandler.getValue(name, value);
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -50,7 +50,7 @@ public:
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
 
   bool runImpl(llvm::Module &module, PipelineShadersResult &pipelineShaders, PipelineState *pipelineState,
-               std::function<llvm::PostDominatorTree &(llvm::Function &)> getPostDominatorTree);
+               const std::function<llvm::PostDominatorTree &(llvm::Function &)> &getPostDominatorTree);
 
   static llvm::StringRef name() { return "Patch LLVM for input import and output export operations"; }
 
@@ -61,7 +61,7 @@ private:
   void processFunction(llvm::Function &func, ShaderStage shaderStage,
                        llvm::SmallVectorImpl<llvm::Function *> &inputCallees,
                        llvm::SmallVectorImpl<llvm::Function *> &otherCallees,
-                       std::function<llvm::PostDominatorTree &(llvm::Function &)> getPostDominatorTree);
+                       const std::function<llvm::PostDominatorTree &(llvm::Function &)> &getPostDominatorTree);
   void initPerShader();
 
   void markExportDone(llvm::Function *func, llvm::PostDominatorTree &postDomTree);

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -2473,7 +2473,7 @@ void NggPrimShader::doEarlyExit(unsigned fullyCulledExportCount) {
 // @param sysValueStart : Start of system value
 void NggPrimShader::runEs(Module *module, Argument *sysValueStart) {
   const bool hasTs = (m_hasTcs || m_hasTes);
-  if (((hasTs && m_hasTes) || (!hasTs && m_hasVs)) == false) {
+  if (!((hasTs && m_hasTes) || (!hasTs && m_hasVs))) {
     // No TES (tessellation is enabled) or VS (tessellation is disabled), don't have to run
     return;
   }
@@ -2943,8 +2943,7 @@ void NggPrimShader::splitEs(Module *module) {
 
   for (auto func : expFuncs) {
     for (auto user : func->users()) {
-      CallInst *const call = dyn_cast<CallInst>(user);
-      assert(call);
+      CallInst *const call = cast<CallInst>(user);
 
       if (call->getParent()->getParent() != esCullDataFetchFunc)
         continue; // Export call doesn't belong to targeted function, skip
@@ -3008,8 +3007,7 @@ void NggPrimShader::splitEs(Module *module) {
 
   for (auto func : expFuncs) {
     for (auto user : func->users()) {
-      CallInst *const call = dyn_cast<CallInst>(user);
-      assert(call);
+      CallInst *const call = cast<CallInst>(user);
 
       if (call->getParent()->getParent() != esDeferredVertexExportFunc)
         continue; // Export call doesn't belong to targeted function, skip
@@ -3186,8 +3184,7 @@ Function *NggPrimShader::mutateGs(Module *module) {
     if (func.getName().startswith(lgcName::NggGsOutputExport)) {
       // Export GS outputs to GS-VS ring
       for (auto user : func.users()) {
-        CallInst *const call = dyn_cast<CallInst>(user);
-        assert(call);
+        CallInst *const call = cast<CallInst>(user);
         m_builder->SetInsertPoint(call);
 
         assert(call->arg_size() == 4);
@@ -3205,8 +3202,7 @@ Function *NggPrimShader::mutateGs(Module *module) {
     } else if (func.isIntrinsic() && func.getIntrinsicID() == Intrinsic::amdgcn_s_sendmsg) {
       // Handle GS message
       for (auto user : func.users()) {
-        CallInst *const call = dyn_cast<CallInst>(user);
-        assert(call);
+        CallInst *const call = cast<CallInst>(user);
         m_builder->SetInsertPoint(call);
 
         if (getShaderStage(call->getParent()->getParent()) != ShaderStageGeometry)
@@ -3330,8 +3326,7 @@ Function *NggPrimShader::mutateCopyShader(Module *module) {
     if (func.getName().startswith(lgcName::NggGsOutputImport)) {
       // Import GS outputs from GS-VS ring
       for (auto user : func.users()) {
-        CallInst *const call = dyn_cast<CallInst>(user);
-        assert(call);
+        CallInst *const call = cast<CallInst>(user);
 
         if (call->getFunction() != copyShaderEntryPoint)
           continue; // Not belong to copy shader
@@ -4573,7 +4568,7 @@ Function *NggPrimShader::createBoxFilterCuller(Module *module) {
 
     // vtxZFmt = (VTX_Z_FMT, PA_CL_VTE_CNTL[9], 0 = 1/W0, 1 = none)
     Value *vtxZFmt = CreateUBfe(paClVteCntl, 9, 1);
-    vtxZFmt = m_builder->CreateTrunc(vtxXyFmt, m_builder->getInt1Ty());
+    vtxZFmt = m_builder->CreateTrunc(vtxZFmt, m_builder->getInt1Ty());
 
     // clipSpaceDef = (DX_CLIP_SPACE_DEF, PA_CL_CLIP_CNTL[19], 0 = OGL clip space, 1 = DX clip space)
     Value *clipSpaceDef = CreateUBfe(paClClipCntl, 19, 1);
@@ -4800,7 +4795,7 @@ Function *NggPrimShader::createSphereCuller(Module *module) {
 
     // vtxZFmt = (VTX_Z_FMT, PA_CL_VTE_CNTL[9], 0 = 1/W0, 1 = none)
     Value *vtxZFmt = CreateUBfe(paClVteCntl, 9, 1);
-    vtxZFmt = m_builder->CreateTrunc(vtxXyFmt, m_builder->getInt1Ty());
+    vtxZFmt = m_builder->CreateTrunc(vtxZFmt, m_builder->getInt1Ty());
 
     // clipSpaceDef = (DX_CLIP_SPACE_DEF, PA_CL_CLIP_CNTL[19], 0 = OGL clip space, 1 = DX clip space)
     Value *clipSpaceDef = CreateUBfe(paClClipCntl, 19, 1);

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -165,7 +165,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
   passMgr.addPass(createModuleToFunctionPassAdaptor(createFunctionToLoopPassAdaptor(PatchLoopMetadata())));
 
   // Check shader cache
-  passMgr.addPass(PatchCheckShaderCache(checkShaderCacheFunc));
+  passMgr.addPass(PatchCheckShaderCache(std::move(checkShaderCacheFunc)));
 
   // Stop timer for patching passes and start timer for optimization passes.
   if (patchTimer) {
@@ -324,7 +324,7 @@ void LegacyPatch::addPasses(PipelineState *pipelineState, legacy::PassManager &p
   // Check shader cache
   auto checkShaderCachePass = createLegacyPatchCheckShaderCache();
   passMgr.add(checkShaderCachePass);
-  checkShaderCachePass->setCallbackFunction(checkShaderCacheFunc);
+  checkShaderCachePass->setCallbackFunction(std::move(checkShaderCacheFunc));
 
   // Stop timer for patching passes and start timer for optimization passes.
   if (patchTimer) {

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1496,15 +1496,14 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
         newLoad->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, None));
 
       return newLoad;
-    } else {
-      StoreInst *const newStore =
-          m_builder->CreateAlignedStore(storeInst->getValueOperand(), pointer, alignment, storeInst->isVolatile());
-      newStore->setOrdering(ordering);
-      newStore->setSyncScopeID(syncScopeID);
-      copyMetadata(newStore, storeInst);
-
-      return newStore;
     }
+    StoreInst *const newStore =
+        m_builder->CreateAlignedStore(storeInst->getValueOperand(), pointer, alignment, storeInst->isVolatile());
+    newStore->setOrdering(ordering);
+    newStore->setSyncScopeID(syncScopeID);
+    copyMetadata(newStore, storeInst);
+
+    return newStore;
   }
 
   switch (ordering) {

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -761,8 +761,7 @@ void PatchBufferOp::visitMemMoveInst(MemMoveInst &memMoveInst) {
   const MaybeAlign srcAlignment = memMoveInst.getParamAlign(1);
 
   // We assume LLVM is not introducing variable length mem moves.
-  ConstantInt *const length = dyn_cast<ConstantInt>(memMoveInst.getArgOperand(2));
-  assert(length);
+  ConstantInt *const length = cast<ConstantInt>(memMoveInst.getArgOperand(2));
 
   // Get a vector type that is the length of the memmove.
   VectorType *const memoryType = FixedVectorType::get(m_builder->getInt8Ty(), length->getZExtValue());
@@ -1320,8 +1319,7 @@ Value *PatchBufferOp::getPointerOperandAsInst(Value *const value) {
     return value;
   }
 
-  ConstantExpr *const constExpr = dyn_cast<ConstantExpr>(value);
-  assert(constExpr);
+  ConstantExpr *const constExpr = cast<ConstantExpr>(value);
 
   Instruction *const newInst = m_builder->Insert(constExpr->getAsInstruction());
 

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -72,7 +72,7 @@ template <class MapType> static void streamMapEntries(MapType &map, raw_ostream 
 
 // =====================================================================================================================
 PatchCheckShaderCache::PatchCheckShaderCache(Pipeline::CheckShaderCacheFunc callbackFunc)
-    : m_callbackFunc(callbackFunc) {
+    : m_callbackFunc(std::move(callbackFunc)) {
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -260,14 +260,13 @@ unsigned PatchInitializeWorkgroupMemory::getTypeSizeInDwords(Type *inputTy) {
   if (inputTy->isArrayTy()) {
     const unsigned elemSize = getTypeSizeInDwords(inputTy->getArrayElementType());
     return inputTy->getArrayNumElements() * elemSize;
-  } else {
-    assert(inputTy->isStructTy());
-    const unsigned memberCount = inputTy->getStructNumElements();
-    unsigned memberSize = 0;
-    for (unsigned idx = 0; idx < memberCount; ++idx)
-      memberSize += getTypeSizeInDwords(inputTy->getStructElementType(idx));
-    return memberSize;
   }
+  assert(inputTy->isStructTy());
+  const unsigned memberCount = inputTy->getStructNumElements();
+  unsigned memberSize = 0;
+  for (unsigned idx = 0; idx < memberCount; ++idx)
+    memberSize += getTypeSizeInDwords(inputTy->getStructElementType(idx));
+  return memberSize;
 }
 
 } // namespace lgc

--- a/lgc/patch/PatchLoopMetadata.cpp
+++ b/lgc/patch/PatchLoopMetadata.cpp
@@ -208,7 +208,8 @@ bool PatchLoopMetadata::runImpl(Loop &loop, PipelineState *pipelineState) {
                                           thresholdMetaNode, false);
             changed = true;
             break;
-          } else if (m_unrollHintThreshold > 0 && mdString->getString().startswith("llvm.loop.unroll.full")) {
+          }
+          if (m_unrollHintThreshold > 0 && mdString->getString().startswith("llvm.loop.unroll.full")) {
             LLVM_DEBUG(dbgs() << "  relaxing llvm.loop.unroll.full to amdgpu.loop.unroll.threshold "
                               << m_unrollHintThreshold << "\n");
             Metadata *thresholdMeta[] = {

--- a/lgc/patch/PatchReadFirstLane.cpp
+++ b/lgc/patch/PatchReadFirstLane.cpp
@@ -159,7 +159,7 @@ bool PatchReadFirstLane::runImpl(Function &function, std::function<bool(const Us
                                  TargetTransformInfo *targetTransformInfo) {
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Read-First-Lane\n");
 
-  m_isDivergentUse = isDivergentUse;
+  m_isDivergentUse = std::move(isDivergentUse);
   m_targetTransformInfo = targetTransformInfo;
 
   bool changed = promoteEqualUniformOps(function);
@@ -280,7 +280,7 @@ bool PatchReadFirstLane::liftReadFirstLane(Function &function) {
   bool changed = false;
 
   // Lift readfirstlanes in each relevant basic block
-  for (auto blockInitialReadFirstLanes : blockInitialReadFirstLanesMap) {
+  for (const auto &blockInitialReadFirstLanes : blockInitialReadFirstLanesMap) {
     BasicBlock *curBb = blockInitialReadFirstLanes.first;
 
     // Step 1: Collect all instructions that "can be assumed uniform" with its divergent uses in a map
@@ -535,7 +535,7 @@ bool PatchReadFirstLane::isAllUsersAssumedUniform(Instruction *inst) {
 void PatchReadFirstLane::applyReadFirstLane(Instruction *inst, BuilderBase &builder) {
   // Guarantee the insert position is behind all PhiNodes
   Instruction *insertPos = inst->getNextNonDebugInstruction();
-  while (dyn_cast<PHINode>(insertPos))
+  while (isa<PHINode>(insertPos))
     insertPos = insertPos->getNextNonDebugInstruction();
   builder.SetInsertPoint(insertPos);
 

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1044,7 +1044,7 @@ void PatchResourceCollect::processShader() {
     // into PAL metadata, for the other half of the pipeline to be compiled against later.
     if (m_pipelineState->getShaderStageMask() == 1U << ShaderStageFragment) {
       FsInputMappings fsInputMappings = {};
-      for (auto it : m_resUsage->inOutUsage.inputLocInfoMap)
+      for (const auto &it : m_resUsage->inOutUsage.inputLocInfoMap)
         fsInputMappings.locationInfo.push_back({it.first.getData(), it.second.getData()});
       for (auto it : m_resUsage->inOutUsage.builtInInputLocMap)
         fsInputMappings.builtInLocationInfo.push_back({it.first, it.second});

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -167,8 +167,9 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       // Set the work group size
       const auto &computeMode = m_pipelineState->getShaderModes()->getComputeShaderMode();
       unsigned flatWorkGroupSize = computeMode.workgroupSizeX * computeMode.workgroupSizeY * computeMode.workgroupSizeZ;
-      auto flatWorkGroupSizeString = std::to_string(flatWorkGroupSize);
-      builder.addAttribute("amdgpu-flat-work-group-size", flatWorkGroupSizeString + "," + flatWorkGroupSizeString);
+      SmallVector<char, 8> attributeBuf;
+      builder.addAttribute("amdgpu-flat-work-group-size",
+                           (Twine(flatWorkGroupSize) + "," + Twine(flatWorkGroupSize)).toStringRef(attributeBuf));
     }
 
     auto gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -434,7 +434,7 @@ void PalMetadata::fixUpRegisters() {
 
   // First find the descriptor sets and push const nodes.
   SmallVector<const ResourceNode *, 4> descSetNodes;
-  const ResourceNode *pushConstNode;
+  const ResourceNode *pushConstNode = nullptr;
   for (const auto &node : m_pipelineState->getUserDataNodes()) {
     if (node.type == ResourceNodeType::DescriptorTableVaPtr && !node.innerTable.empty()) {
       size_t descSet = node.innerTable[0].set;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1540,9 +1540,9 @@ unsigned PipelineState::getVerticesPerPrimitive() {
     const auto &tessMode = getShaderModes()->getTessellationMode();
     if (tessMode.pointMode)
       return 1;
-    else if (tessMode.primitiveMode == PrimitiveMode::Isolines)
+    if (tessMode.primitiveMode == PrimitiveMode::Isolines)
       return 2;
-    else if (tessMode.primitiveMode == PrimitiveMode::Triangles)
+    if (tessMode.primitiveMode == PrimitiveMode::Triangles)
       return 3;
   } else {
     auto primType = getInputAssemblyState().primitiveType;

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -188,7 +188,7 @@ int main(int argc, char **argv) {
 
   // Read the input files.
   SmallVector<std::unique_ptr<MemoryBuffer>, 4> inBuffers;
-  for (auto inFileName : InFiles) {
+  for (const auto &inFileName : InFiles) {
     // Read the input file. getFileOrSTDIN handles the case of inFileName being "-".
     ErrorOr<std::unique_ptr<MemoryBuffer>> fileOrErr = MemoryBuffer::getFileOrSTDIN(inFileName);
     if (std::error_code errorCode = fileOrErr.getError()) {
@@ -338,7 +338,7 @@ int main(int argc, char **argv) {
         return 1;
       }
 
-      if (outputToFile == false) {
+      if (!outputToFile) {
         // Output to stdout.
         outs() << outBuffer;
       } else {

--- a/lgc/tool/lgcdis/lgcdis.cpp
+++ b/lgc/tool/lgcdis/lgcdis.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
 
   // Read and process each input file.
   SmallVector<std::unique_ptr<MemoryBuffer>, 4> inBuffers;
-  for (auto inFileName : InFiles) {
+  for (const auto &inFileName : InFiles) {
     // Read the input file. getFileOrSTDIN handles the case of inFileName being "-".
     ErrorOr<std::unique_ptr<MemoryBuffer>> fileOrErr = MemoryBuffer::getFileOrSTDIN(inFileName);
     if (std::error_code errorCode = fileOrErr.getError()) {

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1032,8 +1032,8 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
   raw_svector_ostream elfStream(*pipelineElf);
 
   if (result == Result::Success) {
-    result = Result::ErrorInvalidShader;
 #if LLPC_ENABLE_EXCEPTION
+    result = Result::ErrorInvalidShader;
     try
 #endif
     {
@@ -1044,7 +1044,9 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       };
 
       pipeline->generate(std::move(pipelineModule), elfStream, checkShaderCacheFunc, timers, cl::NewPassManager == 2);
+#if LLPC_ENABLE_EXCEPTION
       result = Result::Success;
+#endif
     }
 #if LLPC_ENABLE_EXCEPTION
     catch (const char *) {

--- a/llpc/context/llpcShaderCache.cpp
+++ b/llpc/context/llpcShaderCache.cpp
@@ -331,32 +331,29 @@ Result ShaderCache::buildFileName(const char *executableName, const char *cacheF
   // The file name is constructed by taking the executable file name, appending the client string, device ID and
   // GPU index then hashing the result.
   char hashedFileName[PathBufferLen];
-  int length = 0;
   if (ShaderCacheFilename.empty()) {
-    length = snprintf(hashedFileName, PathBufferLen, "%s.%s.%u.%u.%u", executableName, ClientStr, gfxIp.major,
-                      gfxIp.minor, gfxIp.stepping);
+    snprintf(hashedFileName, PathBufferLen, "%s.%s.%u.%u.%u", executableName, ClientStr, gfxIp.major, gfxIp.minor,
+             gfxIp.stepping);
 
     const unsigned nameHash = djbHash(hashedFileName, 0);
-    length = snprintf(hashedFileName, PathBufferLen, "%08x.bin", nameHash);
+    snprintf(hashedFileName, PathBufferLen, "%08x.bin", nameHash);
 
     // Combine the base path, the sub-path and the file name to get the fully qualified path to the cache file
-    length = snprintf(m_fileFullPath, PathBufferLen, "%s%s%s", cacheFilePath, CacheFileSubPath, hashedFileName);
+    snprintf(m_fileFullPath, PathBufferLen, "%s%s%s", cacheFilePath, CacheFileSubPath, hashedFileName);
   } else {
-    length =
-        snprintf(m_fileFullPath, PathBufferLen, "%s%s%s", cacheFilePath, CacheFileSubPath, ShaderCacheFilename.c_str());
+    snprintf(m_fileFullPath, PathBufferLen, "%s%s%s", cacheFilePath, CacheFileSubPath, ShaderCacheFilename.c_str());
   }
 
   assert(cacheFileExists);
   *cacheFileExists = File::exists(m_fileFullPath);
   Result result = Result::Success;
   if (!*cacheFileExists) {
-    length = snprintf(hashedFileName, PathBufferLen, "%s%s", cacheFilePath, CacheFileSubPath);
+    snprintf(hashedFileName, PathBufferLen, "%s%s", cacheFilePath, CacheFileSubPath);
     std::error_code errCode = sys::fs::create_directories(hashedFileName);
     if (!errCode)
       result = Result::Success;
   }
 
-  ((void)length);
   return result;
 }
 

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -102,8 +102,7 @@ void SpirvLower::replaceConstWithInsts(Context *context, Constant *const constVa
     users.push_back(user);
 
   for (Value *const user : users) {
-    Instruction *const inst = dyn_cast<Instruction>(user);
-    assert(inst);
+    Instruction *const inst = cast<Instruction>(user);
 
     // If the instruction is a phi node, we have to insert the new instructions in the correct predecessor.
     if (PHINode *const phiNode = dyn_cast<PHINode>(inst)) {

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -101,8 +101,7 @@ llvm::ModulePass *createSpirvLowerTranslator(ShaderStage stage, const PipelineSh
 // Represents the pass of SPIR-V lowering operations, as the base class.
 class SpirvLower {
 public:
-  explicit SpirvLower()
-    : m_module(nullptr), m_context(nullptr), m_shaderStage(ShaderStageInvalid), m_entryPoint(nullptr) {}
+  explicit SpirvLower() {}
 
   // Add per-shader lowering passes to pass manager
   static void addPasses(Context *context, ShaderStage stage, lgc::PassManager &passMgr, llvm::Timer *lowerTimer
@@ -117,11 +116,11 @@ public:
 protected:
   void init(llvm::Module *module);
 
-  llvm::Module *m_module;       // LLVM module to be run on
-  Context *m_context;           // Associated LLPC context of the LLVM module that passes run on
-  ShaderStage m_shaderStage;    // Shader stage
-  llvm::Function *m_entryPoint; // Entry point of input module
-  lgc::Builder *m_builder;      // LGC builder object
+  llvm::Module *m_module = nullptr;               // LLVM module to be run on
+  Context *m_context = nullptr;                   // Associated LLPC context of the LLVM module that passes run on
+  ShaderStage m_shaderStage = ShaderStageInvalid; // Shader stage
+  llvm::Function *m_entryPoint = nullptr;         // Entry point of input module
+  lgc::Builder *m_builder = nullptr;              // LGC builder object
 };
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -278,7 +278,7 @@ void SpirvLowerGlobal::handleReturnInst() {
       Instruction *terminator = block.getTerminator();
       if (!terminator || terminator->getOpcode() != Instruction::Ret)
         continue;
-      ReturnInst *returnInst = dyn_cast<ReturnInst>(terminator);
+      ReturnInst *returnInst = cast<ReturnInst>(terminator);
       assert(m_retBlock);
       BranchInst::Create(m_retBlock, &block);
       m_retInsts.insert(returnInst);
@@ -300,7 +300,7 @@ void SpirvLowerGlobal::handleCallInst(bool checkEmitCall, bool checkInterpCall) 
     // by interpolateInputElement
     SmallVector<User *> users(function.users());
     for (User *user : users) {
-      assert(dyn_cast<CallInst>(user) && "We should only have CallInst instructions here.");
+      assert(isa<CallInst>(user) && "We should only have CallInst instructions here.");
       CallInst *callInst = cast<CallInst>(user);
       if (checkEmitCall) {
         if (mangledName.startswith(gSPIRVName::EmitVertex) || mangledName.startswith(gSPIRVName::EmitStreamVertex))
@@ -425,10 +425,9 @@ void SpirvLowerGlobal::handleLoadInstGEP(GetElementPtrInst *const getElemPtr, Lo
 
   assert(cast<ConstantInt>(getElemPtr->getOperand(1))->isZero() && "Non-zero GEP first index\n");
 
-  GlobalVariable *inOut = dyn_cast<GlobalVariable>(getElemPtr->getPointerOperand());
-  assert(!dyn_cast<GetElementPtrInst>(getElemPtr->getPointerOperand()) &&
+  GlobalVariable *inOut = cast<GlobalVariable>(getElemPtr->getPointerOperand());
+  assert(!isa<GetElementPtrInst>(getElemPtr->getPointerOperand()) &&
          "Chained GEPs should have been coalesced by SpirvLowerAccessChain.");
-  assert(inOut && "The root of the GEP should always be the global variable.");
 
   for (auto &index : drop_begin(getElemPtr->indices()))
     indexOperands.push_back(toInt32Value(index, &loadInst));
@@ -480,7 +479,7 @@ void SpirvLowerGlobal::handleLoadInst() {
         // We look for load instructions in the GEP users
         for (User *gepUser : gep->users()) {
           // We shouldn't have any chained GEPs here, they are coalesced by the LowerAccessChain pass.
-          assert(!dyn_cast<GetElementPtrInst>(gepUser));
+          assert(!isa<GetElementPtrInst>(gepUser));
           if (LoadInst *loadInst = dyn_cast<LoadInst>(gepUser))
             handleLoadInstGEP(gep, *loadInst, addrSpace);
         }
@@ -534,10 +533,9 @@ void SpirvLowerGlobal::handleStoreInstGEP(GetElementPtrInst *const getElemPtr, S
 
   assert(cast<ConstantInt>(getElemPtr->getOperand(1))->isZero() && "Non-zero GEP first index\n");
 
-  GlobalVariable *output = dyn_cast<GlobalVariable>(getElemPtr->getPointerOperand());
-  assert(!dyn_cast<GetElementPtrInst>(getElemPtr->getPointerOperand()) &&
+  GlobalVariable *output = cast<GlobalVariable>(getElemPtr->getPointerOperand());
+  assert(!isa<GetElementPtrInst>(getElemPtr->getPointerOperand()) &&
          "Chained GEPs should have been coalesced by SpirvLowerAccessChain.");
-  assert(output && "The root of the GEP should always be the global variable.");
 
   for (auto &index : drop_begin(getElemPtr->indices()))
     indexOperands.push_back(toInt32Value(index, &storeInst));
@@ -582,7 +580,7 @@ void SpirvLowerGlobal::handleStoreInst() {
         // We look for store instructions in the GEP users
         for (User *gepUser : gep->users()) {
           // We shouldn't have any chained GEPs here, they are coalesced by the LowerAccessChain pass.
-          assert(!dyn_cast<GetElementPtrInst>(gepUser));
+          assert(!isa<GetElementPtrInst>(gepUser));
           if (StoreInst *storeInst = dyn_cast<StoreInst>(gepUser))
             handleStoreInstGEP(gep, *storeInst);
         }
@@ -1716,8 +1714,7 @@ void SpirvLowerGlobal::lowerBufferBlock() {
               replaceInstsInfo.bitCastInst = bitCast;
             } else {
               // The users of the select must be a GEP.
-              SelectInst *selectInst = dyn_cast<SelectInst>(inst);
-              assert(selectInst);
+              SelectInst *selectInst = cast<SelectInst>(inst);
               assert(selectInst->getTrueValue() == &global || selectInst->getFalseValue() == &global);
               replaceInstsInfo.selectInst = selectInst;
               for (User *selectUser : selectInst->users()) {

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -352,7 +352,7 @@ private:
   void truncConstantIndex(std::vector<Value *> &indices, BasicBlock *bb);
 
   Value *ConvertingSamplerSelectLadderHelper(Value *result, Value *convertingSamplerIdx,
-                                             std::function<Value *(Value *)> createImageOp);
+                                             const std::function<Value *(Value *)> &createImageOp);
 
   Function *createLibraryEntryFunc();
   // ========================================================================================================================

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -333,13 +333,13 @@ DINode *SPIRVToLLVMDbgTran::transTypeEnum(const SPIRVExtInst *DebugInst) {
   if (Flags & SPIRVDebug::FlagIsFwdDecl) {
     return Builder.createForwardDecl(dwarf::DW_TAG_enumeration_type, Name, Scope, File, LineNo, AlignInBits,
                                      SizeInBits);
-  } else {
-    SmallVector<llvm::Metadata *, 16> Elts;
-    for (size_t I = FirstEnumeratorIdx, E = Ops.size(); I < E; I += 2) {
-      uint64_t Val = BM->get<SPIRVConstant>(Ops[I])->getZExtIntValue();
-      StringRef Name = getString(Ops[I + 1]);
-      Elts.push_back(Builder.createEnumerator(Name, Val));
-    }
+  }
+  SmallVector<llvm::Metadata *, 16> Elts;
+  for (size_t I = FirstEnumeratorIdx, E = Ops.size(); I < E; I += 2) {
+    uint64_t Val = BM->get<SPIRVConstant>(Ops[I])->getZExtIntValue();
+    StringRef Name = getString(Ops[I + 1]);
+    Elts.push_back(Builder.createEnumerator(Name, Val));
+  }
     DINodeArray Enumerators = Builder.getOrCreateArray(Elts);
     DIType *UnderlyingType = nullptr;
     SPIRVEntry *E = BM->getEntry(Ops[UnderlyingTypeIdx]);
@@ -347,7 +347,6 @@ DINode *SPIRVToLLVMDbgTran::transTypeEnum(const SPIRVExtInst *DebugInst) {
       UnderlyingType = transDebugInst<DIType>(static_cast<SPIRVExtInst *>(E));
     return Builder.createEnumerationType(Scope, Name, File, LineNo, SizeInBits, AlignInBits, Enumerators,
                                          UnderlyingType, "", UnderlyingType);
-  }
 }
 
 DINode *SPIRVToLLVMDbgTran::transTypeFunction(const SPIRVExtInst *DebugInst) {

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -160,6 +160,7 @@ void SPIRVEntry::decode(std::istream &I) { assert(0 && "Not implemented"); }
 std::vector<SPIRVValue *>
 SPIRVEntry::getValues(const std::vector<SPIRVId> &IdVec) const {
   std::vector<SPIRVValue *> ValueVec;
+  ValueVec.reserve(IdVec.size());
   for (auto I : IdVec)
     ValueVec.push_back(getValue(I));
   return ValueVec;
@@ -168,14 +169,15 @@ SPIRVEntry::getValues(const std::vector<SPIRVId> &IdVec) const {
 std::vector<SPIRVType *>
 SPIRVEntry::getValueTypes(const std::vector<SPIRVId> &IdVec) const {
   std::vector<SPIRVType *> TypeVec;
+  TypeVec.reserve(IdVec.size());
   for (auto I : IdVec)
     TypeVec.push_back(getValue(I)->getType());
   return TypeVec;
 }
 
-std::vector<SPIRVId>
-SPIRVEntry::getIds(const std::vector<SPIRVValue *> ValueVec) const {
+std::vector<SPIRVId> SPIRVEntry::getIds(const std::vector<SPIRVValue *> &ValueVec) const {
   std::vector<SPIRVId> IdVec;
+  IdVec.reserve(ValueVec.size());
   for (auto I : ValueVec)
     IdVec.push_back(I->getId());
   return IdVec;

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -223,7 +223,7 @@ public:
   SPIRVEntry *getOrCreate(SPIRVId TheId) const;
   SPIRVValue *getValue(SPIRVId TheId) const;
   std::vector<SPIRVValue *> getValues(const std::vector<SPIRVId> &) const;
-  std::vector<SPIRVId> getIds(const std::vector<SPIRVValue *>) const;
+  std::vector<SPIRVId> getIds(const std::vector<SPIRVValue *> &) const;
   SPIRVType *getValueType(SPIRVId TheId) const;
   std::vector<SPIRVType *> getValueTypes(const std::vector<SPIRVId> &) const;
 

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -908,8 +908,7 @@ SPIRVValue *SPIRVModuleImpl::addConstant(SPIRVType *Ty, uint64_t V) {
   if (Ty->isTypeBool()) {
     if (V)
       return addConstant(new SPIRVConstantTrue(this, Ty, getId()));
-    else
-      return addConstant(new SPIRVConstantFalse(this, Ty, getId()));
+    return addConstant(new SPIRVConstantFalse(this, Ty, getId()));
   }
   if (Ty->isTypeInt())
     return addIntegerConstant(static_cast<SPIRVTypeInt *>(Ty), V);

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1338,6 +1338,7 @@ SPIRVType *SPIRVModuleImpl::getValueType(SPIRVId TheId) const {
 std::vector<SPIRVValue *>
 SPIRVModuleImpl::getValues(const std::vector<SPIRVId> &IdVec) const {
   std::vector<SPIRVValue *> ValueVec;
+  ValueVec.reserve(IdVec.size());
   for (auto I : IdVec)
     ValueVec.push_back(getValue(I));
   return ValueVec;
@@ -1346,6 +1347,7 @@ SPIRVModuleImpl::getValues(const std::vector<SPIRVId> &IdVec) const {
 std::vector<SPIRVType *>
 SPIRVModuleImpl::getValueTypes(const std::vector<SPIRVId> &IdVec) const {
   std::vector<SPIRVType *> TypeVec;
+  TypeVec.reserve(IdVec.size());
   for (auto I : IdVec)
     TypeVec.push_back(getValue(I)->getType());
   return TypeVec;
@@ -1354,6 +1356,7 @@ SPIRVModuleImpl::getValueTypes(const std::vector<SPIRVId> &IdVec) const {
 std::vector<SPIRVId>
 SPIRVModuleImpl::getIds(const std::vector<SPIRVEntry *> &ValueVec) const {
   std::vector<SPIRVId> IdVec;
+  IdVec.reserve(ValueVec.size());
   for (auto I : ValueVec)
     IdVec.push_back(I->getId());
   return IdVec;
@@ -1362,6 +1365,7 @@ SPIRVModuleImpl::getIds(const std::vector<SPIRVEntry *> &ValueVec) const {
 std::vector<SPIRVId>
 SPIRVModuleImpl::getIds(const std::vector<SPIRVValue *> &ValueVec) const {
   std::vector<SPIRVId> IdVec;
+  IdVec.reserve(ValueVec.size());
   for (auto I : ValueVec)
     IdVec.push_back(I->getId());
   return IdVec;

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVType.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVType.cpp
@@ -184,31 +184,27 @@ unsigned SPIRVType::getDerivedMatrixStride() const {
 SPIRVType* SPIRVType::getCompositeElementType(size_t Index) const {
   if (OpCode == OpTypeStruct)
     return getStructMemberType(Index);
-  else if (OpCode == OpTypeArray)
+  if (OpCode == OpTypeArray)
     return getArrayElementType();
-  else if (OpCode == OpTypeMatrix)
+  if (OpCode == OpTypeMatrix)
     return getMatrixColumnType();
-  else if (OpCode == OpTypeVector)
+  if (OpCode == OpTypeVector)
     return getVectorComponentType();
-  else {
-    llvm_unreachable("Not composite type");
-    return nullptr;
-  }
+  llvm_unreachable("Not composite type");
+  return nullptr;
 }
 
 SPIRVWord SPIRVType::getCompositeElementCount() const {
   if (OpCode == OpTypeStruct)
     return getStructMemberCount();
-  else if (OpCode == OpTypeArray)
+  if (OpCode == OpTypeArray)
     return getArrayLength();
-  else if (OpCode == OpTypeMatrix)
+  if (OpCode == OpTypeMatrix)
     return getMatrixColumnCount();
-  else if (OpCode == OpTypeVector)
+  if (OpCode == OpTypeVector)
     return getVectorComponentCount();
-  else {
-    llvm_unreachable("Not composite type");
-    return 1;
-  }
+  llvm_unreachable("Not composite type");
+  return 1;
 }
 
 bool SPIRVType::isTypeVoid() const {
@@ -308,7 +304,7 @@ SPIRVConstant *SPIRVTypeArray::getLength() const {
     auto MappedConst =
       static_cast<SPIRVSpecConstantOp *>(BV)->getMappedConstant();
     return static_cast<SPIRVConstant *>(MappedConst);
-  } else
+  }
   return get<SPIRVConstant>(Length);
 }
 

--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -597,15 +597,14 @@ bool Document::parse(const TestCaseInfo &info) {
       if (!linePtr) {
         result = endSection();
         break;
-      } else {
-        result = macroSubstituteLine(linePtr, m_currentLineNum + 1, &info.macros, MaxLineBufSize);
-        if (!result)
-          break;
-
-        result = parseLine(linePtr);
-        if (!result)
-          break;
       }
+      result = macroSubstituteLine(linePtr, m_currentLineNum + 1, &info.macros, MaxLineBufSize);
+      if (!result)
+        break;
+
+      result = parseLine(linePtr);
+      if (!result)
+        break;
     }
 
     fclose(configFile);
@@ -1317,10 +1316,8 @@ bool isArrayAccess(const char *str) {
     for (const char *p = lBracket + 1; p != rBracket; ++p) {
       if ((*p >= '0' && *p <= '9') || *p == ' ' || *p == '\t')
         continue;
-      else {
-        result = false;
-        break;
-      }
+      result = false;
+      break;
     }
   }
 

--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -372,6 +372,8 @@ bool Document::parseKey(const char *key, unsigned lineNum, Section *sectionObjec
     if (isArrayAccess(keyTok)) {
       char *lBracket = nullptr;
       result = parseArrayAccess(keyTok, lineNum, &parsedArrayIndex, &lBracket, nullptr, &m_errorMsg);
+      if (!result)
+        break;
       // Remove bracket from string token
       *lBracket = '\0';
       keyTok = trimStringEnd(keyTok);

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -230,14 +230,13 @@ bool PipelineDocument::validate() {
       if (i == m_sectionList.size()) {
         PARSE_ERROR(m_errorMsg, m_sectionList[i]->getLineNum(), "Fails to find related shader info section!\n");
         return false;
-      } else {
-        auto nextSectionType = m_sectionList[i + 1]->getSectionType();
-        if ((nextSectionType != SectionTypeShaderInfo) ||
-            (reinterpret_cast<SectionShaderInfo *>(m_sectionList[i + 1])->getShaderStage() != stage)) {
-          PARSE_ERROR(m_errorMsg, m_sectionList[i + 1]->getLineNum(),
-                      "Unexpected section type. Shader source and shader info must be in pair!\n");
-          return false;
-        }
+      }
+      auto nextSectionType = m_sectionList[i + 1]->getSectionType();
+      if ((nextSectionType != SectionTypeShaderInfo) ||
+          (reinterpret_cast<SectionShaderInfo *>(m_sectionList[i + 1])->getShaderStage() != stage)) {
+        PARSE_ERROR(m_errorMsg, m_sectionList[i + 1]->getLineNum(),
+                    "Unexpected section type. Shader source and shader info must be in pair!\n");
+        return false;
       }
     }
   }

--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -466,12 +466,11 @@ template <class Elf> const msgpack::DocNode *ElfReader<Elf>::getMsgNode() const 
   auto curIter = &(m_iteratorStack.back());
   if (curIter->status == MsgPackIteratorArrayValue)
     return &(*curIter->arrayIt);
-  else if (curIter->status == MsgPackIteratorMapValue)
+  if (curIter->status == MsgPackIteratorMapValue)
     return &(curIter->mapIt->second);
-  else if (curIter->status == MsgPackIteratorMapKey)
+  if (curIter->status == MsgPackIteratorMapKey)
     return &(curIter->mapIt->first);
-  else
-    return curIter->node;
+  return curIter->node;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
- NggPrimShader.cpp used a wrong variable: vtxXyFmt, which should be vtxZFmt
- Remove copies by passing functions by reference and moving them
- Replacing dyn_cast+assert with cast
- Removing assignments that are never read
- Reserving space for vectors before filling them
- Lots of “no else after return/break” fixes, these are in an extra commit

Enable clang-analyzer-* lints.