### PR TITLE
Applying VgprLimit to all shaders

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -420,10 +420,13 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
     shaderOptions.allowReZ = shaderInfo->options.allowReZ;
     shaderOptions.forceLateZ = shaderInfo->options.forceLateZ;
 
-    if (shaderInfo->options.vgprLimit != 0 && shaderInfo->options.vgprLimit != UINT_MAX)
-      shaderOptions.vgprLimit = shaderInfo->options.vgprLimit;
-    else
-      shaderOptions.vgprLimit = VgprLimit;
+    shaderOptions.vgprLimit = shaderInfo->options.vgprLimit;
+
+    if (VgprLimit != 0) {
+      if (VgprLimit < shaderOptions.vgprLimit || shaderOptions.vgprLimit == 0) {
+        shaderOptions.vgprLimit = VgprLimit;
+      }
+    }
 
     if (ScalarizeWaterfallDescriptorLoads.getNumOccurrences() > 0) {
       shaderOptions.scalarizeWaterfallLoads = ScalarizeWaterfallDescriptorLoads;


### PR DESCRIPTION
If a --vgpr-limit is passed it will be applied to all shaders even if they have their own VGPR limit set. The lower of the two limits will be in effect in such a situation.

This avoids situations where some shaders used more VGPRs than allowed and makes this options' semantics less surprising.