### PR TITLE
Keep allocas early

### DIFF
--- a/lgc/builder/BuilderBase.cpp
+++ b/lgc/builder/BuilderBase.cpp
@@ -30,10 +30,23 @@
  */
 #include "lgc/util/BuilderBase.h"
 #include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
 using namespace lgc;
 using namespace llvm;
+
+// =====================================================================================================================
+// Set the insert point to be just past the initial block of allocas in the given function's entry block.
+//
+// Use this method if you need to insert code to define values that are accessible in the entire function.
+void BuilderCommon::setInsertPointPastAllocas(Function &fn) {
+  BasicBlock &bb = fn.getEntryBlock();
+  auto it = bb.begin(), end = bb.end();
+  while (it != end && (isa<AllocaInst>(*it) || isa<DbgInfoIntrinsic>(*it)))
+    ++it;
+  SetInsertPoint(&bb, it);
+}
 
 // =====================================================================================================================
 // Create an LLVM function call to the named function. The callee is built automically based on return

--- a/lgc/interface/lgc/BuilderCommon.h
+++ b/lgc/interface/lgc/BuilderCommon.h
@@ -45,6 +45,11 @@ public:
   BuilderCommon(llvm::BasicBlock *block) : IRBuilder(block) {}
   BuilderCommon(llvm::Instruction *inst) : IRBuilder(inst) {}
 
+  // Set the insert point to be just past the initial block of allocas in the given function's entry block.
+  //
+  // Use this method if you need to insert code to define values that are accessible in the entire function.
+  void setInsertPointPastAllocas(llvm::Function &fn);
+
   // Create an LLVM function call to the named function. The callee is built automically based on return
   // type and its parameters.
   //

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -80,29 +80,24 @@ private:
   llvm::Value *addCallInstForInOutImport(llvm::Type *inOutTy, unsigned addrSpace, llvm::Constant *inOutMeta,
                                          llvm::Value *startLoc, unsigned maxLocOffset, llvm::Value *compIdx,
                                          llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,
-                                         bool isPerVertexDimension, llvm::Instruction *insertPos);
+                                         bool isPerVertexDimension);
 
   void addCallInstForOutputExport(llvm::Value *outputValue, llvm::Constant *outputMeta, llvm::Value *locOffset,
                                   unsigned maxLocOffset, unsigned xfbOffsetAdjust, unsigned xfbBufferAdjust,
-                                  llvm::Value *elemIdx, llvm::Value *vertexIdx, unsigned emitStreamId,
-                                  llvm::Instruction *insertPos);
+                                  llvm::Value *elemIdx, llvm::Value *vertexIdx, unsigned emitStreamId);
 
   Value *loadDynamicIndexedMembers(Type *inOutTy, unsigned addrSpace, llvm::ArrayRef<llvm::Value *> indexOperands,
-                                   Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc, Value *auxInterpValue,
-                                   Instruction *insertPos);
+                                   Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc, Value *auxInterpValue);
 
   llvm::Value *loadInOutMember(llvm::Type *inOutTy, unsigned addrSpace, llvm::ArrayRef<llvm::Value *> indexOperands,
                                unsigned maxLocOffset, llvm::Constant *inOutMeta, llvm::Value *locOffset,
-                               llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,
-                               llvm::Instruction *insertPos);
+                               llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo);
 
   void storeOutputMember(llvm::Type *outputTy, llvm::Value *storeValue, llvm::ArrayRef<llvm::Value *> indexOperands,
                          unsigned maxLocOffset, llvm::Constant *outputMeta, llvm::Value *locOffset,
-                         llvm::Value *vertexIdx, llvm::Instruction *insertPos);
+                         llvm::Value *vertexIdx);
 
   void interpolateInputElement(unsigned interpLoc, llvm::Value *interpInfo, llvm::CallInst &callInst);
-
-  llvm::Value *toInt32Value(llvm::Value *value, llvm::Instruction *insertPos);
 
   std::unordered_map<llvm::Value *, llvm::Value *> m_globalVarProxyMap; // Proxy map for lowering global variables
   std::unordered_map<llvm::Value *, llvm::Value *> m_inputProxyMap;     // Proxy map for lowering inputs

--- a/llpc/test/shaderdb/object/ObjConstant_TestStruct_lit.frag
+++ b/llpc/test/shaderdb/object/ObjConstant_TestStruct_lit.frag
@@ -29,8 +29,8 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: alloca { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> },{{.*}} addrspace(5)
 ; SHADERTEST: alloca <4 x float>,{{.*}} addrspace(5)
+; SHADERTEST: alloca { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> },{{.*}} addrspace(5)
 ; SHADERTEST: store { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> } { [3 x <3 x float>] [<3 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>, <3 x float> <float 5.000000e-01, float 5.000000e-01, float 5.000000e-01>, <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>], [3 x <3 x float>] [<3 x float> <float 1.000000e+00, float 0.000000e+00, float 0.000000e+00>, <3 x float> <float 0.000000e+00, float 1.000000e+00, float 0.000000e+00>, <3 x float> <float 0.000000e+00, float 0.000000e+00, float 1.000000e+00>], i32 1, <2 x i32> <i32 5, i32 5> }, { [3 x <3 x float>], [3 x <3 x float>], i32, <2 x i32> } addrspace(5)* %{{[0-9]*}}
 ; SHADERTEST: load i32, i32 addrspace(5)* %{{[0-9]*}}
 ; SHADERTEST: trunc i32 %{{[0-9]*}} to i1

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultipleConstData.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultipleConstData.pipe
@@ -2,8 +2,8 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -t %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: SYMBOL TABLE:
-; SHADERTEST: 0000000000000000 l O .rodata.cst32 0000000000000020 __unnamed_1.vertex
-; SHADERTEST: 0000000000000020 l O .rodata.cst32 0000000000000020 __unnamed_2.vertex
+; SHADERTEST: 0000000000000020 l O .rodata.cst32 0000000000000020 __unnamed_1.vertex
+; SHADERTEST: 0000000000000000 l O .rodata.cst32 0000000000000020 __unnamed_2.vertex
 ; END_SHADERTEST
 
 


### PR DESCRIPTION
This is a series of self-contained commits whose overall goal is to make sure that `alloca` instructions stay at the beginning of a functions entry block. This is important because later transforms sometimes implement an "intrinsic" by inlining a more complex piece of code with control flow, which leads to `alloca`s outside of the entry block -- and those aren't lowered to registered during code generation.

While at it, this series also completes the IRBuilder-ification of the llpcSpirvLowerGlobal pass.