### PR TITLE
lgc: set cumode target feature based on the wgpMode shader option

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -298,6 +298,9 @@ public:
     m_waveSize[stage] = waveSize;
   }
 
+  // Whether WGP mode is enabled for the given shader stage
+  bool getShaderWgpMode(ShaderStage stage) const;
+
   // Get NGG control settings
   NggControl *getNggControl() { return &m_nggControl; }
 

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -951,7 +951,8 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
 
   const bool userSgprMsb = (userDataCount > 31);
   if (gfxIp.major >= 10) {
-    bool wgpMode = (getShaderWgpMode(ShaderStageVertex) || getShaderWgpMode(ShaderStageTessControl));
+    bool wgpMode = (m_pipelineState->getShaderWgpMode(ShaderStageVertex) ||
+                    m_pipelineState->getShaderWgpMode(ShaderStageTessControl));
 
     SET_REG_GFX10_PLUS_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, MEM_ORDERED, true);
     SET_REG_GFX10_PLUS_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, WGP_MODE, wgpMode);
@@ -1060,8 +1061,8 @@ void ConfigBuilder::buildEsGsRegConfig(ShaderStage shaderStage1, ShaderStage sha
 
   const bool userSgprMsb = (userDataCount > 31);
   if (gfxIp.major == 10) {
-    bool wgpMode =
-        (getShaderWgpMode(hasTs ? ShaderStageTessEval : ShaderStageVertex) || getShaderWgpMode(ShaderStageGeometry));
+    bool wgpMode = m_pipelineState->getShaderWgpMode(hasTs ? ShaderStageTessEval : ShaderStageVertex) ||
+                   m_pipelineState->getShaderWgpMode(ShaderStageGeometry);
 
     SET_REG_GFX10_PLUS_FIELD(&config->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
     SET_REG_GFX10_PLUS_FIELD(&config->esGsRegs, SPI_SHADER_PGM_RSRC1_GS, WGP_MODE, wgpMode);
@@ -1271,9 +1272,9 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
       std::max((hasTs ? tesIntfData->userDataCount : vsIntfData->userDataCount), gsIntfData->userDataCount);
 
   const auto &gsShaderOptions = m_pipelineState->getShaderOptions(ShaderStageGeometry);
-  bool wgpMode = getShaderWgpMode(hasTs ? ShaderStageTessEval : ShaderStageVertex);
+  bool wgpMode = m_pipelineState->getShaderWgpMode(hasTs ? ShaderStageTessEval : ShaderStageVertex);
   if (hasGs)
-    wgpMode = (wgpMode || getShaderWgpMode(ShaderStageGeometry));
+    wgpMode = (wgpMode || m_pipelineState->getShaderWgpMode(ShaderStageGeometry));
 
   SET_REG_FIELD(&config->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, gsShaderOptions.debugMode);
   SET_REG_GFX10_PLUS_FIELD(&config->primShaderRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
@@ -1705,7 +1706,7 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
   unsigned userDataCount = intfData->userDataCount;
 
   const auto &shaderOptions = m_pipelineState->getShaderOptions(shaderStage);
-  bool wgpMode = getShaderWgpMode(shaderStage);
+  bool wgpMode = m_pipelineState->getShaderWgpMode(shaderStage);
 
   SET_REG_FIELD(&config->meshRegs, SPI_SHADER_PGM_RSRC1_GS, DEBUG_MODE, shaderOptions.debugMode);
   SET_REG_GFX10_PLUS_FIELD(&config->meshRegs, SPI_SHADER_PGM_RSRC1_GS, MEM_ORDERED, true);
@@ -1853,7 +1854,7 @@ void ConfigBuilder::buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *confi
   GfxIpVersion gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
 
   if (gfxIp.major >= 10) {
-    bool wgpMode = getShaderWgpMode(shaderStage);
+    bool wgpMode = m_pipelineState->getShaderWgpMode(shaderStage);
 
     SET_REG_GFX10_PLUS_FIELD(config, COMPUTE_PGM_RSRC1, MEM_ORDERED, true);
     SET_REG_GFX10_PLUS_FIELD(config, COMPUTE_PGM_RSRC1, WGP_MODE, wgpMode);
@@ -2183,21 +2184,6 @@ template <typename T> void ConfigBuilder::setupPaSpecificRegisters(T *config) {
   if (posCount > 3) {
     SET_REG_FIELD(config, SPI_SHADER_POS_FORMAT, POS3_EXPORT_FORMAT, SPI_SHADER_4COMP);
   }
-}
-
-// =====================================================================================================================
-// Gets WGP mode enablement for the specified shader stage
-//
-// @param shaderStage : Shader stage
-bool ConfigBuilder::getShaderWgpMode(ShaderStage shaderStage) const {
-  if (shaderStage == ShaderStageCopyShader) {
-    // Treat copy shader as part of geometry shader
-    shaderStage = ShaderStageGeometry;
-  }
-
-  assert(shaderStage <= ShaderStageCompute);
-
-  return m_pipelineState->getShaderOptions(shaderStage).wgpMode;
 }
 
 } // namespace Gfx9

--- a/lgc/patch/Gfx9ConfigBuilder.h
+++ b/lgc/patch/Gfx9ConfigBuilder.h
@@ -75,8 +75,6 @@ private:
 
   void setupVgtTfParam(LsHsRegConfig *config);
   template <typename T> void setupPaSpecificRegisters(T *config);
-
-  bool getShaderWgpMode(ShaderStage shaderStage) const;
 };
 
 } // namespace Gfx9

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -184,9 +184,10 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
 
       targetFeatures += ",+wavefrontsize" + std::to_string(waveSize);
 
-      // Allow driver setting for WGP by forcing backend to set 0
-      // which is then OR'ed with the driver set value
-      targetFeatures += ",+cumode";
+      if (m_pipelineState->getShaderWgpMode(shaderStage))
+        targetFeatures += ",-cumode";
+      else
+        targetFeatures += ",+cumode";
     }
 
     // Enable flat scratch for gfx10.3+

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1323,6 +1323,22 @@ void PipelineState::setShaderDefaultWaveSize(ShaderStage stage) {
 }
 
 // =====================================================================================================================
+// Whether WGP mode is enabled for the given shader stage
+//
+// @param stage : Shader stage
+bool PipelineState::getShaderWgpMode(ShaderStage stage) const {
+  if (stage == ShaderStageCopyShader) {
+    // Treat copy shader as part of geometry shader
+    stage = ShaderStageGeometry;
+  }
+
+  assert(stage <= ShaderStageCompute);
+  assert(stage < m_shaderOptions.size());
+
+  return m_shaderOptions[stage].wgpMode;
+}
+
+// =====================================================================================================================
 // Checks if SW-emulated mesh pipeline statistics is needed
 bool PipelineState::needSwMeshPipelineStats() const {
   return getTargetInfo().getGfxIpVersion().major < 11;

--- a/llpc/test/shaderdb/gfx10/WgpModeDisabled.pipe
+++ b/llpc/test/shaderdb/gfx10/WgpModeDisabled.pipe
@@ -1,0 +1,14 @@
+; RUN: amdllpc  -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: LLPC final pipeline module info
+; SHADERTEST: {{^}}attributes {{.*}}+cumode
+; SHADERTEST: AMDLLPC SUCCESS
+
+[CsGlsl]
+#version 450
+
+void main() {
+}
+
+[CsInfo]
+entryPoint = main
+options.wgpMode = 0

--- a/llpc/test/shaderdb/gfx10/WgpModeEnabled.pipe
+++ b/llpc/test/shaderdb/gfx10/WgpModeEnabled.pipe
@@ -1,0 +1,14 @@
+; RUN: amdllpc  -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: LLPC final pipeline module info
+; SHADERTEST: {{^}}attributes {{.*}}-cumode
+; SHADERTEST: AMDLLPC SUCCESS
+
+[CsGlsl]
+#version 450
+
+void main() {
+}
+
+[CsInfo]
+entryPoint = main
+options.wgpMode = 1


### PR DESCRIPTION
Correctly setting "-cumode" is necessary for correctness when WGP mode is used because it affects the memory model legalizer (i.e., WGP mode requires more cache invalidations).

It seems we got lucky so far, probably in part because we don't use WGP mode that much. I only noticed this by chance when looking through the code.