### PR TITLE
Update SectionPipelineOption MemberCount after PR2041

### DIFF
--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -361,6 +361,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
     INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
+    // One internal member
 #if VKI_RAY_TRACING
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
 #endif
@@ -374,7 +375,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 17;
+  static const unsigned MemberCount = 18;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Add one internal only member to the SectionPipelineOption for the benefit of internal merge process.