### PR TITLE
Add -fno-aligned-new to disable C++17 default aligned new

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -34,6 +34,10 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
             -fno-rtti
             -fPIC
             -std=c++17
+            # Some of the games using old versions of the tcmalloc lib are
+            # crashing when allocating aligned memory. C++17 enables aligned new
+            # by default, so we need to disable it to prevent those crashes.
+            -fno-aligned-new
             -Wno-ignored-qualifiers
             -Wno-missing-field-initializers
             -Wno-invalid-offsetof           # offsetof within non-standard-layout type 'x' is undefined

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -117,6 +117,12 @@ if(ICD_BUILD_LLPC)
             Target
             TransformUtils
         )
+        # Some of the games using old versions of the tcmalloc lib are crashing
+        # when allocating aligned memory. C++17 enables aligned new by default,
+        # so we need to disable it to prevent those crashes.
+        foreach (lib ${llvm_libs})
+          target_compile_options(${lib} PRIVATE "-fno-aligned-new")
+        endforeach()
         target_link_libraries(llpc PUBLIC ${llvm_libs})
     endif()
 

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -128,6 +128,9 @@ if(ICD_BUILD_LLPC)
 
     # Always link statically against libLLVMlgc
     llvm_map_components_to_libnames(extra_llvm_libs lgc)
+    foreach (lib ${extra_llvm_libs})
+      target_compile_options(${lib} PRIVATE "-fno-aligned-new")
+    endforeach()
     target_link_libraries(llpc PUBLIC ${extra_llvm_libs})
 endif()
 


### PR DESCRIPTION
Add the `-fno-aligned-new` flag to LLVM, LLPC and LGC to disable C++17 default aligned new.
Games shipped with an old version of the tcmalloc library may crash when allocating aligned memory with `aligned_alloc`.
C++17 defines `__cpp_aligned_new` by default so we are seeing more crashes since LLVM switched to C++17.
