### PR TITLE
Opaque Pointers: Add payload base type to builtin arguments.

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -71,6 +71,8 @@ enum : unsigned {
   RayDir,          // Ray direction
   RayTMax,         // Ray Tmax
   Payload,         // Payload
+  PayloadType,     // PayloadType - This parameter is not specify in SPIRV API. This was added only to keep base type
+                   //               of the Payload.
   TraceRayCount,   // OpTraceRay params count
 };
 } // namespace TraceRayParam


### PR DESCRIPTION
Extending Ray Tracing builtins with one additional argument (last position) which type is equal to ray tracing payload base type. Translation from SPIRV to LLVM is a last place where base type of ray tracing payload type is known. Later when Ray Tracing function is created base type of payload data is no longer available with opaque pointers turn on.