### PR TITLE
Add mesh shader support: Support mesh shader built-in input 

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -108,6 +108,8 @@ private:
                                           llvm::Value *vertexIdx, llvm::Instruction *insertPos);
   llvm::Value *patchGsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *vertexIdx,
                                          llvm::Instruction *insertPos);
+  llvm::Value *patchMeshBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,
+                                           llvm::Instruction *insertPos);
   llvm::Value *patchFsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *sampleId,
                                          llvm::Instruction *insertPos);
   llvm::Value *getSamplePosOffset(llvm::Type *inputTy, llvm::Value *sampleId, llvm::Instruction *insertPos);

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -74,6 +74,7 @@ const static char MeshTaskReadTaskPayload[] = "lgc.mesh.task.read.task.payload";
 const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload";
 const static char MeshTaskEmitMeshTasks[] = "lgc.mesh.task.emit.mesh.tasks";
 const static char MeshTaskSetMeshOutputs[] = "lgc.mesh.task.set.mesh.outputs";
+const static char MeshTaskGetMeshInput[] = "lgc.mesh.task.get.mesh.input.";
 
 // Get pointer to spill table (as pointer to i8)
 const static char SpillTable[] = "lgc.spill.table";


### PR DESCRIPTION
Mesh shader only has built-in inputs. They are simply translated to
@lgc.mesh.task.get.mesh.input.XXX calls. The calls will be further lowered
in mesh shader processing.