### PR TITLE
Remove use of legacy passes being removed upstream

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -537,7 +537,6 @@ void LegacyPatch::addOptimizationPasses(legacy::PassManager &passMgr, CodeGenOpt
   passMgr.add(createSpeculativeExecutionIfHasBranchDivergencePass());
   passMgr.add(createCorrelatedValuePropagationPass());
   passMgr.add(createCFGSimplificationPass());
-  passMgr.add(createAggressiveInstCombinerPass());
   passMgr.add(createInstructionCombiningPass(1));
   passMgr.add(createLegacyPatchPeepholeOpt());
   passMgr.add(createCFGSimplificationPass());

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -132,7 +132,6 @@ void LgcContext::initialize() {
   initializeScalarOpts(passRegistry);
   initializeVectorization(passRegistry);
   initializeInstCombine(passRegistry);
-  initializeAggressiveInstCombine(passRegistry);
   initializeIPO(passRegistry);
   initializeCodeGen(passRegistry);
   initializeShadowStackGCLoweringPass(passRegistry);


### PR DESCRIPTION
Upstream llvm is removing some of the legacy passes. LLPC has moved over to the new pass manager, and we should remove the code for the legacy pass manager. This is quite a big piece of work. In the meantime, remove AggressiveInstCombiner as it is disappearing from upstream llvm, in preparation for subsequent merge.