### PR TITLE
Fix issues caught by CTS VK.clipping.user_defined.clip_cull_distance.*

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -2148,7 +2148,7 @@ template <typename T> void ConfigBuilder::setupPaSpecificRegisters(T *config) {
     }
 
     unsigned clipDistanceMask = (1 << clipDistanceCount) - 1;
-    unsigned cullDistanceMask = (1 << cullDistanceCount) - 1;
+    unsigned cullDistanceMask = ((1 << cullDistanceCount) - 1) << clipDistanceCount;
 
     // Set fields CLIP_DIST_ENA_0 ~ CLIP_DIST_ENA_7 and CULL_DIST_ENA_0 ~ CULL_DIST_ENA_7
     unsigned paClVsOutCntl = GET_REG(config, PA_CL_VS_OUT_CNTL);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -3092,7 +3092,9 @@ void PatchInOutImportExport::patchTesBuiltInOutputExport(Value *output, unsigned
   case BuiltInClipDistance:
   case BuiltInCullDistance: {
     if ((builtInId == BuiltInPosition && !builtInUsage.position) ||
-        (builtInId == BuiltInPointSize && !builtInUsage.pointSize))
+        (builtInId == BuiltInPointSize && !builtInUsage.pointSize) ||
+        (builtInId == BuiltInClipDistance && builtInUsage.clipDistance == 0) ||
+        (builtInId == BuiltInCullDistance && builtInUsage.cullDistance == 0))
       return;
 
     if (isa<UndefValue>(output)) {


### PR DESCRIPTION
1. The register fields PA_CL_VS_OUT_CNTL.CULL_DIST_ENA_X are not set correctly. If we have 5 clip distances and 3 cull distances, the vertex position export is: cc0: clip[0], clip[1], clip[2], clip[3] cc1: clip[4], cull[0], cull[1], cull[2] So the enablement mask is CLIP_DIST_ENA_0-4=0b11111, CULL_DIST_ENA_5-7=0b111. The previous setting is CULL_DIST_ENA_0-2=0b111.

2. In a pipeline where TS and GS are both present, when gl_CullDistance is exported by TES while GS doesn't read its value, we don't export gl_CullDistance. The usgae is cleared. Thus, we have to check the usage to decide if we have to export it in patchTesBuiltInOutputExport.