### PR TITLE
Opaque pointers: Add command line flag to enable opaque-pointers

### DIFF
--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -80,6 +80,8 @@ cl::opt<unsigned> PalAbiVersion("pal-abi-version", cl::init(0xFFFFFFFF), cl::cat
 
 // -v: enable verbose output
 cl::opt<bool> VerboseOutput("v", cl::cat(LgcCategory), cl::desc("Enable verbose output"), cl::init(false));
+
+cl::opt<bool> OpaquePointers("enable-opaque-pointers", cl::desc("Enable opaque-pointers in LGC"), cl::init(false));
 } // anonymous namespace
 
 // =====================================================================================================================
@@ -115,7 +117,7 @@ int main(int argc, char **argv) {
   LLVMContext context;
   // Temporarily disable opaque pointers (llvm is making opaque the default).
   // TODO: Remove this once work complete on transition to opaque pointers.
-  context.setOpaquePointers(false);
+  context.setOpaquePointers(OpaquePointers);
   LgcContext::initialize();
 
   // Set our category on options that we want to show in -help, and hide other options.

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -67,7 +67,7 @@ Context::Context(GfxIpVersion gfxIp) : LLVMContext(), m_gfxIp(gfxIp) {
   reset();
   // Temporarily disable opaque pointers (llvm is making opaque the default).
   // TODO: Remove this once work complete on transition to opaque pointers.
-  setOpaquePointers(false);
+  setOpaquePointers(GetOpaquePointersFlag());
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -64,6 +64,11 @@ opt<std::string> LogFileDbgs("log-file-dbgs", desc("Name of the file to log info
 opt<std::string> LogFileOuts("log-file-outs", desc("Name of the file to log info from LLPC_OUTS() and LLPC_ERRS()"),
                              value_desc("filename"), init(""));
 
+// TODO: Remove this when LLPC will switch fully to opaque pointers.
+// opaque-pointers flag which is implemented in LLVM is by default enabled. Right now we do not want
+// to enable by default this flag for LLPC, but we need to have some flag to use for transition and for LIT tests.
+opt<bool> OpaquePointers("enable-opaque-pointers", desc("Enable opaque-pointers for LLPC"), init(false));
+
 } // namespace cl
 
 } // namespace llvm
@@ -71,7 +76,9 @@ opt<std::string> LogFileOuts("log-file-outs", desc("Name of the file to log info
 using namespace llvm;
 
 namespace Llpc {
-
+bool GetOpaquePointersFlag() {
+  return cl::OpaquePointers;
+}
 // =====================================================================================================================
 // Gets the value of option "allow-out".
 bool EnableOuts() {

--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -66,4 +66,6 @@ void redirectLogOutput(bool restoreToDefault, unsigned optionCount, const char *
 // Enable/disable the output for debugging.
 void enableDebugOutput(bool restore);
 
+bool GetOpaquePointersFlag();
+
 } // namespace Llpc


### PR DESCRIPTION
Opaque pointer flag which is defined in LLVM is by default enabled. For transition time, we need to have new flag which will be by default disabled. This flag will be used in LIT tests to test opaque and non-opaque pointers. After merging all the patches this flag will be changes to true (by default) and removed if regression does not show up.