### PR TITLE
Add optimization option to swizzle thread group

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 53
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 5
+#define LLPC_INTERFACE_MINOR_VERSION 7
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     53.7 | Add threadGroupSwizzleMode to PipelineOptions                                                         |
 //  |     53.6 | Add scalarizeWaterfallLoads to PipelineShaderOptions                                                  |
 //  |     53.5 | Add forceCsThreadIdSwizzling for thread id swizzle in 8*4                                             |
 //  |     53.4 | Add ldsSpillLimitDwords shader option                                                                 |
@@ -433,6 +434,7 @@ struct PipelineOptions {
                               ///< between 0 and 3.
 #endif
   ResourceLayoutScheme resourceLayoutScheme; ///< Resource layout scheme
+  ThreadGroupSwizzleMode threadGroupSwizzleMode; /// Controls thread group swizzle mode for compute shader.
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -191,6 +191,8 @@ private:
   WorkgroupLayout calculateWorkgroupLayout();
   llvm::Value *reconfigWorkgroup(llvm::Value *localInvocationId, llvm::Instruction *insertPos);
   llvm::Value *swizzleLocalInvocationIdIn8x4(llvm::Value *localInvocationId, llvm::Instruction *insertPos);
+  void createSwizzleThreadGroupFunction();
+
   void exportShadingRate(llvm::Value *shadingRate, llvm::Instruction *insertPos);
   llvm::Value *getShadingRate(llvm::Instruction *insertPos);
 

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -67,6 +67,7 @@ const static char TfBufferStore[] = "lgc.tfbuffer.store.";
 const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
 const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
 const static char SwizzleLocalInvocationId[] = "lgc.swizzle.local.invocation.id";
+const static char SwizzleWorkgroupId[] = "lgc.swizzle.workgroup.id";
 
 const static char MeshTaskReadTaskPayload[] = "lgc.mesh.task.read.task.payload";
 const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload";

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -95,6 +95,15 @@ enum class WaveBreak : unsigned {
   _32x32 = 0x3,   ///< Outside a 32x32 pixel region
 };
 
+// Enumerate the thread group swizzle modes.
+enum class ThreadGroupSwizzleMode : unsigned {
+  Default = 0, // Use the default layout. There is no swizzling conducted.
+  _4x4 = 1,    // The tile size is 4x4 in x and y dimension.
+  _8x8 = 2,    // The tile size is 8x8 in x and y dimension.
+  _16x16 = 3,  // The tile size is 16x16 in x and y dimension.
+  Count,
+};
+
 // Value for shadowDescriptorTable pipeline option.
 static const unsigned ShadowDescriptorTableDisable = ~0U;
 
@@ -129,6 +138,7 @@ struct Options {
   unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
   unsigned pageMigrationEnabled;  // Enable page migration
   ResourceLayoutScheme resourceLayoutScheme; // Resource layout scheme
+  ThreadGroupSwizzleMode threadGroupSwizzleMode; // Thread group swizzle mode
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -280,6 +280,9 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
   options.forceCsThreadIdSwizzling = getPipelineOptions()->forceCsThreadIdSwizzling;
   options.includeIr = (IncludeLlvmIr || getPipelineOptions()->includeIr);
 
+  options.threadGroupSwizzleMode =
+      static_cast<lgc::ThreadGroupSwizzleMode>(getPipelineOptions()->threadGroupSwizzleMode);
+
   switch (getPipelineOptions()->shadowDescriptorTableUsage) {
   case Vkgc::ShadowDescriptorTableUsage::Auto:
     // Use default of 2 for standalone amdllpc.

--- a/llpc/test/shaderdb/core/TestThreadGroupSwizzle.comp
+++ b/llpc/test/shaderdb/core/TestThreadGroupSwizzle.comp
@@ -1,0 +1,30 @@
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16) in;
+
+layout(binding = 0) buffer Buffers
+{
+    uvec3 test;
+};
+
+void main()
+{
+    test = gl_WorkGroupID;
+}
+
+// BEGIN_SWIZZLETEST
+// RUN: amdllpc -v %gfxip %s  --thread-group-swizzle-mode=4x4 | FileCheck -check-prefix=SWIZZLETEST %s
+// SWIZZLETEST-LABEL: {{^// LLPC}} pipeline before-patching results
+// SWIZZLETEST: %{{[0-9]+}} = call <3 x i32> @lgc.swizzle.workgroup.id(<3 x i32> %{{[0-9]+}}, <3 x i32> %{{[0-9]+}})
+// SWIZZLETEST-LABEL: {{^// LLPC}} pipeline patching results
+// SWIZZLETEST: .performSwizzle{{.*}}:
+// SWIZZLETEST: AMDLLPC SUCCESS
+// END_SWIZZLETEST
+// BEGIN_NOTSWIZZLETEST
+// RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=NOTSWIZZLETEST %s
+// NOTSWIZZLETEST-LABEL: {{^// LLPC}} pipeline before-patching results
+// NOTSWIZZLETEST-NOT: lgc.swizzle.workgroup.id
+// NOTSWIZZLETEST-LABEL: {{^// LLPC}} pipeline patching results
+// NOTSWIZZLETEST-NOT: .performSwizzle{{.*}}:
+// NOTSWIZZLETEST: AMDLLPC SUCCESS
+// END_NOTSWIZZLETEST

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -235,6 +235,14 @@ cl::opt<bool> ForceCsThreadIdSwizzling("force-compute-shader-thread-id-swizzling
                                               cl::desc("force compute shader thread-id swizzling"),
                                               cl::init(false));
 
+// -thread-group-swizzle-mode: specifies the thread group swizzle mode
+cl::opt<ThreadGroupSwizzleMode> ThreadGroupSwizzleModeSetting("thread-group-swizzle-mode",
+                                                              cl::desc("Set thread group swizzle mode\n"),
+                                                              cl::init(ThreadGroupSwizzleMode::Default),
+                                                              values(clEnumValN(ThreadGroupSwizzleMode::Default, "default", "disable thread group swizzle"),
+                                                                     clEnumValN(ThreadGroupSwizzleMode::_4x4, "4x4", "tile size is 4x4 in x and y dimension"),
+                                                                     clEnumValN(ThreadGroupSwizzleMode::_8x8, "8x8", "tile size is 8x8 in x and y dimension"),
+                                                                     clEnumValN(ThreadGroupSwizzleMode::_16x16, "16x16", "tile size is 16x16   in x and y dimension")));
 
 // -filter-pipeline-dump-by-type: filter which kinds of pipeline should be disabled.
 cl::opt<unsigned> FilterPipelineDumpByType("filter-pipeline-dump-by-type",
@@ -434,6 +442,7 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
 #endif
   compileInfo->gfxPipelineInfo.options.resourceLayoutScheme = LayoutScheme;
   compileInfo->compPipelineInfo.options.forceCsThreadIdSwizzling = ForceCsThreadIdSwizzling;
+  compileInfo->compPipelineInfo.options.threadGroupSwizzleMode = ThreadGroupSwizzleModeSetting;
 
   // Set NGG control settings
   if (ParsedGfxIp.major >= 10) {

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -138,6 +138,7 @@ Expected<BinaryData> ComputePipelineBuilder::buildComputePipeline() {
     pipelineInfo->options.optimizationLevel = compileInfo.optimizationLevel.getValue();
   }
 #endif
+  pipelineInfo->options.threadGroupSwizzleMode = compileInfo.compPipelineInfo.options.threadGroupSwizzleMode;
 
   PipelineBuildInfo localPipelineInfo = {};
   localPipelineInfo.pComputeInfo = pipelineInfo;

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -65,6 +65,7 @@ std::ostream &operator<<(std::ostream &out, WaveBreakSize waveBreakSize);
 std::ostream &operator<<(std::ostream &out, ShadowDescriptorTableUsage shadowDescriptorTableUsage);
 std::ostream &operator<<(std::ostream &out, VkProvokingVertexModeEXT provokingVertexMode);
 std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout);
+std::ostream &operator<<(std::ostream &out, ThreadGroupSwizzleMode threadGroupSwizzleMode);
 
 template std::ostream &operator<<(std::ostream &out, ElfReader<Elf64> &reader);
 template raw_ostream &operator<<(raw_ostream &out, ElfReader<Elf64> &reader);
@@ -705,6 +706,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
   dumpFile << "options.optimizationLevel = " << options->optimizationLevel << "\n";
 #endif
+  dumpFile << "options.threadGroupSwizzleMode = " << options->threadGroupSwizzleMode << "\n";
 }
 
 // =====================================================================================================================
@@ -1120,6 +1122,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
   hasher->Update(options->optimizationLevel);
 #endif
+  hasher->Update(options->threadGroupSwizzleMode);
 }
 
 // =====================================================================================================================
@@ -2059,6 +2062,26 @@ std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout) {
     break;
   }
 
+  return out << string;
+}
+
+// =====================================================================================================================
+// Translates enum "ThreadGroupSwizzleMode" to string and output to ostream.
+//
+// @param [out] out : Output stream
+// @param threadGroupSwizzleMode : Provoking vertex mode
+std::ostream &operator<<(std::ostream &out, ThreadGroupSwizzleMode threadGroupSwizzleMode) {
+  const char *string = nullptr;
+  switch (threadGroupSwizzleMode) {
+    CASE_CLASSENUM_TO_STRING(ThreadGroupSwizzleMode, Default)
+    CASE_CLASSENUM_TO_STRING(ThreadGroupSwizzleMode, _4x4)
+    CASE_CLASSENUM_TO_STRING(ThreadGroupSwizzleMode, _8x8)
+    CASE_CLASSENUM_TO_STRING(ThreadGroupSwizzleMode, _16x16)
+    break;
+  default:
+    llvm_unreachable("Should never be called!");
+    break;
+  }
   return out << string;
 }
 

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -97,6 +97,11 @@ public:
 
     ADD_CLASS_ENUM_MAP(ResourceLayoutScheme, Compact)
     ADD_CLASS_ENUM_MAP(ResourceLayoutScheme, Indirect)
+
+    ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, Default)
+    ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, _4x4)
+    ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, _8x8)
+    ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, _16x16)
   }
 };
 

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -351,6 +351,7 @@ public:
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
 #endif
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
     INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -362,7 +363,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 12;
+  static const unsigned MemberCount = 13;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
This feature generates new thread group ID based on system thread group
ID for user. The algorithm is generating morton code from the flat
system thread group ID. So that the order of new ID would look like
z-order curve.