### PR TITLE
Use Patch::getLdsVariable instead of LegacyPatch::getLdsVariable

### DIFF
--- a/lgc/patch/NggLdsManager.cpp
+++ b/lgc/patch/NggLdsManager.cpp
@@ -126,7 +126,7 @@ NggLdsManager::NggLdsManager(Module *module, PipelineState *pipelineState, IRBui
   //
   // Create global variable modeling LDS
   //
-  m_lds = LegacyPatch::getLdsVariable(m_pipelineState, module);
+  m_lds = Patch::getLdsVariable(m_pipelineState, module);
 
   memset(&m_ldsRegionStart, InvalidValue, sizeof(m_ldsRegionStart)); // Initialized to invalid value (0xFFFFFFFF)
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -230,7 +230,7 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
   }
 
   if (m_pipelineState->isGsOnChip())
-    m_lds = LegacyPatch::getLdsVariable(m_pipelineState, &module);
+    m_lds = Patch::getLdsVariable(m_pipelineState, &module);
   else
     m_gsVsRingBufDesc = loadGsVsRingBufferDescriptor(builder);
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -157,7 +157,7 @@ bool PatchInOutImportExport::runImpl(Module &module, PipelineShadersResult &pipe
   // Create the global variable that is to model LDS
   // NOTE: ES -> GS ring is always on-chip on GFX9.
   if (m_hasTs || (m_hasGs && (m_pipelineState->isGsOnChip() || m_gfxIp.major >= 9)))
-    m_lds = LegacyPatch::getLdsVariable(m_pipelineState, m_module);
+    m_lds = Patch::getLdsVariable(m_pipelineState, m_module);
 
   // Set buffer formats based on specific GFX
   static const std::array<unsigned char, 4> BufferFormatsGfx9 = {


### PR DESCRIPTION
Just a minor no-op cleanup to remove uses of LegacyPatch:
LegacyPath::getLdsVariable is actually the same as Patch::getLdsVariable
via inheritance.