### PR TITLE
CMakeLists: Yet another iteration on getting dynamic linking right

### DIFF
--- a/lgc/tool/lgc/CMakeLists.txt
+++ b/lgc/tool/lgc/CMakeLists.txt
@@ -24,12 +24,7 @@
  #######################################################################################################################
 
 ### LGC Standalone Compiler ############################################################################################
-add_llvm_tool(lgc
-    lgc.cpp
-)
-
-llvm_map_components_to_libnames(llvm_libs
-    lgc
+set(LLVM_LINK_COMPONENTS
     Core
     AMDGPUAsmParser
     AMDGPUCodeGen
@@ -37,7 +32,15 @@ llvm_map_components_to_libnames(llvm_libs
     AsmParser
     Support
 )
-target_link_libraries(lgc PUBLIC ${llvm_libs})
+
+add_llvm_tool(lgc
+    lgc.cpp
+)
+
+# lgc is linked in separately to account for both static and dynamic library
+# builds.
+llvm_map_components_to_libnames(extra_llvm_libs lgc)
+target_link_libraries(lgc PRIVATE ${extra_llvm_libs})
 
 target_compile_definitions(lgc PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIAN_CPU)
 

--- a/lgc/tool/lgcdis/CMakeLists.txt
+++ b/lgc/tool/lgcdis/CMakeLists.txt
@@ -24,16 +24,19 @@
  #######################################################################################################################
 
 ### LGC disassembler tool ############################################################################################
+set(LLVM_LINK_COMPONENTS
+    AMDGPUDisassembler
+    Support
+)
+
 add_llvm_tool(lgcdis
     lgcdis.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs
-    lgcdis
-    AMDGPUDisassembler
-    Support
-)
-target_link_libraries(lgcdis PUBLIC ${llvm_libs})
+# lgcdis is linked in separately to account for both static and dynamic library
+# builds.
+llvm_map_components_to_libnames(extra_llvm_libs lgcdis)
+target_link_libraries(lgcdis PRIVATE ${extra_llvm_libs})
 
 target_include_directories(lgcdis
 PRIVATE

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -89,32 +89,41 @@ if(ICD_BUILD_LLPC)
     # Export the LLVM build path so that it's available in XGL.
     set(XGL_LLVM_BUILD_PATH ${XGL_LLVM_BUILD_PATH} PARENT_SCOPE)
 
-    llvm_map_components_to_libnames(llvm_libs
-        lgc
-        AMDGPUAsmParser
-        AMDGPUCodeGen
-        AMDGPUDisassembler
-        AMDGPUInfo
-        Analysis
-        BinaryFormat
-        Core
-        Coroutines
-        LTO
-        ipo
-        BitReader
-        BitWriter
-        CodeGen
-        InstCombine
-        IRReader
-        Linker
-        MC
-        Passes
-        ScalarOpts
-        Support
-        Target
-        TransformUtils
-    )
-    target_link_libraries(llpc PUBLIC ${llvm_libs})
+    if (LLVM_LINK_LLVM_DYLIB)
+        # Link dynamically against libLLVM-${version}.so
+        target_link_libraries(llpc PUBLIC LLVM)
+    else()
+        # Link statically against the required component libraries
+        llvm_map_components_to_libnames(llvm_libs
+            AMDGPUAsmParser
+            AMDGPUCodeGen
+            AMDGPUDisassembler
+            AMDGPUInfo
+            Analysis
+            BinaryFormat
+            Core
+            Coroutines
+            LTO
+            ipo
+            BitReader
+            BitWriter
+            CodeGen
+            InstCombine
+            IRReader
+            Linker
+            MC
+            Passes
+            ScalarOpts
+            Support
+            Target
+            TransformUtils
+        )
+        target_link_libraries(llpc PUBLIC ${llvm_libs})
+    endif()
+
+    # Always link statically against libLLVMlgc
+    llvm_map_components_to_libnames(extra_llvm_libs lgc)
+    target_link_libraries(llpc PUBLIC ${extra_llvm_libs})
 endif()
 
 ### Compiler Options ###################################################################################################
@@ -326,33 +335,9 @@ target_include_directories(llpc_standalone_compiler PUBLIC
     ${LLVM_INCLUDE_DIRS}
 )
 
-llvm_map_components_to_libnames(llvm_libs
-    lgc
-    aggressiveinstcombine
-    amdgpuasmparser
-    amdgpucodegen
-    amdgpudisassembler
-    amdgpuinfo
-    analysis
-    asmparser
-    bitreader
-    bitwriter
-    codegen
-    coroutines
-    ipo
-    irreader
-    linker
-    LTO
-    mc
-    passes
-    support
-    target
-    transformutils
-)
 target_link_libraries(llpc_standalone_compiler PUBLIC
     cwpack
     llpc
-    ${llvm_libs}
     metrohash
     spvgen_static
     vfx


### PR DESCRIPTION
This partially reverts commit c38b3beaa6aac8ab574e0c13b548a6d3d61bac05
and replaces it with a more explicit approach.

There are really two key underlying issues:

- lgc is treated partially as an LLVM component library but isn't linked
  into libLLVM-${version}.so. This is as it should be.
- llvm_map_components_to_libnames is really designed to be used together
  with the add_llvm_{executable,library} macros which we don't use
  consistently. These take care of choosing between dynamic vs. static
  linking for LLVM. We do this manually for llpc in this change.