### PR TITLE
Peep through image desc modifications during waterfall generation.

### DIFF
--- a/llpc/test/shaderdb/core/OpTypeSampledImage_TestWaterfallScalarize.frag
+++ b/llpc/test/shaderdb/core/OpTypeSampledImage_TestWaterfallScalarize.frag
@@ -19,6 +19,9 @@ void main()
 // BEGIN_SHADERTEST
 //
 // RUN: amdllpc -scalarize-waterfall-descriptor-loads -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+// Explicitly check GFX10.3 ASIC variants:
+// RUN: amdllpc -scalarize-waterfall-descriptor-loads -v --gfxip=10.3.0 %s | FileCheck -check-prefix=SHADERTEST %s
+// RUN: amdllpc -scalarize-waterfall-descriptor-loads -v --gfxip=10.3.2 %s | FileCheck -check-prefix=SHADERTEST %s
 // SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 // SHADERTEST: call i32 @llvm.amdgcn.waterfall.begin.i32
 // SHADERTEST-NOT: call i32 @llvm.amdgcn.waterfall.begin.i32


### PR DESCRIPTION
An issue was introduced with PR #1827, where waterfall tracing
interacted incorrectly with workaround code that modifies image
descriptors on some GFX10.3 ASICs.
This would result in compilation errors for some shaders.

This patches fixes the issue in two ways:
 * The scalarizer code now correctly updates the non-uniform
   instruction with waterfall replacement values.
 * The tracing code can now peep through workarounds like those
   used on gfx1032, meaning waterfalls output should be identical
   on these ASICs.