### PR TITLE
Update PipelineVsFs_MultiDwordPushConst.pipe

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultiDwordPushConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultiDwordPushConst.pipe
@@ -16,8 +16,7 @@
 ; Check that those parameters are passed in as s2 and s3.
 ; SHADERTEST-LABEL: _amdgpu_ps_main:
 ; SHADERTEST-NEXT: BB0_0
-; SHADERTEST-NEXT: s_mov_b32 s0, 0
-; SHADERTEST-NEXT: v_mov_b32_e32 v0, 0
+; SHADERTEST: v_mov_b32_e32 v0, 0
 ; SHADERTEST-NEXT: v_mov_b32_e32 v5, s2
 ; SHADERTEST-NEXT: v_mov_b32_e32 v6, s3
 ; SHADERTEST: image_gather4_lz v[0:4], v[5:6]


### PR DESCRIPTION
Do not expect 0 as a part of image descriptor, as the test uses an undef as image.

This change is needed to reflect the generated code with upstream LLVM.