### PR TITLE
Remove the function clearInactiveBuiltInInput in PatchResourceCollect

### DIFF
--- a/lgc/include/lgc/patch/PatchResourceCollect.h
+++ b/lgc/include/lgc/patch/PatchResourceCollect.h
@@ -70,7 +70,6 @@ private:
 
   bool isVertexReuseDisabled();
 
-  void clearInactiveBuiltInInput();
   void clearInactiveBuiltInOutput();
   void clearUnusedOutput();
 
@@ -96,7 +95,6 @@ private:
 
   std::vector<llvm::CallInst *> m_deadCalls; // Dead calls
 
-  std::unordered_set<unsigned> m_activeInputBuiltIns;  // IDs of active built-in inputs
   std::unordered_set<unsigned> m_activeOutputBuiltIns; // IDs of active built-in outputs
 
   std::unordered_set<unsigned> m_importedOutputBuiltIns; // IDs of imported built-in outputs


### PR DESCRIPTION
The ADCE pass in lower has already removed such built-in input dead
calls. There is no need of re-checking them and doing follow-up built-in
usage clean-up work. The codes will not be executed. Ideally, front-end
ought to get rid of all dead calls before the IRs are passed to LGC.