### PR TITLE
Fix issues of GS without output variables

### DIFF
--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -802,9 +802,7 @@ template <typename T> void ConfigBuilder::buildGsRegConfig(ShaderStage shaderSta
   SET_REG_FIELD(&config->gsRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
 
   VGT_GS_OUTPRIM_TYPE gsOutputPrimitiveType = TRISTRIP;
-  if (inOutUsage.outputMapLocCount == 0)
-    gsOutputPrimitiveType = POINTLIST;
-  else if (geometryMode.outputPrimitive == OutputPrimitives::Points)
+  if (geometryMode.outputPrimitive == OutputPrimitives::Points)
     gsOutputPrimitiveType = POINTLIST;
   else if (geometryMode.outputPrimitive == OutputPrimitives::LineStrip)
     gsOutputPrimitiveType = LINESTRIP;

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1298,9 +1298,7 @@ void ConfigBuilder::buildEsGsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   SET_REG_FIELD(&config->esGsRegs, VGT_GS_PER_VS, GS_PER_VS, GsThreadsPerVsThread);
 
   VGT_GS_OUTPRIM_TYPE gsOutputPrimitiveType = TRISTRIP;
-  if (gsInOutUsage.outputMapLocCount == 0)
-    gsOutputPrimitiveType = POINTLIST;
-  else if (geometryMode.outputPrimitive == OutputPrimitives::Points)
+  if (geometryMode.outputPrimitive == OutputPrimitives::Points)
     gsOutputPrimitiveType = POINTLIST;
   else if (geometryMode.outputPrimitive == OutputPrimitives::LineStrip)
     gsOutputPrimitiveType = LINESTRIP;

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -777,11 +777,8 @@ void SpirvLowerGlobal::lowerOutput() {
     retInst->eraseFromParent();
   }
 
-  if (m_outputProxyMap.empty()) {
-    // Skip lowering if there is no output
-    // We need to erase emitCalls, otherwise it will always be there.
-    for (auto emitCall : m_emitCalls)
-      emitCall->eraseFromParent();
+  if (m_outputProxyMap.empty() && m_shaderStage != ShaderStageGeometry) {
+    // Skip lowering if there is no output for non-geometry shader
     return;
   }
 

--- a/llpc/test/shaderdb/general/OutputPrimitiveTest.geom
+++ b/llpc/test/shaderdb/general/OutputPrimitiveTest.geom
@@ -1,0 +1,26 @@
+// This test case checks whether the emit instruction and the primitive type are well-handled when there is no output
+// of the geometry shader.
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST-COUNT-2: call void (...) @lgc.create.emit.vertex(i32 0)
+; SHADERTEST-LABEL: _amdgpu_gs_main:
+; SHADERTEST-COUNT-2: s_sendmsg sendmsg(MSG_GS, GS_OP_EMIT, 0)
+; SHADERTEST-LABEL: PalMetadata
+; SHADERTEST-LABEL: .registers:
+; SHADERTEST: VGT_GS_OUT_PRIM_TYPE                          0x0000000000000001
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 450
+layout(lines) in;
+layout(max_vertices = 2, line_strip) out;
+
+void main()
+{
+    EmitVertex();
+    EmitVertex();
+    EndPrimitive();
+}


### PR DESCRIPTION
In the case of a geometry shader without output variables, there are two
issues in current code:
1) the count of emited vertex is incorrect becasue the "Call"
   instructions to emit vertex are removed in the lower pass.
2) The value of VGT_GS_OUT_PRIM_TYPE register doesn't reflect the actual
   primitve type specified by GS since it is always set as POINTLIST.

This change will allow the "Call" instructions to emit vertex to be
lowered and set VGT_GS_OUT_PRIM_TYPE accordingly.