### PR TITLE
Fix issues of packing input/output with XFB outputs

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -118,18 +118,27 @@ public:
   bool isBuiltIn() const { return m_data.bits.isBuiltIn; }
   void setBuiltIn(bool isBuiltIn) { m_data.bits.isBuiltIn = isBuiltIn; }
 
+  bool isFlat() const { return m_data.bits.isFlat; }
+  void setFlat(bool isFlat) { m_data.bits.isFlat = isFlat; }
+
+  bool isCustom() const { return m_data.bits.isCustom; }
+  void setCustom(bool isCustom) { m_data.bits.isCustom = isCustom; }
+
   unsigned getStreamId() const { return m_data.bits.streamId; }
   void setStreamId(unsigned streamId) { m_data.bits.streamId = static_cast<uint16_t>(streamId); }
 
   bool operator<(const InOutLocationInfo &rhs) const { return this->getData() < rhs.getData(); }
+  bool operator!=(const InOutLocationInfo &rhs) const { return this->getData() != rhs.getData(); }
 
 private:
   union {
     struct {
       uint16_t isHighHalf : 1; // High half in case of 16-bit attributes
       uint16_t component : 2;  // The component index
-      uint16_t location : 10;  // The location
+      uint16_t location : 8;   // The location
       uint16_t isBuiltIn : 1;  // Whether location is actually built-in ID
+      uint16_t isFlat : 1;     // Whether is flat shading
+      uint16_t isCustom : 1;   // Whether is custom interpolation
       uint16_t streamId : 2;   // Output vertex stream ID
     } bits;
     uint16_t u16All;
@@ -346,6 +355,9 @@ struct ResourceUsage {
     std::map<unsigned, unsigned> perPrimitiveBuiltInInputLocMap;
     std::map<unsigned, unsigned> perPrimitiveBuiltInOutputLocMap;
 
+    // Map from output location info to the transform feedback info
+    std::map<InOutLocationInfo, XfbOutInfo> locInfoXfbOutInfoMap;
+
     // Transform feedback strides
     unsigned xfbStrides[MaxTransformFeedbackBuffers] = {};
 
@@ -418,9 +430,6 @@ struct ResourceUsage {
       // export generic outputs to fragment shader, always from vertex stream 0):
       //   <location, <component, byteSize>>
       std::unordered_map<unsigned, std::vector<unsigned>> genericOutByteSizes[MaxGsStreams];
-
-      // Map from output location info to the transform feedback info
-      std::map<InOutLocationInfo, XfbOutInfo> locInfoXfbOutInfoMap;
 
       // ID of the vertex stream sent to rasterizer
       unsigned rasterStream = 0;

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -395,7 +395,7 @@ void PatchCopyShader::collectGsGenericOutputInfo(Function *gsEntryPoint) {
 void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
   auto &builtInUsage = resUsage->builtInUsage.gs;
-  auto &locInfoXfbOutInfoMap = resUsage->inOutUsage.gs.locInfoXfbOutInfoMap;
+  auto &locInfoXfbOutInfoMap = resUsage->inOutUsage.locInfoXfbOutInfoMap;
   auto &outputLocInfoMap = resUsage->inOutUsage.outputLocInfoMap;
 
   // Build the map between new location and output value
@@ -726,7 +726,7 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
     outLocInfo.setBuiltIn(true);
     outLocInfo.setStreamId(streamId);
 
-    auto &locInfoXfbOutInfoMap = resUsage->inOutUsage.gs.locInfoXfbOutInfoMap;
+    auto &locInfoXfbOutInfoMap = resUsage->inOutUsage.locInfoXfbOutInfoMap;
     const auto &locInfoXfbOutInfoMapIt = locInfoXfbOutInfoMap.find(outLocInfo);
     if (locInfoXfbOutInfoMapIt != locInfoXfbOutInfoMap.end()) {
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -708,16 +708,18 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
               if (locInfoMapIt == resUsage->inOutUsage.inputLocInfoMap.end()) {
                 // Try the key as the plain location
                 origLocInfo.setComponent(0);
-                locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
                 hasDynIndex = true;
               }
-            } else {
-              locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
             }
           } else {
             origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue());
-            locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
+            if (m_shaderStage == ShaderStageFragment && isInterpolantInputImport) {
+              const unsigned interpMode = cast<ConstantInt>(callInst.getOperand(3))->getZExtValue();
+              origLocInfo.setFlat(interpMode == InOutInfo::InterpModeFlat);
+              origLocInfo.setCustom(interpMode == InOutInfo::InterpModeCustom);
+            }
           }
+          locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
           assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
 
           loc = locInfoMapIt->second.getLocation();

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1355,7 +1355,7 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
           outLocInfoMap.erase(outLocInfo);
         // For GS, we remove transform feedback location info as well if it exists
         if (m_shaderStage == ShaderStageGeometry) {
-          auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.gs.locInfoXfbOutInfoMap;
+          auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.locInfoXfbOutInfoMap;
           if (locInfoXfbOutInfoMap.count(outLocInfo) > 0)
             locInfoXfbOutInfoMap.erase(outLocInfo);
         }
@@ -1655,11 +1655,12 @@ void PatchResourceCollect::matchGenericInOut() {
   if (m_shaderStage == ShaderStageVertex && m_tcsInputHasDynamicIndexing)
     packOutput = false;
   if (packOutput) {
+    // OutputLocInfoMap is used for computing the shader hash and looking remapped location
+    updateOutputLocInfoMapWithPack();
     // Re-create output export calls to pack exp instruction for the last vertex processing stage
     if (m_shaderStage == m_pipelineState->getLastVertexProcessingStage() && m_shaderStage != ShaderStageGeometry)
       reassembleOutputExportCalls();
-    // OutputLocInfoMap is used for computing the shader hash and looking remapped location
-    updateOutputLocInfoMapWithPack();
+    m_outputCalls.clear();
   } else {
     updateOutputLocInfoMapWithUnpack();
   }
@@ -2846,7 +2847,7 @@ void PatchResourceCollect::clearUnusedOutput() {
         // Collect locations of those outputs that are not used
         bool isOutputXfb = false;
         if (m_shaderStage == ShaderStageGeometry)
-          isOutputXfb = inOutUsage.gs.locInfoXfbOutInfoMap.count(locInfoPair.first) > 0;
+          isOutputXfb = inOutUsage.locInfoXfbOutInfoMap.count(locInfoPair.first) > 0;
 
         if (!isOutputXfb && nextInLocInfoMap.find(locInfoPair.first) == nextInLocInfoMap.end()) {
           bool isActiveLoc = false;
@@ -3023,22 +3024,19 @@ void PatchResourceCollect::updateInputLocInfoMapWithPack() {
   // FS: @lgc.input.import.generic.%Type%(i32 location, i32 elemIdx, i1 perPrimitive, i32 interpMode, i32 interpLoc)
   //     @lgc.input.import.interpolant.%Type%(i32 location, i32 locOffset, i32 elemIdx,
   //                                          i32 interpMode, <2 x float> | i32 auxInterpValue)
-
-  // The locations of TCS with dynamic indexing (locOffset/elemIdx) cannot be unpacked
-  // NOTE: Dynamic indexing in FS is processed to be constant in the lower pass.
-  std::vector<CallInst *> packableCalls;
-  packableCalls = std::move(m_inputCalls);
+  // NOTE: Dynamic indexing in FS is processed to be constant in the lower pass and TCS has dynamic indexing will go
+  // through unpacked path
 
   // LDS load/store copes with dword. For 8-bit/16-bit data type, we will extend them to 32-bit
   bool partPipelineHasGs = m_pipelineState->isPartPipeline() && m_pipelineState->getPreRasterHasGs();
   bool isFsAndHasGs = (isFs && (m_pipelineState->hasShaderStage(ShaderStageGeometry) || partPipelineHasGs));
   bool requireDword = isTcs || isGs || isFsAndHasGs;
-  // Create locationMap according to the packable calls
-  m_locationInfoMapManager->createMap(packableCalls, m_shaderStage, requireDword);
+  // Create locationMap
+  m_locationInfoMapManager->createMap(m_inputCalls, m_shaderStage, requireDword);
 
   // Fill inputLocInfoMap of {TCS, GS, FS} for the packable calls
   unsigned newLocIdx = 0;
-  for (auto call : packableCalls) {
+  for (auto call : m_inputCalls) {
     const bool isInterpolant = call->getCalledFunction()->getName().startswith(lgcName::InputImportInterpolant);
     unsigned locOffset = 0;
     unsigned compIdxArgIdx = 1;
@@ -3053,21 +3051,18 @@ void PatchResourceCollect::updateInputLocInfoMapWithPack() {
     InOutLocationInfo origLocInfo;
     origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue() + locOffset);
     origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(compIdxArgIdx))->getZExtValue());
+    if (isFs && isInterpolant) {
+      const unsigned interpMode = cast<ConstantInt>(call->getOperand(3))->getZExtValue();
+      origLocInfo.setFlat(interpMode == InOutInfo::InterpModeFlat);
+      origLocInfo.setCustom(interpMode == InOutInfo::InterpModeCustom);
+    }
     InOutLocationInfoMap::const_iterator mapIter;
     assert(m_locationInfoMapManager->findMap(origLocInfo, mapIter));
     m_locationInfoMapManager->findMap(origLocInfo, mapIter);
     inputLocInfoMap[origLocInfo] = mapIter->second;
     newLocIdx = std::max(newLocIdx, mapIter->second.getLocation() + 1);
   }
-  if (isTcs) {
-    // Fill inputLocInfoMap for the unpackable calls of TCS
-    for (auto &locInfo : inputLocInfoMap) {
-      if (locInfo.second.isInvalid()) {
-        locInfo.second.setData(0);
-        locInfo.second.setLocation(newLocIdx++);
-      }
-    }
-  }
+  m_inputCalls.clear();
 }
 
 // =====================================================================================================================
@@ -3080,64 +3075,102 @@ void PatchResourceCollect::updateOutputLocInfoMapWithPack() {
   if (m_outputCalls.empty())
     return;
 
-  if (m_shaderStage != ShaderStageGeometry) {
-    assert(m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval);
-    auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
-    assert(nextStage != ShaderStageInvalid);
-    // In reassembleOutputExportCalls, the unused calls in next stage have been added into dead call set.
-    bool isMarkedDeadCall = (m_shaderStage == m_pipelineState->getLastVertexProcessingStage());
-    auto &nextStageInputLocInfoMap = m_pipelineState->getShaderResourceUsage(nextStage)->inOutUsage.inputLocInfoMap;
+  assert(m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageTessEval ||
+         m_shaderStage == ShaderStageGeometry);
+  auto nextStage = m_pipelineState->getNextShaderStage(m_shaderStage);
+  assert(nextStage != ShaderStageInvalid);
+  auto &nextStageInputLocInfoMap = m_pipelineState->getShaderResourceUsage(nextStage)->inOutUsage.inputLocInfoMap;
+
+  // Remove unused outputs and update the output map
+  if (m_shaderStage != m_pipelineState->getLastVertexProcessingStage()) {
+    // For VS-{TCS, GS}, the dead output has no matching input of the next stage
     for (auto call : m_outputCalls) {
       InOutLocationInfo origLocInfo;
       origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue());
       origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(1))->getZExtValue());
-
-      auto locInfoMapIt = nextStageInputLocInfoMap.find(origLocInfo);
-      if (locInfoMapIt != nextStageInputLocInfoMap.end())
-        outputLocInfoMap[origLocInfo] = locInfoMapIt->second;
-      else if (!isMarkedDeadCall)
-        m_deadCalls.push_back(call); // unused call in next stage
+      if (nextStageInputLocInfoMap.find(origLocInfo) == nextStageInputLocInfoMap.end())
+        m_deadCalls.push_back(call);
     }
-    m_outputCalls.clear();
-    return;
-  }
+    // The output map should be equal to the input map of the next stage
+    outputLocInfoMap = nextStageInputLocInfoMap;
+  } else {
+    // For {VS, TES, GS}-FS, the dead output is neither a XFB output or a corresponding FS' input.
+    // Collect XFB locations
+    auto &xfbOutLocInfoMap = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.locInfoXfbOutInfoMap;
+    std::set<unsigned> xfbOutputLocs[MaxGsStreams];
+    for (const auto &locInfoPair : xfbOutLocInfoMap) {
+      const auto &locInfo = locInfoPair.first;
+      xfbOutputLocs[locInfo.getStreamId()].insert(locInfo.getLocation());
+    }
 
-  // For GS, the outputLocInfoMap is created according to the output calls in each stream
-  // LDS load/store copes with dword
-  m_locationInfoMapManager->createMap(m_outputCalls, m_shaderStage, true);
-  m_outputCalls.clear();
+    // Collect flat-shading locations and custom interpolation locations
+    std::set<unsigned> flatInputLocs;
+    std::set<unsigned> customInputLocs;
+    for (const auto &locInfoPair : nextStageInputLocInfoMap) {
+      const auto &locInfo = locInfoPair.first;
+      if (locInfo.isFlat())
+        flatInputLocs.insert(locInfo.getLocation());
+      else if (locInfo.isCustom())
+        customInputLocs.insert(locInfo.getLocation());
+    }
 
-  auto &fsInOutUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->inOutUsage;
-  auto &fsInputLocInfoMap = fsInOutUsage.inputLocInfoMap;
-  auto &locationInfoMap = m_locationInfoMapManager->getMap();
+    // Add dead calls
+    for (auto call : m_outputCalls) {
+      InOutLocationInfo origLocInfo;
+      origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue());
+      origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(1))->getZExtValue());
+      unsigned streamId = 0;
+      if (m_shaderStage == ShaderStageGeometry) {
+        streamId = cast<ConstantInt>(call->getOperand(2))->getZExtValue();
+        origLocInfo.setStreamId(streamId);
+      }
+      const unsigned origLocation = origLocInfo.getLocation();
+      bool isUsed = xfbOutputLocs[streamId].count(origLocation) > 0 || flatInputLocs.count(origLocation) > 0 ||
+                    customInputLocs.count(origLocation) > 0 || nextStageInputLocInfoMap.count(origLocInfo) > 0;
+      if (!isUsed)
+        m_deadCalls.push_back(call);
+    }
 
-  const bool hasNullFs = fsInOutUsage.fs.isNullFs || fsInputLocInfoMap.empty();
-  if (!hasNullFs) {
-    // Update mapped location infos (excluding XFB output) in raster stream according to inputLocInfoMap fo FS
-    for (auto locInfoMapIt = locationInfoMap.begin(); locInfoMapIt != locationInfoMap.end();) {
-      const auto &origLocInfo = locInfoMapIt->first;
-      const bool isOutputXfb = inOutUsage.gs.locInfoXfbOutInfoMap.count(locInfoMapIt->first) > 0;
-      if (origLocInfo.getStreamId() == inOutUsage.gs.rasterStream && !isOutputXfb) {
-        if (fsInputLocInfoMap.count(origLocInfo) > 0) {
-          // Get remmapped InOutLocationInfo from the inputLocMap of FS
-          locInfoMapIt->second = fsInputLocInfoMap[origLocInfo];
-          ++locInfoMapIt;
-        } else {
-          // Erase the output that is not used by FS
-          locInfoMapIt = locationInfoMap.erase(locInfoMapIt);
-        }
-      } else {
-        ++locInfoMapIt;
+    auto *locInfoMap = &nextStageInputLocInfoMap;
+
+    // If the outputs are allowed to have no matching inputs, such as XFB output and non-raster streams outputs, we
+    // should build the output map based on output info, otherwise, update the output map via the input map of the next
+    // stage.
+    if (xfbOutLocInfoMap.size() > 0 || xfbOutputLocs[1].size() > 0 || xfbOutputLocs[2].size() > 0 ||
+        xfbOutputLocs[3].size() > 0) {
+      std::vector<InOutLocationInfo> outLocInfos;
+      for (auto call : m_outputCalls) {
+        InOutLocationInfo origLocInfo;
+        origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue());
+        origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(1))->getZExtValue());
+        if (m_shaderStage == ShaderStageGeometry)
+          origLocInfo.setStreamId(cast<ConstantInt>(call->getOperand(2))->getZExtValue());
+        if (flatInputLocs.count(origLocInfo.getLocation()))
+          origLocInfo.setFlat(true);
+        else if (customInputLocs.count(origLocInfo.getLocation()))
+          origLocInfo.setCustom(true);
+        outLocInfos.push_back(origLocInfo);
+      }
+      m_locationInfoMapManager->createMap(outLocInfos, m_shaderStage);
+      locInfoMap = &m_locationInfoMapManager->getMap();
+    }
+
+    // Update the output map
+    for (auto &locInfoPair : *locInfoMap) {
+      InOutLocationInfo origLocInfo;
+      origLocInfo.setStreamId(locInfoPair.first.getStreamId());
+      origLocInfo.setLocation(locInfoPair.first.getLocation());
+      origLocInfo.setComponent(locInfoPair.first.getComponent());
+      outputLocInfoMap.insert({origLocInfo, locInfoPair.second});
+    }
+
+    // update output count per stream for GS
+    if (m_shaderStage == ShaderStageGeometry) {
+      for (auto &locInfoPair : outputLocInfoMap) {
+        auto &outLocCount = inOutUsage.gs.outLocCount[locInfoPair.first.getStreamId()];
+        outLocCount = std::max(outLocCount, locInfoPair.second.getLocation() + 1);
       }
     }
-  }
-
-  outputLocInfoMap = std::move(locationInfoMap);
-  // Update inOutUsage.gs.outLocCount
-  for (auto &locInfoPair : outputLocInfoMap) {
-    const auto &newLocInfo = locInfoPair.second;
-    auto &outLocCount = inOutUsage.gs.outLocCount[newLocInfo.getStreamId()];
-    outLocCount = std::max(outLocCount, newLocInfo.getLocation() + 1);
   }
 }
 
@@ -3171,18 +3204,20 @@ void PatchResourceCollect::reassembleOutputExportCalls() {
   };
 
   // Collect ElementsInfo in each packed location
-  const unsigned locCount = m_locationInfoMapManager->getMap().size();
-  std::vector<ElementsInfo> elementsInfoArray(locCount);
+  auto &outputLocInfoMap = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.outputLocInfoMap;
+  std::vector<ElementsInfo> elementsInfoArray(outputLocInfoMap.size());
 
   for (auto call : m_outputCalls) {
     InOutLocationInfo origLocInfo;
     origLocInfo.setLocation(cast<ConstantInt>(call->getOperand(0))->getZExtValue());
     origLocInfo.setComponent(cast<ConstantInt>(call->getOperand(1))->getZExtValue());
 
-    m_deadCalls.push_back(call);
-    InOutLocationInfoMap::const_iterator mapIter;
-    if (!m_locationInfoMapManager->findMap(origLocInfo, mapIter))
+    auto mapIter = outputLocInfoMap.find(origLocInfo);
+    // Unused scalarized calls have been added into dead call set
+    if (mapIter == outputLocInfoMap.end())
       continue;
+    // Add used scalarized calls to dead call set
+    m_deadCalls.push_back(call);
 
     const unsigned newLoc = mapIter->second.getLocation();
     auto &elementsInfo = elementsInfoArray[newLoc];
@@ -3525,6 +3560,20 @@ void InOutLocationInfoMapManager::createMap(const std::vector<CallInst *> &calls
 }
 
 // =====================================================================================================================
+// Create a locationInfo map for the given shader stage
+//
+// @param locInfos : location infos to process
+// @param shaderStage : Shader stage
+void InOutLocationInfoMapManager::createMap(const std::vector<InOutLocationInfo> &locInfos, ShaderStage shaderStage) {
+  for (const auto &locInfo : locInfos) {
+    LocationSpan span{};
+    span.firstLocationInfo = locInfo;
+    m_locationSpans.insert(span);
+  }
+  buildMap(shaderStage);
+}
+
+// =====================================================================================================================
 // Create a locationInfo map by deserializing the serialized map. Used when compiling the vertex-processing
 // part-pipeline given the packed input map from the separate FS compilation.
 void InOutLocationInfoMapManager::deserializeMap(ArrayRef<std::pair<unsigned, unsigned>> serializedMap) {
@@ -3539,7 +3588,6 @@ void InOutLocationInfoMapManager::deserializeMap(ArrayRef<std::pair<unsigned, un
 // @param call : Call to process
 // @param shaderStage : Shader stage
 // @param requireDword : Whether need extend to dword
-// @param resUsage : The resource usage reference
 void InOutLocationInfoMapManager::addSpan(CallInst *call, ShaderStage shaderStage, bool requireDword) {
   const bool isFs = shaderStage == ShaderStageFragment;
   const bool isInterpolant = call->getCalledFunction()->getName().startswith(lgcName::InputImportInterpolant);
@@ -3572,14 +3620,10 @@ void InOutLocationInfoMapManager::addSpan(CallInst *call, ShaderStage shaderStag
 
   if (isFs && isInterpolant) {
     const unsigned interpMode = cast<ConstantInt>(call->getOperand(3))->getZExtValue();
-    span.compatibilityInfo.isFlat = interpMode == InOutInfo::InterpModeFlat;
-    span.compatibilityInfo.isCustom = interpMode == InOutInfo::InterpModeCustom;
-
-    assert(isInterpolant || (!isInterpolant && !is_contained(m_locationSpans, span)));
+    span.firstLocationInfo.setFlat(interpMode == InOutInfo::InterpModeFlat);
+    span.firstLocationInfo.setCustom(interpMode == InOutInfo::InterpModeCustom);
   }
-  if (!is_contained(m_locationSpans, span)) {
-    m_locationSpans.push_back(span);
-  }
+  m_locationSpans.insert(span);
 }
 
 // =====================================================================================================================
@@ -3587,21 +3631,16 @@ void InOutLocationInfoMapManager::addSpan(CallInst *call, ShaderStage shaderStag
 //
 // @param shaderStage : The shader stage to determine whether to check compatibility
 void InOutLocationInfoMapManager::buildMap(ShaderStage shaderStage) {
+  m_locationInfoMap.clear();
   if (m_locationSpans.empty())
     return;
-  // Sort m_locationSpans based on LocationSpan::GetCompatibilityKey() and InOutLocationInfo::AsIndex()
-  std::sort(m_locationSpans.begin(), m_locationSpans.end());
-
-  m_locationInfoMap.clear();
 
   // Map original InOutLocationInfo to new InOutLocationInfo
   unsigned consecutiveLocation = 0;
   unsigned compIdx = 0;
   bool isHighHalf = false;
   const bool isGs = shaderStage == ShaderStageGeometry;
-  // For GS, the locationSpans in the same stream is compatible.
-  // No need to check compatibility means all locationSpans are compatible.
-  const bool checkCompatibility = shaderStage == ShaderStageFragment || isGs;
+
   for (auto spanIt = m_locationSpans.begin(); spanIt != m_locationSpans.end(); ++spanIt) {
     if (spanIt != m_locationSpans.begin()) {
       // Check the current span with previous span to determine whether it is put in the same location or the next
@@ -3609,9 +3648,7 @@ void InOutLocationInfoMapManager::buildMap(ShaderStage shaderStage) {
       const auto &prevSpan = *(--spanIt);
       ++spanIt;
 
-      bool compatible = true;
-      if (checkCompatibility)
-        compatible = isCompatible(prevSpan, *spanIt, isGs);
+      bool compatible = isCompatible(prevSpan, *spanIt, shaderStage);
 
       // If the current locationSpan is compatible with previous one, increase component index with location unchanged
       // until the component index is up to 4 and increase location index and reset component index to 0. Otherwise,
@@ -3625,8 +3662,10 @@ void InOutLocationInfoMapManager::buildMap(ShaderStage shaderStage) {
           isHighHalf = spanIt->compatibilityInfo.is16Bit ? !isHighHalf : false;
         }
       } else {
+        ++consecutiveLocation;
         // NOTE: For GS, the indexing of remapped location is zero-based in each stream
-        consecutiveLocation = isGs ? 0 : consecutiveLocation + 1;
+        if (isGs && spanIt->firstLocationInfo.getStreamId() != prevSpan.firstLocationInfo.getStreamId())
+          consecutiveLocation = 0;
         compIdx = 0;
         isHighHalf = false;
       }
@@ -3641,7 +3680,7 @@ void InOutLocationInfoMapManager::buildMap(ShaderStage shaderStage) {
     m_locationInfoMap.insert({spanIt->firstLocationInfo, newLocInfo});
 
     // Update component index
-    if ((spanIt->compatibilityInfo.is16Bit && isHighHalf) || !spanIt->compatibilityInfo.is16Bit)
+    if (isHighHalf || !spanIt->compatibilityInfo.is16Bit)
       ++compIdx;
     assert(compIdx <= 4);
   }

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestInOutPacking.pipe
@@ -1,57 +1,68 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -enable-part-pipeline=0 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST_PP0 %s
-; SHADERTEST_PP0-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST_PP0-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP0: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP0: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST_PP0-LABEL: LLPC pipeline before-patching results
+; SHADERTEST_PP0-LABEL: LLPC location input/output mapping results (FS shader)
+; SHADERTEST_PP0: (FS) Input:  loc = 0, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 0, comp = 1 =>  Mapped = 0, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 1, comp = 0 =>  Mapped = 0, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 1, comp = 1 =>  Mapped = 0, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 0 =>  Mapped = 4, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 1 =>  Mapped = 4, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 2 =>  Mapped = 4, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 3 =>  Mapped = 4, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 0 =>  Mapped = 4, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 1 =>  Mapped = 4, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 2 =>  Mapped = 4, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 3 =>  Mapped = 4, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 2 =>  Mapped = 1, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 3 =>  Mapped = 1, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 5, comp = 0 =>  Mapped = 2, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 5, comp = 1 =>  Mapped = 2, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 6, comp = 0 =>  Mapped = 2, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 7, comp = 0 =>  Mapped = 5, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 7, comp = 1 =>  Mapped = 5, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 8, comp = 0 =>  Mapped = 5, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 8, comp = 1 =>  Mapped = 5, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 0 =>  Mapped = 5, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 1 =>  Mapped = 5, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 2 =>  Mapped = 5, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 3 =>  Mapped = 5, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 0 =>  Mapped = 3, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 1 =>  Mapped = 3, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 2 =>  Mapped = 3, 2
+; SHADERTEST_PP0-LABEL: LLPC location input/output mapping results (VS shader)
+; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 0  =>  Mapped = 0, 0
+; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 1  =>  Mapped = 0, 1
+; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 0  =>  Mapped = 0, 2
+; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 1  =>  Mapped = 0, 3
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 0  =>  Mapped = 4, 0
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 1  =>  Mapped = 4, 0
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 2  =>  Mapped = 4, 1
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 3  =>  Mapped = 4, 1
+; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 0  =>  Mapped = 4, 2
+; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 1  =>  Mapped = 4, 2
+; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 2  =>  Mapped = 4, 3
+; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 3  =>  Mapped = 4, 3
+; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 0  =>  Mapped = 1, 0
+; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 1  =>  Mapped = 1, 1
+; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 2  =>  Mapped = 1, 2
+; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 3  =>  Mapped = 1, 3
+; SHADERTEST_PP0: (VS) Output: loc = 5, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST_PP0: (VS) Output: loc = 5, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST_PP0: (VS) Output: loc = 6, comp = 0  =>  Mapped = 2, 2
+; SHADERTEST_PP0: (VS) Output: loc = 7, comp = 0  =>  Mapped = 5, 0
+; SHADERTEST_PP0: (VS) Output: loc = 7, comp = 1  =>  Mapped = 5, 0
+; SHADERTEST_PP0: (VS) Output: loc = 8, comp = 0  =>  Mapped = 5, 1
+; SHADERTEST_PP0: (VS) Output: loc = 8, comp = 1  =>  Mapped = 5, 1
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 0  =>  Mapped = 5, 2
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 1  =>  Mapped = 5, 2
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 2  =>  Mapped = 5, 3
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 3  =>  Mapped = 5, 3
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 0  =>  Mapped = 3, 0
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 1  =>  Mapped = 3, 1
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 2  =>  Mapped = 3, 2
 ; SHADERTEST_PP0: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -61,60 +72,71 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -enable-part-pipeline=1 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST_PP1 %s
 ; Fragment shader part-pipeline:
-; SHADERTEST_PP1-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST_PP1-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 4, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg false, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1.f16(float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call half @llvm.amdgcn.interp.p2.f16(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 1, i1 immarg true, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 3, i32 immarg 2, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 3, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 2, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 3, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 0, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p1(float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.p2(float %{{[0-9]*}}, float %{{[^,]*}}, i32 immarg 1, i32 immarg 0, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 0, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 1, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 0, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 1, i32 immarg 5, i32 %PrimMask)
-; SHADERTEST_PP1: call float @llvm.amdgcn.interp.mov(i32 immarg 2, i32 immarg 2, i32 immarg 5, i32 %PrimMask)
+; SHADERTEST_PP1-LABEL: LLPC pipeline before-patching results
+; SHADERTEST_PP1-LABEL: LLPC location input/output mapping results (FS shader)
+; SHADERTEST_PP1: (FS) Input:  loc = 0, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 0, comp = 1 =>  Mapped = 0, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 1, comp = 0 =>  Mapped = 0, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 1, comp = 1 =>  Mapped = 0, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 0 =>  Mapped = 4, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 1 =>  Mapped = 4, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 2 =>  Mapped = 4, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 3 =>  Mapped = 4, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 0 =>  Mapped = 4, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 1 =>  Mapped = 4, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 2 =>  Mapped = 4, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 3 =>  Mapped = 4, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 2 =>  Mapped = 1, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 3 =>  Mapped = 1, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 5, comp = 0 =>  Mapped = 2, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 5, comp = 1 =>  Mapped = 2, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 6, comp = 0 =>  Mapped = 2, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 7, comp = 0 =>  Mapped = 5, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 7, comp = 1 =>  Mapped = 5, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 8, comp = 0 =>  Mapped = 5, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 8, comp = 1 =>  Mapped = 5, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 0 =>  Mapped = 5, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 1 =>  Mapped = 5, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 2 =>  Mapped = 5, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 3 =>  Mapped = 5, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 0 =>  Mapped = 3, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 1 =>  Mapped = 3, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 2 =>  Mapped = 3, 2
 ; Pre-rasterization part-pipeline:
-; SHADERTEST_PP1-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}32, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}34, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}36, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}33, i32 {{.*}}15, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}35, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
-; SHADERTEST_PP1: call void @llvm.amdgcn.exp.f32(i32 {{.*}}37, i32 {{.*}}7, float {{.*}}, float {{.*}}, float {{.*}}, float undef, i1 {{.*}}false, i1 {{.*}}false)
+; SHADERTEST_PP1-LABEL: LLPC pipeline before-patching results
+; SHADERTEST_PP1-LABEL: LLPC location input/output mapping results (VS shader)
+; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 0  =>  Mapped = 0, 0
+; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 1  =>  Mapped = 0, 1
+; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 0  =>  Mapped = 0, 2
+; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 1  =>  Mapped = 0, 3
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 0  =>  Mapped = 4, 0
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 1  =>  Mapped = 4, 0
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 2  =>  Mapped = 4, 1
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 3  =>  Mapped = 4, 1
+; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 0  =>  Mapped = 4, 2
+; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 1  =>  Mapped = 4, 2
+; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 2  =>  Mapped = 4, 3
+; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 3  =>  Mapped = 4, 3
+; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 0  =>  Mapped = 1, 0
+; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 1  =>  Mapped = 1, 1
+; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 2  =>  Mapped = 1, 2
+; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 3  =>  Mapped = 1, 3
+; SHADERTEST_PP1: (VS) Output: loc = 5, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST_PP1: (VS) Output: loc = 5, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST_PP1: (VS) Output: loc = 6, comp = 0  =>  Mapped = 2, 2
+; SHADERTEST_PP1: (VS) Output: loc = 7, comp = 0  =>  Mapped = 5, 0
+; SHADERTEST_PP1: (VS) Output: loc = 7, comp = 1  =>  Mapped = 5, 0
+; SHADERTEST_PP1: (VS) Output: loc = 8, comp = 0  =>  Mapped = 5, 1
+; SHADERTEST_PP1: (VS) Output: loc = 8, comp = 1  =>  Mapped = 5, 1
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 0  =>  Mapped = 5, 2
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 1  =>  Mapped = 5, 2
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 2  =>  Mapped = 5, 3
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 3  =>  Mapped = 5, 3
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 0  =>  Mapped = 3, 0
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 1  =>  Mapped = 3, 1
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 2  =>  Mapped = 3, 2
 ; SHADERTEST_PP1: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/general/PipelineVsGsFs_TestDwordPacking.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsGsFs_TestDwordPacking.pipe
@@ -1,17 +1,39 @@
 ; Test that GS outputs get extended from 16-bit to 32-bit during in/out packing.
+; Test that unused GS outputs are removed without corresponding item in the mapping table
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -enable-part-pipeline=0 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; RUN: amdllpc -enable-part-pipeline=1 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: LLPC location input/output mapping results (FS shader)
+; SHADERTEST: (FS) Input:  loc = 1, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST: (FS) Input:  loc = 1, comp = 1 =>  Mapped = 0, 1
+; SHADERTEST: (FS) Input:  loc = 1, comp = 2 =>  Mapped = 0, 2
+; SHADERTEST: (FS) Input:  loc = 1, comp = 3 =>  Mapped = 0, 3
+; SHADERTEST: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
+; SHADERTEST: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
+; SHADERTEST: (FS) Input:  loc = 2, comp = 0 =>  Mapped = 2, 0
+; SHADERTEST: (FS) Input:  loc = 2, comp = 1 =>  Mapped = 2, 1
+; SHADERTEST: (FS) Input:  loc = 2, comp = 2 =>  Mapped = 2, 2
+; SHADERTEST: (FS) Input:  loc = 2, comp = 3 =>  Mapped = 2, 3
+; SHADERTEST-LABEL: LLPC location count results (after builtin-to-generic mapping)
+; SHADERTEST: (FS) Input:  loc count = 3
+; SHADERTEST: (FS) Output: loc count = 2
 ; SHADERTEST-LABEL: LLPC location input/output mapping results (GS shader)
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 0  =>  Mapped = 0, 0
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 1  =>  Mapped = 0, 1
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 2  =>  Mapped = 0, 2
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 3  =>  Mapped = 0, 3
-; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 0  =>  Mapped = 1, 0
-; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 1  =>  Mapped = 1, 1
-; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 2  =>  Mapped = 1, 2
-; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 3  =>  Mapped = 1, 3
+; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 2  =>  Mapped = 2, 2
+; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 3  =>  Mapped = 2, 3
+; SHADERTEST: (GS) Output: stream = 0,  loc = 4, comp = 0  =>  Mapped = 1, 0
+; SHADERTEST: (GS) Output: stream = 0,  loc = 4, comp = 1  =>  Mapped = 1, 1
+; SHADERTEST: (GS) Output: stream = 0,  loc = 5, comp = 0  =>  Mapped = 1, 2
+; SHADERTEST: (GS) Output: stream = 0,  loc = 5, comp = 1  =>  Mapped = 1, 3
+; SHADERTEST-LABEL: LLPC location count results (after input/output matching)
+; SHADERTEST: (GS) Input:  loc count = 2
+; SHADERTEST: (GS) Output: loc count = 3
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -42,25 +64,27 @@ entryPoint = main
 #version 450
 #extension GL_AMD_gpu_shader_int16 : require
 layout(triangles) in;
-layout(max_vertices = 3, triangle_strip) out;
+layout(max_vertices = 3, triangle_strip, stream=0) out;
 
-layout(location = 1) out vec4 outp1;
 layout(location = 1) in vec4 inp1[3];
 layout(location = 2) in u16vec4 inp2[3];
+layout(location = 1) out vec4 outp1;
 layout(location = 2) out u16vec4 outp2;
+layout(location = 3) out vec2 outp3;
+layout(location = 4) out vec2 outp4;
+layout(location = 5, xfb_buffer = 0, xfb_offset = 0) out vec2 outp5;
 
 void main()
 {
-    outp2 = inp2[0];
-    gl_Position = gl_in[0].gl_Position;
-    outp1 = inp1[0];
-    EmitVertex();
-    gl_Position = gl_in[1].gl_Position;
-    outp1 = inp1[1];
-    EmitVertex();
-    gl_Position = gl_in[2].gl_Position;
-    outp1 = inp1[2];
-    EmitVertex();
+    for (int i = 0; i < gl_in.length(); ++i)
+    {
+        outp1 = inp1[i];
+        outp2 = inp2[i];
+        outp4 = inp1[i].xy + inp2[i].xy;
+        outp5 = inp1[i].zw + inp2[i].zw;
+        gl_Position = gl_in[i].gl_Position;
+        EmitVertex();
+    }
     EndPrimitive();
 }
 
@@ -72,10 +96,12 @@ entryPoint = main
 #version 450
 #extension GL_AMD_gpu_shader_int16 : require
 
-layout(location = 0) out vec4 outp0;
 layout(location = 1) in vec4 inp1;
 layout(location = 2) flat in u16vec4 inp2;
+layout(location = 4) in vec2 inp4;
+layout(location = 0) out vec4 outp0;
 layout(location = 1) out u16vec4 outp1;
+
 
 vec4 _91(vec4 _101)
 {
@@ -84,7 +110,7 @@ vec4 _91(vec4 _101)
 
 void main()
 {
-    outp0 = inp1;
+    outp0 = inp1 + vec4(inp4, 0, 1.0);
     outp1 = inp2;
 }
 


### PR DESCRIPTION
Current logic of GS output packing is that building the output location map is based on all GS outputs, and then replacing the mapping results of outputs except XFB outputs with FS input mapping result in raster stream.
There are two issues in the GS-FS packing logic.
1. Unused GS outputs (without corresponding inputs in FS) are not removed from the location map. It will cause mismatch between GS outputs and FS inputs.
2. It doesn't work well for the case that some outputs are used for FS interpolation and some XFB outputs are not used by FS. See the below exemaple,
```
[GsGlsl]
layout(triangles) in;
layout(max_vertices = 3, triangle_strip, stream=0) out;

layout(location = 1) in vec4 inp1[3];
layout(location = 2) in u16vec4 inp2[3];
layout(location = 1) out vec4 outp1;
layout(location = 2) out u16vec4 outp2;
layout(location = 3) out vec2 outp3;
layout(location = 4) out vec2 outp4;
layout(location = 5, xfb_buffer = 0, xfb_offset = 0) out vec2 outp5;

void main()
{
    for (int i = 0; i < gl_in.length(); ++i)
    {
        outp1 = inp1[i];
	outp2 = inp2[i];
	outp4 = inp1[i].xy + inp2[i].xy;
        outp5 = inp1[i].zw + inp2[i].zw;
        gl_Position = gl_in[i].gl_Position;
	EmitVertex();
    }
    EndPrimitive();
    }
}

[FsGlsl]

layout(location = 1) in vec4 inp1;
layout(location = 2) flat in u16vec4 inp2;
layout(location = 4) in vec2 inp4;
layout(location = 0) out vec4 outp0;
layout(location = 1) out u16vec4 outp1;

void main()
{
    outp0 = inp1 + vec4(inp4, 0, 1.0);
    outp1 = inp2;
}
```
The FS input mapping results (Use location, component and interp mode for packing)
```
Input:  loc = 1, comp = 0 =>  Mapped = 0, 0
Input:  loc = 1, comp = 1 =>  Mapped = 0, 1
Input:  loc = 1, comp = 2 =>  Mapped = 0, 2
Input:  loc = 1, comp = 3 =>  Mapped = 0, 3
Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
Input:  loc = 2, comp = 0 =>  Mapped = 2, 0
Input:  loc = 2, comp = 1 =>  Mapped = 2, 1
Input:  loc = 2, comp = 2 =>  Mapped = 2, 2
Input:  loc = 2, comp = 3 =>  Mapped = 2, 3
```
The GS output mapping results (Use locations and components for packing)
```
Output: stream = 0,  loc = 1, comp = 0  =>  Mapped = 0, 0
Output: stream = 0,  loc = 1, comp = 1  =>  Mapped = 0, 1
Output: stream = 0,  loc = 1, comp = 2  =>  Mapped = 0, 2
Output: stream = 0,  loc = 1, comp = 3  =>  Mapped = 0, 3
Output: stream = 0,  loc = 2, comp = 0  =>  Mapped = 1, 0
Output: stream = 0,  loc = 2, comp = 1  =>  Mapped = 1, 1
Output: stream = 0,  loc = 2, comp = 2  =>  Mapped = 1, 2
Output: stream = 0,  loc = 2, comp = 3  =>  Mapped = 1, 3
Output: stream = 0,  loc = 4, comp = 0  =>  Mapped = 2, 0
Output: stream = 0,  loc = 4, comp = 1  =>  Mapped = 2, 1
Output: stream = 0,  loc = 5, comp = 0  =>  Mapped = 2, 2
Output: stream = 0,  loc = 5, comp = 1  =>  Mapped = 2, 3
```
After replacing, the GS output mapping is a mess.
```
Output: stream = 0,  loc = 1, comp = 0  =>  Mapped = 0, 0
Output: stream = 0,  loc = 1, comp = 1  =>  Mapped = 0, 1
Output: stream = 0,  loc = 1, comp = 2  =>  Mapped = 0, 2
Output: stream = 0,  loc = 1, comp = 3  =>  Mapped = 0, 3
Output: stream = 0,  loc = 2, comp = 0  =>  Mapped = 2, 0
Output: stream = 0,  loc = 2, comp = 1  =>  Mapped = 2, 1
Output: stream = 0,  loc = 2, comp = 2  =>  Mapped = 2, 2
Output: stream = 0,  loc = 2, comp = 3  =>  Mapped = 2, 3
Output: stream = 0,  loc = 4, comp = 0  =>  Mapped = 1, 0
Output: stream = 0,  loc = 4, comp = 1  =>  Mapped = 1, 1
Output: stream = 0,  loc = 5, comp = 0  =>  Mapped = 2, 2
Output: stream = 0,  loc = 5, comp = 1  =>  Mapped = 2, 3
```
To solve the issues, we have to consider the interpolation info to build GS output map. Therefore, we have to move the flags `isFalt` and `isCustom` from `InOutCompatibilityInfo` to `InOutLocationInfo`. In GS, it can retrive interpolation info from FS input map. On one hand, it can guarantee the GS output map matches the FS input map. On the other hand, it can work well for part-pipeline case.
The related lit tests are updated to cover the cases.