### PR TITLE
Fix for LLVM upstream changes to Optional

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -252,8 +252,7 @@ LgcContext *LgcContext::create(LLVMContext &context, StringRef gpuName, unsigned
 
   LLPC_OUTS("TargetMachine optimization level = " << optLevel << "\n");
 
-  builderContext->m_targetMachine =
-      target->createTargetMachine(triple, gpuName, "", targetOpts, Optional<Reloc::Model>(), None, optLevel);
+  builderContext->m_targetMachine = target->createTargetMachine(triple, gpuName, "", targetOpts, {}, None, optLevel);
   assert(builderContext->m_targetMachine);
   return builderContext;
 }

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -167,7 +167,13 @@ DIType *SPIRVToLLVMDbgTran::transTypePointer(const SPIRVExtInst *DebugInst) {
   DIType *PointeeTy = nullptr;
   if (BM->getEntry(Ops[BaseTypeIdx])->getOpCode() != OpTypeVoid)
     PointeeTy = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 444152
+  // Old version of the code
   Optional<unsigned> AS;
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  std::optional<unsigned> AS;
+#endif
   if (Ops[StorageClassIdx] != ~0U) {
     auto SC = static_cast<SPIRVStorageClassKind>(Ops[StorageClassIdx]);
     AS = SPIRSPIRVAddrSpaceMap::rmap(SC);


### PR DESCRIPTION
There is a series of changes in LLVM upstream to replace uses of Optional with std::optional, for example:
0ca43d44888885 (DebugInfoMetadata: convert Optional to std::optional).

This change updates the functions' arguments to match both versions.