### PR TITLE
Use GlobalVariable instead of AllocaInst for NonWritable variables

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4071,29 +4071,6 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpVariable>(SPIRVValue *con
   else if (storageClass == SPIRVStorageClassKind::StorageClassWorkgroup)
     initializer = UndefValue::get(varType);
 
-  if (storageClass == StorageClassFunction) {
-    assert(getBuilder()->GetInsertBlock());
-
-    // Entry block allocas should appear at the start of the basic block so that if the entry block is split by
-    // function inlining or other transforms later on, the allocas stay in the entry block.
-    //
-    // Note that as of this writing, SPIR-V doesn't have the equivalent of C's alloca() builtin, so all allocas
-    // should be entry block allocas.
-    auto insertPoint = getBuilder()->saveIP();
-    BasicBlock *bb = getBuilder()->GetInsertBlock();
-    assert(bb->isEntryBlock());
-    getBuilder()->SetInsertPoint(bb, bb->getFirstInsertionPt());
-
-    Value *const var = getBuilder()->CreateAlloca(varType, nullptr, spvVar->getName());
-
-    getBuilder()->restoreIP(insertPoint);
-
-    if (initializer)
-      getBuilder()->CreateStore(initializer, var);
-
-    return var;
-  }
-
   bool readOnly = false;
 
   switch (storageClass) {
@@ -4140,6 +4117,29 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpVariable>(SPIRVValue *con
 
     if (allReadOnly)
       readOnly = true;
+  }
+
+  if (!readOnly && storageClass == StorageClassFunction) {
+    assert(getBuilder()->GetInsertBlock());
+
+    // Entry block allocas should appear at the start of the basic block so that if the entry block is split by
+    // function inlining or other transforms later on, the allocas stay in the entry block.
+    //
+    // Note that as of this writing, SPIR-V doesn't have the equivalent of C's alloca() builtin, so all allocas
+    // should be entry block allocas.
+    auto insertPoint = getBuilder()->saveIP();
+    BasicBlock *bb = getBuilder()->GetInsertBlock();
+    assert(bb->isEntryBlock());
+    getBuilder()->SetInsertPoint(bb, bb->getFirstInsertionPt());
+
+    Value *const var = getBuilder()->CreateAlloca(varType, nullptr, spvVar->getName());
+
+    getBuilder()->restoreIP(insertPoint);
+
+    if (initializer)
+      getBuilder()->CreateStore(initializer, var);
+
+    return var;
   }
 
   string varName = spvVar->getName();


### PR DESCRIPTION
For function-scope non-writable variables, using a GlobalVariable is
preferable because it can be initialized statically. An AllocaInst has
to be initialized dynamically by generating StoreInsts to write the
initial value into it.