### PR TITLE
Fix for LLVM upstream deprecation of BasicBlock::getInstList()

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -298,7 +298,13 @@ BranchInst *BuilderImplBase::createIf(Value *condition, bool wantElse, const Twi
   BasicBlock *ifBlock = BasicBlock::Create(getContext(), "", endIfBlock->getParent(), endIfBlock);
   ifBlock->takeName(endIfBlock);
   endIfBlock->setName(instName + ".endif");
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 445640
+  // Old version of the code
   ifBlock->getInstList().splice(ifBlock->end(), endIfBlock->getInstList(), endIfBlock->begin(), GetInsertPoint());
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  ifBlock->splice(ifBlock->end(), endIfBlock, endIfBlock->begin(), GetInsertPoint());
+#endif
 
   // Replace non-phi uses of the original block with the new "if" block.
   SmallVector<Use *, 4> nonPhiUses;

--- a/llpc/lower/llpcSpirvLowerMemoryOp.cpp
+++ b/llpc/lower/llpcSpirvLowerMemoryOp.cpp
@@ -373,8 +373,15 @@ void SpirvLowerMemoryOp::expandStoreInst(StoreInst *storeInst, ArrayRef<GetEleme
     auto storeBlock = checkStoreBlock->splitBasicBlock(storeInst);
     auto endStoreBlock = storeBlock->splitBasicBlock(storeInst);
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 445640
+    // Old version of the code
     Instruction *checkStoreInsertPos = &checkStoreBlock->getInstList().back();
     Instruction *storeInsertPos = &storeBlock->getInstList().front();
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    Instruction *checkStoreInsertPos = &checkStoreBlock->back();
+    Instruction *storeInsertPos = &storeBlock->front();
+#endif
 
     auto getElemPtrCountVal = isType64 ? ConstantInt::get(Type::getInt64Ty(*m_context), getElemPtrCount)
                                        : ConstantInt::get(Type::getInt32Ty(*m_context), getElemPtrCount);

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -584,7 +584,13 @@ bool SpirvLowerRayTracing::runImpl(Module &module) {
       std::vector<CallInst *> callInsts;
 
       for (auto &block : m_entryPoint->getBasicBlockList()) {
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 445640
+        // Old version of the code
         for (auto &inst : block.getInstList()) {
+#else
+        // New version of the code (also handles unknown version, which we treat as latest)
+        for (auto &inst : block) {
+#endif
           if (isa<CallInst>(&inst))
             callInsts.push_back(dyn_cast<CallInst>(&inst));
         }


### PR DESCRIPTION
D139905 makes the function private.