### PR TITLE
Change the initial value of GfxIpVersion and modify the checkers

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -398,15 +398,31 @@ struct ResourceMappingData {
 /// Represents graphics IP version info. See https://llvm.org/docs/AMDGPUUsage.html#processors for more
 /// details.
 struct GfxIpVersion {
-  unsigned major;    ///< Major version
-  unsigned minor;    ///< Minor version
-  unsigned stepping; ///< Stepping info
+  static const unsigned Unspecified = ~0U;
 
-  // GFX IP checkers
+  unsigned major = 0;              ///< Major version
+  unsigned minor = Unspecified;    ///< Minor version
+  unsigned stepping = Unspecified; ///< Stepping info
+
+  /// GFX IP checkers
   bool operator==(const GfxIpVersion &rhs) const {
+    if (rhs.minor == Unspecified && rhs.stepping == Unspecified)
+      return major == rhs.major;
+
+    if (rhs.stepping == Unspecified)
+      return std::tie(major, minor) == std::tie(rhs.major, rhs.minor);
+
+    assert(rhs.minor != Unspecified && rhs.stepping != Unspecified);
     return std::tie(major, minor, stepping) == std::tie(rhs.major, rhs.minor, rhs.stepping);
   }
   bool operator>=(const GfxIpVersion &rhs) const {
+    if (rhs.minor == Unspecified && rhs.stepping == Unspecified)
+      return major >= rhs.major;
+
+    if (rhs.stepping == Unspecified)
+      return std::tie(major, minor) >= std::tie(rhs.major, rhs.minor);
+
+    assert(rhs.minor != Unspecified && rhs.stepping != Unspecified);
     return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
   }
 };

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -37,15 +37,31 @@ namespace lgc {
 // Represents graphics IP version info. See https://llvm.org/docs/AMDGPUUsage.html#processors for more
 // details.
 struct GfxIpVersion {
-  unsigned major;    // Major version
-  unsigned minor;    // Minor version
-  unsigned stepping; // Stepping info
+  static const unsigned Unspecified = ~0U;
+
+  unsigned major = 0;              // Major version
+  unsigned minor = Unspecified;    // Minor version
+  unsigned stepping = Unspecified; // Stepping info
 
   // GFX IP checkers
   bool operator==(const GfxIpVersion &rhs) const {
+    if (rhs.minor == Unspecified && rhs.stepping == Unspecified)
+      return major == rhs.major;
+
+    if (rhs.stepping == Unspecified)
+      return std::tie(major, minor) == std::tie(rhs.major, rhs.minor);
+
+    assert(rhs.minor != Unspecified && rhs.stepping != Unspecified);
     return std::tie(major, minor, stepping) == std::tie(rhs.major, rhs.minor, rhs.stepping);
   }
   bool operator>=(const GfxIpVersion &rhs) const {
+    if (rhs.minor == Unspecified && rhs.stepping == Unspecified)
+      return major >= rhs.major;
+
+    if (rhs.stepping == Unspecified)
+      return std::tie(major, minor) >= std::tie(rhs.major, rhs.minor);
+
+    assert(rhs.minor != Unspecified && rhs.stepping != Unspecified);
     return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
   }
 };


### PR DESCRIPTION
Initialize major version to 0 and minor/stepping version to ~0. This is for us to do more relaxed comparison in GFX IP Checker. We could have such: gfxIp == GfxIpVersion{10, 3}. Actually, we want to check GFX10.3 variants, include 10.3.0, 10.3.1, etc.. If we don't make the change, 10.3.1 will not pass the comparison, leading to wrong follow-up actions.