### PR TITLE
Fix a coding issue of PatchBufferOp::postVisitMemSetInst

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1215,7 +1215,7 @@ void PatchBufferOp::postVisitMemSetInst(MemSetInst &memSetInst) {
     if (stride == 16)
       castDestType = FixedVectorType::get(Type::getInt32Ty(*m_context), 4);
     else {
-      assert(stride < 8);
+      assert(stride <= 8);
       castDestType = m_builder->getIntNTy(stride * 8);
     }
 


### PR DESCRIPTION
A follow-up change of https://github.com/GPUOpen-Drivers/llpc/pull/2117.