### PR TITLE
Extend aggressiveInvariantLoads optimization.

### DIFF
--- a/lgc/include/lgc/state/IntrinsDefs.h
+++ b/lgc/include/lgc/state/IntrinsDefs.h
@@ -66,6 +66,7 @@ static const unsigned GetRealTime = 0x83; // [7] = 1, [6:0] = 3
 
 // Enumerates address spaces valid for AMD GPU (similar to LLVM header AMDGPU.h)
 enum AddrSpace {
+  ADDR_SPACE_FLAT = 0,               // Flat memory
   ADDR_SPACE_GLOBAL = 1,             // Global memory
   ADDR_SPACE_REGION = 2,             // GDS memory
   ADDR_SPACE_LOCAL = 3,              // Local memory
@@ -73,6 +74,7 @@ enum AddrSpace {
   ADDR_SPACE_PRIVATE = 5,            // Private memory
   ADDR_SPACE_CONST_32BIT = 6,        // Constant 32-bit memory
   ADDR_SPACE_BUFFER_FAT_POINTER = 7, // Buffer fat-pointer memory
+  ADDR_SPACE_MAX = ADDR_SPACE_BUFFER_FAT_POINTER
 };
 
 // Enumerates the target for "export" instruction.

--- a/lgc/patch/PatchInvariantLoads.cpp
+++ b/lgc/patch/PatchInvariantLoads.cpp
@@ -31,7 +31,6 @@
 #include "lgc/patch/PatchInvariantLoads.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/PipelineState.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/InitializePasses.h"
@@ -91,6 +90,39 @@ PreservedAnalyses PatchInvariantLoads::run(Function &function, FunctionAnalysisM
   return PreservedAnalyses::all();
 }
 
+static const unsigned UNKNOWN_ADDRESS_SPACE = ADDR_SPACE_MAX + 1;
+
+enum AddrSpaceBit {
+  ADDR_SPACE_FLAT_BIT = 1 << ADDR_SPACE_FLAT,
+  ADDR_SPACE_GLOBAL_BIT = 1 << ADDR_SPACE_GLOBAL,
+  ADDR_SPACE_REGION_BIT = 1 << ADDR_SPACE_REGION,
+  ADDR_SPACE_LOCAL_BIT = 1 << ADDR_SPACE_LOCAL,
+  ADDR_SPACE_CONST_BIT = 1 << ADDR_SPACE_CONST,
+  ADDR_SPACE_PRIVATE_BIT = 1 << ADDR_SPACE_PRIVATE,
+  ADDR_SPACE_CONST_32BIT_BIT = 1 << ADDR_SPACE_CONST_32BIT,
+  ADDR_SPACE_BUFFER_FAT_POINTER_BIT = 1 << ADDR_SPACE_BUFFER_FAT_POINTER,
+  ADDR_SPACE_UNKNOWN_BIT = 1 << UNKNOWN_ADDRESS_SPACE
+};
+
+static unsigned findAddressSpaceAccess(const Instruction *inst) {
+  if (const LoadInst *li = dyn_cast<LoadInst>(inst)) {
+    return std::min(li->getPointerAddressSpace(), UNKNOWN_ADDRESS_SPACE);
+  } else if (const StoreInst *si = dyn_cast<StoreInst>(inst)) {
+    return std::min(si->getPointerAddressSpace(), UNKNOWN_ADDRESS_SPACE);
+  } else {
+    if (const CallInst *ci = dyn_cast<CallInst>(inst)) {
+      auto func = ci->getCalledFunction();
+      if (func) {
+        // Treat these as buffer address space as they do not overlap with private.
+        if (func->getName().startswith("llvm.amdgcn.image") || func->getName().startswith("llvm.amdgcn.raw") ||
+            func->getName().startswith("llvm.amdgcn.struct"))
+          return ADDR_SPACE_BUFFER_FAT_POINTER;
+      }
+    }
+  }
+  return UNKNOWN_ADDRESS_SPACE;
+}
+
 // =====================================================================================================================
 // Executes this LLVM pass on the specified LLVM function.
 //
@@ -115,6 +147,36 @@ bool PatchInvariantLoads::runImpl(Function &function, PipelineState *pipelineSta
                                         : "Attempting aggressive invariant load optimization")
                     << "\n";);
 
+  // This mirrors AMDGPUAliasAnalysis
+  static const unsigned aliasMatrix[] = {
+      /* Flat     */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_GLOBAL_BIT | ADDR_SPACE_LOCAL_BIT | ADDR_SPACE_CONST_BIT |
+          ADDR_SPACE_PRIVATE_BIT | ADDR_SPACE_CONST_32BIT_BIT | ADDR_SPACE_BUFFER_FAT_POINTER_BIT |
+          ADDR_SPACE_UNKNOWN_BIT,
+      /* Global   */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_GLOBAL_BIT | ADDR_SPACE_CONST_BIT | ADDR_SPACE_CONST_32BIT_BIT |
+          ADDR_SPACE_BUFFER_FAT_POINTER_BIT | ADDR_SPACE_UNKNOWN_BIT,
+      /* Region   */
+      ADDR_SPACE_REGION_BIT | ADDR_SPACE_UNKNOWN_BIT,
+      /* Local    */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_LOCAL_BIT | ADDR_SPACE_UNKNOWN_BIT,
+      /* Constant */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_GLOBAL_BIT | ADDR_SPACE_CONST_32BIT_BIT | ADDR_SPACE_BUFFER_FAT_POINTER_BIT |
+          ADDR_SPACE_UNKNOWN_BIT,
+      /* Private  */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_PRIVATE_BIT | ADDR_SPACE_UNKNOWN_BIT,
+      /* Const32  */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_GLOBAL_BIT | ADDR_SPACE_CONST_BIT | ADDR_SPACE_BUFFER_FAT_POINTER_BIT |
+          ADDR_SPACE_UNKNOWN_BIT,
+      /* Buffer   */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_GLOBAL_BIT | ADDR_SPACE_CONST_BIT | ADDR_SPACE_CONST_32BIT_BIT |
+          ADDR_SPACE_BUFFER_FAT_POINTER_BIT | ADDR_SPACE_UNKNOWN_BIT,
+      /* Unknown */
+      ADDR_SPACE_FLAT_BIT | ADDR_SPACE_GLOBAL_BIT | ADDR_SPACE_LOCAL_BIT | ADDR_SPACE_REGION_BIT |
+          ADDR_SPACE_CONST_BIT | ADDR_SPACE_PRIVATE_BIT | ADDR_SPACE_CONST_32BIT_BIT |
+          ADDR_SPACE_BUFFER_FAT_POINTER_BIT | ADDR_SPACE_UNKNOWN_BIT};
+
+  unsigned writtenAddrSpaces = 0;
   std::vector<Instruction *> loads;
 
   for (BasicBlock &block : function) {
@@ -126,13 +188,23 @@ bool PatchInvariantLoads::runImpl(Function &function, PipelineState *pipelineSta
           case Intrinsic::amdgcn_exp_compr:
           case Intrinsic::amdgcn_init_exec:
           case Intrinsic::amdgcn_init_exec_from_input:
+          case Intrinsic::invariant_start:
+          case Intrinsic::invariant_end:
             continue;
           default:
             break;
           }
+        } else if (CallInst *ci = dyn_cast<CallInst>(&inst)) {
+          auto func = ci->getCalledFunction();
+          if (func && func->getName().startswith("lgc.ngg."))
+            continue;
         }
-        LLVM_DEBUG(dbgs() << "Write to memory found, aborting aggressive invariant load optimization\n");
-        return false;
+        unsigned addrSpace = findAddressSpaceAccess(&inst);
+        if (addrSpace == UNKNOWN_ADDRESS_SPACE) {
+          LLVM_DEBUG(dbgs() << "Write to unknown memory found, aborting aggressive invariant load optimization\n");
+          return false;
+        }
+        writtenAddrSpaces |= aliasMatrix[addrSpace];
       } else if (inst.mayReadFromMemory()) {
         loads.push_back(&inst);
       }
@@ -144,19 +216,33 @@ bool PatchInvariantLoads::runImpl(Function &function, PipelineState *pipelineSta
     return false;
   }
 
-  auto &context = function.getContext();
-  for (Instruction *inst : loads) {
-    bool isInvariant = inst->hasMetadata(LLVMContext::MD_invariant_load);
-    if (isInvariant && clearInvariants) {
+  if (clearInvariants) {
+    bool changed = false;
+    for (Instruction *inst : loads) {
+      if (!inst->hasMetadata(LLVMContext::MD_invariant_load))
+        continue;
+
       LLVM_DEBUG(dbgs() << "Removing invariant metadata: " << *inst << "\n");
       inst->setMetadata(LLVMContext::MD_invariant_load, nullptr);
-    } else if (!isInvariant && !clearInvariants) {
-      LLVM_DEBUG(dbgs() << "Marking load invariant: " << *inst << "\n");
-      inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(context, None));
+      changed = true;
     }
+    return changed;
   }
 
-  return true;
+  auto &context = function.getContext();
+  bool changed = false;
+  for (Instruction *inst : loads) {
+    if (inst->hasMetadata(LLVMContext::MD_invariant_load))
+      continue;
+    if (writtenAddrSpaces && (writtenAddrSpaces & (1 << findAddressSpaceAccess(inst))))
+      continue;
+
+    LLVM_DEBUG(dbgs() << "Marking load invariant: " << *inst << "\n");
+    inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(context, None));
+    changed = true;
+  }
+
+  return changed;
 }
 
 } // namespace lgc


### PR DESCRIPTION
- Avoid further intrinsics as sources of writes.
- Add basic address space based alias analysis. This allows reads for some types of address to be marked even when shader contains writes.