### PR TITLE
Add inverseSqrt to LLPC builder

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -165,6 +165,7 @@ public:
   llvm::Value *CreateExp(llvm::Value *x, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateLog(llvm::Value *x, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
+  llvm::Value *CreateInverseSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
 
   // General arithmetic operations.
   llvm::Value *CreateSAbs(llvm::Value *x, const llvm::Twine &instName = "") override final;

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -96,6 +96,8 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "log";
   case Sqrt:
     return "sqrt";
+  case InverseSqrt:
+    return "inverse.sqrt";
   case SAbs:
     return "sabs";
   case FSign:
@@ -655,6 +657,15 @@ Value *BuilderRecorder::CreateLog(Value *x, const Twine &instName) {
 // @param instName : Name to give final instruction
 Value *BuilderRecorder::CreateSqrt(Value *x, const Twine &instName) {
   return record(Sqrt, x->getType(), x, instName);
+}
+
+// =====================================================================================================================
+// Create inverse square root operation
+//
+// @param x : Input value X
+// @param instName : Name to give final instruction
+Value *BuilderRecorder::CreateInverseSqrt(Value *x, const Twine &instName) {
+  return record(InverseSqrt, x->getType(), x, instName);
 }
 
 // =====================================================================================================================
@@ -2078,6 +2089,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Determinant:
     case Exp:
     case Sqrt:
+    case InverseSqrt:
     case Log:
     case MatrixInverse:
     case Opcode::CrossProduct:

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -324,6 +324,10 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     return m_builder->CreateSqrt(args[0]);
   }
 
+  case BuilderRecorder::InverseSqrt: {
+    return m_builder->CreateInverseSqrt(args[0]);
+  }
+
   case BuilderRecorder::SAbs: {
     return m_builder->CreateSAbs(args[0]);
   }

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -104,6 +104,7 @@ public:
     Exp,
     Log,
     Sqrt,
+    InverseSqrt,
     SAbs,
     FSign,
     SSign,
@@ -298,6 +299,7 @@ public:
   llvm::Value *CreateExp(llvm::Value *x, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateLog(llvm::Value *x, const llvm::Twine &instName = "") override final;
   llvm::Value *CreateSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
+  llvm::Value *CreateInverseSqrt(llvm::Value *x, const llvm::Twine &instName = "") override final;
 
   // General arithmetic operations.
   llvm::Value *CreateSAbs(llvm::Value *x, const llvm::Twine &instName = "") override final;

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -433,6 +433,12 @@ public:
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateSqrt(llvm::Value *x, const llvm::Twine &instName = "") = 0;
 
+  // Create an inverse square root operation for a scalar or vector FP type
+  //
+  // @param x : Input value X
+  // @param instName : Name to give instruction(s)
+  virtual llvm::Value *CreateInverseSqrt(llvm::Value *x, const llvm::Twine &instName = "") = 0;
+
   // Create "signed integer abs" operation for a scalar or vector integer value.
   //
   // @param x : Input value X

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
@@ -20,10 +20,40 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract double (...) @lgc.create.sqrt.f64(double
-; SHADERTEST: = fdiv reassoc nnan nsz arcp contract double 1.000000e+00, %[[SQRT]]
-; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.sqrt.v3f64(<3 x double>
-; SHADERTEST: = fdiv reassoc nnan nsz arcp contract <3 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>, %[[SQRT3]]
+; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract double (...) @lgc.create.inverse.sqrt.f64(double
+; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.inverse.sqrt.v3f64(<3 x double>
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST: %[[X:[^ ,]*]] = load double, double addrspace(7)*
+; SHADERTEST: %[[SCALING:[^ ,]*]] = fcmp reassoc nnan nsz arcp contract olt double %[[X]], 0x1000000000000000
+; SHADERTEST: %[[SCALE_UP:[^ ,]*]] = select i1 %[[SCALING]], i32 256, i32 0
+; SHADERTEST: %[[SCALE_DOWN:[^ ,]*]] = select i1 %[[SCALING]], i32 128, i32 0
+; SHADERTEST: %[[SCALE_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.amdgcn.ldexp.f64(double %[[X]], i32 %[[SCALE_UP]])
+; SHADERTEST: %[[EXP_OF_SCALE_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_X]])
+; SHADERTEST: %[[TOO_SMALL_SCALE_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_X]], -1021
+; SHADERTEST: %[[NEW_SCALE_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_X]], double 0.000000e+00, double %[[SCALE_X]]
+; SHADERTEST: %[[Y:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.amdgcn.rsq.f64(double %[[NEW_SCALE_X]])
+; SHADERTEST: %[[G0:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double %[[NEW_SCALE_X]], %[[Y]]
+; SHADERTEST: %[[H0:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double 5.000000e-01, %[[Y]]
+; SHADERTEST: %[[NEG_H0:[^ ,]*]] = fneg reassoc nnan nsz arcp contract double %[[H0]]
+; SHADERTEST: %[[R0:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H0]], double %[[G0]], double 5.000000e-01)
+; SHADERTEST: %[[G1:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[G0]], double %[[R0]], double %[[G0]])
+; SHADERTEST: %[[H1:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H0]], double %[[R0]], double %[[H0]])
+; SHADERTEST: %[[NEG_H1:[^ ,]*]] = fneg reassoc nnan nsz arcp contract double %[[H1]]
+; SHADERTEST: %[[R1:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H1]], double %[[G1]], double 5.000000e-01)
+; SHADERTEST: %[[G2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[G1]], double %[[R1]], double %[[G1]])
+; SHADERTEST: %[[H2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H1]], double %[[R1]], double %[[H1]])
+; SHADERTEST: %[[NEG_H2:[^ ,]*]] = fneg reassoc nnan nsz arcp contract double %[[H2]]
+; SHADERTEST: %[[R2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H2]], double %[[G2]], double 5.000000e-01)
+; SHADERTEST: %[[H3:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H2]], double %[[R2]], double %[[H2]])
+; SHADERTEST: %[[RSQ_X:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double 2.000000e+00, %[[H3]]
+; SHADERTEST: %[[SCALE_RSQ_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.amdgcn.ldexp.f64(double %[[RSQ_X]], i32 %[[SCALE_DOWN]])
+; SHADERTEST: %[[EXP_OF_SCALE_RSQ_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_RSQ_X]])
+; SHADERTEST: %[[TOO_SMALL_SCALE_RSQ_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_RSQ_X]], -1021
+; SHADERTEST: %[[NEW_SCALE_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_RSQ_X]], double 0.000000e+00, double %[[SCALE_RSQ_X]]
+; SHADERTEST: %[[SPECIAL_X:[^ ,]*]] = call i1 @llvm.amdgcn.class.f64(double %[[NEW_SCALE_X]], i32 608)
+; SHADERTEST: %[[FINAL_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[SPECIAL_X]], double %[[Y]], double %[[NEW_SCALE_RSQ_X]]
+
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtFloat_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtFloat_lit.frag
@@ -20,10 +20,8 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.sqrt.f32(float
-; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn float 1.000000e+00, %[[SQRT]]
-; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.sqrt.v3f32(<3 x float>
-; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn <3 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %[[SQRT3]]
+; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.inverse.sqrt.f32(float
+; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.inverse.sqrt.v3f32(<3 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtVec4Const_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtVec4Const_lit.frag
@@ -14,8 +14,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %[[SQRT4:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.sqrt.v4f32(<4 x float>
-; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, %[[SQRT4]]
+; SHADERTEST: %[[SQRT4:[^ ,]*]] = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.inverse.sqrt.v4f32(<4 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestExponentialFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestExponentialFuncs_lit.frag
@@ -39,8 +39,7 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.exp2.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> @llvm.log2.v3f16(<3 x half>
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.sqrt.v3f16(<3 x half>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.sqrt.v3f16(<3 x half>
-; SHADERTEST: = fdiv reassoc nnan nsz arcp contract afn <3 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00>,
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x half> (...) @lgc.create.inverse.sqrt.v3f16(<3 x half>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -8257,8 +8257,7 @@ Value *SPIRVToLLVM::transGLSLExtInst(SPIRVExtInst *extInst, BasicBlock *bb) {
 
   case GLSLstd450InverseSqrt: {
     // Inverse square root
-    auto sqrt = getBuilder()->CreateSqrt(args[0]);
-    return getBuilder()->CreateFDiv(ConstantFP::get(sqrt->getType(), 1.0), sqrt);
+    return getBuilder()->CreateInverseSqrt(args[0]);
   }
 
   case GLSLstd450Determinant:


### PR DESCRIPTION
HW has native rsq instruction, so we ought to generate it directly without using 1.0/sqrt.