### PR TITLE
Add task shader support: Fix some issues that are found by tests

### DIFF
--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -69,6 +69,7 @@ const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invoca
 const static char SwizzleLocalInvocationId[] = "lgc.swizzle.local.invocation.id";
 const static char SwizzleWorkgroupId[] = "lgc.swizzle.workgroup.id";
 
+const static char MeshTaskCallPrefix[] = "lgc.mesh.task.";
 const static char MeshTaskReadTaskPayload[] = "lgc.mesh.task.read.task.payload";
 const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload";
 const static char MeshTaskEmitMeshTasks[] = "lgc.mesh.task.emit.mesh.tasks";

--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -89,8 +89,6 @@ private:
   bool m_accessTaskPayload = false;                 // Whether task shader has payload access operations
   llvm::Value *m_shaderRingEntryIndex = nullptr;    // Shader ring entry index of current workgroup
   llvm::Value *m_payloadRingEntryOffset = nullptr;  // Entry offset (in bytes) of the payload ring
-  llvm::Value *m_drawDataRingEntryOffset = nullptr; // Entry offset (in bytes) of the draw data ring
-  llvm::Value *m_drawDataReadyBit = nullptr;        // Flag indicating whether the draw data is ready for CP to fetch
 };
 
 } // namespace lgc

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1147,16 +1147,19 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       userDataArgs.push_back(UserDataArg(numWorkgroupsPtrTy, "numWorkgroupsPtr", UserDataMapping::Workgroup, nullptr));
     }
   } else if (m_shaderStage == ShaderStageTask) {
-    auto taskIntfData = m_pipelineState->getShaderInterfaceData(ShaderStageTask);
+    // Draw index.
+    if (userDataUsage->isSpecialUserDataUsed(UserDataMapping::DrawIndex))
+      specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "drawIndex", UserDataMapping::DrawIndex));
+
     specialUserDataArgs.push_back(UserDataArg(FixedVectorType::get(builder.getInt32Ty(), 3), "meshTaskDispatchDims",
                                               UserDataMapping::MeshTaskDispatchDims,
-                                              &taskIntfData->entryArgIdxs.task.dispatchDims));
+                                              &intfData->entryArgIdxs.task.dispatchDims));
     specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshTaskRingIndex",
                                               UserDataMapping::MeshTaskRingIndex,
-                                              &taskIntfData->entryArgIdxs.task.baseRingEntryIndex));
+                                              &intfData->entryArgIdxs.task.baseRingEntryIndex));
     specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshPipeStatsBuf",
                                               UserDataMapping::MeshPipeStatsBuf,
-                                              &taskIntfData->entryArgIdxs.task.pipeStatsBuf));
+                                              &intfData->entryArgIdxs.task.pipeStatsBuf));
   }
 
   // Allocate register for stream-out buffer table, to go before the user data node args (unlike all the ones

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -69,6 +69,12 @@ const char *ShaderInputs::getSpecialUserDataName(UserDataMapping kind) {
     return "VertexBufferTable";
   case UserDataMapping::NggCullingData:
     return "NggCullingData";
+  case UserDataMapping::MeshTaskDispatchDims:
+    return "MeshTaskDispatchDims";
+  case UserDataMapping::MeshTaskRingIndex:
+    return "MeshTaskRingIndex";
+  case UserDataMapping::MeshPipeStatsBuf:
+    return "MeshPipeStatsBuf";
   default:
     return "";
   }
@@ -83,6 +89,8 @@ CallInst *ShaderInputs::getSpecialUserData(UserDataMapping kind, BuilderBase &bu
   Type *ty = builder.getInt32Ty();
   if (kind == UserDataMapping::NggCullingData)
     ty = builder.getInt64Ty();
+  else if (kind == UserDataMapping::MeshTaskDispatchDims)
+    ty = FixedVectorType::get(builder.getInt32Ty(), 3);
   else if (kind == UserDataMapping::Workgroup)
     ty = FixedVectorType::get(builder.getInt32Ty(), 3)->getPointerTo(ADDR_SPACE_CONST);
   return builder.CreateNamedCall((Twine(lgcName::SpecialUserData) + getSpecialUserDataName(kind)).str(), ty,


### PR DESCRIPTION
- DrawIndex is supposed to be supported in task shader. It was missing
  originally.
- Task payload with non 32-bit data types was not well handled. They
  ought to be lowered in middle-end since LLVM backend won't support
  them as expected.
- Some shared codes that handling shader ring entry index calculation
  and shader ring buffer descriptor getting were not well placed.