### PR TITLE
Fix the regression of PR#2137

### DIFF
--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -170,7 +170,7 @@ std::pair<Value *, Value *> PatchPreparePipelineAbi::readTessFactors(PipelineSta
 
     Value *readPtr = builder.CreateGEP(lds->getValueType(), lds, {builder.getInt32(0), ldsOffset});
     readPtr = builder.CreateBitCast(readPtr, PointerType::get(readTy, readPtr->getType()->getPointerAddressSpace()));
-    return builder.CreateLoad(readTy, readPtr);
+    return builder.CreateAlignedLoad(readTy, readPtr, Align(4));
   };
 
   unsigned numOuterTfs = 0;


### PR DESCRIPTION
The PR (https://github.com/GPUOpen-Drivers/llpc/pull/2137) has a latent issue of reading TF from on-chip LDS. We mistakenly use CreateLoad which always assumes the alignment is from the specified load type. Rather, we can only ensure the alignment is dword. So CreateAlignedLoad should be used instead to explicitly specify dword alignment.