### PR TITLE
lgc: streamline generic FS input IR

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -562,9 +562,7 @@ private:
   // Mark fragment output type
   void markFsOutputType(llvm::Type *outputTy, unsigned location, InOutInfo outputInfo);
 
-  // Modify aux interp value according to custom interp mode, and its helper functions.
-  llvm::Value *modifyAuxInterpValue(llvm::Value *auxInterpValue, InOutInfo inputInfo);
-  llvm::Value *evalIjOffsetNoPersp(llvm::Value *offset);
+  std::tuple<unsigned, llvm::Value *> getInterpModeAndValue(InOutInfo inputInfo, llvm::Value *auxInterpValue);
   llvm::Value *evalIjOffsetSmooth(llvm::Value *offset);
   llvm::Value *adjustIj(llvm::Value *value, llvm::Value *offset);
 

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -86,8 +86,8 @@ private:
                                       InterpParam interpParam, llvm::Value *primMask, unsigned bitWidth, bool highHalf);
 
   llvm::Value *patchFsGenericInputImport(llvm::Type *inputTy, unsigned location, llvm::Value *locOffset,
-                                         llvm::Value *compIdx, bool isPerPrimitive, llvm::Value *auxInterpValue,
-                                         unsigned interpMode, unsigned interpLoc, bool highHalf, BuilderBase &builder);
+                                         llvm::Value *compIdx, bool isPerPrimitive, unsigned interpMode,
+                                         llvm::Value *interpValue, bool highHalf, BuilderBase &builder);
 
   llvm::Value *patchTcsGenericOutputImport(llvm::Type *outputTy, unsigned location, llvm::Value *locOffset,
                                            llvm::Value *compIdx, llvm::Value *vertexIdx, BuilderBase &builder);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -3346,7 +3346,7 @@ void PatchResourceCollect::scalarizeGenericInput(CallInst *call) {
   builder.SetInsertPoint(call);
   // TCS: @lgc.input.import.generic.%Type%(i32 location, i32 locOffset, i32 elemIdx, i32 vertexIdx)
   // GS: @lgc.input.import.generic.%Type%(i32 location, i32 elemIdx, i32 vertexIdx)
-  // FS: @lgc.input.import.generic.%Type%(i32 location, i32 elemIdx, i1 perPrimitive, i32 interpMode, i32 interpLoc)
+  // FS: @lgc.input.import.generic.%Type%(i32 location, i32 elemIdx)
   //     @lgc.input.import.interpolant.%Type%(i32 location, i32 locOffset, i32 elemIdx,
   //                                          i32 interpMode, <2 x float> | i32 auxInterpValue)
   SmallVector<Value *, 5> args;
@@ -3567,7 +3567,7 @@ void InOutLocationInfoMapManager::addSpan(CallInst *call, ShaderStage shaderStag
   // For VS/TES-FS, 32-bit and 16-bit are packed separately; For VS-TCS, VS/TES-GS and GS-FS, they are packed together
   span.compatibilityInfo.is16Bit = bitWidth == 16;
 
-  if (isFs) {
+  if (isFs && isInterpolant) {
     const unsigned interpMode = cast<ConstantInt>(call->getOperand(3))->getZExtValue();
     span.compatibilityInfo.isFlat = interpMode == InOutInfo::InterpModeFlat;
     span.compatibilityInfo.isCustom = interpMode == InOutInfo::InterpModeCustom;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1476,8 +1476,11 @@ StringRef PipelineState::getBuiltInName(BuiltInKind builtIn) {
   case BuiltInInterpPerspCentroid:
     return "InterpPerspCentroid";
   case BuiltInInterpLinearCentroid:
-    return "InterpLinearCenteroid";
-
+    return "InterpLinearCentroid";
+  case BuiltInInterpPerspSample:
+    return "InterpPerspSample";
+  case BuiltInInterpLinearSample:
+    return "InterpLinearSample";
   default:
     llvm_unreachable("Should never be called!");
     return "unknown";

--- a/lgc/test/ScalarizeInputWithDynamicIndexUser.lgc
+++ b/lgc/test/ScalarizeInputWithDynamicIndexUser.lgc
@@ -10,13 +10,13 @@ target triple = "amdgcn--amdpal"
 ; CHECK: define dllexport spir_func void @lgc.shader.VS.main()
 ; CHECK: call void @lgc.output.export.generic.i32.i32.v4f32(i32 2, i32 0, <4 x float> %[[#]])
 ; CHECK: define dllexport spir_func void @lgc.shader.FS.main()
-; CHECK: [[IMPORT0:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i1.i32.i32(i32 2, i32 0, i1 false, i32 0, i32 1)
+; CHECK: [[IMPORT0:%[0-9]+]] = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 2, i32 0, i32 0, i32 0, <2 x float> %InterpPerspCenter)
 ; CHECK-NEXT: [[INSERTELEMENT0:%[0-9]+]] = insertelement <4 x float> undef, float [[IMPORT0]], i64 0
-; CHECK-NEXT: [[IMPORT1:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i1.i32.i32(i32 2, i32 1, i1 false, i32 0, i32 1)
+; CHECK-NEXT: [[IMPORT1:%[0-9]+]] = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 2, i32 0, i32 1, i32 0, <2 x float> %InterpPerspCenter)
 ; CHECK-NEXT: [[INSERTELEMENT1:%[0-9]+]] = insertelement <4 x float> [[INSERTELEMENT0]], float [[IMPORT1]], i64 1
-; CHECK-NEXT: [[IMPORT2:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i1.i32.i32(i32 2, i32 2, i1 false, i32 0, i32 1)
+; CHECK-NEXT: [[IMPORT2:%[0-9]+]] = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 2, i32 0, i32 2, i32 0, <2 x float> %InterpPerspCenter)
 ; CHECK-NEXT: [[INSERTELEMENT2:%[0-9]+]] = insertelement <4 x float> [[INSERTELEMENT1]], float [[IMPORT2]], i64 2
-; CHECK-NEXT: [[IMPORT3:%[0-9]+]] = call float @lgc.input.import.generic.f32.i32.i32.i1.i32.i32(i32 2, i32 3, i1 false, i32 0, i32 1)
+; CHECK-NEXT: [[IMPORT3:%[0-9]+]] = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 2, i32 0, i32 3, i32 0, <2 x float> %InterpPerspCenter)
 ; CHECK-NEXT: [[INSERTELEMENT3:%[0-9]+]] = insertelement <4 x float> [[INSERTELEMENT2]], float [[IMPORT3]], i64 3
 ; CHECK-NEXT: [[UBFE:%[0-9]+]] = call i32 @llvm.amdgcn.ubfe.i32(i32 12816, i32 0, i32 4)
 ; CHECK-NEXT: [[SELECT:%[0-9]+]] = select i1 false, i32 12816, i32 [[UBFE]]

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1098,6 +1098,8 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
       inOutInfo.setInterpLoc(interpLoc);
 
       if (builtIn == lgc::BuiltInBaryCoord || builtIn == lgc::BuiltInBaryCoordNoPerspKHR) {
+        if (inOutInfo.getInterpLoc() == InterpLocUnknown)
+          inOutInfo.setInterpLoc(InterpLocCenter);
         return m_builder->CreateReadBaryCoord(builtIn, inOutInfo, auxInterpValue);
       }
 

--- a/llpc/test/shaderdb/extensions/Ext16bitStorage_TestFsInput_lit.frag
+++ b/llpc/test/shaderdb/extensions/Ext16bitStorage_TestFsInput_lit.frag
@@ -26,10 +26,10 @@ void main (void)
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call <3 x i16> @lgc.input.import.generic.v3i16{{.*}}
-; SHADERTEST-DAG: call <3 x half> @lgc.input.import.generic.v3f16{{.*}}
-; SHADERTEST-DAG: call i16 @lgc.input.import.generic.i16{{.*}}
-; SHADERTEST-DAG: call half @lgc.input.import.generic.f16{{.*}}
+; SHADERTEST-DAG: call <3 x i16> @lgc.input.import.interpolant.v3i16{{.*}}
+; SHADERTEST-DAG: call <3 x half> @lgc.input.import.interpolant.v3f16{{.*}}
+; SHADERTEST-DAG: call i16 @lgc.input.import.interpolant.i16{{.*}}
+; SHADERTEST-DAG: call half @lgc.input.import.interpolant.f16{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroidNoPersp_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroidNoPersp_lit.frag
@@ -5,8 +5,8 @@
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtCentroid.p64f32(float addrspace(64)* @{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtCentroid.p64v4f32(<4 x float> addrspace(64)* @{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpLinearCentroid(i32 268435462)
-; SHADERTEST: %{{[0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid(i32 268435458)
+; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpLinearCentroid.v2f32.i32(i32 268435462)
+; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 268435458)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroid_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroid_lit.frag
@@ -20,8 +20,8 @@ void main()
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtCentroid.p64f32(float addrspace(64)* @{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtCentroid.p64v4f32(<4 x float> addrspace(64)* @{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid(i32 268435458)
-; SHADERTEST: %{{[0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid(i32 268435458)
+; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 268435458)
+; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 268435458)
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtSample_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtSample_lit.frag
@@ -29,7 +29,7 @@ void main()
 ; SHADERTEST-DAG: = call <3 x float> @lgc.input.import.builtin.InterpPullMode.v3f32.i32(
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32
 ; SHADERTEST-DAG: = call float @lgc.input.import.interpolant.f32.i32.i32.i32.i32.v2f32(i32 0, i32 0, i32 0, i32 0, <2 x float>
-; SHADERTEST-DAG: = call <4 x float> @lgc.input.import.interpolant.v4f32.i32.i32.i32.i32.v2f32(i32 1, i32 0, i32 0, i32 1, <2 x float>
+; SHADERTEST-DAG: = call <4 x float> @lgc.input.import.interpolant.v4f32.i32.i32.i32.i32.i32(i32 1, i32 0, i32 0, i32 1, i32 poison
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p1(float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call float @llvm.amdgcn.interp.p2(float %{{.*}}, float %{{.*}}, i32 immarg 0, i32 immarg 0, i32 %{{.*}})

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestInterpFuncs_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestInterpFuncs_lit.frag
@@ -19,7 +19,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: %{{[0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid(i32 {{.*}})
+; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 {{.*}})
 ; SHADERTEST: %{{[0-9]*}} = call <4 x half> @lgc.input.import.interpolant.v4f16.i32.i32.i32.i32.v2f32(i32 0, i32 0, i32 0, i32 0, <2 x float> %{{.*}})
 ; SHADERTEST: = call <2 x float> @lgc.input.import.builtin.SamplePosOffset.v2f32.i32.i32(
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode

--- a/llpc/test/shaderdb/object/ObjInput_TestFsBasic_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsBasic_lit.frag
@@ -19,9 +19,9 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call <2 x i32> @lgc.input.import.generic.v2i32{{.*}}
-; SHADERTEST-DAG: call i32 @lgc.input.import.generic{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-DAG: call <2 x i32> @lgc.input.import.interpolant.v2i32{{.*}}
+; SHADERTEST-DAG: call i32 @lgc.input.import.interpolant.{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/object/ObjInput_TestFsCompSpecifier_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsCompSpecifier_lit.frag
@@ -15,8 +15,8 @@ void main (void)
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <2 x float> @lgc.input.import.generic.v2f32{{.*}}
-; SHADERTEST: call float @lgc.input.import.generic.f32{{.*}}
+; SHADERTEST: call <2 x float> @lgc.input.import.interpolant.v2f32{{.*}}
+; SHADERTEST: call float @lgc.input.import.interpolant.f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
 ; SHADERTEST: call float @llvm.amdgcn.interp.p2(float %{{[^,]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)

--- a/llpc/test/shaderdb/object/ObjInput_TestFsDouble_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsDouble_lit.frag
@@ -24,10 +24,10 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call <4 x double> @lgc.input.import.generic.v4f64.
-; SHADERTEST-DAG: call <4 x double> @lgc.input.import.generic.v4f64.
-; SHADERTEST-DAG: call <3 x double> @lgc.input.import.generic.v3f64.
-; SHADERTEST-DAG: call <3 x double> @lgc.input.import.generic.v3f64.
+; SHADERTEST-DAG: call <4 x double> @lgc.input.import.interpolant.v4f64.
+; SHADERTEST-DAG: call <4 x double> @lgc.input.import.interpolant.v4f64.
+; SHADERTEST-DAG: call <3 x double> @lgc.input.import.interpolant.v3f64.
+; SHADERTEST-DAG: call <3 x double> @lgc.input.import.interpolant.v3f64.
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-28: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/object/ObjInput_TestFsInBlock_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsInBlock_lit.frag
@@ -29,12 +29,12 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call i32 @lgc.input.import.generic{{.*}}
-; SHADERTEST-DAG: call <3 x float> @lgc.input.import.generic.v3f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-DAG: call i32 @lgc.input.import.interpolant.{{.*}}
+; SHADERTEST-DAG: call <3 x float> @lgc.input.import.interpolant.v3f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-DAG: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST-DAG: call float @llvm.amdgcn.interp.p1

--- a/llpc/test/shaderdb/object/ObjInput_TestFsInterpQualifierInBlock_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsInterpQualifierInBlock_lit.frag
@@ -22,9 +22,9 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call i32 @lgc.input.import.generic{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-DAG: call i32 @lgc.input.import.interpolant{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-DAG: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST-DAG: call float @llvm.amdgcn.interp.p1

--- a/llpc/test/shaderdb/object/ObjInput_TestFsInterpQualifierOnStruct_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsInterpQualifierOnStruct_lit.frag
@@ -22,8 +22,8 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
-; SHADERTEST: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
+; SHADERTEST: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-DAG: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST-DAG: call float @llvm.amdgcn.interp.p2

--- a/llpc/test/shaderdb/object/ObjInput_TestFsInterpQualifier_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsInterpQualifier_lit.frag
@@ -27,7 +27,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-COUNT-7: call float @lgc.input.import.generic.f32{{.*}}
+; SHADERTEST-COUNT-7: call float @lgc.input.import.interpolant.f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call float @llvm.amdgcn.interp.p1
 ; SHADERTEST: call float @llvm.amdgcn.interp.p2

--- a/llpc/test/shaderdb/object/ObjInput_TestFsMatrixArray_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsMatrixArray_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-COUNT-8: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-COUNT-8: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-32: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/object/ObjInput_TestFsMatrix_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsMatrix_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-COUNT-4: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-COUNT-4: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-16: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/object/ObjInput_TestFsStruct_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsStruct_lit.frag
@@ -29,10 +29,10 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-DAG: call i32 @lgc.input.import.generic{{.*}}
-; SHADERTEST-DAG: call <3 x float> @lgc.input.import.generic.v3f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
-; SHADERTEST-DAG: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-DAG: call i32 @lgc.input.import.interpolant{{.*}}
+; SHADERTEST-DAG: call <3 x float> @lgc.input.import.interpolant.v3f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
+; SHADERTEST-DAG: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-20: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/object/ObjInput_TestFsVectorArray_lit.frag
+++ b/llpc/test/shaderdb/object/ObjInput_TestFsVectorArray_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST-COUNT-2: call <4 x float> @lgc.input.import.generic.v4f32{{.*}}
+; SHADERTEST-COUNT-2: call <4 x float> @lgc.input.import.interpolant.v4f32{{.*}}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-COUNT-8: call float @llvm.amdgcn.interp.mov
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
LGC IR now contains one of the following operations for reading an FS input:

- @lgc.input.import.generic.%T%(i32 location, i32 elemIdx) Used for per-primitive inputs, i.e. in mesh shader pipelines.

- @lgc.input.import.interpolant.%Type%(i32 location, i32 locOffset, i32 elemIdx, i32 interpMode, <2 x float> | i32 interpValue) Used for not-per-primitive (per-vertex / interpolated) inputs. interpMode is one of: - InterpModeSmooth: interpolate in the normal way, using barycentrics from interpValue - InterpModeCustom: retrieve the values of one of the vertices; interpValue is the (hardware) vertex index (0, 1, or 2) - InterpModeFlat: flat shading, interpValue is ignored

This simplifies the IR relative to the status quo, where the handling of interpolation location (center / centroid / sample) is spread across the frontend building of IR and PatchInOutImportExport. Now, this is handled consistently in the frontend. Note the associated slight reduction in code size.

The alternative would have been to always handle locations in PatchInOutImportExport and streamline the IR to allow (mode, location, aux) tuples to be represented such that the required information survives in the IR.

The disadvantage of the chosen solution is that it results in slightly larger IR, since operations to read barycentrics are explicitly included. The advantage is that the definition of the IR is simpler.