### PR TITLE
Stop using llvm::None

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1491,7 +1491,7 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
       copyMetadata(newLoad, loadInst);
 
       if (isInvariant)
-        newLoad->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, None));
+        newLoad->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, {}));
 
       return newLoad;
     }
@@ -1611,7 +1611,7 @@ Value *PatchBufferOp::replaceLoadStore(Instruction &inst) {
       if (isInvariant && accessSize >= 4) {
         CallInst *call = m_builder->CreateIntrinsic(Intrinsic::amdgcn_s_buffer_load, intAccessType,
                                                     {bufferDesc, offsetVal, m_builder->getInt32(coherent.u32All)});
-        call->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, None));
+        call->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, {}));
         part = call;
       } else {
         unsigned intrinsicID = Intrinsic::amdgcn_raw_buffer_load;

--- a/lgc/patch/PatchInvariantLoads.cpp
+++ b/lgc/patch/PatchInvariantLoads.cpp
@@ -253,7 +253,7 @@ bool PatchInvariantLoads::runImpl(Function &function, PipelineState *pipelineSta
       continue;
 
     LLVM_DEBUG(dbgs() << "Marking load invariant: " << *inst << "\n");
-    inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(context, None));
+    inst->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(context, {}));
     changed = true;
   }
 

--- a/lgc/patch/PatchLoopMetadata.cpp
+++ b/lgc/patch/PatchLoopMetadata.cpp
@@ -63,7 +63,7 @@ MDNode *PatchLoopMetadata::updateMetadata(MDNode *loopId, ArrayRef<StringRef> pr
   bool found = false;
   SmallVector<Metadata *, 4> mds;
   // Reserve first location for self reference to the loopId metadata node.
-  TempMDTuple tempNode = MDNode::getTemporary(*m_context, None);
+  TempMDTuple tempNode = MDNode::getTemporary(*m_context, {});
   mds.push_back(tempNode.get());
   for (unsigned i = 1, operandCount = loopId->getNumOperands(); i < operandCount; ++i) {
     Metadata *op = loopId->getOperand(i);

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -252,7 +252,7 @@ LgcContext *LgcContext::create(LLVMContext &context, StringRef gpuName, unsigned
 
   LLPC_OUTS("TargetMachine optimization level = " << optLevel << "\n");
 
-  builderContext->m_targetMachine = target->createTargetMachine(triple, gpuName, "", targetOpts, {}, None, optLevel);
+  builderContext->m_targetMachine = target->createTargetMachine(triple, gpuName, "", targetOpts, {}, {}, optLevel);
   assert(builderContext->m_targetMachine);
   return builderContext;
 }

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -146,7 +146,7 @@ static bool runPassPipeline(Pipeline &pipeline, Module &module, raw_pwrite_strea
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
   lgcContext->preparePassManager(*passMgr);
 
-  PassBuilder passBuilder(lgcContext->getTargetMachine(), PipelineTuningOptions(), None,
+  PassBuilder passBuilder(lgcContext->getTargetMachine(), PipelineTuningOptions(), {},
                           &passMgr->getInstrumentationCallbacks());
   Patch::registerPasses(passBuilder);
 

--- a/lgc/util/PassManager.cpp
+++ b/lgc/util/PassManager.cpp
@@ -213,7 +213,7 @@ void PassManagerImpl::run(Module &module) {
   // We register LLVM's default analysis sets late to be sure our custom
   // analyses are added beforehand.
   if (!initialized) {
-    PassBuilder passBuilder(m_targetMachine, PipelineTuningOptions(), None, &m_instrumentationCallbacks);
+    PassBuilder passBuilder(m_targetMachine, PipelineTuningOptions(), {}, &m_instrumentationCallbacks);
     passBuilder.registerModuleAnalyses(m_moduleAnalysisManager);
     passBuilder.registerCGSCCAnalyses(m_cgsccAnalysisManager);
     passBuilder.registerFunctionAnalyses(m_functionAnalysisManager);

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -593,7 +593,7 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
 // @returns : Formatted bytes, e.g., `ab c4 ef 00`.
 template <typename T> static FormattedBytes formatBytesLittleEndian(ArrayRef<T> data) {
   ArrayRef<uint8_t> bytes(reinterpret_cast<const uint8_t *>(data.data()), data.size() * sizeof(T));
-  return format_bytes(bytes, /* FirstByteOffset = */ None, /* NumPerLine = */ 16, /* ByteGroupSize = */ 1);
+  return format_bytes(bytes, /* FirstByteOffset = */ {}, /* NumPerLine = */ 16, /* ByteGroupSize = */ 1);
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -1458,7 +1458,7 @@ void SpirvLowerRayTracing::createDbgInfo(Module &module, Function *func) {
   DIFile *file = builder.createFile(func->getName(), ".");
 
   // Create the DISubprogram for the module entry function
-  auto *funcTy = builder.createSubroutineType(builder.getOrCreateTypeArray(llvm::None));
+  auto *funcTy = builder.createSubroutineType(builder.getOrCreateTypeArray({}));
   auto spFlags = DISubprogram::SPFlagDefinition;
   auto subProgram =
       builder.createFunction(file, func->getName(), module.getName(), file, 0, funcTy, 0, DINode::FlagZero, spFlags);

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -577,7 +577,7 @@ static Error processInputs(ICompiler *compiler, InputSpecGroup &inputSpecs) {
   //
   // Build pipeline
   //
-  Optional<PipelineDumpOptions> dumpOptions = None;
+  Optional<PipelineDumpOptions> dumpOptions;
   if (cl::EnablePipelineDump) {
     dumpOptions.emplace();
     dumpOptions->pDumpDir = cl::PipelineDumpDir.c_str();

--- a/llpc/tool/llpcPipelineBuilder.cpp
+++ b/llpc/tool/llpcPipelineBuilder.cpp
@@ -82,7 +82,7 @@ namespace StandaloneCompiler {
 //
 // @param compiler : LLPC compiler object.
 // @param [in/out] compileInfo : Compilation info of LLPC standalone tool.
-// @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when `llvm::None` is passed.
+// @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when `std::nullopt` is passed.
 // @param printPipelineInfo : Whether to print pipeline info (hash, filenames) before compilation.
 // @returns : Concrete `PipelineBuilder` object for this pipeline type.
 std::unique_ptr<PipelineBuilder> createPipelineBuilder(ICompiler &compiler, CompileInfo &compileInfo,

--- a/llpc/tool/llpcPipelineBuilder.h
+++ b/llpc/tool/llpcPipelineBuilder.h
@@ -56,7 +56,7 @@ public:
   //
   // @param compiler : LLPC compiler object.
   // @param [in/out] compileInfo : Compilation info of LLPC standalone tool. This will be modified by `build()`.
-  // @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when `llvm::None` is passed.
+  // @param dumpOptions : Pipeline dump options. Pipeline dumps are disabled when `std::nullopt` is passed.
   // @param printPipelineInfo : Whether to print pipeline info (hash, filenames) before compilation.
   PipelineBuilder(ICompiler &compiler, CompileInfo &compileInfo, llvm::Optional<Vkgc::PipelineDumpOptions> dumpOptions,
                   bool printPipelineInfo)
@@ -95,7 +95,7 @@ public:
 
   // Returns the pipeline dump options.
   //
-  // @returns : `PipelineDumpOptions` or `llpc::None` if pipeline dumps were not requested.
+  // @returns : `PipelineDumpOptions` or `std::nullopt` if pipeline dumps were not requested.
   llvm::Optional<Vkgc::PipelineDumpOptions> &getDumpOptions() { return m_dumpOptions; }
 
   // Returns true iff pipeline dumps are requested.
@@ -120,7 +120,7 @@ public:
 private:
   ICompiler &m_compiler;
   CompileInfo &m_compileInfo;
-  llvm::Optional<Vkgc::PipelineDumpOptions> m_dumpOptions = llvm::None;
+  llvm::Optional<Vkgc::PipelineDumpOptions> m_dumpOptions = {};
   bool m_printPipelineInfo = false;
 };
 

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -902,7 +902,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(SPIRVLoopMerge *lm, BranchInst *bi) {
   if (!lm)
     return;
   llvm::MDString *name = nullptr;
-  auto temp = MDNode::getTemporary(*m_context, None);
+  auto temp = MDNode::getTemporary(*m_context, {});
   auto self = MDNode::get(*m_context, temp.get());
   self->replaceOperandWith(0, self);
   std::vector<llvm::Metadata *> mDs;

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -953,7 +953,7 @@ DebugLoc SPIRVToLLVMDbgTran::transDebugScope(const SPIRVInstruction *SpirvInst, 
     if (llvm::Function::isInternalLinkage(F->getLinkage())) {
       SPFlags |= DISubprogram::SPFlagLocalToUnit;
     }
-    auto *Ty = Builder.createSubroutineType(Builder.getOrCreateTypeArray(None));
+    auto *Ty = Builder.createSubroutineType(Builder.getOrCreateTypeArray({}));
     Sub = Builder.createFunction(DF, FN, FN, DF, LN, Ty, LN, DINode::FlagZero, SPFlags);
     FuncMap[SF->getId()] = Sub;
     assert(F->getSubprogram() == Sub || F->getSubprogram() == nullptr);


### PR DESCRIPTION
llvm::None is deprecated in favor of std::nullopt, but in fact most uses can be omitted or replaced with {}.