### PR TITLE
Fix interpolation location for builtIn

### DIFF
--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1099,7 +1099,7 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
 
       if (builtIn == lgc::BuiltInBaryCoord || builtIn == lgc::BuiltInBaryCoordNoPerspKHR) {
         if (inOutInfo.getInterpLoc() == InterpLocUnknown)
-          inOutInfo.setInterpLoc(InterpLocCenter);
+          inOutInfo.setInterpLoc(inOutMeta.InterpLoc);
         return m_builder->CreateReadBaryCoord(builtIn, inOutInfo, auxInterpValue);
       }
 


### PR DESCRIPTION
If interpolation location is unknown, we should use the qualifier.