### PR TITLE
Add float atomic min/max intrinsic support for GPURT

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracingIntrinsics.h
+++ b/llpc/lower/llpcSpirvLowerRayTracingIntrinsics.h
@@ -49,6 +49,9 @@ public:
 protected:
   void createLoadDwordAtAddr(llvm::Function *func, llvm::Type *loadTy);
   void createConvertF32toF16(llvm::Function *func, unsigned roundingMode);
+  void createGetBaseAddrFromResource(llvm::Function *func);
+  void createAtomicFMinMaxAtAddr(llvm::Function *func, bool isMin, bool is64Ty);
+  void createAtomicLdsFMinMax(llvm::Function *func, bool isMin);
 
 private:
   bool processIntrinsicsFunction(llvm::Function *func);


### PR DESCRIPTION
This commit adds support for several GPURT intrinsic that perform float atomic min/max operations on buffer and LDS.

Known issue: For LDS intrinsic (AmdExtAtomicLdsFMin/AmdExtAtomicLdsFMax), we need to pass in the `groupshared` variable as function parameter, however, HLSL does not allow function parameter to be `groupshared`, but can call a function with a groupshared argument. SPIRVReader will always assert because of the mismatch function call. We fix the mismatch by mutating the parameter in later pass.