### PR TITLE
lgc: remove obsolete comment

### DIFF
--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -109,7 +109,6 @@ bool PatchPreparePipelineAbi::runImpl(Module &module, PipelineShadersResult &pip
 
   m_gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
 
-  // If we've only to set the calling conventions, do that now.
   if (m_gfxIp.major >= 9)
     mergeShader(module);
 


### PR DESCRIPTION
This comment is outdated since commit 6675da21156281 ("lgc: set
AMDGPU_xx calling conventions as soon as possible"). Previously, this
pass could be run in one of two different modes, and the comment is a
reference to that.