### PR TITLE
Support the specific subgroupSize

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 54
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 7
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -81,8 +81,9 @@
 //  @page VersionHistory
 //  %Version History
 //  | %Version | Change Description                                                                                    |
-//  | -------- | ---------------------------------------------------------------------------------------------|
-//  |     54.1 | Add overrideForceThreadIdSwizzling overrideShaderThreadGroupSizeX, overrideShaderThreadGroupSizeY
+//  | -------- | ------------------------------------------------------------------------------------------------------|
+//  |     54.2 | Add subgroupSize to PipelineShaderOptions                                                             |
+//  |     54.1 | Add overrideForceThreadIdSwizzling overrideShaderThreadGroupSizeX, overrideShaderThreadGroupSizeY     |
 //  |          | and overrideShaderThreadGroupSizeZ  to PipelineShaderOptions                                          |
 //  |     54.0 | Add overrideThreadGroupSizeX, overrideThreadGroupSizeY and overrideThreadGroupSizeZ to PipelineOptions|
 //  |     53.7 | Add threadGroupSwizzleMode to PipelineOptions                                                         |
@@ -621,6 +622,8 @@ struct PipelineShaderOptions {
   /// disables limiting the number of thread-groups to launch. This field is ignored for graphics shaders.
   unsigned maxThreadGroupsPerComputeUnit;
 
+  unsigned subgroupSize;       ///< The number of invocations in each subgroup, it is a power-of-two. 0 means
+                               ///  the size is unspecified, the current reasonable value should be 32 or 64.
   unsigned waveSize;           ///< Control the number of threads per wavefront (GFX10+)
   bool wgpMode;                ///< Whether to choose WGP mode or CU mode (GFX10+)
   WaveBreakSize waveBreakSize; ///< Size of region to force the end of a wavefront (GFX10+).

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1049,7 +1049,7 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
     // gl_NumSubgroups = (workgroupSize + gl_SubGroupSize - 1) / gl_SubgroupSize
     auto &mode = m_pipelineState->getShaderModes()->getComputeShaderMode();
     unsigned workgroupSize = mode.workgroupSizeX * mode.workgroupSizeY * mode.workgroupSizeZ;
-    unsigned subgroupSize = m_pipelineState->getShaderWaveSize(m_shaderStage);
+    unsigned subgroupSize = m_pipelineState->getShaderSubgroupSize(m_shaderStage);
     unsigned numSubgroups = (workgroupSize + subgroupSize - 1) / subgroupSize;
     return getInt32(numSubgroups);
   }
@@ -1075,7 +1075,7 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
   case BuiltInSubgroupId: {
     // gl_SubgroupID = gl_LocationInvocationIndex / gl_SubgroupSize
     Value *localInvocationIndex = readCsBuiltIn(BuiltInLocalInvocationIndex);
-    unsigned subgroupSize = getPipelineState()->getShaderWaveSize(m_shaderStage);
+    unsigned subgroupSize = getPipelineState()->getShaderSubgroupSize(m_shaderStage);
     return CreateLShr(localInvocationIndex, getInt32(Log2_32(subgroupSize)));
   }
 

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -407,7 +407,11 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
 
     shaderOptions.waveSize = shaderInfo->options.waveSize;
     shaderOptions.wgpMode = shaderInfo->options.wgpMode;
-    if (!shaderInfo->options.allowVaryWaveSize) {
+
+    // If subgroupSize is specified, we should use the specified value.
+    if (shaderInfo->options.subgroupSize != 0)
+      shaderOptions.subgroupSize = shaderInfo->options.subgroupSize;
+    else if (!shaderInfo->options.allowVaryWaveSize) {
       // allowVaryWaveSize is disabled, so use -subgroup-size (default 64) to override the wave
       // size for a shader that uses gl_SubgroupSize.
       shaderOptions.subgroupSize = SubgroupSize;


### PR DESCRIPTION
VK_EXT_subgroup_size_control optionally allows applications to force a

specific subgroup size, which means we must use the value when

subgroupSize is set.

Currently waveSize and subgroupSize should be the same, replacing

'getShaderWaveSize' with 'getShaderSubgroupSize' to get the value of

subgroupSize looks cleaner.

Signed-off-by: dwang102 <dong.wang@amd.com>