### PR TITLE
Fix for upstream changes to StandardInstrumentations

### DIFF
--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -32,9 +32,10 @@
 
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/Target/TargetMachine.h"
 
 namespace lgc {
+
+class LgcContext;
 
 // =====================================================================================================================
 // Public interface of LLPC middle-end's legacy::PassManager override
@@ -50,7 +51,7 @@ public:
 // Public interface of LLPC middle-end's PassManager override
 class PassManager : public llvm::ModulePassManager {
 public:
-  static PassManager *Create(llvm::TargetMachine *targetMachine = nullptr);
+  static PassManager *Create(LgcContext *lgcContext);
   virtual ~PassManager() {}
   template <typename PassBuilderT> bool registerFunctionAnalysis(PassBuilderT &&PassBuilder) {
     return m_functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -220,7 +220,7 @@ void PipelineState::generateWithNewPassManager(std::unique_ptr<Module> pipelineM
   Timer *codeGenTimer = timers.size() >= 3 ? timers[2] : nullptr;
 
   // Set up "whole pipeline" passes, where we have a single module representing the whole pipeline.
-  std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(getLgcContext()->getTargetMachine()));
+  std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(getLgcContext()));
   passMgr->setPassIndex(&passIndex);
   Patch::registerPasses(*passMgr);
   passMgr->registerFunctionAnalysis([&] { return getLgcContext()->getTargetMachine()->getTargetIRAnalysis(); });

--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -88,7 +88,7 @@ std::pair<lgc::PassManager &, LegacyPassManager &> PassManagerCache::getPassMana
   // TODO: Creation of a normal compilation pass manager, not just one for a glue shader.
   assert(info.isGlue && "Non-glue shader compilation not implemented yet");
 
-  passManagers.first.reset(PassManager::Create(m_lgcContext->getTargetMachine()));
+  passManagers.first.reset(PassManager::Create(m_lgcContext));
   passManagers.first->registerFunctionAnalysis([&] { return m_lgcContext->getTargetMachine()->getTargetIRAnalysis(); });
 
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -137,7 +137,7 @@ static bool isIsaText(StringRef data) {
 static bool runPassPipeline(Pipeline &pipeline, Module &module, raw_pwrite_stream &outStream) {
   // Set up "whole pipeline" passes, where we have a single module representing the whole pipeline.
   LgcContext *lgcContext = pipeline.getLgcContext();
-  std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(lgcContext->getTargetMachine()));
+  std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(lgcContext));
   passMgr->registerFunctionAnalysis([&] { return lgcContext->getTargetMachine()->getTargetIRAnalysis(); });
   passMgr->registerModuleAnalysis([&] { return PipelineShaders(); });
   passMgr->registerModuleAnalysis([&] { return PipelineStateWrapper(static_cast<PipelineState *>(&pipeline)); });

--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "lgc/PassManager.h"
+#include "lgc/LgcContext.h"
 #include "lgc/util/Debug.h"
 #include "llvm/Analysis/CFGPrinter.h"
 #include "llvm/IR/PrintPasses.h"
@@ -103,7 +104,7 @@ private:
 // This is the implementation subclass of the PassManager class declared in PassManager.h
 class PassManagerImpl final : public lgc::PassManager {
 public:
-  PassManagerImpl(TargetMachine *targetMachine);
+  PassManagerImpl(LgcContext *lgcContext);
   void registerPass(StringRef passName, StringRef className) override;
   void run(Module &module) override;
   void setPassIndex(unsigned *passIndex) override { m_passIndex = passIndex; }
@@ -161,8 +162,8 @@ lgc::LegacyPassManager *lgc::LegacyPassManager::Create() {
 //
 // @param targetMachine : Optional target machine argument. Must be provided if the AMDLLPC target specific alias
 // analysis pass needs to be registered.
-lgc::PassManager *lgc::PassManager::Create(TargetMachine *targetMachine) {
-  return new PassManagerImpl(targetMachine);
+lgc::PassManager *lgc::PassManager::Create(LgcContext *lgcContext) {
+  return new PassManagerImpl(lgcContext);
 }
 
 // =====================================================================================================================
@@ -175,10 +176,15 @@ LegacyPassManagerImpl::LegacyPassManagerImpl() : LegacyPassManager() {
 }
 
 // =====================================================================================================================
-PassManagerImpl::PassManagerImpl(TargetMachine *targetMachine)
-    : PassManager(), m_targetMachine(targetMachine),
-      m_instrumentationStandard(cl::DebugPassManager, cl::DebugPassManager || cl::VerifyIr,
-                                /*PrintPassOpts=*/{true, false, true}) {
+PassManagerImpl::PassManagerImpl(LgcContext *lgcContext)
+    : PassManager(), m_targetMachine(lgcContext->getTargetMachine()),
+      m_instrumentationStandard(
+#if !LLVM_MAIN_REVISION || LLVM_MAIN_REVISION >= 442861
+          // New version of the code (also handles unknown version, which we treat as latest)
+          lgcContext->getContext(),
+#endif
+          cl::DebugPassManager, cl::DebugPassManager || cl::VerifyIr,
+          /*PrintPassOpts=*/{true, false, true}) {
   if (!cl::DumpCfgAfter.empty())
     report_fatal_error("The --dump-cfg-after option is not supported with the new pass manager.");
 

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1129,7 +1129,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       context->getBuilder()->setShaderStage(getLgcShaderStage(entryStage));
 
       if (cl::NewPassManager) {
-        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(context->getLgcContext()));
         lowerPassMgr->setPassIndex(&passIndex);
         SpirvLower::registerPasses(*lowerPassMgr);
 
@@ -1248,7 +1248,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       context->getBuilder()->setShaderStage(getLgcShaderStage(entryStage));
       bool success;
       if (cl::NewPassManager) {
-        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+        std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(context->getLgcContext()));
         lowerPassMgr->setPassIndex(&passIndex);
         SpirvLower::registerPasses(*lowerPassMgr);
 
@@ -2193,7 +2193,7 @@ Result Compiler::buildRayTracingPipelineElf(Context *context, Module *module, El
   bool success;
   unsigned passIndex = 0;
   if (cl::NewPassManager) {
-    std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+    std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(context->getLgcContext()));
     lowerPassMgr->setPassIndex(&passIndex);
     SpirvLower::registerPasses(*lowerPassMgr);
 
@@ -2412,7 +2412,7 @@ Result Compiler::buildRayTracingPipelineInternal(Context *context, ArrayRef<cons
 
     bool success;
     if (cl::NewPassManager) {
-      std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+      std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(context->getLgcContext()));
       lowerPassMgr->setPassIndex(&passIndex);
       SpirvLower::registerPasses(*lowerPassMgr);
 
@@ -2448,7 +2448,7 @@ Result Compiler::buildRayTracingPipelineInternal(Context *context, ArrayRef<cons
 
     bool success;
     if (cl::NewPassManager) {
-      std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create());
+      std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(context->getLgcContext()));
       lowerPassMgr->setPassIndex(&passIndex);
       SpirvLower::registerPasses(*lowerPassMgr);
 


### PR DESCRIPTION
Upstream LLVM patch https://reviews.llvm.org/D137149 changed the StandardInstrumentations class such that it requires access to the LLVMContext.

Previously lgc::PassManager only had access to the TargetMachine. This patch changes it to take an LgcContext instead, from where it can get both the TargetMachine and the LLVMContext.