### PR TITLE
Add SRD stride variable in resource node struct

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -347,6 +347,7 @@ struct ResourceMappingNode {
     struct {
       unsigned set;     ///< Descriptor set
       unsigned binding; ///< Descriptor binding
+      unsigned stride;  ///< Descriptor stride
       unsigned reserv0;
       unsigned reserv1;
       unsigned reserv2;

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -297,6 +297,7 @@ struct ResourceNode {
                                       // If pipeline option "useResourceBindingRange" is set, then this is the
                                       //  start of a range of bindings whose size is sizeInDwords/stride.
       unsigned stride;                // Size of each descriptor in the indexable range in dwords.
+      unsigned srdStride;             // Size of each SRD in one descriptor set node
       unsigned immutableSize;         // Size (in units of DescriptorSizeSampler bytes) of immutableValue array
       const uint32_t *immutableValue; // Array of dwords for immutable sampler.
     };


### PR DESCRIPTION
The SRD stride variable is used to load a descriptor with an offset value
rather than a fixed image descritor size. For example, if the client uses
full combined image sampler descriptor set layout with multi-planar
YCbCr image, the descriptor stride between each planes should be the size of
image descriptor and sampler descriptor.

The load with offset changes would be in the later commits.