### PR TITLE
Recreate LGC context if optimization level changes

### DIFF
--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -136,6 +136,9 @@ public:
   // Returns the optimization level for the context.
   llvm::CodeGenOpt::Level getOptimizationLevel() const;
 
+  // Returns the optimization level used for context initialization.
+  llvm::CodeGenOpt::Level getInitialOptimizationLevel() const { return m_initialOptLevel; }
+
   // Utility method to create a start/stop timer pass
   static llvm::ModulePass *createStartStopTimer(llvm::Timer *timer, bool starting);
 
@@ -167,6 +170,7 @@ private:
   TargetInfo *m_targetInfo = nullptr;             // Target info
   unsigned m_palAbiVersion = 0xFFFFFFFF;          // PAL pipeline ABI version to compile for
   PassManagerCache *m_passManagerCache = nullptr; // Pass manager cache and creator
+  llvm::CodeGenOpt::Level m_initialOptLevel;      // Optimization level at initialization
 };
 
 } // namespace lgc

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -215,9 +215,10 @@ bool LgcContext::isGpuNameValid(llvm::StringRef gpuName) {
 // @param context : LLVM context to give each Builder
 // @param gpuName : LLVM GPU name (e.g. "gfx900"); empty to use -mcpu option setting
 // @param palAbiVersion : PAL pipeline ABI version to compile for
+// @param optLevel : LLVM optimization level used to initialize target machine
 LgcContext *LgcContext::create(LLVMContext &context, StringRef gpuName, unsigned palAbiVersion,
                                CodeGenOpt::Level optLevel) {
-  assert(Initialized && "Must call LgcContext::Initialize before LgcContext::create");
+  assert(Initialized && "Must call LgcContext::initialize before LgcContext::create");
 
   LgcContext *builderContext = new LgcContext(context, palAbiVersion);
 
@@ -247,6 +248,9 @@ LgcContext *LgcContext::create(LLVMContext &context, StringRef gpuName, unsigned
     targetOpts.MCOptions.ShowMCEncoding = true;
     targetOpts.MCOptions.AsmVerbose = true;
   }
+
+  // Save optimization level given at initialization.
+  builderContext->m_initialOptLevel = optLevel;
 
   // If the "opt" option is given, set the optimization level to that value.
   if (OptLevel.getPosition() != 0) {

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -84,8 +84,8 @@ void Context::reset() {
 // =====================================================================================================================
 // Get (create if necessary) LgcContext
 LgcContext *Context::getLgcContext() {
-  if (!m_builderContext) {
-    // First time: Create the LgcContext.
+  // Create the LgcContext on first execution or optimization level change.
+  if (!m_builderContext || m_builderContext->getInitialOptimizationLevel() != getOptimizationLevel()) {
     std::string gpuName = LgcContext::getGpuNameString(m_gfxIp.major, m_gfxIp.minor, m_gfxIp.stepping);
     m_builderContext.reset(
         LgcContext::create(*this, gpuName, PAL_CLIENT_INTERFACE_MAJOR_VERSION, getOptimizationLevel()));

--- a/llpc/unittests/context/CMakeLists.txt
+++ b/llpc/unittests/context/CMakeLists.txt
@@ -24,5 +24,6 @@
  #######################################################################################################################
 
 add_llpc_unittest(LlpcContextTests
+  testOptLevel.cpp
   testShaderCache.cpp
 )

--- a/llpc/unittests/context/testOptLevel.cpp
+++ b/llpc/unittests/context/testOptLevel.cpp
@@ -1,0 +1,87 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Advanced Micro Devices, Inc.. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+#include "llpc.h"
+#include "llpcComputeContext.h"
+#include "llpcContext.h"
+#include "llpcGraphicsContext.h"
+#include "llpcUtil.h"
+#include "lgc/CommonDefs.h"
+#include "lgc/LgcContext.h"
+#include "gmock/gmock.h"
+
+using namespace lgc;
+using namespace llvm;
+using namespace llvm::CodeGenOpt;
+
+namespace Llpc {
+namespace {
+
+constexpr GfxIpVersion GfxIp = {9, 0, 0};
+
+// cppcheck-suppress syntaxError
+TEST(LlpcContextTests, MatchPipelineOptLevel) {
+  MetroHash::Hash cacheHash = {};
+  MetroHash::Hash pipelineHash = {};
+
+  LgcContext::initialize();
+
+  Context *context = new Context(GfxIp);
+
+  for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
+    GraphicsPipelineBuildInfo pipelineInfo = {};
+    pipelineInfo.options.optimizationLevel = optLevel;
+
+    GraphicsContext graphicsContext(GfxIp, &pipelineInfo, &pipelineHash, &cacheHash);
+
+    context->attachPipelineContext(&graphicsContext);
+
+    if (optLevel == Level::None) {
+      // None might not be possible, so accept >= Level::None
+      EXPECT_GE(context->getLgcContext()->getOptimizationLevel(), optLevel);
+    } else {
+      EXPECT_EQ(context->getLgcContext()->getOptimizationLevel(), optLevel);
+    }
+  }
+
+  for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
+    ComputePipelineBuildInfo pipelineInfo = {};
+    pipelineInfo.options.optimizationLevel = optLevel;
+
+    ComputeContext computeContext(GfxIp, &pipelineInfo, &pipelineHash, &cacheHash);
+
+    context->attachPipelineContext(&computeContext);
+
+    if (optLevel == Level::None) {
+      // None might not be possible, so accept >= Level::None
+      EXPECT_GE(context->getLgcContext()->getOptimizationLevel(), optLevel);
+    } else {
+      EXPECT_EQ(context->getLgcContext()->getOptimizationLevel(), optLevel);
+    }
+  }
+}
+
+} // namespace
+} // namespace Llpc


### PR DESCRIPTION
LGC context must be recreated if pipeline context optimization level
changes so that the target machine optimization level is correct.