### PR TITLE
Remove PatchBufferOp handling for array stores

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1540,25 +1540,13 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
   if (!isLoad) {
     storeValue = storeInst->getValueOperand();
     Type *storeTy = storeValue->getType();
-    if (storeTy->isArrayTy()) {
-      const unsigned elemCount = cast<ArrayType>(storeTy)->getNumElements();
-      Value *castValue = UndefValue::get(castType);
-      for (unsigned elemIdx = 0; elemIdx != elemCount; ++elemIdx) {
-        Value *elem = m_builder->CreateExtractValue(storeValue, elemIdx);
-        elem = m_builder->CreateBitCast(elem, smallestType);
-        castValue = m_builder->CreateInsertElement(castValue, elem, elemIdx);
-      }
-      storeValue = castValue;
-      copyMetadata(storeValue, storeInst);
-    } else {
-      if (storeTy->isPointerTy()) {
-        storeValue = m_builder->CreatePtrToInt(storeValue, m_builder->getIntNTy(bytesToHandle * 8));
-        copyMetadata(storeValue, storeInst);
-      }
-
-      storeValue = m_builder->CreateBitCast(storeValue, castType);
+    if (storeTy->isPointerTy()) {
+      storeValue = m_builder->CreatePtrToInt(storeValue, m_builder->getIntNTy(bytesToHandle * 8));
       copyMetadata(storeValue, storeInst);
     }
+
+    storeValue = m_builder->CreateBitCast(storeValue, castType);
+    copyMetadata(storeValue, storeInst);
   }
 
   // The index in pStoreValue which we use next


### PR DESCRIPTION
PatchBufferOp has special handling for stores of array type, but it
seems unsound because it assumes that the array element type and
smallestType are the same size. Apparently it is never used anyway so
remove it.