### PR TITLE
Header now required for log2 use

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -41,6 +41,7 @@
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include <cmath>
 
 #define DEBUG_TYPE "lgc-patch-in-out-import-export"
 


### PR DESCRIPTION
Upstream changes mean that cmath is now required when using log2