### PR TITLE
lgc/patch: fix some issues of the VS-TCS interface

### DIFF
--- a/lgc/include/lgc/patch/PatchResourceCollect.h
+++ b/lgc/include/lgc/patch/PatchResourceCollect.h
@@ -109,6 +109,7 @@ private:
   std::unique_ptr<InOutLocationInfoMapManager>
       m_locationInfoMapManager; // Pointer to InOutLocationInfoMapManager instance
 
+  bool m_tcsInputHasDynamicIndexing = false; // Whether there is a dynamically indexed TCS input.
   bool m_processMissingFs = false; // Whether to process a missing FS (part-pipeline compilation).
 };
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -943,13 +943,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
       auto locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
 
       if (m_shaderStage == ShaderStageTessControl) {
-        // NOTE: If location offset is a constant, we have to add it to the unmapped location before querying
-        // the mapped location. Meanwhile, we have to adjust the location offset to 0 (rebase it).
         locOffset = callInst.getOperand(1);
-        if (isa<ConstantInt>(locOffset)) {
-          value += cast<ConstantInt>(locOffset)->getZExtValue();
-          locOffset = ConstantInt::get(Type::getInt32Ty(*m_context), 0);
-        }
 
         // NOTE: For generic outputs of tessellation control shader, they could be per-patch ones.
         if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {

--- a/llpc/test/shaderdb/general/PipelineTess_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/general/PipelineTess_TestInOutPacking.pipe
@@ -1,26 +1,35 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -enable-part-pipeline=0 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST_PP0 %s
 ; SHADERTEST_PP0-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 40
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 1
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 2
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 3
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 8
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 12
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 16
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 20
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 4
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 24
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 28
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 32
-; SHADERTEST_PP0: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 36
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 4
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 10
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 12
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 8
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 52
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 96
-; SHADERTEST_PP0: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 24
+
+; SHADERTEST_PP0: define {{.*}} @_amdgpu_ls_main
+; SHADERTEST_PP0: [[VERTEX_BASE:%[0-9a-zA-Z.]+]] = mul i32 %RelVertexId,
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 44
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 45
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 46
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 47
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 1
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 4
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 5
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 8
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 9
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 10
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 12
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 16
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 20
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 24
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 28
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 29
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 30
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 31
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 32
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 33
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 36
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 37
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 38
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 39
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 40
+; SHADERTEST_PP0: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 41
 ; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}3, float %{{[0-9]*}}, float %{{[0-9]*}}, float undef, float undef, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i32 %PrimMask)
@@ -44,26 +53,34 @@
 ; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
 ; Pre-rasterization part-pipeline:
 ; SHADERTEST_PP1-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 40
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 1
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 2
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 3
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 8
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 12
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 16
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 20
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 4
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 24
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 28
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 32
-; SHADERTEST_PP1: %{{[0-9]*}} = add i32 %{{[0-9]*}}, 36
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 4
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 10
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 12
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 8
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 52
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 96
-; SHADERTEST_PP1: %{{[0-9]*}} = add nuw nsw i32 %{{[0-9]*}}, 24
+; SHADERTEST_PP1: define {{.*}} @_amdgpu_ls_main
+; SHADERTEST_PP1: [[VERTEX_BASE:%[0-9a-zA-Z.]+]] = mul i32 %RelVertexId,
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 44
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 45
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 46
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 47
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 1
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 4
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 5
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 8
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 9
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 10
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 12
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 16
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 20
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 24
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 28
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 29
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 30
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 31
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 32
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 33
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 36
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 37
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 38
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 39
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 40
+; SHADERTEST_PP1: %{{[0-9]*}} = {{add|or}} i32 [[VERTEX_BASE]], 41
 ; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, float %{{[0-9]*}}, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}3, float %{{[0-9]*}}, float %{{[0-9]*}}, float undef, float undef, i1 {{.*}}false, i1 {{.*}}false)
 ; SHADERTEST_PP1: AMDLLPC SUCCESS


### PR DESCRIPTION
Playing around with pass ordering uncovered some bugs related to dynamic indexing of TCS inputs (as well as dynamic indexing that becomes static thanks to loop unrolling).

I've decided to fix this conservatively for now.