### PR TITLE
Stop using Function::getBasicBlockList

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -1612,7 +1612,7 @@ void SpirvLowerRayQuery::createIntersectBvh(Function *func) {
 // Create sample gpu time
 //
 void SpirvLowerRayQuery::createSampleGpuTime(llvm::Function *func) {
-  assert(func->getBasicBlockList().size() == 1);
+  assert(func->size() == 1);
   m_builder->SetInsertPoint(func->getEntryBlock().getTerminator());
   Value *clocksHiPtr = func->getArg(0);
   Value *clocksLoPtr = func->getArg(1);

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -583,7 +583,7 @@ bool SpirvLowerRayTracing::runImpl(Module &module) {
       // Assuming AnyHit/Intersect module is inlined, find the processed call instructions first
       std::vector<CallInst *> callInsts;
 
-      for (auto &block : m_entryPoint->getBasicBlockList()) {
+      for (auto &block : *m_entryPoint) {
         for (auto &inst : block.getInstList()) {
           if (isa<CallInst>(&inst))
             callInsts.push_back(dyn_cast<CallInst>(&inst));
@@ -2079,7 +2079,7 @@ void SpirvLowerRayTracing::createCallableShaderEntryFunc(Function *func) {
 // @param func : Function to gather ReturnInst
 // @param rets : returned vector of  ReturnInst instructions
 void SpirvLowerRayTracing::getFuncRets(Function *func, SmallVector<Instruction *, 4> &rets) {
-  for (auto &block : func->getBasicBlockList()) {
+  for (auto &block : *func) {
     auto blockTerm = block.getTerminator();
     if (blockTerm != nullptr && isa<ReturnInst>(blockTerm))
       rets.push_back(blockTerm);

--- a/llpc/lower/llpcSpirvLowerRayTracingIntrinsics.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracingIntrinsics.cpp
@@ -136,7 +136,7 @@ bool SpirvLowerRayTracingIntrinsics::processIntrinsicsFunction(Function *func) {
 // @param func : Function to create
 // @param loadTy : Base type of the load value
 void SpirvLowerRayTracingIntrinsics::createLoadDwordAtAddr(Function *func, Type *loadTy) {
-  assert(func->getBasicBlockList().size() == 1);
+  assert(func->size() == 1);
   (*func->begin()).eraseFromParent();
 
   Type *loadPtrTy = loadTy->getPointerTo(SPIRAS_Global);
@@ -178,7 +178,7 @@ void SpirvLowerRayTracingIntrinsics::createConvertF32toF16(Function *func, unsig
   //   return uint3(f32tof16NegInf/PosInf(inVec));
   // }
 
-  assert(func->getBasicBlockList().size() == 1);
+  assert(func->size() == 1);
   (*func->begin()).eraseFromParent();
 
   BasicBlock *entryBlock = BasicBlock::Create(m_builder->getContext(), "", func);


### PR DESCRIPTION
It has been made private by upstream LLVM patch
https://reviews.llvm.org/D140162