### PR TITLE
Add option to disable LLVM scalarizer pass.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ------------------------------------------------------------------------------------------------------|
+//  |     54.4 | Add disableScalarizer to PipelineOptions                                                              |
 //  |     54.3 | Add usePointSize to ShaderModuleUsage                                                                 |
 //  |     54.2 | Add subgroupSize to PipelineShaderOptions                                                             |
 //  |     54.1 | Add overrideForceThreadIdSwizzling overrideShaderThreadGroupSizeX, overrideShaderThreadGroupSizeY     |
@@ -436,6 +437,7 @@ struct PipelineOptions {
   bool reserved1f;                                       /// Reserved for future functionality
   bool enableInterpModePatch; ///< If set, per-sample interpolation for nonperspective and smooth input is enabled
   bool pageMigrationEnabled;  ///< If set, page migration is enabled
+  bool disableScalarizer;     ///< If set, LLVM scalarizer pass is disabled
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
   uint32_t optimizationLevel; ///< The higher the number the more optimizations will be performed.  Valid values are
                               ///< between 0 and 3.

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 54
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 3
+#define LLPC_INTERFACE_MINOR_VERSION 4
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -136,7 +136,8 @@ public:
   static llvm::GlobalVariable *getLdsVariable(PipelineState *pipelineState, llvm::Module *module);
 
 protected:
-  static void addOptimizationPasses(lgc::PassManager &passMgr, llvm::CodeGenOpt::Level optLevel);
+  static void addOptimizationPasses(lgc::PassManager &passMgr, llvm::CodeGenOpt::Level optLevel,
+                                    bool disableScalarizer);
 
   void init(llvm::Module *module);
 

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -137,7 +137,7 @@ public:
 
 protected:
   static void addOptimizationPasses(lgc::PassManager &passMgr, llvm::CodeGenOpt::Level optLevel,
-                                    bool disableScalarizer);
+                                    PipelineState *pipelineState);
 
   void init(llvm::Module *module);
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -141,6 +141,7 @@ struct Options {
   unsigned reserved1f;                // Reserved for future functionality
   unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
   unsigned pageMigrationEnabled;  // Enable page migration
+  bool disableScalarizer; // Don't run the scalarizer.
   ResourceLayoutScheme resourceLayoutScheme; // Resource layout scheme
   ThreadGroupSwizzleMode threadGroupSwizzleMode; // Thread group swizzle mode
 };

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -141,7 +141,7 @@ struct Options {
   unsigned reserved1f;                // Reserved for future functionality
   unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
   unsigned pageMigrationEnabled;  // Enable page migration
-  bool disableScalarizer; // Don't run the scalarizer.
+  bool disableScalarizer;         // Don't run the scalarizer.
   ResourceLayoutScheme resourceLayoutScheme; // Resource layout scheme
   ThreadGroupSwizzleMode threadGroupSwizzleMode; // Thread group swizzle mode
 };

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -155,7 +155,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
     LgcContext::createAndAddStartStopTimer(passMgr, optTimer, true);
   }
 
-  addOptimizationPasses(passMgr, optLevel, pipelineState->getOptions().disableScalarizer);
+  addOptimizationPasses(passMgr, optLevel, pipelineState);
 
   if (patchTimer) {
     LgcContext::createAndAddStartStopTimer(passMgr, optTimer, false);
@@ -379,8 +379,8 @@ void LegacyPatch::addPasses(PipelineState *pipelineState, legacy::PassManager &p
 // @param [in/out] passMgr : Pass manager to add passes to
 // @param optLevel : The optimization level uses to adjust the aggressiveness of
 //                   passes and which passes to add.
-// @param disableScalarizer : Whether the scalarizer pass should be disabled.
-void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level optLevel, bool disableScalarizer) {
+// @param pipelineState : The current pipeline state.
+void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level optLevel, PipelineState *pipelineState) {
   LLPC_OUTS("PassManager optimization level = " << optLevel << "\n");
 
   passMgr.addPass(ForceFunctionAttrsPass());
@@ -415,7 +415,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
   fpm.addPass(LoopUnrollPass(
       LoopUnrollOptions(optLevel).setPeeling(true).setRuntime(false).setUpperBound(false).setPartial(false)));
   
-  if (!disableScalarizer)
+  if (!pipelineState->getOptions().disableScalarizer)
     fpm.addPass(ScalarizerPass());
     
   fpm.addPass(PatchLoadScalarizer());

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -414,10 +414,10 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
   fpm.addPass(createFunctionToLoopPassAdaptor(std::move(lpm2), true));
   fpm.addPass(LoopUnrollPass(
       LoopUnrollOptions(optLevel).setPeeling(true).setRuntime(false).setUpperBound(false).setPartial(false)));
-  
+
   if (!pipelineState->getOptions().disableScalarizer)
     fpm.addPass(ScalarizerPass());
-    
+
   fpm.addPass(PatchLoadScalarizer());
   fpm.addPass(InstSimplifyPass());
   fpm.addPass(NewGVNPass());

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -359,7 +359,7 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
   options.resourceLayoutScheme = static_cast<lgc::ResourceLayoutScheme>(getPipelineOptions()->resourceLayoutScheme);
 
   options.disableScalarizer = (DisableScalarizer || getPipelineOptions()->disableScalarizer);
-  
+
   // Driver report full subgroup lanes for compute shader, here we just set fullSubgroups as default options
   options.fullSubgroups = true;
   if (pipeline)

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -100,6 +100,9 @@ static cl::opt<bool> DisableFetchShader("disable-fetch-shader", cl::desc("Disabl
 static cl::opt<bool> DisableColorExportShader("disable-color-export-shader", cl::desc("Disable color export shaders"),
                                               cl::init(false));
 
+// -disable-scalarizer: disable the LLVM Scalarizer pass
+static cl::opt<bool> DisableScalarizer("disable-scalarizer", cl::desc("Disable LLVM scalarizer pass"), cl::init(false));
+
 // -subgroup-size: sub-group size exposed via Vulkan API.
 static cl::opt<int> SubgroupSize("subgroup-size", cl::desc("Sub-group size exposed via Vulkan API"), cl::init(64));
 
@@ -355,6 +358,8 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
   options.pageMigrationEnabled = getPipelineOptions()->pageMigrationEnabled;
   options.resourceLayoutScheme = static_cast<lgc::ResourceLayoutScheme>(getPipelineOptions()->resourceLayoutScheme);
 
+  options.disableScalarizer = (DisableScalarizer || getPipelineOptions()->disableScalarizer);
+  
   // Driver report full subgroup lanes for compute shader, here we just set fullSubgroups as default options
   options.fullSubgroups = true;
   if (pipeline)


### PR DESCRIPTION
We found that disabling the scalarizer pass helps
with generating v_pk_* instructions and in some cases
with VGPR usage, but we cannot go with completely
disabling the scalarizer pass for now.
This patch adds a new LLPC CLI option which
can be used to control running the scalarizer
pass, which should help with experiments.