### PR TITLE
Remove scalarBlockLayout and robustBufferAccess from Context

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1037,11 +1037,6 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
   bool hasError = false;
   context->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>(&hasError));
 
-  // Set a couple of pipeline options for front-end use.
-  // TODO: The front-end should not be using pipeline options.
-  context->setScalarBlockLayout(context->getPipelineContext()->getPipelineOptions()->scalarBlockLayout);
-  context->setRobustBufferAccess(context->getPipelineContext()->getPipelineOptions()->robustBufferAccess);
-
   // Set up middle-end objects.
   LgcContext *builderContext = context->getLgcContext();
   std::unique_ptr<Pipeline> pipeline(builderContext->createPipeline());

--- a/llpc/context/llpcContext.h
+++ b/llpc/context/llpcContext.h
@@ -82,27 +82,6 @@ public:
 
   llvm::CodeGenOpt::Level getOptimizationLevel() const;
 
-  // Set value of scalarBlockLayout option. This gets called with the value from PipelineOptions when
-  // starting a pipeline compile.
-  void setScalarBlockLayout(bool scalarBlockLayout) { m_scalarBlockLayout = scalarBlockLayout; }
-
-  // Get value of scalarBlockLayout for front-end use. If there have been any pipeline compiles in this context,
-  // then it returns the value from the most recent one. If there have not been any pipeline compiles in this
-  // context yet, then it returns false.
-  // TODO: This is not correct behavior. The front-end should not be using pipeline options. Possibly
-  // scalarBlockLayout is a whole-device option that should be passed into LLPC in a different way.
-  bool getScalarBlockLayout() const { return m_scalarBlockLayout; }
-
-  // Set value of robustBufferAccess option. This gets called with the value from PipelineOptions when
-  // starting a pipeline compile.
-  void setRobustBufferAccess(bool robustBufferAccess) { m_robustBufferAccess = robustBufferAccess; }
-
-  // Get value of robustBufferAccess for front-end use. If there have been any pipeline compiles in this context,
-  // then it returns the value from the most recent one. If there have not been any pipeline compiles in this
-  // context yet, then it returns false.
-  // TODO: This is not correct behavior. The front-end should not be using pipeline options.
-  bool getRobustBufferAccess() const { return m_robustBufferAccess; }
-
   std::unique_ptr<llvm::Module> loadLibrary(const BinaryData *lib);
 
   // Wrappers of interfaces of pipeline context
@@ -146,8 +125,6 @@ private:
   std::unique_ptr<lgc::LgcContext> m_builderContext; // Builder context
 
   std::unique_ptr<llvm::TargetMachine> m_targetMachine; // Target machine
-  bool m_scalarBlockLayout = false;                     // scalarBlockLayout option from last pipeline compile
-  bool m_robustBufferAccess = false;                    // robustBufferAccess option from last pipeline compile
 
   unsigned m_useCount = 0; // Number of times this context is used.
 };

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -332,7 +332,7 @@ void SpirvLowerMemoryOp::recordStoreExpandInfo(StoreInst *storeInst, ArrayRef<Ge
 // @param dynIndex : Dynamic index
 void SpirvLowerMemoryOp::expandStoreInst(StoreInst *storeInst, ArrayRef<GetElementPtrInst *> getElemPtrs,
                                          Value *dynIndex) {
-  const bool robustBufferAccess = m_context->getRobustBufferAccess();
+  const bool robustBufferAccess = m_context->getPipelineContext()->getPipelineOptions()->robustBufferAccess;
   const unsigned getElemPtrCount = getElemPtrs.size();
   bool isType64 = (dynIndex->getType()->getPrimitiveSizeInBits() == 64);
   Value *firstStoreDest = getElemPtrs[0];

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1642,7 +1642,7 @@ Value *SPIRVToLLVM::addLoadInstRecursively(SPIRVType *const spvType, Value *load
     loadPointer = getBuilder()->CreateBitCast(loadPointer, castType);
     loadType = vectorType;
 
-    const bool scalarBlockLayout = static_cast<Llpc::Context &>(getBuilder()->getContext()).getScalarBlockLayout();
+    const bool scalarBlockLayout = getPipelineOptions()->scalarBlockLayout;
 
     if (!scalarBlockLayout)
       alignmentType = vectorType;
@@ -1780,7 +1780,7 @@ void SPIRVToLLVM::addStoreInstRecursively(SPIRVType *const spvType, Value *store
       Type *const castType = storeType->getPointerTo(storePointer->getType()->getPointerAddressSpace());
       storePointer = getBuilder()->CreateBitCast(storePointer, castType);
 
-      const bool scalarBlockLayout = static_cast<Llpc::Context &>(getBuilder()->getContext()).getScalarBlockLayout();
+      const bool scalarBlockLayout = getPipelineOptions()->scalarBlockLayout;
 
       if (!scalarBlockLayout)
         alignmentType = storeType;


### PR DESCRIPTION
Both are available in the pipeline options.

I don’t know why they were set in the Context previously, but in Vulkan,
they seem to be device options, so they should be set for every pipeline
anyway (see `PipelineCompiler::ApplyPipelineOptions` in `icd/api/pipeline_compiler.cpp`).