### PR TITLE
Fixes for upstream llvm changes to function memory attributes

### DIFF
--- a/lgc/builder/BuilderBase.cpp
+++ b/lgc/builder/BuilderBase.cpp
@@ -61,8 +61,22 @@ CallInst *BuilderCommon::CreateNamedCall(StringRef funcName, Type *retTy, ArrayR
     func->setCallingConv(CallingConv::C);
     func->addFnAttr(Attribute::NoUnwind);
 
-    for (auto attrib : attribs)
-      func->addFnAttr(attrib);
+    for (auto attrib : attribs) {
+      switch (attrib) {
+      default:
+        func->addFnAttr(attrib);
+        break;
+      case Attribute::ReadNone:
+        func->setDoesNotAccessMemory();
+        break;
+      case Attribute::ReadOnly:
+        func->setOnlyReadsMemory();
+        break;
+      case Attribute::WriteOnly:
+        func->setOnlyWritesMemory();
+        break;
+      }
+    }
   }
 
   auto call = CreateCall(func, args, instName);

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -2151,7 +2151,7 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::SubgroupBallotFindMsb:
     case Opcode::SubgroupBallotInclusiveBitCount:
       // Functions that don't access memory.
-      func->addFnAttr(Attribute::ReadNone);
+      func->setDoesNotAccessMemory();
       break;
     case Opcode::ImageGather:
     case Opcode::ImageLoad:
@@ -2168,13 +2168,13 @@ Instruction *BuilderRecorder::record(BuilderRecorder::Opcode opcode, Type *resul
     case Opcode::ReadPerVertexInput:
     case Opcode::ReadTaskPayload:
       // Functions that only read memory.
-      func->addFnAttr(Attribute::ReadOnly);
+      func->setOnlyReadsMemory();
       // Must be marked as returning for DCE.
       func->addFnAttr(Attribute::WillReturn);
       break;
     case Opcode::ImageStore:
       // Functions that only write memory.
-      func->addFnAttr(Attribute::WriteOnly);
+      func->setOnlyWritesMemory();
       break;
     case Opcode::ImageAtomic:
     case Opcode::ImageAtomicCompareSwap:

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -160,7 +160,7 @@ Instruction *MiscBuilder::CreateReadClock(bool realtime, const Twine &instName) 
   readClock->addAttribute(AttributeList::FunctionIndex, Attribute::ReadOnly);
 #else
   // New version of the code (also handles unknown version, which we treat as latest)
-  readClock->addFnAttr(Attribute::ReadOnly);
+  readClock->setOnlyReadsMemory();
 #endif
 
   // NOTE: The inline ASM is to prevent optimization of backend compiler.

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -4055,7 +4055,7 @@ Function *NggPrimShader::createBackfaceCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingBackface, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -4282,7 +4282,7 @@ Function *NggPrimShader::createFrustumCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingFrustum, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -4538,7 +4538,7 @@ Function *NggPrimShader::createBoxFilterCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingBoxFilter, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -4761,7 +4761,7 @@ Function *NggPrimShader::createSphereCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingSphere, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -5126,7 +5126,7 @@ Function *NggPrimShader::createSmallPrimFilterCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingSmallPrimFilter, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -5402,7 +5402,7 @@ Function *NggPrimShader::createCullDistanceCuller(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingCullDistance, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();
@@ -5480,7 +5480,7 @@ Function *NggPrimShader::createFetchCullingRegister(Module *module) {
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::NggCullingFetchReg, module);
 
   func->setCallingConv(CallingConv::C);
-  func->addFnAttr(Attribute::ReadOnly);
+  func->setOnlyReadsMemory();
   func->addFnAttr(Attribute::AlwaysInline);
 
   auto argIt = func->arg_begin();

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -5470,7 +5470,7 @@ void PatchInOutImportExport::createSwizzleThreadGroupFunction() {
   func->setCallingConv(CallingConv::C);
   func->addFnAttr(Attribute::NoUnwind);
   func->addFnAttr(Attribute::AlwaysInline);
-  func->addFnAttr(Attribute::ReadNone);
+  func->setDoesNotAccessMemory();
   func->setLinkage(GlobalValue::InternalLinkage);
 
   auto argIt = func->arg_begin();

--- a/lgc/test/CsComputeLibrary.lgc
+++ b/lgc/test/CsComputeLibrary.lgc
@@ -8,7 +8,7 @@
 ; CHECK: define amdgpu_gfx void @func(i32 inreg %globalTable, i32 inreg %perShaderTable, <3 x i32> addrspace(4)* inreg %numWorkgroupsPtr, i32 inreg %descTable2, i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %3, i32 inreg %4, i32 inreg %5, i32 inreg %6, i32 inreg %7, i32 inreg %8, i32 inreg %9, i32 inreg %spillTable, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId) #0 !lgc.shaderstage !7 {
 
 ; CHECK: IR Dump After Patch LLVM to set up target features
-; CHECK: attributes #0 = { nounwind "amdgpu-flat-work-group-size"="6,6"
+; CHECK: attributes #0 = { nounwind {{.*}}"amdgpu-flat-work-group-size"="6,6"
 
 ; ModuleID = 'lgcPipeline'
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"

--- a/lgc/test/InOutPackingNonZeroBase.lgc
+++ b/lgc/test/InOutPackingNonZeroBase.lgc
@@ -65,7 +65,7 @@ define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !spi
   ret void
 }
 
-; Function Attrs: nounwind readonly willreturn
+; Function Attrs: nounwind {{readonly willreturn|willreturn memory\(read\)}}
 declare <3 x float> @lgc.create.read.generic.input.v3f32(...) local_unnamed_addr #1
 
 ; Function Attrs: nounwind
@@ -101,11 +101,11 @@ define dllexport spir_func void @lgc.shader.FS.main() local_unnamed_addr #0 !spi
   ret void
 }
 
-; Function Attrs: nounwind readonly willreturn
+; Function Attrs: nounwind {{readonly willreturn|willreturn memory\(read\)}}
 declare float @lgc.create.read.generic.input.f32(...) local_unnamed_addr #1
 
 attributes #0 = { nounwind }
-attributes #1 = { nounwind readonly willreturn }
+attributes #1 = { nounwind willreturn }
 
 !lgc.client = !{!0}
 !lgc.options = !{!1}


### PR DESCRIPTION
Upstream LLVM commit 304f1d59ca41 "[IR] Switch everything to use memory attribute" changed readnone, readonly and writeonly from function attributes into parameter attributes.