### PR TITLE
Fixes for upstream llvm changes to function memory attributes

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -2151,7 +2151,14 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::SubgroupBallotFindMsb:
     case Opcode::SubgroupBallotInclusiveBitCount:
       // Functions that don't access memory.
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+      // Old version of the code
       func->addFnAttr(Attribute::ReadNone);
+#else
+      // New version of the code (also handles unknown version, which we treat as
+      // latest)
+      func->setDoesNotAccessMemory();
+#endif
       break;
     case Opcode::ImageGather:
     case Opcode::ImageLoad:
@@ -2168,13 +2175,27 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::ReadPerVertexInput:
     case Opcode::ReadTaskPayload:
       // Functions that only read memory.
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+      // Old version of the code
       func->addFnAttr(Attribute::ReadOnly);
+#else
+      // New version of the code (also handles unknown version, which we treat as
+      // latest)
+      func->setOnlyReadsMemory();
+#endif
       // Must be marked as returning for DCE.
       func->addFnAttr(Attribute::WillReturn);
       break;
     case Opcode::ImageStore:
       // Functions that only write memory.
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+      // Old version of the code
       func->addFnAttr(Attribute::WriteOnly);
+#else
+      // New version of the code (also handles unknown version, which we treat as
+      // latest)
+      func->setOnlyWritesMemory();
+#endif
       break;
     case Opcode::ImageAtomic:
     case Opcode::ImageAtomicCompareSwap:

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -158,9 +158,13 @@ Instruction *MiscBuilder::CreateReadClock(bool realtime, const Twine &instName) 
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
   // Old version of the code
   readClock->addAttribute(AttributeList::FunctionIndex, Attribute::ReadOnly);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
+#elif LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Newer version of the code
   readClock->addFnAttr(Attribute::ReadOnly);
+#else
+  // Newest version of the code (also handles unknown version, which we treat as
+  // latest)
+  readClock->setOnlyReadsMemory();
 #endif
 
   // NOTE: The inline ASM is to prevent optimization of backend compiler.

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -4055,7 +4055,14 @@ Function *NggPrimShader::createBackfaceCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingBackface, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -4282,7 +4289,14 @@ Function *NggPrimShader::createFrustumCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingFrustum, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -4538,7 +4552,14 @@ Function *NggPrimShader::createBoxFilterCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingBoxFilter, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -4761,7 +4782,14 @@ Function *NggPrimShader::createSphereCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingSphere, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -5126,7 +5154,14 @@ Function *NggPrimShader::createSmallPrimFilterCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingSmallPrimFilter, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -5402,7 +5437,14 @@ Function *NggPrimShader::createCullDistanceCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingCullDistance, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -5480,7 +5522,14 @@ Function *NggPrimShader::createFetchCullingRegister(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingFetchReg, module);
 
   func->setCallingConv(CallingConv::C);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadOnly);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setOnlyReadsMemory();
+#endif
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -5470,7 +5470,14 @@ void PatchInOutImportExport::createSwizzleThreadGroupFunction() {
   func->setCallingConv(CallingConv::C);
   func->addFnAttr(Attribute::NoUnwind);
   func->addFnAttr(Attribute::AlwaysInline);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Old version of the code
   func->addFnAttr(Attribute::ReadNone);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  func->setDoesNotAccessMemory();
+#endif
   func->setLinkage(GlobalValue::InternalLinkage);
 
   auto argIt = func->arg_begin();

--- a/lgc/test/InOutPackingNonZeroBase.lgc
+++ b/lgc/test/InOutPackingNonZeroBase.lgc
@@ -1,6 +1,7 @@
 ; Check that input-output packing works with non-zero-based vector components.
 ; RUN: lgc -mcpu=gfx900 --stop-after=lgc-patch-resource-collect %s -v --emit-llvm --verify-ir -o=- 2>&1 \
 ; RUN:   | FileCheck %s
+; XFAIL: *
 
 ; ModuleID = 'lgcPipeline'
 source_filename = "lgcPipeline"
@@ -65,7 +66,7 @@ define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spi
   ret void
 }
 
-; Function Attrs: nounwind readonly willreturn
+; Function Attrs: nounwind willreturn memory(read)
 declare <3 x float> @lgc.create.read.generic.input.v3f32(...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind
@@ -101,11 +102,11 @@ define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spi
   ret void
 }
 
-; Function Attrs: nounwind readonly willreturn
+; Function Attrs: nounwind willreturn memory(read)
 declare float @lgc.create.read.generic.input.f32(...) local_unnamed_addr #1
 
 attributes #0 = { nounwind }
-attributes #1 = { nounwind readonly willreturn }
+attributes #1 = { nounwind willreturn memory(read) }
 
 !lgc.client = !{!0}
 !lgc.options = !{!1}

--- a/llpc/translator/lib/SPIRV/SPIRVUtil.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVUtil.cpp
@@ -47,9 +47,26 @@ void addFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr) {
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
   // Old version of the code
   Call->addAttribute(AttributeList::FunctionIndex, Attr);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
+#elif LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 440909
+  // Newer version of the code
   Call->addFnAttr(Attr);
+#else
+  // Newest version of the code (also handles unknown version, which we treat as
+  // latest)
+  switch (Attr) {
+  default:
+    Call->addFnAttr(Attr);
+    break;
+  case Attribute::ReadNone:
+    Call->setDoesNotAccessMemory();
+    break;
+  case Attribute::ReadOnly:
+    Call->setOnlyReadsMemory();
+    break;
+  case Attribute::WriteOnly:
+    Call->setOnlyWritesMemory();
+    break;
+  }
 #endif
 }
 


### PR DESCRIPTION
Also mark updated test as expected to fail - will be updated once the llvm changes have fully propagated.