### PR TITLE
Add nsaThreshold to PipelineShaderOptions

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 55
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     55.1 | Add nsaThreshold to PipelineShaderOptions
 //  |     55.0 | Remove isInternalRtShader from module options                                                         |
 //  |     54.9 | Add internalRtShaders to PipelineOptions to allow for dumping this data                               |
 //  |     54.6 | Add reverseThreadGroup to PipelineOptions                                                             |
@@ -761,6 +762,9 @@ struct PipelineShaderOptions {
   /// the contents of the color and depth/stencil attachments
   /// from the shader during draw. Because of that possibility you have to use late-z
   bool forceLateZ;
+
+  /// Minimum number of addresses to use NSA encoding on GFX10+ (0 = backend decides).
+  unsigned nsaThreshold;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -245,6 +245,9 @@ struct ShaderOptions {
   // from the shader during draw. Because of that possibility you have to use late-z
   bool forceLateZ;
 
+  /// Minimum number of addresses to use NSA encoding on GFX10+ (0 = backend decides).
+  unsigned nsaThreshold;
+
   ShaderOptions() {
     // The memory representation of this struct gets written into LLVM metadata. To prevent uninitialized values from
     // being written, we force everything to 0, including alignment gaps.

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -928,6 +928,9 @@ void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
       builder.addAttribute("amdgpu-lds-spill-limit-dwords", std::to_string(shaderOptions->ldsSpillLimitDwords));
   }
 
+  if (shaderOptions->nsaThreshold != 0)
+    builder.addAttribute("amdgpu-nsa-threshold", std::to_string(shaderOptions->nsaThreshold));
+
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396807
   // Old version of the code
   AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -526,6 +526,8 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
     shaderOptions.overrideShaderThreadGroupSizeY = shaderInfo->options.overrideShaderThreadGroupSizeY;
     shaderOptions.overrideShaderThreadGroupSizeZ = shaderInfo->options.overrideShaderThreadGroupSizeZ;
 
+    shaderOptions.nsaThreshold = shaderInfo->options.nsaThreshold;
+
     pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);
   }
 }

--- a/llpc/test/shaderdb/general/NsaThreshold.pipe
+++ b/llpc/test/shaderdb/general/NsaThreshold.pipe
@@ -1,0 +1,19 @@
+; RUN: amdllpc -v -gfxip=10.1 %s | FileCheck -check-prefix=CHECK %s
+
+; CHECK-NOT: {{^}}attributes #0 {{.*}} "amdgpu-nsa-threshold"
+; CHECK: {{^}}attributes #1 {{.*}} "amdgpu-nsa-threshold"="2"
+
+[VsGlsl]
+#version 450 core
+void main() { }
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 450
+void main() { }
+
+[FsInfo]
+entryPoint = main
+options.nsaThreshold = 2

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -609,6 +609,7 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.overrideShaderThreadGroupSizeX = " << shaderInfo->options.overrideShaderThreadGroupSizeX << "\n";
   dumpFile << "options.overrideShaderThreadGroupSizeY = " << shaderInfo->options.overrideShaderThreadGroupSizeY << "\n";
   dumpFile << "options.overrideShaderThreadGroupSizeZ = " << shaderInfo->options.overrideShaderThreadGroupSizeZ << "\n";
+  dumpFile << "options.nsaThreshold = " << shaderInfo->options.nsaThreshold << "\n";
   dumpFile << "\n";
 }
 
@@ -1580,6 +1581,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.overrideShaderThreadGroupSizeX);
       hasher->Update(options.overrideShaderThreadGroupSizeY);
       hasher->Update(options.overrideShaderThreadGroupSizeZ);
+      hasher->Update(options.nsaThreshold);
     }
   }
 }

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -158,6 +158,7 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeX, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -166,7 +167,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 33;
+  static const unsigned MemberCount = 34;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
This creates a function attribute which is passed to the backend to adjust the amount of NSA encoding used on MIMG instructions.