### PR TITLE
Set alignment of shared variables to 4

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4165,7 +4165,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpVariable>(SPIRVValue *con
                          GlobalVariable::NotThreadLocal, addrSpace);
 
   if (addrSpace == SPIRAS_Local) {
-    globalVar->setAlignment(MaybeAlign(16));
+    globalVar->setAlignment(MaybeAlign(4));
 
     // NOTE: Give shared variable a name to skip "global optimize pass".
     // The pass will change constant store operations to initializerand this


### PR DESCRIPTION
The alignment of shared variable ought to be 4 rather than 16. Aligning to
dword is enough.