### PR TITLE
Add interface for trace ray library manager

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1076,6 +1076,7 @@ void PipelineDumper::dumpRayTracingRtState(const RtState *rtState, std::ostream 
              << "\n";
   dumpStream << "rtState.enableOptimalLdsStackSizeForUnified = " << rtState->enableOptimalLdsStackSizeForUnified
              << "\n";
+  dumpStream << "rtState.enableTraceRaySpecialization = " << rtState->enableTraceRaySpecialization << "\n";
 
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
   for (unsigned i = 0; i < RT_ENTRY_FUNC_COUNT; ++i) {
@@ -1148,6 +1149,7 @@ void PipelineDumper::updateHashForRtState(const RtState *rtState, MetroHash64 *h
   hasher->Update(rtState->enableRayTracingCounters);
   hasher->Update(rtState->enableOptimalLdsStackSizeForIndirect);
   hasher->Update(rtState->enableOptimalLdsStackSizeForUnified);
+  hasher->Update(rtState->enableTraceRaySpecialization);
 
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
   for (unsigned i = 0; i < RT_ENTRY_FUNC_COUNT; ++i) {

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -588,6 +588,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayTracingCounters, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForIndirect, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForUnified, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableTraceRaySpecialization, MemberTypeBool, false);
     INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_exportConfig, MemberTypeRayTracingShaderExportConfig, true);
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
     INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtFuncTable, MemberTypeGpurtFuncTable, true);
@@ -609,9 +610,9 @@ public:
 
 private:
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
-  static const unsigned MemberCount = 28;
+  static const unsigned MemberCount = 29;
 #else
-  static const unsigned MemberCount = 27;
+  static const unsigned MemberCount = 28;
 #endif
   static StrToMemberAddr m_addrTable[MemberCount];
 


### PR DESCRIPTION
Add helper interface ITraceRayLibMgr, driver will inherit and implement it, and compiler will use it to obtain a trace ray library index.

This is the preparation for the upcoming change to implement trace ray specialization functionality.

Background:
In indirect mode, when trace ray specialization is chosen, compiler will not build trace ray library along with pipeline shaders. Instead, a trace ray library table will be built by driver, and compiler will query the index to it by providing necessary trace ray parameters. Driver will compile specialized trace ray libraies based on the given paramters and cache them, so that they can be shared between different RT pipelines. This will prvent compiling and uploading a same library for multiple times.