### PR TITLE
Remove support for building against older LLVMs

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -480,13 +480,7 @@ Value *DescBuilder::CreatePtrDiff(llvm::Type *ty, llvm::Value *lhs, llvm::Value 
   Type *const rhsType = rhs->getType();
   if (!lhsType->isPointerTy() || lhsType->getPointerAddressSpace() != ADDR_SPACE_BUFFER_FAT_POINTER ||
       !rhsType->isPointerTy() || rhsType->getPointerAddressSpace() != ADDR_SPACE_BUFFER_FAT_POINTER)
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 412285
-    // Old version of the code
-    return IRBuilderBase::CreatePtrDiff(lhs, rhs, instName);
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
     return IRBuilderBase::CreatePtrDiff(ty, lhs, rhs, instName);
-#endif
 
   // Add a dummy value of the pointer element type so we can later determine its size
   Value *dummyValue = Constant::getNullValue(ty);

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -155,13 +155,7 @@ Instruction *MiscBuilder::CreateReadClock(bool realtime, const Twine &instName) 
     readClock = CreateIntrinsic(Intrinsic::amdgcn_s_memrealtime, {}, {}, nullptr, instName);
   } else
     readClock = CreateIntrinsic(Intrinsic::readcyclecounter, {}, {}, nullptr, instName);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-  // Old version of the code
-  readClock->addAttribute(AttributeList::FunctionIndex, Attribute::ReadOnly);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   readClock->setOnlyReadsMemory();
-#endif
 
   // NOTE: The inline ASM is to prevent optimization of backend compiler.
   InlineAsm *asmFunc = InlineAsm::get(FunctionType::get(getInt64Ty(), {getInt64Ty()}, false), "; %1", "=r,0", true);

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -4217,13 +4217,8 @@ Function *NggPrimShader::createBackfaceCuller(Module *module) {
 
     // threshold = (10 ^ (-backfaceExponent)) / |w0 * w1 * w2|
     auto threshold = m_builder->CreateNeg(backfaceExponent);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 391319
-    threshold = m_builder->CreateIntrinsic(Intrinsic::powi, m_builder->getFloatTy(),
-                                           {ConstantFP::get(m_builder->getFloatTy(), 10.0), threshold});
-#else
     threshold = m_builder->CreateIntrinsic(Intrinsic::powi, {m_builder->getFloatTy(), threshold->getType()},
                                            {ConstantFP::get(m_builder->getFloatTy(), 10.0), threshold});
-#endif
 
     auto rcpAbsW0W1W2 = m_builder->CreateFDiv(ConstantFP::get(m_builder->getFloatTy(), 1.0), absW0W1W2);
     threshold = m_builder->CreateFMul(threshold, rcpAbsW0W1W2);

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -470,11 +470,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
   fpm.addPass(ReassociatePass());
   LoopPassManager lpm;
   lpm.addPass(LoopRotatePass());
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 418547
-  lpm.addPass(LICMPass());
-#else
   lpm.addPass(LICMPass(LICMOptions()));
-#endif
   fpm.addPass(createFunctionToLoopPassAdaptor(std::move(lpm), true));
   fpm.addPass(SimplifyCFGPass());
   fpm.addPass(InstCombinePass(1));

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -844,13 +844,7 @@ void PatchEntryPointMutate::processCalls(Function &func, SmallVectorImpl<Type *>
 // =====================================================================================================================
 // Set Attributes on new function
 void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 409358
-  // Old version of the code
-  AttrBuilder builder;
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
   AttrBuilder builder(entryPoint->getContext());
-#endif
   if (m_shaderStage == ShaderStageFragment) {
     auto &builtInUsage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->builtInUsage.fs;
     SpiPsInputAddr spiPsInputAddr = {};
@@ -940,15 +934,7 @@ void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
   builder.addAttribute("amdgpu-memory-bound", shaderOptions->favorLatencyHiding ? "true" : "false");
   builder.addAttribute("amdgpu-wave-limiter", "false");
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396807
-  // Old version of the code
-  AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);
-  entryPoint->addAttributes(attribIdx, builder);
-#else
-  // New version of the code (also handles unknown version, which we treat as
-  // latest)
   entryPoint->addFnAttrs(builder);
-#endif
 
   // NOTE: Remove "readnone" attribute for entry-point. If GS is empty, this attribute will allow
   // LLVM optimization to remove sendmsg(GS_DONE). It is unexpected.

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -126,13 +126,7 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       continue;
 
     std::string targetFeatures(globalFeatures);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 409358
-    // Old version of the code
-    AttrBuilder builder;
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
     AttrBuilder builder(module->getContext());
-#endif
 
     ShaderStage shaderStage = lgc::getShaderStage(&*func);
 
@@ -195,14 +189,9 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
       targetFeatures += ",+cumode";
     }
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 414671
-    // Old version of the code
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
     // Enable flat scratch for gfx10.3+
     if (gfxIp.major == 10 && gfxIp.minor >= 3)
       targetFeatures += ",+enable-flat-scratch";
-#endif
 
     if (m_pipelineState->getTargetInfo().getGpuProperty().supportsXnack) {
       // Enable or disable xnack depending on whether page migration is enabled.
@@ -238,15 +227,7 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
 
     builder.addAttribute("target-features", targetFeatures);
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396807
-    // Old version of the code
-    AttributeList::AttrIndex attribIdx = AttributeList::AttrIndex(AttributeList::FunctionIndex);
-    func->addAttributes(attribIdx, builder);
-#else
-    // New version of the code (also handles unknown version, which we treat as
-    // latest)
     func->addFnAttrs(builder);
-#endif
   }
 }
 

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -42,15 +42,9 @@
 #include "llvm/CodeGen/CommandFlags.h"
 #include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/InitializePasses.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/CommandLine.h"
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 401324
-// Old version
-#include "llvm/Support/TargetRegistry.h"
-#else
-// New version (and unknown version)
-#include "llvm/MC/TargetRegistry.h"
-#endif
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"

--- a/lgc/state/ShaderStage.cpp
+++ b/lgc/state/ShaderStage.cpp
@@ -166,13 +166,7 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
   if (append) {
     // Old arguments first.
     for (unsigned idx = 0; idx != oldFuncTy->getNumParams(); ++idx)
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-      // Old version of the code
-      argAttrs.push_back(oldAttrList.getParamAttributes(idx));
-#else
-      // New version of the code (also handles unknown version, which we treat as latest)
       argAttrs.push_back(oldAttrList.getParamAttrs(idx));
-#endif
   }
 
   // New arguments.
@@ -183,21 +177,11 @@ Function *lgc::addFunctionArgs(Function *oldFunc, Type *retTy, ArrayRef<Type *> 
   if (!append) {
     // Old arguments.
     for (unsigned idx = 0; idx != argTys.size(); ++idx)
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-      // Old version of the code
-      argAttrs.push_back(oldAttrList.getParamAttributes(idx));
-  }
-  // Construct new AttributeList and set it on the new function.
-  newFunc->setAttributes(AttributeList::get(oldFunc->getContext(), oldAttrList.getFnAttributes(),
-                                            oldAttrList.getRetAttributes(), argAttrs));
-#else
-      // New version of the code (also handles unknown version, which we treat as latest)
       argAttrs.push_back(oldAttrList.getParamAttrs(idx));
   }
   // Construct new AttributeList and set it on the new function.
   newFunc->setAttributes(
       AttributeList::get(oldFunc->getContext(), oldAttrList.getFnAttrs(), oldAttrList.getRetAttrs(), argAttrs));
-#endif
 
   // Set the shader stage on the new function (implemented with IR metadata).
   setShaderStage(newFunc, getShaderStage(oldFunc));

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -240,13 +240,7 @@ std::condition_variable_any Compiler::m_helperThreadConditionVariable;
 // @param userData : An argument which will be passed to the installed error handler
 // @param reason : Error reason
 // @param genCrashDiag : Whether diagnostic should be generated
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 400826
-// Old version of the code
-static void fatalErrorHandler(void *userData, const std::string &reason, bool genCrashDiag) {
-#else
-// New version of the code (also handles unknown version, which we treat as latest)
 static void fatalErrorHandler(void *userData, const char *reason, bool genCrashDiag) {
-#endif
   LLPC_ERRS("LLVM FATAL ERROR: " << reason << "\n");
 #if LLPC_ENABLE_EXCEPTION
   throw("LLVM fatal error");
@@ -2389,10 +2383,6 @@ Result Compiler::buildRayTracingPipelineInternal(Context *context, ArrayRef<cons
 
   bool hasError = false;
   context->setDiagnosticHandler(std::make_unique<LlpcDiagnosticHandler>(&hasError));
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 381316
-  // Old version of the code
-  context->setInlineAsmDiagnosticHandler(InlineAsmDiagHandler, &hasError);
-#endif
 
   // Set up middle-end objects.
   LgcContext *builderContext = context->getLgcContext();

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -220,11 +220,7 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 
   // Remove redundant load/store operations and do minimal optimization
   // It is required by SpirvLowerImageOp.
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 404149
-  passMgr.addPass(createModuleToFunctionPassAdaptor(SROA()));
-#else
   passMgr.addPass(createModuleToFunctionPassAdaptor(SROAPass()));
-#endif
   passMgr.addPass(GlobalOptPass());
   passMgr.addPass(createModuleToFunctionPassAdaptor(ADCEPass()));
   passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(2)));

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -1540,33 +1540,16 @@ void SpirvLowerRayQuery::createIntersectBvh(Function *func) {
   Value *origin = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), argIt);
   argIt++;
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 406441
-  // Construct vec3 = {0.0, 1.0, 0.0}
-  auto zero = ConstantFP::get(m_builder->getFloatTy(), 0.0f);
-  auto one = ConstantFP::get(m_builder->getFloatTy(), 1.0f);
-  Value *constVec = ConstantVector::get({zero, one, zero});
-
-  // vec4 origin = vec4(origin.xyz, 1.0);
-  origin = m_builder->CreateShuffleVector(origin, constVec, ArrayRef<int>{0, 1, 2, 4});
-#endif
   // Ray dir vec3 type
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), FixedVectorType::get(m_builder->getFloatTy(), 3)));
   Value *dir = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), argIt);
   argIt++;
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 406441
-  // vec4 dir = vec4(dir.xyz, 0.0)
-  dir = m_builder->CreateShuffleVector(dir, constVec, ArrayRef<int>{0, 1, 2, 3});
-#endif
   // Ray inv_dir vec3 type
   // TODO: Remove this when LLPC will switch fully to opaque pointers.
   assert(IS_OPAQUE_OR_POINTEE_TYPE_MATCHES(argIt->getType(), FixedVectorType::get(m_builder->getFloatTy(), 3)));
   Value *invDir = m_builder->CreateLoad(FixedVectorType::get(m_builder->getFloatTy(), 3), argIt);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 406441
-  // vec4 inDir = vec4(invDir, 0.0)
-  invDir = m_builder->CreateShuffleVector(invDir, constVec, ArrayRef<int>{0, 1, 2, 3});
-#endif
   argIt++;
 
   // uint flag

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -176,15 +176,8 @@ void SpirvLowerTranslator::translateSpirvToLlvm(const PipelineShaderInfo *shader
     }
     // Not shader entry-point.
     func.setLinkage(GlobalValue::InternalLinkage);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-    // Old version of the code
-    if (func.getAttributes().hasFnAttribute(Attribute::NoInline))
-      func.removeFnAttr(Attribute::NoInline);
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
     if (func.hasFnAttribute(Attribute::NoInline))
       func.removeFnAttr(Attribute::NoInline);
-#endif
     func.addFnAttr(Attribute::AlwaysInline);
   }
 }

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -353,9 +353,6 @@ template <typename T> void move(std::vector<T> &V, size_t Begin, size_t End, siz
   V.insert(V.begin() + Target, Segment.begin(), Segment.end());
 }
 
-void removeFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr);
-void addFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr);
-
 Function *getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes, StringRef Name,
                               AttributeList *Attrs = nullptr, bool TakeName = true);
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1946,14 +1946,8 @@ Constant *SPIRVToLLVM::buildConstStoreRecursively(SPIRVType *const spvType, Type
                                      constStoreValue->getAggregateElement(i));
 
       if (needsPad) {
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 428736
-        // Old version of the code
-        constElements[i] = ConstantExpr::getInsertValue(constElements[i], constElement, 0);
-#else
-        // New version of the code (also handles unknown version, which we treat as latest).
         constElements[i] = llvm::ConstantFoldInsertValueInstruction(constElements[i], constElement, 0);
         assert(constElements[i] && "unexpected error creating aggregate initializer, malformed aggregate?");
-#endif
       } else {
         constElements[i] = constElement;
       }
@@ -4194,14 +4188,8 @@ Constant *SPIRVToLLVM::transInitializer(SPIRVValue *const spvValue, Type *const 
 
       Constant *const initializer = transInitializer(spvMembers[i], type->getStructElementType(memberIndex));
 
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 428736
-      // Old version of the code
-      structInitializer = ConstantExpr::getInsertValue(structInitializer, initializer, memberIndex);
-#else
-      // New version of the code (also handles unknown version, which we treat as latest).
       structInitializer = llvm::ConstantFoldInsertValueInstruction(structInitializer, initializer, memberIndex);
       assert(structInitializer && "unexpected error creating aggregate initializer, malformed aggregate?");
-#endif
     }
 
     return structInitializer;
@@ -4221,25 +4209,13 @@ Constant *SPIRVToLLVM::transInitializer(SPIRVValue *const spvValue, Type *const 
       if (needsPad) {
         Type *const elementType = type->getArrayElementType()->getStructElementType(0);
         Constant *const initializer = transInitializer(spvElements[i], elementType);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 428736
-        // Old version of the code
-        arrayInitializer = ConstantExpr::getInsertValue(arrayInitializer, initializer, {i, 0});
-#else
-        // New version of the code (also handles unknown version, which we treat as latest).
         arrayInitializer = llvm::ConstantFoldInsertValueInstruction(arrayInitializer, initializer, {i, 0});
         assert(arrayInitializer && "unexpected error creating aggregate initializer, malformed aggregate?");
-#endif
       } else {
         Type *const elementType = type->getArrayElementType();
         Constant *const initializer = transInitializer(spvElements[i], elementType);
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 428736
-        // Old version of the code
-        arrayInitializer = ConstantExpr::getInsertValue(arrayInitializer, initializer, i);
-#else
-        // New version of the code (also handles unknown version, which we treat as latest).
         arrayInitializer = llvm::ConstantFoldInsertValueInstruction(arrayInitializer, initializer, i);
         assert(arrayInitializer && "unexpected error creating aggregate initializer, malformed aggregate?");
-#endif
       }
     }
 
@@ -5671,13 +5647,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *bf) {
 
     SPIRVWord maxOffset = 0;
     if (ba->hasDecorate(DecorationMaxByteOffset, 0, &maxOffset)) {
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 409358
-      // Old version of the code
-      AttrBuilder builder;
-#else
-      // New version of the code (also handles unknown version, which we treat as latest)
       AttrBuilder builder(*m_context);
-#endif
       builder.addDereferenceableAttr(maxOffset);
       i->addAttrs(builder);
     }
@@ -8901,7 +8871,7 @@ Value *SPIRVToLLVM::transGLSLBuiltinFromExtInst(SPIRVExtInst *bc, BasicBlock *bb
   }
   CallInst *call = CallInst::Create(func, args, bc->getName(), bb);
   setCallingConv(call);
-  addFnAttr(m_context, call, Attribute::NoUnwind);
+  call->addFnAttr(Attribute::NoUnwind);
   return call;
 }
 

--- a/llpc/translator/lib/SPIRV/SPIRVUtil.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVUtil.cpp
@@ -43,26 +43,6 @@
 
 namespace SPIRV {
 
-void addFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr) {
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-  // Old version of the code
-  Call->addAttribute(AttributeList::FunctionIndex, Attr);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
-  Call->addFnAttr(Attr);
-#endif
-}
-
-void removeFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr) {
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 396596
-  // Old version of the code
-  Call->removeAttribute(AttributeList::FunctionIndex, Attr);
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
-  Call->removeFnAttr(Attr);
-#endif
-}
-
 Function *getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes, StringRef Name, AttributeList *Attrs,
                               bool TakeName) {
   const std::string MangledName(Name);


### PR DESCRIPTION
Remove workarounds for building against any LLVM source that is older than the current state of the amd-gfx-gpuopen-dev branch of https://github.com/GPUOpen-Drivers/llvm-project.