### PR TITLE
Fix unused push const variable

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1390,6 +1390,18 @@ void PatchEntryPointMutate::addUserDataArgs(SmallVectorImpl<UserDataArg> &userDa
           addUserDataArg(userDataArgs, node.offsetInDwords + dwordOffset, pushConstOffset.dwordSize,
                          "pushConst" + Twine(dwordOffset), &pushConstOffset.entryArgIdx, builder);
         }
+
+        if (!userDataUsage->pushConstSpill) {
+          // Fill the unused push const that occupys sgpr.
+          if (!userDataUsage->pushConstOffsets.empty()) {
+            const UserDataNodeUsage &pushConstOffset =
+                userDataUsage->pushConstOffsets[userDataUsage->pushConstOffsets.size() - 1];
+            unsigned actualEnd = userDataUsage->pushConstOffsets.size() + pushConstOffset.dwordSize - 1;
+            for (; actualEnd < node.sizeInDwords; actualEnd++)
+              addUserDataArg(userDataArgs, node.offsetInDwords + actualEnd, 1, "pushConst" + Twine(actualEnd), nullptr,
+                             builder);
+          }
+        }
       } else {
         // Mark push constant for spill for compute library.
         userDataUsage->pushConstSpill = true;

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestUnusedPushconstDwords.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestUnusedPushconstDwords.pipe
@@ -1,0 +1,96 @@
+// Test unused push constant dwords
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v --gfxip=10.3.0 %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: .registers:
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_2                     0x0000000000000000
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_3                     0x0000000000000001
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_4                     0x0000000000000002
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_5                     0x0000000000000003
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_6                     0x0000000000000004
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_7                     0x0000000000000005
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_8                     0x0000000000000006
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_9                     0x0000000000000007
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_10                    0x0000000000000008
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_11                    0x0000000000000009
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_12                    0x000000000000000A
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_13                    0x000000000000000B
+// The unused dword
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_14                    0x000000000000000C
+; SHADERTEST: SPI_SHADER_USER_DATA_GS_15                    0x000000001000000B
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 54
+
+[VsGlsl]
+#version 450
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 vsColor;
+layout( push_constant ) uniform constants
+{
+	vec4 scale;
+	vec4 offset;
+	vec4 color;
+	int layer; // unused
+} pc;
+
+void main (void)
+{
+    gl_Position = position * pc.scale + pc.offset;
+    vsColor     = pc.color;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+#extension GL_EXT_multiview : require
+layout(location = 0) in vec4 vsColor;
+layout(location = 0) out vec4 fsColor;
+
+void main (void)
+{
+    fsColor   = vsColor;
+    fsColor.z = 0.15f * gl_ViewIndex;
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 66
+userDataNode[0].type = PushConst
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 13
+userDataNode[0].set = 0xFFFFFFFF
+userDataNode[0].binding = 0
+userDataNode[1].visibility = 4
+userDataNode[1].type = StreamOutTableVaPtr
+userDataNode[1].offsetInDwords = 13
+userDataNode[1].sizeInDwords = 1
+userDataNode[2].visibility = 2
+userDataNode[2].type = IndirectUserDataVaPtr
+userDataNode[2].offsetInDwords = 14
+userDataNode[2].sizeInDwords = 1
+userDataNode[2].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+enableMultiView = 1
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+nggState.enableNgg = 1
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 16
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0


### PR DESCRIPTION
Unused push const variables still also occupy spgr. In the following

operators, we will calculate the offset of the spgr according to the

arguments of entrypoint, so we must fill the whole push const.