### PR TITLE
Fix the dummy export for 'alpha to coverage'

### DIFF
--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -482,7 +482,7 @@ bool LowerFragColorExport::runImpl(Module &module, PipelineShadersResult &pipeli
         static_cast<ExportFormat>(m_pipelineState->computeExportFormat(exp.ty, exp.location));
   }
   bool dummyExport =
-      (m_pipelineState->getTargetInfo().getGfxIpVersion().major < 10 || m_resUsage->builtInUsage.fs.discard);
+      (m_pipelineState->getTargetInfo().getGfxIpVersion().major < 11 || m_resUsage->builtInUsage.fs.discard);
   fragColorExport.generateExportInstructions(m_info, m_exportValues, exportFormat, dummyExport, builder);
 
   const auto &builtInUsage = m_resUsage->builtInUsage.fs;
@@ -850,6 +850,9 @@ void FragColorExport::generateExportInstructions(ArrayRef<lgc::ColorExportInfo> 
 
   if (!lastExport && dummyExport) {
     lastExport = FragColorExport::addDummyExport(builder);
+    // Set CB shader mask, if alphaToCoverage is enabled, we need to enable the output mask for the alpha channel
+    auto resUage = m_pipelineState->getShaderResourceUsage(ShaderStageFragment);
+    resUage->inOutUsage.fs.cbShaderMask |= m_pipelineState->getColorExportState().alphaToCoverageEnable ? 0x8 : 0x0;
   }
 
   if (lastExport)

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -933,12 +933,15 @@ void PalMetadata::updateSpiShaderColFormat(ArrayRef<ColorExportInfo> exps, bool 
   }
 
   if (spiShaderColFormat == 0 && hasDepthExpFmtZero) {
-    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major < 10 || killEnabled) {
+    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major < 11 || killEnabled) {
       // NOTE: Hardware requires that fragment shader always exports "something" (color or depth) to the SX.
       // If both SPI_SHADER_Z_FORMAT and SPI_SHADER_COL_FORMAT are zero, we need to override
       // SPI_SHADER_COL_FORMAT to export one channel to MRT0. This dummy export format will be masked
       // off by CB_SHADER_MASK.
-      spiShaderColFormat = SPI_SHADER_32_R;
+      //
+      // Need to expose a format with alpha channel for Alpha-to-Coverage case
+      spiShaderColFormat =
+          m_pipelineState->getColorExportState().alphaToCoverageEnable ? SPI_SHADER_32_AR : SPI_SHADER_32_R;
     }
   }
   setRegister(mmSPI_SHADER_COL_FORMAT, spiShaderColFormat);

--- a/llpc/test/shaderdb/general/PipelineVsFs_alpha_to_coverage_no_color_attachment.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_alpha_to_coverage_no_color_attachment.pipe
@@ -1,0 +1,67 @@
+; Check the alpha to coverage and no color attachment
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc -enable-opaque-pointers=true -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: .registers
+; SHADERTEST: CB_SHADER_MASK 0x0000000000000008
+; SHADERTEST: SPI_SHADER_COL_FORMAT 0x0000000000000003
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+[Version]
+version = 57
+
+[VsGlsl]
+#version 310 es
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec4 color;
+layout(location = 0) out highp vec4 vtxColor;
+void main (void)
+{
+    gl_Position = position;
+    vtxColor = color;
+}
+
+[VsInfo]
+entryPoint = main
+
+[FsGlsl]
+#version 310 es
+layout(location = 0) in highp vec4 vtxColor;
+layout(location = 0) out highp vec4 fragColor;
+void main (void)
+{
+   fragColor = vtxColor;
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 4
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 2
+userDataNode[1].type = IndirectUserDataVaPtr
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 1
+userDataNode[1].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP
+numSamples = 2
+alphaToCoverageEnable = 1
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 32
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[0].offset = 0
+attribute[1].location = 1
+attribute[1].binding = 0
+attribute[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
+attribute[1].offset = 16


### PR DESCRIPTION
We must export a format and shader mask with alpha channel if enable

alpha to coverage, even if there is no color buffer output.