### PR TITLE
lgc/test: fix some lgc.create.get.desc.ptr calls

### DIFF
--- a/lgc/test/CsReconfigWorkgroup.lgc
+++ b/lgc/test/CsReconfigWorkgroup.lgc
@@ -48,7 +48,7 @@ define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
-  %imgdescptr = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.v8i32(i32 1, i32 0, i32 1, i32 0)
+  %imgdescptr = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.v8i32(i32 1, i32 0, i32 0, i32 1)
   %imgdesc = load <8 x i32>, <8 x i32> addrspace(4)* %imgdescptr
   %imgload = call <2 x float> (...) @lgc.create.image.load.v2f32(i32 1, i32 0, <8 x i32> %imgdesc, <2 x i32><i32 1, i32 2>)
   %storeptr = getelementptr i8, i8 addrspace(7)* %0, i64 16
@@ -95,7 +95,7 @@ define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc
   %1 = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 27, i32 0, i32 undef, i32 undef)
   %2 = bitcast i8 addrspace(7)* %0 to <3 x i32> addrspace(7)*
   store <3 x i32> %1, <3 x i32> addrspace(7)* %2, align 4
-  %imgdescptr = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.v8i32(i32 1, i32 0, i32 1, i32 0)
+  %imgdescptr = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.v8i32(i32 1, i32 0, i32 0, i32 1)
   %imgdesc = load <8 x i32>, <8 x i32> addrspace(4)* %imgdescptr
   %imgload = call <2 x float> (...) @lgc.create.image.load.v2f32(i32 1, i32 0, <8 x i32> %imgdesc, <2 x i32><i32 1, i32 2>)
   %storeptr = getelementptr i8, i8 addrspace(7)* %0, i64 16

--- a/lgc/test/lgcdis.lgc
+++ b/lgc/test/lgcdis.lgc
@@ -42,7 +42,7 @@ declare void @lgc.create.write.generic.output(...) #1
 define dllexport void @lgc.shader.FS.main() !lgc.shaderstage !25 {
 entry:
   %TEXCOORD = call <2 x float> (...) @lgc.create.read.generic.input.v2f32(i32 1, i32 0, i32 0, i32 1, i32 16, i32 undef)
-  %imageptr = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 1, i32 1, i32 0)
+  %imageptr = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 1, i32 0, i32 1)
   %image = load <8 x i32>, <8 x i32> addrspace(4)* %imageptr, align 32
   %samplerptr = call <4 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v4i32(i32 2, i32 2, i32 0, i32 2)
   %sampler = load <4 x i32>, <4 x i32> addrspace(4)* %samplerptr, align 16


### PR DESCRIPTION
They were updated incorrectly in a recent change.

Fixes: 4b96f4cd4ad ("Add abstractType input parameter to the getDescPtr (#1998)")

As a side note @s-perron: I noticed this in an only slightly related cleanup because I happened to change some assertions. As-is, they're referring to non-existing nodes, but the test doesn't catch that. This is the kind of thing that reduces my fervor for lit testing at least as it stands. I think there are higher-level changes we could theoretically make to improve that, but they require some investment.