### PR TITLE
Rework of multi-view

### DIFF
--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1980,11 +1980,17 @@ Value *ImageBuilder::handleFragCoordViewIndex(Value *coord, unsigned flags, unsi
     case ShaderStageVertex:
       builtInUsage.vs.viewIndex = true;
       break;
+    case ShaderStageTessControl:
+      builtInUsage.tcs.viewIndex = true;
+      break;
     case ShaderStageTessEval:
       builtInUsage.tes.viewIndex = true;
       break;
     case ShaderStageGeometry:
       builtInUsage.gs.viewIndex = true;
+      break;
+    case ShaderStageMesh:
+      builtInUsage.mesh.viewIndex = true;
       break;
     case ShaderStageFragment:
       builtInUsage.fs.viewIndex = true;

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1307,6 +1307,10 @@ Value *InOutBuilder::readVsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
     return ShaderInputs::getVertexIndex(builder, *getLgcContext());
   case BuiltInInstanceIndex:
     return ShaderInputs::getInstanceIndex(builder, *getLgcContext());
+  case BuiltInViewIndex:
+    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+      return ShaderInputs::getSpecialUserData(UserDataMapping::ViewId, builder);
+    return builder.getInt32(0);
   default:
     // Not handled; caller will handle with lgc.input.import.builtin, which is then lowered in PatchInOutImportExport.
     return nullptr;

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -102,7 +102,6 @@ private:
                                     llvm::Value *compIdx, llvm::Value *vertexOrPrimitiveIdx, bool isPerPrimitive,
                                     BuilderBase &builder);
 
-  llvm::Value *patchVsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, BuilderBase &builder);
   llvm::Value *patchTcsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,
                                           llvm::Value *vertexIdx, BuilderBase &builder);
   llvm::Value *patchTesBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,
@@ -220,6 +219,7 @@ private:
   // and gl_Layer is 16-bit low part). Thus, the export is delayed with them merged together.
   llvm::Value *m_viewportIndex; // Correspond to "out int gl_ViewportIndex"
   llvm::Value *m_layer;         // Correspond to "out int gl_Layer"
+  llvm::Value *m_viewIndex;     // Correspond to "in int gl_Layer"
 
   bool m_hasTs; // Whether the pipeline has tessellation shaders
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -595,7 +595,8 @@ struct InterfaceData {
 
       // Fragment shader
       struct {
-        unsigned primMask; // Primitive mask
+        unsigned viewIndex; // View Index
+        unsigned primMask;  // Primitive mask
 
         // Perspective interpolation (I/J)
         struct {

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -2080,15 +2080,6 @@ void MeshTaskShader::exportPrimitive() {
     }
   }
 
-  if (enableMultiView) {
-    if (inOutUsage.mesh.perPrimitiveBuiltInExportLocs.count(BuiltInViewIndex) > 0) {
-      assert(viewIndex);
-      const unsigned exportLoc = inOutUsage.mesh.perPrimitiveBuiltInExportLocs[BuiltInViewIndex];
-      primAttrExports.push_back({startLoc + exportLoc, viewIndex});
-      ++inOutUsage.primExpCount;
-    }
-  }
-
   bool exportViewportIndex = false;
   if (builtInUsage.viewportIndex) {
     exportViewportIndex = true;

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -505,14 +505,14 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
   if (builtInUsage.primitiveId)
     builtInPairs.push_back(std::make_pair(BuiltInPrimitiveId, builder.getInt32Ty()));
 
-  const auto enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
-  if (builtInUsage.layer || enableMultiView) {
-    // NOTE: If multi-view is enabled, always export gl_ViewIndex rather than gl_Layer.
-    builtInPairs.push_back(std::make_pair(enableMultiView ? BuiltInViewIndex : BuiltInLayer, builder.getInt32Ty()));
-  }
+  if (builtInUsage.layer)
+    builtInPairs.push_back(std::make_pair(BuiltInLayer, builder.getInt32Ty()));
 
   if (builtInUsage.viewportIndex)
     builtInPairs.push_back(std::make_pair(BuiltInViewportIndex, builder.getInt32Ty()));
+
+  if (m_pipelineState->getInputAssemblyState().enableMultiView)
+    builtInPairs.push_back(std::make_pair(BuiltInViewIndex, builder.getInt32Ty()));
 
   if (builtInUsage.primitiveShadingRate)
     builtInPairs.push_back(std::make_pair(BuiltInPrimitiveShadingRate, builder.getInt32Ty()));

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1237,9 +1237,6 @@ void PatchResourceCollect::processMissingFs() {
     case BuiltInLayer:
       m_resUsage->builtInUsage.fs.layer = true;
       break;
-    case BuiltInViewIndex:
-      m_resUsage->builtInUsage.fs.viewIndex = true;
-      break;
     case BuiltInViewportIndex:
       m_resUsage->builtInUsage.fs.viewportIndex = true;
       break;
@@ -1856,12 +1853,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
       }
 
-      if (nextBuiltInUsage.viewIndex) {
-        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewIndex) != nextInOutUsage.builtInInputLocMap.end());
-        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewIndex];
-        inOutUsage.builtInOutputLocMap[BuiltInViewIndex] = mapLoc;
-      }
-
       if (nextBuiltInUsage.viewportIndex) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
@@ -1971,9 +1962,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
 
       if (builtInUsage.vs.layer)
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = availOutMapLoc++;
-
-      if (builtInUsage.vs.viewIndex)
-        inOutUsage.builtInOutputLocMap[BuiltInViewIndex] = availOutMapLoc++;
     }
 
     inOutUsage.outputMapLocCount = std::max(inOutUsage.outputMapLocCount, availOutMapLoc);
@@ -2002,9 +1990,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       if (builtInUsage.tcs.cullDistanceIn > 4)
         ++availInMapLoc;
     }
-
-    if (builtInUsage.tcs.viewIndex)
-      inOutUsage.builtInInputLocMap[BuiltInViewIndex] = availInMapLoc++;
 
     // Map built-in outputs to generic ones
     if (nextStage == ShaderStageTessEval) {
@@ -2209,18 +2194,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
       }
-
-      if (nextBuiltInUsage.viewIndex) {
-        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewIndex) != nextInOutUsage.builtInInputLocMap.end());
-        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewIndex];
-        inOutUsage.builtInOutputLocMap[BuiltInViewIndex] = mapLoc;
-      }
-
-      if (nextBuiltInUsage.viewportIndex) {
-        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
-        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
-        inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
-      }
     } else if (nextStage == ShaderStageGeometry) {
       // TES  ==>  GS
       const auto &nextBuiltInUsage = nextResUsage->builtInUsage.gs;
@@ -2284,9 +2257,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
 
       if (builtInUsage.tes.layer)
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = availOutMapLoc++;
-
-      if (builtInUsage.tes.viewIndex)
-        inOutUsage.builtInOutputLocMap[BuiltInViewIndex] = availOutMapLoc++;
     }
 
     inOutUsage.inputMapLocCount = std::max(inOutUsage.inputMapLocCount, availInMapLoc);
@@ -2335,11 +2305,11 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
     if (builtInUsage.gs.layer)
       mapGsBuiltInOutput(BuiltInLayer, 1);
 
-    if (builtInUsage.gs.viewIndex)
-      mapGsBuiltInOutput(BuiltInViewIndex, 1);
-
     if (builtInUsage.gs.viewportIndex)
       mapGsBuiltInOutput(BuiltInViewportIndex, 1);
+
+    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+      mapGsBuiltInOutput(BuiltInViewIndex, 1);
 
     if (builtInUsage.gs.primitiveShadingRate)
       mapGsBuiltInOutput(BuiltInPrimitiveShadingRate, 1);
@@ -2376,12 +2346,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         builtInOutLocs[BuiltInLayer] = mapLoc;
       }
 
-      if (nextBuiltInUsage.viewIndex) {
-        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewIndex) != nextInOutUsage.builtInInputLocMap.end());
-        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewIndex];
-        builtInOutLocs[BuiltInViewIndex] = mapLoc;
-      }
-
       if (nextBuiltInUsage.viewportIndex) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
@@ -2416,15 +2380,11 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
 
       if (builtInUsage.gs.layer)
         builtInOutLocs[BuiltInLayer] = availOutMapLoc++;
-
-      if (builtInUsage.gs.viewIndex)
-        builtInOutLocs[BuiltInViewIndex] = availOutMapLoc++;
     }
 
     inOutUsage.inputMapLocCount = std::max(inOutUsage.inputMapLocCount, availInMapLoc);
   } else if (m_shaderStage == ShaderStageMesh) {
     // Mesh shader -> XXX
-    const bool enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
     unsigned availOutMapLoc = inOutUsage.outputMapLocCount;
     unsigned availPerPrimitiveOutMapLoc = inOutUsage.perPrimitiveOutputMapLocCount;
 
@@ -2525,13 +2485,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.perPrimitiveBuiltInInputLocMap[BuiltInViewportIndex];
         inOutUsage.mesh.perPrimitiveBuiltInExportLocs[BuiltInViewportIndex] = mapLoc;
       }
-
-      if (enableMultiView && nextBuiltInUsage.viewIndex) {
-        assert(nextInOutUsage.perPrimitiveBuiltInInputLocMap.find(BuiltInViewIndex) !=
-               nextInOutUsage.perPrimitiveBuiltInInputLocMap.end());
-        const unsigned mapLoc = nextInOutUsage.perPrimitiveBuiltInInputLocMap[BuiltInViewIndex];
-        inOutUsage.mesh.perPrimitiveBuiltInExportLocs[BuiltInViewIndex] = mapLoc;
-      }
     } else if (nextStage == ShaderStageInvalid) {
       // Mesh shader only
       unsigned availPerPrimitiveExportLoc = inOutUsage.perPrimitiveOutputMapLocCount;
@@ -2580,13 +2533,6 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         inOutUsage.perPrimitiveBuiltInInputLocMap[BuiltInViewportIndex] = availPerPrimitiveInMapLoc++;
       else
         inOutUsage.builtInInputLocMap[BuiltInViewportIndex] = availInMapLoc++;
-    }
-
-    if (builtInUsage.fs.viewIndex) {
-      if (prevStage == ShaderStageMesh)
-        inOutUsage.perPrimitiveBuiltInInputLocMap[BuiltInViewIndex] = availPerPrimitiveInMapLoc++;
-      else
-        inOutUsage.builtInInputLocMap[BuiltInViewIndex] = availInMapLoc++;
     }
 
     if (builtInUsage.fs.clipDistance > 0 || builtInUsage.fs.cullDistance > 0) {

--- a/llpc/test/shaderdb/general/PipelineGs_TestViewIndexAndLayer.pipe
+++ b/llpc/test/shaderdb/general/PipelineGs_TestViewIndexAndLayer.pipe
@@ -4,12 +4,13 @@
 ; RUN: amdllpc -v --gfxip=10.3.0 %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: _amdgpu_vs_main:
-// gl_ViewIndex = 0
-; SHADERTEST: v_mov_b32_e32 v[[VIEWINDEX:[0-9]*]], 0
 // export gl_Layer
 ; SHADERTEST: exp pos1 off, off, {{v[0-9]*}}, off done
-// export gl_ViewIndex
-; SHADERTEST: exp param1 v[[VIEWINDEX]], off, off, off
+
+; SHADERTEST-LABEL: _amdgpu_ps_main:
+// gl_ViewIndex = 0
+; SHADERTEST: v_cvt_pkrtz_f16_f32_e32 {{v[0-9]*}}, 0, {{v[0-9]*}}
+
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1460,6 +1460,9 @@ void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo 
   // Topology is required when BaryCoord is used
   hasher->Update(pipeline->iaState.topology);
 
+  // View index in fragment shader depends on the enablement of multi-view
+  hasher->Update(pipeline->iaState.enableMultiView);
+
   if (!isRelocatableShader) {
     hasher->Update(rsState->innerCoverage);
     hasher->Update(rsState->numSamples);


### PR DESCRIPTION
Previously, we use a generic output to export gl_ViewIndex to fragment shader. This is an awkward solution. View index is an uniform value and could be obtained from special user data. Therefore, we can get it from fragment shader user data directly rather than using generic input with flat shading.

This change try to resolve these issues:

1. Fragment shader will read gl_ViewIndex from special user data, not from a generic input. Mapping gl_ViewIndex to a generic output/input is removed except for geometry shader. This is because geometry shader will write gl_ViewIndex to GS-VS ring and this is needed by copy shader when reading the value back.

2. When gl_ViewIndex is not used in vertex processing shaders, we still need to export it to vertex position data if multi-view is enabled.

3. If gl_ViewIndex and gl_Layer are both used in vertex processing shaders, gl_ViewIndex will be exported to vertex position data if multi-view is enabled and gl_Layer will only be exported to a generic output if next stage references it.

4. If multi-view is disabled, gl_ViewIndex is always 0 and will not be loaded from user data.

Multi-view in geometry shader is not enabled in Vulkan driver. There is no obvious reason for disabling it. The CTS group could pass: VK.multiview.*geometry*. Will try to enable the capability flag.