### PR TITLE
More MC Streamer upstream de-capitalization prep

### DIFF
--- a/lgc/disassembler/Disassembler.cpp
+++ b/lgc/disassembler/Disassembler.cpp
@@ -254,7 +254,13 @@ void ObjDisassembler::processSection(ELFSectionRef sectionRef) {
 #endif
   unsigned sectFlags = sectionRef.getFlags();
   MCSection *sect = m_context->getELFSection(cantFail(sectionRef.getName()), sectType, sectFlags);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 425813
+  // Old version of code
   m_streamer->SwitchSection(sect);
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  m_streamer->switchSection(sect);
+#endif
 
   // Create all symbols in this section. Also emit directives for symbol type and size,
   // adding a synthesized label for the end of the symbol.


### PR DESCRIPTION
An extra de-capitalization change coming from upstream LLVM.
This is a flag day change.

Missed in first de-cap change as original function not removed. (Now it has, so
this change is required).