### PR TITLE
Fix API barrier issue in mesh shader

### DIFF
--- a/lgc/include/lgc/patch/PatchPreparePipelineAbi.h
+++ b/lgc/include/lgc/patch/PatchPreparePipelineAbi.h
@@ -34,6 +34,8 @@
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
+#include "llvm/Analysis/CycleAnalysis.h"
+#include "llvm/Analysis/PostDominators.h"
 
 namespace lgc {
 
@@ -41,11 +43,20 @@ namespace lgc {
 // Pass to prepare the pipeline ABI
 class PatchPreparePipelineAbi final : public Patch, public llvm::PassInfoMixin<PatchPreparePipelineAbi> {
 public:
+  // A collection of handler functions to get the analysis info of the given function
+  struct FunctionAnalysisHandlers {
+    // Function to get the post dominator tree of the given function
+    std::function<llvm::PostDominatorTree &(llvm::Function &)> getPostDomTree;
+    // Function to get the cycle info of the given function
+    std::function<llvm::CycleInfo &(llvm::Function &)> getCycleInfo;
+  };
+
   PatchPreparePipelineAbi();
 
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
 
-  bool runImpl(llvm::Module &module, PipelineShadersResult &pipelineShaders, PipelineState *pipelineState);
+  bool runImpl(llvm::Module &module, PipelineShadersResult &pipelineShaders, PipelineState *pipelineState,
+               FunctionAnalysisHandlers &analysisHandlers);
 
   static llvm::StringRef name() { return "Patch LLVM for preparing pipeline ABI"; }
 
@@ -58,6 +69,8 @@ private:
 
   PipelineState *m_pipelineState;           // Pipeline state
   PipelineShadersResult *m_pipelineShaders; // API shaders in the pipeline
+  FunctionAnalysisHandlers
+      *m_analysisHandlers; // A collection of handler functions to get the analysis info of the given function
 
   bool m_hasVs;   // Whether the pipeline has vertex shader
   bool m_hasTcs;  // Whether the pipeline has tessellation control shader

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -28,6 +28,7 @@
  * @brief LLPC source file: contains implementation of class lgc::MeshTaskShader.
  ***********************************************************************************************************************
  */
+ 
 #include "MeshTaskShader.h"
 #include "Gfx9Chip.h"
 #include "ShaderMerger.h"

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -28,7 +28,6 @@
  * @brief LLPC source file: contains implementation of class lgc::MeshTaskShader.
  ***********************************************************************************************************************
  */
- 
 #include "MeshTaskShader.h"
 #include "Gfx9Chip.h"
 #include "ShaderMerger.h"


### PR DESCRIPTION
API mesh shader could contain API barriers. For API mesh waves, those barriers will be executed while the extra waves that do vertex/primitive exporting don't execute such barriers. Thus, extra waves will be out of sync when they hit the post barrier after API mesh shader completion. A case is shown:

```
layout(local_size_x = 10, local_size_y = 4, local_size_z = 1) in; layout(triangles, max_vertices = 96, max_primitives = 32) out;

void main() {
  // Do something
  barrier();
  // Continue to do other things
}
```

On wave32, there are 2 waves executing API mesh shader while there are 3 waves do vertex/primitive exporting. The processing is as follow:

```
...
if (API mesh threads) {
  // Do somthing
  barrier (API barrier)
  // Continue to do other things
}

barrier (Post barrier)
Get mesh output count
...
```

The third wave that doesn't execute API mesh shader will be out of sync when it hits the post barrier. At the same time, the other two waves that execute API mesh shader just hit the API barrier.

Since barrier could be placed in uniform condition flow, we have to handle two cases:

1. When all API barriers are placed in the entry-point, we can count the actual number of API barriers and add additional barriers in extra wave to matching the number.

2. If there are API barriers in uniform condition flow, we add dynamical handling. The idea is similar to the above but we need a barrier flag in LDS and an auxiliary barrier toggle. The processing is described in checkNeedBarrierFlag().