### PR TITLE
Fix compiler warning

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -166,16 +166,14 @@ PipelineContext::PipelineContext(GfxIpVersion gfxIp, MetroHash::Hash *pipelineHa
 #if VKI_RAY_TRACING
                                  ,
                                  const Vkgc::RtState *rtState
-
 #endif
                                  )
-    : m_gfxIp(gfxIp), m_pipelineHash(*pipelineHash), m_cacheHash(*cacheHash),
+    : m_gfxIp(gfxIp), m_pipelineHash(*pipelineHash), m_cacheHash(*cacheHash)
 #if VKI_RAY_TRACING
-
-      m_rtState(rtState),
-
+      ,
+      m_rtState(rtState)
 #endif
-      m_resourceMapping() {
+{
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Compilers complained that m_resourceMapping is initialized before m_rtState. m_resourceMapping does not have any arguments, so we can just remove it’s explicit initialization in the constructor.