### PR TITLE
lgc/DescBuilder: assert that resource nodes can be found

### DIFF
--- a/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
+++ b/llpc/test/shaderdb/general/CsTimerProfileTest.pipe
@@ -41,3 +41,13 @@ void main()
 
 [CsInfo]
 entryPoint = main
+userDataNode[0].type = DescriptorBuffer
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 4
+userDataNode[0].set = 0
+userDataNode[0].binding = 0
+userDataNode[1].type = DescriptorBuffer
+userDataNode[1].offsetInDwords = 4
+userDataNode[1].sizeInDwords = 4
+userDataNode[1].set = 0
+userDataNode[1].binding = 1


### PR DESCRIPTION
These assertions should always be true, and if they did fail, then continuing with an `undef` value isn't much better because it will result in incorrect code anyway.

As nice side effect, this happens to likely paper over some issues with an internal use case of the compiler.

Add `ResourceMapping` for test 