### PR TITLE
lgc: Add static getBuiltInTy method

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -230,7 +230,8 @@ unsigned Builder::getAddrSpaceConst() {
 //
 // @param builtIn : Built-in kind
 // @param inOutInfo : Extra input/output info (shader-defined array size)
-Type *Builder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
+// @param context : LLVMContext
+Type *Builder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo, LLVMContext &context) {
   enum TypeCode : unsigned {
     a2f32,
     a4f32,
@@ -267,41 +268,41 @@ Type *Builder::getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
 
   switch (typeCode) {
   case TypeCode::a2f32:
-    return ArrayType::get(getFloatTy(), 2);
+    return ArrayType::get(Type::getFloatTy(context), 2);
   case TypeCode::a4f32:
-    return ArrayType::get(getFloatTy(), 4);
+    return ArrayType::get(Type::getFloatTy(context), 4);
   // For ClipDistance and CullDistance, the shader determines the array size.
   case TypeCode::af32:
-    return ArrayType::get(getFloatTy(), arraySize);
+    return ArrayType::get(Type::getFloatTy(context), arraySize);
   // For SampleMask and PrimitivePointIndices, the shader determines the array size.
   case TypeCode::ai32:
-    return ArrayType::get(getInt32Ty(), arraySize);
+    return ArrayType::get(Type::getInt32Ty(context), arraySize);
   // For PrimitiveLineIndices, the shader determines the array size.
   case TypeCode::av2i32:
-    return ArrayType::get(FixedVectorType::get(getInt32Ty(), 2), arraySize);
+    return ArrayType::get(FixedVectorType::get(Type::getInt32Ty(context), 2), arraySize);
   // For PrimitiveTriangleIndices, the shader determines the array size.
   case TypeCode::av3i32:
-    return ArrayType::get(FixedVectorType::get(getInt32Ty(), 3), arraySize);
+    return ArrayType::get(FixedVectorType::get(Type::getInt32Ty(context), 3), arraySize);
   case TypeCode::f32:
-    return getFloatTy();
+    return Type::getFloatTy(context);
   case TypeCode::i1:
-    return getInt1Ty();
+    return Type::getInt1Ty(context);
   case TypeCode::i32:
-    return getInt32Ty();
+    return Type::getInt32Ty(context);
   case TypeCode::i64:
-    return getInt64Ty();
+    return Type::getInt64Ty(context);
   case TypeCode::v2f32:
-    return FixedVectorType::get(getFloatTy(), 2);
+    return FixedVectorType::get(Type::getFloatTy(context), 2);
   case TypeCode::v3f32:
-    return FixedVectorType::get(getFloatTy(), 3);
+    return FixedVectorType::get(Type::getFloatTy(context), 3);
   case TypeCode::v4f32:
-    return FixedVectorType::get(getFloatTy(), 4);
+    return FixedVectorType::get(Type::getFloatTy(context), 4);
   case TypeCode::v3i32:
-    return FixedVectorType::get(getInt32Ty(), 3);
+    return FixedVectorType::get(Type::getInt32Ty(context), 3);
   case TypeCode::v4i32:
-    return FixedVectorType::get(getInt32Ty(), 4);
+    return FixedVectorType::get(Type::getInt32Ty(context), 4);
   case TypeCode::a4v3f32:
-    return ArrayType::get(FixedVectorType::get(getFloatTy(), 3), 4);
+    return ArrayType::get(FixedVectorType::get(Type::getFloatTy(context), 3), 4);
   default:
     llvm_unreachable("Should never be called!");
     return nullptr;

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1230,12 +1230,21 @@ public:
                                                   unsigned xfbBuffer, unsigned xfbStride, llvm::Value *xfbOffset,
                                                   InOutInfo outputInfo) = 0;
 
+  // Get the type of a built-in -- static edition of the method below, so you can use it without a Builder object.
+  //
+  // @param builtIn : Built-in kind, one of the BuiltIn* constants
+  // @param inOutInfo : Extra input/output info (shader-defined array length)
+  // @param context : LLVMContext
+  static llvm::Type *getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo, llvm::LLVMContext &context);
+
   // Get the type of a built-in. Where the built-in has a shader-defined array length (ClipDistance,
   // CullDistance, SampleMask), inOutInfo.GetArraySize() is used as the array size.
   //
   // @param builtIn : Built-in kind, one of the BuiltIn* constants
   // @param inOutInfo : Extra input/output info (shader-defined array length)
-  llvm::Type *getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo);
+  llvm::Type *getBuiltInTy(BuiltInKind builtIn, InOutInfo inOutInfo) {
+    return getBuiltInTy(builtIn, inOutInfo, getContext());
+  }
 
   // Create a read of barycoord input value.
   // The type of the returned value is the fixed type of the specified built-in (see BuiltInDefs.h),


### PR DESCRIPTION
Will allow a front-end pass to call it when it does not have an lgc::Builder.