### PR TITLE
[VFX] Eliminate manual member counting

### DIFF
--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -46,7 +46,6 @@ std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
 StrToMemberAddr SectionColorBuffer::m_addrTable[SectionColorBuffer::MemberCount];
 StrToMemberAddr SectionCompileLog::m_addrTable[SectionCompileLog::MemberCount];
-StrToMemberAddr SectionShader::m_addrTable[SectionShader::MemberCount];
 StrToMemberAddr SectionVertexInputBinding::m_addrTable[SectionVertexInputBinding::MemberCount];
 StrToMemberAddr SectionVertexInputAttribute::m_addrTable[SectionVertexInputAttribute::MemberCount];
 StrToMemberAddr SectionVertexInputDivisor::m_addrTable[SectionVertexInputDivisor::MemberCount];
@@ -103,7 +102,6 @@ public:
 
     Section::initSectionInfo();
     SectionCompileLog::initialAddrTable();
-    SectionShader::initialAddrTable();
     SectionColorBuffer::initialAddrTable();
     SectionVertexInputBinding::initialAddrTable();
     SectionVertexInputAttribute::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionColorBuffer::m_addrTable[SectionColorBuffer::MemberCount];
 StrToMemberAddr SectionVertexInputBinding::m_addrTable[SectionVertexInputBinding::MemberCount];
 StrToMemberAddr SectionVertexInputAttribute::m_addrTable[SectionVertexInputAttribute::MemberCount];
 StrToMemberAddr SectionVertexInputDivisor::m_addrTable[SectionVertexInputDivisor::MemberCount];
@@ -100,7 +99,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionColorBuffer::initialAddrTable();
     SectionVertexInputBinding::initialAddrTable();
     SectionVertexInputAttribute::initialAddrTable();
     SectionVertexInputDivisor::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,8 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionSpecInfo::m_addrTable[SectionSpecInfo::MemberCount];
-
 #ifndef VFX_DISABLE_SPVGEN
 // =====================================================================================================================
 // A helper method to convert ShaderStage enumerant to corresponding SpvGenStage enumerant.
@@ -94,7 +92,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionSpecInfo::initialAddrTable();
   };
 };
 

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -47,7 +47,6 @@ std::map<std::string, SectionInfo> Section::m_sectionInfo;
 StrToMemberAddr SectionSpecConstItem::m_addrTable[SectionSpecConstItem::MemberCount];
 StrToMemberAddr SectionSpecConst::m_addrTable[SectionSpecConst::MemberCount];
 StrToMemberAddr SectionColorBuffer::m_addrTable[SectionColorBuffer::MemberCount];
-StrToMemberAddr SectionVersion::m_addrTable[SectionVersion::MemberCount];
 StrToMemberAddr SectionCompileLog::m_addrTable[SectionCompileLog::MemberCount];
 StrToMemberAddr SectionShader::m_addrTable[SectionShader::MemberCount];
 StrToMemberAddr SectionVertexInputBinding::m_addrTable[SectionVertexInputBinding::MemberCount];
@@ -107,7 +106,6 @@ public:
     Section::initSectionInfo();
     SectionSpecConstItem::initialAddrTable();
     SectionSpecConst::initialAddrTable();
-    SectionVersion::initialAddrTable();
     SectionCompileLog::initialAddrTable();
     SectionShader::initialAddrTable();
     SectionColorBuffer::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionVertexInputBinding::m_addrTable[SectionVertexInputBinding::MemberCount];
 StrToMemberAddr SectionVertexInputAttribute::m_addrTable[SectionVertexInputAttribute::MemberCount];
 StrToMemberAddr SectionVertexInputDivisor::m_addrTable[SectionVertexInputDivisor::MemberCount];
 StrToMemberAddr SectionVertexInput::m_addrTable[SectionVertexInput::MemberCount];
@@ -99,7 +98,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionVertexInputBinding::initialAddrTable();
     SectionVertexInputAttribute::initialAddrTable();
     SectionVertexInputDivisor::initialAddrTable();
     SectionVertexInput::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -129,11 +129,11 @@ static ParserInit Init;
 // @param tableSize : Size of above table
 // @param sectionType : Section type
 // @param sectionName : Name of this section.
-Section::Section(StrToMemberAddr *addrTable, unsigned tableSize, SectionType sectionType, const char *sectionName)
-    : m_sectionType(sectionType), m_sectionName(sectionName), m_lineNum(0), m_memberTable(addrTable),
-      m_tableSize(tableSize), m_isActive(false){
+Section::Section(StrToMemberAddrArrayRef addrTable, SectionType sectionType, const char *sectionName)
+    : m_sectionType(sectionType), m_sectionName(sectionName), m_lineNum(0), m_memberTable(addrTable.data),
+      m_tableSize(addrTable.size), m_isActive(false){
 
-                              };
+                                   };
 
 // =====================================================================================================================
 // Initializes static variable m_sectionInfo

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionVertexInputDivisor::m_addrTable[SectionVertexInputDivisor::MemberCount];
 StrToMemberAddr SectionVertexInput::m_addrTable[SectionVertexInput::MemberCount];
 StrToMemberAddr SectionSpecEntryItem::m_addrTable[SectionSpecEntryItem::MemberCount];
 StrToMemberAddr SectionSpecInfo::m_addrTable[SectionSpecInfo::MemberCount];
@@ -97,7 +96,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionVertexInputDivisor::initialAddrTable();
     SectionVertexInput::initialAddrTable();
     SectionSpecEntryItem::initialAddrTable();
     SectionSpecInfo::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionSpecConst::m_addrTable[SectionSpecConst::MemberCount];
 StrToMemberAddr SectionColorBuffer::m_addrTable[SectionColorBuffer::MemberCount];
 StrToMemberAddr SectionCompileLog::m_addrTable[SectionCompileLog::MemberCount];
 StrToMemberAddr SectionShader::m_addrTable[SectionShader::MemberCount];
@@ -103,7 +102,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionSpecConst::initialAddrTable();
     SectionCompileLog::initialAddrTable();
     SectionShader::initialAddrTable();
     SectionColorBuffer::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionVertexInput::m_addrTable[SectionVertexInput::MemberCount];
 StrToMemberAddr SectionSpecEntryItem::m_addrTable[SectionSpecEntryItem::MemberCount];
 StrToMemberAddr SectionSpecInfo::m_addrTable[SectionSpecInfo::MemberCount];
 
@@ -96,7 +95,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionVertexInput::initialAddrTable();
     SectionSpecEntryItem::initialAddrTable();
     SectionSpecInfo::initialAddrTable();
   };

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionSpecConstItem::m_addrTable[SectionSpecConstItem::MemberCount];
 StrToMemberAddr SectionSpecConst::m_addrTable[SectionSpecConst::MemberCount];
 StrToMemberAddr SectionColorBuffer::m_addrTable[SectionColorBuffer::MemberCount];
 StrToMemberAddr SectionCompileLog::m_addrTable[SectionCompileLog::MemberCount];
@@ -104,7 +103,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionSpecConstItem::initialAddrTable();
     SectionSpecConst::initialAddrTable();
     SectionCompileLog::initialAddrTable();
     SectionShader::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionVertexInputAttribute::m_addrTable[SectionVertexInputAttribute::MemberCount];
 StrToMemberAddr SectionVertexInputDivisor::m_addrTable[SectionVertexInputDivisor::MemberCount];
 StrToMemberAddr SectionVertexInput::m_addrTable[SectionVertexInput::MemberCount];
 StrToMemberAddr SectionSpecEntryItem::m_addrTable[SectionSpecEntryItem::MemberCount];
@@ -98,7 +97,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionVertexInputAttribute::initialAddrTable();
     SectionVertexInputDivisor::initialAddrTable();
     SectionVertexInput::initialAddrTable();
     SectionSpecEntryItem::initialAddrTable();

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -44,7 +44,6 @@ namespace Vfx {
 // Static variables in class Section and derived class
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
-StrToMemberAddr SectionSpecEntryItem::m_addrTable[SectionSpecEntryItem::MemberCount];
 StrToMemberAddr SectionSpecInfo::m_addrTable[SectionSpecInfo::MemberCount];
 
 #ifndef VFX_DISABLE_SPVGEN
@@ -95,7 +94,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionSpecEntryItem::initialAddrTable();
     SectionSpecInfo::initialAddrTable();
   };
 };

--- a/tool/vfx/vfxSection.cpp
+++ b/tool/vfx/vfxSection.cpp
@@ -45,7 +45,6 @@ namespace Vfx {
 std::map<std::string, SectionInfo> Section::m_sectionInfo;
 
 StrToMemberAddr SectionColorBuffer::m_addrTable[SectionColorBuffer::MemberCount];
-StrToMemberAddr SectionCompileLog::m_addrTable[SectionCompileLog::MemberCount];
 StrToMemberAddr SectionVertexInputBinding::m_addrTable[SectionVertexInputBinding::MemberCount];
 StrToMemberAddr SectionVertexInputAttribute::m_addrTable[SectionVertexInputAttribute::MemberCount];
 StrToMemberAddr SectionVertexInputDivisor::m_addrTable[SectionVertexInputDivisor::MemberCount];
@@ -101,7 +100,6 @@ public:
     initEnumMap();
 
     Section::initSectionInfo();
-    SectionCompileLog::initialAddrTable();
     SectionColorBuffer::initialAddrTable();
     SectionVertexInputBinding::initialAddrTable();
     SectionVertexInputAttribute::initialAddrTable();

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -532,23 +532,22 @@ class SectionSpecConstItem : public Section {
 public:
   typedef SpecConstItem SubState;
 
-  SectionSpecConstItem() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "specConst"){};
-
-  // Setup member name to member address mapping.
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, i, MemberTypeIVec4, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, f, MemberTypeFVec4, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, d, MemberTypeDVec2, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
+  SectionSpecConstItem() : Section(getAddrTable(), SectionTypeUnset, "specConst"){};
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 3;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, i, MemberTypeIVec4, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, f, MemberTypeFVec4, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, d, MemberTypeDVec2, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -509,20 +509,19 @@ bool Section::set(unsigned lineNum, const char *memberName, unsigned arrayIndex,
 // Represents the document version.
 class SectionVersion : public Section {
 public:
-  SectionVersion() : Section({m_addrTable, MemberCount}, SectionTypeVersion, nullptr) { m_version = 0; };
-
-  // Setup member name to member mapping.
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_NAME_TO_ADDR(SectionVersion, m_version, MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
+  SectionVersion() : Section(getAddrTable(), SectionTypeVersion, nullptr) { m_version = 0; };
 
   void getSubState(unsigned &state) { state = m_version; };
 
 private:
-  static const unsigned MemberCount = 1;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionVersion, m_version, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   unsigned m_version; // Document version
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -684,26 +684,24 @@ class SectionShaderGroup : public Section {
 public:
   typedef VkRayTracingShaderGroupCreateInfoKHR SubState;
 
-  SectionShaderGroup() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "groups") {
-    memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, type, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, generalShader, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, closestHitShader, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, anyHitShader, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, intersectionShader, MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
+  SectionShaderGroup() : Section(getAddrTable(), SectionTypeUnset, "groups") { memset(&m_state, 0, sizeof(m_state)); }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 5;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, type, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, generalShader, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, closestHitShader, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, anyHitShader, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, intersectionShader, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -648,19 +648,9 @@ class SectionColorBuffer : public Section {
 public:
   typedef ColorBuffer SubState;
 
-  SectionColorBuffer() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "colorBuffer") {
+  SectionColorBuffer() : Section(getAddrTable(), SectionTypeUnset, "colorBuffer") {
     memset(&m_state, 0, sizeof(m_state));
     m_state.channelWriteMask = 0xF;
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, format, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendEnable, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendSrcAlphaToColor, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, channelWriteMask, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionColorBuffer, m_palFormat, MemberTypeString, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -670,8 +660,18 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 5;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, format, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendEnable, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendSrcAlphaToColor, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, channelWriteMask, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionColorBuffer, m_palFormat, MemberTypeString, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
   std::string m_palFormat;

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -713,24 +713,24 @@ class SectionVertexInputBinding : public Section {
 public:
   typedef VkVertexInputBindingDescription SubState;
 
-  SectionVertexInputBinding() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "binding") {
+  SectionVertexInputBinding() : Section(getAddrTable(), SectionTypeUnset, "binding") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, binding, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, stride, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, inputRate, MemberTypeEnum, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 3;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, binding, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, stride, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, inputRate, MemberTypeEnum, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -882,7 +882,7 @@ class SectionSpecInfo : public Section {
 public:
   typedef VkSpecializationInfo SubState;
 
-  SectionSpecInfo() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "specConst") {
+  SectionSpecInfo() : Section(getAddrTable(), SectionTypeUnset, "specConst") {
     m_intData = &m_bufMem;
     m_uintData = &m_bufMem;
     m_int64Data = &m_bufMem;
@@ -890,19 +890,6 @@ public:
     m_floatData = &m_bufMem;
     m_doubleData = &m_bufMem;
     m_float16Data = &m_bufMem;
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionSpecInfo, m_mapEntry, MemberTypeSpecEntryItem, true);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_intData, MemberTypeIArray, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uintData, MemberTypeUArray, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_int64Data, MemberTypeI64Array, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uint64Data, MemberTypeU64Array, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_floatData, MemberTypeFArray, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_doubleData, MemberTypeDArray, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_float16Data, MemberTypeF16Array, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -919,8 +906,21 @@ public:
   }
 
 private:
-  static const unsigned MemberCount = 8;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionSpecInfo, m_mapEntry, MemberTypeSpecEntryItem, true);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_intData, MemberTypeIArray, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uintData, MemberTypeUArray, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_int64Data, MemberTypeI64Array, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uint64Data, MemberTypeU64Array, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_floatData, MemberTypeFArray, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_doubleData, MemberTypeDArray, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_float16Data, MemberTypeF16Array, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   std::vector<SectionSpecEntryItem> m_mapEntry;
   std::vector<uint8_t> *m_intData;     // Contains int data of this buffer

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -770,23 +770,23 @@ class SectionVertexInputDivisor : public Section {
 public:
   typedef VkVertexInputBindingDivisorDescriptionEXT SubState;
 
-  SectionVertexInputDivisor() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "divisor") {
+  SectionVertexInputDivisor() : Section(getAddrTable(), SectionTypeUnset, "divisor") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, binding, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, divisor, MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 2;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, binding, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, divisor, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -797,17 +797,9 @@ class SectionVertexInput : public Section {
 public:
   typedef VkPipelineVertexInputStateCreateInfo SubState;
 
-  SectionVertexInput() : Section({m_addrTable, MemberCount}, SectionTypeVertexInputState, nullptr) {
+  SectionVertexInput() : Section(getAddrTable(), SectionTypeVertexInputState, nullptr) {
     memset(&m_vkDivisorState, 0, sizeof(m_vkDivisorState));
     m_vkDivisorState.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT;
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_attribute, MemberTypeVertexInputAttributeItem, true);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_binding, MemberTypeVertexInputBindingItem, true);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_divisor, MemberTypeVertexInputDivisorItem, true);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -836,8 +828,16 @@ public:
   };
 
 private:
-  static const unsigned MemberCount = 3;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_attribute, MemberTypeVertexInputAttributeItem, true);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_binding, MemberTypeVertexInputBindingItem, true);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_divisor, MemberTypeVertexInputDivisorItem, true);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   std::vector<SectionVertexInputAttribute> m_attribute;                // Vertex input attribute
   std::vector<SectionVertexInputBinding> m_binding;                    // Vertex input binding

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -588,15 +588,8 @@ class SectionShader : public Section {
 public:
   typedef ShaderSource SubState;
   SectionShader(const SectionInfo &info)
-      : Section({m_addrTable, MemberCount}, info.type, nullptr), m_shaderType(static_cast<ShaderType>(info.propertyLo)),
+      : Section(getAddrTable(), info.type, nullptr), m_shaderType(static_cast<ShaderType>(info.propertyLo)),
         m_shaderStage(static_cast<ShaderStage>(info.propertyHi)) {}
-
-  // Setup member name to member address mapping.
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_NAME_TO_ADDR(SectionShader, m_fileName, MemberTypeString, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
 
   virtual bool isShaderSourceSection();
 
@@ -609,11 +602,17 @@ public:
   ShaderStage getShaderStage() { return m_shaderStage; }
 
 private:
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShader, m_fileName, MemberTypeString, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
+
   bool compileGlsl(const char *entryPoint, std::string *errorMsg);
   bool assembleSpirv(std::string *errorMsg);
-
-  static const unsigned MemberCount = 1;
-  static StrToMemberAddr m_addrTable[MemberCount];
 
   std::string m_fileName;        // External shader source file name
   std::string m_shaderSource;    // Shader source code

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -198,7 +198,7 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
 
 // =====================================================================================================================
 // Initiates a member to address table
-#define VEC_INIT_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                         \
+#define INIT_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                             \
   do {                                                                                                                 \
     addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
     StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
@@ -213,7 +213,7 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
 
 // =====================================================================================================================
 // Initiates a state's member to address table
-#define VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                   \
+#define INIT_STATE_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                       \
   do {                                                                                                                 \
     addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
     StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
@@ -228,7 +228,7 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
 
 // =====================================================================================================================
 // Initiates a state's member to address table with explicit name
-#define VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(T, name, member, getter, type, _isObject)                           \
+#define INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(T, name, member, getter, type, _isObject)                               \
   do {                                                                                                                 \
     addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
     StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
@@ -243,7 +243,7 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
 
 // =====================================================================================================================
 // Initiates a array member to address table
-#define VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(T, name, type, maxSize, _isObject)                                          \
+#define INIT_MEMBER_ARRAY_NAME_TO_ADDR(T, name, type, maxSize, _isObject)                                              \
   do {                                                                                                                 \
     addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
     StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
@@ -258,7 +258,7 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
 
 // =====================================================================================================================
 // Initiates a dynamic array member to address table
-#define VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(T, name, type, _isObject)                                                \
+#define INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(T, name, type, _isObject)                                                    \
   do {                                                                                                                 \
     addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
     StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
@@ -270,66 +270,6 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
     tableItem.arrayMaxSize = VfxDynamicArrayId;                                                                        \
     tableItem.isSection = _isObject;                                                                                   \
   } while (false)
-
-// =====================================================================================================================
-// Initiates a member to address table
-#define INIT_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                             \
-  tableItem->memberName = STRING(name);                                                                                \
-  if (!strncmp(tableItem->memberName, "m_", 2))                                                                        \
-    tableItem->memberName += 2;                                                                                        \
-  tableItem->getMember = GetMemberHelper<decltype(&T::name), &T::name>::getMemberPtr;                                  \
-  tableItem->memberType = type;                                                                                        \
-  tableItem->arrayMaxSize = 1;                                                                                         \
-  tableItem->isSection = _isObject;                                                                                    \
-  ++tableItem;
-
-// =====================================================================================================================
-// Initiates a state's member to address table
-#define INIT_STATE_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                       \
-  tableItem->memberName = STRING(name);                                                                                \
-  if (!strncmp(tableItem->memberName, "m_", 2))                                                                        \
-    tableItem->memberName += 2;                                                                                        \
-  tableItem->getMember = GetSubStateMemberHelper<T, decltype(&SubState::name), &SubState::name>::getMemberPtr;         \
-  tableItem->memberType = type;                                                                                        \
-  tableItem->arrayMaxSize = 1;                                                                                         \
-  tableItem->isSection = _isObject;                                                                                    \
-  ++tableItem;
-
-// =====================================================================================================================
-// Initiates a state's member to address table with explicit name
-#define INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(T, name, member, getter, type, _isObject)                               \
-  tableItem->memberName = STRING(name);                                                                                \
-  if (!strncmp(tableItem->memberName, "m_", 2))                                                                        \
-    tableItem->memberName += 2;                                                                                        \
-  tableItem->getMember = getter;                                                                                       \
-  tableItem->memberType = type;                                                                                        \
-  tableItem->arrayMaxSize = 1;                                                                                         \
-  tableItem->isSection = _isObject;                                                                                    \
-  ++tableItem;
-
-// =====================================================================================================================
-// Initiates a array member to address table
-#define INIT_MEMBER_ARRAY_NAME_TO_ADDR(T, name, type, maxSize, _isObject)                                              \
-  tableItem->memberName = STRING(name);                                                                                \
-  if (!strncmp(tableItem->memberName, "m_", 2))                                                                        \
-    tableItem->memberName += 2;                                                                                        \
-  tableItem->getMember = GetMemberHelper<decltype(&T::name), &T::name>::getMemberPtr;                                  \
-  tableItem->memberType = type;                                                                                        \
-  tableItem->arrayMaxSize = maxSize;                                                                                   \
-  tableItem->isSection = _isObject;                                                                                    \
-  ++tableItem;
-
-// =====================================================================================================================
-// Initiates a dynamic array member to address table
-#define INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(T, name, type, _isObject)                                                    \
-  tableItem->memberName = STRING(name);                                                                                \
-  if (!strncmp(tableItem->memberName, "m_", 2))                                                                        \
-    tableItem->memberName += 2;                                                                                        \
-  tableItem->getMember = GetMemberHelper<decltype(&T::name), &T::name>::getMemberPtr;                                  \
-  tableItem->memberType = type;                                                                                        \
-  tableItem->arrayMaxSize = VfxDynamicArrayId;                                                                         \
-  tableItem->isSection = _isObject;                                                                                    \
-  ++tableItem;
 
 // =====================================================================================================================
 // Cases a section to sub section
@@ -517,7 +457,7 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionVersion, m_version, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionVersion, m_version, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -541,9 +481,9 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, i, MemberTypeIVec4, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, f, MemberTypeFVec4, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, d, MemberTypeDVec2, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, i, MemberTypeIVec4, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, f, MemberTypeFVec4, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecConstItem, d, MemberTypeDVec2, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -572,8 +512,8 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionSpecConst, m_specConst, MemberTypeSpecConstItem, MaxSpecConstantCount,
-                                         true);
+      INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionSpecConst, m_specConst, MemberTypeSpecConstItem, MaxSpecConstantCount,
+                                     true);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -605,7 +545,7 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShader, m_fileName, MemberTypeString, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionShader, m_fileName, MemberTypeString, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -663,11 +603,11 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, format, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendEnable, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendSrcAlphaToColor, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, channelWriteMask, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionColorBuffer, m_palFormat, MemberTypeString, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, format, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendEnable, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, blendSrcAlphaToColor, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionColorBuffer, channelWriteMask, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionColorBuffer, m_palFormat, MemberTypeString, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -693,11 +633,11 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, type, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, generalShader, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, closestHitShader, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, anyHitShader, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, intersectionShader, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, type, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, generalShader, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, closestHitShader, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, anyHitShader, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderGroup, intersectionShader, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -724,9 +664,9 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, binding, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, stride, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, inputRate, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, binding, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, stride, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputBinding, inputRate, MemberTypeEnum, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -752,10 +692,10 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, location, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, binding, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, format, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, offset, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, location, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, binding, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, format, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, offset, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -781,8 +721,8 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, binding, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, divisor, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, binding, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputDivisor, divisor, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -831,9 +771,9 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_attribute, MemberTypeVertexInputAttributeItem, true);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_binding, MemberTypeVertexInputBindingItem, true);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_divisor, MemberTypeVertexInputDivisorItem, true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_attribute, MemberTypeVertexInputAttributeItem, true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_binding, MemberTypeVertexInputBindingItem, true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionVertexInput, m_divisor, MemberTypeVertexInputDivisorItem, true);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -865,9 +805,9 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, constantID, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, offset, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, size, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, constantID, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, offset, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, size, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -909,14 +849,14 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionSpecInfo, m_mapEntry, MemberTypeSpecEntryItem, true);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_intData, MemberTypeIArray, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uintData, MemberTypeUArray, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_int64Data, MemberTypeI64Array, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uint64Data, MemberTypeU64Array, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_floatData, MemberTypeFArray, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_doubleData, MemberTypeDArray, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_float16Data, MemberTypeF16Array, false);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionSpecInfo, m_mapEntry, MemberTypeSpecEntryItem, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_intData, MemberTypeIArray, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uintData, MemberTypeUArray, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_int64Data, MemberTypeI64Array, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_uint64Data, MemberTypeU64Array, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_floatData, MemberTypeFArray, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_doubleData, MemberTypeDArray, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionSpecInfo, m_float16Data, MemberTypeF16Array, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -741,25 +741,25 @@ class SectionVertexInputAttribute : public Section {
 public:
   typedef VkVertexInputAttributeDescription SubState;
 
-  SectionVertexInputAttribute() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "binding") {
+  SectionVertexInputAttribute() : Section(getAddrTable(), SectionTypeUnset, "binding") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, location, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, binding, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, format, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, offset, MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 4;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, location, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, binding, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, format, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionVertexInputAttribute, offset, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -558,14 +558,7 @@ class SectionSpecConst : public Section {
 public:
   typedef SpecConst SubState;
 
-  SectionSpecConst(const char *name = nullptr) : Section({m_addrTable, MemberCount}, SectionTypeUnset, name){};
-
-  // Setup member name to member address mapping.
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionSpecConst, m_specConst, MemberTypeSpecConstItem, MaxSpecConstantCount, true);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
+  SectionSpecConst(const char *name = nullptr) : Section(getAddrTable(), SectionTypeUnset, name){};
 
   void getSubState(SubState &state) {
     state.numSpecConst = 0;
@@ -576,8 +569,15 @@ public:
   }
 
 private:
-  static const unsigned MemberCount = 3;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionSpecConst, m_specConst, MemberTypeSpecConstItem, MaxSpecConstantCount,
+                                         true);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SectionSpecConstItem m_specConst[MaxSpecConstantCount]; // Spec constant for one shader stage
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -854,24 +854,24 @@ class SectionSpecEntryItem : public Section {
 public:
   typedef VkSpecializationMapEntry SubState;
 
-  SectionSpecEntryItem() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "mapEntry") {
+  SectionSpecEntryItem() : Section(getAddrTable(), SectionTypeUnset, "mapEntry") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, constantID, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, offset, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, size, MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 3;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, constantID, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, offset, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionSpecEntryItem, size, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -625,16 +625,20 @@ private:
 // Represents the class that includes all kinds of compile log, This section is ignored in Document::GetDocument
 class SectionCompileLog : public Section {
 public:
-  SectionCompileLog() : Section({m_addrTable, MemberCount}, SectionTypeCompileLog, nullptr) {}
-
-  // Setup member name to member address mapping.
-  static void initialAddrTable() {}
+  SectionCompileLog() : Section(getAddrTable(), SectionTypeCompileLog, nullptr) {}
 
   virtual void addLine(const char *line) { m_compileLog += line; };
 
 private:
-  static const unsigned MemberCount = 1;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  // Returns an empty table currently
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
+
   std::string m_compileLog; // Compile Log
 };
 

--- a/tool/vfx/vfxSection.h
+++ b/tool/vfx/vfxSection.h
@@ -198,6 +198,81 @@ inline SectionInfo initSectionItemInfo(SectionType type, uint16_t propertyLo, ui
 
 // =====================================================================================================================
 // Initiates a member to address table
+#define VEC_INIT_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                         \
+  do {                                                                                                                 \
+    addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
+    StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
+    tableItem.memberName = STRING(name);                                                                               \
+    if (!strncmp(tableItem.memberName, "m_", 2))                                                                       \
+      tableItem.memberName += 2;                                                                                       \
+    tableItem.getMember = GetMemberHelper<decltype(&T::name), &T::name>::getMemberPtr;                                 \
+    tableItem.memberType = type;                                                                                       \
+    tableItem.arrayMaxSize = 1;                                                                                        \
+    tableItem.isSection = _isObject;                                                                                   \
+  } while (false)
+
+// =====================================================================================================================
+// Initiates a state's member to address table
+#define VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                   \
+  do {                                                                                                                 \
+    addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
+    StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
+    tableItem.memberName = STRING(name);                                                                               \
+    if (!strncmp(tableItem.memberName, "m_", 2))                                                                       \
+      tableItem.memberName += 2;                                                                                       \
+    tableItem.getMember = GetSubStateMemberHelper<T, decltype(&SubState::name), &SubState::name>::getMemberPtr;        \
+    tableItem.memberType = type;                                                                                       \
+    tableItem.arrayMaxSize = 1;                                                                                        \
+    tableItem.isSection = _isObject;                                                                                   \
+  } while (false)
+
+// =====================================================================================================================
+// Initiates a state's member to address table with explicit name
+#define VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(T, name, member, getter, type, _isObject)                           \
+  do {                                                                                                                 \
+    addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
+    StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
+    tableItem.memberName = STRING(name);                                                                               \
+    if (!strncmp(tableItem.memberName, "m_", 2))                                                                       \
+      tableItem.memberName += 2;                                                                                       \
+    tableItem.getMember = getter;                                                                                      \
+    tableItem.memberType = type;                                                                                       \
+    tableItem.arrayMaxSize = 1;                                                                                        \
+    tableItem.isSection = _isObject;                                                                                   \
+  } while (false)
+
+// =====================================================================================================================
+// Initiates a array member to address table
+#define VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(T, name, type, maxSize, _isObject)                                          \
+  do {                                                                                                                 \
+    addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
+    StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
+    tableItem.memberName = STRING(name);                                                                               \
+    if (!strncmp(tableItem.memberName, "m_", 2))                                                                       \
+      tableItem.memberName += 2;                                                                                       \
+    tableItem.getMember = GetMemberHelper<decltype(&T::name), &T::name>::getMemberPtr;                                 \
+    tableItem.memberType = type;                                                                                       \
+    tableItem.arrayMaxSize = maxSize;                                                                                  \
+    tableItem.isSection = _isObject;                                                                                   \
+  } while (false)
+
+// =====================================================================================================================
+// Initiates a dynamic array member to address table
+#define VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(T, name, type, _isObject)                                                \
+  do {                                                                                                                 \
+    addrTableInitializer.push_back(StrToMemberAddr());                                                                 \
+    StrToMemberAddr &tableItem = addrTableInitializer.back();                                                          \
+    tableItem.memberName = STRING(name);                                                                               \
+    if (!strncmp(tableItem.memberName, "m_", 2))                                                                       \
+      tableItem.memberName += 2;                                                                                       \
+    tableItem.getMember = GetMemberHelper<decltype(&T::name), &T::name>::getMemberPtr;                                 \
+    tableItem.memberType = type;                                                                                       \
+    tableItem.arrayMaxSize = VfxDynamicArrayId;                                                                        \
+    tableItem.isSection = _isObject;                                                                                   \
+  } while (false)
+
+// =====================================================================================================================
+// Initiates a member to address table
 #define INIT_MEMBER_NAME_TO_ADDR(T, name, type, _isObject)                                                             \
   tableItem->memberName = STRING(name);                                                                                \
   if (!strncmp(tableItem->memberName, "m_", 2))                                                                        \

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,7 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-StrToMemberAddr SectionResourceMappingNode::m_addrTable[SectionResourceMappingNode::MemberCount];
 StrToMemberAddr SectionShaderInfo::m_addrTable[SectionShaderInfo::MemberCount];
 StrToMemberAddr SectionResourceMapping::m_addrTable[SectionResourceMapping::MemberCount];
 StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
@@ -61,7 +60,6 @@ public:
 
     SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
-    SectionResourceMappingNode::initialAddrTable();
     SectionShaderInfo::initialAddrTable();
     SectionResourceMapping::initialAddrTable();
     SectionPipelineOption::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,7 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-StrToMemberAddr SectionResourceMapping::m_addrTable[SectionResourceMapping::MemberCount];
 StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
 StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
 StrToMemberAddr SectionPipelineOption::m_addrTable[SectionPipelineOption::MemberCount];
@@ -58,7 +57,6 @@ public:
 
     SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
-    SectionResourceMapping::initialAddrTable();
     SectionPipelineOption::initialAddrTable();
     SectionNggState::initialAddrTable();
 #if VKI_RAY_TRACING

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -14,7 +14,6 @@ StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCoun
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
 StrToMemberAddr SectionRtState::m_addrTable[SectionRtState::MemberCount];
-StrToMemberAddr SectionRayTracingShaderExportConfig::m_addrTable[SectionRayTracingShaderExportConfig::MemberCount];
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
 StrToMemberAddr SectionGpurtFuncTable::m_addrTable[SectionGpurtFuncTable::MemberCount];
 #endif
@@ -57,7 +56,6 @@ public:
     SectionRayTracingState::initialAddrTable();
     SectionShaderGroup::initialAddrTable();
     SectionRtState::initialAddrTable();
-    SectionRayTracingShaderExportConfig::initialAddrTable();
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
     SectionGpurtFuncTable::initAddrTable();
 #endif

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,7 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-StrToMemberAddr SectionShaderInfo::m_addrTable[SectionShaderInfo::MemberCount];
 StrToMemberAddr SectionResourceMapping::m_addrTable[SectionResourceMapping::MemberCount];
 StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
 StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
@@ -59,7 +58,6 @@ public:
 
     SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
-    SectionShaderInfo::initialAddrTable();
     SectionResourceMapping::initialAddrTable();
     SectionPipelineOption::initialAddrTable();
     SectionNggState::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,7 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
 #if VKI_RAY_TRACING
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
@@ -46,7 +45,6 @@ public:
 #endif
     INIT_SECTION_INFO("ResourceMapping", SectionTypeResourceMapping, 0)
 
-    SectionComputeState::initialAddrTable();
 #if VKI_RAY_TRACING
     SectionRayTracingState::initialAddrTable();
     SectionShaderGroup::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,10 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-#if VKI_RAY_TRACING
-StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
-#endif
-
 // =====================================================================================================================
 // Dummy class used to initialize all VK special sections
 class VkSectionParserInit {
@@ -42,10 +38,6 @@ public:
     INIT_SECTION_INFO("callInfo", SectionTypeShaderInfo, ShaderStage::ShaderStageRayTracingCallable)
 #endif
     INIT_SECTION_INFO("ResourceMapping", SectionTypeResourceMapping, 0)
-
-#if VKI_RAY_TRACING
-    SectionShaderGroup::initialAddrTable();
-#endif
   };
 
   void initEnumMap() {

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -14,9 +14,6 @@ StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCoun
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
 StrToMemberAddr SectionRtState::m_addrTable[SectionRtState::MemberCount];
-#if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
-StrToMemberAddr SectionGpurtFuncTable::m_addrTable[SectionGpurtFuncTable::MemberCount];
-#endif
 #endif
 
 // =====================================================================================================================
@@ -56,9 +53,6 @@ public:
     SectionRayTracingState::initialAddrTable();
     SectionShaderGroup::initialAddrTable();
     SectionRtState::initialAddrTable();
-#if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
-    SectionGpurtFuncTable::initAddrTable();
-#endif
 #endif
   };
 

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -13,7 +13,6 @@ StrToMemberAddr SectionResourceMapping::m_addrTable[SectionResourceMapping::Memb
 StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
 StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
 StrToMemberAddr SectionPipelineOption::m_addrTable[SectionPipelineOption::MemberCount];
-StrToMemberAddr SectionShaderOption::m_addrTable[SectionShaderOption::MemberCount];
 StrToMemberAddr SectionNggState::m_addrTable[SectionNggState::MemberCount];
 #if VKI_RAY_TRACING
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
@@ -63,7 +62,6 @@ public:
     SectionShaderInfo::initialAddrTable();
     SectionResourceMapping::initialAddrTable();
     SectionPipelineOption::initialAddrTable();
-    SectionShaderOption::initialAddrTable();
     SectionNggState::initialAddrTable();
 #if VKI_RAY_TRACING
     SectionRayTracingState::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -10,7 +10,6 @@ namespace Vfx {
 
 StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
 StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
-StrToMemberAddr SectionNggState::m_addrTable[SectionNggState::MemberCount];
 #if VKI_RAY_TRACING
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
@@ -55,7 +54,6 @@ public:
 
     SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
-    SectionNggState::initialAddrTable();
 #if VKI_RAY_TRACING
     SectionRayTracingState::initialAddrTable();
     SectionShaderGroup::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,7 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
 StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
 #if VKI_RAY_TRACING
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
@@ -47,7 +46,6 @@ public:
 #endif
     INIT_SECTION_INFO("ResourceMapping", SectionTypeResourceMapping, 0)
 
-    SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
 #if VKI_RAY_TRACING
     SectionRayTracingState::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -22,7 +22,6 @@ StrToMemberAddr SectionIndirectCalleeSavedRegs::m_addrTable[SectionIndirectCalle
 StrToMemberAddr SectionGpurtFuncTable::m_addrTable[SectionGpurtFuncTable::MemberCount];
 #endif
 #endif
-StrToMemberAddr SectionExtendedRobustness::m_addrTable[SectionExtendedRobustness::MemberCount];
 
 // =====================================================================================================================
 // Dummy class used to initialize all VK special sections
@@ -69,7 +68,6 @@ public:
     SectionGpurtFuncTable::initAddrTable();
 #endif
 #endif
-    SectionExtendedRobustness::initialAddrTable();
   };
 
   void initEnumMap() {

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -9,7 +9,6 @@ using namespace Vkgc;
 namespace Vfx {
 
 #if VKI_RAY_TRACING
-StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
 StrToMemberAddr SectionRtState::m_addrTable[SectionRtState::MemberCount];
 #endif
@@ -46,7 +45,6 @@ public:
     INIT_SECTION_INFO("ResourceMapping", SectionTypeResourceMapping, 0)
 
 #if VKI_RAY_TRACING
-    SectionRayTracingState::initialAddrTable();
     SectionShaderGroup::initialAddrTable();
     SectionRtState::initialAddrTable();
 #endif

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -8,7 +8,6 @@ using namespace Vkgc;
 
 namespace Vfx {
 
-StrToMemberAddr SectionDescriptorRangeValueItem::m_addrTable[SectionDescriptorRangeValueItem::MemberCount];
 StrToMemberAddr SectionResourceMappingNode::m_addrTable[SectionResourceMappingNode::MemberCount];
 StrToMemberAddr SectionShaderInfo::m_addrTable[SectionShaderInfo::MemberCount];
 StrToMemberAddr SectionResourceMapping::m_addrTable[SectionResourceMapping::MemberCount];
@@ -62,7 +61,6 @@ public:
 
     SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
-    SectionDescriptorRangeValueItem::initialAddrTable();
     SectionResourceMappingNode::initialAddrTable();
     SectionShaderInfo::initialAddrTable();
     SectionResourceMapping::initialAddrTable();

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -10,7 +10,6 @@ namespace Vfx {
 
 #if VKI_RAY_TRACING
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
-StrToMemberAddr SectionRtState::m_addrTable[SectionRtState::MemberCount];
 #endif
 
 // =====================================================================================================================
@@ -46,7 +45,6 @@ public:
 
 #if VKI_RAY_TRACING
     SectionShaderGroup::initialAddrTable();
-    SectionRtState::initialAddrTable();
 #endif
   };
 

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -15,7 +15,6 @@ StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::Memb
 StrToMemberAddr SectionShaderGroup::m_addrTable[SectionShaderGroup::MemberCount];
 StrToMemberAddr SectionRtState::m_addrTable[SectionRtState::MemberCount];
 StrToMemberAddr SectionRayTracingShaderExportConfig::m_addrTable[SectionRayTracingShaderExportConfig::MemberCount];
-StrToMemberAddr SectionIndirectCalleeSavedRegs::m_addrTable[SectionIndirectCalleeSavedRegs::MemberCount];
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
 StrToMemberAddr SectionGpurtFuncTable::m_addrTable[SectionGpurtFuncTable::MemberCount];
 #endif
@@ -59,7 +58,6 @@ public:
     SectionShaderGroup::initialAddrTable();
     SectionRtState::initialAddrTable();
     SectionRayTracingShaderExportConfig::initialAddrTable();
-    SectionIndirectCalleeSavedRegs::initialAddrTable();
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
     SectionGpurtFuncTable::initAddrTable();
 #endif

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -10,7 +10,6 @@ namespace Vfx {
 
 StrToMemberAddr SectionGraphicsState::m_addrTable[SectionGraphicsState::MemberCount];
 StrToMemberAddr SectionComputeState::m_addrTable[SectionComputeState::MemberCount];
-StrToMemberAddr SectionPipelineOption::m_addrTable[SectionPipelineOption::MemberCount];
 StrToMemberAddr SectionNggState::m_addrTable[SectionNggState::MemberCount];
 #if VKI_RAY_TRACING
 StrToMemberAddr SectionRayTracingState::m_addrTable[SectionRayTracingState::MemberCount];
@@ -56,7 +55,6 @@ public:
 
     SectionGraphicsState::initialAddrTable();
     SectionComputeState::initialAddrTable();
-    SectionPipelineOption::initialAddrTable();
     SectionNggState::initialAddrTable();
 #if VKI_RAY_TRACING
     SectionRayTracingState::initialAddrTable();

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -263,16 +263,8 @@ class SectionResourceMapping : public Section {
 public:
   typedef Vkgc::ResourceMappingData SubState;
 
-  SectionResourceMapping() : Section({m_addrTable, MemberCount}, SectionTypeResourceMapping, "ResourceMapping") {
+  SectionResourceMapping() : Section(getAddrTable(), SectionTypeResourceMapping, "ResourceMapping") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_descriptorRangeValue, MemberTypeDescriptorRangeValue,
-                                      true);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_userDataNode, MemberTypeResourceMappingNode, true);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -297,8 +289,18 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 2;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_descriptorRangeValue,
+                                            MemberTypeDescriptorRangeValue, true);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_userDataNode, MemberTypeResourceMappingNode,
+                                            true);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
+
   SubState m_state;
   std::vector<SectionDescriptorRangeValueItem> m_descriptorRangeValue; // Contains descriptor range value
   std::vector<SectionResourceMappingNode> m_userDataNode;              // Contains user data node

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -121,59 +121,56 @@ class SectionShaderOption : public Section {
 public:
   typedef Vkgc::PipelineShaderOptions SubState;
 
-  SectionShaderOption() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "options") {
-    memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, trapPresent, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, debugMode, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enablePerformanceData, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowReZ, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLateZ, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, vgprLimit, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, sgprLimit, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, maxThreadGroupsPerComputeUnit, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveSize, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, subgroupSize, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, wgpMode, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveBreakSize, MemberTypeEnum, false);
-
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, adjustDepthImportVrs, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicmThreshold, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollHintThreshold, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, ldsSpillLimitDwords, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarizeWaterfallLoads, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeX, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableInvariantLoads, MemberTypeBool, false);
-
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
+  SectionShaderOption() : Section(getAddrTable(), SectionTypeUnset, "options") { memset(&m_state, 0, sizeof(m_state)); }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 36;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, trapPresent, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, debugMode, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enablePerformanceData, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowReZ, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLateZ, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, vgprLimit, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, sgprLimit, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, maxThreadGroupsPerComputeUnit, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveSize, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, subgroupSize, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, wgpMode, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveBreakSize, MemberTypeEnum, false);
+
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, adjustDepthImportVrs, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicmThreshold, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollHintThreshold, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, ldsSpillLimitDwords, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarizeWaterfallLoads, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeX, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableInvariantLoads, MemberTypeBool, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -572,43 +572,8 @@ private:
 class SectionRtState : public Section {
 public:
   typedef Vkgc::RtState SubState;
-  SectionRtState() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "rtState") {
-    memset(&m_state, 0, sizeof(m_state));
-  }
+  SectionRtState() : Section(getAddrTable(), SectionTypeUnset, "rtState") { memset(&m_state, 0, sizeof(m_state)); }
 
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_bvhResDescSize, MemberTypeInt, false);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRtState, m_bvhResDesc, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, nodeStrideShift, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, staticPipelineFlags, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, triCompressMode, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, pipelineFlags, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeX, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeY, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeZ, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, boxSortHeuristicMode, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMode, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMask, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, rayQueryCsSwizzle, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsStackSize, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchRaysThreadGroupSize, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsSizePerThreadGroup, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, outerTileSize, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchDimSwizzleMode, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayQueryCsSwizzle, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysInnerSwizzle, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysOuterSwizzle, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, forceInvalidAccelStruct, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayTracingCounters, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForIndirect, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForUnified, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_exportConfig, MemberTypeRayTracingShaderExportConfig, true);
-#if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
-    INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtFuncTable, MemberTypeGpurtFuncTable, true);
-#endif
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
   void getSubState(SubState &state) {
     state = m_state;
     state.bvhResDesc.dataSizeInDwords = m_bvhResDescSize;
@@ -623,8 +588,42 @@ public:
   SubState &getSubStateRef() { return m_state; }
 
 private:
-  static const unsigned MemberCount = 30;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_bvhResDescSize, MemberTypeInt, false);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRtState, m_bvhResDesc, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, nodeStrideShift, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, staticPipelineFlags, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, triCompressMode, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, pipelineFlags, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeX, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeY, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeZ, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, boxSortHeuristicMode, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMode, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMask, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, rayQueryCsSwizzle, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsStackSize, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchRaysThreadGroupSize, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsSizePerThreadGroup, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, outerTileSize, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchDimSwizzleMode, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayQueryCsSwizzle, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysInnerSwizzle, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysOuterSwizzle, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, forceInvalidAccelStruct, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayTracingCounters, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForIndirect, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForUnified, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_exportConfig, MemberTypeRayTracingShaderExportConfig, true);
+#if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtFuncTable, MemberTypeGpurtFuncTable, true);
+#endif
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
   SectionRayTracingShaderExportConfig m_exportConfig;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -721,19 +721,22 @@ class SectionComputeState : public Section {
 public:
   typedef ComputePipelineState SubState;
 
-  SectionComputeState() : Section({m_addrTable, MemberCount}, SectionTypeComputeState, nullptr) {
+  SectionComputeState() : Section(getAddrTable(), SectionTypeComputeState, nullptr) {
     memset(&m_state, 0, sizeof(m_state));
   }
 
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionComputeState, deviceIndex, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_options, MemberTypePipelineOption, true);
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionComputeState, deviceIndex, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_options, MemberTypePipelineOption, true);
 #if VKI_RAY_TRACING
-    INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_shaderLibrary, MemberTypeString, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_rtState, MemberTypeRtState, true);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_shaderLibrary, MemberTypeString, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_rtState, MemberTypeRtState, true);
 #endif
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
   }
 
   void getSubState(const std::string &docFilename, SubState &state, std::string *errorMsg) {
@@ -754,9 +757,6 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 5;
-  static StrToMemberAddr m_addrTable[MemberCount];
-
   SubState m_state;
   SectionPipelineOption m_options;
 #if VKI_RAY_TRACING

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -24,13 +24,13 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, visibility, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, type, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, set, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, binding, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, arraySize, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_uintData, MemberTypeUArray, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_intData, MemberTypeIArray, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, visibility, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, type, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, set, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, binding, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, arraySize, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_uintData, MemberTypeUArray, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_intData, MemberTypeIArray, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -75,18 +75,17 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, m_visibility, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, type, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, sizeInDwords, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, offsetInDwords, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, set, srdRange.set,
-                                                 SectionResourceMappingNode::getResourceMapNodeSet, MemberTypeInt,
-                                                 false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, binding, srdRange.binding,
-                                                 SectionResourceMappingNode::getResourceMapNodeBinding, MemberTypeInt,
-                                                 false);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMappingNode, m_next, MemberTypeResourceMappingNode, true);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+      INIT_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, m_visibility, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, type, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, sizeInDwords, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, offsetInDwords, MemberTypeInt, false);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, set, srdRange.set,
+                                             SectionResourceMappingNode::getResourceMapNodeSet, MemberTypeInt, false);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, binding, srdRange.binding,
+                                             SectionResourceMappingNode::getResourceMapNodeBinding, MemberTypeInt,
+                                             false);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMappingNode, m_next, MemberTypeResourceMappingNode, true);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
           SectionResourceMappingNode, indirectUserDataCount, userDataPtr.sizeInDwords,
           SectionResourceMappingNode::getResourceMapNodeUserDataCount, MemberTypeInt, false);
       return addrTableInitializer;
@@ -130,43 +129,43 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, trapPresent, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, debugMode, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enablePerformanceData, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowReZ, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLateZ, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, vgprLimit, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, sgprLimit, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, maxThreadGroupsPerComputeUnit, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveSize, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, subgroupSize, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, wgpMode, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveBreakSize, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, trapPresent, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, debugMode, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enablePerformanceData, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowReZ, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLateZ, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, vgprLimit, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, sgprLimit, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, maxThreadGroupsPerComputeUnit, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveSize, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, subgroupSize, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, wgpMode, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, waveBreakSize, MemberTypeEnum, false);
 
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, adjustDepthImportVrs, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicmThreshold, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollHintThreshold, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, ldsSpillLimitDwords, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarizeWaterfallLoads, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeX, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableInvariantLoads, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, forceLoopUnrollCount, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, useSiScheduler, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, updateDescInElf, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, allowVaryWaveSize, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, enableLoadScalarizer, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicm, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollThreshold, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarThreshold, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fp32DenormalMode, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLoopUnroll, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, adjustDepthImportVrs, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableLicmThreshold, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, unrollHintThreshold, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, dontUnrollHintThreshold, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, fastMathFlags, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableFastMathFlags, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, ldsSpillLimitDwords, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, scalarizeWaterfallLoads, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeX, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableInvariantLoads, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -231,12 +230,12 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_entryPoint, MemberTypeString, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_specConst, MemberTypeSpecInfo, true);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_options, MemberTypeShaderOption, true);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_descriptorRangeValue, MemberTypeDescriptorRangeValue,
-                                            true);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_userDataNode, MemberTypeResourceMappingNode, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_entryPoint, MemberTypeString, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_specConst, MemberTypeSpecInfo, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_options, MemberTypeShaderOption, true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_descriptorRangeValue, MemberTypeDescriptorRangeValue,
+                                        true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_userDataNode, MemberTypeResourceMappingNode, true);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -292,10 +291,9 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_descriptorRangeValue,
-                                            MemberTypeDescriptorRangeValue, true);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_userDataNode, MemberTypeResourceMappingNode,
-                                            true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_descriptorRangeValue, MemberTypeDescriptorRangeValue,
+                                        true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMapping, m_userDataNode, MemberTypeResourceMappingNode, true);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -326,9 +324,9 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustBufferAccess, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustImageAccess, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, nullDescriptor, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustBufferAccess, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustImageAccess, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, nullDescriptor, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -357,27 +355,27 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeDisassembly, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceCsThreadIdSwizzling, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeX, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeY, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeZ, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeDisassembly, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceCsThreadIdSwizzling, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeX, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeY, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeZ, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
 #endif
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
       // One internal member
 #if VKI_RAY_TRACING
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
 #endif
       return addrTableInitializer;
     }();
@@ -403,21 +401,21 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableNgg, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableGsUse, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceCullingMode, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableVertexReuse, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBackfaceCulling, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFrustumCulling, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBoxFilterCulling, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSphereCulling, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSmallPrimFilter, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableCullDistanceCulling, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, backfaceExponent, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, subgroupSizing, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, primsPerSubgroup, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, vertsPerSubgroup, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableNgg, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableGsUse, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceCullingMode, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableVertexReuse, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBackfaceCulling, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFrustumCulling, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBoxFilterCulling, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSphereCulling, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSmallPrimFilter, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableCullDistanceCulling, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, backfaceExponent, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, subgroupSizing, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, primsPerSubgroup, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, vertsPerSubgroup, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -444,36 +442,33 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
-          SectionIndirectCalleeSavedRegs, raygen, raygen,
-          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
-                                                                         indirectCalleeSavedRegs.raygen)>,
-          MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, miss, miss,
-                                                 SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                                     Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.miss)>,
-                                                 MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, raygen, raygen,
+                                             SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
+                                                 Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.raygen)>,
+                                             MemberTypeInt, false);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, miss, miss,
+                                             SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
+                                                 Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.miss)>,
+                                             MemberTypeInt, false);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
           SectionIndirectCalleeSavedRegs, closestHit, closestHit,
           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
                                                                          indirectCalleeSavedRegs.closestHit)>,
           MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
-          SectionIndirectCalleeSavedRegs, anyHit, anyHit,
-          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
-                                                                         indirectCalleeSavedRegs.anyHit)>,
-          MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, anyHit, anyHit,
+                                             SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
+                                                 Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.anyHit)>,
+                                             MemberTypeInt, false);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
           SectionIndirectCalleeSavedRegs, intersection, intersection,
           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
                                                                          indirectCalleeSavedRegs.intersection)>,
           MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
-          SectionIndirectCalleeSavedRegs, callable, callable,
-          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
-                                                                         indirectCalleeSavedRegs.callable)>,
-          MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, callable, callable,
+                                             SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
+                                                 Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.callable)>,
+                                             MemberTypeInt, false);
+      INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
           SectionIndirectCalleeSavedRegs, traceRays, traceRays,
           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
                                                                          indirectCalleeSavedRegs.traceRays)>,
@@ -503,20 +498,18 @@ public:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, indirectCallingConvention, MemberTypeInt,
-                                         false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableUniformNoReturn, MemberTypeBool,
-                                         false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableTraceRayArgsInLds, MemberTypeBool,
-                                         false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, readsDispatchRaysIndex, MemberTypeBool,
-                                         false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableDynamicLaunch, MemberTypeBool,
-                                         false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, emitRaytracingShaderDataToken,
-                                         MemberTypeBool, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, m_indirectCalleeSavedRegs,
-                                   MemberTypeIndirectCalleeSavedRegs, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, indirectCallingConvention, MemberTypeInt,
+                                     false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableUniformNoReturn, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableTraceRayArgsInLds, MemberTypeBool,
+                                     false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, readsDispatchRaysIndex, MemberTypeBool,
+                                     false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableDynamicLaunch, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, emitRaytracingShaderDataToken, MemberTypeBool,
+                                     false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, m_indirectCalleeSavedRegs,
+                               MemberTypeIndirectCalleeSavedRegs, true);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -555,8 +548,8 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGpurtFuncTable, m_pFunc, MemberTypeString, Vkgc::RT_ENTRY_FUNC_COUNT,
-                                         false);
+      INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGpurtFuncTable, m_pFunc, MemberTypeString, Vkgc::RT_ENTRY_FUNC_COUNT,
+                                     false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -591,34 +584,34 @@ private:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_bvhResDescSize, MemberTypeInt, false);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRtState, m_bvhResDesc, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, nodeStrideShift, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, staticPipelineFlags, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, triCompressMode, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, pipelineFlags, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeX, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeY, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeZ, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, boxSortHeuristicMode, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMode, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMask, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, rayQueryCsSwizzle, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsStackSize, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchRaysThreadGroupSize, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsSizePerThreadGroup, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, outerTileSize, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchDimSwizzleMode, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayQueryCsSwizzle, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysInnerSwizzle, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysOuterSwizzle, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, forceInvalidAccelStruct, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayTracingCounters, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForIndirect, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForUnified, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_exportConfig, MemberTypeRayTracingShaderExportConfig, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_bvhResDescSize, MemberTypeInt, false);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRtState, m_bvhResDesc, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, nodeStrideShift, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, staticPipelineFlags, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, triCompressMode, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, pipelineFlags, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeX, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeY, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, threadGroupSizeZ, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, boxSortHeuristicMode, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMode, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, counterMask, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, rayQueryCsSwizzle, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsStackSize, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchRaysThreadGroupSize, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, ldsSizePerThreadGroup, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, outerTileSize, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, dispatchDimSwizzleMode, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayQueryCsSwizzle, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysInnerSwizzle, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableDispatchRaysOuterSwizzle, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, forceInvalidAccelStruct, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableRayTracingCounters, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForIndirect, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForUnified, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_exportConfig, MemberTypeRayTracingShaderExportConfig, true);
 #if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 15
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtFuncTable, MemberTypeGpurtFuncTable, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtFuncTable, MemberTypeGpurtFuncTable, true);
 #endif
       return addrTableInitializer;
     }();
@@ -648,34 +641,34 @@ public:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, topology, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, provokingVertexMode, MemberTypeEnum, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, patchControlPoints, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, deviceIndex, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, disableVertexReuse, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, depthClipEnable, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, rasterizerDiscardEnable, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, perSampleShading, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, numSamples, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, pixelShaderSamples, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, samplePatternIdx, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, usrClipPlaneMask, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, alphaToCoverageEnable, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendEnable, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, switchWinding, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableMultiView, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_options, MemberTypePipelineOption, true);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_nggState, MemberTypeNggState, true);
-      VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, m_colorBuffer, MemberTypeColorBufferItem,
-                                         Vkgc::MaxColorTargets, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, topology, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, provokingVertexMode, MemberTypeEnum, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, patchControlPoints, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, deviceIndex, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, disableVertexReuse, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, depthClipEnable, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, rasterizerDiscardEnable, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, perSampleShading, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, numSamples, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, pixelShaderSamples, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, samplePatternIdx, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, usrClipPlaneMask, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, alphaToCoverageEnable, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendEnable, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, switchWinding, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableMultiView, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_options, MemberTypePipelineOption, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_nggState, MemberTypeNggState, true);
+      INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, m_colorBuffer, MemberTypeColorBufferItem,
+                                     Vkgc::MaxColorTargets, true);
 
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableUberFetchShader, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableEarlyCompile, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableUberFetchShader, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableEarlyCompile, MemberTypeBool, false);
 
 #if VKI_RAY_TRACING
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_shaderLibrary, MemberTypeString, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_rtState, MemberTypeRtState, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_shaderLibrary, MemberTypeString, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_rtState, MemberTypeRtState, true);
 #endif
       return addrTableInitializer;
     }();
@@ -727,11 +720,11 @@ public:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionComputeState, deviceIndex, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_options, MemberTypePipelineOption, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionComputeState, deviceIndex, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_options, MemberTypePipelineOption, true);
 #if VKI_RAY_TRACING
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_shaderLibrary, MemberTypeString, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_rtState, MemberTypeRtState, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_shaderLibrary, MemberTypeString, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionComputeState, m_rtState, MemberTypeRtState, true);
 #endif
       return addrTableInitializer;
     }();
@@ -779,17 +772,17 @@ public:
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, deviceIndex, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_options, MemberTypePipelineOption, true);
-      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRayTracingState, m_groups, MemberTypeShaderGroup, true);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_shaderTraceRay, MemberTypeString, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, maxRecursionDepth, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, indirectStageMask, MemberTypeInt, false);
-      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_rtState, MemberTypeRtState, true);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, payloadSizeMaxInLib, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, attributeSizeMaxInLib, MemberTypeInt, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, hasPipelineLibrary, MemberTypeBool, false);
-      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, pipelineLibStageMask, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, deviceIndex, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_options, MemberTypePipelineOption, true);
+      INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRayTracingState, m_groups, MemberTypeShaderGroup, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_shaderTraceRay, MemberTypeString, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, maxRecursionDepth, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, indirectStageMask, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_rtState, MemberTypeRtState, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, payloadSizeMaxInLib, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, attributeSizeMaxInLib, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, hasPipelineLibrary, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, pipelineLibStageMask, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -343,35 +343,8 @@ class SectionPipelineOption : public Section {
 public:
   typedef Vkgc::PipelineOptions SubState;
 
-  SectionPipelineOption() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "options") {
+  SectionPipelineOption() : Section(getAddrTable(), SectionTypeUnset, "options") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeDisassembly, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceCsThreadIdSwizzling, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeX, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeY, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeZ, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
-#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
-#endif
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
-    // One internal member
-#if VKI_RAY_TRACING
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
-#endif
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -381,8 +354,35 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 18;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeDisassembly, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, scalarBlockLayout, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, includeIr, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, robustBufferAccess, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reconfigWorkgroupLayout, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceCsThreadIdSwizzling, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeX, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeY, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, overrideThreadGroupSizeZ, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTableUsage, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, shadowDescriptorTablePtrHigh, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, resourceLayoutScheme, MemberTypeEnum, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION >= 53
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizationLevel, MemberTypeInt, false);
+#endif
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
+      // One internal member
+#if VKI_RAY_TRACING
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
+#endif
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
   SectionExtendedRobustness m_extendedRobustness;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -540,14 +540,8 @@ private:
 class SectionGpurtFuncTable : public Section {
 public:
   typedef Vkgc::GpurtFuncTable SubState;
-  SectionGpurtFuncTable() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "gpurtFuncTable") {
+  SectionGpurtFuncTable() : Section(getAddrTable(), SectionTypeUnset, "gpurtFuncTable") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGpurtFuncTable, m_pFunc, MemberTypeString, Vkgc::RT_ENTRY_FUNC_COUNT, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -558,8 +552,15 @@ public:
   SubState &getSubStateRef() { return m_state; }
 
 private:
-  static const unsigned MemberCount = 1;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGpurtFuncTable, m_pFunc, MemberTypeString, Vkgc::RT_ENTRY_FUNC_COUNT,
+                                         false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
   std::string m_pFunc[Vkgc::RT_ENTRY_FUNC_COUNT];

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -48,26 +48,9 @@ class SectionResourceMappingNode : public Section {
 public:
   typedef Vkgc::ResourceMappingNode SubState;
 
-  SectionResourceMappingNode() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "userDataNode") {
+  SectionResourceMappingNode() : Section(getAddrTable(), SectionTypeUnset, "userDataNode") {
     memset(&m_state, 0, sizeof(m_state));
     m_visibility = 0;
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, m_visibility, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, type, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, sizeInDwords, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, offsetInDwords, MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, set, srdRange.set,
-                                           SectionResourceMappingNode::getResourceMapNodeSet, MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, binding, srdRange.binding,
-                                           SectionResourceMappingNode::getResourceMapNodeBinding, MemberTypeInt, false);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMappingNode, m_next, MemberTypeResourceMappingNode, true);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, indirectUserDataCount, userDataPtr.sizeInDwords,
-                                           SectionResourceMappingNode::getResourceMapNodeUserDataCount, MemberTypeInt,
-                                           false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   SubState &getSubStateRef() { return m_state; };
@@ -89,6 +72,28 @@ public:
   }
 
 private:
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, m_visibility, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, type, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, sizeInDwords, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionResourceMappingNode, offsetInDwords, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, set, srdRange.set,
+                                                 SectionResourceMappingNode::getResourceMapNodeSet, MemberTypeInt,
+                                                 false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionResourceMappingNode, binding, srdRange.binding,
+                                                 SectionResourceMappingNode::getResourceMapNodeBinding, MemberTypeInt,
+                                                 false);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionResourceMappingNode, m_next, MemberTypeResourceMappingNode, true);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionResourceMappingNode, indirectUserDataCount, userDataPtr.sizeInDwords,
+          SectionResourceMappingNode::getResourceMapNodeUserDataCount, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
+
   static void *getResourceMapNodeSet(void *obj) {
     SectionResourceMappingNode *castedObj = static_cast<SectionResourceMappingNode *>(obj);
     return static_cast<void *>(&castedObj->m_state.srdRange.set);
@@ -103,9 +108,6 @@ private:
     SectionResourceMappingNode *castedObj = static_cast<SectionResourceMappingNode *>(obj);
     return static_cast<void *>(&castedObj->m_state.userDataPtr.sizeInDwords);
   }
-
-  static const unsigned MemberCount = 11;
-  static StrToMemberAddr m_addrTable[MemberCount];
 
   std::vector<SectionResourceMappingNode> m_next; // Next resource mapping node
   uint32_t m_visibility;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -773,24 +773,27 @@ class SectionRayTracingState : public Section {
 public:
   typedef RayTracingPipelineState SubState;
 
-  SectionRayTracingState() : Section({m_addrTable, MemberCount}, SectionTypeComputeState, nullptr) {
+  SectionRayTracingState() : Section(getAddrTable(), SectionTypeComputeState, nullptr) {
     memset(&m_state, 0, sizeof(m_state));
   }
 
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, deviceIndex, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_options, MemberTypePipelineOption, true);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRayTracingState, m_groups, MemberTypeShaderGroup, true);
-    INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_shaderTraceRay, MemberTypeString, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, maxRecursionDepth, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, indirectStageMask, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_rtState, MemberTypeRtState, true);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, payloadSizeMaxInLib, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, attributeSizeMaxInLib, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, hasPipelineLibrary, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, pipelineLibStageMask, MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, deviceIndex, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_options, MemberTypePipelineOption, true);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRayTracingState, m_groups, MemberTypeShaderGroup, true);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_shaderTraceRay, MemberTypeString, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, maxRecursionDepth, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, indirectStageMask, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_rtState, MemberTypeRtState, true);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, payloadSizeMaxInLib, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, attributeSizeMaxInLib, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, hasPipelineLibrary, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, pipelineLibStageMask, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
   }
 
   void getSubState(const std::string &docFilename, SubState &state, std::string *errorMsg) {
@@ -815,9 +818,6 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 11;
-  static StrToMemberAddr m_addrTable[MemberCount];
-
   SubState m_state;
   SectionPipelineOption m_options;
   SectionRtState m_rtState;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -181,20 +181,8 @@ class SectionShaderInfo : public Section {
 public:
   typedef Vkgc::PipelineShaderInfo SubState;
   SectionShaderInfo(const SectionInfo &info)
-      : Section({m_addrTable, MemberCount}, info.type, nullptr),
-        m_shaderStage(static_cast<ShaderStage>(info.property)) {
+      : Section(getAddrTable(), info.type, nullptr), m_shaderStage(static_cast<ShaderStage>(info.property)) {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_entryPoint, MemberTypeString, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_specConst, MemberTypeSpecInfo, true);
-    INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_options, MemberTypeShaderOption, true);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_descriptorRangeValue, MemberTypeDescriptorRangeValue, true);
-    INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_userDataNode, MemberTypeResourceMappingNode, true);
-
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) {
@@ -240,8 +228,20 @@ public:
   }
 
 private:
-  static const unsigned MemberCount = 5;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_entryPoint, MemberTypeString, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_specConst, MemberTypeSpecInfo, true);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionShaderInfo, m_options, MemberTypeShaderOption, true);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_descriptorRangeValue, MemberTypeDescriptorRangeValue,
+                                            true);
+      VEC_INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionShaderInfo, m_userDataNode, MemberTypeResourceMappingNode, true);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
+
   SubState m_state;
   SectionSpecInfo m_specConst;   // Specialization constant info
   SectionShaderOption m_options; // Pipeline shader options

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -8,23 +8,12 @@ class SectionDescriptorRangeValueItem : public Section {
 public:
   typedef Vkgc::StaticDescriptorValue SubState;
 
-  SectionDescriptorRangeValueItem() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "descriptorRangeValue") {
+  SectionDescriptorRangeValueItem() : Section(getAddrTable(), SectionTypeUnset, "descriptorRangeValue") {
     m_intData = &m_bufMem;
     m_uintData = &m_bufMem;
     memset(&m_state, 0, sizeof(m_state));
   }
 
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, visibility, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, type, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, set, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, binding, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, arraySize, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_uintData, MemberTypeUArray, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_intData, MemberTypeIArray, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
   void getSubState(SubState &state) {
     state = m_state;
     state.pValue = m_bufMem.size() > 0 ? (const unsigned *)(&m_bufMem[0]) : nullptr;
@@ -32,8 +21,20 @@ public:
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 7;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, visibility, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, type, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, set, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, binding, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, arraySize, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_uintData, MemberTypeUArray, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionDescriptorRangeValueItem, m_intData, MemberTypeIArray, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   std::vector<uint8_t> *m_intData;
   std::vector<uint8_t> *m_uintData;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -8,7 +8,7 @@ class SectionDescriptorRangeValueItem : public Section {
 public:
   typedef Vkgc::StaticDescriptorValue SubState;
 
-  SectionDescriptorRangeValueItem() : Section(m_addrTable, MemberCount, SectionTypeUnset, "descriptorRangeValue") {
+  SectionDescriptorRangeValueItem() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "descriptorRangeValue") {
     m_intData = &m_bufMem;
     m_uintData = &m_bufMem;
     memset(&m_state, 0, sizeof(m_state));
@@ -47,7 +47,7 @@ class SectionResourceMappingNode : public Section {
 public:
   typedef Vkgc::ResourceMappingNode SubState;
 
-  SectionResourceMappingNode() : Section(m_addrTable, MemberCount, SectionTypeUnset, "userDataNode") {
+  SectionResourceMappingNode() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "userDataNode") {
     memset(&m_state, 0, sizeof(m_state));
     m_visibility = 0;
   }
@@ -118,7 +118,7 @@ class SectionShaderOption : public Section {
 public:
   typedef Vkgc::PipelineShaderOptions SubState;
 
-  SectionShaderOption() : Section(m_addrTable, MemberCount, SectionTypeUnset, "options") {
+  SectionShaderOption() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "options") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -181,7 +181,8 @@ class SectionShaderInfo : public Section {
 public:
   typedef Vkgc::PipelineShaderInfo SubState;
   SectionShaderInfo(const SectionInfo &info)
-      : Section(m_addrTable, MemberCount, info.type, nullptr), m_shaderStage(static_cast<ShaderStage>(info.property)) {
+      : Section({m_addrTable, MemberCount}, info.type, nullptr),
+        m_shaderStage(static_cast<ShaderStage>(info.property)) {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -262,7 +263,7 @@ class SectionResourceMapping : public Section {
 public:
   typedef Vkgc::ResourceMappingData SubState;
 
-  SectionResourceMapping() : Section(m_addrTable, MemberCount, SectionTypeResourceMapping, "ResourceMapping") {
+  SectionResourceMapping() : Section({m_addrTable, MemberCount}, SectionTypeResourceMapping, "ResourceMapping") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -312,7 +313,7 @@ class SectionExtendedRobustness : public Section {
 public:
   typedef Vkgc::ExtendedRobustness SubState;
 
-  SectionExtendedRobustness() : Section(m_addrTable, MemberCount, SectionTypeUnset, "extendedRobustness") {
+  SectionExtendedRobustness() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "extendedRobustness") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -341,7 +342,7 @@ class SectionPipelineOption : public Section {
 public:
   typedef Vkgc::PipelineOptions SubState;
 
-  SectionPipelineOption() : Section(m_addrTable, MemberCount, SectionTypeUnset, "options") {
+  SectionPipelineOption() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "options") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -392,7 +393,7 @@ class SectionNggState : public Section {
 public:
   typedef Vkgc::NggState SubState;
 
-  SectionNggState() : Section(m_addrTable, MemberCount, SectionTypeUnset, "nggState") {
+  SectionNggState() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "nggState") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -433,7 +434,7 @@ private:
 class SectionIndirectCalleeSavedRegs : public Section {
 public:
   typedef Vkgc::RayTracingShaderExportConfig SubState;
-  SectionIndirectCalleeSavedRegs() : Section(m_addrTable, MemberCount, SectionTypeUnset, "exportConfig") {
+  SectionIndirectCalleeSavedRegs() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "exportConfig") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -493,7 +494,7 @@ private:
 class SectionRayTracingShaderExportConfig : public Section {
 public:
   typedef Vkgc::RayTracingShaderExportConfig SubState;
-  SectionRayTracingShaderExportConfig() : Section(m_addrTable, MemberCount, SectionTypeUnset, "exportConfig") {
+  SectionRayTracingShaderExportConfig() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "exportConfig") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -534,7 +535,7 @@ private:
 class SectionGpurtFuncTable : public Section {
 public:
   typedef Vkgc::GpurtFuncTable SubState;
-  SectionGpurtFuncTable() : Section(m_addrTable, MemberCount, SectionTypeUnset, "gpurtFuncTable") {
+  SectionGpurtFuncTable() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "gpurtFuncTable") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -565,7 +566,7 @@ private:
 class SectionRtState : public Section {
 public:
   typedef Vkgc::RtState SubState;
-  SectionRtState() : Section(m_addrTable, MemberCount, SectionTypeUnset, "rtState") {
+  SectionRtState() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "rtState") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -635,7 +636,7 @@ class SectionGraphicsState : public Section {
 public:
   typedef GraphicsPipelineState SubState;
 
-  SectionGraphicsState() : Section(m_addrTable, MemberCount, SectionTypeGraphicsState, nullptr) {
+  SectionGraphicsState() : Section({m_addrTable, MemberCount}, SectionTypeGraphicsState, nullptr) {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -713,7 +714,7 @@ class SectionComputeState : public Section {
 public:
   typedef ComputePipelineState SubState;
 
-  SectionComputeState() : Section(m_addrTable, MemberCount, SectionTypeComputeState, nullptr) {
+  SectionComputeState() : Section({m_addrTable, MemberCount}, SectionTypeComputeState, nullptr) {
     memset(&m_state, 0, sizeof(m_state));
   }
 
@@ -765,7 +766,7 @@ class SectionRayTracingState : public Section {
 public:
   typedef RayTracingPipelineState SubState;
 
-  SectionRayTracingState() : Section(m_addrTable, MemberCount, SectionTypeComputeState, nullptr) {
+  SectionRayTracingState() : Section({m_addrTable, MemberCount}, SectionTypeComputeState, nullptr) {
     memset(&m_state, 0, sizeof(m_state));
   }
 

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -432,43 +432,8 @@ private:
 class SectionIndirectCalleeSavedRegs : public Section {
 public:
   typedef Vkgc::RayTracingShaderExportConfig SubState;
-  SectionIndirectCalleeSavedRegs() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "exportConfig") {
+  SectionIndirectCalleeSavedRegs() : Section(getAddrTable(), SectionTypeUnset, "exportConfig") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, raygen, raygen,
-                                           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                               Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.raygen)>,
-                                           MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, miss, miss,
-                                           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                               Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.miss)>,
-                                           MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, closestHit, closestHit,
-                                           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                               Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.closestHit)>,
-                                           MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, anyHit, anyHit,
-                                           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                               Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.anyHit)>,
-                                           MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
-        SectionIndirectCalleeSavedRegs, intersection, intersection,
-        SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
-                                                                       indirectCalleeSavedRegs.intersection)>,
-        MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, callable, callable,
-                                           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                               Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.callable)>,
-                                           MemberTypeInt, false);
-    INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, traceRays, traceRays,
-                                           SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
-                                               Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.traceRays)>,
-                                           MemberTypeInt, false);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) { state.indirectCalleeSavedRegs = m_state.indirectCalleeSavedRegs; }
@@ -476,13 +441,52 @@ public:
   SubState &getSubStateRef() { return m_state; }
 
 private:
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionIndirectCalleeSavedRegs, raygen, raygen,
+          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
+                                                                         indirectCalleeSavedRegs.raygen)>,
+          MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(SectionIndirectCalleeSavedRegs, miss, miss,
+                                                 SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(
+                                                     Vkgc::RayTracingShaderExportConfig, indirectCalleeSavedRegs.miss)>,
+                                                 MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionIndirectCalleeSavedRegs, closestHit, closestHit,
+          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
+                                                                         indirectCalleeSavedRegs.closestHit)>,
+          MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionIndirectCalleeSavedRegs, anyHit, anyHit,
+          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
+                                                                         indirectCalleeSavedRegs.anyHit)>,
+          MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionIndirectCalleeSavedRegs, intersection, intersection,
+          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
+                                                                         indirectCalleeSavedRegs.intersection)>,
+          MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionIndirectCalleeSavedRegs, callable, callable,
+          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
+                                                                         indirectCalleeSavedRegs.callable)>,
+          MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_EXPLICITNAME_TO_ADDR(
+          SectionIndirectCalleeSavedRegs, traceRays, traceRays,
+          SectionIndirectCalleeSavedRegs::GetExportConfigMember<offsetof(Vkgc::RayTracingShaderExportConfig,
+                                                                         indirectCalleeSavedRegs.traceRays)>,
+          MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
+
   template <size_t Offset> static void *GetExportConfigMember(void *pObj) {
     constexpr size_t ExportConfigOffset = offsetof(SectionIndirectCalleeSavedRegs, m_state);
     return reinterpret_cast<uint8_t *>(pObj) + ExportConfigOffset + Offset;
   }
-
-  static const unsigned MemberCount = 7;
-  static StrToMemberAddr m_addrTable[MemberCount];
 
   SubState m_state;
 };

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -315,25 +315,24 @@ class SectionExtendedRobustness : public Section {
 public:
   typedef Vkgc::ExtendedRobustness SubState;
 
-  SectionExtendedRobustness() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "extendedRobustness") {
+  SectionExtendedRobustness() : Section(getAddrTable(), SectionTypeUnset, "extendedRobustness") {
     memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustBufferAccess, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustImageAccess, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, nullDescriptor, MemberTypeBool, false);
-
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
   }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 3;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustBufferAccess, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, robustImageAccess, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionExtendedRobustness, nullDescriptor, MemberTypeBool, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -394,37 +394,34 @@ class SectionNggState : public Section {
 public:
   typedef Vkgc::NggState SubState;
 
-  SectionNggState() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "nggState") {
-    memset(&m_state, 0, sizeof(m_state));
-  }
-
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableNgg, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableGsUse, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceCullingMode, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableVertexReuse, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBackfaceCulling, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFrustumCulling, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBoxFilterCulling, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSphereCulling, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSmallPrimFilter, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableCullDistanceCulling, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, backfaceExponent, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, subgroupSizing, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, primsPerSubgroup, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, vertsPerSubgroup, MemberTypeInt, false);
-
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
-  }
+  SectionNggState() : Section(getAddrTable(), SectionTypeUnset, "nggState") { memset(&m_state, 0, sizeof(m_state)); }
 
   void getSubState(SubState &state) { state = m_state; };
   SubState &getSubStateRef() { return m_state; };
 
 private:
-  static const unsigned MemberCount = 17;
-  static StrToMemberAddr m_addrTable[MemberCount];
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableNgg, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableGsUse, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, forceCullingMode, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, compactMode, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableVertexReuse, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBackfaceCulling, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableFrustumCulling, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableBoxFilterCulling, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSphereCulling, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableSmallPrimFilter, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, enableCullDistanceCulling, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, backfaceExponent, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, subgroupSizing, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, primsPerSubgroup, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionNggState, vertsPerSubgroup, MemberTypeInt, false);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
+  }
 
   SubState m_state;
 };

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -642,42 +642,45 @@ class SectionGraphicsState : public Section {
 public:
   typedef GraphicsPipelineState SubState;
 
-  SectionGraphicsState() : Section({m_addrTable, MemberCount}, SectionTypeGraphicsState, nullptr) {
+  SectionGraphicsState() : Section(getAddrTable(), SectionTypeGraphicsState, nullptr) {
     memset(&m_state, 0, sizeof(m_state));
   }
 
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, topology, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, provokingVertexMode, MemberTypeEnum, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, patchControlPoints, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, deviceIndex, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, disableVertexReuse, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, depthClipEnable, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, rasterizerDiscardEnable, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, perSampleShading, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, numSamples, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, pixelShaderSamples, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, samplePatternIdx, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, usrClipPlaneMask, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, alphaToCoverageEnable, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendEnable, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, switchWinding, MemberTypeInt, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableMultiView, MemberTypeInt, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_options, MemberTypePipelineOption, true);
-    INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_nggState, MemberTypeNggState, true);
-    INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, m_colorBuffer, MemberTypeColorBufferItem,
-                                   Vkgc::MaxColorTargets, true);
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, topology, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, provokingVertexMode, MemberTypeEnum, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, patchControlPoints, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, deviceIndex, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, disableVertexReuse, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, depthClipEnable, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, rasterizerDiscardEnable, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, perSampleShading, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, numSamples, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, pixelShaderSamples, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, samplePatternIdx, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, usrClipPlaneMask, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, alphaToCoverageEnable, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendEnable, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, switchWinding, MemberTypeInt, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableMultiView, MemberTypeInt, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_options, MemberTypePipelineOption, true);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_nggState, MemberTypeNggState, true);
+      VEC_INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, m_colorBuffer, MemberTypeColorBufferItem,
+                                         Vkgc::MaxColorTargets, true);
 
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableUberFetchShader, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableEarlyCompile, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dynamicVertexStride, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableUberFetchShader, MemberTypeBool, false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableEarlyCompile, MemberTypeBool, false);
 
 #if VKI_RAY_TRACING
-    INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_shaderLibrary, MemberTypeString, false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_rtState, MemberTypeRtState, true);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_shaderLibrary, MemberTypeString, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_rtState, MemberTypeRtState, true);
 #endif
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
   }
 
   void getSubState(const std::string &docFilename, SubState &state, std::string *errorMsg) {
@@ -702,8 +705,6 @@ public:
 
 private:
   SectionNggState m_nggState;
-  static const unsigned MemberCount = 25;
-  static StrToMemberAddr m_addrTable[MemberCount];
   SubState m_state;
   SectionColorBuffer m_colorBuffer[Vkgc::MaxColorTargets]; // Color buffer
   SectionPipelineOption m_options;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -496,24 +496,30 @@ private:
 class SectionRayTracingShaderExportConfig : public Section {
 public:
   typedef Vkgc::RayTracingShaderExportConfig SubState;
-  SectionRayTracingShaderExportConfig() : Section({m_addrTable, MemberCount}, SectionTypeUnset, "exportConfig") {
+  SectionRayTracingShaderExportConfig() : Section(getAddrTable(), SectionTypeUnset, "exportConfig") {
     memset(&m_state, 0, sizeof(m_state));
   }
 
-  static void initialAddrTable() {
-    StrToMemberAddr *tableItem = m_addrTable;
-
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, indirectCallingConvention, MemberTypeInt,
-                                   false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableUniformNoReturn, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableTraceRayArgsInLds, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, readsDispatchRaysIndex, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableDynamicLaunch, MemberTypeBool, false);
-    INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, emitRaytracingShaderDataToken, MemberTypeBool,
-                                   false);
-    INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, m_indirectCalleeSavedRegs,
-                             MemberTypeIndirectCalleeSavedRegs, true);
-    VFX_ASSERT(tableItem - &m_addrTable[0] <= MemberCount);
+  static StrToMemberAddrArrayRef getAddrTable() {
+    static std::vector<StrToMemberAddr> addrTable = []() {
+      std::vector<StrToMemberAddr> addrTableInitializer;
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, indirectCallingConvention, MemberTypeInt,
+                                         false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableUniformNoReturn, MemberTypeBool,
+                                         false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableTraceRayArgsInLds, MemberTypeBool,
+                                         false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, readsDispatchRaysIndex, MemberTypeBool,
+                                         false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, enableDynamicLaunch, MemberTypeBool,
+                                         false);
+      VEC_INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, emitRaytracingShaderDataToken,
+                                         MemberTypeBool, false);
+      VEC_INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingShaderExportConfig, m_indirectCalleeSavedRegs,
+                                   MemberTypeIndirectCalleeSavedRegs, true);
+      return addrTableInitializer;
+    }();
+    return {addrTable.data(), addrTable.size()};
   }
 
   void getSubState(SubState &state) {
@@ -524,9 +530,6 @@ public:
   SubState &getSubStateRef() { return m_state; }
 
 private:
-  static const unsigned MemberCount = 7;
-  static StrToMemberAddr m_addrTable[MemberCount];
-
   SubState m_state;
   SectionIndirectCalleeSavedRegs m_indirectCalleeSavedRegs;
 };


### PR DESCRIPTION
Manually defined member counts have repeatedly caused issues where counters where not increased where they should have been, or were incorrectly updated when porting changed to closed-source where the member count differs.

A further complication is that member counts needed to replicate any conditional #ifdefs logic on members.

<s>
Now, instead move member definitions to separate .def "headers" which define the members using a new `PROCESS_STATE_MEMBER` macro.

The .def files are included multiple times, where the `PROCESS_STATE_MEMBER` macro is redefined depending on the context:
 * To define the actual members, we set `PROCESS_STATE_MEMBER` to `INIT_STATE_MEMBER_NAME_TO_ADDR`. 
 * To statically count the number of members, we set `PROCESS_STATE_MEMBER` to ` + 1`.

We wrap the calculation of the sum in parentheses to ensure that a `;` in the .def file does not silently break the calculation.

This commit only performs this change on one of the structs for discussion.
</s>

Following a suggestion by @nhaehnle , instead of the original approach outlined above, we use local static `std::vector` objects to hold the address tables. 