### PR TITLE
Adding overrideThreadGroupSizeX/overrideThreadGroupSizeY/overrideThre…

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -44,7 +44,7 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 53
+#define LLPC_INTERFACE_MAJOR_VERSION 54
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 7
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     54.0 | Add overrideThreadGroupSizeX,overrideThreadGroupSizeY and overrideThreadGroupSizeZ to PipelineOptions |
 //  |     53.7 | Add threadGroupSwizzleMode to PipelineOptions                                                         |
 //  |     53.6 | Add scalarizeWaterfallLoads to PipelineShaderOptions                                                  |
 //  |     53.5 | Add forceCsThreadIdSwizzling for thread id swizzle in 8*4                                             |
@@ -433,8 +434,11 @@ struct PipelineOptions {
   uint32_t optimizationLevel; ///< The higher the number the more optimizations will be performed.  Valid values are
                               ///< between 0 and 3.
 #endif
-  ResourceLayoutScheme resourceLayoutScheme; ///< Resource layout scheme
-  ThreadGroupSwizzleMode threadGroupSwizzleMode; /// Controls thread group swizzle mode for compute shader.
+  unsigned overrideThreadGroupSizeX;             ///< Override value for ThreadGroupSizeX
+  unsigned overrideThreadGroupSizeY;             ///< Override value for ThreadGroupSizeY
+  unsigned overrideThreadGroupSizeZ;             ///< Override value for ThreadGroupSizeZ
+  ResourceLayoutScheme resourceLayoutScheme;     ///< Resource layout scheme
+  ThreadGroupSwizzleMode threadGroupSwizzleMode; ///< Controls thread group swizzle mode for compute shader.
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.


### PR DESCRIPTION
…adGroupSizeZ into PipelineOptions for tuning

Setting values for overrideThreadGroupSizeX/Y/Z can be: 8/8/1 or
16/16/1. Default value is 0/0/0