### PR TITLE
Support extended multiplication on non-32bit integers

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4909,7 +4909,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     Value *val0 = transValue(bc->getOperand(0), f, bb);
     Value *val1 = transValue(bc->getOperand(1), f, bb);
     Type *inTy = val0->getType();
-    Type *extendedTy = lgc::Builder::getConditionallyVectorizedTy(getBuilder()->getInt64Ty(), val0->getType());
+    const unsigned bitWidth = inTy->getScalarSizeInBits();
+    Type *extendedTy = inTy->getExtendedType();
     if (oc == OpUMulExtended) {
       val0 = getBuilder()->CreateZExt(val0, extendedTy);
       val1 = getBuilder()->CreateZExt(val1, extendedTy);
@@ -4920,7 +4921,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     Value *mul = getBuilder()->CreateMul(val0, val1);
     Value *loResult = getBuilder()->CreateTrunc(mul, inTy);
     Value *hiResult =
-        getBuilder()->CreateTrunc(getBuilder()->CreateLShr(mul, ConstantInt::get(mul->getType(), 32)), inTy);
+        getBuilder()->CreateTrunc(getBuilder()->CreateLShr(mul, ConstantInt::get(mul->getType(), bitWidth)), inTy);
     Value *result = UndefValue::get(transType(bc->getType()));
     result = getBuilder()->CreateInsertValue(result, loResult, 0);
     result = getBuilder()->CreateInsertValue(result, hiResult, 1);


### PR DESCRIPTION
The current implementation of OpUMulExtended/OpSMulExtended only works
on 32-bit integers. This change is to support 8/16/64-bit integers. For
8/16-bit integers, it's easy to modify the original code by performing
right shifting according to the actual bit width instead of constant 32.
For 64-bit integers, it's to perform the extended multiplication based
on the formula:
```
A * B = (ah * 2^32 + al) (bh * 2^32 + bl)
      = ah * bh * 2^64 + ah * bl * 2^32 + al * bh * 2^32 + al * bl
```