### PR TITLE
Opaque pointers: Check if GV was created from OpVariable

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7282,7 +7282,9 @@ bool SPIRVToLLVM::checkContains64BitType(SPIRVType *bt) {
 
 bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
   auto gv = dyn_cast<GlobalVariable>(v);
-  if (gv) {
+  // Some SPIR-V instructions (e.g. OpAccessChain) can become no-ops in LLVM IR,
+  // so we must explicitly check both the SPIR-V opcode and the LLVM type.
+  if (gv && bv->getOpCode() == OpVariable) {
     auto as = gv->getType()->getAddressSpace();
     if (as == SPIRAS_Input || as == SPIRAS_Output) {
       // Translate decorations of inputs and outputs


### PR DESCRIPTION
This function (transShaderDecoration) is called after translation SPIRV instruction to LLVM instructions and it is updating some of Global Variable meta data.
Additional check, which ensures that Global Variale was created from OpVariable needs to be added. This is because for opaque pointer mode OpAccessChain not always is converted to GetElementPtr. If OpAccessChain is a zero-index then GetElementPtr instruction will be skipped and source of OpAccessChain will be taken. From SPIRV to LLVM translation perspective this will look like OpAccessChain is converted to Global Variable. Despite the fact that we are skipping here Global Variable initialization of meta data, this Global Variable was initialized before, when translation from OpVariable to Global Variable took place.