### PR TITLE
Add mesh shader support: Add in/out matching and built-in mapping

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -434,6 +434,21 @@ struct ResourceUsage {
     } gs;
 
     struct {
+      // Map from IDs of built-in outputs to locations of generic per-vertex outputs (used by vertex export to export
+      // built-in outputs to fragment shader)
+      std::map<BuiltInKind, unsigned> builtInExportLocs;
+
+      // Map from IDs of per-primitive built-in outputs to locations of generic per-primitive outputs (used by vertex
+      // export to export built-in outputs to fragment shader)
+      std::map<BuiltInKind, unsigned> perPrimitiveBuiltInExportLocs;
+
+      // Count of mapped location for generic outputs (excluding those special locations to which the built-ins
+      // are mapped)
+      unsigned genericOutputMapLocCount = 0;
+      unsigned perPrimitiveGenericOutputMapLocCount = 0;
+    } mesh;
+
+    struct {
       // Original shader specified locations before location map (from tightly packed locations to shader
       // specified locations)
       //


### PR DESCRIPTION
Add per-primitive in/out matching for mesh shader. Also, map mesh shader
built-ins to generic outputs (per-vertex built-ins to per-vertex generic
outputs and per-primitive built-ins to per-primitive generic outputs).
Some built-in input mappings of fragment shader are adjusted because if
the previous stage is mesh shader, they are viewed as per-primitive
inputs rather than per-vertex inputs, such as PrimitiveId,
ViewportIndex, Layer, ViewIndex.