### PR TITLE
Re-enable shaderdb tests

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetReloc.pipe
@@ -1,7 +1,6 @@
 ; Test that the DescSet relocation is generated.  If this starts to fail we need to change the test to make sure it
 ; is generated.
 ; BEGIN_SHADERTEST
-; REQUIRES: do-not-run-me
 ; RUN: amdllpc \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %gfxip %s %s -v | FileCheck -check-prefix=SHADERTEST %s

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_DescSetRelocMissing.pipe
@@ -1,7 +1,6 @@
 ; Test that the DescSet relocation is generated.  If this starts to fail we need to change the test to make sure it
 ; is generated.
 ; BEGIN_SHADERTEST
-; REQUIRES: do-not-run-me
 ; RUN: amdllpc \
 ; RUN:         -enable-relocatable-shader-elf \
 ; RUN:         -o %t.elf %gfxip %s %s -v | FileCheck -check-prefix=SHADERTEST %s


### PR DESCRIPTION
They were disabled before an llvm update.
They should be passing again.