### PR TITLE
Slightly improve CMake code

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -1,4 +1,8 @@
 function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
+    target_compile_features("${PROJECT_NAME}" PUBLIC cxx_std_17)
+    set_target_properties("${PROJECT_NAME}" PROPERTIES CXX_EXTENSIONS OFF)
+    set_target_properties("${PROJECT_NAME}" PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         if(ENABLE_WERROR)
             target_compile_options("${PROJECT_NAME}" PRIVATE
@@ -32,8 +36,6 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
 
         target_compile_options("${PROJECT_NAME}" PRIVATE $<$<COMPILE_LANGUAGE:CXX>:
             -fno-rtti
-            -fPIC
-            -std=c++17
             # Some of the games using old versions of the tcmalloc lib are
             # crashing when allocating aligned memory. C++17 enables aligned new
             # by default, so we need to disable it to prevent those crashes.
@@ -97,9 +99,6 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
                 /wd4800 # forcing value to bool 'true' or 'false' (performance warning)
                 /wd6246 # Local declaration of 'S' hides declaration of the same name in outer scope
                 /wd6323 # Use of arithmetic operator on Boolean type(s)
-        )
-        target_compile_options("${PROJECT_NAME}" PRIVATE
-          /std:c++17
         )
 
         target_compile_definitions("${PROJECT_NAME}" PRIVATE _SCL_SECURE_NO_WARNINGS)

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -49,7 +49,6 @@ if(ICD_BUILD_LLPC)
     set(LLVM_EXTERNAL_LGC_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../lgc)
 
     # Set other LLVM settings.
-    set(LLVM_ENABLE_ASSERTIONS ${CMAKE_BUILD_TYPE_DEBUG} CACHE BOOL Force)
     set(LLVM_TARGETS_TO_BUILD AMDGPU CACHE STRING Force)
     set(LLVM_BUILD_TESTS OFF CACHE BOOL Force)
     set(LLVM_BUILD_TOOLS ${LLPC_BUILD_LLVM_TOOLS} CACHE BOOL Force)
@@ -383,10 +382,8 @@ target_link_libraries(llpc_standalone_compiler PUBLIC
     spvgen_static
     vfx
     vkgc_headers
+    ${CMAKE_DL_LIBS}
 )
-if(UNIX)
-    target_link_libraries(llpc_standalone_compiler PUBLIC dl)
-endif()
 
 if (NOT LLVM_LINK_LLVM_DYLIB)
     llvm_map_components_to_libnames(llvm_libs


### PR DESCRIPTION
Make options independant of the used compiler

- Set C++ standard through target_compile_features
- Set PIE through target properties
- Link to `CMAKE_DL_LIBS`
- Remove forcing LLVM_ENABLE_ASSERTIONS=OFF, I don’t understand why it was there in the first place (and multi-config builds can’t depend on the CMAKE_BUILD_TYPE)