### PR TITLE
Use Int8Ty as pointee type for load of a buffer descriptor

### DIFF
--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -432,12 +432,12 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
 
   // Replayer implementations of DescBuilder methods
   case BuilderRecorder::Opcode::LoadBufferDesc: {
+    assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(call->getType(), m_builder->getInt8Ty()));
     return m_builder->CreateLoadBufferDesc(cast<ConstantInt>(args[0])->getZExtValue(), // descSet
                                            cast<ConstantInt>(args[1])->getZExtValue(), // binding
                                            args[2],                                    // pDescIndex
                                            cast<ConstantInt>(args[3])->getZExtValue(), // flags
-                                           isa<PointerType>(call->getType()) ? call->getType()->getPointerElementType()
-                                                                             : nullptr); // pPointeeTy
+                                           m_builder->getInt8Ty());                    // pPointeeTy
   }
 
   case BuilderRecorder::Opcode::GetDescStride:


### PR DESCRIPTION
 Right now for all loads of a buffer descriptor Int8Ty type is used.
 Additionally this change is removing need to use getPointerElementTy,
 which is needed for opaque-pointer transition.