### PR TITLE
Create canonical form in ArithBuilder::createInsertBitField

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -1242,10 +1242,9 @@ Value *ArithBuilder::CreateInsertBitField(Value *base, Value *insert, Value *off
   offset = CreateZExtOrTrunc(offset, base->getType());
   count = CreateZExtOrTrunc(count, base->getType());
 
-  Value *baseXorInsert = CreateXor(CreateShl(insert, offset), base);
   Constant *one = ConstantInt::get(count->getType(), 1);
   Value *mask = CreateShl(CreateSub(CreateShl(one, count), one), offset);
-  Value *result = CreateXor(CreateAnd(baseXorInsert, mask), base);
+  Value *result = CreateOr(CreateAnd(CreateShl(insert, offset), mask), CreateAnd(base, CreateNot(mask)));
   Value *isWholeField = CreateICmpEQ(
       count, ConstantInt::get(count->getType(), count->getType()->getScalarType()->getPrimitiveSizeInBits()));
   return CreateSelect(isWholeField, insert, result, instName);


### PR DESCRIPTION
When translating `bitfieldInsert` instructions within the `ArithBuilder`, a form which later gets picked up by `InstCombine` will be generated. Unfortunately, this form does not support `bitfieldInsert` instructions with one `bitfieldInsert` being the base for another `bitfieldInsert`. The resulting sequence can not be matched into multiple `v_bfi` instructions in the backend.

By directly generating the canonical form in the `ArithBuilder,` single `v_bfi` instructions will still be generated, but dependent `v_bfi` instructions with one being the base for another one end up being simplified by `SimplifyDemandedBits`.
However, in such cases, the original inverted bitmask for the outer `bitfieldInsert` can be reconstructed, as long as the constants are disjoint and are a partition of -1. This means, the sequence can be transformed into multiple, dependent `v_bfi` instructions during ISel. This is part of a backend change currently in progress.