### PR TITLE
Fix an issue of primitive ID in mesh shader

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1780,8 +1780,10 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
   SET_REG_FIELD(&config->meshRegs, GE_NGG_SUBGRP_CNTL, THDS_PER_SUBGRP, calcFactor.primAmpFactor);
 
   const bool enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
-  const bool hasPrimitivePayload = builtInUsage.primitiveId || builtInUsage.layer || builtInUsage.viewportIndex ||
-                                   builtInUsage.primitiveShadingRate || enableMultiView;
+  bool hasPrimitivePayload =
+      builtInUsage.layer || builtInUsage.viewportIndex || builtInUsage.primitiveShadingRate || enableMultiView;
+  if (gfxIp.major < 11)
+    hasPrimitivePayload |= builtInUsage.primitiveId;
   SET_REG_FIELD(&config->meshRegs, SPI_SHADER_IDX_FORMAT, IDX0_EXPORT_FORMAT,
                 hasPrimitivePayload ? SPI_SHADER_2COMP : SPI_SHADER_1COMP);
   SET_REG_GFX10_PLUS_FIELD(&config->meshRegs, VGT_DRAW_PAYLOAD_CNTL, EN_PRIM_PAYLOAD, hasPrimitivePayload);

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1953,9 +1953,9 @@ void MeshTaskShader::exportPrimitive() {
   Value *primitivePayload = nullptr;
   Value *primitiveId = nullptr;
   if (builtInUsage.primitiveId) {
+    primitiveId = readMeshBuiltInFromLds(BuiltInPrimitiveId);
     if (m_gfxIp.major < 11) {
       // [16:0] = Pipeline primitive ID
-      primitiveId = readMeshBuiltInFromLds(BuiltInPrimitiveId);
       auto primitiveIdMaskAndShift = m_builder->CreateAnd(primitiveId, 0x1FFFF);
       if (primitivePayload)
         primitivePayload = m_builder->CreateOr(primitivePayload, primitiveIdMaskAndShift);


### PR DESCRIPTION
The primitive ID passed to primitive payload is only for GFX10.3. Future GPU generation doesn't have such field for primitive ID.