### PR TITLE
Clamp shader stage for spirv lower pass

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -391,6 +391,15 @@ void SpirvLower::init(Module *module) {
   } else {
     m_shaderStage = getShaderStageFromModule(m_module);
     m_entryPoint = getEntryPoint(m_module);
+    if (m_shaderStage == ShaderStageInvalid) {
+#if VKI_RAY_TRACING
+      // There might be cases we fail to get shader stage from a module that is not directly converted from SPIR-V, for
+      // example, unified ray tracing pipeline shader, or entry for indirect ray tracing pipeline. In such case, clamp
+      // the shader stage to compute.
+#endif
+      assert(m_entryPoint);
+      m_shaderStage = ShaderStageCompute;
+    }
   }
   m_builder = m_context->getBuilder();
 }


### PR DESCRIPTION
Assertion is hit after #2147, when we are using `m_shaderStage` to determine whether we want to force NURI for a module, while that module is not converted directly from SPIR-V, to be specific, a unified ray tracing pipeline shader, or an entry module for indirect ray tracing pipeline. We have `ShaderStageInvalid` in such case.

This commit clamps `ShaderStageInvalid` to `ShaderStageCompute` to allow further usage of `m_shaderStage` in spirv lower passes. This should be safe as no lower pass relies on `ShaderStageInvalid` to do anything, and `ShaderStageInvalid` is always caused by hand-made module that, in effect, is a compute module.

(I'm not sure how the VKI_RAY_TRACING macro is required, but I tend to keep comments that mentioned RT inside it to avoid any possible sanitization problem.)

Fixes: Assertion (and crash?) triggered in RT related CTS, such as dEQP-VK.binding_model.shader_access.secondary_cmd_buf.multiple_discontiguous_descriptor_sets.descriptor_array.ray_tracing.chit