### PR TITLE
update_llpc.sh: update Git submodules

### DIFF
--- a/docker/update-llpc.sh
+++ b/docker/update-llpc.sh
@@ -9,3 +9,4 @@ cat /vulkandriver/build_info.txt
 git -C /vulkandriver/drivers/llpc remote add origin https://github.com/"$LLPC_REPO_NAME".git
 git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" --update-head-ok
 git -C /vulkandriver/drivers/llpc checkout "$LLPC_REPO_SHA"
+git -C /vulkandriver/drivers/llpc submodule update --init


### PR DESCRIPTION
This should allow CI to pass on PRs after llvm-dialects has been added, including for the PR that adds llvm-dialects as a submodule.

(I don't know how to meaningfully test such a change, though...)

See: https://github.com/GPUOpen-Drivers/llpc/pull/2023