### PR TITLE
Fix issues caught by CTS VK.clipping.user_defined.clip_cull_distance.*

### DIFF
--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -491,7 +491,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
     }
 
     unsigned clipDistanceMask = (1 << clipDistanceCount) - 1;
-    unsigned cullDistanceMask = (1 << cullDistanceCount) - 1;
+    unsigned cullDistanceMask = ((1 << cullDistanceCount) - 1) << clipDistanceCount;
 
     // Set fields CLIP_DIST_ENA_0 ~ CLIP_DIST_ENA_7 and CULL_DIST_ENA_0 ~ CULL_DIST_ENA_7
     unsigned paClVsOutCntl = GET_REG(&config->vsRegs, PA_CL_VS_OUT_CNTL);


### PR DESCRIPTION
A missing change to fix pre-GFX9 GPUs issues (similar to the commit https://github.com/GPUOpen-Drivers/llpc/commit/35e4e23b)