### PR TITLE
Remove LGC builder direct mode

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -45,7 +45,6 @@ BuilderImpl::BuilderImpl(LgcContext *builderContext, Pipeline *pipeline)
       ImageBuilder(builderContext), InOutBuilder(builderContext), MatrixBuilder(builderContext),
       MiscBuilder(builderContext), SubgroupBuilder(builderContext) {
   m_pipelineState = reinterpret_cast<PipelineState *>(pipeline);
-  m_pipelineState->setNoReplayer();
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "lgc/builder/BuilderReplayer.h"
+#include "BuilderImpl.h"
 #include "lgc/LgcContext.h"
 #include "lgc/builder/BuilderRecorder.h"
 #include "lgc/state/PipelineState.h"
@@ -126,7 +127,7 @@ bool BuilderReplayer::runImpl(Module &module, PipelineState *pipelineState) {
 
   // Create the BuilderImpl to replay into, passing it the PipelineState
   LgcContext *builderContext = pipelineState->getLgcContext();
-  m_builder.reset(builderContext->createBuilder(pipelineState, /*useBuilderRecorder=*/false));
+  m_builder.reset(new BuilderImpl(builderContext, pipelineState));
 
   SmallVector<Function *, 8> funcsToRemove;
 

--- a/lgc/include/lgc/patch/Patch.h
+++ b/lgc/include/lgc/patch/Patch.h
@@ -126,9 +126,9 @@ public:
   Patch() : m_module(nullptr), m_context(nullptr), m_shaderStage(ShaderStageInvalid), m_entryPoint(nullptr) {}
   virtual ~Patch() {}
 
-  static void addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, bool addReplayerPass,
-                        llvm::Timer *patchTimer, llvm::Timer *optTimer,
-                        Pipeline::CheckShaderCacheFunc checkShaderCacheFunc, llvm::CodeGenOpt::Level optLevel);
+  static void addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, llvm::Timer *patchTimer,
+                        llvm::Timer *optTimer, Pipeline::CheckShaderCacheFunc checkShaderCacheFunc,
+                        llvm::CodeGenOpt::Level optLevel);
 
   // Register all the patching passes into the given pass manager
   static void registerPasses(lgc::PassManager &passMgr);

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -255,10 +255,6 @@ public:
   // Find the single root resource node of the given type
   const ResourceNode *findSingleRootResourceNode(ResourceNodeType nodeType) const;
 
-  // Set "no replayer" flag, saying that this pipeline is being compiled with a BuilderImpl so does not
-  // need a BuilderReplayer pass.
-  void setNoReplayer() { m_noReplayer = true; }
-
   // Accessors for vertex input descriptions.
   llvm::ArrayRef<VertexInputDescription> getVertexInputDescriptions() const { return m_vertexInputDescriptions; }
   const VertexInputDescription *findVertexInputDescription(unsigned location) const;
@@ -484,7 +480,6 @@ private:
   void readGraphicsState(llvm::Module *module);
 
   std::string m_lastError;   // Error to be reported by getLastError()
-  bool m_noReplayer = false; // True if no BuilderReplayer needed
   bool m_emitLgc = false;    // Whether -emit-lgc is on
   // Whether generating pipeline or unlinked part-pipeline
   PipelineLink m_pipelineLink = PipelineLink::WholePipeline;

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -111,12 +111,10 @@ public:
   // Create a Pipeline object for a pipeline compile
   Pipeline *createPipeline();
 
-  // Create a Builder object. For a shader compile (pPipelineState is nullptr), useBuilderRecorder is ignored
-  // because it always uses BuilderRecorder.
+  // Create a Builder object
   //
   // @param pipeline : Pipeline object for pipeline compile, nullptr for shader compile
-  // @param useBuilderRecorder : True to use BuilderRecorder, false to use BuilderImpl
-  Builder *createBuilder(Pipeline *pipeline, bool useBuilderRecorder);
+  Builder *createBuilder(Pipeline *pipeline);
 
   // Prepare a legacy pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
   // think that we have library functions.

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -108,16 +108,14 @@ namespace lgc {
 // @param checkShaderCacheFunc : Callback function to check shader cache
 // @param optLevel : The optimization level uses to adjust the aggressiveness of
 //                   passes and which passes to add.
-void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, bool addReplayerPass, Timer *patchTimer,
-                      Timer *optTimer, Pipeline::CheckShaderCacheFunc checkShaderCacheFunc,
-                      CodeGenOpt::Level optLevel) {
+void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, Timer *patchTimer, Timer *optTimer,
+                      Pipeline::CheckShaderCacheFunc checkShaderCacheFunc, CodeGenOpt::Level optLevel) {
   // Start timer for patching passes.
   if (patchTimer)
     LgcContext::createAndAddStartStopTimer(passMgr, patchTimer, true);
 
-  // If using BuilderRecorder rather than BuilderImpl, replay the Builder calls now
-  if (addReplayerPass)
-    passMgr.addPass(BuilderReplayer(pipelineState));
+  // We're using BuilderRecorder; replay the Builder calls now
+  passMgr.addPass(BuilderReplayer(pipelineState));
 
   if (raw_ostream *outs = getLgcOuts()) {
     passMgr.addPass(PrintModulePass(*outs,

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -288,15 +288,11 @@ Pipeline *LgcContext::createPipeline() {
 }
 
 // =====================================================================================================================
-// Create a Builder object. For a shader compile (pPipeline is nullptr), useBuilderRecorder is ignored
-// because it always uses BuilderRecorder.
+// Create a Builder object.
 //
 // @param pipeline : Pipeline object for pipeline compile, nullptr for shader compile
-// @param useBuilderRecorder : True to use BuilderRecorder, false to use BuilderImpl
-Builder *LgcContext::createBuilder(Pipeline *pipeline, bool useBuilderRecorder) {
-  if (!pipeline || useBuilderRecorder || EmitLgc)
-    return Builder::createBuilderRecorder(this, pipeline, EmitLgc);
-  return Builder::createBuilderImpl(this, pipeline);
+Builder *LgcContext::createBuilder(Pipeline *pipeline) {
+  return Builder::createBuilderRecorder(this, pipeline, EmitLgc);
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -197,11 +197,6 @@ extern opt<std::string> LogFileOuts;
 
 } // namespace llvm
 
-// -use-builder-recorder
-static cl::opt<bool> UseBuilderRecorder("use-builder-recorder",
-                                        cl::desc("Do lowering via recording and replaying LLPC builder"),
-                                        cl::init(true));
-
 namespace Llpc {
 
 sys::Mutex Compiler::m_contextPoolMutex;
@@ -1071,7 +1066,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
   std::unique_ptr<Pipeline> pipeline(builderContext->createPipeline());
   context->getPipelineContext()->setPipelineState(&*pipeline, /*hasher=*/nullptr,
                                                   pipelineLink == PipelineLink::Unlinked);
-  context->setBuilder(builderContext->createBuilder(&*pipeline, UseBuilderRecorder));
+  context->setBuilder(builderContext->createBuilder(&*pipeline));
 
   std::unique_ptr<Module> pipelineModule;
 
@@ -2300,7 +2295,7 @@ void helperThreadBuildRayTracingPipelineElf(IHelperThreadProvider *helperThreadP
   LgcContext *builderContext = context->getLgcContext();
   std::unique_ptr<Pipeline> pipeline(builderContext->createPipeline());
   helperThreadPayload->rayTracingContext->setPipelineState(&*pipeline, /*hasher=*/nullptr, false);
-  context->setBuilder(builderContext->createBuilder(&*pipeline, UseBuilderRecorder));
+  context->setBuilder(builderContext->createBuilder(&*pipeline));
 
   TimerProfiler timerProfiler(context->getPipelineHashCode(), "LLPC", TimerProfiler::PipelineTimerEnableMask);
 
@@ -2392,7 +2387,7 @@ Result Compiler::buildRayTracingPipelineInternal(Context *context, ArrayRef<cons
   LgcContext *builderContext = context->getLgcContext();
   std::unique_ptr<Pipeline> pipeline(builderContext->createPipeline());
   rayTracingContext->setPipelineState(&*pipeline, /*hasher=*/nullptr, unlinked);
-  context->setBuilder(builderContext->createBuilder(&*pipeline, UseBuilderRecorder));
+  context->setBuilder(builderContext->createBuilder(&*pipeline));
 
   // Create empty modules and set target machine in each.
   std::vector<Module *> modules(shaderInfo.size());


### PR DESCRIPTION
LGC has two modes of building IR: BuilderRecorder/BuilderReplayer, and builder direct (use BuilderImpl directly).

We have never actually used builder direct mode, and Nicolai's forthcoming dialect changes kinda break the model. So this commit removes the ability to use builder direct mode.