### PR TITLE
Make internalRtShaders a pipeline option

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -44,10 +44,10 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 54
+#define LLPC_INTERFACE_MAJOR_VERSION 55
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 6
+#define LLPC_INTERFACE_MINOR_VERSION 0
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -81,7 +81,9 @@
 //  @page VersionHistory
 //  %Version History
 //  | %Version | Change Description                                                                                    |
-//  | -------- | ------------------------------------------------------------------------------------------------------|
+//  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     55.0 | Remove isInternalRtShader from module options                                                         |
+//  |     54.9 | Add internalRtShaders to PipelineOptions to allow for dumping this data                               |
 //  |     54.6 | Add reverseThreadGroup to PipelineOptions                                                             |
 #if VKI_RAY_TRACING
 //  |     54.4 | Add isReplay to RayTracingPipelineBuildInfo for ray tracing capture replay feature                    |
@@ -482,6 +484,12 @@ struct PipelineOptions {
   ResourceLayoutScheme resourceLayoutScheme;     ///< Resource layout scheme
   ThreadGroupSwizzleMode threadGroupSwizzleMode; ///< Controls thread group swizzle mode for compute shader.
   bool reverseThreadGroup;                       ///< If set, enable thread group reversing
+
+#if VKI_RAY_TRACING
+  bool internalRtShaders; ///< Whether this pipeline has internal raytracing shaders
+#else
+  bool reserved15;
+#endif
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -146,6 +146,11 @@ struct Options {
   unsigned reverseThreadGroupBufferDescSet;      // Descriptor set ID of the internal buffer for reverse thread group
                                                  // optimization
   unsigned reverseThreadGroupBufferBinding; // Binding ID of the internal buffer for reverse thread group optimization
+#if VKI_RAY_TRACING
+  bool internalRtShaders; // Enable internal RT shader intrinsics
+#else
+  bool reserved15;
+#endif
 };
 
 // Middle-end per-shader options to pass to SetShaderOptions.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -480,6 +480,9 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
       shaderOptions.waveSize = getRayTracingWaveSize();
     }
 #endif
+#if VKI_RAY_TRACING
+    options.internalRtShaders = getPipelineOptions()->internalRtShaders;
+#endif
 
     // Use a static cast from Vkgc WaveBreakSize to LGC WaveBreak, and static assert that
     // that is valid.

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -112,7 +112,9 @@ struct ShaderModuleOptions {
   bool enableOpt; ///< Enable translate & lower phase in build shader module
 #endif
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 55
   bool isInternalRtShader; ///< Whether this shader is an internal raytracing shader
+#endif
 #endif
 };
 

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -316,6 +316,13 @@ cl::opt<ResourceLayoutScheme> LayoutScheme("resource-layout-scheme", cl::desc("T
 cl::opt<bool> AssertToMsgBox("assert-to-msgbox", cl::desc("Pop message box when assert is hit"));
 #endif
 
+#if VKI_RAY_TRACING
+// -enable-internal-rt-shaders: enable intrinsics for internal RT shaders
+cl::opt<bool> EnableInternalRtShaders("enable-internal-rt-shaders",
+                                      cl::desc("Enable intrinsics for internal RT shaders"),
+                                      cl::init(false));
+#endif
+
 } // namespace
 // clang-format on
 namespace llvm {
@@ -502,6 +509,10 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
     nggState.primsPerSubgroup = NggPrimsPerSubgroup;
     nggState.vertsPerSubgroup = NggVertsPerSubgroup;
   }
+
+#if VKI_RAY_TRACING
+  compileInfo->internalRtShaders = EnableInternalRtShaders;
+#endif
 
   return Result::Success;
 }

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -104,6 +104,9 @@ struct CompileInfo {
   bool scratchAccessBoundsChecks; // Whether to enable scratch access bounds checks
   VfxPipelineType pipelineType;   // Pipeline type
   llvm::Optional<llvm::CodeGenOpt::Level> optimizationLevel; // The optimization level to pass the compiler
+#if VKI_RAY_TRACING
+  bool internalRtShaders; // Whether to enable intrinsics for internal RT shaders
+#endif
 };
 
 // Callback function to allocate buffer for building shader module and building pipeline.

--- a/llpc/tool/llpcComputePipelineBuilder.cpp
+++ b/llpc/tool/llpcComputePipelineBuilder.cpp
@@ -144,6 +144,9 @@ Expected<BinaryData> ComputePipelineBuilder::buildComputePipeline() {
 #endif
   pipelineInfo->options.threadGroupSwizzleMode = compileInfo.compPipelineInfo.options.threadGroupSwizzleMode;
   pipelineInfo->options.reverseThreadGroup = compileInfo.compPipelineInfo.options.reverseThreadGroup;
+#if VKI_RAY_TRACING
+  pipelineInfo->options.internalRtShaders = compileInfo.internalRtShaders;
+#endif
 
   PipelineBuildInfo localPipelineInfo = {};
   localPipelineInfo.pComputeInfo = pipelineInfo;

--- a/llpc/tool/llpcGraphicsPipelineBuilder.cpp
+++ b/llpc/tool/llpcGraphicsPipelineBuilder.cpp
@@ -150,6 +150,9 @@ Expected<BinaryData> GraphicsPipelineBuilder::buildGraphicsPipeline() {
     pipelineInfo->options.optimizationLevel = compileInfo.optimizationLevel.value();
   }
 #endif
+#if VKI_RAY_TRACING
+  pipelineInfo->options.internalRtShaders = compileInfo.internalRtShaders;
+#endif
 
   PipelineBuildInfo localPipelineInfo = {};
   localPipelineInfo.pGraphicsInfo = pipelineInfo;

--- a/llpc/unittests/util/testPipelineDumper.cpp
+++ b/llpc/unittests/util/testPipelineDumper.cpp
@@ -351,6 +351,26 @@ TEST(PipelineDumperTest, TestReverseThreadGroupCompute) {
   HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
   runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
 }
+#if VKI_RAY_TRACING
+// =====================================================================================================================
+// Test the internalRtShaders option.
+
+TEST(PipelineDumperTest, TestInternalRTShadersGraphics) {
+  ModifyGraphicsBuildInfo modifyBuildInfo = [](GraphicsPipelineBuildInfo *buildInfo) {
+    buildInfo->options.internalRtShaders = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &) { return false; };
+  runGraphicsPipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestInternalRTShadersCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.internalRtShaders = true;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+#endif
 
 } // namespace
 } // namespace Llpc

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -791,6 +791,10 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
 #endif
   dumpFile << "options.threadGroupSwizzleMode = " << options->threadGroupSwizzleMode << "\n";
   dumpFile << "options.reverseThreadGroup = " << options->reverseThreadGroup << "\n";
+
+#if VKI_RAY_TRACING
+  dumpFile << "options.internalRtShaders = " << options->internalRtShaders << "\n";
+#endif
 }
 
 // =====================================================================================================================
@@ -1501,6 +1505,10 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
 #endif
   hasher->Update(options->threadGroupSwizzleMode);
   hasher->Update(options->reverseThreadGroup);
+
+#if VKI_RAY_TRACING
+  hasher->Update(options->internalRtShaders);
+#endif
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -361,6 +361,9 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
     INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
+#if VKI_RAY_TRACING
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
+#endif
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 


### PR DESCRIPTION
Currently the usage of internal RT shader intrinsics is not captured by the pipeline state, and there is no way to activate these from the command line. This makes it impossible to recompile an internal RT shader, such as BuildBVH on the command line.

Move the isInternalRtShader module option to a pipeline option. Add a command line option -enable-internal-rt-shaders.

Load and dump internalRtShaders option to .pipe files. An XGL change is required for the dump state to be accurate.