### PR TITLE
NGG coding rework: Add a helper createFenceAndBarrier and rename createUBfe

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -284,13 +284,12 @@ private:
   }
 
   llvm::BasicBlock *createBlock(llvm::Function *parent, const llvm::Twine &blockName = "");
-
-  llvm::Value *CreateUBfe(llvm::Value *value, unsigned offset, unsigned count);
+  llvm::Value *createUBfe(llvm::Value *value, unsigned offset, unsigned count);
+  void createFenceAndBarrier();
 
   static const unsigned NullPrim = (1u << 31); // Null primitive data (invalid)
 
   PipelineState *m_pipelineState; // Pipeline state
-  llvm::LLVMContext *m_context;   // LLVM context
   GfxIpVersion m_gfxIp;           // Graphics IP version info
 
   const NggControl *m_nggControl; // NGG control settings


### PR DESCRIPTION
1. Add createFenceAndBarrier. This operation is frequently used in NGG.
2. Rename CreateUBfe to createUBfe. Respect the coding requirements.
3. Remove the member m_context. This is redundant.