### PR TITLE
Add DPP support info to GpuProperty

### DIFF
--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -77,6 +77,9 @@ struct GpuProperty {
     unsigned diffSignedness : 1; // Whether the components of two vectors have the diff signedness
   } supportIntegerDotFlag;       // The flag indicates the HW supports integer dot product
   unsigned supportsXnack;        // GPU supports XNACK
+  bool supportsDpp;              // GPU supports DPP
+  bool supportsDppRowXmask;      // GPU supports DPP ROW_XMASK
+  bool supportsPermLaneDpp;      // GPU supports perm lane DPP
 };
 
 // Contains flags for all of the hardware workarounds which affect pipeline compilation.

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -189,6 +189,7 @@ static void setGfx705Info(TargetInfo *targetInfo) {
 static void setGfx8BaseInfo(TargetInfo *targetInfo) {
   setGfx7BaseInfo(targetInfo);
   targetInfo->getGpuProperty().maxSgprsAvailable = 102;
+  targetInfo->getGpuProperty().supportsDpp = true;
 }
 
 // gfx8
@@ -295,6 +296,9 @@ static void setGfx906Info(TargetInfo *targetInfo) {
 static void setGfx10Info(TargetInfo *targetInfo) {
   setGfx9BaseInfo(targetInfo);
   targetInfo->getGpuProperty().maxSgprsAvailable = 106;
+
+  targetInfo->getGpuProperty().supportsPermLaneDpp = true;
+  targetInfo->getGpuProperty().supportsDppRowXmask = true;
 
   // Compiler is free to choose wave mode if forced wave size is not specified.
   if (NativeWaveSize != 0) {


### PR DESCRIPTION
Adds dpp target info as appropriate, so that it may be used in lgc passes.

Partially merges #1997.