### PR TITLE
Change builder methods to use CreateNamedCall instead of emitCall

### DIFF
--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1926,7 +1926,7 @@ Value *ImageBuilder::handleFragCoordViewIndex(Value *coord, unsigned flags, unsi
     std::string callName = lgcName::InputImportBuiltIn;
     Type *builtInTy = FixedVectorType::get(getFloatTy(), 4);
     addTypeMangling(builtInTy, {}, callName);
-    Value *fragCoord = emitCall(callName, builtInTy, getInt32(BuiltInFragCoord), {}, &*GetInsertPoint());
+    Value *fragCoord = CreateNamedCall(callName, builtInTy, getInt32(BuiltInFragCoord), {});
     fragCoord->setName("FragCoord");
     fragCoord = CreateShuffleVector(fragCoord, fragCoord, ArrayRef<int>{0, 1});
     fragCoord = CreateFPToSI(fragCoord, FixedVectorType::get(getInt32Ty(), 2));
@@ -1966,7 +1966,7 @@ Value *ImageBuilder::handleFragCoordViewIndex(Value *coord, unsigned flags, unsi
     std::string callName = lgcName::InputImportBuiltIn;
     Type *builtInTy = getInt32Ty();
     addTypeMangling(builtInTy, {}, callName);
-    Value *viewIndex = emitCall(callName, builtInTy, getInt32(BuiltInViewIndex), {}, &*GetInsertPoint());
+    Value *viewIndex = CreateNamedCall(callName, builtInTy, getInt32(BuiltInViewIndex), {});
     viewIndex->setName("ViewIndex");
     coord = CreateInsertElement(coord, viewIndex, 2);
   }

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -111,7 +111,7 @@ Value *InOutBuilder::CreateReadPerVertexInput(Type *resultTy, unsigned location,
         vertexIndex,
     });
     addTypeMangling(resultTy, args, callName);
-    return emitCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn}, &*GetInsertPoint());
+    return CreateNamedCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn});
   };
 
   unsigned oddOffset = 0, evenOffset = 0;
@@ -286,7 +286,7 @@ Value *InOutBuilder::readGenericInputOutput(bool isOutput, Type *resultTy, unsig
 
   std::string callName(baseCallName);
   addTypeMangling(resultTy, args, callName);
-  Value *result = emitCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn}, &*GetInsertPoint());
+  Value *result = CreateNamedCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn});
 
   result->setName(instName);
   return result;
@@ -376,7 +376,7 @@ Instruction *InOutBuilder::CreateWriteGenericOutput(Value *valueToWrite, unsigne
 
   std::string llpcCallName = lgcName::OutputExportGeneric;
   addTypeMangling(nullptr, args, llpcCallName);
-  return emitCall(llpcCallName, getVoidTy(), args, {}, &*GetInsertPoint());
+  return CreateNamedCall(llpcCallName, getVoidTy(), args, {});
 }
 
 // =====================================================================================================================
@@ -573,8 +573,8 @@ Value *InOutBuilder::modifyAuxInterpValue(Value *auxInterpValue, InOutInfo input
         resUsage->builtInUsage.fs.centroid = true;
       }
 
-      auxInterpValue = emitCall(evalInstName, FixedVectorType::get(getFloatTy(), 2), {evalArg}, Attribute::ReadOnly,
-                                &*GetInsertPoint());
+      auxInterpValue =
+          CreateNamedCall(evalInstName, FixedVectorType::get(getFloatTy(), 2), {evalArg}, Attribute::ReadOnly);
     } else {
       // Generate code to evaluate the I,J coordinates.
       if (inputInfo.getInterpLoc() == InOutInfo::InterpLocSample)
@@ -741,7 +741,7 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
   args.push_back(getInt32(streamId));
   args.push_back(valueToWrite);
   addTypeMangling(nullptr, args, instName);
-  return emitCall(instName, getVoidTy(), args, {}, &*GetInsertPoint());
+  return CreateNamedCall(instName, getVoidTy(), args, {});
 }
 
 // =====================================================================================================================
@@ -863,7 +863,7 @@ Value *InOutBuilder::readBuiltIn(bool isOutput, BuiltInKind builtIn, InOutInfo i
   std::string callName = isOutput ? lgcName::OutputImportBuiltIn : lgcName::InputImportBuiltIn;
   callName += PipelineState::getBuiltInName(builtIn);
   addTypeMangling(resultTy, args, callName);
-  Value *result = emitCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn}, &*GetInsertPoint());
+  Value *result = CreateNamedCall(callName, resultTy, args, {Attribute::ReadOnly, Attribute::WillReturn});
 
   if (instName.isTriviallyEmpty())
     result->setName(PipelineState::getBuiltInName(builtIn));
@@ -1151,7 +1151,7 @@ Instruction *InOutBuilder::CreateWriteBuiltInOutput(Value *valueToWrite, BuiltIn
   std::string callName = lgcName::OutputExportBuiltIn;
   callName += PipelineState::getBuiltInName(builtIn);
   addTypeMangling(nullptr, args, callName);
-  return cast<Instruction>(emitCall(callName, getVoidTy(), args, {}, &*GetInsertPoint()));
+  return cast<Instruction>(CreateNamedCall(callName, getVoidTy(), args, {}));
 }
 
 // =====================================================================================================================
@@ -1167,7 +1167,7 @@ Value *InOutBuilder::CreateReadTaskPayload(Type *resultTy, Value *byteOffset, co
 
   std::string callName = lgcName::MeshTaskReadTaskPayload;
   addTypeMangling(resultTy, byteOffset, callName);
-  return emitCall(callName, resultTy, byteOffset, {}, &*GetInsertPoint());
+  return CreateNamedCall(callName, resultTy, byteOffset, {});
 }
 
 // =====================================================================================================================
@@ -1182,7 +1182,7 @@ Instruction *InOutBuilder::CreateWriteTaskPayload(Value *valueToWrite, Value *by
 
   std::string callName = lgcName::MeshTaskWriteTaskPayload;
   addTypeMangling(nullptr, {byteOffset, valueToWrite}, callName);
-  return emitCall(callName, getVoidTy(), {byteOffset, valueToWrite}, {}, &*GetInsertPoint());
+  return CreateNamedCall(callName, getVoidTy(), {byteOffset, valueToWrite}, {});
 }
 
 // =====================================================================================================================

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -49,7 +49,7 @@ Instruction *MiscBuilder::CreateEmitVertex(unsigned streamId) {
   // Get GsWaveId
   std::string callName = lgcName::InputImportBuiltIn;
   callName += "GsWaveId.i32.i32";
-  Value *gsWaveId = emitCall(callName, getInt32Ty(), getInt32(BuiltInGsWaveId), {}, &*GetInsertPoint());
+  Value *gsWaveId = CreateNamedCall(callName, getInt32Ty(), getInt32(BuiltInGsWaveId), {});
 
   // Do the sendmsg.
   // [9:8] = stream, [5:4] = 2 (emit), [3:0] = 2 (GS)
@@ -67,7 +67,7 @@ Instruction *MiscBuilder::CreateEndPrimitive(unsigned streamId) {
   // Get GsWaveId
   std::string callName = lgcName::InputImportBuiltIn;
   callName += "GsWaveId.i32.i32";
-  Value *gsWaveId = emitCall(callName, getInt32Ty(), getInt32(BuiltInGsWaveId), {}, &*GetInsertPoint());
+  Value *gsWaveId = CreateNamedCall(callName, getInt32Ty(), getInt32(BuiltInGsWaveId), {});
 
   // Do the sendmsg.
   // [9:8] = stream, [5:4] = 1 (cut), [3:0] = 2 (GS)
@@ -128,8 +128,7 @@ Value *MiscBuilder::CreateIsHelperInvocation(const Twine &instName) {
 Instruction *MiscBuilder::CreateEmitMeshTasks(Value *groupCountX, Value *groupCountY, Value *groupCountZ,
                                               const Twine &instName) {
   assert(m_shaderStage == ShaderStageTask); // Only valid for task shader
-  return emitCall(lgcName::MeshTaskEmitMeshTasks, getVoidTy(), {groupCountX, groupCountY, groupCountZ}, {},
-                  &*GetInsertPoint());
+  return CreateNamedCall(lgcName::MeshTaskEmitMeshTasks, getVoidTy(), {groupCountX, groupCountY, groupCountZ}, {});
 }
 
 // =====================================================================================================================
@@ -142,7 +141,7 @@ Instruction *MiscBuilder::CreateEmitMeshTasks(Value *groupCountX, Value *groupCo
 // @returns Instruction to set the actual size of mesh outputs
 Instruction *MiscBuilder::CreateSetMeshOutputs(Value *vertexCount, Value *primitiveCount, const Twine &instName) {
   assert(m_shaderStage == ShaderStageMesh); // Only valid for mesh shader
-  return emitCall(lgcName::MeshTaskSetMeshOutputs, getVoidTy(), {vertexCount, primitiveCount}, {}, &*GetInsertPoint());
+  return CreateNamedCall(lgcName::MeshTaskSetMeshOutputs, getVoidTy(), {vertexCount, primitiveCount}, {});
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
emitCall is just a thin wrapper around the builder method
CreateNamedCall. It is simpler for builder methods to call
CreateNamedCall directly.