### PR TITLE
lgc/patch: some cleanups in the pass pipeline

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -125,6 +125,9 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
                                     "// LLPC pipeline before-patching results\n"));
   }
 
+  // Run IPSCCP before EntryPointMutate to avoid adding unnecessary arguments to an entry point.
+  passMgr.addPass(IPSCCPPass());
+
   // Build null fragment shader if necessary
   passMgr.addPass(PatchNullFragShader());
 
@@ -148,9 +151,6 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
 
   // Lower fragment export operations.
   passMgr.addPass(LowerFragColorExport());
-
-  // Run IPSCCP before EntryPointMutate to avoid adding unnecessary arguments to an entry point.
-  passMgr.addPass(IPSCCPPass());
 
   // Patch entry-point mutation
   passMgr.addPass(PatchEntryPointMutate());

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -97,3 +97,5 @@ attributes #1 = { nounwind readonly }
 attributes #2 = { nounwind writeonly }
 
 !0 = !{i32 1}
+
+!lgc.unlinked = !{!0}


### PR DESCRIPTION
Separate commits with:

* minor functional change of moving the IPSCCP pass out of the way
* cleanup comments