### PR TITLE
Rework of TF store

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -205,10 +205,6 @@ private:
   void recordVertexAttribExport(unsigned location, llvm::ArrayRef<llvm::Value *> attribValues);
   void exportVertexAttribs(llvm::Instruction *insertPos);
 
-  void storeTessFactors();
-  void storeTessFactorToBuffer(llvm::ArrayRef<llvm::Value *> outerTessFactors,
-                               llvm::ArrayRef<llvm::Value *> innerTessFactors, llvm::Instruction *insertPos);
-
   GfxIpVersion m_gfxIp;                     // Graphics IP version info
   PipelineSystemValues m_pipelineSysValues; // Cache of ShaderSystemValues objects, one per shader stage
 

--- a/lgc/include/lgc/patch/PatchPreparePipelineAbi.h
+++ b/lgc/include/lgc/patch/PatchPreparePipelineAbi.h
@@ -60,12 +60,20 @@ public:
 
   static llvm::StringRef name() { return "Patch LLVM for preparing pipeline ABI"; }
 
+  static std::pair<llvm::Value *, llvm::Value *> readTessFactors(PipelineState *pipelineState, llvm::Value *relPatchId,
+                                                                 llvm::IRBuilder<> &builder);
+  static void writeTessFactors(PipelineState *pipelineState, llvm::Value *tfBufferDesc, llvm::Value *tfBufferBase,
+                               llvm::Value *relPatchId, llvm::Value *outerTf, llvm::Value *innerTf,
+                               llvm::IRBuilder<> &builder);
+
 private:
   void mergeShader(llvm::Module &module);
 
   void setAbiEntryNames(llvm::Module &module);
 
   void addAbiMetadata(llvm::Module &module);
+
+  void storeTessFactors(llvm::Function *entryPoint);
 
   PipelineState *m_pipelineState;           // Pipeline state
   PipelineShadersResult *m_pipelineShaders; // API shaders in the pipeline

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -34,6 +34,7 @@
 #include "MeshTaskShader.h"
 #include "ShaderMerger.h"
 #include "lgc/state/PalMetadata.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Debug.h"
 
@@ -137,6 +138,9 @@ bool PatchPreparePipelineAbi::runImpl(Module &module, PipelineShadersResult &pip
 
   m_gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
 
+  if (auto hsEntryPoint = m_pipelineShaders->getEntryPoint(ShaderStageTessControl))
+    storeTessFactors(hsEntryPoint);
+
   if (m_gfxIp.major >= 9)
     mergeShader(module);
 
@@ -147,6 +151,181 @@ bool PatchPreparePipelineAbi::runImpl(Module &module, PipelineShadersResult &pip
   m_pipelineState->getPalMetadata()->finalizePipeline(m_pipelineState->isWholePipeline());
 
   return true; // Modified the module.
+}
+
+// =====================================================================================================================
+// Read tessellation factors from on-chip LDS.
+//
+// @param pipelineState : Pipeline state
+// @param relPatchId : Relative patch ID
+// @param builder : IR builder to insert instructions
+std::pair<Value *, Value *> PatchPreparePipelineAbi::readTessFactors(PipelineState *pipelineState, Value *relPatchId,
+                                                                     IRBuilder<> &builder) {
+  auto module = builder.GetInsertBlock()->getModule();
+  auto lds = Patch::getLdsVariable(pipelineState, module);
+
+  // Helper to read value from LDS
+  auto readValueFromLds = [&](Type *readTy, Value *ldsOffset) {
+    assert(readTy->getScalarSizeInBits() == 32); // Only accept 32-bit data
+
+    Value *readPtr = builder.CreateGEP(lds->getValueType(), lds, {builder.getInt32(0), ldsOffset});
+    readPtr = builder.CreateBitCast(readPtr, PointerType::get(readTy, readPtr->getType()->getPointerAddressSpace()));
+    return builder.CreateLoad(readTy, readPtr);
+  };
+
+  unsigned numOuterTfs = 0;
+  unsigned numInnerTfs = 0;
+
+  const auto primitiveMode = pipelineState->getShaderModes()->getTessellationMode().primitiveMode;
+  switch (primitiveMode) {
+  case PrimitiveMode::Triangles:
+    numOuterTfs = 3;
+    numInnerTfs = 1;
+    break;
+  case PrimitiveMode::Quads:
+    numOuterTfs = 4;
+    numInnerTfs = 2;
+    break;
+  case PrimitiveMode::Isolines:
+    numOuterTfs = 2;
+    numInnerTfs = 0;
+    break;
+  default:
+    llvm_unreachable("Unknown primitive mode!");
+    break;
+  }
+
+  const auto tessFactorStart =
+      pipelineState->getShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor.onChip.tessFactorStart;
+
+  assert(numOuterTfs >= 2 && numOuterTfs <= 4);
+  // ldsOffset = tessFactorStart + relativeId * MaxTessFactorsPerPatch
+  Value *ldsOffset = builder.CreateMul(relPatchId, builder.getInt32(MaxTessFactorsPerPatch));
+  ldsOffset = builder.CreateAdd(ldsOffset, builder.getInt32(tessFactorStart));
+  Value *outerTf = readValueFromLds(FixedVectorType::get(builder.getFloatTy(), numOuterTfs), ldsOffset);
+
+  // NOTE: For isoline, the outer tessellation factors have to be exchanged, which is required by HW.
+  if (primitiveMode == PrimitiveMode::Isolines) {
+    assert(numOuterTfs == 2);
+    outerTf = builder.CreateShuffleVector(outerTf, ArrayRef<int>{1, 0});
+  }
+
+  assert(numInnerTfs <= 2);
+  Value *innerTf = nullptr;
+  if (numInnerTfs > 0) {
+    // ldsOffset = tessFactorStart + relativeId * MaxTessFactorsPerPatch + 4
+    Value *ldsOffset = builder.CreateMul(relPatchId, builder.getInt32(MaxTessFactorsPerPatch));
+    ldsOffset = builder.CreateAdd(ldsOffset, builder.getInt32(tessFactorStart + 4));
+    innerTf = readValueFromLds(FixedVectorType::get(builder.getFloatTy(), numInnerTfs), ldsOffset);
+  }
+
+  return std::make_pair(outerTf, innerTf);
+}
+
+// =====================================================================================================================
+// Write tessellation factors to TF buffer.
+//
+// @param pipelineState : Pipeline state
+// @param tfBufferDesc : TF buffer descriptor
+// @param tfBufferBase : TF buffer base offset
+// @param relPatchId : Relative patch ID
+// @param outerTf : Outer tessellation factors to write to TF buffer
+// @param innerTf : Inner tessellation factors to write to TF buffer
+// @param builder : IR builder to insert instructions
+void PatchPreparePipelineAbi::writeTessFactors(PipelineState *pipelineState, Value *tfBufferDesc, Value *tfBufferBase,
+                                               Value *relPatchId, Value *outerTf, Value *innerTf,
+                                               IRBuilder<> &builder) {
+  // NOTE: Tessellation factors are from tessellation level array and we have:
+  //   Isoline:
+  //     TF[0] = outerTF[0]
+  //     TF[1] = outerTF[1]
+  //   Triangle:
+  //     TF[0] = outerTF[0]
+  //     TF[1] = outerTF[1]
+  //     TF[2] = outerTF[2]
+  //     TF[3] = innerTF[0]
+  //   Quad:
+  //     TF[0] = outerTF[0]
+  //     TF[1] = outerTF[1]
+  //     TF[2] = outerTF[2]
+  //     TF[3] = outerTF[3]
+  //     TF[4] = innerTF[0]
+  //     TF[5] = innerTF[1]
+  if (pipelineState->isTessOffChip()) {
+    if (pipelineState->getTargetInfo().getGfxIpVersion().major <= 8) {
+      // NOTE: Additional 4-byte offset is required for tessellation off-chip mode (pre-GFX9).
+      tfBufferBase = builder.CreateAdd(tfBufferBase, builder.getInt32(4));
+    }
+  }
+
+  const auto &calcFactor = pipelineState->getShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor;
+  Value *tfBufferOffset = builder.CreateMul(relPatchId, builder.getInt32(calcFactor.tessFactorStride * sizeof(float)));
+
+  CoherentFlag coherent = {};
+  coherent.bits.glc = true;
+
+  const auto numOuterTfs = cast<FixedVectorType>(outerTf->getType())->getNumElements();
+  const auto numInnerTfs = innerTf ? cast<FixedVectorType>(innerTf->getType())->getNumElements()
+                                   : 0; // Isoline doesn't have inner tessellation factors
+
+  (void(numOuterTfs)); // Unused
+  (void(numInnerTfs));
+
+  auto bufferFormatX2 = BUF_NUM_FORMAT_FLOAT << 4 | BUF_DATA_FORMAT_32_32;
+  auto bufferFormatX4 = BUF_NUM_FORMAT_FLOAT << 4 | BUF_DATA_FORMAT_32_32_32_32;
+  if (pipelineState->getTargetInfo().getGfxIpVersion().major == 10) {
+    bufferFormatX2 = BUF_FORMAT_32_32_FLOAT_GFX10;
+    bufferFormatX4 = BUF_FORMAT_32_32_32_32_FLOAT_GFX10;
+  }
+
+  auto primitiveMode = pipelineState->getShaderModes()->getTessellationMode().primitiveMode;
+  if (primitiveMode == PrimitiveMode::Isolines) {
+    assert(numOuterTfs == 2 && numInnerTfs == 0);
+
+    builder.CreateIntrinsic(Intrinsic::amdgcn_raw_tbuffer_store, outerTf->getType(),
+                            {outerTf,                             // vdata
+                             tfBufferDesc,                        // rsrc
+                             tfBufferOffset,                      // voffset
+                             tfBufferBase,                        // soffset
+                             builder.getInt32(bufferFormatX2),    // format
+                             builder.getInt32(coherent.u32All)}); // glc
+
+  } else if (primitiveMode == PrimitiveMode::Triangles) {
+    assert(numOuterTfs == 3 && numInnerTfs == 1);
+
+    // For triangle, we can combine outer tessellation factors with inner ones
+    Value *tessFactor = builder.CreateShuffleVector(outerTf, ArrayRef<int>{0, 1, 2, 3});
+    tessFactor =
+        builder.CreateInsertElement(tessFactor, builder.CreateExtractElement(innerTf, static_cast<uint64_t>(0)), 3);
+
+    builder.CreateIntrinsic(Intrinsic::amdgcn_raw_tbuffer_store, tessFactor->getType(),
+                            {tessFactor,                          // vdata
+                             tfBufferDesc,                        // rsrc
+                             tfBufferOffset,                      // voffset
+                             tfBufferBase,                        // soffset
+                             builder.getInt32(bufferFormatX4),    // format
+                             builder.getInt32(coherent.u32All)}); // glc
+  } else {
+    assert(primitiveMode == PrimitiveMode::Quads);
+    assert(numOuterTfs == 4 && numInnerTfs == 2);
+
+    builder.CreateIntrinsic(Intrinsic::amdgcn_raw_tbuffer_store, outerTf->getType(),
+                            {outerTf,                             // vdata
+                             tfBufferDesc,                        // rsrc
+                             tfBufferOffset,                      // voffset
+                             tfBufferBase,                        // soffset
+                             builder.getInt32(bufferFormatX4),    // format
+                             builder.getInt32(coherent.u32All)}); // glc
+
+    tfBufferOffset = builder.CreateAdd(tfBufferOffset, builder.getInt32(4 * sizeof(float)));
+    builder.CreateIntrinsic(Intrinsic::amdgcn_raw_tbuffer_store, innerTf->getType(),
+                            {innerTf,                             // vdata
+                             tfBufferDesc,                        // rsrc
+                             tfBufferOffset,                      // voffset
+                             tfBufferBase,                        // soffset
+                             builder.getInt32(bufferFormatX2),    // format
+                             builder.getInt32(coherent.u32All)}); // glc
+  }
 }
 
 // =====================================================================================================================
@@ -329,6 +508,43 @@ void PatchPreparePipelineAbi::addAbiMetadata(Module &module) {
     Gfx9::ConfigBuilder configBuilder(&module, m_pipelineState);
     configBuilder.buildPalMetadata();
   }
+}
+
+// =====================================================================================================================
+// Handle the store of tessellation factors.
+//
+// @param entryPoint : Entry-point of tessellation control shader
+void PatchPreparePipelineAbi::storeTessFactors(Function *entryPoint) {
+  assert(getShaderStage(entryPoint) == ShaderStageTessControl); // Must be tessellation control shader
+
+  // Find the return instruction
+  Instruction *retInst = nullptr;
+  for (auto &block : *entryPoint) {
+    retInst = dyn_cast<ReturnInst>(block.getTerminator());
+    if (retInst) {
+      assert(retInst->getType()->isVoidTy());
+      break;
+    }
+  }
+  assert(retInst); // Must have return instruction
+
+  IRBuilder<> builder(*m_context);
+  builder.SetInsertPoint(retInst);
+
+  PipelineSystemValues pipelineSysValues;
+  pipelineSysValues.initialize(m_pipelineState);
+
+  const auto tfBufferDesc = pipelineSysValues.get(entryPoint)->getTessFactorBufDesc();
+  const auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageTessControl)->entryArgIdxs.tcs;
+  const auto tfBufferBase = getFunctionArgument(entryPoint, entryArgIdxs.tfBufferBase);
+  const auto relPatchId = pipelineSysValues.get(entryPoint)->getRelativeId();
+
+  // Read back tessellation factors and write them to TF buffer
+  auto tessFactors = readTessFactors(m_pipelineState, relPatchId, builder);
+  writeTessFactors(m_pipelineState, tfBufferDesc, tfBufferBase, relPatchId, tessFactors.first, tessFactors.second,
+                   builder);
+
+  pipelineSysValues.clear();
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2061,6 +2061,8 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
           builtInUsage.tcs.cullDistance = 0;
       }
 
+      // NOTE: We shouldn't clear the usage of tessellation levels if the next stage doesn't read them back because they
+      // are always required to be written to TF buffer.
       if (nextBuiltInUsage.tessLevelOuter) {
         assert(nextInOutUsage.perPatchBuiltInInputLocMap.find(BuiltInTessLevelOuter) !=
                nextInOutUsage.perPatchBuiltInInputLocMap.end());


### PR DESCRIPTION
Defer TF store from the phase of in/out handling to the phase of preparing pipeline ABI. Add two functions readTessFactors and writeTessFactors. These functions will be used by future TF optimization in shader merger as well.

The basic logic of TF store is not changed. Just some coding refactoring.