### PR TITLE
Enable Misc Side Bus optimization

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -2139,6 +2139,10 @@ template <typename T> void ConfigBuilder::setupPaSpecificRegisters(T *config) {
     paClVsOutCntl |= clipDistanceMask;
     paClVsOutCntl |= (cullDistanceMask << 8);
     SET_REG(config, PA_CL_VS_OUT_CNTL, paClVsOutCntl);
+
+    // On 10.3+ all auxiliary position exports are optimized, not just the misc exports.
+    if (gfxIp >= GfxIpVersion{10, 3})
+      SET_REG_FIELD(config, PA_CL_VS_OUT_CNTL, VS_OUT_MISC_SIDE_BUS_ENA, true);
   }
 
   unsigned posCount = 1; // gl_Position is always exported

--- a/llpc/test/shaderdb/gfx10/PipelineVsFs_TestVsOutMiscSideBusEna.pipe
+++ b/llpc/test/shaderdb/gfx10/PipelineVsFs_TestVsOutMiscSideBusEna.pipe
@@ -1,0 +1,28 @@
+; Test that VS_OUT_MISC_SIDE_BUS_ENA (0x1000000) is set correctly.
+
+; RUN: amdllpc  -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: LLPC final ELF info
+; SHADERTEST: PA_CL_VS_OUT_CNTL 0x0000000001400001
+; SHADERTEST: AMDLLPC SUCCESS
+
+[VsGlsl]
+#version 450
+
+out float gl_ClipDistance[1];
+
+void main() {
+	gl_Position = vec4(1.0);
+	gl_ClipDistance[0] = 1.0;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+
+void main() { }
+
+[FsInfo]
+entryPoint = main
+


### PR DESCRIPTION
Enable performance optimization where SX outputs vs_out_misc_vec
data on extra side bus.

On 10.3+ all auxiliary position exports are optimized, not just
the misc exports, so enable it also if gl_ClipDistance/gl_CullDistance
is used.