### PR TITLE
Set CS stage metadata ThreadgroupDimensions

### DIFF
--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -302,6 +302,17 @@ void ConfigBuilderBase::setNggSubgroupSize(unsigned value) {
 }
 
 // =====================================================================================================================
+// Set thread group dimensions
+//
+// @param values : Values to set
+void ConfigBuilderBase::setThreadgroupDimensions(llvm::ArrayRef<unsigned> values) {
+  auto hwShaderNode = getHwShaderNode(Util::Abi::HardwareStage::Cs);
+  auto &arrayNode = hwShaderNode[Util::Abi::HardwareStageMetadataKey::ThreadgroupDimensions].getArray(true);
+  for (unsigned i = 0; i < values.size(); ++i)
+    arrayNode[i] = values[i];
+}
+
+// =====================================================================================================================
 /// Append a single entry to the PAL register metadata.
 ///
 /// @param [in] key : The metadata key (usually a register address).

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -82,6 +82,7 @@ protected:
   void setLdsSizeByteSize(Util::Abi::HardwareStage hwStage, unsigned value);
   void setEsGsLdsSize(unsigned value);
   void setNggSubgroupSize(unsigned value);
+  void setThreadgroupDimensions(llvm::ArrayRef<unsigned> values);
   unsigned setupFloatingPointMode(ShaderStage shaderStage);
 
   void appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config);

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -993,7 +993,7 @@ void ConfigBuilder::buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *confi
   const auto resUsage = m_pipelineState->getShaderResourceUsage(shaderStage);
   const auto &builtInUsage = resUsage->builtInUsage.cs;
   const auto &computeMode = m_pipelineState->getShaderModes()->getComputeShaderMode();
-  unsigned workgroupSizes[3];
+  unsigned workgroupSizes[3] = {};
 
   switch (static_cast<WorkgroupLayout>(builtInUsage.workgroupLayout)) {
   case WorkgroupLayout::Unknown:
@@ -1033,6 +1033,8 @@ void ConfigBuilder::buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *confi
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_X, NUM_THREAD_FULL, workgroupSizes[0]);
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_Y, NUM_THREAD_FULL, workgroupSizes[1]);
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_Z, NUM_THREAD_FULL, workgroupSizes[2]);
+
+  setThreadgroupDimensions(workgroupSizes);
 
   setNumAvailSgprs(Util::Abi::HardwareStage::Cs, resUsage->numSgprsAvailable);
   setNumAvailVgprs(Util::Abi::HardwareStage::Cs, resUsage->numVgprsAvailable);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1864,6 +1864,8 @@ void ConfigBuilder::buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *confi
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_Y, NUM_THREAD_FULL, workgroupSizes[1]);
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_Z, NUM_THREAD_FULL, workgroupSizes[2]);
 
+  setThreadgroupDimensions(workgroupSizes);
+
   setNumAvailSgprs(Util::Abi::HardwareStage::Cs, resUsage->numSgprsAvailable);
   setNumAvailVgprs(Util::Abi::HardwareStage::Cs, resUsage->numVgprsAvailable);
 


### PR DESCRIPTION
This metadata was missing and PAL makes some assert of its existence. We
add it now.