### PR TITLE
lgc/PassManager: use report_fatal_error for bad command-line options

### DIFF
--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -172,7 +172,7 @@ PassManagerImpl::PassManagerImpl(TargetMachine *targetMachine)
       m_instrumentationStandard(cl::DebugPassManager, cl::DebugPassManager || cl::VerifyIr,
                                 /*PrintPassOpts=*/{true, false, true}) {
   if (!cl::DumpCfgAfter.empty())
-    llvm_unreachable("The --dump-cfg-after option is not supported with the new pass manager.");
+    report_fatal_error("The --dump-cfg-after option is not supported with the new pass manager.");
 
   // Setup custom instrumentation callbacks and register LLVM's default module
   // analyses to the analysis manager.


### PR DESCRIPTION
llvm_unreachable() is like assert() in that it should only be used to
flag conditions that are programmer error. Depending on the build
options, the compiler may actually optimize code based on the assumption
that it is never reached, and so paths that would reach it become
undefined behavior.

The arguably correct thing to do here is a report_fatal_error(), because
the condition can only be reached via bad debug settings.