### PR TITLE
Set alignment of shared variables to 4

### DIFF
--- a/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
+++ b/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
@@ -5,9 +5,9 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @[[LDS0:[^ ]*]] = addrspace(3) global <{ [8 x i32] }> undef, align 16
-; SHADERTEST: @[[LDS1:[^ ]*]] = addrspace(3) global <{ [4 x i32] }> undef, align 16
-; SHADERTEST: @[[LDS2:[^ ]*]] = addrspace(3) global <{ [16 x i8], [4 x i32] }> undef, align 16
+; SHADERTEST: @[[LDS0:[^ ]*]] = addrspace(3) global <{ [8 x i32] }> undef, align 4
+; SHADERTEST: @[[LDS1:[^ ]*]] = addrspace(3) global <{ [4 x i32] }> undef, align 4
+; SHADERTEST: @[[LDS2:[^ ]*]] = addrspace(3) global <{ [16 x i8], [4 x i32] }> undef, align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 0), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 1), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [4 x i32] }>, <{ [4 x i32] }> addrspace(3)* @[[LDS1]], i32 0, i32 0, i32 2), align 4
@@ -26,22 +26,22 @@
 ; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS0]], i32 0, i32 0, i32 7), align 4
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: @[[LDS:[^ ]*]] = local_unnamed_addr addrspace(3) global <{ [8 x i32] }> undef, align 16
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 0), align 16
+; SHADERTEST: @[[LDS:[^ ]*]] = local_unnamed_addr addrspace(3) global <{ [8 x i32] }> undef, align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 0), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 1), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 2), align 8
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 2), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 3), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 4), align 16
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 4), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 5), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 6), align 8
+; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 6), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 7), align 4
-; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 0), align 16
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 0), align 4
 ; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 1), align 4
-; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 2), align 8
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 2), align 4
 ; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 3), align 4
-; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 4), align 16
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 4), align 4
 ; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 5), align 4
-; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 6), align 8
+; SHADERTEST: load i32, i32 addrspace(3)* getelementptr inbounds (<{ [8 x i32] }>, <{ [8 x i32] }> addrspace(3)* @[[LDS]], i32 0, i32 0, i32 6), align 4
 ; index = 7 is optimized.
 
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestSharedVarLoadStore_lit.comp
+++ b/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestSharedVarLoadStore_lit.comp
@@ -46,8 +46,8 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST-COUNT-4: getelementptr {{.*}}[4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 {{%?[0-9]+}}, i32 {{[0-3]}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: load i8, i8 addrspace(3)* getelementptr inbounds ([4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 0, i32 0), align 16
-; SHADERTEST: store i8 %{{[0-9]*}}, i8 addrspace(3)* getelementptr inbounds ([4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 0, i32 0), align 16
+; SHADERTEST: load i8, i8 addrspace(3)* getelementptr inbounds ([4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 0, i32 0), align 4
+; SHADERTEST: store i8 %{{[0-9]*}}, i8 addrspace(3)* getelementptr inbounds ([4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 0, i32 0), align 4
 ; SHADERTEST-COUNT-3: load <{{[2-4]}} x i8>, <{{[2-4]}} x i8> addrspace(3)* getelementptr inbounds ([4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 {{[1-3]}}, i32 {{[1-3]}}), align {{[2|4]}}
 ; SHADERTEST-COUNT-3: store <{{[2-4]}} x i8> %{{[0-9]*}}, <{{[2-4]}} x i8> addrspace(3)* getelementptr inbounds ([4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }], [4 x { i8, <2 x i8>, <3 x i8>, <4 x i8> }] addrspace(3)* @{{.*}}, i32 0, i32 {{[1-3]}}, i32 {{[1-3]}}), align {{[2|4]}}
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4165,7 +4165,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpVariable>(SPIRVValue *con
                          GlobalVariable::NotThreadLocal, addrSpace);
 
   if (addrSpace == SPIRAS_Local) {
-    globalVar->setAlignment(MaybeAlign(16));
+    globalVar->setAlignment(MaybeAlign(4));
 
     // NOTE: Give shared variable a name to skip "global optimize pass".
     // The pass will change constant store operations to initializerand this


### PR DESCRIPTION
The alignment of shared variable ought to be 4 rather than 16. Aligning to
dword is enough.