### PR TITLE
Handle empty map types in MessagePack iterator.

### DIFF
--- a/util/vkgcElfReader.cpp
+++ b/util/vkgcElfReader.cpp
@@ -376,7 +376,11 @@ template <class Elf> bool ElfReader<Elf>::getNextMsgNode() {
     curIter.mapIt = map->begin();
     curIter.mapEnd = map->end();
     m_msgPackMapLevel++;
-    curIter.status = MsgPackIteratorMapPair;
+    if (curIter.mapIt == curIter.mapEnd) {
+      // Empty map.
+      curIter.status = MsgPackIteratorMapEnd;
+    } else
+      curIter.status = MsgPackIteratorMapPair;
     m_iteratorStack.push_back(curIter);
     skipPostCheck = true;
   } else if (curIter.status == MsgPackIteratorMapPair) {


### PR DESCRIPTION
MessagePack reader cannot assume the next node after MapBegin is a MapPair.