### PR TITLE
Return error message when resource is not found

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -80,6 +80,8 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
 
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
     if (!node) {
+      if (!m_pipelineState->isUnlinked())
+        getPipelineState()->setError("Resource node is not found!");
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getBufferDescTy(pointeeTy));
     }
@@ -163,6 +165,8 @@ Value *DescBuilder::CreateGetDescStride(ResourceNodeType descType, unsigned desc
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(descType, descSet, binding);
     if (!node) {
+      if (!m_pipelineState->isUnlinked())
+        m_pipelineState->setError("Resource node is not found!");
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getInt32Ty());
     }
@@ -189,6 +193,8 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType concreteType, ResourceNode
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
     if (!node) {
+      if (!m_pipelineState->isUnlinked())
+        m_pipelineState->setError("Resource node is not found!");
       // We did not find the resource node. Return an undef value.
       return UndefValue::get(getDescPtrTy(concreteType));
     }

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -63,6 +63,8 @@ public:
   virtual void run(llvm::Module &module) = 0;
   virtual void setPassIndex(unsigned *passIndex) = 0;
 
+  llvm::ModuleAnalysisManager *getAnalysisManager() { return &m_moduleAnalysisManager; }
+
 protected:
   llvm::FunctionAnalysisManager m_functionAnalysisManager;
   llvm::ModuleAnalysisManager m_moduleAnalysisManager;

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -244,6 +244,12 @@ void PipelineState::generateWithNewPassManager(std::unique_ptr<Module> pipelineM
     // Run the codegen passes
     codegenPassMgr->run(*pipelineModule);
   }
+
+  if (!m_noReplayer) {
+    PipelineState *pipelineState =
+        passMgr->getAnalysisManager()->getResult<PipelineStateWrapper>(*pipelineModule).getPipelineState();
+    setError(pipelineState->getLastError());
+  }
 }
 
 void PipelineState::generateWithLegacyPassManager(std::unique_ptr<Module> pipelineModule, raw_pwrite_stream &outStream,

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1225,7 +1225,6 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
 
   if (result == Result::Success) {
 #if LLPC_ENABLE_EXCEPTION
-    result = Result::ErrorInvalidShader;
     try
 #endif
     {
@@ -1235,13 +1234,15 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
           timerProfiler.getTimer(TimerCodeGen),
       };
 
-      pipeline->generate(std::move(pipelineModule), elfStream, checkShaderCacheFunc, timers, cl::NewPassManager == 2);
-#if LLPC_ENABLE_EXCEPTION
-      result = Result::Success;
-#endif
+      if (pipeline->generate(std::move(pipelineModule), elfStream, checkShaderCacheFunc, timers,
+                             cl::NewPassManager == 2))
+        result = Result::Success;
+      else
+        result = Result::ErrorInvalidShader;
     }
 #if LLPC_ENABLE_EXCEPTION
     catch (const char *) {
+      result = Result::ErrorInvalidShader;
     }
 #endif
   }

--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -177,7 +177,7 @@ bool CacheAccessor::lookUpInShaderCache(const MetroHash::Hash &hash, bool alloca
 //
 // @param elf : The binary encoding of the elf to place in the cache.
 void CacheAccessor::setElfInCache(BinaryData elf) {
-  if (m_shaderCacheEntryState == ShaderEntryState::Compiling && m_shaderCacheEntry) {
+  if (m_shaderCacheEntryState == ShaderEntryState::Compiling && m_shaderCacheEntry && elf.codeSize != 0) {
     updateShaderCache(elf);
     mustSucceed(m_shaderCache->retrieveShader(m_shaderCacheEntry, &m_elf.pCode, &m_elf.codeSize),
                 "Failed to retrieve shader");


### PR DESCRIPTION
When creating pipeline, there is no matching resource we still return a
correct result, which is not expected.

This change is fixing this behavior, but it is invalid for relocatable
shader, because we can't know if it is compiling a single shader with
amdllpc.

In addition, fixes the CacheAccessor destructor error. when cache state is `Compiling`, elf can't be empty, otherwise we will trigger the assertion in ShaderCache::retrieveShader.