### PR TITLE
Add a new method to factor out PA-specific register settings

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.h
+++ b/lgc/patch/Gfx9ConfigBuilder.h
@@ -74,6 +74,7 @@ private:
   void buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *config);
 
   void setupVgtTfParam(LsHsRegConfig *config);
+  template <typename T> void setupPaSpecificRegisters(T *config);
 
   bool getShaderWgpMode(ShaderStage shaderStage) const;
 };


### PR DESCRIPTION
Add a new method setupPaSpecificRegisters. PA-specific register
(including some SPI registers controlling export) configuration
are put in this method. It is used by buildVsRegConfig and
buildPrimShaderRegConfig at present (will be used by
buildMeshRegConfig in the future).