### PR TITLE
[CI] Fix asan+ubsan build

### DIFF
--- a/.github/workflows/build-amdvlk-docker.yml
+++ b/.github/workflows/build-amdvlk-docker.yml
@@ -14,12 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         host-os:        ["ubuntu-20.04"]
-        image-template: ["amdvlk_%s%s:nightly"]
+        image-template: ["amdvlkadmin/amdvlk_%s%s:nightly"]
         branch:         [dev]
         config:         [Release]
         feature-set:    ["+gcc", "+gcc+assertions",
-                         "+clang", "+clang+coverage",
-                         "+clang+shadercache+coverage+assertions",
+                         "+clang",
+                         "+clang+shadercache+ubsan+asan",
+                         "+clang+shadercache+ubsan+asan+assertions",
                          "+clang+shadercache+tsan"]
         generator:      [Ninja]
     steps:
@@ -47,10 +48,10 @@ jobs:
                          --build-arg CONFIG="${{ matrix.config }}" \
                          --build-arg FEATURES="${{ matrix.feature-set }}" \
                          --build-arg GENERATOR="${{ matrix.generator }}" \
-                         --tag "${{secrets.DOCKER_USR}}/$IMAGE_TAG"
+                         --tag "$IMAGE_TAG"
       - name: Login Docker
         run: |
-          echo "${{ secrets.DOCKER_PWD }}" | docker login -u ${{ secrets.DOCKER_USR }} --password-stdin
+          echo "${{ secrets.DOCKER_PWD }}" | docker login -u amdvlkadmin --password-stdin
       - name: Push the new image
         run: |
-          docker push "${{secrets.DOCKER_USR}}/$IMAGE_TAG"
+          docker push "$IMAGE_TAG"

--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         host-os:             ["ubuntu-20.04"]
-        image-template:      ["amdvlk_%s%s:nightly"]
+        image-template:      ["amdvlkadmin/amdvlk_%s%s:nightly"]
         config:              [Release]
         feature-set:         ["+gcc", "+gcc+assertions",
-                              "+clang", "+clang+coverage",
+                              "+clang",
                               "+clang+shadercache+tsan"]
     steps:
       - name: Free up disk space
@@ -43,10 +43,10 @@ jobs:
           CONFIG_TAG=$(printf "%s%s" "$CONFIG_LOWER" "$FEATURES_LOWER")
           echo "CONFIG_TAG=$CONFIG_TAG" | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
-        run: docker pull "amdvlkadmin/$IMAGE_TAG"
+        run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
         run: docker build . --file docker/llpc.Dockerfile
-                             --build-arg AMDVLK_IMAGE="amdvlkadmin/$IMAGE_TAG"
+                             --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
                              --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                              --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                              --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"

--- a/.github/workflows/check-clang-tidy-llpc.yml
+++ b/.github/workflows/check-clang-tidy-llpc.yml
@@ -15,13 +15,13 @@ jobs:
           git checkout ${GITHUB_SHA}
       - name: Generate Docker base image tag string
         run: |
-          echo "IMAGE_TAG=amdvlk_release_clang:nightly" \
+          echo "IMAGE_TAG=amdvlkadmin/amdvlk_release_clang:nightly" \
             | tee -a $GITHUB_ENV
       - name: Fetch the latest prebuilt AMDVLK
-        run: docker pull "amdvlkadmin/$IMAGE_TAG"
+        run: docker pull "$IMAGE_TAG"
       - name: Build and Test with Docker
         run: docker build . --file docker/llpc-clang-tidy.Dockerfile
-                            --build-arg AMDVLK_IMAGE="amdvlkadmin/$IMAGE_TAG"
+                            --build-arg AMDVLK_IMAGE="$IMAGE_TAG"
                             --build-arg LLPC_REPO_NAME="${GITHUB_REPOSITORY}"
                             --build-arg LLPC_REPO_REF="${GITHUB_REF}"
                             --build-arg LLPC_REPO_SHA="${GITHUB_SHA}"

--- a/docker/amdvlk.Dockerfile
+++ b/docker/amdvlk.Dockerfile
@@ -93,7 +93,7 @@ RUN EXTRA_COMPILER_FLAGS=() \
     && if echo "$FEATURES" | grep -q "+asan" ; then \
          SANITIZERS+=("Address"); \
          echo "export ASAN_OPTIONS=detect_leaks=0" >> /vulkandriver/env.sh; \
-         echo "export LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so)" >> /vulkandriver/env.sh; \
+         echo "export LD_LIBRARY_PATH=$(dirname $(clang -print-file-name=libclang_rt.asan-x86_64.so))" >> /vulkandriver/env.sh; \
        fi \
     && if echo "$FEATURES" | grep -q "+ubsan" ; then \
          SANITIZERS+=("Undefined"); \

--- a/docker/llpc-clang-tidy.Dockerfile
+++ b/docker/llpc-clang-tidy.Dockerfile
@@ -3,7 +3,7 @@
 # Sample invocation:
 #    docker build .                                                                                         \
 #      --file docker/llpc-clang-tidy.Dockerfile                                                             \
-#      --build-arg AMDVLK_IMAGE=***/amdvlk_release_clang:nightly                                            \
+#      --build-arg AMDVLK_IMAGE=amdvlkadmin/amdvlk_release_clang:nightly                                    \
 #      --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                                                      \
 #      --build-arg LLPC_REPO_REF=<GIT_REF>                                                                  \
 #      --build-arg LLPC_REPO_SHA=<GIT_SHA>                                                                  \

--- a/docker/llpc.Dockerfile
+++ b/docker/llpc.Dockerfile
@@ -3,7 +3,7 @@
 # Sample invocation:
 #    docker build .                                                                                       \
 #      --file docker/llpc.Dockerfile                                                                      \
-#      --build-arg AMDVLK_IMAGE=***/amdvlk_%s%s:nightly                                                   \
+#      --build-arg AMDVLK_IMAGE=amdvlkadmin/amdvlk_release_gcc_assertions:nightly                         \
 #      --build-arg LLPC_REPO_NAME=GPUOpen-Drivers/llpc                                                    \
 #      --build-arg LLPC_REPO_REF=<GIT_REF>                                                                \
 #      --build-arg LLPC_REPO_SHA=<GIT_SHA>                                                                \


### PR DESCRIPTION
- Change `LD_PRELOAD` to `LD_LIBRARY_PATH`, which fixes building gpurt with asan+ubsan enabled.
- Enable sanitizer builds for the image, enabling it for PRs will come later, when the images are built and working.
- Disable coverage builds, the comments are gone and I don’t think anybode looks at their results (except for passing).
- Move `amdvlkadmin/` into the `image-template` to reduce duplication of the image path. This gets rid of the `DOCKER_USR` secret, which wasn’t that secret anyway.