### PR TITLE
Barycentric supporting interpolation in different modes

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -953,7 +953,9 @@ Value *InOutBuilder::readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo i
       Value *sampleNum = vertexIndex;
       vertexIndex = nullptr;
       args.push_back(sampleNum);
-    }
+    } else if (builtIn == BuiltInBaryCoord || builtIn == BuiltInBaryCoordNoPerspKHR)
+      // BuiltInBaryCoord requires interpolate mode.
+      args.push_back(getInt32(inOutInfo.getInterpLoc()));
     assert(!index && !vertexIndex);
     break;
   default:

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -453,7 +453,7 @@ void SpirvLowerGlobal::handleLoadInstGEP(GetElementPtrInst *const getElemPtr, Lo
   }
 
   Value *loadValue = loadInOutMember(inOutTy, addrSpace, indexOperands, 0, inOutMetaVal, nullptr, vertexIdx,
-                                     InterpLocUnknown, nullptr);
+                                     InterpLocUnknown, nullptr, false);
   m_loadInsts.insert(&loadInst);
   loadInst.replaceAllUsesWith(loadValue);
 }
@@ -1007,6 +1007,8 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
         // Array built-in without vertex indexing (ClipDistance/CullDistance).
         lgc::InOutInfo inOutInfo;
         inOutInfo.setArraySize(inOutTy->getArrayNumElements());
+        // For Barycentric interplotation
+        inOutInfo.setInterpLoc(interpLoc);
         if (addrSpace == SPIRAS_Input) {
           inOutValue = m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(inOutMeta.Value), inOutInfo,
                                                          vertexIdx, nullptr);
@@ -1038,11 +1040,10 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
         for (unsigned idx = 0; idx < elemCount; ++idx) {
           Value *elem = nullptr;
           if (inOutMeta.PerVertexDimension) {
-            assert(inOutMeta.InterpLoc == InterpLocCustom);
+            assert(inOutMeta.InterpMode == InterpModeCustom);
             elem = addCallInstForInOutImport(elemTy, addrSpace, elemMeta, nullptr, 0, nullptr, 0, inOutMeta.InterpLoc,
                                              m_builder->getInt32(idx), true);
-          }
-          else {
+          } else {
             // Handle array elements recursively
             // elemLocOffset = locOffset + stride * idx
             Value *elemLocOffset = nullptr;
@@ -1087,6 +1088,7 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
 
       lgc::InOutInfo inOutInfo;
       inOutInfo.setArraySize(maxLocOffset);
+      inOutInfo.setInterpLoc(interpLoc);
       if (addrSpace == SPIRAS_Input)
         inOutValue = m_builder->CreateReadBuiltInInput(builtIn, inOutInfo, vertexIdx, elemIdx);
       else
@@ -1388,13 +1390,20 @@ void SpirvLowerGlobal::addCallInstForOutputExport(Value *outputValue, Constant *
 //                       - Vertex no. (0 ~ 2) for "InterpLocCustom"
 Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrSpace, ArrayRef<Value *> indexOperands,
                                                    Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc,
-                                                   Value *auxInterpValue) {
+                                                   Value *auxInterpValue, bool isPerVertexDimension) {
   // Currently this is only used in fragment shader on loading interpolate sources.
   assert(m_shaderStage == ShaderStageFragment);
 
+  ShaderInOutMetadata inOutMeta = {};
   Value *inOutValue = UndefValue::get(inOutTy);
   if (inOutTy->isArrayTy()) {
     assert(inOutMetaVal->getNumOperands() == 4);
+    inOutMeta.U64All[0] = cast<ConstantInt>(inOutMetaVal->getOperand(2))->getZExtValue();
+    inOutMeta.U64All[1] = cast<ConstantInt>(inOutMetaVal->getOperand(3))->getZExtValue();
+    if (inOutMeta.PerVertexDimension) {
+      assert(inOutMeta.InterpMode == InterpModeCustom);
+      isPerVertexDimension = true;
+    }
 
     auto elemMeta = cast<Constant>(inOutMetaVal->getOperand(1));
     unsigned stride = cast<ConstantInt>(inOutMetaVal->getOperand(0))->getZExtValue();
@@ -1407,13 +1416,18 @@ Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrS
       const uint64_t elemCount = inOutTy->getArrayNumElements();
       for (unsigned idx = 0; idx < elemCount; ++idx) {
         Value *elemLocOffset = nullptr;
-        if (isa<ConstantInt>(locOffset))
-          elemLocOffset = m_builder->getInt32(cast<ConstantInt>(locOffset)->getZExtValue() + stride * idx);
-        else
-          elemLocOffset = m_builder->CreateAdd(locOffset, m_builder->getInt32(stride * idx));
+        if (inOutMeta.PerVertexDimension) {
+          auxInterpValue = m_builder->getInt32(idx);
+          elemLocOffset = m_builder->getInt32(0);
+        } else {
+          if (isa<ConstantInt>(locOffset))
+            elemLocOffset = m_builder->getInt32(cast<ConstantInt>(locOffset)->getZExtValue() + stride * idx);
+          else
+            elemLocOffset = m_builder->CreateAdd(locOffset, m_builder->getInt32(stride * idx));
+        }
 
         auto elem = loadDynamicIndexedMembers(elemTy, addrSpace, indexOperands.drop_front(), elemMeta, elemLocOffset,
-                                              interpLoc, auxInterpValue);
+                                              interpLoc, auxInterpValue, isPerVertexDimension);
         inOutValue = m_builder->CreateInsertValue(inOutValue, elem, {idx});
       }
       return inOutValue;
@@ -1428,7 +1442,7 @@ Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrS
       elemLocOffset = m_builder->CreateAdd(locOffset, m_builder->getInt32(stride * elemIdx));
 
     Value *elem = loadDynamicIndexedMembers(elemTy, addrSpace, indexOperands.drop_front(), elemMeta, elemLocOffset,
-                                            interpLoc, auxInterpValue);
+                                            interpLoc, auxInterpValue, isPerVertexDimension);
     return m_builder->CreateInsertValue(inOutValue, elem, {elemIdx});
   }
 
@@ -1440,7 +1454,7 @@ Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrS
     auto memberMeta = cast<Constant>(inOutMetaVal->getOperand(memberIdx));
 
     auto loadValue = loadDynamicIndexedMembers(memberTy, addrSpace, indexOperands.drop_front(), memberMeta, locOffset,
-                                               interpLoc, auxInterpValue);
+                                               interpLoc, auxInterpValue, isPerVertexDimension);
     return m_builder->CreateInsertValue(inOutValue, loadValue, {memberIdx});
   }
 
@@ -1452,16 +1466,16 @@ Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrS
       loadTy = cast<VectorType>(inOutTy)->getElementType();
       compIdx = indexOperands.front();
       Value *compValue = addCallInstForInOutImport(loadTy, addrSpace, inOutMetaVal, locOffset, 0, compIdx, nullptr,
-                                                   interpLoc, auxInterpValue, false);
+                                                   interpLoc, auxInterpValue, isPerVertexDimension);
       return m_builder->CreateInsertElement(inOutValue, compValue, compIdx);
     }
     return addCallInstForInOutImport(loadTy, addrSpace, inOutMetaVal, locOffset, 0, compIdx, nullptr, interpLoc,
-                                     auxInterpValue, false);
+                                     auxInterpValue, isPerVertexDimension);
   }
 
   // Simple scalar type
   return addCallInstForInOutImport(inOutTy, addrSpace, inOutMetaVal, locOffset, 0, nullptr, nullptr, interpLoc,
-                                   auxInterpValue, false);
+                                   auxInterpValue, isPerVertexDimension);
 }
 
 // =====================================================================================================================
@@ -1480,14 +1494,15 @@ Value *SpirvLowerGlobal::loadDynamicIndexedMembers(Type *inOutTy, unsigned addrS
 // "InterpLocCustom"
 Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, ArrayRef<Value *> indexOperands,
                                          unsigned maxLocOffset, Constant *inOutMetaVal, Value *locOffset,
-                                         Value *vertexIdx, unsigned interpLoc, Value *auxInterpValue) {
+                                         Value *vertexIdx, unsigned interpLoc, Value *auxInterpValue,
+                                         bool isPerVertexDimension) {
   assert(m_shaderStage == ShaderStageTessControl || m_shaderStage == ShaderStageTessEval ||
          m_shaderStage == ShaderStageFragment);
 
   if (indexOperands.empty()) {
     // All indices have been processed
     return addCallInstForInOutImport(inOutTy, addrSpace, inOutMetaVal, locOffset, maxLocOffset, nullptr, vertexIdx,
-                                     interpLoc, auxInterpValue, false);
+                                     interpLoc, auxInterpValue, isPerVertexDimension);
   }
 
   if (inOutTy->isArrayTy()) {
@@ -1505,26 +1520,36 @@ Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, Arra
       assert(indexOperands.size() == 1);
       auto elemIdx = indexOperands.front();
       return addCallInstForInOutImport(elemTy, addrSpace, elemMeta, locOffset, inOutTy->getArrayNumElements(), elemIdx,
-                                       vertexIdx, interpLoc, auxInterpValue, false);
+                                       vertexIdx, interpLoc, auxInterpValue, isPerVertexDimension);
     }
 
     // NOTE: If the relative location offset is not specified, initialize it to 0.
     if (!locOffset)
       locOffset = m_builder->getInt32(0);
-    // elemLocOffset = locOffset + stride * elemIdx
-    unsigned stride = cast<ConstantInt>(inOutMetaVal->getOperand(0))->getZExtValue();
-    auto elemIdx = indexOperands.front();
-    Value *elemLocOffset = m_builder->CreateMul(m_builder->getInt32(stride), elemIdx);
-    elemLocOffset = m_builder->CreateAdd(locOffset, elemLocOffset);
 
-    // Mark the end+1 possible location offset if the index is variable. The Builder call needs it
-    // so it knows how many locations to mark as used by this access.
-    if (maxLocOffset == 0 && !isa<ConstantInt>(elemIdx)) {
-      maxLocOffset = cast<ConstantInt>(locOffset)->getZExtValue() + stride * inOutTy->getArrayNumElements();
+    Value *elemLocOffset = nullptr;
+
+    if (inOutMeta.PerVertexDimension) {
+      // The input is a pervertex variable. The location offset is 0.
+      assert(inOutMeta.InterpMode == InterpModeCustom);
+      auxInterpValue = indexOperands.front();
+      elemLocOffset = m_builder->getInt32(0);
+    } else {
+      // elemLocOffset = locOffset + stride * elemIdx
+      unsigned stride = cast<ConstantInt>(inOutMetaVal->getOperand(0))->getZExtValue();
+      auto elemIdx = indexOperands.front();
+      elemLocOffset = m_builder->CreateMul(m_builder->getInt32(stride), elemIdx);
+      elemLocOffset = m_builder->CreateAdd(locOffset, elemLocOffset);
+
+      // Mark the end+1 possible location offset if the index is variable. The Builder call needs it
+      // so it knows how many locations to mark as used by this access.
+      if (maxLocOffset == 0 && !isa<ConstantInt>(elemIdx)) {
+        maxLocOffset = cast<ConstantInt>(locOffset)->getZExtValue() + stride * inOutTy->getArrayNumElements();
+      }
     }
 
     return loadInOutMember(elemTy, addrSpace, indexOperands.drop_front(), maxLocOffset, elemMeta, elemLocOffset,
-                           vertexIdx, interpLoc, auxInterpValue);
+                           vertexIdx, interpLoc, auxInterpValue, inOutMeta.PerVertexDimension);
   }
 
   if (inOutTy->isStructTy()) {
@@ -1535,7 +1560,7 @@ Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, Arra
     auto memberMeta = cast<Constant>(inOutMetaVal->getOperand(memberIdx));
 
     return loadInOutMember(memberTy, addrSpace, indexOperands.drop_front(), maxLocOffset, memberMeta, locOffset,
-                           vertexIdx, interpLoc, auxInterpValue);
+                           vertexIdx, interpLoc, auxInterpValue, isPerVertexDimension);
   }
 
   if (inOutTy->isVectorTy()) {
@@ -1546,7 +1571,7 @@ Value *SpirvLowerGlobal::loadInOutMember(Type *inOutTy, unsigned addrSpace, Arra
     Value *compIdx = indexOperands.front();
 
     return addCallInstForInOutImport(loadTy, addrSpace, inOutMetaVal, locOffset, maxLocOffset, compIdx, vertexIdx,
-                                     interpLoc, auxInterpValue, false);
+                                     interpLoc, auxInterpValue, isPerVertexDimension);
   }
 
   llvm_unreachable("Should never be called!");
@@ -2057,7 +2082,7 @@ void SpirvLowerGlobal::interpolateInputElement(unsigned interpLoc, Value *auxInt
 
   if (getElemPtr->hasAllConstantIndices()) {
     auto loadValue = loadInOutMember(inputTy, SPIRAS_Input, makeArrayRef(indexOperands).drop_front(), 0, inputMeta,
-                                     nullptr, nullptr, interpLoc, auxInterpValue);
+                                     nullptr, nullptr, interpLoc, auxInterpValue, false);
 
     m_interpCalls.insert(&callInst);
     callInst.replaceAllUsesWith(loadValue);
@@ -2070,7 +2095,7 @@ void SpirvLowerGlobal::interpolateInputElement(unsigned interpLoc, Value *auxInt
                                     &*(m_entryPoint->begin()->getFirstInsertionPt()));
     // Load all possibly accessed values
     auto loadValue = loadDynamicIndexedMembers(inputTy, SPIRAS_Input, makeArrayRef(indexOperands).drop_front(),
-                                               inputMeta, nullptr, interpLoc, auxInterpValue);
+                                               inputMeta, nullptr, interpLoc, auxInterpValue, false);
 
     m_builder->CreateStore(loadValue, interpPtr);
 

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -87,11 +87,13 @@ private:
                                   llvm::Value *elemIdx, llvm::Value *vertexIdx, unsigned emitStreamId);
 
   Value *loadDynamicIndexedMembers(Type *inOutTy, unsigned addrSpace, llvm::ArrayRef<llvm::Value *> indexOperands,
-                                   Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc, Value *auxInterpValue);
+                                   Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc, Value *auxInterpValue,
+                                   bool isPerVertexDimension);
 
   llvm::Value *loadInOutMember(llvm::Type *inOutTy, unsigned addrSpace, llvm::ArrayRef<llvm::Value *> indexOperands,
                                unsigned maxLocOffset, llvm::Constant *inOutMeta, llvm::Value *locOffset,
-                               llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo);
+                               llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,
+                               bool isPerVertexDimension);
 
   void storeOutputMember(llvm::Type *outputTy, llvm::Value *storeValue, llvm::ArrayRef<llvm::Value *> indexOperands,
                          unsigned maxLocOffset, llvm::Constant *outputMeta, llvm::Value *locOffset,

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_line_list.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_line_list.pipe
@@ -4,7 +4,7 @@
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
-; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32(i32 5286)
+; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32.i32(i32 5286, i32 0)
 
 // barycentric coordinate: (1 - i - j, i + j, 0)
 ; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
@@ -4,7 +4,7 @@
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
-; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32(i32 5286)
+; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32.i32(i32 5286, i32 0)
 
 // barycentric coordinate: (i ,j , 1 - i - j).
 // Triangle_Fan depends the parity of primitive.

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_list.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_list.pipe
@@ -4,7 +4,7 @@
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: define dllexport spir_func void @lgc.shader.FS.main()
-; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32(i32 5286)
+; SHADERTEST: call <3 x float> @lgc.input.import.builtin.BaryCoord.v3f32.i32.i32(i32 5286, i32 0)
 
 // barycentric coordinate: (i ,j , 1 - i - j)
 ; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestInterpAtCentriodBarycentric.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestInterpAtCentriodBarycentric.pipe
@@ -1,0 +1,256 @@
+// gl_BaryCoordNoPerspEXT requires different interpolant mode. This tests interpolateAtCentroid(gl_BaryCoordNoPerspEXT)
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: @[[BaryCoord:[^ ]*]] = external addrspace(64) global <3 x float>
+; SHADERTEST: call spir_func <3 x float> @interpolateAtCentroid.p64v3f32(<3 x float> addrspace(64)* @[[BaryCoord]])
+
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; The second argument (i32 32) respects that interpLoc is InterpLocCentroid.
+; SHADERTEST: call <3 x float> (...) @lgc.create.read.builtin.input.v3f32(i32 5287, i32 32, i32 undef, i32 undef)
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: %[[InterpCenter0:[^ ]*]] = extractelement <2 x float> %LinearInterpCenter, i64 0
+; SHADERTEST: %[[InterpCentroid0:[^ ]*]] = extractelement <2 x float> %LinearInterpCentroid, i64 0
+; SHADERTEST: %[[InterpCenter1:[^ ]*]] = extractelement <2 x float> %LinearInterpCenter, i64 1
+; SHADERTEST: %[[InterpCentroid1:[^ ]*]] = extractelement <2 x float> %LinearInterpCentroid, i64 1
+; SHADERTEST: %[[CMP:[0-9]*]] = icmp slt i32 %PrimMask, 0
+; SHADERTEST: %[[ICoord:[^ ]*]] = select i1 %[[CMP]], float %[[InterpCenter0]], float %[[InterpCentroid0]]
+; SHADERTEST: %[[JCoord:[^ ]*]] = select i1 %[[CMP]], float %[[InterpCenter1]], float %[[InterpCentroid1]]
+; SHADERTEST: %{{[0-9]*}} = fsub float 1.000000e+00, %[[ICoord]]
+; SHADERTEST: %{{[0-9]*}} = fsub float %{{[0-9]*}}, %[[JCoord]]
+
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 54
+
+[VsSpirv]
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 45
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %gl_VertexIndex %_ %reference1 %reference2
+               OpSource GLSL 450
+               OpName %main "main"
+               OpName %gl_VertexIndex "gl_VertexIndex"
+               OpName %gl_PerVertex "gl_PerVertex"
+               OpMemberName %gl_PerVertex 0 "gl_Position"
+               OpMemberName %gl_PerVertex 1 "gl_PointSize"
+               OpMemberName %gl_PerVertex 2 "gl_ClipDistance"
+               OpMemberName %gl_PerVertex 3 "gl_CullDistance"
+               OpName %_ ""
+               OpName %reference1 "reference1"
+               OpName %reference2 "reference2"
+               OpDecorate %gl_VertexIndex BuiltIn VertexIndex
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %reference1 NoPerspective
+               OpDecorate %reference1 Centroid
+               OpDecorate %reference1 Location 0
+               OpDecorate %reference2 NoPerspective
+               OpDecorate %reference2 Centroid
+               OpDecorate %reference2 Location 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Input_int = OpTypePointer Input %int
+%gl_VertexIndex = OpVariable %_ptr_Input_int Input
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+      %int_0 = OpConstant %int 0
+    %float_0 = OpConstant %float 0
+%float_n0_899999976 = OpConstant %float -0.899999976
+    %float_1 = OpConstant %float 1
+         %26 = OpConstantComposite %v4float %float_0 %float_n0_899999976 %float_0 %float_1
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%_ptr_Output_float = OpTypePointer Output %float
+ %reference1 = OpVariable %_ptr_Output_float Output
+   %float_n1 = OpConstant %float -1
+ %reference2 = OpVariable %_ptr_Output_float Output
+%float_0_899999976 = OpConstant %float 0.899999976
+  %float_0_5 = OpConstant %float 0.5
+  %float_1_5 = OpConstant %float 1.5
+         %37 = OpConstantComposite %v4float %float_n0_899999976 %float_0_899999976 %float_0_5 %float_1_5
+%float_0_800000012 = OpConstant %float 0.800000012
+         %41 = OpConstantComposite %v4float %float_0_899999976 %float_0_899999976 %float_1 %float_0_800000012
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %9 = OpLoad %int %gl_VertexIndex
+               OpSelectionMerge %13 None
+               OpSwitch %9 %13 0 %10 1 %11 2 %12
+         %10 = OpLabel
+         %28 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %28 %26
+               OpStore %reference1 %float_n1
+               OpStore %reference2 %float_n1
+               OpBranch %13
+         %11 = OpLabel
+         %38 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %38 %37
+               OpStore %reference1 %float_0
+               OpStore %reference2 %float_0
+               OpBranch %13
+         %12 = OpLabel
+         %42 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %42 %41
+               OpStore %reference1 %float_1
+               OpStore %reference2 %float_1
+               OpBranch %13
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+[VsInfo]
+entryPoint = main
+
+[FsSpirv]
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 70
+; Schema: 0
+               OpCapability Shader
+               OpCapability InterpolationFunction
+               OpCapability FragmentBarycentricKHR
+               OpExtension "SPV_KHR_fragment_shader_barycentric"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_BaryCoordNoPerspEXT %reference1 %result_color %reference2
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpSourceExtension "GL_AMD_gpu_shader_half_float"
+               OpSourceExtension "GL_AMD_shader_explicit_vertex_parameter"
+               OpSourceExtension "GL_EXT_fragment_shader_barycentric"
+               OpName %main "main"
+               OpName %bary_coord "bary_coord"
+               OpName %gl_BaryCoordNoPerspEXT "gl_BaryCoordNoPerspEXT"
+               OpName %data_v0 "data_v0"
+               OpName %reference1 "reference1"
+               OpName %data_v1 "data_v1"
+               OpName %data_v2 "data_v2"
+               OpName %expected_result "expected_result"
+               OpName %result_color "result_color"
+               OpName %reference2 "reference2"
+               OpDecorate %gl_BaryCoordNoPerspEXT BuiltIn BaryCoordNoPerspKHR
+               OpDecorate %reference1 Location 0
+               OpDecorate %reference1 PerVertexKHR
+               OpDecorate %result_color Location 0
+               OpDecorate %reference2 NoPerspective
+               OpDecorate %reference2 Centroid
+               OpDecorate %reference2 Location 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+%gl_BaryCoordNoPerspEXT = OpVariable %_ptr_Input_v3float Input
+%_ptr_Function_float = OpTypePointer Function %float
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+%_arr_float_uint_3 = OpTypeArray %float %uint_3
+%_ptr_Input__arr_float_uint_3 = OpTypePointer Input %_arr_float_uint_3
+ %reference1 = OpVariable %_ptr_Input__arr_float_uint_3 Input
+        %int = OpTypeInt 32 1
+      %int_2 = OpConstant %int 2
+%_ptr_Input_float = OpTypePointer Input %float
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%result_color = OpVariable %_ptr_Output_v4float Output
+ %reference2 = OpVariable %_ptr_Input_float Input
+%float_9_99999975en06 = OpConstant %float 9.99999975e-06
+       %bool = OpTypeBool
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+         %65 = OpConstantComposite %v4float %float_0 %float_1 %float_0 %float_1
+         %66 = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+     %v4bool = OpTypeVector %bool 4
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+ %bary_coord = OpVariable %_ptr_Function_v3float Function
+    %data_v0 = OpVariable %_ptr_Function_float Function
+    %data_v1 = OpVariable %_ptr_Function_float Function
+    %data_v2 = OpVariable %_ptr_Function_float Function
+%expected_result = OpVariable %_ptr_Function_float Function
+         %12 = OpExtInst %v3float %1 InterpolateAtCentroid %gl_BaryCoordNoPerspEXT
+         %13 = OpVectorShuffle %v3float %12 %12 2 0 1
+               OpStore %bary_coord %13
+         %24 = OpAccessChain %_ptr_Input_float %reference1 %int_2
+         %25 = OpLoad %float %24
+               OpStore %data_v0 %25
+         %28 = OpAccessChain %_ptr_Input_float %reference1 %int_0
+         %29 = OpLoad %float %28
+               OpStore %data_v1 %29
+         %32 = OpAccessChain %_ptr_Input_float %reference1 %int_1
+         %33 = OpLoad %float %32
+               OpStore %data_v2 %33
+         %36 = OpAccessChain %_ptr_Function_float %bary_coord %uint_0
+         %37 = OpLoad %float %36
+         %38 = OpLoad %float %data_v0
+         %39 = OpFMul %float %37 %38
+         %41 = OpAccessChain %_ptr_Function_float %bary_coord %uint_1
+         %42 = OpLoad %float %41
+         %43 = OpLoad %float %data_v1
+         %44 = OpFMul %float %42 %43
+         %45 = OpFAdd %float %39 %44
+         %47 = OpAccessChain %_ptr_Function_float %bary_coord %uint_2
+         %48 = OpLoad %float %47
+         %49 = OpLoad %float %data_v2
+         %50 = OpFMul %float %48 %49
+         %51 = OpFAdd %float %45 %50
+               OpStore %expected_result %51
+         %55 = OpLoad %float %expected_result
+         %57 = OpLoad %float %reference2
+         %58 = OpFSub %float %55 %57
+         %59 = OpExtInst %float %1 FAbs %58
+         %62 = OpFOrdLessThan %bool %59 %float_9_99999975en06
+         %68 = OpCompositeConstruct %v4bool %62 %62 %62 %62
+         %69 = OpSelect %v4float %68 %65 %66
+               OpStore %result_color %69
+               OpReturn
+               OpFunctionEnd
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 4
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 2
+userDataNode[1].type = IndirectUserDataVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].indirectUserDataCount = 0
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+nggState.enableNgg = 0


### PR DESCRIPTION
gl_Barycentric requires to be used as a parameter of interpolateAt*,

which means we use sample/centriod mode to update the IJCoordnate.

We don't clear if interpolateAtOffset can be used, so this change don't

include it.