### PR TITLE
[CI] Rename remotes to origin

### DIFF
--- a/docker/update-llpc.sh
+++ b/docker/update-llpc.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Update the driver and clone a specified version of LLPC.
 # Shared code between docker containers.
-set -e
+set -euxo pipefail
 
 # Sync the repos. Replace the base LLPC with a freshly checked-out one.
 cat /vulkandriver/build_info.txt
 (cd /vulkandriver && repo sync -c --no-clone-bundle -j$(nproc))
-git -C /vulkandriver/drivers/llpc remote add origin https://github.com/"$LLPC_REPO_NAME".git
+git -C /vulkandriver/drivers/llpc remote rename vulkan-github origin
+git -C /vulkandriver/drivers/llpc/imported/llvm-dialects remote rename vulkan-github origin
 git -C /vulkandriver/drivers/llpc fetch origin +"$LLPC_REPO_SHA":"$LLPC_REPO_REF" --update-head-ok
 git -C /vulkandriver/drivers/llpc checkout "$LLPC_REPO_SHA"
 git -C /vulkandriver/drivers/llpc submodule update --init


### PR DESCRIPTION
Calling the remote 'origin' seems to fix issues when pulling with submodules. I couldn’t reproduce this outside of docker, with my newer git version, so probably this was a bug that is now fixed in git.

I tested with Ubuntu 22.04 as the base image, so the issue is still there, even if we update the base image.

This should fix the build issue in #2023.