### PR TITLE
Add an option to force using non uniform resource index

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 57
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     57.1 | Add forceNonUniformResourceIndexStageMask to PipelineOptions                                          |
 //  |     57.0 | Merge aggressiveInvariantLoads and disableInvariantLoads to an enumerated option                      |
 //  |     56.2 | Add aggressiveInvariantLoads and disableInvariantLoads to PipelineShaderOptions                       |
 //  |     56.1 | Add struct UberFetchShaderAttribInfo                                                                  |
@@ -508,6 +509,7 @@ struct PipelineOptions {
 #else
   bool reserved15;
 #endif
+  unsigned forceNonUniformResourceIndexStageMask; ///< Mask of the stage to force using non-uniform resource index.
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -2428,20 +2428,24 @@ void SpirvLowerGlobal::lowerBufferBlock() {
               // The second index is the block index.
               Value *const blockIndex = indices[1];
 
-              bool isNonUniform = false;
+              bool isNonUniform = isShaderStageInMask(
+                  m_shaderStage,
+                  m_context->getPipelineContext()->getPipelineOptions()->forceNonUniformResourceIndexStageMask);
 
-              // Run the users of the GEP to check for any nonuniform calls.
-              for (User *const user : getElemPtr->users()) {
-                CallInst *const call = dyn_cast<CallInst>(user);
-                // If the user is not a call or the call is the function pointer call, bail.
-                if (!call)
-                  continue;
-                auto callee = call->getCalledFunction();
-                if (!callee)
-                  continue;
-                // If the call is our non uniform decoration, record we are non uniform.
-                isNonUniform = callee->getName().startswith(gSPIRVName::NonUniform);
-                break;
+              if (!isNonUniform) {
+                // Run the users of the GEP to check for any nonuniform calls.
+                for (User *const user : getElemPtr->users()) {
+                  CallInst *const call = dyn_cast<CallInst>(user);
+                  // If the user is not a call or the call is the function pointer call, bail.
+                  if (!call)
+                    continue;
+                  auto callee = call->getCalledFunction();
+                  if (!callee)
+                    continue;
+                  // If the call is our non uniform decoration, record we are non uniform.
+                  isNonUniform = callee->getName().startswith(gSPIRVName::NonUniform);
+                  break;
+                }
               }
               if (!isNonUniform) {
                 // Run the users of the block index to check for any nonuniform calls.

--- a/llpc/test/shaderdb/core/TestForceNonUniformResourceIndex.frag
+++ b/llpc/test/shaderdb/core/TestForceNonUniformResourceIndex.frag
@@ -1,0 +1,33 @@
+// Test not forcing NURI
+// BEGIN_SHADERTEST
+// RUN: amdllpc -v %gfxip %s --force-non-uniform-resource-index-stage-mask=0x00000000 | FileCheck -check-prefix=NOTFORCENURITEST %s
+// NOTFORCENURITEST-LABEL: {{^// LLPC}} pipeline before-patching results
+// When not forcing NURI (Non Uniform Resource Index), there should be a `readfirstlane`.
+// NOTFORCENURITEST: %{{[0-9]+}} = call i32 @llvm.amdgcn.readfirstlane(i32 %{{[0-9]+}})
+// NOTFORCENURITEST: AMDLLPC SUCCESS
+// END_SHADERTEST
+
+// Test forcing NURI
+// BEGIN_SHADERTEST
+// RUN: amdllpc -v %gfxip %s --force-non-uniform-resource-index-stage-mask=0xFFFFFFFF | FileCheck -check-prefix=FORCENURITEST %s
+// FORCENURITEST-LABEL: {{^// LLPC}} pipeline before-patching results
+// When forcing NURI (Non Uniform Resource Index), there should not be a `readfirstlane`.
+// FORCENURITEST-NOT: %{{[0-9]+}} = call i32 @llvm.amdgcn.readfirstlane(i32 %{{[0-9]+}})
+// FORCENURITEST: AMDLLPC SUCCESS
+// END_SHADERTEST
+
+#version 450
+
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(set = 0, binding = 0) buffer Data
+{
+    vec4 color;
+} data[];
+
+layout(location = 0) out vec4 FragColor;
+layout(location = 0) in flat int index;
+void main()
+{
+  FragColor = data[index].color;
+}

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -276,6 +276,11 @@ cl::opt<unsigned> OverrideThreadGroupSizeZ("override-threadGroupSizeZ",
 // -reverse-thread-group
 cl::opt<bool> ReverseThreadGroup("reverse-thread-group", cl::desc("Reverse thread group ID\n"), cl::init(false));
 
+// -force-non-uniform-resource-index-stage-mask
+cl::opt<unsigned> ForceNonUniformResourceIndexStageMask("force-non-uniform-resource-index-stage-mask",
+                                                        cl::desc("Stage mask to force non uniform resource index\n"),
+                                                        cl::init(0));
+
 // -filter-pipeline-dump-by-type: filter which kinds of pipeline should be disabled.
 cl::opt<unsigned> FilterPipelineDumpByType("filter-pipeline-dump-by-type",
                                            cl::desc("Filter which types of pipeline dump are disabled\n"
@@ -489,6 +494,13 @@ static Result initCompileInfo(CompileInfo *compileInfo) {
   compileInfo->compPipelineInfo.options.overrideThreadGroupSizeZ = OverrideThreadGroupSizeZ;
   compileInfo->compPipelineInfo.options.threadGroupSwizzleMode = ThreadGroupSwizzleModeSetting;
   compileInfo->compPipelineInfo.options.reverseThreadGroup = ReverseThreadGroup;
+
+  compileInfo->compPipelineInfo.options.forceNonUniformResourceIndexStageMask = ForceNonUniformResourceIndexStageMask;
+  compileInfo->gfxPipelineInfo.options.forceNonUniformResourceIndexStageMask = ForceNonUniformResourceIndexStageMask;
+#if VKI_RAY_TRACING
+  compileInfo->rayTracePipelineInfo.options.forceNonUniformResourceIndexStageMask =
+      ForceNonUniformResourceIndexStageMask;
+#endif
 
   // Set NGG control settings
   if (ParsedGfxIp.major >= 10) {

--- a/llpc/unittests/util/testPipelineDumper.cpp
+++ b/llpc/unittests/util/testPipelineDumper.cpp
@@ -372,5 +372,25 @@ TEST(PipelineDumperTest, TestInternalRTShadersCompute) {
 }
 #endif
 
+// =====================================================================================================================
+// Test the forceNonUniformResourceIndexStageMask option.
+
+TEST(PipelineDumperTest, TestForceNonUniformResourceIndexStageMaskGraphics) {
+  ModifyGraphicsBuildInfo modifyBuildInfo = [](GraphicsPipelineBuildInfo *buildInfo) {
+    buildInfo->options.forceNonUniformResourceIndexStageMask = ~0u;
+  };
+
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
+  runGraphicsPipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
+TEST(PipelineDumperTest, TestForceNonUniformResourceIndexStageMaskCompute) {
+  ModifyComputeBuildInfo modifyBuildInfo = [](ComputePipelineBuildInfo *buildInfo) {
+    buildInfo->options.forceNonUniformResourceIndexStageMask = ~0u;
+  };
+  HashModifiedFunc expectHashToBeEqual = [](const GenerateHashParams &params) { return false; };
+  runComputePipelineVariations(modifyBuildInfo, expectHashToBeEqual);
+}
+
 } // namespace
 } // namespace Llpc

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -804,6 +804,9 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
 #if VKI_RAY_TRACING
   dumpFile << "options.internalRtShaders = " << options->internalRtShaders << "\n";
 #endif
+
+  dumpFile << "options.forceNonUniformResourceIndexStageMask = " << options->forceNonUniformResourceIndexStageMask
+           << "\n";
 }
 
 // =====================================================================================================================
@@ -1525,6 +1528,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
 #if VKI_RAY_TRACING
   hasher->Update(options->internalRtShaders);
 #endif
+  hasher->Update(options->forceNonUniformResourceIndexStageMask);
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -374,6 +374,8 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, threadGroupSwizzleMode, MemberTypeEnum, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, reverseThreadGroup, MemberTypeBool, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceNonUniformResourceIndexStageMask, MemberTypeInt,
+                                     false);
       // One internal member
 #if VKI_RAY_TRACING
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);


### PR DESCRIPTION
This option will force LLPC to apply NURI (Non Uniform Resource Index) when accessing resource in specified shader stages, by treating all resources are decorated by `NonUniformEXT`.

This will allow us to measure performance impact of switching default to NURI, and help further optimization.