### PR TITLE
Add a new helper isGfx(major, minor) to GfxIpVersion

### DIFF
--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -48,6 +48,9 @@ struct GfxIpVersion {
   bool operator>=(const GfxIpVersion &rhs) const {
     return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
   }
+  bool isGfx(unsigned rhsMajor, unsigned rhsMinor) const {
+    return std::tie(major, minor) == std::tie(rhsMajor, rhsMinor);
+  }
 };
 
 // Represents the properties of GPU device.

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1621,7 +1621,7 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
 
   unsigned numInterp = resUsage->inOutUsage.fs.interpInfo.size() - numPrimInterp;
   SET_REG_FIELD(&config->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, numInterp);
-  if (gfxIp == GfxIpVersion{10, 3})
+  if (gfxIp.isGfx(10, 3))
     SET_REG_GFX10_3_PLUS_EXCLUSIVE_FIELD(&config->psRegs, SPI_PS_IN_CONTROL, NUM_PRIM_INTERP, numPrimInterp);
 
   if (pointCoordLoc != InvalidValue) {

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -2667,7 +2667,7 @@ Value *MeshTaskShader::readMeshBuiltInFromLds(BuiltInKind builtIn) {
 // @returns : HW-specific shading rate
 Value *MeshTaskShader::convertToHwShadingRate(Value *primitiveShadingRate) {
 
-  assert(m_gfxIp == GfxIpVersion({10, 3})); // Must be GFX10.3
+  assert(m_gfxIp.isGfx(10, 3)); // Must be GFX10.3
 
   // NOTE: The shading rates have different meanings in HW and LGC interface. GFX10.3 HW supports 2-pixel mode
   // and 4-pixel mode is not supported. But the spec requires us to accept unsupported rates and clamp them to

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -694,7 +694,7 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
         gsPrimsPerSubgroup = nggControl->primsPerSubgroup;
         break;
       case NggSubgroupSizing::Auto:
-        if (m_pipelineState->getTargetInfo().getGfxIpVersion() == GfxIpVersion{10, 1}) {
+        if (m_pipelineState->getTargetInfo().getGfxIpVersion().isGfx(10, 1)) {
           esVertsPerSubgroup = Gfx9::NggMaxThreadsPerSubgroup / 2 - 2;
           gsPrimsPerSubgroup = Gfx9::NggMaxThreadsPerSubgroup / 2;
         } else {
@@ -741,9 +741,9 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
           esVertsPerSubgroup = std::min(esVertsPerSubgroup, OptimalVerticesPerPrimitiveForTess * gsPrimsPerSubgroup);
 
         // Low values of esVertsPerSubgroup are illegal. These numbers below come from HW restrictions.
-        if (gfxIp == GfxIpVersion{10, 3})
+        if (gfxIp.isGfx(10, 3))
           esVertsPerSubgroup = std::max(29u, esVertsPerSubgroup);
-        else if (gfxIp == GfxIpVersion{10, 1})
+        else if (gfxIp.isGfx(10, 1))
           esVertsPerSubgroup = std::max(24u, esVertsPerSubgroup);
       } else {
         // If GS is not present, instance count must be 1
@@ -822,9 +822,9 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
                                               Gfx9::NggMaxThreadsPerSubgroup));
 
         // Low values of esVertsPerSubgroup are illegal. These numbers below come from HW restrictions.
-        if (gfxIp == GfxIpVersion{10, 3})
+        if (gfxIp.isGfx(10, 3))
           esVertsPerSubgroup = std::max(29u, esVertsPerSubgroup);
-        else if (gfxIp == GfxIpVersion{10, 1})
+        else if (gfxIp.isGfx(10, 1))
           esVertsPerSubgroup = std::max(24u, esVertsPerSubgroup);
 
 #if VKI_RAY_TRACING


### PR DESCRIPTION
The original checker operator== will try to do a full comparison with (major,minor,stepping). Actually, we often would like to do fuzzy matching of (major,minor). The variants of a certain pair (major,minor) are viewed as the same GPU generation by compiler most of the time.