### PR TITLE
lgc/PatchBufferOp: avoid an unnecessary heap allocation

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -92,7 +92,7 @@ private:
   llvm::DenseSet<llvm::Value *> m_invariantSet;                // The invariant set.
   llvm::DenseSet<llvm::Value *> m_divergenceSet;               // The divergence set.
   llvm::SmallVector<llvm::Instruction *, 16> m_postVisitInsts; // The post process instruction set.
-  std::unique_ptr<llvm::IRBuilder<>> m_builder;                // The IRBuilder.
+  llvm::IRBuilder<> *m_builder;                                // The IRBuilder.
   llvm::LLVMContext *m_context;                                // The LLVM context.
   PipelineState *m_pipelineState;                              // The pipeline state
 

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -120,7 +120,9 @@ bool PatchBufferOp::runImpl(Function &function, PipelineState *pipelineState,
   m_pipelineState = pipelineState;
   m_isDivergent = std::move(isDivergent);
   m_context = &function.getContext();
-  m_builder = std::make_unique<IRBuilder<>>(*m_context);
+
+  IRBuilder<> builder(*m_context);
+  m_builder = &builder;
 
   // Invoke visitation of the target instructions.
 


### PR DESCRIPTION
The IRBuilder's lifetime is de facto scoped to each individual run, so we may as well allocate it on the stack.