### PR TITLE
Add aggressiveInvariantLoads and disableInvariantLoads options

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 55
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,7 +82,8 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
-//  |     55.1 | Add nsaThreshold to PipelineShaderOptions
+//  |     55.2 | Add aggressiveInvariantLoads and disableInvariantLoads to PipelineShaderOptions                       |
+//  |     55.1 | Add nsaThreshold to PipelineShaderOptions                                                             |
 //  |     55.0 | Remove isInternalRtShader from module options                                                         |
 //  |     54.9 | Add internalRtShaders to PipelineOptions to allow for dumping this data                               |
 //  |     54.6 | Add reverseThreadGroup to PipelineOptions                                                             |
@@ -765,6 +766,12 @@ struct PipelineShaderOptions {
 
   /// Minimum number of addresses to use NSA encoding on GFX10+ (0 = backend decides).
   unsigned nsaThreshold;
+
+  /// Aggressively mark shader loads as invariant (where it is safe to do so).
+  bool aggressiveInvariantLoads;
+
+  /// Strip invariant load metadata.
+  bool disableInvariantLoads;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -151,6 +151,7 @@ target_sources(LLVMlgc PRIVATE
     patch/PatchEntryPointMutate.cpp
     patch/PatchImageDerivatives.cpp
     patch/PatchInOutImportExport.cpp
+    patch/PatchInvariantLoads.cpp
     patch/PatchLlvmIrInclusion.cpp
     patch/PatchLoadScalarizer.cpp
     patch/PatchLoopMetadata.cpp

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -64,6 +64,7 @@ void initializeLegacyPatchReadFirstLanePass(PassRegistry &);
 void initializeLegacyPatchWaveSizeAdjustPass(PassRegistry &);
 void initializeLegacyPatchImageDerivativesPass(PassRegistry &);
 void initializeLegacyPatchInitializeWorkgroupMemoryPass(PassRegistry &);
+void initializeLegacyPatchInvariantLoadsPass(PassRegistry &);
 } // namespace llvm
 
 namespace lgc {
@@ -94,6 +95,7 @@ inline void initializePatchPasses(llvm::PassRegistry &passRegistry) {
   initializeLegacyPatchWaveSizeAdjustPass(passRegistry);
   initializeLegacyPatchImageDerivativesPass(passRegistry);
   initializeLegacyPatchInitializeWorkgroupMemoryPass(passRegistry);
+  initializeLegacyPatchInvariantLoadsPass(passRegistry);
 }
 
 llvm::ModulePass *createLegacyLowerFragColorExport();
@@ -116,6 +118,7 @@ llvm::FunctionPass *createLegacyPatchReadFirstLane();
 llvm::ModulePass *createLegacyPatchWaveSizeAdjust();
 llvm::ModulePass *createLegacyPatchImageDerivatives();
 llvm::ModulePass *createLegacyPatchInitializeWorkgroupMemory();
+llvm::FunctionPass *createLegacyPatchInvariantLoads();
 class PipelineState;
 class PassManager;
 

--- a/lgc/include/lgc/patch/PatchInvariantLoads.h
+++ b/lgc/include/lgc/patch/PatchInvariantLoads.h
@@ -24,31 +24,45 @@
  **********************************************************************************************************************/
 /**
  ***********************************************************************************************************************
- * @file  PassRegistry.inc
- * @brief LLPC header file: used as the registry of LLPC patching passes
+ * @file  PatchInvariantLoads.h
+ * @brief LLPC header file: contains declaration of class lgc::PatchInvariantLoads.
  ***********************************************************************************************************************
  */
+#pragma once
 
-LLPC_PASS("lgc-builder-replayer", BuilderReplayer)
+#include "lgc/state/PipelineState.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
 
-LLPC_PASS("lgc-patch-resource-collect", PatchResourceCollect)
-LLPC_PASS("lgc-patch-initialize-workgroup-memory", PatchInitializeWorkgroupMemory)
-LLPC_PASS("lgc-patch-image-derivatives", PatchImageDerivatives)
-LLPC_PASS("lgc-patch-in-out-import-export", PatchInOutImportExport)
-LLPC_PASS("lgc-patch-invariant-loads", PatchInvariantLoads)
-LLPC_PASS("lgc-patch-setup-target-features", PatchSetupTargetFeatures)
-LLPC_PASS("lgc-patch-copy-shader", PatchCopyShader)
-LLPC_PASS("lgc-patch-prepare-pipeline-abi", PatchPreparePipelineAbi)
-LLPC_PASS("lgc-patch-read-first-lane", PatchReadFirstLane)
-LLPC_PASS("lgc-patch-llvm-ir-inclusion", PatchLlvmIrInclusion)
-LLPC_PASS("lgc-patch-wave-size-adjust", PatchWaveSizeAdjust)
-LLPC_PASS("lgc-patch-peephole-opt", PatchPeepholeOpt)
-LLPC_PASS("lgc-patch-entry-point-mutate", PatchEntryPointMutate)
-LLPC_PASS("lgc-patch-check-shader-cache", PatchCheckShaderCache)
-LLPC_PASS("lgc-patch-loop-metadata", PatchLoopMetadata)
-LLPC_PASS("lgc-patch-buffer-op", PatchBufferOp)
-LLPC_PASS("lgc-patch-workarounds", PatchWorkarounds)
-LLPC_PASS("lgc-patch-load-scalarizer", PatchLoadScalarizer)
-LLPC_PASS("lgc-patch-null-frag-shader", PatchNullFragShader)
+namespace lgc {
 
-#undef LLPC_PASS
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for image operations
+class PatchInvariantLoads : public llvm::PassInfoMixin<PatchInvariantLoads> {
+public:
+  llvm::PreservedAnalyses run(llvm::Function &function, llvm::FunctionAnalysisManager &analysisManager);
+
+  bool runImpl(llvm::Function &function, PipelineState *pipelineState);
+
+  static llvm::StringRef name() { return "Patch metadata for invariant loads"; }
+};
+
+// =====================================================================================================================
+// Represents the pass of LLVM patching operations for image operations
+class LegacyPatchInvariantLoads : public llvm::FunctionPass {
+public:
+  LegacyPatchInvariantLoads();
+
+  void getAnalysisUsage(llvm::AnalysisUsage &analysisUsage) const override;
+  bool runOnFunction(llvm::Function &function) override;
+
+  static char ID; // ID of this pass
+
+private:
+  LegacyPatchInvariantLoads(const LegacyPatchInvariantLoads &) = delete;
+  LegacyPatchInvariantLoads &operator=(const LegacyPatchInvariantLoads &) = delete;
+
+  PatchInvariantLoads m_impl;
+};
+
+} // namespace lgc

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -248,6 +248,12 @@ struct ShaderOptions {
   /// Minimum number of addresses to use NSA encoding on GFX10+ (0 = backend decides).
   unsigned nsaThreshold;
 
+  /// Aggressively mark shader loads as invariant (where it is safe to do so).
+  bool aggressiveInvariantLoads;
+
+  /// Strip invariant load metadata.
+  bool disableInvariantLoads;
+
   ShaderOptions() {
     // The memory representation of this struct gets written into LLVM metadata. To prevent uninitialized values from
     // being written, we force everything to 0, including alignment gaps.

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -42,6 +42,7 @@
 #include "lgc/patch/PatchImageOpCollect.h"
 #include "lgc/patch/PatchInOutImportExport.h"
 #include "lgc/patch/PatchInitializeWorkgroupMemory.h"
+#include "lgc/patch/PatchInvariantLoads.h"
 #include "lgc/patch/PatchLlvmIrInclusion.h"
 #include "lgc/patch/PatchLoadScalarizer.h"
 #include "lgc/patch/PatchLoopMetadata.h"
@@ -148,6 +149,8 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, b
   passMgr.addPass(AlwaysInlinerPass());
   passMgr.addPass(GlobalDCEPass());
 
+  // Patch invariant load and loop metadata.
+  passMgr.addPass(createModuleToFunctionPassAdaptor(PatchInvariantLoads()));
   passMgr.addPass(createModuleToFunctionPassAdaptor(createFunctionToLoopPassAdaptor(PatchLoopMetadata())));
 
   if (patchTimer) {
@@ -294,6 +297,9 @@ void LegacyPatch::addPasses(PipelineState *pipelineState, legacy::PassManager &p
   // Prior to general optimization, do function inlining and dead function removal
   passMgr.add(createAlwaysInlinerLegacyPass());
   passMgr.add(createGlobalDCEPass());
+
+  // Patch invariant load metadata before optimizations.
+  passMgr.add(createLegacyPatchInvariantLoads());
 
   // Patch loop metadata
   passMgr.add(createLegacyPatchLoopMetadata());

--- a/lgc/patch/PatchInvariantLoads.cpp
+++ b/lgc/patch/PatchInvariantLoads.cpp
@@ -1,0 +1,166 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  PatchInvariantLoads.cpp
+ * @brief LLPC source file: contains implementation of class lgc::PatchInvariantLoads.
+ ***********************************************************************************************************************
+ */
+#include "lgc/patch/PatchInvariantLoads.h"
+#include "lgc/patch/Patch.h"
+#include "lgc/state/PipelineState.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "lgc-patch-invariant-loads"
+
+using namespace llvm;
+using namespace lgc;
+
+namespace lgc {
+
+// =====================================================================================================================
+// Initializes static members.
+char LegacyPatchInvariantLoads::ID = 0;
+
+// =====================================================================================================================
+// Pass creator, creates the pass
+FunctionPass *createLegacyPatchInvariantLoads() {
+  return new LegacyPatchInvariantLoads();
+}
+
+// =====================================================================================================================
+LegacyPatchInvariantLoads::LegacyPatchInvariantLoads() : llvm::FunctionPass(ID) {
+}
+
+// =====================================================================================================================
+// Get the analysis usage of this pass.
+//
+// @param [out] analysisUsage : The analysis usage.
+void LegacyPatchInvariantLoads::getAnalysisUsage(AnalysisUsage &analysisUsage) const {
+  analysisUsage.addRequired<LegacyPipelineStateWrapper>();
+}
+
+// =====================================================================================================================
+// Executes this LLVM pass on the specified LLVM function.
+//
+// @param [in/out] function : Function that we will patch.
+// @returns : True if the module was modified by the transformation and false otherwise
+bool LegacyPatchInvariantLoads::runOnFunction(Function &function) {
+  PipelineState *pipelineState = getAnalysis<LegacyPipelineStateWrapper>().getPipelineState(function.getParent());
+  return m_impl.runImpl(function, pipelineState);
+}
+
+// =====================================================================================================================
+// Executes this LLVM pass on the specified LLVM function.
+//
+// @param [in/out] function : Function that we will patch.
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+// @returns : The preserved analyses (The analyses that are still valid after this pass)
+PreservedAnalyses PatchInvariantLoads::run(Function &function, FunctionAnalysisManager &analysisManager) {
+  const auto &moduleAnalysisManager = analysisManager.getResult<ModuleAnalysisManagerFunctionProxy>(function);
+  PipelineState *pipelineState =
+      moduleAnalysisManager.getCachedResult<PipelineStateWrapper>(*function.getParent())->getPipelineState();
+  if (runImpl(function, pipelineState))
+    return PreservedAnalyses::none();
+  return PreservedAnalyses::all();
+}
+
+// =====================================================================================================================
+// Executes this LLVM pass on the specified LLVM function.
+//
+// @param [in/out] function : Function that we will patch.
+// @param [in/out] pipelineState : Pipeline state object to use for this pass
+// @returns : True if the function was modified by the transformation and false otherwise
+bool PatchInvariantLoads::runImpl(Function &function, PipelineState *pipelineState) {
+  LLVM_DEBUG(dbgs() << "Run the pass Patch-Invariant-Loads\n");
+
+  auto shaderStage = lgc::getShaderStage(&function);
+  if (shaderStage == ShaderStageInvalid)
+    return false;
+
+  auto &options = pipelineState->getShaderOptions(shaderStage);
+  bool clearInvariants = options.disableInvariantLoads;
+  bool aggressiveInvariants = options.aggressiveInvariantLoads && !clearInvariants;
+
+  if (!(clearInvariants || aggressiveInvariants))
+    return false;
+
+  LLVM_DEBUG(dbgs() << (clearInvariants ? "Removing invariant load flags"
+                                        : "Attempting aggressive invariant load optimization")
+                    << "\n";);
+
+  std::vector<Instruction *> loads;
+
+  for (BasicBlock &block : function) {
+    for (Instruction &inst : block) {
+      if (!clearInvariants && inst.mayWriteToMemory()) {
+        if (IntrinsicInst *ii = dyn_cast<IntrinsicInst>(&inst)) {
+          switch (ii->getIntrinsicID()) {
+          case Intrinsic::amdgcn_exp:
+          case Intrinsic::amdgcn_exp_compr:
+          case Intrinsic::amdgcn_init_exec:
+          case Intrinsic::amdgcn_init_exec_from_input:
+            continue;
+          default:
+            break;
+          }
+        }
+        LLVM_DEBUG(dbgs() << "Write to memory found, aborting aggressive invariant load optimization\n");
+        return false;
+      } else if (inst.mayReadFromMemory()) {
+        loads.push_back(&inst);
+      }
+    }
+  }
+
+  if (loads.empty()) {
+    LLVM_DEBUG(dbgs() << "Shader has no memory loads\n");
+    return false;
+  }
+
+  auto &context = function.getContext();
+  for (Instruction *inst : loads) {
+    bool isInvariant = inst->hasMetadata(LLVMContext::MD_invariant_load);
+    if (isInvariant && clearInvariants) {
+      LLVM_DEBUG(dbgs() << "Removing invariant metadata: " << *inst << "\n");
+      inst->setMetadata(LLVMContext::MD_invariant_load, nullptr);
+    } else if (!isInvariant && !clearInvariants) {
+      LLVM_DEBUG(dbgs() << "Marking load invariant: " << *inst << "\n");
+      inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(context, None));
+    }
+  }
+
+  return true;
+}
+
+} // namespace lgc
+
+// =====================================================================================================================
+// Initializes the pass of LLVM patch image derivative operations dependent on discards.
+INITIALIZE_PASS(LegacyPatchInvariantLoads, DEBUG_TYPE, "Patch invariant loads", false, false)

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -528,6 +528,9 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
 
     shaderOptions.nsaThreshold = shaderInfo->options.nsaThreshold;
 
+    shaderOptions.aggressiveInvariantLoads = shaderInfo->options.aggressiveInvariantLoads;
+    shaderOptions.disableInvariantLoads = shaderInfo->options.disableInvariantLoads;
+
     pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);
   }
 }

--- a/llpc/test/shaderdb/general/AggressiveInvariantLoads.pipe
+++ b/llpc/test/shaderdb/general/AggressiveInvariantLoads.pipe
@@ -1,0 +1,68 @@
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST: load <4 x i32>, <4 x i32> addrspace(4)* %4, align 16, !invariant.load
+; SHADERTEST: load <4 x float>, <4 x float> addrspace(4)* %4, align 16, !invariant.load
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
+
+[VsGlsl]
+#version 450
+
+layout( location = 0 ) in vec4 app_position;
+
+void main() {
+  gl_Position = app_position;
+}
+
+[VsInfo]
+entryPoint = main
+options.aggressiveInvariantLoads = 1
+
+[FsGlsl]
+#version 450
+
+layout( location = 0 ) out vec4 frag_color;
+
+layout( push_constant ) uniform ColorBlock {
+  vec4 Color;
+} PushConstant;
+
+void main() {
+   frag_color = PushConstant.Color;
+}
+
+[FsInfo]
+entryPoint = main
+options.aggressiveInvariantLoads = 1
+
+[ResourceMapping]
+userDataNode[0].visibility = 2
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 4
+userDataNode[1].visibility = 66
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = PushConst
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 4
+userDataNode[1].next[0].set = 0xFFFFFFFF
+userDataNode[1].next[0].binding = 0
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+options.resourceLayoutScheme = Indirect
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 12
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0

--- a/llpc/test/shaderdb/general/DisableInvariantLoads.pipe
+++ b/llpc/test/shaderdb/general/DisableInvariantLoads.pipe
@@ -1,0 +1,66 @@
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
+; SHADERTEST-NOT: !invariant.load
+
+[VsGlsl]
+#version 450
+
+layout( location = 0 ) in vec4 app_position;
+
+void main() {
+  gl_Position = app_position;
+}
+
+[VsInfo]
+entryPoint = main
+options.disableInvariantLoads = 1
+
+[FsGlsl]
+#version 450
+
+layout( location = 0 ) out vec4 frag_color;
+
+layout( push_constant ) uniform ColorBlock {
+  vec4 Color;
+} PushConstant;
+
+void main() {
+   frag_color = PushConstant.Color;
+}
+
+[FsInfo]
+entryPoint = main
+options.disableInvariantLoads = 1
+
+[ResourceMapping]
+userDataNode[0].visibility = 2
+userDataNode[0].type = IndirectUserDataVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[0].indirectUserDataCount = 4
+userDataNode[1].visibility = 66
+userDataNode[1].type = DescriptorTableVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].next[0].type = PushConst
+userDataNode[1].next[0].offsetInDwords = 0
+userDataNode[1].next[0].sizeInDwords = 4
+userDataNode[1].next[0].set = 0xFFFFFFFF
+userDataNode[1].next[0].binding = 0
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_R8G8B8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+options.resourceLayoutScheme = Indirect
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 12
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32_SFLOAT
+attribute[0].offset = 0

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -610,6 +610,8 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.overrideShaderThreadGroupSizeY = " << shaderInfo->options.overrideShaderThreadGroupSizeY << "\n";
   dumpFile << "options.overrideShaderThreadGroupSizeZ = " << shaderInfo->options.overrideShaderThreadGroupSizeZ << "\n";
   dumpFile << "options.nsaThreshold = " << shaderInfo->options.nsaThreshold << "\n";
+  dumpFile << "options.aggressiveInvariantLoads = " << shaderInfo->options.aggressiveInvariantLoads << "\n";
+  dumpFile << "options.disableInvariantLoads = " << shaderInfo->options.disableInvariantLoads << "\n";
   dumpFile << "\n";
 }
 
@@ -1582,6 +1584,8 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.overrideShaderThreadGroupSizeY);
       hasher->Update(options.overrideShaderThreadGroupSizeZ);
       hasher->Update(options.nsaThreshold);
+      hasher->Update(options.aggressiveInvariantLoads);
+      hasher->Update(options.disableInvariantLoads);
     }
   }
 }

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -159,6 +159,8 @@ public:
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
     INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeBool, false);
+    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableInvariantLoads, MemberTypeBool, false);
 
     VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
@@ -167,7 +169,7 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 34;
+  static const unsigned MemberCount = 36;
   static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;


### PR DESCRIPTION
Add patching pass to modify invariant load metadata based on aggressiveInvariantLoads and disableInvariantLoads in PipelineShaderOptions.

If aggressiveInvariantLoads is set then all loads in a shader are marked invariant if there are no memory writes in the shader. Note: barriers, discards, and inline asm are considered writes to memory so this generally safe.

If disableInvariantLoads is set then all invariant load metadata is striped from loads in the shader.
This is useful for optimising edges where sink in causing unwanted register pressure increases.