### PR TITLE
Add lgc::Pipeline::getShaderStage()

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -702,7 +702,7 @@ public:
   // @param stage : Shader stage, or ShaderStageInvalid if none
   static void markShaderEntryPoint(llvm::Function *func, ShaderStage stage);
 
-  // Get a function's shader stage, as marked by markShaderEntryPoint.
+  // Get a function's shader stage.
   //
   // @param func : Function to check
   // @returns stage : Shader stage, or ShaderStageInvalid if none

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -698,9 +698,15 @@ public:
   // with irLink(). This is a static method in Pipeline, as it does not need a Pipeline object, and can be used
   // in the front-end before a shader is associated with a pipeline.
   //
-  // @param func : Shader entry-point function
-  // @param stage : Shader stage
+  // @param func : Function to mark
+  // @param stage : Shader stage, or ShaderStageInvalid if none
   static void markShaderEntryPoint(llvm::Function *func, ShaderStage stage);
+
+  // Get a function's shader stage, as marked by markShaderEntryPoint.
+  //
+  // @param func : Function to check
+  // @returns stage : Shader stage, or ShaderStageInvalid if none
+  static ShaderStage getShaderStage(llvm::Function *func);
 
   // Link the individual shader modules into a single pipeline module. The front-end must have
   // finished calling Builder::Create* methods and finished building the IR. In the case that

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -73,7 +73,7 @@ void Pipeline::markShaderEntryPoint(Function *func, ShaderStage stage) {
 }
 
 // =====================================================================================================================
-// Get a function's shader stage, as marked by markShaderEntryPoint.
+// Get a function's shader stage.
 //
 // @param func : Function to check
 // @returns stage : Shader stage, or ShaderStageInvalid if none

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -58,15 +58,27 @@ ElfLinker *createElfLinkerImpl(PipelineState *pipelineState, llvm::ArrayRef<llvm
 // in the front-end before a shader is associated with a pipeline.
 //
 // @param func : Shader entry-point function
-// @param stage : Shader stage
+// @param stage : Shader stage or ShaderStageInvalid
 void Pipeline::markShaderEntryPoint(Function *func, ShaderStage stage) {
   // We mark the shader entry-point function by
   // 1. marking it external linkage and DLLExportStorageClass; and
   // 2. adding the shader stage metadata.
   // The shader stage metadata for any other non-inlined functions in the module is added in irLink().
-  func->setLinkage(GlobalValue::ExternalLinkage);
-  func->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
+  if (stage != ShaderStageInvalid) {
+    func->setLinkage(GlobalValue::ExternalLinkage);
+    func->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
+  } else
+    func->setDLLStorageClass(GlobalValue::DefaultStorageClass);
   setShaderStage(func, stage);
+}
+
+// =====================================================================================================================
+// Get a function's shader stage, as marked by markShaderEntryPoint.
+//
+// @param func : Function to check
+// @returns stage : Shader stage, or ShaderStageInvalid if none
+ShaderStage Pipeline::getShaderStage(llvm::Function *func) {
+  return lgc::getShaderStage(func);
 }
 
 // =====================================================================================================================

--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -55,8 +55,12 @@ void lgc::setShaderStage(Module *module, ShaderStage stage) {
   auto stageMetaNode = MDNode::get(
       module->getContext(), {ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(module->getContext()), stage))});
   for (Function &func : *module) {
-    if (!func.isDeclaration())
-      func.setMetadata(mdKindId, stageMetaNode);
+    if (!func.isDeclaration()) {
+      if (stage != ShaderStageInvalid)
+        func.setMetadata(mdKindId, stageMetaNode);
+      else
+        func.eraseMetadata(mdKindId);
+    }
   }
 }
 
@@ -64,12 +68,15 @@ void lgc::setShaderStage(Module *module, ShaderStage stage) {
 // Set shader stage metadata on a function
 //
 // @param [in/out] func : Function to set shader stage on
-// @param stage : Shader stage to set
+// @param stage : Shader stage to set or ShaderStageInvalid
 void lgc::setShaderStage(Function *func, ShaderStage stage) {
   unsigned mdKindId = func->getContext().getMDKindID(ShaderStageMetadata);
-  auto stageMetaNode = MDNode::get(
-      func->getContext(), {ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(func->getContext()), stage))});
-  func->setMetadata(mdKindId, stageMetaNode);
+  if (stage != ShaderStageInvalid) {
+    auto stageMetaNode = MDNode::get(
+        func->getContext(), {ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(func->getContext()), stage))});
+    func->setMetadata(mdKindId, stageMetaNode);
+  } else
+    func->eraseMetadata(mdKindId);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
... allowing the front-end to get the shader stage for a function back that it set earlier. Also allow setting a shader stage of invalid, removing any previous shader stage mark for the function.