### PR TITLE
Add mesh shader support: Fix an issue of unlinked mesh/fragment pipeline

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -666,9 +666,10 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         auto locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
         if (m_shaderStage == ShaderStageTessEval ||
             (m_shaderStage == ShaderStageFragment &&
-             m_pipelineState->getPrevShaderStage(m_shaderStage) == ShaderStageMesh)) {
+             (m_pipelineState->getPrevShaderStage(m_shaderStage) == ShaderStageMesh ||
+              m_pipelineState->isUnlinked()))) {
           // NOTE: For generic inputs of tessellation evaluation shader or fragment shader whose previous shader stage
-          // is mesh shader, they could be per-patch ones or per-primitive ones.
+          // is mesh shader or is in unlinked pipeline, they could be per-patch ones or per-primitive ones.
           if (locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end()) {
             loc = locInfoMapIt->second.getLocation();
           } else if (resUsage->inOutUsage.perPatchInputLocMap.find(value) !=


### PR DESCRIPTION
For unlinked mesh/fragment pipeline, we don't go into right code path to
fetch the mapped location for a per-primitive input of fragment shader.
The original condition was to check fragment shader's previous stage. But in
unlinked pipeline, the previous stage is invalid stage, we have to check
unlinked state.