### PR TITLE
Opaque Pointers: Add missing zero-index elements in coalesced GEP

### DIFF
--- a/llpc/lower/llpcSpirvLowerAccessChain.h
+++ b/llpc/lower/llpcSpirvLowerAccessChain.h
@@ -51,6 +51,8 @@ public:
 
 private:
   llvm::GetElementPtrInst *tryToCoalesceChain(llvm::GetElementPtrInst *getElemPtr, unsigned addrSpace);
+  void appendZeroIndexToMatchTypes(llvm::SmallVectorImpl<llvm::Value *> &indexOperands, llvm::Type *typeToMatch,
+                                   llvm::Type *baseType);
 };
 
 // =====================================================================================================================


### PR DESCRIPTION
Lower Access Chain is coalescing multiple chained GEPs into single GEP instruction. For opaque pointers some of the GEPs (which have all zero-index) are removed and these leads to creation of coalesced GEP with wrong indices.