### PR TITLE
Add mesh shader support: Correct the stage mask for ViewIndex

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1615,6 +1615,8 @@ unsigned InOutBuilder::getBuiltInValidMask(BuiltInKind builtIn, bool isOutput) {
     MVDG = shaderStageToMask(ShaderStageMesh, ShaderStageVertex, ShaderStageTessEval, ShaderStageGeometry),
     MVHDG = shaderStageToMask(ShaderStageMesh, ShaderStageVertex, ShaderStageTessControl, ShaderStageTessEval,
                               ShaderStageGeometry),
+    MVHDGP = shaderStageToMask(ShaderStageMesh, ShaderStageVertex, ShaderStageTessControl, ShaderStageTessEval,
+                               ShaderStageGeometry, ShaderStageFragment),
     N = 0,
     P = shaderStageToMask(ShaderStageFragment),
     T = shaderStageToMask(ShaderStageTask),

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -101,7 +101,7 @@ BUILTIN(TessCoord, 13, N, D, v3f32)                      // (u,v,w) coord of tes
 BUILTIN(TessLevelInner, 12, H, D, a2f32)                 // Tessellation inner levels
 BUILTIN(TessLevelOuter, 11, H, D, a4f32)                 // Tessellation outer levels
 BUILTIN(VertexIndex, 42, N, V, i32)                      // Index of current vertex
-BUILTIN(ViewIndex, 4440, N, VHDGP, i32)                  // View index
+BUILTIN(ViewIndex, 4440, N, MVHDGP, i32)                 // View index
 BUILTIN(ViewportIndex, 10, MVDG, P, i32)                 // Viewport index
 BUILTIN(WorkgroupId, 26, N, TMC, v3i32)                  // ID of global workgroup
 BUILTIN(WorkgroupSize, 25, N, TMC, v3i32)                // Size of global workgroup


### PR DESCRIPTION
ViewIndex could be used in mesh shader. The original stage mask is
incorrect.