### PR TITLE
Disable optimization level test if LLPC client version requirement is not met

### DIFF
--- a/llpc/unittests/context/testOptLevel.cpp
+++ b/llpc/unittests/context/testOptLevel.cpp
@@ -41,6 +41,7 @@ namespace {
 
 constexpr GfxIpVersion GfxIp = {9, 0, 0};
 
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
 // cppcheck-suppress syntaxError
 TEST(LlpcContextTests, MatchPipelineOptLevel) {
   MetroHash::Hash cacheHash = {};
@@ -82,6 +83,7 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
     }
   }
 }
+#endif
 
 } // namespace
 } // namespace Llpc


### PR DESCRIPTION
The field `pipelineInfo.options.optimizationLevel` is only present when `LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53`.