### PR TITLE
Fix invalid structured control flow.

### DIFF
--- a/llpc/test/shaderdb/core/OpBranchConditional_TestLoopContinue.spvasm
+++ b/llpc/test/shaderdb/core/OpBranchConditional_TestLoopContinue.spvasm
@@ -111,10 +111,10 @@
          %69 = OpVectorExtractDynamic %14 %67 %35
                OpBranch %70
          %70 = OpLabel
-         %71 = OpPhi %12 %39 %68 %72 %73
-         %74 = OpPhi %14 %29 %68 %75 %73
-         %76 = OpPhi %14 %69 %68 %77 %73
-               OpLoopMerge %78 %70 None
+         %71 = OpPhi %12 %39 %68 %72 %85
+         %74 = OpPhi %14 %29 %68 %75 %85
+         %76 = OpPhi %14 %69 %68 %77 %85
+               OpLoopMerge %78 %85 None
                OpBranch %79
          %79 = OpLabel
          %80 = OpFOrdGreaterThan %11 %74 %30
@@ -129,7 +129,9 @@
          %77 = OpFAdd %14 %76 %74
          %72 = OpISub %12 %71 %36
          %83 = OpSGreaterThan %11 %72 %35
-               OpBranchConditional %83 %70 %78
+               OpBranchConditional %83 %85 %78
+         %85 = OpLabel
+               OpBranch %70
          %78 = OpLabel
          %84 = OpVectorInsertDynamic %16 %67 %77 %35
                OpReturnValue %84

--- a/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
+++ b/llpc/test/shaderdb/fuzzer/GraphicsFuzz_TestOpCopyObjectFromAccessChain.spvasm
@@ -33,7 +33,7 @@
         %199 = OpVariable %108 Function
                OpBranch %205
         %205 = OpLabel
-        %279 = OpPhi %73 %76 %5 %76 %233
+        %279 = OpPhi %73 %76 %5
                OpSelectionMerge %233 None
                OpSwitch %22 %242
         %242 = OpLabel
@@ -41,5 +41,5 @@
         %454 = OpCopyObject %23 %217
                OpReturn
         %233 = OpLabel
-               OpBranch %205
+               OpReturn
                OpFunctionEnd


### PR DESCRIPTION
There are stricter validation checks for structured control flow
(https://github.com/KhronosGroup/SPIRV-Tools/pull/4832).
These new checks were flagging these two tests as invalid.

The failures only occur with the latest SPIRV-Tools master branch, which
we use internally.

The fix to the first test (conditional inside a loop) involves splitting the back-edge
to satisfy the new validation.

The fuzzer test was creating an invalid loop.  The simplest change I could
think of was to make it a simple return, removing the invalid back-edge.
This forced the change on the `OpPhi` (which was already a simple 
constant assignment, so the semantics are the same)