### PR TITLE
lgc/patch: Fix an outdated comment

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -148,7 +148,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
   // Run IPSCCP before EntryPointMutate to avoid adding unnecessary arguments to an entry point.
   passMgr.addPass(IPSCCPPass());
 
-  // Patch entry-point mutation (should be done before external library link)
+  // Patch entry-point mutation
   passMgr.addPass(PatchEntryPointMutate());
 
   // Patch workgroup memory initializaion.


### PR DESCRIPTION
There hasn't been an external bitcode library to link against for a
while now..