### PR TITLE
NGG coding rework: Move NGG passthrough handling to a separate function

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -185,8 +185,9 @@ private:
 
   void buildPrimShaderCbLayoutLookupTable();
 
-  void constructPrimShaderWithoutGs(llvm::Module *module);
-  void constructPrimShaderWithGs(llvm::Module *module);
+  void buildPassthroughPrimShader(llvm::Function *entryPoint);
+  void buildPrimShader(llvm::Function *entryPoint);
+  void buildPrimShaderWithGs(llvm::Function *entryPoint);
 
   void initWaveThreadInfo(llvm::Value *mergedGroupInfo, llvm::Value *mergedWaveInfo);
 


### PR DESCRIPTION
Move all NGG passthrough handling to a new function for clearness. Also, rename NGG primitive shader builders.