### PR TITLE
[CI] Migrate to gcloud Artifact Registry

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         host-os:        ["ubuntu-20.04"]
-        image-template: ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
+        image-template: ["us-docker.pkg.dev/stadia-open-source/amdvlk-public-ci/amdvlk_%s%s:nightly"]
         branch:         [dev]
         config:         [Release]
         feature-set:    ["+gcc", "+gcc+assertions",

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         host-os:             ["ubuntu-20.04"]
-        image-template:      ["gcr.io/stadia-open-source/amdvlk_%s%s:nightly"]
+        image-template:      ["us-docker.pkg.dev/stadia-open-source/amdvlk-public-ci/amdvlk_%s%s:nightly"]
         config:              [Release]
         feature-set:         ["+gcc", "+gcc+assertions",
                               "+clang", "+clang+coverage",

--- a/.github/workflows/check-clang-tidy-llpc.yml
+++ b/.github/workflows/check-clang-tidy-llpc.yml
@@ -15,7 +15,8 @@ jobs:
           git checkout ${GITHUB_SHA}
       - name: Generate Docker base image tag string
         run: |
-          echo "IMAGE_TAG=gcr.io/stadia-open-source/amdvlk_release_clang:nightly" | tee -a $GITHUB_ENV
+          echo "IMAGE_TAG=us-docker.pkg.dev/stadia-open-source/amdvlk-public-ci/amdvlk_release_clang:nightly" \
+            | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
         run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker

--- a/docker/llpc-clang-tidy.Dockerfile
+++ b/docker/llpc-clang-tidy.Dockerfile
@@ -1,13 +1,13 @@
 #
 # Dockerfile for LLPC Continuous Integration.
 # Sample invocation:
-#    docker build . --file docker/llpc-clang-tidy.Dockerfile                                  \
-#                   --build-arg AMDVLK_IMAGE=gcr.io/stadia-open-source/amdvlk:nightly         \
-#                   --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                           \
-#                   --build-arg LLPC_REPO_REF=<GIT_REF>                                       \
-#                   --build-arg LLPC_REPO_SHA=<GIT_SHA>                                       \
-#                   --build-arg LLPC_BASE_REF=<GIT_REF>                                       \
-#                   --tag llpc-ci/llpc
+#    docker build .                                                                                         \
+#      --file docker/llpc-clang-tidy.Dockerfile                                                             \
+#      --build-arg AMDVLK_IMAGE=us-docker.pkg.dev/stadia-open-source/amdvlk-public-ci/clang_release:nightly \
+#      --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                                                      \
+#      --build-arg LLPC_REPO_REF=<GIT_REF>                                                                  \
+#      --build-arg LLPC_REPO_SHA=<GIT_SHA>                                                                  \
+#      --tag llpc-ci/llpc
 #
 # Required arguments:
 # - AMDVLK_IMAGE: Base image name for prebuilt amdvlk

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -1,13 +1,14 @@
 #
 # Dockerfile for LLPC Continuous Integration.
 # Sample invocation:
-#    docker build . --file docker/llpc.Dockerfile                                             \
-#                   --build-arg AMDVLK_IMAGE=gcr.io/stadia-open-source/amdvlk:nightly         \
-#                   --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                           \
-#                   --build-arg LLPC_REPO_REF=<GIT_REF>                                       \
-#                   --build-arg LLPC_REPO_SHA=<GIT_SHA>                                       \
-#                   --build-arg FEATURES="+coverage"                                          \
-#                   --tag llpc-ci/llpc
+#    docker build .                                                                                       \
+#      --file docker/llpc.Dockerfile                                                                      \
+#      --build-arg AMDVLK_IMAGE=us-docker.pkg.dev/stadia-open-source/amdvlk-public-ci/gcc_release:nightly \
+#      --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                                                    \
+#      --build-arg LLPC_REPO_REF=<GIT_REF>                                                                \
+#      --build-arg LLPC_REPO_SHA=<GIT_SHA>                                                                \
+#      --build-arg FEATURES="+coverage"                                                                   \
+#      --tag llpc-ci/llpc
 #
 # Required arguments:
 # - AMDVLK_IMAGE: Base image name for prebuilt amdvlk


### PR DESCRIPTION
Container Registries have been deprecated:
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr,
so switch to the Artifact Registry.

The biggest difference for us is that AR allows for
multiple repositories per project. And unline CR, it is supported by
the gcloud python API.

I copied all historical images over and will do a cleanup once all CI
workflows have been migrated.