### PR TITLE
Opaque Pointers: Handle name mangling.

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -524,6 +524,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryInitializeKHR>
   // NOTE: Initialize rayQuery.committed to zero, as a workaround for CTS that uses it without committed intersection.
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!traceRaysArgs[0]->getType()->isOpaquePointerTy()) {
+    traceRaysArgs[0] = m_builder->CreateBitCast(
+        traceRaysArgs[0], rayQueryTy->getPointerTo(traceRaysArgs[0]->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(traceRaysArgs[0]->getType()->getScalarType(), rayQueryTy));
   Value *committedAddr =
       m_builder->CreateGEP(rayQueryTy, traceRaysArgs[0], {zero, m_builder->getInt32(RayQueryParams::Committed)});
@@ -635,6 +640,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryProceedKHR>(Fu
   Value *rayQuery = func->arg_begin();
   Type *rayQueryEltTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
 
   // Initialize ldsUsage for the shader stage
@@ -691,6 +701,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetIntersectio
   committed = m_builder->CreateTrunc(committed, m_builder->getInt1Ty());
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   rayQuery = m_builder->CreateLoad(rayQueryTy, rayQuery);
   auto pCandidateTy = m_builder->CreateExtractValue(rayQuery, RayQueryParams::CandidateType);
@@ -721,6 +736,11 @@ Value *SpirvLowerRayQuery::createIntersectSystemValue(Function *func, unsigned r
   intersect = m_builder->CreateTrunc(intersect, m_builder->getInt1Ty());
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   rayQuery = m_builder->CreateLoad(rayQueryTy, rayQuery);
   auto candidate = m_builder->CreateExtractValue(rayQuery, RayQueryParams::Candidate);
@@ -750,6 +770,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetIntersectio
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
   Value *intersect = func->arg_begin() + 1;
   Value *rayTMinAddr = m_builder->CreateGEP(rayQueryEltTy, rayQuery,
@@ -758,6 +783,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetIntersectio
 
   intersect = m_builder->CreateTrunc(intersect, m_builder->getInt1Ty());
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   rayQuery = m_builder->CreateLoad(rayQueryTy, rayQuery);
@@ -783,6 +813,11 @@ void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetIntersectionInstanceCus
   Value *rayQuery = func->arg_begin();
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   rayQuery = m_builder->CreateLoad(rayQueryTy, rayQuery);
   auto instanceNodeAddr = createGetInstanceNodeAddr(instanceNodePtr, rayQuery);
@@ -804,6 +839,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetIntersectio
   // Extract instance node address from instance node pointer
   Value *rayQuery = func->arg_begin();
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   rayQuery = m_builder->CreateLoad(rayQueryTy, rayQuery);
@@ -880,6 +920,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryTerminateKHR>(
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
 
   {
@@ -930,6 +975,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGenerateInters
   Value *hitT = func->arg_begin() + 1;
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   Value *rayQueryVal = m_builder->CreateLoad(rayQueryTy, rayQuery);
   auto candidateTy = m_builder->CreateExtractValue(rayQueryVal, RayQueryParams::CandidateType);
@@ -977,6 +1027,10 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryConfirmInterse
   m_builder->SetInsertPoint(entryBlock);
   Value *rayQuery = func->arg_begin();
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   Value *rayQueryVal = m_builder->CreateLoad(rayQueryTy, rayQuery);
@@ -1011,6 +1065,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetRayTMinKHR>
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
   Value *rayTMinAddr = m_builder->CreateGEP(rayQueryEltTy, rayQuery,
                                             {m_builder->getInt32(0), m_builder->getInt32(RayQueryParams::RayTMin)});
@@ -1029,6 +1088,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetRayFlagsKHR
 
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
   Value *rayFlagsAddr = m_builder->CreateGEP(rayQueryEltTy, rayQuery,
@@ -1054,6 +1118,11 @@ void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetIntersectionCandidateAA
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
   Value *candidateTypeAddr = m_builder->CreateGEP(
       rayQueryEltTy, rayQuery, {m_builder->getInt32(0), m_builder->getInt32(RayQueryParams::CandidateType)});
@@ -1076,6 +1145,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetWorldRayDir
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
   Value *dirAddr = m_builder->CreateGEP(rayQueryEltTy, rayQuery,
                                         {m_builder->getInt32(0), m_builder->getInt32(RayQueryParams::RayDesc),
@@ -1094,6 +1168,11 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryGetWorldRayOri
 
   Value *rayQuery = func->arg_begin();
   auto rayQueryEltTy = getRayQueryInternalTy(m_builder);
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryEltTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType()->getScalarType(), rayQueryEltTy));
   Value *originAddr = m_builder->CreateGEP(rayQueryEltTy, rayQuery,
@@ -1116,6 +1195,11 @@ void SpirvLowerRayQuery::createIntersectMatrix(Function *func, unsigned builtInI
 
   Value *rayQuery = func->arg_begin();
   auto rayQueryTy = getRayQueryInternalTy(m_builder);
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!rayQuery->getType()->isOpaquePointerTy()) {
+    rayQuery =
+        m_builder->CreateBitCast(rayQuery, rayQueryTy->getPointerTo(rayQuery->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(rayQuery->getType(), rayQueryTy));
   rayQuery = m_builder->CreateLoad(rayQueryTy, rayQuery);
@@ -1476,25 +1560,41 @@ void SpirvLowerRayQuery::createIntersectBvh(Function *func) {
 
   auto argIt = func->arg_begin();
 
+  Value *arg = argIt;
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg = m_builder->CreateBitCast(
+        arg, FixedVectorType::get(m_builder->getInt32Ty(), 2)->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), FixedVectorType::get(m_builder->getInt32Ty(), 2)));
-  Value *address = m_builder->CreateLoad(FixedVectorType::get(m_builder->getInt32Ty(), 2), argIt);
-  argIt++;
+  Value *address = m_builder->CreateLoad(FixedVectorType::get(m_builder->getInt32Ty(), 2), arg);
+  arg = ++argIt;
 
   // Address int64 type
   address = m_builder->CreateBitCast(address, m_builder->getInt64Ty());
 
   // Ray extent float Type
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg =
+        m_builder->CreateBitCast(arg, m_builder->getFloatTy()->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), m_builder->getFloatTy()));
-  Value *extent = m_builder->CreateLoad(m_builder->getFloatTy(), argIt);
-  argIt++;
+  Value *extent = m_builder->CreateLoad(m_builder->getFloatTy(), arg);
+  arg = ++argIt;
 
   // Ray origin vec3 Type
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg = m_builder->CreateBitCast(
+        arg, FixedVectorType::get(m_builder->getFloatTy(), 3)->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), FixedVectorType::get(m_builder->getFloatTy(), 3)));
-  Value *origin = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), argIt);
-  argIt++;
+  Value *origin = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), arg);
+  arg = ++argIt;
 
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 406441
   // Construct vec3 = {0.0, 1.0, 0.0}
@@ -1507,9 +1607,14 @@ void SpirvLowerRayQuery::createIntersectBvh(Function *func) {
 #endif
   // Ray dir vec3 type
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg = m_builder->CreateBitCast(
+        arg, FixedVectorType::get(m_builder->getFloatTy(), 3)->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), FixedVectorType::get(m_builder->getFloatTy(), 3)));
-  Value *dir = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), argIt);
-  argIt++;
+  Value *dir = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), arg);
+  arg = ++argIt;
 
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 406441
   // vec4 dir = vec4(dir.xyz, 0.0)
@@ -1517,24 +1622,39 @@ void SpirvLowerRayQuery::createIntersectBvh(Function *func) {
 #endif
   // Ray inv_dir vec3 type
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg = m_builder->CreateBitCast(
+        arg, FixedVectorType::get(m_builder->getFloatTy(), 3)->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), FixedVectorType::get(m_builder->getFloatTy(), 3)));
-  Value *invDir = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), argIt);
+  Value *invDir = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), arg);
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 406441
   // vec4 inDir = vec4(invDir, 0.0)
   invDir = m_builder->CreateShuffleVector(invDir, constVec, ArrayRef<int>{0, 1, 2, 3});
 #endif
-  argIt++;
+  arg = ++argIt;
 
   // uint flag
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg =
+        m_builder->CreateBitCast(arg, m_builder->getInt32Ty()->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), m_builder->getInt32Ty()));
-  Value *flags = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt);
-  argIt++;
+  Value *flags = m_builder->CreateLoad(m_builder->getInt32Ty(), arg);
+  arg = ++argIt;
 
   // uint expansion
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  if (!arg->getType()->isOpaquePointerTy()) {
+    arg =
+        m_builder->CreateBitCast(arg, m_builder->getInt32Ty()->getPointerTo(arg->getType()->getPointerAddressSpace()));
+  }
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), m_builder->getInt32Ty()));
-  Value *expansion = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt);
+  Value *expansion = m_builder->CreateLoad(m_builder->getInt32Ty(), arg);
   const unsigned boxExpansionShift = 23;
   expansion = m_builder->CreateShl(expansion, boxExpansionShift);
 

--- a/llpc/test/shaderdb/extensions/ExtExplicitVertexParam_TestInterpFunc_lit.frag
+++ b/llpc/test/shaderdb/extensions/ExtExplicitVertexParam_TestInterpFunc_lit.frag
@@ -18,8 +18,8 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: call {{.*}} <2 x float> @InterpolateAtVertexAMD.p64v2f32.i32
-; SHADERTEST: call {{.*}} <2 x i32> @InterpolateAtVertexAMD.p64v2i32.i32
+; SHADERTEST: call {{.*}} <2 x float> @InterpolateAtVertexAMD.v2f32.p64.i32
+; SHADERTEST: call {{.*}} <2 x i32> @InterpolateAtVertexAMD.v2i32.p64.i32
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: call <2 x float> @lgc.input.import.interpolant.v2f32{{.*}}
 ; SHADERTEST: call <2 x i32> @lgc.input.import.interpolant.v2i32{{.*}}

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroidNoPersp_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroidNoPersp_lit.frag
@@ -2,8 +2,8 @@
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtCentroid.p64f32(float addrspace(64)* @{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtCentroid.p64v4f32(<4 x float> addrspace(64)* @{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtCentroid.f32.p64(i8 addrspace(64)* {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtCentroid.v4f32.p64(i8 addrspace(64)* {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpLinearCentroid.v2f32.i32(i32 268435462)
 ; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 268435458)

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroid_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtCentroid_lit.frag
@@ -17,8 +17,8 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtCentroid.p64f32(float addrspace(64)* @{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtCentroid.p64v4f32(<4 x float> addrspace(64)* @{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtCentroid.f32.p64(i8 addrspace(64)* {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtCentroid.v4f32.p64(i8 addrspace(64)* {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 268435458)
 ; SHADERTEST: %{{[A-Za-z0-9]*}} = call <2 x float> @lgc.input.import.builtin.InterpPerspCentroid.v2f32.i32(i32 268435458)

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtOffset_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtOffset_lit.frag
@@ -22,8 +22,8 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtOffset.p64f32.v2f32(float addrspace(64)* @{{.*}}, <2 x float> %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* @{{.*}}, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtOffset.f32.p64.v2f32(i8 addrspace(64)* {{.*}}, <2 x float> %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* {{.*}}, <2 x float> %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtSample_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateAtSample_lit.frag
@@ -22,8 +22,8 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtSample.p64f32.i32(float addrspace(64)* @{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtSample.p64v4f32.i32(<4 x float> addrspace(64)* @{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} float @interpolateAtSample.f32.p64.i32(i8 addrspace(64)* {{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtSample.v4f32.p64.i32(i8 addrspace(64)* {{.*}}, i32 %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST-DAG: = call <2 x float> @lgc.input.import.builtin.SamplePosOffset.v2f32.i32.i32(
 ; SHADERTEST-DAG: = call <3 x float> @lgc.input.import.builtin.InterpPullMode.v3f32.i32(

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DArray.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DArray.frag
@@ -15,7 +15,7 @@ void main()
 /*
 ; RUN: amdllpc -verify-ir -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DArrayInStruct.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DArrayInStruct.frag
@@ -26,7 +26,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DStructArray.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx1DStructArray.frag
@@ -26,7 +26,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx2DArrayInStruct.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx2DArrayInStruct.frag
@@ -28,7 +28,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx2DArrayInStructInArray.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx2DArrayInStructInArray.frag
@@ -27,7 +27,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx2DStructArray.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx2DStructArray.frag
@@ -25,7 +25,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx3DArray.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdx3DArray.frag
@@ -17,7 +17,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.p64v4f32.v2f32(<4 x float> addrspace(64)* %{{.*}}, <2 x float> {{.*}})
+; SHADERTEST: %{{[0-9]*}} = call {{.*}} <4 x float> @interpolateAtOffset.v4f32.p64.v2f32(i8 addrspace(64)* %{{.*}}, <2 x float> {{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST: = call <3 x float> @lgc.input.import.builtin.InterpPullMode
 ; SHADERTEST-COUNT-12: = call i32 @llvm.amdgcn.mov.dpp.i32(i32

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdxVector.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInterpolateDynIdxVector.frag
@@ -16,7 +16,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST-COUNT-2: %{{[0-9]*}} = call {{.*}} float @interpolateAtSample.p64f32.i32(float addrspace(64)* %{{.*}}, i32 %{{.*}})
+; SHADERTEST-COUNT-2: %{{[0-9]*}} = call {{.*}} float @interpolateAtSample.f32.p64.i32(i8 addrspace(64)* %{{.*}}, i32 %{{.*}})
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
 ; SHADERTEST-DAG: = call <2 x float> @lgc.input.import.builtin.SamplePosOffset.v2f32.i32.i32(
 ; SHADERTEST-DAG: = call <3 x float> @lgc.input.import.builtin.InterpPullMode.v3f32.i32(

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestInterpAtCentriodBarycentric.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestInterpAtCentriodBarycentric.pipe
@@ -5,7 +5,7 @@
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: @[[BaryCoord:[^ ]*]] = external addrspace(64) global <3 x float>
-; SHADERTEST: call spir_func <3 x float> @interpolateAtCentroid.p64v3f32(<3 x float> addrspace(64)* @[[BaryCoord]])
+; SHADERTEST: call spir_func <3 x float> @interpolateAtCentroid.v3f32.p64(i8 addrspace(64)* bitcast (<3 x float> addrspace(64)* @[[BaryCoord]]
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; The second argument (i32 32) respects that interpLoc is InterpLocCentroid.

--- a/llpc/translator/lib/SPIRV/SPIRVReader.h
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.h
@@ -286,6 +286,9 @@ private:
     return t;
   }
 
+  // TODO: Remove this when LLPC will switch fully to opaque pointers.
+  void castPtrArgsToPtri8ForNonOpaquePointers(std::vector<Value *> &args, std::vector<Type *> &argTys);
+
   Type *getPointeeType(SPIRVValue *v);
 
   Type *tryGetAccessChainRetType(SPIRVValue *v) {


### PR DESCRIPTION
With opaque pointers we are not able to get base type of the pointer, so while creating mangled function name we are able only to indicate that we are dealing with pointer type (func_name.p7 instead of func_name.p7v4f32). This is way return type of the function has been added while mangling the function name.
Second change (which will be later reverted) which is added in this patch is casting all pointer types used in function to i8*.