### PR TITLE
Add new interface CreateIntegerDotProductNew()

### DIFF
--- a/lgc/builder/BuilderImpl.h
+++ b/lgc/builder/BuilderImpl.h
@@ -50,6 +50,10 @@ public:
   llvm::Value *CreateIntegerDotProduct(llvm::Value *vector1, llvm::Value *vector2, llvm::Value *accumulator,
                                        unsigned flags, const llvm::Twine &instName = "") override final;
 
+  // Create scalar from integer dot product of vector
+  llvm::Value *CreateIntegerDotProductNew(llvm::Value *vector1, llvm::Value *vector2, llvm::Value *accumulator,
+                                          unsigned flags, const llvm::Twine &instName = "") override final;
+
 protected:
   // Get the ShaderModes object.
   ShaderModes *getShaderModes() override final;

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -392,6 +392,24 @@ Value *BuilderRecorder::CreateIntegerDotProduct(Value *vector1, Value *vector2, 
 }
 
 // =====================================================================================================================
+// Create code to calculate the dot product of two integer vectors, with optional accumulator, using hardware support
+// where available. The factor inputs are always <N x iM> of the same type, N can be arbitrary and M must be 4, 8, 16,
+// 32, or 64 Use a value of 0 for no accumulation and the value type is consistent with the result type. The result is
+// saturated if there is an accumulator. Only the final addition to the accumulator needs to be saturated.
+// Intermediate overflows of the dot product can lead to an undefined result.
+//
+// @param vector1 : The integer Vector 1
+// @param vector2 : The integer Vector 2
+// @param accumulator : The accumulator to the scalar of dot product
+// @param flags : The first bit marks whether Vector 1 is signed and the second bit marks whether Vector 2 is signed
+// @param instName : Name to give instruction(s)
+Value *BuilderRecorder::CreateIntegerDotProductNew(Value *vector1, Value *vector2, Value *accumulator, unsigned flags,
+                                                   const Twine &instName) {
+  return record(Opcode::IntegerDotProduct, accumulator->getType(), {vector1, vector2, accumulator, getInt32(flags)},
+                instName);
+}
+
+// =====================================================================================================================
 // In the GS, emit the current values of outputs (as written by CreateWriteBuiltIn and CreateWriteOutput) to
 // the current output primitive in the specified output-primitive stream number.
 //

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -257,6 +257,9 @@ public:
   llvm::Value *CreateIntegerDotProduct(llvm::Value *vector1, llvm::Value *vector2, llvm::Value *accumulator,
                                        unsigned flags, const llvm::Twine &instName = "") override final;
 
+  llvm::Value *CreateIntegerDotProductNew(llvm::Value *vector1, llvm::Value *vector2, llvm::Value *accumulator,
+                                          unsigned flags, const llvm::Twine &instName = "") override final;
+
   // -----------------------------------------------------------------------------------------------------------------
   // Arithmetic operations
 

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -231,6 +231,20 @@ public:
   virtual llvm::Value *CreateIntegerDotProduct(llvm::Value *vector1, llvm::Value *vector2, llvm::Value *accumulator,
                                                unsigned flags, const llvm::Twine &instName = "") = 0;
 
+  // Create code to calculate the dot product of two integer vectors, with optional accumulator, using hardware support
+  // where available. The factor inputs are always <N x iM> of the same type, N can be arbitrary and M must be 4, 8, 16,
+  // 32, or 64 Use a value of 0 for no accumulation and the value type is consistent with the result type. The result is
+  // saturated if there is an accumulator. Only the final addition to the accumulator needs to be saturated.
+  // Intermediate overflows of the dot product can lead to an undefined result.
+  //
+  // @param vector1 : The integer Vector 1
+  // @param vector2 : The integer Vector 2
+  // @param accumulator : The accumulator to the scalar of dot product
+  // @param flags : The first bit marks whether Vector 1 is signed and the second bit marks whether Vector 2 is signed
+  // @param instName : Name to give instruction(s)
+  virtual llvm::Value *CreateIntegerDotProductNew(llvm::Value *vector1, llvm::Value *vector2, llvm::Value *accumulator,
+                                                  unsigned flags, const llvm::Twine &instName = "") = 0;
+
   // Create a call to the specified intrinsic with one operand, mangled on its type.
   // This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math
   // flags from the Builder if none are specified by fmfSource.

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -6875,8 +6875,18 @@ Value *SPIRVToLLVM::transSPIRVIntegerDotProductFromInst(SPIRVInstruction *bi, Ba
                                : getBuilder()->getIntN(returnTy->getScalarSizeInBits(), 0);
 
   if (vector1->getType()->isIntegerTy(32)) {
-    // Cast i32 to <4xi8>
-    auto vecTy = FixedVectorType::get(getBuilder()->getInt8Ty(), 4);
+    const unsigned operandId = hasAccumulator ? 3 : 2;
+    SPIRVConstant *constOp = static_cast<SPIRVConstant *>(bc->getOperand(operandId));
+    spv::PackedVectorFormat packedVecFormat = static_cast<spv::PackedVectorFormat>(constOp->getZExtIntValue());
+    Type *vecTy = nullptr;
+    switch (packedVecFormat) {
+    case spv::PackedVectorFormatPackedVectorFormat4x8Bit:
+      vecTy = FixedVectorType::get(getBuilder()->getInt8Ty(), 4);
+      break;
+    default:
+      llvm_unreachable("invalid packed vector format");
+      break;
+    }
     vector1 = getBuilder()->CreateBitCast(vector1, vecTy);
     vector2 = getBuilder()->CreateBitCast(vector2, vecTy);
   }


### PR DESCRIPTION
Re-implement interger dot product in `CreateIntergerDotProductNew()`.
The factor inputs are `<N x iM>` of the same type, where N can be
arbitrary and M must be 4, 8, 16, 32 or 64.

Note: The old interface is still in use in this change. I'm going to
replace the old one after this PR is ported to the internal repo.