### PR TITLE
Update tests for upstream llvm

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
@@ -1,14 +1,15 @@
 ; Test that the DescSet relocation is generated.  If this starts to fail we need to change the test to make sure it
 ; is generated.
 ; BEGIN_SHADERTEST
+; REQUIRES: do-not-run-me
 ; RUN: amdllpc \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %gfxip %s %s -v | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
 ; SHADERTEST: {{^_amdgpu_cs_main:}}
 ; SHADERTEST-NEXT: BB0_0:
-; SHADERTEST-NEXT: s_ashr_i32 {{s[0-9]*}}, descset_14@abs32@lo, 31
 ; SHADERTEST-NEXT: s_getpc_b64
+; SHADERTEST-NEXT: s_ashr_i32 {{s[0-9]*}}, descset_14@abs32@lo, 31
 ; SHADERTEST-NEXT: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, descset_14@abs32@lo
 ; The spill threshold in this case is 47 because it will have to load the descriptor table pointer from the root table.
 ; SHADERTEST: .spill_threshold: 0x000000000000002F
@@ -18,8 +19,8 @@
 ; BEGIN_SHADERTEST2
 ; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2: 0000000000000000 <_amdgpu_cs_main>:
-; SHADERTEST2-NEXT: s_ashr_i32 {{s[0-9]*}}, 0xbc, 31 // 000000000000
 ; SHADERTEST2-NEXT: s_getpc_b64
+; SHADERTEST2-NEXT: s_ashr_i32 {{s[0-9]*}}, 0xbc, 31 // 000000000004
 ; SHADERTEST2-NEXT: s_add_u32 {{s[0-9]*}}, {{s[0-9]*}}, 0xbc
 ; END_SHADERTEST2
 

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
@@ -1,12 +1,14 @@
 ; Test that the DescSet relocation is generated.  If this starts to fail we need to change the test to make sure it
 ; is generated.
 ; BEGIN_SHADERTEST
+; REQUIRES: do-not-run-me
 ; RUN: amdllpc \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %gfxip %s %s -v | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^//}} LLPC final ELF info
 ; SHADERTEST: {{^_amdgpu_cs_main:}}
 ; SHADERTEST-NEXT: BB0_0:
+; SHADERTEST-NEXT: s_getpc_b64
 ; SHADERTEST-NEXT: s_ashr_i32 {{s[0-9]*}}, descset_14@abs32@lo, 31
 ; The spill threshold in this case is 0 because it will have to load the descriptor from the root table.
 ; SHADERTEST: .spill_threshold: 0x0000000000000000
@@ -17,7 +19,8 @@
 ; BEGIN_SHADERTEST2
 ; RUN: llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST2 %s
 ; SHADERTEST2: 0000000000000000 <_amdgpu_cs_main>:
-; SHADERTEST2-NEXT: s_ashr_i32 {{s[0-9]*}}, 0, 31 // 000000000000
+; SHADERTEST2-NEXT: s_getpc_b64
+; SHADERTEST2-NEXT: s_ashr_i32 {{s[0-9]*}}, 0, 31 // 000000000004
 ; END_SHADERTEST2
 
 [Version]


### PR DESCRIPTION
The generated instructions are reordered with upstream llvm.
Disable the tests for now and re-enable them when llvm is updated.