### PR TITLE
CMakeLists: prefer to use llvm_map_components_to_libnames

### DIFF
--- a/lgc/tool/lgc/CMakeLists.txt
+++ b/lgc/tool/lgc/CMakeLists.txt
@@ -24,7 +24,11 @@
  #######################################################################################################################
 
 ### LGC Standalone Compiler ############################################################################################
-set(LLVM_LINK_COMPONENTS
+add_llvm_tool(lgc
+    lgc.cpp
+)
+
+llvm_map_components_to_libnames(llvm_libs
     lgc
     Core
     AMDGPUAsmParser
@@ -33,12 +37,7 @@ set(LLVM_LINK_COMPONENTS
     AsmParser
     Support
 )
-
-add_llvm_tool(lgc
-    lgc.cpp
-)
-
-add_dependencies(lgc LLVMlgc)
+target_link_libraries(lgc PUBLIC ${llvm_libs})
 
 target_compile_definitions(lgc PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIAN_CPU)
 

--- a/lgc/tool/lgcdis/CMakeLists.txt
+++ b/lgc/tool/lgcdis/CMakeLists.txt
@@ -24,17 +24,16 @@
  #######################################################################################################################
 
 ### LGC disassembler tool ############################################################################################
-set(LLVM_LINK_COMPONENTS
-    lgcdis
-    AMDGPUDisassembler
-    Support
-)
-
 add_llvm_tool(lgcdis
     lgcdis.cpp
 )
 
-add_dependencies(lgcdis LLVMlgcdis)
+llvm_map_components_to_libnames(llvm_libs
+    lgcdis
+    AMDGPUDisassembler
+    Support
+)
+target_link_libraries(lgcdis PUBLIC ${llvm_libs})
 
 target_include_directories(lgcdis
 PRIVATE


### PR DESCRIPTION
This fixes the build of lgc and lgcdis when LLVM is compiled as a
shared library.

The underlying issue is that the lgc and lgcdis *libraries* are not
linked into the libLLVM-*.so, but the LLVM_LINK_COMPONENTS mechanism
assumes that they are.