### PR TITLE
Add SinkingPass after PatchBufferOp

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -87,6 +87,7 @@
 #include "llvm/Transforms/Scalar/SROA.h"
 #include "llvm/Transforms/Scalar/Scalarizer.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
+#include "llvm/Transforms/Scalar/Sink.h"
 #include "llvm/Transforms/Scalar/SpeculativeExecution.h"
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
@@ -204,6 +205,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
     fpm.addPass(PromotePass());
     fpm.addPass(ADCEPass());
     fpm.addPass(PatchBufferOp());
+    fpm.addPass(SinkingPass());
     fpm.addPass(InstCombinePass());
     fpm.addPass(SimplifyCFGPass());
     passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
@@ -216,6 +218,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
   } else {
     FunctionPassManager fpm;
     fpm.addPass(PatchBufferOp());
+    fpm.addPass(SinkingPass());
     fpm.addPass(InstCombinePass(2));
     passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
   }
@@ -346,6 +349,7 @@ void LegacyPatch::addPasses(PipelineState *pipelineState, legacy::PassManager &p
 
   // Patch buffer operations (must be after optimizations)
   passMgr.add(createLegacyPatchBufferOp());
+  passMgr.add(createSinkingPass());
   passMgr.add(createInstructionCombiningPass(2));
 
   // Fully prepare the pipeline ABI (must be after optimizations)


### PR DESCRIPTION
The intention is to allow us to stop running the IR SinkingPass as part
of the backend codegen pass pipeline, which is very unusual. Currently
SinkingPass seems to be required to clean up some of the IR generated by
PatchBufferOp so I have placed it there. In future it would be good to
remove it altogether, since it can have bad effects on register
pressure.