### PR TITLE
Add new member 'primOrVertexIndex' to wave/thread info

### DIFF
--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -153,6 +153,7 @@ private:
     llvm::Value *waveIdInSubgroup;
     llvm::Value *threadIdInWave;
     llvm::Value *threadIdInSubgroup;
+    llvm::Value *primOrVertexIndex;
   } m_waveThreadInfo = {};
 
   bool m_accessTaskPayload = false;                // Whether task shader has payload access operations


### PR DESCRIPTION
This member is initialized to thread ID in subgroup. It is used to handle primitive/vertex export. It seems somewhat redundant for GFX10.3 but will be useful for row export of future generation since the value is not necessarily equal to thread ID in subgroup any more.