### PR TITLE
lgc/patch: Add more `const` in PatchInOutImportExport

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -371,7 +371,7 @@ struct ResourceUsage {
     struct {
       // Map from IDs of built-in outputs to locations of generic outputs (used by copy shader to export built-in
       // outputs to fragment shader, always from vertex stream 0)
-      std::unordered_map<unsigned, unsigned> builtInOutLocs;
+      std::map<unsigned, unsigned> builtInOutLocs;
 
       // Map from tightly packed locations to byte sizes of generic outputs (used by copy shader to
       // export generic outputs to fragment shader, always from vertex stream 0):


### PR DESCRIPTION
This fell out of a review of this pass's place in the compilation
pipeline.

Unify some relatively redundant code paths. ResourceUsage::inOutUsage.gs.builtInOutLocs
becomes a std::map for consistency. This actually fixes a potential issue:
that map is fed into the cache hash calculations, so it's better
to use a map with guaranteed deterministic ordering.