### PR TITLE
Stop using deprecated Optional::getPointer. NFC.

### DIFF
--- a/llpc/tool/llpcPipelineBuilder.cpp
+++ b/llpc/tool/llpcPipelineBuilder.cpp
@@ -121,7 +121,7 @@ std::unique_ptr<PipelineBuilder> createPipelineBuilder(ICompiler &compiler, Comp
 void *PipelineBuilder::runPreBuildActions(PipelineBuildInfo buildInfo) {
   void *pipelineDumpHandle = nullptr;
   if (shouldDumpPipelines())
-    pipelineDumpHandle = IPipelineDumper::BeginPipelineDump(m_dumpOptions.getPointer(), buildInfo);
+    pipelineDumpHandle = IPipelineDumper::BeginPipelineDump(&m_dumpOptions.value(), buildInfo);
 
   if (m_printPipelineInfo)
     printPipelineInfo(buildInfo);


### PR DESCRIPTION
This method was deprecated by upstream LLVM patch https://reviews.llvm.org/D138621.