### PR TITLE
lgcdis: Split ascii output into lines for easier reading

### DIFF
--- a/lgc/test/lgcdis-ascii.txt
+++ b/lgc/test/lgcdis-ascii.txt
@@ -1,0 +1,17 @@
+; RUN: llvm-mc -triple=amdgcn-- -mcpu=gfx1030 -filetype=obj %s | lgcdis - | FileCheck %s
+
+; Test to check that ASCII data is disassembled as ASCII, separating just after
+; a bunch of consecutive newlines.
+
+; CHECK: .ascii "line 1\n\n"
+; CHECK-NEXT: .ascii "line 3\n"
+; CHECK-NEXT: .asciz "line 4"
+
+.rodata
+
+.ascii "line 1"
+.byte 10
+.byte 10
+.ascii "line 3"
+.byte 10
+.asciz "line 4"


### PR DESCRIPTION
Instead of

    .asciz "line1\n\nline3\nline4"

you now get

    .ascii "line1\n\n"
    .ascii "line3\n"
    .asciz "line4"