### PR TITLE
Add optimization option to override threadGroupSize

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -116,6 +116,9 @@ struct Options {
   unsigned reconfigWorkgroupLayout;    // If set, allows automatic workgroup reconfigure to take place on
                                        //   compute shaders.
   bool forceCsThreadIdSwizzling;       // Force rearranges threadId within group into blocks of 8*8 or 8*4.
+  unsigned overrideThreadGroupSizeX;   // Override value for thread group size.X
+  unsigned overrideThreadGroupSizeY;   // Override value for thread group size.Y
+  unsigned overrideThreadGroupSizeZ;   // Override value for thread group size.Z
   unsigned includeIr;                  // If set, the IR for all compiled shaders will be included in the
                                        //   pipeline ELF.
   unsigned nggFlags;                   // Flags to control NGG (NggFlag* values ored together)

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -278,6 +278,9 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
   options.includeDisassembly = (cl::EnablePipelineDump || EnableOuts() || getPipelineOptions()->includeDisassembly);
   options.reconfigWorkgroupLayout = getPipelineOptions()->reconfigWorkgroupLayout;
   options.forceCsThreadIdSwizzling = getPipelineOptions()->forceCsThreadIdSwizzling;
+  options.overrideThreadGroupSizeX = getPipelineOptions()->overrideThreadGroupSizeX;
+  options.overrideThreadGroupSizeY = getPipelineOptions()->overrideThreadGroupSizeY;
+  options.overrideThreadGroupSizeZ = getPipelineOptions()->overrideThreadGroupSizeZ;
   options.includeIr = (IncludeLlvmIr || getPipelineOptions()->includeIr);
 
   options.threadGroupSwizzleMode =

--- a/llpc/test/shaderdb/core/OverrideThreadGroupSize16X16X1.spvasm
+++ b/llpc/test/shaderdb/core/OverrideThreadGroupSize16X16X1.spvasm
@@ -1,0 +1,105 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v %gfxip %s \ 
+; RUN:   --override-threadGroupSizeX=16 --override-threadGroupSizeY=16 --override-threadGroupSizeZ=1 \
+; RUN: | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTESTTEST: !llpc.compute.mode = !{!0}
+; SHADERTESTTEST: !0 = !{i32 16, i32 16, i32 1}
+; SHADERTESTTEST: AMDLLPC SUCCESS
+; END_SHADERTESTTEST
+
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+                OpCapability Shader
+                OpCapability VariablePointers
+                OpExtension "SPV_KHR_variable_pointers"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main" %wg_var %diff_var %lid_var %gid_var
+                OpExecutionMode %main LocalSize 16 4 1
+
+                OpDecorate %struct_17 Block
+                OpMemberDecorate %struct_17 0 Offset 0
+                OpDecorate %runtime_17 ArrayStride 68
+                OpDecorate %array_17 ArrayStride 4
+
+                OpDecorate %diff_var DescriptorSet 0
+                OpDecorate %diff_var Binding 0
+
+                OpDecorate %lid_var BuiltIn LocalInvocationId
+                OpDecorate %gid_var BuiltIn GlobalInvocationId
+
+        %void = OpTypeVoid
+        %bool = OpTypeBool
+         %int = OpTypeInt 32 1
+       %int_0 = OpConstant %int 0
+       %int_1 = OpConstant %int 1
+       %int_4 = OpConstant %int 4
+      %int_16 = OpConstant %int 16
+      %int_17 = OpConstant %int 17
+      %int_64 = OpConstant %int 64
+        %int3 = OpTypeVector %int 3
+
+%ptr_input_int3 = OpTypePointer Input %int3
+
+     %array_4 = OpTypeArray %int %int_4
+%array_array_4 = OpTypeArray %array_4 %int_16
+%ptr_array_array_4 = OpTypePointer Workgroup %array_array_4
+%ptr_array_4 = OpTypePointer Workgroup %array_4
+ %ptr_wg_int = OpTypePointer Workgroup %int
+
+    %array_17 = OpTypeArray %int %int_17
+  %runtime_17 = OpTypeRuntimeArray %array_17
+   %struct_17 = OpTypeStruct %runtime_17
+%ptr_struct_17 = OpTypePointer StorageBuffer %struct_17
+%ptr_array_17 = OpTypePointer StorageBuffer %array_17
+     %ptr_int = OpTypePointer StorageBuffer %int
+
+      %wg_var = OpVariable %ptr_array_array_4 Workgroup
+    %diff_var = OpVariable %ptr_struct_17 StorageBuffer
+     %lid_var = OpVariable %ptr_input_int3 Input
+     %gid_var = OpVariable %ptr_input_int3 Input
+
+     %void_fn = OpTypeFunction %void
+        %main = OpFunction %void None %void_fn
+       %entry = OpLabel
+         %gid = OpLoad %int3 %gid_var
+       %gid_x = OpCompositeExtract %int %gid 0
+       %gid_y = OpCompositeExtract %int %gid 1
+         %lid = OpLoad %int3 %lid_var
+       %lid_x = OpCompositeExtract %int %lid 0
+       %lid_y = OpCompositeExtract %int %lid 1
+ %array_gep_0 = OpAccessChain %ptr_array_4 %wg_var %int_0
+   %array_gep = OpAccessChain %ptr_array_4 %wg_var %lid_x
+  %lid_y_is_1 = OpIEqual %bool %lid_y %int_1
+                OpSelectionMerge %loop None
+                OpBranchConditional %lid_y_is_1 %then %loop
+
+        %then = OpLabel
+                ; Compute results for outer array
+  %large_diff = OpPtrDiff %int %array_gep %array_gep_0
+%large_diff_gep = OpAccessChain %ptr_int %diff_var %int_0 %gid_x %int_16
+                OpStore %large_diff_gep %large_diff
+                ;
+                OpBranch %loop
+
+        %loop = OpLabel
+           %i = OpPhi %int %int_0 %entry %int_0 %then %inc_i %loop
+       %inc_i = OpIAdd %int %i %int_1
+       %i_cmp = OpIEqual %bool %inc_i %int_4
+  %lid_offset = OpIMul %int %lid_y %int_4
+%out_gep_index = OpIAdd %int %i %lid_offset
+                ; Compute results for inner array
+     %ref_gep = OpAccessChain %ptr_wg_int %array_gep %lid_y
+     %cmp_gep = OpAccessChain %ptr_wg_int %array_gep %i
+        %diff = OpPtrDiff %int %ref_gep %cmp_gep
+    %diff_gep = OpAccessChain %ptr_int %diff_var %int_0 %gid_x %out_gep_index
+                OpStore %diff_gep %diff
+                ;
+                OpLoopMerge %exit %loop None
+                OpBranchConditional %i_cmp %exit %loop
+        %exit = OpLabel
+                OpReturn
+                OpFunctionEnd

--- a/llpc/test/shaderdb/core/OverrideThreadGroupSize8X8X1.spvasm
+++ b/llpc/test/shaderdb/core/OverrideThreadGroupSize8X8X1.spvasm
@@ -1,0 +1,105 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v %gfxip %s \ 
+; RUN:   --override-threadGroupSizeX=8 --override-threadGroupSizeY=8 --override-threadGroupSizeZ=1 \
+; RUN: | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTESTTEST: !llpc.compute.mode = !{!0}
+; SHADERTESTTEST: !0 = !{i32 8, i32 8, i32 1}
+; SHADERTESTTEST: AMDLLPC SUCCESS
+; END_SHADERTESTTEST
+
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 58
+; Schema: 0
+                OpCapability Shader
+                OpCapability VariablePointers
+                OpExtension "SPV_KHR_variable_pointers"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main" %wg_var %diff_var %lid_var %gid_var
+                OpExecutionMode %main LocalSize 16 4 1
+
+                OpDecorate %struct_17 Block
+                OpMemberDecorate %struct_17 0 Offset 0
+                OpDecorate %runtime_17 ArrayStride 68
+                OpDecorate %array_17 ArrayStride 4
+
+                OpDecorate %diff_var DescriptorSet 0
+                OpDecorate %diff_var Binding 0
+
+                OpDecorate %lid_var BuiltIn LocalInvocationId
+                OpDecorate %gid_var BuiltIn GlobalInvocationId
+
+        %void = OpTypeVoid
+        %bool = OpTypeBool
+         %int = OpTypeInt 32 1
+       %int_0 = OpConstant %int 0
+       %int_1 = OpConstant %int 1
+       %int_4 = OpConstant %int 4
+      %int_16 = OpConstant %int 16
+      %int_17 = OpConstant %int 17
+      %int_64 = OpConstant %int 64
+        %int3 = OpTypeVector %int 3
+
+%ptr_input_int3 = OpTypePointer Input %int3
+
+     %array_4 = OpTypeArray %int %int_4
+%array_array_4 = OpTypeArray %array_4 %int_16
+%ptr_array_array_4 = OpTypePointer Workgroup %array_array_4
+%ptr_array_4 = OpTypePointer Workgroup %array_4
+ %ptr_wg_int = OpTypePointer Workgroup %int
+
+    %array_17 = OpTypeArray %int %int_17
+  %runtime_17 = OpTypeRuntimeArray %array_17
+   %struct_17 = OpTypeStruct %runtime_17
+%ptr_struct_17 = OpTypePointer StorageBuffer %struct_17
+%ptr_array_17 = OpTypePointer StorageBuffer %array_17
+     %ptr_int = OpTypePointer StorageBuffer %int
+
+      %wg_var = OpVariable %ptr_array_array_4 Workgroup
+    %diff_var = OpVariable %ptr_struct_17 StorageBuffer
+     %lid_var = OpVariable %ptr_input_int3 Input
+     %gid_var = OpVariable %ptr_input_int3 Input
+
+     %void_fn = OpTypeFunction %void
+        %main = OpFunction %void None %void_fn
+       %entry = OpLabel
+         %gid = OpLoad %int3 %gid_var
+       %gid_x = OpCompositeExtract %int %gid 0
+       %gid_y = OpCompositeExtract %int %gid 1
+         %lid = OpLoad %int3 %lid_var
+       %lid_x = OpCompositeExtract %int %lid 0
+       %lid_y = OpCompositeExtract %int %lid 1
+ %array_gep_0 = OpAccessChain %ptr_array_4 %wg_var %int_0
+   %array_gep = OpAccessChain %ptr_array_4 %wg_var %lid_x
+  %lid_y_is_1 = OpIEqual %bool %lid_y %int_1
+                OpSelectionMerge %loop None
+                OpBranchConditional %lid_y_is_1 %then %loop
+
+        %then = OpLabel
+                ; Compute results for outer array
+  %large_diff = OpPtrDiff %int %array_gep %array_gep_0
+%large_diff_gep = OpAccessChain %ptr_int %diff_var %int_0 %gid_x %int_16
+                OpStore %large_diff_gep %large_diff
+                ;
+                OpBranch %loop
+
+        %loop = OpLabel
+           %i = OpPhi %int %int_0 %entry %int_0 %then %inc_i %loop
+       %inc_i = OpIAdd %int %i %int_1
+       %i_cmp = OpIEqual %bool %inc_i %int_4
+  %lid_offset = OpIMul %int %lid_y %int_4
+%out_gep_index = OpIAdd %int %i %lid_offset
+                ; Compute results for inner array
+     %ref_gep = OpAccessChain %ptr_wg_int %array_gep %lid_y
+     %cmp_gep = OpAccessChain %ptr_wg_int %array_gep %i
+        %diff = OpPtrDiff %int %ref_gep %cmp_gep
+    %diff_gep = OpAccessChain %ptr_int %diff_var %int_0 %gid_x %out_gep_index
+                OpStore %diff_gep %diff
+                ;
+                OpLoopMerge %exit %loop None
+                OpBranchConditional %i_cmp %exit %loop
+        %exit = OpLabel
+                OpReturn
+                OpFunctionEnd

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -243,6 +243,28 @@ cl::opt<ThreadGroupSwizzleMode> ThreadGroupSwizzleModeSetting("thread-group-swiz
                                                                      clEnumValN(ThreadGroupSwizzleMode::_4x4, "4x4", "tile size is 4x4 in x and y dimension"),
                                                                      clEnumValN(ThreadGroupSwizzleMode::_8x8, "8x8", "tile size is 8x8 in x and y dimension"),
                                                                      clEnumValN(ThreadGroupSwizzleMode::_16x16, "16x16", "tile size is 16x16   in x and y dimension")));
+// -override-threadGroupSizeX
+cl::opt<unsigned> OverrideThreadGroupSizeX("override-threadGroupSizeX",
+                                              cl::desc("override threadGroupSize X\n"
+                                                       "0x00 - No override\n"
+                                                       "0x08 - Override threadGroupSizeX with Value:8 in wave32 or wave64\n"
+                                                       "0x10 - Override threadGroupSizeX with Value:16 in wave64\n"),
+                                              cl::init(0));
+
+// -override-threadGroupSizeY
+cl::opt<unsigned> OverrideThreadGroupSizeY("override-threadGroupSizeY",
+                                              cl::desc("override threadGroupSize Y\n"
+                                                       "0x00 - No override\n"
+                                                       "0x08 - Override threadGroupSizeY with Value:8 in wave32 or wave64\n"
+                                                       "0x10 - Override threadGroupSizeY with Value:16 in wave64\n"),
+                                              cl::init(0));
+
+// -override-threadGroupSizeZ
+cl::opt<unsigned> OverrideThreadGroupSizeZ("override-threadGroupSizeZ",
+                                              cl::desc("override threadGroupSize Z\n"
+                                                       "0x00 - No override\n"
+                                                       "0x01 - Override threadGroupSizeZ with Value:1 in wave32 or wave64\n"),
+                                              cl::init(0));
 
 // -filter-pipeline-dump-by-type: filter which kinds of pipeline should be disabled.
 cl::opt<unsigned> FilterPipelineDumpByType("filter-pipeline-dump-by-type",
@@ -442,6 +464,9 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
 #endif
   compileInfo->gfxPipelineInfo.options.resourceLayoutScheme = LayoutScheme;
   compileInfo->compPipelineInfo.options.forceCsThreadIdSwizzling = ForceCsThreadIdSwizzling;
+  compileInfo->compPipelineInfo.options.overrideThreadGroupSizeX = OverrideThreadGroupSizeX;
+  compileInfo->compPipelineInfo.options.overrideThreadGroupSizeY = OverrideThreadGroupSizeY;
+  compileInfo->compPipelineInfo.options.overrideThreadGroupSizeZ = OverrideThreadGroupSizeZ;
   compileInfo->compPipelineInfo.options.threadGroupSwizzleMode = ThreadGroupSwizzleModeSetting;
 
   // Set NGG control settings

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -133,6 +133,9 @@ Expected<BinaryData> ComputePipelineBuilder::buildComputePipeline() {
   pipelineInfo->options.scalarBlockLayout = compileInfo.scalarBlockLayout;
   pipelineInfo->options.enableScratchAccessBoundsChecks = compileInfo.scratchAccessBoundsChecks;
   pipelineInfo->options.forceCsThreadIdSwizzling = compileInfo.compPipelineInfo.options.forceCsThreadIdSwizzling;
+  pipelineInfo->options.overrideThreadGroupSizeX = compileInfo.compPipelineInfo.options.overrideThreadGroupSizeX;
+  pipelineInfo->options.overrideThreadGroupSizeY = compileInfo.compPipelineInfo.options.overrideThreadGroupSizeY;
+  pipelineInfo->options.overrideThreadGroupSizeZ = compileInfo.compPipelineInfo.options.overrideThreadGroupSizeZ;
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
   if (compileInfo.optimizationLevel.hasValue()) {
     pipelineInfo->options.optimizationLevel = compileInfo.optimizationLevel.getValue();

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6955,14 +6955,23 @@ bool SPIRVToLLVM::transMetadata() {
             }
           }
         }
-
-        // clang-format off
-          ComputeShaderMode computeMode = {};
+        ComputeShaderMode computeMode = {};
+        unsigned overrideThreadGroupSizeX = getPipelineOptions()->overrideThreadGroupSizeX;
+        unsigned overrideThreadGroupSizeY = getPipelineOptions()->overrideThreadGroupSizeY;
+        unsigned overrideThreadGroupSizeZ = getPipelineOptions()->overrideThreadGroupSizeZ;
+        if (overrideThreadGroupSizeX != 0 || overrideThreadGroupSizeY != 0 || overrideThreadGroupSizeZ != 0) {
+          computeMode.workgroupSizeX = overrideThreadGroupSizeX;
+          computeMode.workgroupSizeY = overrideThreadGroupSizeY;
+          computeMode.workgroupSizeZ = overrideThreadGroupSizeZ;
+          getBuilder()->setComputeShaderMode(computeMode);
+        } else {
+          // clang-format off
           computeMode.workgroupSizeX = workgroupSizeX;
           computeMode.workgroupSizeY = workgroupSizeY;
           computeMode.workgroupSizeZ = workgroupSizeZ;
           getBuilder()->setComputeShaderMode(computeMode);
         // clang-format on
+        }
       } else
         llvm_unreachable("Invalid execution model");
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -443,6 +443,7 @@ private:
   // ========================================================================================================================
   void insertScratchBoundsChecks(SPIRVValue *const memOp, const ScratchBoundsCheckData &scratchBoundsCheckData,
                                  Function *parent);
+
 }; // class SPIRVToLLVM
 
 } // namespace SPIRV

--- a/llpc/unittests/util/testPipelineDumper.cpp
+++ b/llpc/unittests/util/testPipelineDumper.cpp
@@ -297,6 +297,32 @@ TEST(PipelineDumperTest, TestForceCsThreadIdSwizzlingCompute) {
   HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
   runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
 }
+
+// =====================================================================================================================
+// Test overrideThreadGroupSize option.
+
+TEST(PipelineDumperTest, TestOverrideThreadGroupSizeValue1Compute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.overrideThreadGroupSizeX = 8;
+    buildInfo->options.overrideThreadGroupSizeY = 8;
+    buildInfo->options.overrideThreadGroupSizeZ = 1;
+  };
+
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestOverrideThreadGroupSizeValue2Compute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.overrideThreadGroupSizeX = 16;
+    buildInfo->options.overrideThreadGroupSizeY = 16;
+    buildInfo->options.overrideThreadGroupSizeZ = 1;
+  };
+
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
 #endif
 
 // =====================================================================================================================

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -695,6 +695,9 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
   dumpFile << "options.robustBufferAccess = " << options->robustBufferAccess << "\n";
   dumpFile << "options.reconfigWorkgroupLayout = " << options->reconfigWorkgroupLayout << "\n";
   dumpFile << "options.forceCsThreadIdSwizzling = " << options->forceCsThreadIdSwizzling << "\n";
+  dumpFile << "options.overrideThreadGroupSizeX = " << options->overrideThreadGroupSizeX << "\n";
+  dumpFile << "options.overrideThreadGroupSizeY = " << options->overrideThreadGroupSizeY << "\n";
+  dumpFile << "options.overrideThreadGroupSizeZ = " << options->overrideThreadGroupSizeZ << "\n";
   dumpFile << "options.shadowDescriptorTableUsage = " << options->shadowDescriptorTableUsage << "\n";
   dumpFile << "options.shadowDescriptorTablePtrHigh = " << options->shadowDescriptorTablePtrHigh << "\n";
   dumpFile << "options.extendedRobustness.robustBufferAccess = " << options->extendedRobustness.robustBufferAccess
@@ -1100,6 +1103,9 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
   hasher->Update(options->robustBufferAccess);
   hasher->Update(options->reconfigWorkgroupLayout);
   hasher->Update(options->forceCsThreadIdSwizzling);
+  hasher->Update(options->overrideThreadGroupSizeX);
+  hasher->Update(options->overrideThreadGroupSizeY);
+  hasher->Update(options->overrideThreadGroupSizeZ);
   hasher->Update(options->enableRelocatableShaderElf);
   hasher->Update(options->disableImageResourceCheck);
   hasher->Update(options->enableScratchAccessBoundsChecks);

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -345,6 +345,9 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceCsThreadIdSwizzling, MemberTypeBool, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeX, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeY, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeZ, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
@@ -363,7 +366,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 13;
+  static const unsigned MemberCount = 15;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
This is the main part for adding the option.
The default value for the overrideThreadGroup size value is {0,0,0}