### PR TITLE
Fix user data limit issue of task shader

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1522,9 +1522,9 @@ void PatchEntryPointMutate::determineUnspilledUserDataArgs(ArrayRef<UserDataArg>
                                 &userDataUsage->spillTable.entryArgIdx);
 
   // Figure out how many sgprs we have available for userDataArgs.
-  // We have s0-s31 (s0-s15 for <=GFX8, or for a compute shader on any chip) for everything, so take off the number
+  // We have s0-s31 (s0-s15 for <=GFX8, or for a compute/task shader on any chip) for everything, so take off the number
   // of registers used by specialUserDataArgs.
-  unsigned userDataEnd = m_shaderStage == ShaderStageCompute
+  unsigned userDataEnd = (m_shaderStage == ShaderStageCompute || m_shaderStage == ShaderStageTask)
                              ? InterfaceData::MaxCsUserDataCount
                              : m_pipelineState->getTargetInfo().getGpuProperty().maxUserDataCount;
 

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -380,10 +380,12 @@ void PalMetadata::setUserDataEntry(ShaderStage stage, unsigned userDataIndex, un
   unsigned userDataReg = getUserDataReg0(stage);
 
   // Assert that the supplied user data index is not too big.
-  assert(userDataIndex + dwordCount <= 32 &&
-         (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 || stage != ShaderStageCompute ||
-          userDataIndex + dwordCount <= 16) &&
-         "Out of range user data index");
+  bool inRange = userDataIndex + dwordCount <= 16;
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 && stage != ShaderStageCompute &&
+      stage != ShaderStageTask)
+    inRange = userDataIndex + dwordCount <= 32;
+  assert(inRange && "Out of range user data index");
+  (void(inRange)); // Unused
 
   // Update userDataLimit if userData is a 0-based integer for root user data dword offset.
   if (userDataValue < InterfaceData::MaxSpillTableSize && userDataValue + dwordCount > m_userDataLimit->getUInt())


### PR DESCRIPTION
For task shader, the user data limit for task shader is the same as compute shader because it is mapped to HW CS eventually. The check was missing originally, leading to CTS VK.binding_model.*.task.* failures.

Also, fix an assert when checking if user data index is in range. The previous check is unclear and is incorrect.