### PR TITLE
lgc: Build unit tests only when LLPC tests are enabled.

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -216,6 +216,6 @@ add_subdirectory(disassembler)
 add_subdirectory(tool/lgc)
 add_subdirectory(test)
 
-if (LGC_BUILD_UNITTESTS)
+if (LLPC_BUILD_TESTS)
   add_subdirectory(unittests)
 endif()

--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -215,4 +215,7 @@ target_sources(LLVMlgc PRIVATE
 add_subdirectory(disassembler)
 add_subdirectory(tool/lgc)
 add_subdirectory(test)
-add_subdirectory(unittests)
+
+if (LGC_BUILD_UNITTESTS)
+  add_subdirectory(unittests)
+endif()


### PR DESCRIPTION
I have an internal project that needs to statically link with llpc. In order to save on build times, I disabled LLVM tests but this results in a situation where Lgc's unittests project now fails to link due to a missing llvm_gtest_main.lib file.

Currently there appears to be no way to opt-out of lgc's unittests project without modifying lgc's CMakeLists.txt file. This is questionable - are all LLPC project users really interested in building these unit tests?

This PR makes the inclusion of lgc's unittests project's subdirectory conditional upon the status of a new LGC_BUILD_UNITTESTS CMake option. It assumes the unit tests should not be included by default. I can adjust the PR, if it would make more sense for these tests to be instead included by default.