### PR TITLE
[CI] Re-enable sanitizer builds

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -19,6 +19,8 @@ jobs:
         config:              [Release]
         feature-set:         ["+gcc", "+gcc+assertions",
                               "+clang",
+                              "+clang+shadercache+ubsan+asan",
+                              "+clang+shadercache+ubsan+asan+assertions",
                               "+clang+shadercache+tsan"]
     steps:
       - name: Free up disk space


### PR DESCRIPTION
The base image now succeeds to build, so we can enable sanitizer builds again.