### PR TITLE
lgc: increase the effectiveness of the shader cache

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -130,6 +130,9 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
   // Patch resource collecting, remove inactive resources (should be the first preliminary pass)
   passMgr.addPass(PatchResourceCollect());
 
+  // Check shader cache
+  passMgr.addPass(PatchCheckShaderCache(std::move(checkShaderCacheFunc)));
+
   // Patch wave size adjusting heuristic
   passMgr.addPass(PatchWaveSizeAdjust());
 
@@ -163,9 +166,6 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
 
   // Patch loop metadata
   passMgr.addPass(createModuleToFunctionPassAdaptor(createFunctionToLoopPassAdaptor(PatchLoopMetadata())));
-
-  // Check shader cache
-  passMgr.addPass(PatchCheckShaderCache(std::move(checkShaderCacheFunc)));
 
   // Stop timer for patching passes and start timer for optimization passes.
   if (patchTimer) {


### PR DESCRIPTION
Two commits that aim to remove more code earlier when a shader cache hit is encountered. The overall diff is small, but I split this into separate patches for better testability and bisectability.