### PR TITLE
Add patching pass to annotate discard to demote requirements.

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -161,6 +161,7 @@ target_sources(LLVMlgc PRIVATE
     patch/PatchCheckShaderCache.cpp
     patch/PatchCopyShader.cpp
     patch/PatchEntryPointMutate.cpp
+    patch/PatchImageDerivatives.cpp
     patch/PatchInOutImportExport.cpp
     patch/PatchLlvmIrInclusion.cpp
     patch/PatchLoadScalarizer.cpp

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -62,6 +62,7 @@ void initializeLegacyPatchSetupTargetFeaturesPass(PassRegistry &);
 void initializeLegacyPatchWorkaroundsPass(PassRegistry &);
 void initializeLegacyPatchReadFirstLanePass(PassRegistry &);
 void initializeLegacyPatchWaveSizeAdjustPass(PassRegistry &);
+void initializeLegacyPatchImageDerivativesPass(PassRegistry &);
 void initializeLegacyPatchInitializeWorkgroupMemoryPass(PassRegistry &);
 } // namespace llvm
 
@@ -91,6 +92,7 @@ inline void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializeLegacyPatchWorkaroundsPass(passRegistry);
   initializeLegacyPatchReadFirstLanePass(passRegistry);
   initializeLegacyPatchWaveSizeAdjustPass(passRegistry);
+  initializeLegacyPatchImageDerivativesPass(passRegistry);
   initializeLegacyPatchInitializeWorkgroupMemoryPass(passRegistry);
 }
 
@@ -112,6 +114,7 @@ llvm::ModulePass *createLegacyPatchSetupTargetFeatures();
 llvm::ModulePass *createLegacyPatchWorkarounds();
 llvm::FunctionPass *createLegacyPatchReadFirstLane();
 llvm::ModulePass *createLegacyPatchWaveSizeAdjust();
+llvm::ModulePass *createLegacyPatchImageDerivatives();
 llvm::ModulePass *createLegacyPatchInitializeWorkgroupMemory();
 class PipelineState;
 class PassManager;

--- a/lgc/include/lgc/patch/PatchImageDerivatives.h
+++ b/lgc/include/lgc/patch/PatchImageDerivatives.h
@@ -24,30 +24,46 @@
  **********************************************************************************************************************/
 /**
  ***********************************************************************************************************************
- * @file  PassRegistry.inc
- * @brief LLPC header file: used as the registry of LLPC patching passes
+ * @file  PatchImageDerivatives.h
+ * @brief LLPC header file: contains declaration of class lgc::PatchImageDerivatives.
  ***********************************************************************************************************************
  */
+#pragma once
 
-LLPC_PASS("lgc-builder-replayer", BuilderReplayer)
+#include "lgc/state/PipelineState.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
 
-LLPC_PASS("lgc-patch-resource-collect", PatchResourceCollect)
-LLPC_PASS("lgc-patch-initialize-workgroup-memory", PatchInitializeWorkgroupMemory)
-LLPC_PASS("lgc-patch-image-derivatives", PatchImageDerivatives)
-LLPC_PASS("lgc-patch-in-out-import-export", PatchInOutImportExport)
-LLPC_PASS("lgc-patch-setup-target-features", PatchSetupTargetFeatures)
-LLPC_PASS("lgc-patch-copy-shader", PatchCopyShader)
-LLPC_PASS("lgc-patch-prepare-pipeline-abi", PatchPreparePipelineAbi)
-LLPC_PASS("lgc-patch-read-first-lane", PatchReadFirstLane)
-LLPC_PASS("lgc-patch-llvm-ir-inclusion", PatchLlvmIrInclusion)
-LLPC_PASS("lgc-patch-wave-size-adjust", PatchWaveSizeAdjust)
-LLPC_PASS("lgc-patch-peephole-opt", PatchPeepholeOpt)
-LLPC_PASS("lgc-patch-entry-point-mutate", PatchEntryPointMutate)
-LLPC_PASS("lgc-patch-check-shader-cache", PatchCheckShaderCache)
-LLPC_PASS("lgc-patch-loop-metadata", PatchLoopMetadata)
-LLPC_PASS("lgc-patch-buffer-op", PatchBufferOp)
-LLPC_PASS("lgc-patch-workarounds", PatchWorkarounds)
-LLPC_PASS("lgc-patch-load-scalarizer", PatchLoadScalarizer)
-LLPC_PASS("lgc-patch-null-frag-shader", PatchNullFragShader)
+namespace lgc {
 
-#undef LLPC_PASS
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for image operations
+class PatchImageDerivatives : public llvm::PassInfoMixin<PatchImageDerivatives> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+
+  bool runImpl(llvm::Module &module, PipelineState *pipelineState);
+
+  static llvm::StringRef name() { return "Patch attributes when image derivatives dependent on discard"; }
+};
+
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for image operations
+class LegacyPatchImageDerivatives : public llvm::ModulePass {
+public:
+  LegacyPatchImageDerivatives();
+
+  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override;
+
+  bool runOnModule(llvm::Module &module) override;
+
+  static char ID; // ID of this pass
+
+private:
+  LegacyPatchImageDerivatives(const LegacyPatchImageDerivatives &) = delete;
+  LegacyPatchImageDerivatives &operator=(const LegacyPatchImageDerivatives &) = delete;
+
+  PatchImageDerivatives m_impl;
+};
+
+} // namespace lgc

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -38,6 +38,7 @@
 #include "lgc/patch/PatchCheckShaderCache.h"
 #include "lgc/patch/PatchCopyShader.h"
 #include "lgc/patch/PatchEntryPointMutate.h"
+#include "lgc/patch/PatchImageDerivatives.h"
 #include "lgc/patch/PatchImageOpCollect.h"
 #include "lgc/patch/PatchInOutImportExport.h"
 #include "lgc/patch/PatchInitializeWorkgroupMemory.h"
@@ -197,6 +198,8 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
     passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
   }
 
+  passMgr.addPass(PatchImageDerivatives());
+
   // Set up target features in shader entry-points.
   // NOTE: Needs to be done after post-NGG function inlining, because LLVM refuses to inline something
   // with conflicting attributes. Attributes could conflict on GFX10 because PatchSetupTargetFeatures
@@ -349,6 +352,8 @@ void LegacyPatch::addPasses(PipelineState *pipelineState, legacy::PassManager &p
       passMgr.add(LgcContext::createStartStopTimer(patchTimer, true));
     }
   }
+
+  passMgr.add(createLegacyPatchImageDerivatives());
 
   // Set up target features in shader entry-points.
   // NOTE: Needs to be done after post-NGG function inlining, because LLVM refuses to inline something

--- a/lgc/patch/PatchImageDerivatives.cpp
+++ b/lgc/patch/PatchImageDerivatives.cpp
@@ -1,0 +1,201 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchImageDerivatives.cpp
+ * @brief LLPC source file: contains implementation of class lgc::PatchImageDerivatives.
+ ***********************************************************************************************************************
+ */
+#include "lgc/patch/PatchImageDerivatives.h"
+#include "lgc/patch/Patch.h"
+#include "lgc/state/PipelineState.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "lgc-patch-image-derivatives"
+
+using namespace llvm;
+using namespace lgc;
+
+namespace lgc {
+
+// =====================================================================================================================
+// Initializes static members.
+char LegacyPatchImageDerivatives::ID = 0;
+
+// =====================================================================================================================
+// Pass creator, creates the pass
+ModulePass *createLegacyPatchImageDerivatives() {
+  return new LegacyPatchImageDerivatives();
+}
+
+// =====================================================================================================================
+LegacyPatchImageDerivatives::LegacyPatchImageDerivatives() : llvm::ModulePass(ID) {
+}
+
+// =====================================================================================================================
+// Get the analysis usage of this pass.
+//
+// @param [out] analysisUsage : The analysis usage.
+void LegacyPatchImageDerivatives::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
+  analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+}
+
+// =====================================================================================================================
+// Executes this LLVM patching pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+// @returns : True if the module was modified by the transformation and false otherwise
+bool LegacyPatchImageDerivatives::runOnModule(Module &module) {
+  PipelineState *pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(&module);
+  return m_impl.runImpl(module, pipelineState);
+}
+
+// =====================================================================================================================
+// Executes this LLVM patching pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+// @returns : The preserved analyses (The analyses that are still valid after this pass)
+PreservedAnalyses PatchImageDerivatives::run(Module &module, ModuleAnalysisManager &analysisManager) {
+  PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
+  if (runImpl(module, pipelineState))
+    return PreservedAnalyses::all(); // Note: this patching never invalidates analysis data
+  return PreservedAnalyses::all();
+}
+
+static bool usesImplicitDerivatives(StringRef name) {
+  if (!(name.startswith("llvm.amdgcn.image.sample") || name.startswith("llvm.amdgcn.image.gather")))
+    return false;
+  if (name.find(".l.") != std::string::npos || name.find(".d.") != std::string::npos)
+    return false;
+  return true;
+}
+
+// =====================================================================================================================
+// Executes this LLVM patching pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+// @param pipelineState : Pipeline state
+// @returns : True if the module was modified by the transformation and false otherwise
+bool PatchImageDerivatives::runImpl(llvm::Module &module, PipelineState *pipelineState) {
+  LLVM_DEBUG(dbgs() << "Run the pass Patch-Image-Derivatives\n");
+
+  if (!pipelineState->hasShaderStage(ShaderStageFragment))
+    return false;
+  ResourceUsage *resUsage = pipelineState->getShaderResourceUsage(ShaderStageFragment);
+  if (!resUsage->builtInUsage.fs.discard)
+    return false;
+
+  SmallSet<BasicBlock *, 4> killBlocks;
+  DenseSet<BasicBlock *> derivativeBlocks;
+
+  // Find all blocks containing a kill or an image operation which uses implicit derivatives.
+  for (Function &func : module) {
+    if (!func.isIntrinsic())
+      continue;
+
+    const bool isKill = func.getIntrinsicID() == Intrinsic::amdgcn_kill;
+    if (!(isKill || usesImplicitDerivatives(func.getName())))
+      continue;
+
+    for (User *user : func.users()) {
+      CallInst *call = cast<CallInst>(user);
+      // Only record blocks for fragment shader
+      if (getShaderStage(call->getFunction()) != ShaderStageFragment)
+        continue;
+
+      if (isKill) {
+        killBlocks.insert(call->getParent());
+      } else {
+        derivativeBlocks.insert(call->getParent());
+      }
+    }
+  }
+
+  // Note: in theory killBlocks should not be empty here, but it is cheap to check.
+  if (killBlocks.empty() || derivativeBlocks.empty())
+    return false;
+
+  DenseSet<BasicBlock *> visitedBlocks;
+  SmallVector<BasicBlock *> roots;
+  SmallVector<BasicBlock *> worklist;
+
+  // Establish roots from kill blocks.
+  for (BasicBlock *killBlock : killBlocks) {
+    // Normally a kill will be reached from a conditional branch.
+    // Find the block containing the conditional branch and record it as a search root.
+    // If the entry point is a reached then record it as a root.
+    visitedBlocks.insert(killBlock);
+    append_range(worklist, predecessors(killBlock));
+
+    while (!worklist.empty()) {
+      BasicBlock *potentialRoot = worklist.pop_back_val();
+      if (visitedBlocks.count(potentialRoot))
+        continue;
+      visitedBlocks.insert(potentialRoot);
+      if (!potentialRoot->getUniqueSuccessor() || !potentialRoot->getSingleSuccessor()) {
+        roots.push_back(potentialRoot);
+      } else {
+        append_range(worklist, predecessors(potentialRoot));
+      }
+    }
+  }
+  assert(worklist.empty());
+
+  // Breadth first search from roots looking for any block containing derivatives.
+  visitedBlocks.clear();
+  for (BasicBlock *root : roots)
+    append_range(worklist, successors(root));
+  while (!worklist.empty()) {
+    BasicBlock *testBlock = worklist.pop_back_val();
+    if (visitedBlocks.count(testBlock))
+      continue;
+
+    visitedBlocks.insert(testBlock);
+    if (derivativeBlocks.count(testBlock)) {
+      // Reached a derivative block; search can stop.
+      // Mark fragment shader as requiring discard to demote conversion.
+      LLVM_DEBUG(dbgs() << "Detected implicit derivatives used after kill.\n");
+      Function *fsFunc = testBlock->getParent();
+      fsFunc->addFnAttr("amdgpu-transform-discard-to-demote");
+      return true;
+    }
+
+    append_range(worklist, successors(testBlock));
+  }
+
+  // No paths from kills to derivatives exist.
+  return false;
+}
+
+} // namespace lgc
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patch image derivative operations dependent on discards.
+INITIALIZE_PASS(LegacyPatchImageDerivatives, DEBUG_TYPE, "Patch image derivatives after discards", false, false)

--- a/llpc/test/shaderdb/general/DiscardToDemoteTransformations.frag
+++ b/llpc/test/shaderdb/general/DiscardToDemoteTransformations.frag
@@ -1,7 +1,8 @@
-// Check that amdllpc does not enable discard-to-demote transforms by default and that
-// they can be enabled on demand. This should affect the generated code and cache hash.
+// Check that amdllpc enables discard-to-demote transforms automatically and that they
+// can be disabled on demand. This should affect the generated code and cache hash.
 
 // RUN: amdllpc %gfxip --v %s \
+// RUN:   --amdgpu-conditional-discard-transformations=0 \
 // RUN:   | tee %t.disabled | FileCheck %s --check-prefix=DISABLED
 //
 // DISABLED-LABEL: {{^}}SPIR-V disassembly
@@ -18,8 +19,6 @@
 // DISABLED-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 
 // RUN: amdllpc %gfxip --v %s \
-// RUN:   --amdgpu-conditional-discard-transformations \
-// RUN:   --amdgpu-transform-discard-to-demote \
 // RUN:   | tee %t.enabled | FileCheck %s --check-prefix=ENABLED
 //
 // ENABLED-LABEL: {{^}}SPIR-V disassembly

--- a/llpc/test/shaderdb/general/DiscardToDemoteTransformationsNotRequired.frag
+++ b/llpc/test/shaderdb/general/DiscardToDemoteTransformationsNotRequired.frag
@@ -1,0 +1,35 @@
+// Check that amdllpc does not apply discard-to-demote attribute to legal discards.
+
+// RUN: amdllpc %gfxip --v %s |\
+// RUN:   FileCheck %s --check-prefix=CHECK
+//
+// CHECK-LABEL: {{^}}SPIR-V disassembly
+// CHECK:             OpImageSampleImplicitLod
+// CHECK:       {{^}} {{OpKill|OpTerminateInvocation}}
+// CHECK:             OpImageRead
+// CHECK-LABEL: {{^}}// LLPC SPIR-V lowering results
+// CHECK:       call void (...) @lgc.create.kill()
+// CHECK-LABEL: {{^}}// LLPC pipeline patching results
+// CHECK:       call void @llvm.amdgcn.kill(i1 false)
+// CHECK-NOT:   "amdgpu-transform-discard-to-demote"
+// CHECK-LABEL: {{^}}// LLPC final ELF info
+// CHECK:       _amdgpu_ps_main:
+// CHECK:       s_wqm_b64 exec, exec
+// CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+#version 450
+
+layout (location = 0) in vec2 texCoordIn;
+layout (location = 1) in flat int discardPixel;
+
+layout (binding = 0) uniform sampler2D image1;
+layout (binding = 1, rgba32f) uniform image2D image2;
+
+layout (location = 0) out vec4 fragColor;
+
+void main() {
+  fragColor = texture(image1, texCoordIn);
+  if (discardPixel != 0)
+    discard;
+  fragColor += imageLoad(image2, ivec2(texCoordIn));
+}


### PR DESCRIPTION
While the Vulkan standard indicates that implicit derivatives are
undefined after a discard operation, many shaders attempt early
discard in ways which leads to undefined behaviour.
Attempt to detect these cases by searching forward in program
order from blocks which conditionally reach discards looking for
image operations which require implicit derivatives.
If any such path exists from a discard to implicit derivative use,
then annotate the fragment shader with
"amdgpu-transform-discard-to-demote".
This will trigger the backend AMDGPUConditionalDiscard pass,
when enabled, to attempt to replace discards with demotes.
(Demotes have defined behaviour for implicit derivatives.)