### PR TITLE
Extra fixes for internalRtShaders move to pipeline option

### DIFF
--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -440,8 +440,12 @@ BinaryData ShaderModuleHelper::getShaderCode(const ShaderModuleBuildInfo *shader
   const BinaryData &shaderBinary = shaderInfo->shaderBin;
   bool trimDebugInfo = cl::TrimDebugInfo;
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 55
   trimDebugInfo = trimDebugInfo &&
                   !(shaderInfo->options.pipelineOptions.internalRtShaders || shaderInfo->options.isInternalRtShader);
+#else
+  trimDebugInfo = trimDebugInfo && !(shaderInfo->options.pipelineOptions.internalRtShaders);
+#endif
 #endif
   if (trimDebugInfo) {
     code.codeSize = trimSpirvDebugInfo(&shaderBinary, codeBuffer);
@@ -461,8 +465,12 @@ unsigned ShaderModuleHelper::getCodeSize(const ShaderModuleBuildInfo *shaderInfo
   const BinaryData &shaderBinary = shaderInfo->shaderBin;
   bool trimDebugInfo = cl::TrimDebugInfo;
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 55
   trimDebugInfo = trimDebugInfo &&
                   !(shaderInfo->options.pipelineOptions.internalRtShaders || shaderInfo->options.isInternalRtShader);
+#else
+  trimDebugInfo = trimDebugInfo && !(shaderInfo->options.pipelineOptions.internalRtShaders);
+#endif
 #endif
   if (!trimDebugInfo)
     return shaderBinary.codeSize;


### PR DESCRIPTION
Missed some cases where LLPC_CLIENT_INTERFACE_MAJOR_VERSION guards are required.