### PR TITLE
Tweak LLVM module path to work with Visual Studio generator

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -144,16 +144,13 @@ set_compiler_options(llpc ${LLPC_ENABLE_WERROR})
 
 ### Defines/Includes/Sources ###########################################################################################
 if(ICD_BUILD_LLPC)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm)
+    list(APPEND CMAKE_MODULE_PATH
+        ${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm
+        ${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm   # Workaround for multi-config generators (e.g. VS)
+    )
     include(LLVMConfig)
     message(STATUS "LLVM executables: " ${LLVM_TOOLS_BINARY_DIR})
     message(STATUS "LLVM libraries: " ${LLVM_BUILD_LIBRARY_DIR})
-    execute_process(
-        COMMAND ${LLVM_TOOLS_BINARY_DIR}/llvm-config --libs amdgpu analysis bitreader bitwriter codegen irreader linker mc passes support target transformutils
-        OUTPUT_VARIABLE LLVM_LINK_FLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    message(STATUS "LLVM link options:" ${LLVM_LINK_FLAGS})
 endif()
 target_compile_definitions(llpc PRIVATE ${TARGET_ARCHITECTURE_ENDIANESS}ENDIAN_CPU)
 target_compile_definitions(llpc PRIVATE _SPIRV_LLVM_API)


### PR DESCRIPTION
I believe there is a bug in LLVM. The CMake modules will get copied to the build directory with a path such as `build_dir/compiler/llpc/llvm/$(Configuration)/lib/cmake/llvm`. With a literal, non-expanded `$(Configuration)` token in there, which doesn't make much sense.

The fix looks generic, but it won't help Ninja Multi-Config. For that I will just try to get the root cause fixed in LLVM.

The execute_process change is not needed, I added it for clarity that this command most of the time doesn't even work (because the file isn't there).