### PR TITLE
Add mesh shader support: Add new resource usage and interface data

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -533,7 +533,7 @@ private:
 
   // Mark usage for a generic (user) input or output
   void markGenericInputOutputUsage(bool isOutput, unsigned location, unsigned locationCount, InOutInfo &inOutInfo,
-                                   llvm::Value *vertexIndex);
+                                   llvm::Value *vertexOrPrimIndex);
 
   // Mark interpolation info for FS input.
   void markInterpolationInfo(InOutInfo &interpInfo);

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -241,6 +241,30 @@ struct ResourceUsage {
         unsigned primitiveShadingRate : 1; // Whether gl_PrimitiveShadingRate is used
       } gs;
 
+      // Mesh shader
+      struct {
+        // Input
+        unsigned drawIndex : 1;            // Whether gl_DrawIDARB is used
+        unsigned viewIndex : 1;            // Whether gl_ViewIndex is used
+        unsigned numWorkgroups : 1;        // Whether gl_NumWorkGroups is used
+        unsigned workgroupId : 1;          // Whether gl_WorkGroupID is used
+        unsigned localInvocationId : 1;    // Whether gl_LocalInvocationID is used
+        unsigned globalInvocationId : 1;   // Whether gl_GlobalInvocationID is used
+        unsigned localInvocationIndex : 1; // Whether gl_LocalInvocationIndex is used
+        unsigned subgroupId : 1;           // Whether gl_SubgroupID is used
+        unsigned numSubgroups : 1;         // Whether gl_NumSubgroups is used
+        // Output
+        unsigned pointSize : 1;            // Whether gl_PointSize is used
+        unsigned position : 1;             // Whether gl_Position is used
+        unsigned clipDistance : 4;         // Array size gl_ClipDistance[] (0 means unused)
+        unsigned cullDistance : 4;         // Array size gl_CullDistance[] (0 means unused)
+        unsigned primitiveId : 1;          // Whether gl_PrimitiveID is used
+        unsigned viewportIndex : 1;        // Whether gl_ViewportIndex is used
+        unsigned layer : 1;                // Whether gl_Layer is used
+        unsigned cullPrimitive : 1;        // Whether gl_CullPrimitive is used
+        unsigned primitiveShadingRate : 1; // Whether gl_PrimitiveShadingRate is used
+      } mesh;
+
       // Fragment shader
       struct {
         // Interpolation
@@ -304,12 +328,18 @@ struct ResourceUsage {
     std::map<unsigned, unsigned> perPatchInputLocMap;
     std::map<unsigned, unsigned> perPatchOutputLocMap;
 
+    std::map<unsigned, unsigned> perPrimitiveInputLocMap;
+    std::map<unsigned, unsigned> perPrimitiveOutputLocMap;
+
     // Map from built-in IDs to specially assigned locations
     std::map<unsigned, unsigned> builtInInputLocMap;
     std::map<unsigned, unsigned> builtInOutputLocMap;
 
     std::map<unsigned, unsigned> perPatchBuiltInInputLocMap;
     std::map<unsigned, unsigned> perPatchBuiltInOutputLocMap;
+
+    std::map<unsigned, unsigned> perPrimitiveBuiltInInputLocMap;
+    std::map<unsigned, unsigned> perPrimitiveBuiltInOutputLocMap;
 
     // Transform feedback strides
     unsigned xfbStrides[MaxTransformFeedbackBuffers] = {};
@@ -326,8 +356,11 @@ struct ResourceUsage {
     unsigned outputMapLocCount = 0;
     unsigned perPatchInputMapLocCount = 0;
     unsigned perPatchOutputMapLocCount = 0;
+    unsigned perPrimitiveInputMapLocCount = 0;
+    unsigned perPrimitiveOutputMapLocCount = 0;
 
-    unsigned expCount = 0; // Export count (number of "exp" instructions) for generic outputs
+    unsigned expCount = 0;     // Export count (number of "exp" instructions) for generic per-vertex outputs
+    unsigned primExpCount = 0; // Export count (number of "exp" instructions) for generic per-primitive outputs
 
     struct {
       struct {
@@ -514,6 +547,15 @@ struct InterfaceData {
         unsigned viewIndex;                       // View Index
         StreamOutData streamOutData;              // Stream-out Data
       } gs;
+
+      // Mesh shader
+      struct {
+        unsigned drawIndex;          // Draw index
+        unsigned viewIndex;          // View index
+        unsigned dispatchDims;       // Dispatch dimensions
+        unsigned baseRingEntryIndex; // Base entry index (first workgroup) of mesh/task shader ring for current dispatch
+        unsigned pipeStatsBuf;       // Pipeline statistics buffer
+      } mesh;
 
       // Fragment shader
       struct {

--- a/lgc/patch/PatchCheckShaderCache.cpp
+++ b/lgc/patch/PatchCheckShaderCache.cpp
@@ -135,10 +135,14 @@ bool PatchCheckShaderCache::runImpl(Module &module, PipelineState *pipelineState
     streamMapEntries(resUsage->inOutUsage.outputLocInfoMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchInputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchOutputLocMap, stream);
+    streamMapEntries(resUsage->inOutUsage.perPrimitiveInputLocMap, stream);
+    streamMapEntries(resUsage->inOutUsage.perPrimitiveOutputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.builtInInputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.builtInOutputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchBuiltInInputLocMap, stream);
     streamMapEntries(resUsage->inOutUsage.perPatchBuiltInOutputLocMap, stream);
+    streamMapEntries(resUsage->inOutUsage.perPrimitiveBuiltInInputLocMap, stream);
+    streamMapEntries(resUsage->inOutUsage.perPrimitiveBuiltInOutputLocMap, stream);
 
     if (stage == ShaderStageGeometry) {
       // NOTE: For geometry shader, copy shader will use this special map info (from built-in outputs to

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1160,6 +1160,24 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
     specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshPipeStatsBuf",
                                               UserDataMapping::MeshPipeStatsBuf,
                                               &intfData->entryArgIdxs.task.pipeStatsBuf));
+  } else if (m_shaderStage == ShaderStageMesh) {
+    if (m_pipelineState->getShaderResourceUsage(ShaderStageMesh)->builtInUsage.mesh.drawIndex) {
+      specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "drawIndex", UserDataMapping::DrawIndex,
+                                                &intfData->entryArgIdxs.mesh.drawIndex));
+    }
+    if (m_pipelineState->getInputAssemblyState().enableMultiView) {
+      specialUserDataArgs.push_back(
+          UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.mesh.viewIndex));
+    }
+    specialUserDataArgs.push_back(UserDataArg(FixedVectorType::get(builder.getInt32Ty(), 3), "meshTaskDispatchDims",
+                                              UserDataMapping::MeshTaskDispatchDims,
+                                              &intfData->entryArgIdxs.mesh.dispatchDims));
+    specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshTaskRingIndex",
+                                              UserDataMapping::MeshTaskRingIndex,
+                                              &intfData->entryArgIdxs.mesh.baseRingEntryIndex));
+    specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "meshPipeStatsBuf",
+                                              UserDataMapping::MeshPipeStatsBuf,
+                                              &intfData->entryArgIdxs.mesh.pipeStatsBuf));
   }
 
   // Allocate register for stream-out buffer table, to go before the user data node args (unlike all the ones

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -611,6 +611,10 @@ uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage
     sgprInputDescs = GsSgprInputs;
     vgprInputDescs = GsVgprInputs;
     break;
+  case ShaderStageMesh:
+    // NOTE: Mesh shader is finally mapped to HW GS in fast launch mode. Therefore, we don't add SGPR and VGPR inputs
+    // here. Instead, this is deferred to mesh shader lowering in later phase.
+    break;
   case ShaderStageFragment:
     sgprInputDescs = FsSgprInputs;
     vgprInputDescs = FsVgprInputs;

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -354,7 +354,7 @@ Value *ShaderSystemValues::getMeshPipeStatsBufPtr() {
       entryArgIdx = intfData->entryArgIdxs.task.pipeStatsBuf;
       break;
     case ShaderStageMesh:
-      llvm_unreachable("Not implemented!");
+      entryArgIdx = intfData->entryArgIdxs.mesh.pipeStatsBuf;
       break;
     default:
       llvm_unreachable("Should never be called!");


### PR DESCRIPTION
- Add new resource usage. Record the built-in usage of mesh shader
  built-in inputs and outputs.

- Add new interface data. Mesh shader and fragment shader now have to
  record per-primitive outputs and inputs (both for generic ones and
  for built-in ones). This will be used later when we handling inputs
  and outputs.

- Add new entry-point arguments for mesh shader. We currently need
  draw index, view index, dispatch dimensions, base payload ring entry
  index, mesh pipeline statistics buffer address. In the future, we need
  vertex index as an extra argument. The vertex index is to emulate
  flattened workgroup ID for mesh shader (mapped to VGPR v5).

- Map current mesh shader entry-point arguments to user data SGPRs.