### PR TITLE
Remove unnecessary registers in PipelineTaskMeshFsRegConfig

### DIFF
--- a/lgc/patch/Gfx9Chip.cpp
+++ b/lgc/patch/Gfx9Chip.cpp
@@ -349,8 +349,6 @@ PipelineMeshFsRegConfig::PipelineMeshFsRegConfig(GfxIpVersion gfxIp) : meshRegs(
 // @param gfxIp : Graphics IP version info
 PipelineTaskMeshFsRegConfig::PipelineTaskMeshFsRegConfig(GfxIpVersion gfxIp)
     : taskRegs(gfxIp), meshRegs(gfxIp), psRegs(gfxIp) {
-  INIT_REG(VGT_SHADER_STAGES_EN);
-  INIT_REG_GFX10(gfxIp.major, IA_MULTI_VGT_PARAM_PIPED);
 }
 
 } // namespace Gfx9

--- a/lgc/patch/Gfx9Chip.h
+++ b/lgc/patch/Gfx9Chip.h
@@ -568,9 +568,6 @@ struct PipelineTaskMeshFsRegConfig {
   MeshRegConfig meshRegs; // Mesh -> hardware primitive shader (NGG, ES-GS)
   PsRegConfig psRegs;     // FS   -> hardware PS
 
-  DEF_REG(VGT_SHADER_STAGES_EN);
-  DEF_REG(IA_MULTI_VGT_PARAM_PIPED);
-
   PipelineTaskMeshFsRegConfig(GfxIpVersion gfxIp);
 };
 


### PR DESCRIPTION
The registers VGT_SHADER_STAGES_EN and IA_MULTI_VGT_PARAM_PIPED are included in MeshRegConfig. No need of adding them in PipelineTaskMeshFsRegConfig.