### PR TITLE
Fix subgroupId when forceCsThreadIdSwizzling is used

### DIFF
--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -49,6 +49,10 @@ static const BuiltInKind BuiltInNumSamples = static_cast<BuiltInKind>(0x10000008
 static const BuiltInKind BuiltInSamplePatternIdx = static_cast<BuiltInKind>(0x10000009);
 static const BuiltInKind BuiltInGsWaveId = static_cast<BuiltInKind>(0x1000000A);
 
+// Internal builts-ins for compute input when thread id is swizzled
+static const BuiltInKind BuiltInHwLocalInvocationId = static_cast<BuiltInKind>(0x1000000B);
+static const BuiltInKind BuiltInHwLocalInvocationIndex = static_cast<BuiltInKind>(0x1000000C);
+
 // Names used for calls added to IR to represent various actions internally.
 namespace lgcName {
 const static char InternalCallPrefix[] = "lgc.";


### PR DESCRIPTION
… global setting cause corruption

##Description##
This issue is due to subgroup-id using.
Currently, the subgroup-id calculation will follow: subgroup_id = LocalInvocationIndex/Subgroupsize.
Without swizzling, it's no problem.
But after swizzling, the invocationIndex has also been changed, but in expect, the subgroup_id should not be changed.
To understand this, it can be thought in this way:
"there is an (Api)LocalInvocation{Id,Index}, which is the one that is provided when SPIR-V loads from the corresponding builtin. Then, there is a (Hw)LocalInvocation{Id,Index}, which are based on the VGPRs initialized by HW at wave launch. Traditionally, ApiLocalInvocationId was always the same as HwLocalInvocationId. With swizzling, they are different."

##Fix##
For pre-Navi21, it should calculate with HWLocalInvocationIndex, which should be calculated from shader input localInvocationId.
From Navi21, it should parse the subgroup_id(wave_id) from intialized SGPR.
To be conservative, this fix will only work on swizzling cases.
