### PR TITLE
Make module name more clearer

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1097,7 +1097,7 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
       if (moduleDataEx->binType == BinaryType::MultiLlvmBc) {
         result = Result::ErrorInvalidShader;
       } else {
-        module = new Module((Twine("llpc") + getShaderStageName(shaderInfoEntry->entryStage)).str() +
+        module = new Module((Twine("llpc") + "_" + getShaderStageName(shaderInfoEntry->entryStage)).str() + "_" +
                                 std::to_string(getModuleIdByIndex(shaderIndex)),
                             *context);
       }

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestRelocatableSeparateCompilation.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_TestRelocatableSeparateCompilation.pipe
@@ -6,11 +6,11 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-EMPTY:
 ; SHADERTEST-NEXT: ; ModuleID = 'lgcPipeline'
-; SHADERTEST-NEXT: source_filename = "llpcvertex
+; SHADERTEST-NEXT: source_filename = "llpc_vertex
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST-EMPTY:
 ; SHADERTEST-NEXT: ; ModuleID = 'lgcPipeline'
-; SHADERTEST-NEXT: source_filename = "llpcfragment
+; SHADERTEST-NEXT: source_filename = "llpc_fragment
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
Add underline between name and moduleIndex
llpcvertex2 would become llpc_vertex_2