### PR TITLE
Heuristically enable aggressive invariant loads optimisation.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -44,10 +44,10 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 56
+#define LLPC_INTERFACE_MAJOR_VERSION 57
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 2
+#define LLPC_INTERFACE_MINOR_VERSION 0
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     57.0 | Merge aggressiveInvariantLoads and disableInvariantLoads to an enumerated option                      |
 //  |     56.2 | Add aggressiveInvariantLoads and disableInvariantLoads to PipelineShaderOptions                       |
 //  |     56.1 | Add struct UberFetchShaderAttribInfo                                                                  |
 //  |     56.0 | Move maxRayLength to RtState                                                                          |
@@ -655,6 +656,9 @@ inline unsigned compact32(ShaderHash hash) {
           static_cast<unsigned>(hash.upper) ^ static_cast<unsigned>(hash.upper >> 32));
 }
 
+/// Represent a pipeline option which can be automatic as well as explicitly set.
+enum InvariantLoads : unsigned { Auto = 0, EnableOptimization = 1, DisableOptimization = 2, ClearInvariants = 3 };
+
 /// Represents per shader stage options.
 struct PipelineShaderOptions {
   ShaderHash clientHash;      ///< Client-supplied unique shader hash. A value of zero indicates that LLPC should
@@ -779,10 +783,7 @@ struct PipelineShaderOptions {
   unsigned nsaThreshold;
 
   /// Aggressively mark shader loads as invariant (where it is safe to do so).
-  bool aggressiveInvariantLoads;
-
-  /// Strip invariant load metadata.
-  bool disableInvariantLoads;
+  InvariantLoads aggressiveInvariantLoads;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -154,6 +154,9 @@ struct Options {
 #endif
 };
 
+/// Represent a pipeline option which can be automatic as well as explicitly set.
+enum InvariantLoadsOption : unsigned { Auto = 0, EnableOptimization = 1, DisableOptimization = 2, ClearInvariants = 3 };
+
 // Middle-end per-shader options to pass to SetShaderOptions.
 // Note: new fields must be added to the end of this structure to maintain test compatibility.
 struct ShaderOptions {
@@ -255,10 +258,7 @@ struct ShaderOptions {
   unsigned nsaThreshold;
 
   /// Aggressively mark shader loads as invariant (where it is safe to do so).
-  bool aggressiveInvariantLoads;
-
-  /// Strip invariant load metadata.
-  bool disableInvariantLoads;
+  InvariantLoadsOption aggressiveInvariantLoads;
 
   ShaderOptions() {
     // The memory representation of this struct gets written into LLVM metadata. To prevent uninitialized values from

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -530,8 +530,18 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
 
     shaderOptions.nsaThreshold = shaderInfo->options.nsaThreshold;
 
-    shaderOptions.aggressiveInvariantLoads = shaderInfo->options.aggressiveInvariantLoads;
-    shaderOptions.disableInvariantLoads = shaderInfo->options.disableInvariantLoads;
+    static_assert(static_cast<InvariantLoadsOption>(InvariantLoads::Auto) == InvariantLoadsOption::Auto, "Mismatch");
+    static_assert(static_cast<InvariantLoadsOption>(InvariantLoads::EnableOptimization) ==
+                      InvariantLoadsOption::EnableOptimization,
+                  "Mismatch");
+    static_assert(static_cast<InvariantLoadsOption>(InvariantLoads::DisableOptimization) ==
+                      InvariantLoadsOption::DisableOptimization,
+                  "Mismatch");
+    static_assert(static_cast<InvariantLoadsOption>(InvariantLoads::ClearInvariants) ==
+                      InvariantLoadsOption::ClearInvariants,
+                  "Mismatch");
+    shaderOptions.aggressiveInvariantLoads =
+        static_cast<InvariantLoadsOption>(shaderInfo->options.aggressiveInvariantLoads);
 
     pipeline->setShaderOptions(getLgcShaderStage(static_cast<ShaderStage>(stage)), shaderOptions);
   }

--- a/llpc/test/shaderdb/general/AggressiveInvariantLoads.pipe
+++ b/llpc/test/shaderdb/general/AggressiveInvariantLoads.pipe
@@ -16,7 +16,7 @@ void main() {
 
 [VsInfo]
 entryPoint = main
-options.aggressiveInvariantLoads = 1
+options.aggressiveInvariantLoads = EnableOptimization
 
 [FsGlsl]
 #version 450
@@ -33,7 +33,7 @@ void main() {
 
 [FsInfo]
 entryPoint = main
-options.aggressiveInvariantLoads = 1
+options.aggressiveInvariantLoads = EnableOptimization
 
 [ResourceMapping]
 userDataNode[0].visibility = 2

--- a/llpc/test/shaderdb/general/DisableInvariantLoads.pipe
+++ b/llpc/test/shaderdb/general/DisableInvariantLoads.pipe
@@ -14,7 +14,7 @@ void main() {
 
 [VsInfo]
 entryPoint = main
-options.disableInvariantLoads = 1
+options.aggressiveInvariantLoads = ClearInvariants
 
 [FsGlsl]
 #version 450
@@ -31,7 +31,7 @@ void main() {
 
 [FsInfo]
 entryPoint = main
-options.disableInvariantLoads = 1
+options.aggressiveInvariantLoads = ClearInvariants
 
 [ResourceMapping]
 userDataNode[0].visibility = 2

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -69,6 +69,7 @@ std::ostream &operator<<(std::ostream &out, ShadowDescriptorTableUsage shadowDes
 std::ostream &operator<<(std::ostream &out, VkProvokingVertexModeEXT provokingVertexMode);
 std::ostream &operator<<(std::ostream &out, ResourceLayoutScheme layout);
 std::ostream &operator<<(std::ostream &out, ThreadGroupSwizzleMode threadGroupSwizzleMode);
+std::ostream &operator<<(std::ostream &out, InvariantLoads invariants);
 
 template std::ostream &operator<<(std::ostream &out, ElfReader<Elf64> &reader);
 template raw_ostream &operator<<(raw_ostream &out, ElfReader<Elf64> &reader);
@@ -614,7 +615,6 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.overrideShaderThreadGroupSizeZ = " << shaderInfo->options.overrideShaderThreadGroupSizeZ << "\n";
   dumpFile << "options.nsaThreshold = " << shaderInfo->options.nsaThreshold << "\n";
   dumpFile << "options.aggressiveInvariantLoads = " << shaderInfo->options.aggressiveInvariantLoads << "\n";
-  dumpFile << "options.disableInvariantLoads = " << shaderInfo->options.disableInvariantLoads << "\n";
   dumpFile << "\n";
 }
 
@@ -1596,7 +1596,6 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.overrideShaderThreadGroupSizeZ);
       hasher->Update(options.nsaThreshold);
       hasher->Update(options.aggressiveInvariantLoads);
-      hasher->Update(options.disableInvariantLoads);
     }
   }
 }
@@ -2507,6 +2506,25 @@ std::ostream &operator<<(std::ostream &out, ThreadGroupSwizzleMode threadGroupSw
     llvm_unreachable("Should never be called!");
     break;
   }
+  return out << string;
+}
+
+// =====================================================================================================================
+// Translates enum "InvariantLoads" to string and output to ostream.
+//
+// @param [out] out : Output stream
+// @param option : Value to convert
+std::ostream &operator<<(std::ostream &out, InvariantLoads option) {
+  const char *string = nullptr;
+  switch (option) {
+    CASE_CLASSENUM_TO_STRING(InvariantLoads, Auto)
+    CASE_CLASSENUM_TO_STRING(InvariantLoads, EnableOptimization)
+    CASE_CLASSENUM_TO_STRING(InvariantLoads, DisableOptimization)
+    CASE_CLASSENUM_TO_STRING(InvariantLoads, ClearInvariants)
+  default:
+    llvm_unreachable("Should never be called!");
+  }
+
   return out << string;
 }
 

--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -1174,7 +1174,7 @@ bool parseEnumName(char *enumName, unsigned lineNum, IUFValue *output, std::stri
   result = getEnumValue(enumName, value);
 
   if (!result) {
-    PARSE_ERROR(*errorMsg, lineNum, "unknow enum");
+    PARSE_ERROR(*errorMsg, lineNum, "unknown enum");
   } else
     output->iVec4[0] = value;
 

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -88,6 +88,11 @@ public:
     ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, _4x4)
     ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, _8x8)
     ADD_CLASS_ENUM_MAP(ThreadGroupSwizzleMode, _16x16)
+
+    ADD_CLASS_ENUM_MAP(InvariantLoads, Auto)
+    ADD_CLASS_ENUM_MAP(InvariantLoads, EnableOptimization)
+    ADD_CLASS_ENUM_MAP(InvariantLoads, DisableOptimization)
+    ADD_CLASS_ENUM_MAP(InvariantLoads, ClearInvariants)
   }
 };
 

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -165,8 +165,7 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeY, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, overrideShaderThreadGroupSizeZ, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
-      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeBool, false);
-      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, disableInvariantLoads, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeEnum, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};


### PR DESCRIPTION
On GFX10+ aggressive invariant load labelling is beneficial to VGPR pressure on many shader types with very few outliers. (Based on an analysis of common game shaders.)

Change the aggressiveInvariantLoads shader option to a tristate with the default value being Auto, mean heuristics are applied. With explicit Enable and Disable values are also possible.