### PR TITLE
Opaque Pointers: Handle lack of zero-index GEPs in LowerGlobal

### DIFF
--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -53,12 +53,10 @@ public:
   void handleReturnInst();
 
   void handleLoadInst();
-  void handleLoadInstGlobal(LoadInst &loadInst, const unsigned addrSpace);
-  void handleLoadInstGEP(GetElementPtrInst *const getElemPtr, LoadInst &loadInst, const unsigned addrSpace);
+  void handleLoadInstGEP(GlobalVariable *inOut, ArrayRef<Value *> indexOperands, LoadInst &loadInst);
 
   void handleStoreInst();
-  void handleStoreInstGlobal(StoreInst &storeInst);
-  void handleStoreInstGEP(GetElementPtrInst *const getElemPtr, StoreInst &storeInst);
+  void handleStoreInstGEP(GlobalVariable *output, ArrayRef<Value *> indexOperands, StoreInst &storeInst);
 
   void handleAtomicInst();
   void handleAtomicInstGlobal(Instruction &atomicInst);
@@ -94,19 +92,20 @@ private:
                                    Constant *inOutMetaVal, Value *locOffset, unsigned interpLoc, Value *auxInterpValue,
                                    bool isPerVertexDimension);
 
-  llvm::Value *loadInOutMember(llvm::Type *inOutTy, unsigned addrSpace, llvm::ArrayRef<llvm::Value *> indexOperands,
-                               unsigned maxLocOffset, llvm::Constant *inOutMeta, llvm::Value *locOffset,
-                               llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,
-                               bool isPerVertexDimension);
+  llvm::Value *loadInOutMember(llvm::Type *inOutTy, llvm::Type *loadType, unsigned addrSpace,
+                               llvm::ArrayRef<llvm::Value *> indexOperands, unsigned maxLocOffset,
+                               llvm::Constant *inOutMeta, llvm::Value *locOffset, llvm::Value *vertexIdx,
+                               unsigned interpLoc, llvm::Value *interpInfo, bool isPerVertexDimension);
 
-  void storeOutputMember(llvm::Type *outputTy, llvm::Value *storeValue, llvm::ArrayRef<llvm::Value *> indexOperands,
-                         unsigned maxLocOffset, llvm::Constant *outputMeta, llvm::Value *locOffset,
-                         llvm::Value *vertexOrPrimitiveIdx);
+  void storeOutputMember(llvm::Type *outputTy, llvm::Type *storeTy, llvm::Value *storeValue,
+                         llvm::ArrayRef<llvm::Value *> indexOperands, unsigned maxLocOffset, llvm::Constant *outputMeta,
+                         llvm::Value *locOffset, llvm::Value *vertexOrPrimitiveIdx);
 
-  llvm::Value *loadIndexedValueFromTaskPayload(llvm::Type *indexedTy, llvm::ArrayRef<llvm::Value *> indexOperands,
-                                               llvm::Constant *metadata, llvm::Value *extraByteOffset);
+  llvm::Value *loadIndexedValueFromTaskPayload(llvm::Type *indexedTy, llvm::Type *loadTy,
+                                               llvm::ArrayRef<llvm::Value *> indexOperands, llvm::Constant *metadata,
+                                               llvm::Value *extraByteOffset);
   llvm::Value *loadValueFromTaskPayload(llvm::Type *loadTy, llvm::Constant *metadata, llvm::Value *extraByteOffset);
-  void storeIndexedValueToTaskPayload(llvm::Type *indexedTy, llvm::Value *storeValue,
+  void storeIndexedValueToTaskPayload(llvm::Type *indexedTy, llvm::Type *storeTy, llvm::Value *storeValue,
                                       llvm::ArrayRef<llvm::Value *> indexOperands, llvm::Constant *metadata,
                                       llvm::Value *extraByteOffset);
   void storeValueToTaskPayload(llvm::Value *storeValue, llvm::Constant *metadata, llvm::Value *extraByteOffse);
@@ -116,7 +115,8 @@ private:
   llvm::Value *atomicOpWithValueInTaskPayload(llvm::Instruction *atomicInst, llvm::Constant *metadata,
                                               llvm::Value *extraByteOffset);
 
-  void interpolateInputElement(unsigned interpLoc, llvm::Value *interpInfo, llvm::CallInst &callInst);
+  void interpolateInputElement(unsigned interpLoc, llvm::Value *interpInfo, llvm::CallInst &callInst,
+                               GlobalVariable *gv, ArrayRef<Value *> indexOperands);
 
   std::unordered_map<llvm::Value *, llvm::Value *> m_globalVarProxyMap; // Proxy map for lowering global variables
   std::unordered_map<llvm::Value *, llvm::Value *> m_inputProxyMap;     // Proxy map for lowering inputs


### PR DESCRIPTION
Opaque pointers are removing zero-indexes from GEP instructions
which are not changing pointer address. These leads to elimination of
all trailing zero-indexes from GEP instruction or even deletion of
entire GEP instruction (if all indices are zero).
LLPC uses GEP's indices while doing GlobalVariable Lowering. Indices
are used to unpack GlobalVariable type and MetaData.
    
This patch is changing API of functions such as handleLoadInstGEP,
handleStoreGEP and interpolateInputElement. From now functions will accept
array of indices instead of GEP instruction (interpolateInputElement
was getting GEP internally from CallInst).
Additionally this patch is removing functions, such as
handleLoadInstGlobal and handleStoreInstGlobal. From now
handle(Load/Store)InstGEP will handle cases where global user is a load/store,
GEP or load/store but with mismatch of types of load/store and global.
Mismatch can happen if zero-index GEP was removed and global is used
directly by load/store.