### PR TITLE
Update the number of available SGPRs

### DIFF
--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -188,6 +188,7 @@ static void setGfx705Info(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx8BaseInfo(TargetInfo *targetInfo) {
   setGfx7BaseInfo(targetInfo);
+  targetInfo->getGpuProperty().maxSgprsAvailable = 102;
 }
 
 // gfx8
@@ -293,6 +294,7 @@ static void setGfx906Info(TargetInfo *targetInfo) {
 // @param [in/out] targetInfo : Target info
 static void setGfx10Info(TargetInfo *targetInfo) {
   setGfx9BaseInfo(targetInfo);
+  targetInfo->getGpuProperty().maxSgprsAvailable = 106;
 
   // Compiler is free to choose wave mode if forced wave size is not specified.
   if (NativeWaveSize != 0) {


### PR DESCRIPTION
Update the number of available general purpose SGPRs to 102 on GFX8+ and
then to 106 on GFX10+. I think this does not affect codegen but it makes
it less confusing for humans reading the PAL metadata.