### PR TITLE
Change the interface of CreateLoadPushConstantsPtr

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -216,6 +216,12 @@ Type *Builder::getDescPtrTy(ResourceNodeType descType) {
   return getDescTy(descType)->getPointerTo(ADDR_SPACE_CONST);
 }
 
+// ====================================================================================================================
+// Get address space of constant memory.
+unsigned Builder::getAddrSpaceConst() {
+  return ADDR_SPACE_CONST;
+}
+
 // =====================================================================================================================
 // Get the type of a built-in. Where the built-in has a shader-defined array size (ClipDistance,
 // CullDistance, SampleMask), inOutInfo.GetArraySize() is used as the array size.

--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -298,7 +298,7 @@ public:
                                 const llvm::Twine &instName) override final;
 
   // Create a load of the push constants pointer.
-  llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *pushConstantsTy, const llvm::Twine &instName) override final;
+  llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *returnTy, const llvm::Twine &instName) override final;
 
   // Create a buffer length query based on the specified descriptor.
   llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1099,11 +1099,10 @@ Value *BuilderRecorder::CreateGetDescPtr(ResourceNodeType descType, unsigned des
 // =====================================================================================================================
 // Create a load of the spill table pointer for push constants.
 //
-// @param pushConstantsTy : Type of the push constants table that the returned pointer will point to
+// @param returnTy : Return type of the load
 // @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreateLoadPushConstantsPtr(Type *pushConstantsTy, const Twine &instName) {
-  Type *resultTy = PointerType::get(pushConstantsTy, ADDR_SPACE_CONST);
-  return record(Opcode::LoadPushConstantsPtr, resultTy, {}, instName);
+Value *BuilderRecorder::CreateLoadPushConstantsPtr(Type *returnTy, const Twine &instName) {
+  return record(Opcode::LoadPushConstantsPtr, returnTy, {}, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -451,7 +451,7 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
                                        cast<ConstantInt>(args[2])->getZExtValue()); // binding
 
   case BuilderRecorder::Opcode::LoadPushConstantsPtr: {
-    return m_builder->CreateLoadPushConstantsPtr(call->getType()->getPointerElementType()); // pPushConstantsTy
+    return m_builder->CreateLoadPushConstantsPtr(call->getType()); // returnTy
   }
 
   case BuilderRecorder::Opcode::GetBufferDescLength: {

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -219,10 +219,9 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType descType, unsigned descSet
 // This returns a pointer to the ResourceNodeType::PushConst resource in the top-level user data table.
 // The type passed must have the correct size for the push constants.
 //
-// @param pushConstantsTy : Type of the push constants table that the returned pointer will point to
+// @param returnTy : Return type of the load
 // @param instName : Name to give instruction(s)
-Value *DescBuilder::CreateLoadPushConstantsPtr(Type *pushConstantsTy, const Twine &instName) {
-  Type *returnTy = pushConstantsTy->getPointerTo(ADDR_SPACE_CONST);
+Value *DescBuilder::CreateLoadPushConstantsPtr(Type *returnTy, const Twine &instName) {
   const bool isIndirect = getPipelineState()->getOptions().resourceLayoutScheme == ResourceLayoutScheme::Indirect;
   if (isIndirect) {
     // Push const is the sub node of DescriptorTableVaPtr.

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -363,7 +363,7 @@ public:
   llvm::Value *CreateGetDescPtr(ResourceNodeType descType, unsigned descSet, unsigned binding,
                                 const llvm::Twine &instName) override final;
 
-  llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *pushConstantsTy, const llvm::Twine &instName) override final;
+  llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *returnTy, const llvm::Twine &instName) override final;
 
   llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
                                          const llvm::Twine &instName = "") override final;

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -720,6 +720,9 @@ public:
   // @param descType : Descriptor type, one of the ResourceNodeType values
   llvm::Type *getDescPtrTy(ResourceNodeType descType);
 
+  // Get address space of constant memory.
+  unsigned getAddrSpaceConst();
+
   // Create a get of the stride (in bytes) of a descriptor. Returns an i32 value.
   //
   // @param descType : Descriptor type, one of ResourceNodeType::DescriptorSampler, DescriptorResource,
@@ -744,9 +747,9 @@ public:
   // Create a load of the push constants pointer.
   // This returns a pointer to the ResourceNodeType::PushConst resource in the top-level user data table.
   //
-  // @param pushConstantsTy : Type that the returned pointer will point to
+  // @param returnTy : Return type of the load
   // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *pushConstantsTy, const llvm::Twine &instName = "") = 0;
+  virtual llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *returnTy, const llvm::Twine &instName = "") = 0;
 
   // Create a buffer length query based on the specified descriptor, subtracting an offset from the length. The result
   // is 0 for a null descriptor when allowNullDescriptor is enabled.

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1983,7 +1983,8 @@ void SpirvLowerGlobal::lowerPushConsts() {
       MDNode *metaNode = global.getMetadata(gSPIRVMD::PushConst);
       auto pushConstSize = mdconst::dyn_extract<ConstantInt>(metaNode->getOperand(0))->getZExtValue();
       Type *const pushConstantsType = ArrayType::get(m_builder->getInt8Ty(), pushConstSize);
-      Value *pushConstants = m_builder->CreateLoadPushConstantsPtr(pushConstantsType);
+      Value *pushConstants =
+          m_builder->CreateLoadPushConstantsPtr(pushConstantsType->getPointerTo(m_builder->getAddrSpaceConst()));
 
       auto addrSpace = pushConstants->getType()->getPointerAddressSpace();
       Type *const castType = global.getValueType()->getPointerTo(addrSpace);


### PR DESCRIPTION
 This change aims to avoid using getPointerElementTy (opaque pointers transition).

 Before this change CreateLoadPushConstantsPtr received (as first parameter) base type for
 return load type and later (inside CreateLoadPushConstantsPtr) pointer type was created.

 After this change the responsibility of creating pointer type to base type for load was moved
 to caller which is invoking CreateLoadPushConstantsPtr.