### PR TITLE
lgc/dialect: add buffer.length and buffer.ptr.diff

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -156,10 +156,6 @@ StringRef BuilderRecorder::getCallName(Opcode opcode) {
     return "get.desc.ptr";
   case Opcode::LoadPushConstantsPtr:
     return "load.push.constants.ptr";
-  case Opcode::GetBufferDescLength:
-    return "get.buffer.desc.length";
-  case Opcode::PtrDiff:
-    return "buffer.ptrdiff";
   case Opcode::ReadGenericInput:
     return "read.generic.input";
   case Opcode::ReadPerVertexInput:
@@ -1139,27 +1135,6 @@ Value *BuilderRecorder::CreateLoadPushConstantsPtr(Type *returnTy, const Twine &
 }
 
 // =====================================================================================================================
-// Create a buffer length query based on the specified descriptor.
-//
-// @param bufferDesc : The buffer descriptor to query.
-// @param instName : Name to give instruction(s).
-Value *BuilderRecorder::CreateGetBufferDescLength(Value *const bufferDesc, Value *offset, const Twine &instName) {
-  return record(Opcode::GetBufferDescLength, getInt32Ty(), {bufferDesc, offset}, instName);
-}
-
-// =====================================================================================================================
-// Return the i64 difference between two buffer fat pointer values, dividing out the size of the pointed-to objects.
-//
-// @param ty : Element type of the pointers.
-// @param lhs : Left hand side of the subtraction.
-// @param rhs : Reft hand side of the subtraction.
-// @param instName : Name to give instruction(s)
-Value *BuilderRecorder::CreatePtrDiff(llvm::Type *ty, llvm::Value *lhs, llvm::Value *rhs, const llvm::Twine &instName) {
-  // We can't store a type, so store a zero value of the type instead
-  return record(Opcode::PtrDiff, getInt64Ty(), {Constant::getNullValue(ty), lhs, rhs}, instName);
-}
-
-// =====================================================================================================================
 // Create an image load.
 //
 // @param resultTy : Result type
@@ -2119,7 +2094,6 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::Fma:
     case Opcode::FpTruncWithRounding:
     case Opcode::Fract:
-    case Opcode::GetBufferDescLength:
     case Opcode::GetDescPtr:
     case Opcode::GetDescStride:
     case Opcode::GetWaveSize:
@@ -2133,7 +2107,6 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::MatrixTimesVector:
     case Opcode::NormalizeVector:
     case Opcode::OuterProduct:
-    case Opcode::PtrDiff:
     case Opcode::QuantizeToFp16:
     case Opcode::Reflect:
     case Opcode::Refract:

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -423,17 +423,6 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     return m_builder->CreateLoadPushConstantsPtr(call->getType()); // returnTy
   }
 
-  case BuilderRecorder::Opcode::GetBufferDescLength: {
-    return m_builder->CreateGetBufferDescLength(args[0],  // buffer descriptor
-                                                args[1]); // offset
-  }
-
-  case BuilderRecorder::Opcode::PtrDiff: {
-    return m_builder->CreatePtrDiff(args[0]->getType(), // ty
-                                    args[1],            // lhs
-                                    args[2]);           // rhs
-  }
-
   // Replayer implementations of ImageBuilder methods
   case BuilderRecorder::Opcode::ImageLoad: {
     unsigned dim = cast<ConstantInt>(args[0])->getZExtValue();

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -305,14 +305,6 @@ public:
   // Create a load of the push constants pointer.
   llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *returnTy, const llvm::Twine &instName) override final;
 
-  // Create a buffer length query based on the specified descriptor.
-  llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
-                                         const llvm::Twine &instName = "") override final;
-
-  // Return the i64 difference between two pointers, dividing out the size of the pointed-to objects.
-  llvm::Value *CreatePtrDiff(llvm::Type *ty, llvm::Value *lhs, llvm::Value *rhs,
-                             const llvm::Twine &instName = "") override final;
-
 private:
   DescBuilder() = delete;
   DescBuilder(const DescBuilder &) = delete;

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -127,8 +127,6 @@ public:
     GetDescStride,
     GetDescPtr,
     LoadPushConstantsPtr,
-    GetBufferDescLength,
-    PtrDiff,
 
     // Image
     ImageLoad,
@@ -366,12 +364,6 @@ public:
                                 unsigned binding, const llvm::Twine &instName) override final;
 
   llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *returnTy, const llvm::Twine &instName) override final;
-
-  llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
-                                         const llvm::Twine &instName = "") override final;
-
-  llvm::Value *CreatePtrDiff(llvm::Type *ty, llvm::Value *lhs, llvm::Value *rhs,
-                             const llvm::Twine &instName = "") override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Image operations

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -102,10 +102,7 @@ const static char SpecialUserData[] = "lgc.special.user.data.";
 // Get shader input. Arg is ShaderInput enum value.
 const static char ShaderInput[] = "lgc.shader.input.";
 
-const static char LaterCallPrefix[] = "lgc.late.";
 const static char LateLaunderFatPointer[] = "lgc.late.launder.fat.pointer";
-const static char LateBufferLength[] = "lgc.late.buffer.desc.length";
-const static char LateBufferPtrDiff[] = "lgc.late.buffer.ptrdiff";
 
 // Names of global variables
 const static char ImmutableSamplerGlobal[] = "lgc.immutable.sampler";

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -766,25 +766,6 @@ public:
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateLoadPushConstantsPtr(llvm::Type *returnTy, const llvm::Twine &instName = "") = 0;
 
-  // Create a buffer length query based on the specified descriptor, subtracting an offset from the length. The result
-  // is 0 for a null descriptor when allowNullDescriptor is enabled.
-  //
-  // @param bufferDesc : The buffer descriptor to query.
-  // @param offset: The offset to subtract from the buffer length.
-  // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreateGetBufferDescLength(llvm::Value *const bufferDesc, llvm::Value *offset,
-                                                 const llvm::Twine &instName = "") = 0;
-
-  // Return the i64 difference between two pointers, dividing out the size of the pointed-to objects.
-  // For buffer fat pointers, delays the translation to patch phase.
-  //
-  // @param ty : Element type of the pointers.
-  // @param lhs : Left hand side of the subtraction.
-  // @param rhs : Reft hand side of the subtraction.
-  // @param instName : Name to give instruction(s)
-  virtual llvm::Value *CreatePtrDiff(llvm::Type *ty, llvm::Value *lhs, llvm::Value *rhs,
-                                     const llvm::Twine &instName = "") = 0;
-
   // -----------------------------------------------------------------------------------------------------------------
   // Image operations
 

--- a/lgc/interface/lgc/BuilderCommon.h
+++ b/lgc/interface/lgc/BuilderCommon.h
@@ -46,6 +46,15 @@ public:
   BuilderCommon(llvm::BasicBlock *block) : llvm_dialects::Builder(block) {}
   BuilderCommon(llvm::Instruction *inst) : llvm_dialects::Builder(inst) {}
 
+  // Return the i64 difference between two pointers, dividing out the size of the pointed-to objects.
+  // For buffer fat pointers, delays the translation to patch phase.
+  //
+  // @param ty : Element type of the pointers.
+  // @param lhs : Left hand side of the subtraction.
+  // @param rhs : Reft hand side of the subtraction.
+  // @param instName : Name to give instruction(s)
+  llvm::Value *CreatePtrDiff(llvm::Type *ty, llvm::Value *lhs, llvm::Value *rhs, const llvm::Twine &instName = "");
+
   // Create an LLVM function call to the named function. The callee is built automatically based on return
   // type and its parameters.
   //

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -36,3 +36,51 @@ def V4I32 : FixedVectorType<4, I32>;
 
 class LgcOp<string mnemonic_, list<Trait> traits_ = []>
     : Op<LgcDialect, mnemonic_, traits_ # [NoUnwind]>;
+
+// TODO: Enable this once we have made the switch to opaque pointers.
+//def BufferDescToPtrOp : LgcOp<"buffer.desc.to.ptr", [ReadNone, WillReturn]> {
+//  let arguments = (ins V4I32:$desc);
+//  let results = (outs BufferPointer:$result);
+//
+//  let summary = "convert a buffer descriptor into a buffer pointer";
+//  let description = [{
+//    Given a buffer descriptor for a storage buffer, returns a fat buffer pointer to the start of the buffer.
+//
+//    The descriptor must be a null descriptor or a valid descriptor for a storage buffer aka raw buffer, i.e. a buffer
+//    for which the indexing feature of BUFFER_LOAD_* instructions is never used.
+//  }];
+//}
+
+def BufferLengthOp : LgcOp<"buffer.length", [Memory<[]>, WillReturn]> {
+  // TODO: Change to BufferPointer after we switch to opaque pointers.
+  let arguments = (ins AnyPointerType:$pointer, I32:$offset);
+  let results = (outs I32:$result);
+
+  let summary = "return the size of a buffer";
+  let description = [{
+    Return the number of bytes available in the buffer pointed to by `pointer`, starting at a byte `offset` from the
+    pointer.
+
+    `offset` is interpreted as an unsigned integer. If `offset` is greater than the total size of the buffer, or if the
+    buffer is a null buffer, behavior depends on the `allowNullDescriptors` setting:
+    - if null descriptors are allowed, the offset is properly clamped and 0 is returned.
+    - if null descriptors are *not* allowed, the return value is poison.
+  }];
+}
+
+def BufferPtrDiffOp : LgcOp<"buffer.ptr.diff", [Memory<[]>, WillReturn]> {
+  // TODO: Change to BufferPointer after we switch to opaque pointers.
+  let arguments = (ins AnyPointerType:$lhs, AnyPointerType:$rhs);
+  let results = (outs I64:$result);
+
+  let verifier = [(SameTypes $lhs, $rhs)];
+
+  let summary = "return the difference between buffer pointers in bytes";
+  let description = [{
+    Return the (signed) distance `lhs - rhs` from rhs to lhs in bytes.
+
+    If `lhs` and `rhs` have different pointer provenance, the result is poison.
+
+    If `lhs` and `rhs` are both null, the result is 0.
+  }];
+}

--- a/llpc/test/shaderdb/core/OpArrayLength_TestGeneral_lit.frag
+++ b/llpc/test/shaderdb/core/OpArrayLength_TestGeneral_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call i32 {{.*}}@lgc.create.get.buffer.desc.length.i32(
-; SHADERTEST: call i32 {{.*}}@lgc.create.get.buffer.desc.length.i32(
+; SHADERTEST: call i32 {{.*}}@lgc.buffer.length(
+; SHADERTEST: call i32 {{.*}}@lgc.buffer.length(
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/core/OpPtrDiff_Buffer_mem.spvasm
+++ b/llpc/test/shaderdb/core/OpPtrDiff_Buffer_mem.spvasm
@@ -1,33 +1,7 @@
-; BEGIN_SHADERTEST
-; REQUIRES: do-not-run-me
-; RUN: amdllpc -enable-opaque-pointers=true -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call i64 (...) @lgc.create.buffer.ptrdiff.i64(i32 0, ptr addrspace(7) {{@[0-9]+}}, ptr addrspace(7) {{%[0-9]+}})
-; SHADERTEST: call i64 (...) @lgc.create.buffer.ptrdiff.i64(i64 0, ptr addrspace(7) {{@[0-9]+}}, ptr addrspace(7) {{%[0-9]+}})
+; RUN: amdllpc -emit-lgc -gfxip 11.0 -o - %s | FileCheck -check-prefix=SHADERTEST %s
 
-; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-
-; SHADERTEST: call i64 @lgc.late.buffer.ptrdiff.i32.p7.p7(i32 0, ptr addrspace(7) {{%[0-9]+}}, ptr addrspace(7) {{%[0-9]+}})
-; SHADERTEST: call i64 @lgc.late.buffer.ptrdiff.i64.p7.p7(i64 0, ptr addrspace(7) {{%[0-9]+}}, ptr addrspace(7) {{%[0-9]+}})
-
-; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-
-; SHADERTEST: [[a:%[0-9a-zA-Z.]+]] = shl i32 {{%[0-9a-zA-Z.]+}}, 2
-; SHADERTEST: [[b:%[0-9]+]] = zext i32 [[a]] to i64
-; SHADERTEST: [[c:%[0-9]+]] = sub nsw i64 0, [[b]]
-; SHADERTEST: [[d1:%[0-9]+]] = ashr exact i64 [[c]], 2
-
-; SHADERTEST: [[a:%[0-9a-zA-Z.]+]] = shl i32 {{%[0-9a-zA-Z.]+}}, 3
-; SHADERTEST: [[b:%[0-9]+]] = zext i32 [[a]] to i64
-; SHADERTEST: [[c:%[0-9]+]] = sub nsw i64 0, [[b]]
-; SHADERTEST: [[d:%[0-9]+]] = ashr exact i64 [[c]], 3
-; SHADERTEST: [[e:%[0-9]+]] = trunc i64 [[d]] to i32
-
-; SHADERTEST: [[e1:%[0-9a-zA-Z.]+]] = bitcast i64 [[d1]] to <2 x i32>
-; SHADERTEST: {{%[0-9]+}} = insertelement <2 x i32> [[e1]], i32 [[e]], i64 1
-
-; SHADERTEST: AMDLLPC SUCCESS
-; END_SHADERTEST
+; SHADERTEST: call i64 {{.*}}@lgc.buffer.ptr.diff(ptr addrspace(7) {{%[0-9]+}}, ptr addrspace(7) {{%[0-9]+}})
+; SHADERTEST: call i64 {{.*}}@lgc.buffer.ptr.diff(ptr addrspace(7) {{%[0-9]+}}, ptr addrspace(7) {{%[0-9]+}})
 
 ; SPIR-V
 ; Version: 1.4

--- a/llpc/test/shaderdb/object/ObjStorageBlock_TestUseStorageBuffer_lit.frag
+++ b/llpc/test/shaderdb/object/ObjStorageBlock_TestUseStorageBuffer_lit.frag
@@ -19,7 +19,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: call i32 {{.*}}@lgc.create.get.buffer.desc.length.i32(
+; SHADERTEST: call i32 {{.*}}@lgc.buffer.length(
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -48,6 +48,7 @@
 #include "llpcCompiler.h"
 #include "llpcContext.h"
 #include "llpcPipelineContext.h"
+#include "lgc/LgcDialect.h"
 #include "lgc/Pipeline.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -2836,7 +2837,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpArrayLength>(SPIRVValue *
   const StructLayout *const structLayout = m_m->getDataLayout().getStructLayout(structType);
   const unsigned offset = static_cast<unsigned>(structLayout->getElementOffset(remappedMemberIndex));
   Value *const offsetVal = getBuilder()->getInt32(offset);
-  Value *const arrayBytes = getBuilder()->CreateGetBufferDescLength(structure, offsetVal);
+  Value *const arrayBytes = getBuilder()->create<BufferLengthOp>(structure, offsetVal);
 
   Type *const memberType = structType->getStructElementType(remappedMemberIndex)->getArrayElementType();
   const unsigned stride = static_cast<unsigned>(m_m->getDataLayout().getTypeSizeInBits(memberType) / 8);


### PR DESCRIPTION
Builds on #2023.

Convert existing "LGC intrinsics" to start a "sub-dialect" for buffer
fat pointers, i.e. LLVM IR pointers whose underlying representation is
a buffer descriptor -- essentially a base + buffer size -- and an
offset into the buffer.

buffer.desc.to.ptr is still missing because of opaque pointer troubles.
Basically, llvm-dialects doesn't know how to handle an operation that
returns a non-opaque pointer, and it doesn't make much sense to spend
effort on adding that support anymore. So I plan to add
buffer.desc.to.ptr once we've fully transitioned to opaque pointers.
    
Some `ashr / sdiv` become `lshr` in the test cases. This is okay because
the resulting value is truncated.