### PR TITLE
Port PassManagerCache to the NPM

### DIFF
--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -51,9 +51,14 @@ void GlueShader::compile(raw_pwrite_stream &outStream) {
   palMetadata->record(&*module);
   delete palMetadata;
 
-  // Get the pass manager and run it on the module, generating ELF.
-  LegacyPassManager &passManager = m_lgcContext->getPassManagerCache()->getGlueShaderPassManager(outStream);
-  passManager.run(*module);
+  // Get the pass managers and run them on the module, generating ELF.
+  std::pair<lgc::PassManager &, LegacyPassManager &> passManagers =
+      m_lgcContext->getPassManagerCache()->getGlueShaderPassManager(outStream);
+  // Run IR passes
+  passManagers.first.run(*module);
+  // Run Codegen Passes
+  passManagers.second.run(*module);
+
   m_lgcContext->getPassManagerCache()->resetStream();
 }
 

--- a/lgc/include/lgc/state/PassManagerCache.h
+++ b/lgc/include/lgc/state/PassManagerCache.h
@@ -81,15 +81,20 @@ public:
   PassManagerCache(LgcContext *lgcContext) : m_lgcContext(lgcContext) {}
 
   // Get pass manager for glue shader compilation
-  LegacyPassManager &getGlueShaderPassManager(llvm::raw_pwrite_stream &outStream);
+  // NOTE: This function returns two pass managers, a new pass manager for the
+  // IR passes and a legacy pass manager for the codegen passes. We should
+  // switch to using a single new pass manager once LLVM upstream codegen is
+  // ported to the new pass manager.
+  std::pair<lgc::PassManager &, LegacyPassManager &> getGlueShaderPassManager(llvm::raw_pwrite_stream &outStream);
 
   void resetStream();
 
 private:
-  LegacyPassManager &getPassManager(const PassManagerInfo &info, llvm::raw_pwrite_stream &outStream);
+  std::pair<lgc::PassManager &, LegacyPassManager &> getPassManager(const PassManagerInfo &info,
+                                                                    llvm::raw_pwrite_stream &outStream);
 
   LgcContext *m_lgcContext;
-  llvm::StringMap<std::unique_ptr<LegacyPassManager>> m_cache;
+  llvm::StringMap<std::pair<std::unique_ptr<PassManager>, std::unique_ptr<LegacyPassManager>>> m_cache;
   raw_proxy_ostream m_proxyStream;
 };
 


### PR DESCRIPTION
This patch ports the `PassManagerCache` class to the new pass manager.
Since the upstream codegen passes are not yet fully ported to the NPM, we now have two pass managers for each entry in the cache, one for the IR passes (new pass manager) and one for the Codegen passes (legacy pass manager).
Once upstream LLVM codegen passes are fully ported to the NPM, we can switch back to having a single pass manager for each entry in the cache.