### PR TITLE
Set wave size 32 for compute shader with small workgroup

### DIFF
--- a/llpc/test/shaderdb/gfx10/TestWaveSize.comp
+++ b/llpc/test/shaderdb/gfx10/TestWaveSize.comp
@@ -1,0 +1,17 @@
+#version 450
+
+// Test that wavefront size is 32.
+
+layout(local_size_x = 3, local_size_y = 3, local_size_y = 3) in;
+void main()
+{
+}
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} final ELF info
+; SHADERTEST: .wavefront_size: 0x0000000000000020
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST


### PR DESCRIPTION
Force wave size to 32 for compute-like shader (that includes compute,
task and mesh) when the workgroup size is not larger than 32.
    
This improves performance, as we know the other 32 lanes would
be inactive if wave size was 64.