### PR TITLE
Replace with using stride offset to load descriptor

### DIFF
--- a/llpc/test/shaderdb/core/OpFunctionCall_TestArguTexArray_lit.frag
+++ b/llpc/test/shaderdb/core/OpFunctionCall_TestArguTexArray_lit.frag
@@ -27,7 +27,7 @@ void main()
 ; RUN: amdllpc -enable-opaque-pointers=true -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-COUNT-2: call {{.*}} <4 x float> @{{.*}}
-; SHADERTEST: define internal {{.*}} <4 x float> @{{.*}}({ { {{<8 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32 }, { {{<4 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32 } } %{{[a-zA-Z0-9]+}}, {{<2 x float> addrspace\(5\)\*|ptr addrspace\(5\)}} %{{[a-z0-9]+}})
+; SHADERTEST: define internal {{.*}} <4 x float> @{{.*}}({ { {{<8 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32, i32 }, { {{<4 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32 } } %{{[a-zA-Z0-9]+}}, {{<2 x float> addrspace\(5\)\*|ptr addrspace\(5\)}} %{{[a-z0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpFunctionCall_TestParamSimpleTex_lit.frag
+++ b/llpc/test/shaderdb/core/OpFunctionCall_TestParamSimpleTex_lit.frag
@@ -21,7 +21,7 @@ void main()
 ; RUN: amdllpc -enable-opaque-pointers=true -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-COUNT-2: call {{.*}} <4 x float> @{{.*}}
-; SHADERTEST: define internal {{.*}}<4 x float> @{{.*}}({ { {{<8 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32 }, { {{<4 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32 } } %{{[a-zA-Z0-9]+}}, {{<2 x float> addrspace\(5\)\*|ptr addrspace\(5\)}} %{{[a-z0-9]+}})
+; SHADERTEST: define internal {{.*}}<4 x float> @{{.*}}({ { {{<8 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32, i32 }, { {{<4 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32 } } %{{[a-zA-Z0-9]+}}, {{<2 x float> addrspace\(5\)\*|ptr addrspace\(5\)}} %{{[a-z0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpFunctionCall_TestParamTexArray_lit.frag
+++ b/llpc/test/shaderdb/core/OpFunctionCall_TestParamTexArray_lit.frag
@@ -27,7 +27,7 @@ void main()
 ; RUN: amdllpc -enable-opaque-pointers=true -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-COUNT-2: call {{.*}} <4 x float> @{{.*}}
-; SHADERTEST: define internal {{.*}}<4 x float> @{{.*}}({ { ptr addrspace(4), i32 }, { ptr addrspace(4), i32, i32 } } %{{[a-zA-Z0-9]+}}, ptr addrspace(5) %{{[a-z0-9]+}})
+; SHADERTEST: define internal {{.*}}<4 x float> @{{.*}}({ { {{<8 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32, i32 }, { {{<4 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32 } } %{{[a-zA-Z0-9]+}}, {{<2 x float> addrspace\(5\)\*|ptr addrspace\(5\)}} %{{[a-z0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpFunctionCall_TestParamTexNestedCall_lit.frag
+++ b/llpc/test/shaderdb/core/OpFunctionCall_TestParamTexNestedCall_lit.frag
@@ -32,7 +32,7 @@ void main()
 ; RUN: amdllpc -enable-opaque-pointers=true -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-COUNT-2: call {{.*}} <4 x float> @{{.*}}
-; SHADERTEST: define internal {{.*}}<4 x float> @{{.*}}({ { ptr addrspace(4), i32 }, { ptr addrspace(4), i32, i32 } } %{{[a-zA-Z0-9]+}}, ptr addrspace(5) %{{[a-z0-9]+}})
+; SHADERTEST: define internal {{.*}}<4 x float> @{{.*}}({ { {{<8 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32, i32 }, { {{<4 x i32> addrspace\(4\)\*|ptr addrspace\(4\)}}, i32, i32 } } %{{[a-zA-Z0-9]+}}, {{<2 x float> addrspace\(5\)\*|ptr addrspace\(5\)}} %{{[a-z0-9]+}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
In order to accordance with combined image sampler type in spec, replace
with single descriptor stride offset of per-plane SRD to address a image
desripotr rather than a fixed image descriptor size.