### PR TITLE
Mark DescriptorConstBufferCompact unsupported by relocatable

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -926,7 +926,8 @@ static bool isUnrelocatableResourceMappingRootNode(const ResourceMappingNode *no
     const ResourceMappingNode *startInnerNode = node->tablePtr.pNext;
     const ResourceMappingNode *endInnerNode = startInnerNode + node->tablePtr.nodeCount;
     for (const ResourceMappingNode *innerNode = startInnerNode; innerNode != endInnerNode; ++innerNode) {
-      if (innerNode->type == ResourceMappingNodeType::DescriptorBufferCompact)
+      if ((innerNode->type == ResourceMappingNodeType::DescriptorBufferCompact) ||
+          (innerNode->type == ResourceMappingNodeType::DescriptorConstBufferCompact))
         // The code to handle a compact descriptor cannot be easily patched, so relocatable shaders assume there are
         // no compact descriptors.
         return true;
@@ -943,6 +944,7 @@ static bool isUnrelocatableResourceMappingRootNode(const ResourceMappingNode *no
   case ResourceMappingNodeType::DescriptorCombinedTexture:
   case ResourceMappingNodeType::DescriptorTexelBuffer:
   case ResourceMappingNodeType::DescriptorBufferCompact:
+  case ResourceMappingNodeType::DescriptorConstBufferCompact:
     // Generic descriptors in the top level are not handled by the linker.
     return true;
   case ResourceMappingNodeType::InlineBuffer:


### PR DESCRIPTION
Like DescriptorBufferCompact, DescriptorConstBufferCompact should also be considered as unsupported by relocatable.

This fixes an internal driver change that uses DescriptorConstBufferCompact but causes failure on LLPC.