### PR TITLE
Fix a IR verification error of switch

### DIFF
--- a/llpc/test/shaderdb/core/OpPhi_TestMultiIncomingFromSwitch.spvasm
+++ b/llpc/test/shaderdb/core/OpPhi_TestMultiIncomingFromSwitch.spvasm
@@ -1,0 +1,116 @@
+; RUN: amdllpc -verify-ir -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: br i1 %{{.*}}, label %[[PREDECESSOR:[0-9]*]], label %{{.*}}
+; SHADERTEST: [[PREDECESSOR]]:
+; SHADERTEST: switch i32 %{{.*}}, label %[[SUCCESSOR:[0-9]*]] [
+; SHADERTEST-NEXT: i32 0, label %[[CASE0:[0-9]*]]
+; SHADERTEST-NEXT: i32 1, label %[[CASE1:[0-9]*]]
+; SHADERTEST-NEXT: i32 2, label %[[SUCCESSOR]]
+; SHADERTEST-NEXT: ]
+; SHADERTEST: [[SUCCESSOR]]:
+; SHADERTEST-NEXT: %{{.*}} = phi float [ 5.000000e-01, %[[PREDECESSOR]] ], [ %{{.*}}, %{{.*}} ], [ 5.000000e-01, %[[PREDECESSOR]] ]
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 66
+; Schema: 0
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %_GLF_color
+               OpExecutionMode %main OriginUpperLeft
+               OpSource ESSL 310
+               OpName %main "main"
+               OpName %i "i"
+               OpName %buf0 "buf0"
+               OpMemberName %buf0 0 "injectionSwitch"
+               OpName %_ ""
+               OpName %value "value"
+               OpName %y "y"
+               OpName %_GLF_color "_GLF_color"
+               OpMemberDecorate %buf0 0 Offset 0
+               OpDecorate %buf0 Block
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %_GLF_color Location 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Function_int = OpTypePointer Function %int
+      %int_0 = OpConstant %int 0
+      %int_2 = OpConstant %int 2
+      %float = OpTypeFloat 32
+    %v2float = OpTypeVector %float 2
+       %buf0 = OpTypeStruct %v2float
+%_ptr_Uniform_buf0 = OpTypePointer Uniform %buf0
+          %_ = OpVariable %_ptr_Uniform_buf0 Uniform
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+       %bool = OpTypeBool
+%_ptr_Function_float = OpTypePointer Function %float
+  %float_0_5 = OpConstant %float 0.5
+    %float_1 = OpConstant %float 1
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+ %_GLF_color = OpVariable %_ptr_Output_v4float Output
+      %int_1 = OpConstant %int 1
+    %float_0 = OpConstant %float 0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %i = OpVariable %_ptr_Function_int Function
+      %value = OpVariable %_ptr_Function_int Function
+          %y = OpVariable %_ptr_Function_float Function
+               OpStore %i %int_0
+               OpBranch %10
+         %10 = OpLabel
+         %63 = OpPhi %int %int_0 %5 %62 %13
+               OpLoopMerge %12 %13 None
+               OpBranch %14
+         %14 = OpLabel
+         %25 = OpAccessChain %_ptr_Uniform_float %_ %int_0 %uint_0
+         %26 = OpLoad %float %25
+         %27 = OpConvertFToS %int %26
+         %28 = OpIAdd %int %int_2 %27
+         %30 = OpSLessThan %bool %63 %28
+               OpBranchConditional %30 %11 %12
+         %11 = OpLabel
+               OpStore %value %63
+               OpStore %y %float_0_5
+               OpSelectionMerge %40 None
+               OpSwitch %63 %39 0 %37 1 %38 2 %39
+         %39 = OpLabel
+         %65 = OpPhi %float %float_0_5 %11 %45 %38
+         %47 = OpFOrdEqual %bool %65 %float_1
+               OpSelectionMerge %49 None
+               OpBranchConditional %47 %48 %49
+         %48 = OpLabel
+         %55 = OpIAdd %int %63 %int_1
+         %56 = OpConvertSToF %float %55
+         %58 = OpCompositeConstruct %v4float %56 %float_0 %float_0 %float_1
+               OpStore %_GLF_color %58
+               OpReturn
+         %49 = OpLabel
+               OpBranch %40
+         %37 = OpLabel
+         %42 = OpFAdd %float %float_0_5 %float_0_5
+               OpStore %y %42
+               OpBranch %38
+         %38 = OpLabel
+         %64 = OpPhi %float %float_0_5 %11 %42 %37
+         %45 = OpExtInst %float %1 FClamp %float_1 %float_0_5 %64
+               OpStore %y %45
+               OpBranch %39
+         %40 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+         %62 = OpIAdd %int %63 %int_1
+               OpStore %i %62
+               OpBranch %10
+         %12 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4771,8 +4771,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
   case OpSwitch: {
     auto bs = static_cast<SPIRVSwitch *>(bv);
     auto select = transValue(bs->getSelect(), f, bb);
-    auto ls =
-        SwitchInst::Create(select, dyn_cast<BasicBlock>(transValue(bs->getDefault(), f, bb)), bs->getNumPairs(), bb);
+    auto defaultSuccessor = dyn_cast<BasicBlock>(transValue(bs->getDefault(), f, bb));
+    recordBlockPredecessor(defaultSuccessor, bb);
+    auto ls = SwitchInst::Create(select, defaultSuccessor, bs->getNumPairs(), bb);
     bs->foreachPair([&](SPIRVSwitch::LiteralTy literals, SPIRVBasicBlock *label) {
       assert(!literals.empty() && "Literals should not be empty");
       assert(literals.size() <= 2 && "Number of literals should not be more then two");


### PR DESCRIPTION
SPIR-V switch could have the same destination block referenced by case branch and the default branch. See this:

  %11 = OpLabel
        OpStore %value %63
        OpStore %y %float_0_5
        OpSelectionMerge %40 None
        OpSwitch %63 %39 0 %37 1 %38 2 %39
  %39 = OpLabel
  %65 = OpPhi %float %float_0_5 %11 %45 %38

One case branch and the default branch have the same destination block. In the destination block, the PHI node has two incomings from the same predecessor block. LLVM requires each incoming of PHI node must be specified. We handled such case before but didn't process default block at that time.