### PR TITLE
lgc/InOutBuilder: add missing break to prevent fall-through

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -991,6 +991,7 @@ Value *InOutBuilder::normalizeBaryCoord(Value *iJCoord) {
   case PrimitiveType::Point: {
     // Points
     barycoord = ConstantVector::get({one, zero, zero});
+    break;
   }
   case PrimitiveType::LineList:
   case PrimitiveType::LineStrip: {


### PR DESCRIPTION
Fixes: 2d28dce34f48 ("Refine the barycoord (#1980)")