### PR TITLE
Fix a coding typo of PatchBufferOp::postVisitMemCpyInst

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1084,7 +1084,7 @@ void PatchBufferOp::postVisitMemCpyInst(MemCpyInst &memCpyInst) {
     if (stride == 16) {
       memoryType = FixedVectorType::get(Type::getInt32Ty(*m_context), 4);
     } else {
-      assert(stride < 8);
+      assert(stride <= 8);
       memoryType = m_builder->getIntNTy(stride * 8);
     }
 


### PR DESCRIPTION
We check stride to decide the casting type. If the stride is 16, the casting type is <4 x i32>. If the stride is <=8, the casting type is intN.