### PR TITLE
Tag MultiDispatchInfo argument for LDS spilling

### DIFF
--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -171,6 +171,16 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       builder.addAttribute("amdgpu-flat-work-group-size",
                            (Twine(flatWorkGroupSize) + "," + Twine(flatWorkGroupSize)).toStringRef(attributeBuf));
     }
+    if (func->getCallingConv() == CallingConv::AMDGPU_CS) {
+      // Tag the position of MultiDispatchInfo argument, so the backend knows which
+      // sgpr needs to be preloaded for COMPUTE_PGM_RSRC2.tg_size_en (Work-Group Info).
+      // This is needed for LDS spilling.
+      for (unsigned i = 0, e = func->arg_size(); i != e; ++i) {
+        if (func->getArg(i)->getName().equals("MultiDispatchInfo")) {
+          builder.addAttribute("amdgpu-work-group-info-arg-no", std::to_string(i));
+        }
+      }
+    }
 
     auto gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
 

--- a/llpc/test/shaderdb/general/PipelineCs_LdsSpillLimitDwordsOption.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_LdsSpillLimitDwordsOption.pipe
@@ -1,16 +1,18 @@
 ; Check that ldsSpillLimitDwords shader option gets propagated to the backend as amdgpu-lds-spill-limit-dwords attribute.
+; Check that amdgpu-work-group-info-arg-no is set.
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: "amdgpu-lds-spill-limit-dwords"="1024"
+; SHADERTEST: "amdgpu-work-group-info-arg-no"="3"
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
 [CsGlsl]
 #version 450
 
-layout(local_size_x = 2, local_size_y = 3) in;
+layout(local_size_x = 2, local_size_y = 3, local_size_z = 11) in;
 void main()
 {
 }


### PR DESCRIPTION
If the LDS spilling is requested, tag the position of MultiDispatchInfo argument, so the backend knows which sgpr needs to be preloaded for COMPUTE_PGM_RSRC2.tg_size_en (Work-Group Info).

The WG info is needed to generate correct offsets in the spill code if the workgroup size is larger than wavefront size, as it uses DS_READ_ADDTID/DS_WRITE_ADDTID instructions.