### PR TITLE
Sync behaviour of --vgpr-limit, --sgpr-limit

### DIFF
--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -440,10 +440,16 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
         shaderOptions.scalarizeWaterfallLoads = true;
     }
 
-    if (shaderInfo->options.sgprLimit != 0 && shaderInfo->options.sgprLimit != UINT_MAX)
-      shaderOptions.sgprLimit = shaderInfo->options.sgprLimit;
-    else
-      shaderOptions.sgprLimit = SgprLimit;
+    shaderOptions.sgprLimit = shaderInfo->options.sgprLimit;
+
+    if (shaderOptions.sgprLimit == UINT_MAX)
+      shaderOptions.sgprLimit = 0;
+
+    if (SgprLimit != 0) {
+      if (SgprLimit < shaderOptions.sgprLimit || shaderOptions.sgprLimit == 0) {
+        shaderOptions.sgprLimit = SgprLimit;
+      }
+    }
 
     if (shaderInfo->options.maxThreadGroupsPerComputeUnit != 0)
       shaderOptions.maxThreadGroupsPerComputeUnit = shaderInfo->options.maxThreadGroupsPerComputeUnit;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -422,6 +422,9 @@ void PipelineContext::setOptionsInPipeline(Pipeline *pipeline, Util::MetroHash64
 
     shaderOptions.vgprLimit = shaderInfo->options.vgprLimit;
 
+    if (shaderOptions.vgprLimit == UINT_MAX)
+      shaderOptions.vgprLimit = 0;
+
     if (VgprLimit != 0) {
       if (VgprLimit < shaderOptions.vgprLimit || shaderOptions.vgprLimit == 0) {
         shaderOptions.vgprLimit = VgprLimit;


### PR DESCRIPTION
Re-add support of UINT_MAX for unlimited VGPRS in a shader, and make --sgpr-limit semantics consistent with new --vgpr-limit behavior introduced previously.