### PR TITLE
Handle subgroup mbcnt where mask is 32 bit

### DIFF
--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -268,7 +268,8 @@ Value *SubgroupBuilder::CreateSubgroupBallotInclusiveBitCount(Value *const value
 // @param instName : Name to give final instruction.
 Value *SubgroupBuilder::CreateSubgroupBallotExclusiveBitCount(Value *const value, const Twine &instName) {
   if (getShaderSubgroupSize() <= 32)
-    return CreateSubgroupMbcnt(CreateExtractElement(value, getInt32(0)), "");
+    // Directly invoke the required mbcnt_lo intrinsic since CreateSubgroupMbcnt expects a 64-bit mask
+    return CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {CreateExtractElement(value, getInt32(0)), getInt32(0)});
   Value *result = CreateShuffleVector(value, UndefValue::get(value->getType()), ArrayRef<int>{0, 1});
   result = CreateBitCast(result, getInt64Ty());
   return CreateSubgroupMbcnt(result, "");


### PR DESCRIPTION
In some cases where the subgroupsize is <= 32, the mask that is passed in can be 32 bit.
Add code to handle this case, but leave the 64 bit variant as well, since it is still possible to have a subgroupsize of <= 32 and get a 64 bit mask.