### PR TITLE
Move setOptionsInPipeline call position

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -232,13 +232,13 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, Util::MetroHash64 *ha
       pipeline->setPreRasterHasGs(true);
   }
 
-  // Give the pipeline options to the middle-end, and/or hash them.
-  setOptionsInPipeline(pipeline, hasher);
-
   if (!unlinked) {
     // Give the user data nodes to the middle-end, and/or hash them.
     setUserDataInPipeline(pipeline, hasher, stageMask);
   }
+
+  // Give the pipeline options to the middle-end, and/or hash them.
+  setOptionsInPipeline(pipeline, hasher);
 
   if (isGraphics()) {
     if ((stageMask & ~shaderStageToMask(ShaderStageFragment)) && (!unlinked || DisableFetchShader)) {


### PR DESCRIPTION
Move setOptionsInPipeline function call after setUserDataInPipeline, Our
internal project use calculation result from setUserDataInPipeline for
the setOptionsInPipeline. this PR means to reduce merge conflict.