### PR TITLE
Fix incorrect assert in buildPipelineVsFsRegConfig

### DIFF
--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -55,7 +55,7 @@ void ConfigBuilder::buildPalMetadata() {
     const bool hasTs = (m_hasTcs || m_hasTes);
 
     if (!m_pipelineState->isWholePipeline() && m_pipelineState->hasShaderStage(ShaderStageFragment)) {
-      // FS-only shader compilation
+      // FS-only shader compilation (part-pipeline compilation)
       buildPipelineVsFsRegConfig();
     } else if (!hasTs && !m_hasGs) {
       // VS-FS pipeline

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -56,7 +56,7 @@ void ConfigBuilder::buildPalMetadata() {
     const bool enableNgg = m_pipelineState->getNggControl()->enableNgg;
 
     if (!m_pipelineState->isWholePipeline() && m_pipelineState->hasShaderStage(ShaderStageFragment)) {
-      // FS-only shader or part-pipeline compilation
+      // FS-only shader (part-pipeline compilation)
       buildPipelineVsFsRegConfig();
     } else if (m_hasTask) {
       // Task-Mesh-FS pipeline
@@ -98,7 +98,9 @@ void ConfigBuilder::buildPalMetadata() {
 // Builds register configuration for graphics pipeline (VS-FS), or FS-only shader compilation
 void ConfigBuilder::buildPipelineVsFsRegConfig() {
   GfxIpVersion gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
-  assert(gfxIp.major <= 10);
+  const bool partPipeline = !m_pipelineState->isWholePipeline() && m_pipelineState->hasShaderStage(ShaderStageFragment);
+  assert(gfxIp.major <= 10 || partPipeline); // Must be GFX10 or below, or part-pipeline compilation
+  (void(partPipeline));                      // Unused
 
   PipelineVsFsRegConfig config(gfxIp);
 


### PR DESCRIPTION
When part-pipeline compilation is enabled, this function will be called. For whole pipeline compilation, the GFX IP should be not greater than GFX10. For part-pipeline compilation, this assert is inappropriate.