### PR TITLE
Fix crash when dumping ELF with empty map entry

### DIFF
--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -376,7 +376,10 @@ template <class Elf> bool ElfReader<Elf>::getNextMsgNode() {
     curIter.mapIt = map->begin();
     curIter.mapEnd = map->end();
     m_msgPackMapLevel++;
-    curIter.status = MsgPackIteratorMapPair;
+    if (curIter.mapIt == curIter.mapEnd)
+      curIter.status = MsgPackIteratorMapEnd;
+    else
+      curIter.status = MsgPackIteratorMapPair;
     m_iteratorStack.push_back(curIter);
     skipPostCheck = true;
   } else if (curIter.status == MsgPackIteratorMapPair) {


### PR DESCRIPTION
Recently PAL has a change on pipeline ABI, and our internal compiler
may generate ELF with an empty map entry.

This commit deal with that case by skipping the empty map.