### PR TITLE
Add mesh shader support: Support mesh shader generic output

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -329,7 +329,7 @@ Instruction *InOutBuilder::CreateWriteGenericOutput(Value *valueToWrite, unsigne
   switch (m_shaderStage) {
   case ShaderStageVertex:
   case ShaderStageTessEval: {
-    // VS:  @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, %Type% outputValue)
+    // VS: @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, %Type% outputValue)
     // TES: @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, %Type% outputValue)
     assert(locationOffset == getInt32(0));
     args.push_back(getInt32(location));
@@ -337,18 +337,23 @@ Instruction *InOutBuilder::CreateWriteGenericOutput(Value *valueToWrite, unsigne
     break;
   }
 
-  case ShaderStageTessControl: {
+  case ShaderStageTessControl:
+  case ShaderStageMesh: {
     // TCS: @lgc.output.export.generic.%Type%(i32 location, i32 locOffset, i32 elemIdx, i32 vertexIdx,
     //                                        %Type% outputValue)
+    // Mesh: @lgc.output.export.generic.%Type%(i32 location, i32 locOffset, i32 elemIdx, i32 vertexOrPrimitiveIdx, i1
+    //                                         perPrimitive, %Type% outputValue)
     args.push_back(getInt32(location));
     args.push_back(locationOffset);
     args.push_back(elemIdx);
     args.push_back(vertexOrPrimitiveIndex ? vertexOrPrimitiveIndex : getInt32(InvalidValue));
+    if (m_shaderStage == ShaderStageMesh)
+      args.push_back(getInt1(outputInfo.isPerPrimitive()));
     break;
   }
 
   case ShaderStageGeometry: {
-    // GS:  @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, i32 streamId, %Type% outputValue)
+    // GS: @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, i32 streamId, %Type% outputValue)
     unsigned streamId = outputInfo.hasStreamId() ? outputInfo.getStreamId() : InvalidValue;
     assert(locationOffset == getInt32(0));
     args.push_back(getInt32(location));
@@ -361,7 +366,7 @@ Instruction *InOutBuilder::CreateWriteGenericOutput(Value *valueToWrite, unsigne
     // Mark fragment output type.
     markFsOutputType(valueToWrite->getType(), location, outputInfo);
 
-    // FS:  @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, %Type% outputValue)
+    // FS: @lgc.output.export.generic.%Type%(i32 location, i32 elemIdx, %Type% outputValue)
     assert(locationOffset == getInt32(0));
     args.push_back(getInt32(location));
     args.push_back(elemIdx);

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -100,6 +100,9 @@ private:
                                    llvm::Instruction *insertPos);
   void patchGsGenericOutputExport(llvm::Value *output, unsigned location, unsigned compIdx, unsigned streamId,
                                   llvm::Instruction *insertPos);
+  void patchMeshGenericOutputExport(llvm::Value *output, unsigned location, llvm::Value *locOffset,
+                                    llvm::Value *compIdx, llvm::Value *vertexOrPrimitiveIdx, bool isPerPrimitive,
+                                    llvm::Instruction *insertPos);
 
   llvm::Value *patchVsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Instruction *insertPos);
   llvm::Value *patchTcsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -75,6 +75,8 @@ const static char MeshTaskWriteTaskPayload[] = "lgc.mesh.task.write.task.payload
 const static char MeshTaskEmitMeshTasks[] = "lgc.mesh.task.emit.mesh.tasks";
 const static char MeshTaskSetMeshOutputs[] = "lgc.mesh.task.set.mesh.outputs";
 const static char MeshTaskGetMeshInput[] = "lgc.mesh.task.get.mesh.input.";
+const static char MeshTaskWriteVertexOutput[] = "lgc.mesh.task.write.vertex.output.";
+const static char MeshTaskWritePrimitiveOutput[] = "lgc.mesh.task.write.primitive.output.";
 
 // Get pointer to spill table (as pointer to i8)
 const static char SpillTable[] = "lgc.spill.table";

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1481,6 +1481,14 @@ void PipelineState::initializeInOutPackState() {
     m_outputPackState[ShaderStageVertex] = true;
     m_outputPackState[ShaderStageTessEval] = true;
     m_outputPackState[ShaderStageGeometry] = true;
+
+    // NOTE: For mesh shader, we don't do in-out packing currently in that mesh shader could emit per-vertex outputs
+    // and per-primitive outputs, which introduces additional complexity and this complexity increases with the
+    // involvement of dynamic indexing.
+    if (hasShaderStage(ShaderStageMesh)) {
+      m_outputPackState[ShaderStageMesh] = false;
+      m_inputPackState[ShaderStageFragment] = false;
+    }
   } else {
     // For unlinked shaders, we can do in-out packing if the pipeline has two adjacent shaders.
     // We are assuming that if any of the vertex processing, then the vertex processing stages are complete.  For


### PR DESCRIPTION
The generic outputs of mesh shader are simply translated to two kinds of
calls:

1. Per-vertex outputs -> lgc.mesh.task.write.vertex.output(i32
   outputOffset, i32 vertexIndex, i32 outputValue)
2. Per-primitive outputs -> lgc.mesh.task.write.primitive.output(i32
   outputOffset, i32 primitiveIndex, i32 outputValue)

The calls will be further lowered in mesh shader processing.