### PR TITLE
Fix for LLVM upstream changes in SROA

### DIFF
--- a/llpc/test/shaderdb/core/OpAtomicXXX_TestSharedVariable_lit.comp
+++ b/llpc/test/shaderdb/core/OpAtomicXXX_TestSharedVariable_lit.comp
@@ -13,7 +13,7 @@ layout(binding = 0) uniform Uniforms
     int index;
 };
 
-uvec4 u4;
+shared uvec4 u4;
 
 void main()
 {

--- a/llpc/test/shaderdb/object/ObjUniformBlock_TestLoadMatrix_lit.vert
+++ b/llpc/test/shaderdb/object/ObjUniformBlock_TestLoadMatrix_lit.vert
@@ -4,6 +4,7 @@ layout(std140, binding = 0) uniform Block
 {
     int  i;
     mat4 m4;
+    int  j;
 } block;
 
 void main()
@@ -11,7 +12,7 @@ void main()
     int i = block.i;
     mat4 m4 = block.m4;
     m4[i] = vec4(2.0);
-    gl_Position = m4[i];
+    gl_Position = m4[block.j];
 }
 // BEGIN_SHADERTEST
 /*
@@ -23,7 +24,6 @@ void main()
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 32, i32 0)
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 48, i32 0)
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 64, i32 0)
-; SHADERTEST: store <4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, {{<4 x float> addrspace\(.*\)*|ptr addrspace\(.*\)}} %{{[0-9]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/object/ObjUniformBlock_TestLoadScalarArray_lit.vert
+++ b/llpc/test/shaderdb/object/ObjUniformBlock_TestLoadScalarArray_lit.vert
@@ -4,6 +4,7 @@ layout(std140, binding = 0) uniform Block
 {
     float f1[2];
     int  i;
+    int  j;
 } block;
 
 void main()
@@ -11,7 +12,7 @@ void main()
     int i = block.i;
     float f1[2] = block.f1;
     f1[i] = 2.0;
-    gl_Position = vec4(f1[i]);
+    gl_Position = vec4(f1[block.j]);
 }
 // BEGIN_SHADERTEST
 /*
@@ -22,7 +23,6 @@ void main()
 ; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 32, i32 0)
 ; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 0, i32 0)
 ; SHADERTEST: call i32 @llvm.amdgcn.s.buffer.load.i32(<4 x i32> %{{[0-9]*}}, i32 16, i32 0)
-; SHADERTEST: store float 2.000000e+00, {{float addrspace\(.*\)*|ptr addrspace\(.*\)}} %{{[0-9]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/object/ObjUniformBlock_TestLoadVectorArray_lit.vert
+++ b/llpc/test/shaderdb/object/ObjUniformBlock_TestLoadVectorArray_lit.vert
@@ -4,6 +4,7 @@ layout(std140, binding = 0) uniform Block
 {
     int  i;
     vec4 f4[4];
+    int  j;
 } block;
 
 void main()
@@ -11,7 +12,7 @@ void main()
     int i = block.i;
     vec4 f4[4] = block.f4;
     f4[i] = vec4(2.0);
-    gl_Position = f4[i];
+    gl_Position = f4[block.j];
 }
 // BEGIN_SHADERTEST
 /*
@@ -23,7 +24,6 @@ void main()
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 32, i32 0)
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 48, i32 0)
 ; SHADERTEST: call <4 x i32> @llvm.amdgcn.s.buffer.load.v4i32(<4 x i32> %{{[0-9]*}}, i32 64, i32 0)
-; SHADERTEST: store <4 x float> <float 2.000000e+00, float 2.000000e+00, float 2.000000e+00, float 2.000000e+00>, {{<4 x float> addrspace\(.*\)*|ptr addrspace\(.*\)}} %{{[0-9]*}}
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */


### PR DESCRIPTION
Update tests to account for a new optimization in SROA that rewrites stores (introduced in 89a6106ce50689c733be13aaef4be5f3f73708a2).

ObjUniformBlock_Test* tests:
- These tests are quite old, but I am working on the assumption that the key parts are s.buffer.load() arguments.
- With the LLVM commit in question, the store to local memory is no longer present.
- Also made tests more robusts by introducing another index variable in a block, as an optimizing compiler could potentially remove loads.

OpAtomicXXX_TestSharedVariable_lit.comp:
- Made the test more robust by replacing the local variable with shared variable to prevent unwanted optimizations.