### PR TITLE
Remove macros LLPC_BUILD_GFX11 and LLPC_BUILD_NAVI31

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -55,12 +55,6 @@ target_link_libraries(LLVMlgc PUBLIC llvm_dialects)
 
 ### Cached Project Options #############################################################################################
 option(LLPC_BUILD_NAVI12 "LLPC support for NAVI12?" OFF)
-#if VKI_BUILD_GFX11
-option(LLPC_BUILD_GFX11 "LLPC support for GFX11?" OFF)
-#endif
-#if VKI_BUILD_NAVI31
-option(LLPC_BUILD_NAVI31 "LLPC support for NAVI31?" OFF)
-#endif
 option(LLPC_ENABLE_WERROR "Build LLPC with more errors" OFF)
 
 ### Compiler Options ###################################################################################################
@@ -93,6 +87,7 @@ target_compile_definitions(LLVMlgc PRIVATE
         CHIP_HDR_NAVI22
         CHIP_HDR_NAVI23
         CHIP_HDR_NAVI24
+        CHIP_HDR_NAVI31
         )
 
 target_compile_definitions(LLVMlgc PRIVATE CHIP_HDR_RENOIR)
@@ -103,21 +98,6 @@ target_compile_definitions(LLVMlgc PRIVATE CHIP_HDR_RENOIR)
         CHIP_HDR_NAVI12
     )
   endif()
-#if VKI_BUILD_GFX11
-  if(LLPC_BUILD_GFX11)
-    target_compile_definitions(LLVMlgc PUBLIC
-        LLPC_BUILD_GFX11
-    )
-  endif()
-#endif
-#if VKI_BUILD_NAVI31
-  if(LLPC_BUILD_NAVI31)
-    target_compile_definitions(LLVMlgc PRIVATE
-        LLPC_BUILD_NAVI31
-        CHIP_HDR_NAVI31
-    )
-  endif()
-#endif
 
 if(WIN32)
     target_compile_definitions(LLVMlgc PRIVATE
@@ -206,16 +186,9 @@ target_sources(LLVMlgc PRIVATE
     patch/ShaderMerger.cpp
     patch/SystemValues.cpp
     patch/VertexFetch.cpp
+    patch/PatchImageOpCollect.cpp
     patch/PatchWaveSizeAdjust.cpp
 )
-
-#if LLPC_BUILD_GFX11
-if(LLPC_BUILD_GFX11)
-  target_sources(LLVMlgc PRIVATE
-    patch/PatchImageOpCollect.cpp
-  )
-endif()
-#endif
 
 # lgc/state
 target_sources(LLVMlgc PRIVATE

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -601,12 +601,10 @@ Value *DescBuilder::buildBufferCompactDesc(Value *desc) {
     sqBufRsrcWord3.gfx10.resourceLevel = 1;
     sqBufRsrcWord3.gfx10.oobSelect = 2;
     assert(sqBufRsrcWord3.u32All == 0x21014FAC);
-#if LLPC_BUILD_GFX11
   } else if (gfxIp.major == 11) {
     sqBufRsrcWord3.gfx11.format = BUF_FORMAT_32_UINT;
     sqBufRsrcWord3.gfx11.oobSelect = 2;
     assert(sqBufRsrcWord3.u32All == 0x20014FAC);
-#endif
   } else {
     llvm_unreachable("Not implemented!");
   }

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -740,7 +740,6 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
   assert(xfbBuffer < MaxTransformFeedbackBuffers);
   assert(streamId < MaxGsStreams);
 
-#if LLPC_BUILD_GFX11
   if (m_shaderStage == ShaderStageGeometry && getPipelineState()->enableSwXfb()) {
     // NOTE: For SW-emulated stream-out, we disable GS output packing. This is because
     // the packing operation might cause a vector components belong to different vectors after the
@@ -749,7 +748,6 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
     getPipelineState()->setPackOutput(ShaderStageGeometry, false);
     getPipelineState()->setPackInput(ShaderStageFragment, false);
   }
-#endif
 
   // Collect the XFB output.
   XfbOutInfo xfbOutInfo = {};
@@ -1196,7 +1194,6 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
     Value *localInvocationId =
         ShaderInputs::getInput(ShaderInput::LocalInvocationId, BuilderBase::get(*this), *getLgcContext());
 
-#if LLPC_BUILD_GFX11
     // On GFX11, it is a single VGPR and we need to extract the three components.
     if (getPipelineState()->getTargetInfo().getGfxIpVersion().major >= 11) {
       static const unsigned mask = 0x3ff;
@@ -1217,7 +1214,6 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
 
       localInvocationId = unpackedLocalInvocationId;
     }
-#endif
 
     // Unused dimensions need zero-initializing.
     if (shaderMode.workgroupSizeZ <= 1) {

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -152,11 +152,9 @@ Instruction *MiscBuilder::CreateSetMeshOutputs(Value *vertexCount, Value *primit
 Instruction *MiscBuilder::CreateReadClock(bool realtime, const Twine &instName) {
   CallInst *readClock = nullptr;
   if (realtime) {
-#if LLPC_BUILD_GFX11
     if (getPipelineState()->getTargetInfo().getGfxIpVersion().major >= 11)
       readClock = CreateNamedCall("llvm.amdgcn.s.sendmsg.rtn", getInt64Ty(), getInt32(GetRealTime), {}, instName);
     else
-#endif
       readClock = CreateIntrinsic(Intrinsic::amdgcn_s_memrealtime, {}, {}, nullptr, instName);
   } else
     readClock = CreateIntrinsic(Intrinsic::readcyclecounter, {}, {}, nullptr, instName);

--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -516,13 +516,10 @@ Value *SubgroupBuilder::CreateSubgroupClusteredReduction(GroupArithOp groupArith
                                          createPermLaneX16(result, result, UINT32_MAX, UINT32_MAX, true, false)),
           result);
 
-#if LLPC_BUILD_GFX11
       if (supportPermLane64Dpp()) {
         result = CreateSelect(CreateICmpEQ(clusterSize, getInt32(64)),
                               createGroupArithmeticOperation(groupArithOp, result, createPermLane64(result)), result);
-      } else
-#endif
-      {
+      } else {
         Value *const broadcast31 = CreateSubgroupBroadcast(result, getInt32(31), instName);
         Value *const broadcast63 = CreateSubgroupBroadcast(result, getInt32(63), instName);
 
@@ -1324,7 +1321,6 @@ Value *SubgroupBuilder::createPermLaneX16(Value *const origValue, Value *const u
       {getInt32(selectBitsLow), getInt32(selectBitsHigh), getInt1(fetchInactive), getInt1(boundCtrl)});
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Create a call to permute lane 64.
 //
@@ -1336,7 +1332,6 @@ Value *SubgroupBuilder::createPermLane64(Value *const updateValue) {
 
   return CreateMapToInt32(mapFunc, updateValue, {});
 }
-#endif
 
 // =====================================================================================================================
 // Create a call to ds swizzle.

--- a/lgc/builder/YCbCrAddressHandler.cpp
+++ b/lgc/builder/YCbCrAddressHandler.cpp
@@ -60,10 +60,8 @@ void YCbCrAddressHandler::genBaseAddress(unsigned planeCount) {
   case 6:
   case 7:
   case 8:
-#if LLPC_BUILD_GFX11
-  case 11:
-#endif
-  case 9: {
+  case 9:
+  case 11: {
     pipeBankXor1 = pipeBankXorNone;
     pipeBankXor2 = pipeBankXorNone;
     break;
@@ -169,10 +167,8 @@ void YCbCrAddressHandler::genHeightAndPitch(unsigned bits, unsigned bpp, unsigne
 
     break;
   }
-#if LLPC_BUILD_GFX11
-  case 11:
-#endif
-  case 10: {
+  case 10:
+  case 11: {
     const unsigned elementBytes = bpp >> 3;
     const unsigned pitchAlign = (256 / elementBytes);
 

--- a/lgc/builder/YCbCrConverter.cpp
+++ b/lgc/builder/YCbCrConverter.cpp
@@ -394,7 +394,6 @@ void YCbCrConverter::genImgDescChroma() {
                                   m_builder->getInt32(ImageBuilder::ImgFmtGfx10::IMG_FMT_8_8_8_8_UNORM__GFX10CORE));
       break;
     }
-#if LLPC_BUILD_GFX11
     case 11: {
       isGbGrFmt = m_builder->CreateICmpEQ(
           imgDataFmt, m_builder->getInt32(ImageBuilder::ImgFmtGfx11::IMG_FMT_BG_RG_UNORM__GFX104PLUS));
@@ -405,7 +404,6 @@ void YCbCrConverter::genImgDescChroma() {
                                   m_builder->getInt32(ImageBuilder::ImgFmtGfx11::IMG_FMT_8_8_8_8_UNORM__GFX104PLUS));
       break;
     }
-#endif
     default:
       llvm_unreachable("GFX IP not supported!");
       break;

--- a/lgc/disassembler/PalMetadataRegs.cpp
+++ b/lgc/disassembler/PalMetadataRegs.cpp
@@ -334,10 +334,8 @@ const PalMetadataReg PalMetadataRegs[] = {
     {0xA298, "VGT_GSVS_RING_OFFSET_1"},
     {0xA299, "VGT_GSVS_RING_OFFSET_2"},
     {0xA29A, "VGT_GSVS_RING_OFFSET_3"},
-#if LLPC_BUILD_GFX11
-// TODO: VGT_GS_OUT_PRIM_TYPE is here only up to gfx10. A different
-// register number takes over the name in gfx11+.
-#endif
+    // TODO: VGT_GS_OUT_PRIM_TYPE is here only up to gfx10. A different
+    // register number takes over the name in gfx11+.
     {0xA29B, "VGT_GS_OUT_PRIM_TYPE"},
     {0xA2A1, "VGT_PRIMITIVEID_EN"},
     {0xA2A5, "VGT_GS_MAX_PRIMS_PER_SUBGROUP"},
@@ -369,9 +367,7 @@ const PalMetadataReg PalMetadataRegs[] = {
     {0xC258, "IA_MULTI_VGT_PARAM_PIPED"}, // TODO: Known as IA_MULTI_VGT_PARAM on gfx9 only (not present <=gfx8)
     {0xC25F, "GE_STEREO_CNTL"},
     {0xC262, "GE_USER_VGPR_EN"},
-#if LLPC_BUILD_GFX11
     {0xC266, "VGT_GS_OUT_PRIM_TYPE"}, // TODO: gfx11+. A different register number has the same name up to gfx10.
-#endif
 };
 
 } // anonymous namespace

--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -1108,10 +1108,9 @@ void OutputSection::write(raw_pwrite_stream &outStream, ELF::Elf64_Shdr *shdr) {
     // On GFX10 in .text, also add padding at the end of the section: align to an instruction cache line
     // boundary, then add another 3 cache lines worth of padding.
     uint64_t cacheLineSize = 64;
-#if LLPC_BUILD_GFX11
     if (m_linker->getPipelineState()->getTargetInfo().getGfxIpVersion().major >= 11)
       cacheLineSize = 128;
-#endif
+
     uint64_t alignmentGap = (-size & (cacheLineSize - 1)) + 3 * cacheLineSize;
     while (alignmentGap != 0) {
       size_t thisSize = std::min(alignmentGap, paddingUnit - (size & (paddingUnit - 1)));

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -480,13 +480,11 @@ private:
     IMG_FMT_BG_RG_UNORM__GFX10CORE = 151,
   };
 
-#if LLPC_BUILD_GFX11
   enum ImgFmtGfx11 {
     IMG_FMT_8_8_8_8_UNORM__GFX104PLUS = 42,
     IMG_FMT_GB_GR_UNORM__GFX104PLUS = 82,
     IMG_FMT_BG_RG_UNORM__GFX104PLUS = 86,
   };
-#endif
 
   static const unsigned AtomicOpCompareSwap = 1;
 };

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -81,14 +81,13 @@ private:
   llvm::Value *convertToFloat(llvm::Value *value, bool signedness, BuilderBase &builder) const;
   llvm::Value *convertToInt(llvm::Value *value, bool signedness, BuilderBase &builder) const;
 
-#if LLPC_BUILD_GFX11
   llvm::Value *dualSourceSwizzle(BuilderBase &builder);
 
   // Colors to be exported for dual-source-blend
   llvm::SmallVector<llvm::Value *, 4> m_blendSources[2];
   // Number of color channels for dual-source-blend
   unsigned m_blendSourceChannels;
-#endif
+
   llvm::LLVMContext *m_context;   // LLVM context
   PipelineState *m_pipelineState; // The pipeline state
 };

--- a/lgc/include/lgc/patch/PatchWaveSizeAdjust.h
+++ b/lgc/include/lgc/patch/PatchWaveSizeAdjust.h
@@ -45,10 +45,9 @@ public:
   bool runImpl(llvm::Module &module, PipelineState *pipelineState);
 
   static llvm::StringRef name() { return "Patch LLVM for per-shader wave size adjustment"; }
-#if LLPC_BUILD_GFX11
+
 private:
   bool is16BitArithmeticOp(llvm::Instruction *inst);
-#endif
 };
 
 } // namespace lgc

--- a/lgc/include/lgc/patch/SystemValues.h
+++ b/lgc/include/lgc/patch/SystemValues.h
@@ -59,11 +59,9 @@ public:
   // Get the descriptor for tessellation factor (TF) buffer (TCS output)
   llvm::Value *getTessFactorBufDesc();
 
-#if LLPC_BUILD_GFX11
   // Get the descriptor for vertex attribute ring buffer (for VS, TES, and copy shader output)
   llvm::Value *getAttribRingBufDesc();
 
-#endif
   // Get the descriptor for task payload ring buffer (for task and mesh shader)
   llvm::Value *getTaskPayloadRingBufDesc();
 
@@ -109,10 +107,8 @@ public:
   // Get stream-out buffer descriptor
   llvm::Value *getStreamOutBufDesc(unsigned xfbBuffer);
 
-#if LLPC_BUILD_GFX11
   // Get stream-out buffer offset
   llvm::Value *getStreamOutBufOffset(unsigned xfbBuffer);
-#endif
 
   // Test if shadow descriptor table is enabled
   bool isShadowDescTableEnabled() const;
@@ -121,10 +117,8 @@ private:
   // Get stream-out buffer table pointer
   std::pair<llvm::Type *, llvm::Instruction *> getStreamOutTablePtr();
 
-#if LLPC_BUILD_GFX11
   // Get stream-out control buffer pointer
   llvm::Instruction *getStreamOutControlBufPtr();
-#endif
 
   // Make 64-bit pointer of specified type from 32-bit int, extending with the specified value, or PC if InvalidValue
   llvm::Instruction *makePointer(llvm::Value *lowValue, llvm::Type *ptrTy, unsigned highValue);
@@ -140,20 +134,16 @@ private:
   PipelineState *m_pipelineState;         // Pipeline state
   ShaderStage m_shaderStage;              // Shader stage
 
-  llvm::Value *m_esGsRingBufDesc = nullptr; // ES -> GS ring buffer descriptor (VS, TES, and GS)
-  llvm::Value *m_tfBufDesc = nullptr;       // Descriptor for tessellation factor (TF) buffer (TCS)
-  llvm::Value *m_offChipLdsDesc = nullptr;  // Descriptor for off-chip LDS buffer (TCS and TES)
-#if LLPC_BUILD_GFX11
+  llvm::Value *m_esGsRingBufDesc = nullptr;   // ES -> GS ring buffer descriptor (VS, TES, and GS)
+  llvm::Value *m_tfBufDesc = nullptr;         // Descriptor for tessellation factor (TF) buffer (TCS)
+  llvm::Value *m_offChipLdsDesc = nullptr;    // Descriptor for off-chip LDS buffer (TCS and TES)
   llvm::Value *m_attribRingBufDesc = nullptr; // Descriptor for vertex attribute ring buffer (VS, TES, and copy shader)
-#endif
   llvm::Value *m_taskPayloadRingBufDesc = nullptr;  // Descriptor for task payload ring buffer (task and mesh shader)
   llvm::Value *m_taskDrawDataRingBufDesc = nullptr; // Descriptor for task draw data ring buffer (task and mesh shader)
   llvm::SmallVector<llvm::Value *, MaxGsStreams>
       m_gsVsRingBufDescs; // GS -> VS ring buffer descriptor (GS out and copy shader in)
-  llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufDescs; // Stream-out buffer descriptors
-#if LLPC_BUILD_GFX11
+  llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufDescs;   // Stream-out buffer descriptors
   llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufOffsets; // Stream-out buffer offsets
-#endif
 
   llvm::Value *m_primitiveId = nullptr;                             // PrimitiveId (TCS)
   llvm::Value *m_invocationId = nullptr;                            // InvocationId (TCS)
@@ -168,10 +158,8 @@ private:
   llvm::Value *m_meshPipeStatsBufPtr = nullptr;              // Mesh pipeline statistics buffer pointer
   llvm::Value *m_internalPerShaderTablePtr = nullptr;        // Internal per shader table pointer
   llvm::Instruction *m_streamOutTablePtr = nullptr;          // Stream-out buffer table pointer
-#if LLPC_BUILD_GFX11
-  llvm::Instruction *m_streamOutControlBufPtr = nullptr; // Stream-out control buffer pointer
-#endif
-  llvm::Instruction *m_pc = nullptr; // Program counter as <2 x i32>
+  llvm::Instruction *m_streamOutControlBufPtr = nullptr;     // Stream-out control buffer pointer
+  llvm::Instruction *m_pc = nullptr;                         // Program counter as <2 x i32>
 };
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -111,9 +111,7 @@ static constexpr char StreamOutTableAddress[] = ".stream_out_table_address";
 static constexpr char IndirectUserDataTableAddresses[] = ".indirect_user_data_table_addresses";
 static constexpr char NggSubgroupSize[] = ".nggSubgroupSize";
 static constexpr char NumInterpolants[] = ".num_interpolants";
-#if LLPC_BUILD_GFX11
 static constexpr char StreamOutVertexStrides[] = ".streamout_vertex_strides";
-#endif
 static constexpr char Api[] = ".api";
 static constexpr char ApiCreateInfo[] = ".api_create_info";
 static constexpr char PsSampleMask[] = ".ps_sample_mask";
@@ -179,10 +177,8 @@ enum class UserDataMapping : unsigned {
                                      //  Mesh/Task shader rings for the shader to consume.
   MeshPipeStatsBuf = 0x10000014,     // 32-bit GPU virtual address of a buffer storing the shader-emulated mesh
                                      //  pipeline stats query.
-#if LLPC_BUILD_GFX11
-  StreamOutControlBuf = 0x10000016, // 32-bit GPU virtual address to the streamout control buffer for GPUs that
-                                    // use SW-emulated streamout.
-#endif
+  StreamOutControlBuf = 0x10000016,  // 32-bit GPU virtual address to the streamout control buffer for GPUs that
+                                     // use SW-emulated streamout.
 
   // Values used in a user data PAL metadata register to be resolved at link time.
   // This is part of the "unlinked" ABI, so should arguably be in AbiUnlinked.h.

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -119,20 +119,16 @@ const static char LsHsEntryPoint[] = "lgc.shader.LSHS.main";
 const static char NggEsEntryPoint[] = "lgc.ngg.ES.main";
 const static char NggEsCullDataFetch[] = "lgc.ngg.ES.cull.data.fetch";
 const static char NggEsDeferredVertexExport[] = "lgc.ngg.ES.deferred.vertex.export";
-#if LLPC_BUILD_GFX11
 const static char NggEsXfbOutputFetch[] = "lgc.ngg.ES.xfb.output.fetch";
 const static char NggAttribExport[] = "lgc.ngg.attrib.export";
 const static char NggXfbOutputExport[] = "lgc.ngg.xfb.output.export.";
-#endif
 
 const static char NggGsEntryPoint[] = "lgc.ngg.GS.main";
 const static char NggGsOutputExport[] = "lgc.ngg.GS.output.export.";
 const static char NggGsOutputImport[] = "lgc.ngg.GS.output.import.";
 const static char NggGsEmit[] = "lgc.ngg.GS.emit";
 const static char NggGsCut[] = "lgc.ngg.GS.cut";
-#if LLPC_BUILD_GFX11
 const static char NggGsXfbOutputFetch[] = "lgc.ngg.GS.xfb.output.fetch";
-#endif
 
 const static char NggCopyShaderEntryPoint[] = "lgc.ngg.COPY.main";
 const static char NggPrimShaderEntryPoint[] = "lgc.shader.PRIM.main";

--- a/lgc/include/lgc/state/IntrinsDefs.h
+++ b/lgc/include/lgc/state/IntrinsDefs.h
@@ -79,22 +79,20 @@ enum AddrSpace {
 
 // Enumerates the target for "export" instruction.
 enum ExportTarget {
-  EXP_TARGET_MRT_0 = 0,   // MRT 0..7
-  EXP_TARGET_Z = 8,       // Z
-  EXP_TARGET_PS_NULL = 9, // Null pixel shader export (no data)
-  EXP_TARGET_POS_0 = 12,  // Position 0
-  EXP_TARGET_POS_1 = 13,  // Position 1
-  EXP_TARGET_POS_2 = 14,  // Position 2
-  EXP_TARGET_POS_3 = 15,  // Position 3
-  EXP_TARGET_POS_4 = 16,  // Position 4
-  EXP_TARGET_PRIM = 20,   // NGG primitive data (connectivity data)
-#if LLPC_BUILD_GFX11
+  EXP_TARGET_MRT_0 = 0,       // MRT 0..7
+  EXP_TARGET_Z = 8,           // Z
+  EXP_TARGET_PS_NULL = 9,     // Null pixel shader export (no data)
+  EXP_TARGET_POS_0 = 12,      // Position 0
+  EXP_TARGET_POS_1 = 13,      // Position 1
+  EXP_TARGET_POS_2 = 14,      // Position 2
+  EXP_TARGET_POS_3 = 15,      // Position 3
+  EXP_TARGET_POS_4 = 16,      // Position 4
+  EXP_TARGET_PRIM = 20,       // NGG primitive data (connectivity data)
   EXP_TARGET_DUAL_SRC_0 = 21, // Dual source blend left
   EXP_TARGET_DUAL_SRC_1 = 22, // Dual source blend right
-#endif
-  EXP_TARGET_PARAM_0 = 32,  // Param 0
-                            // Param 1..30
-  EXP_TARGET_PARAM_31 = 63, // Param 31
+  EXP_TARGET_PARAM_0 = 32,    // Param 0
+                              // Param 1..30
+  EXP_TARGET_PARAM_31 = 63,   // Param 31
 };
 
 // Enumerates shader export format used for "export" instruction.
@@ -406,7 +404,6 @@ enum BufFormat {
   BUF_FORMAT_32_32_32_32_SINT_GFX10 = 0x0000004C,
   BUF_FORMAT_32_32_32_32_FLOAT_GFX10 = 0x0000004D,
 
-#if LLPC_BUILD_GFX11
   BUF_FORMAT_10_11_11_FLOAT_GFX11 = 0x0000001E,
   BUF_FORMAT_11_11_10_FLOAT_GFX11 = 0x0000001F,
   BUF_FORMAT_10_10_10_2_UNORM_GFX11 = 0x00000020,
@@ -441,7 +438,6 @@ enum BufFormat {
   BUF_FORMAT_32_32_32_32_UINT_GFX11 = 0x0000003D,
   BUF_FORMAT_32_32_32_32_SINT_GFX11 = 0x0000003E,
   BUF_FORMAT_32_32_32_32_FLOAT_GFX11 = 0x0000003F,
-#endif
 };
 
 // Enumerates destination selection of data in memory buffer.
@@ -511,12 +507,10 @@ union SqBufRsrcWord1 {
     unsigned swizzleEnable : 1;
   } bits;
 
-#if LLPC_BUILD_GFX11
   struct {
     unsigned : 30;
     unsigned swizzleEnable : 2;
   } gfx11;
-#endif
 
   unsigned u32All;
 };
@@ -567,7 +561,6 @@ union SqBufRsrcWord3 {
     unsigned : 2;
   } gfx10;
 
-#if LLPC_BUILD_GFX11
   struct {
     unsigned : 12;
     unsigned format : 6;
@@ -575,7 +568,6 @@ union SqBufRsrcWord3 {
     unsigned oobSelect : 2;
     unsigned : 2;
   } gfx11;
-#endif
 
   unsigned u32All;
 };

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -271,10 +271,8 @@ public:
   // ring is on-chip.
   bool isGsOnChip() const { return m_gsOnChip; }
 
-#if LLPC_BUILD_GFX11
   // Determine whether can use tessellation factor optimization
   bool canOptimizeTessFactor();
-#endif
 
   // Gets wave size for the specified shader stage
   unsigned getShaderWaveSize(ShaderStage stage);
@@ -304,10 +302,8 @@ public:
   // Checks if row export for mesh shader is enabled or not
   bool enableMeshRowExport() const;
 
-#if LLPC_BUILD_GFX11
   // Checks if SW-emulated stream-out should be enabled
   bool enableSwXfb();
-#endif
 
   // Gets resource usage of the specified shader stage
   ResourceUsage *getShaderResourceUsage(ShaderStage shaderStage);

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -164,10 +164,7 @@ struct ResourceUsage {
   unsigned numSgprsAvailable = UINT32_MAX; // Number of available SGPRs
   unsigned numVgprsAvailable = UINT32_MAX; // Number of available VGPRs
   bool useImages = false;                  // Whether images are used
-
-#if LLPC_BUILD_GFX11
-  bool useImageOp = false; // Whether image instruction is called (for GFX11+, pixel wait sync+)
-#endif
+  bool useImageOp = false;                 // Whether image instruction is called (for GFX11+, pixel wait sync+)
 
 #if VKI_RAY_TRACING
   bool useRayQueryLdsStack = false; // Whether ray query uses LDS stack
@@ -362,11 +359,9 @@ struct ResourceUsage {
     // Map from output location info to the transform feedback info
     std::map<InOutLocationInfo, XfbOutInfo> locInfoXfbOutInfoMap;
 
-#if LLPC_BUILD_GFX11
     // Count of transform feedback output export call (each call is to export <4 x dword> at most), used in SW emulated
     // stream-out for GFX11+
     unsigned xfbOutputExpCount = 0;
-#endif
 
     // Count of mapped location for inputs/outputs (including those special locations to which the built-ins
     // are mapped)
@@ -390,15 +385,13 @@ struct ResourceUsage {
                                            // "hsNumPatch")
         // On-chip calculation factors
         struct {
-          unsigned outPatchStart;   // Offset into LDS where vertices of output patches start
-                                    // (in dword, correspond to "hsOutputBase")
-          unsigned patchConstStart; // Offset into LDS where patch constants start (in dword,
-                                    // correspond to "patchConstBase")
-          unsigned tessFactorStart; // Offset into LDS where tess factor start (in dword)
-#if LLPC_BUILD_GFX11
+          unsigned outPatchStart;       // Offset into LDS where vertices of output patches start
+                                        // (in dword, correspond to "hsOutputBase")
+          unsigned patchConstStart;     // Offset into LDS where patch constants start (in dword,
+                                        // correspond to "patchConstBase")
+          unsigned tessFactorStart;     // Offset into LDS where tess factor start (in dword)
           unsigned hsPatchCountStart;   // Offset into LDS where count of HS patches start (in dword)
           unsigned specialTfValueStart; // Offset into LDS where special TF value start (in dword)
-#endif
         } onChip;
 
         // Off-chip calculation factors
@@ -414,12 +407,10 @@ struct ResourceUsage {
         unsigned outPatchSize; // Size of an output patch output (in dword, correspond to
                                // "patchOutputSize")
 
-        unsigned patchConstSize;   // Size of an output patch constants (in dword)
-        unsigned tessFactorStride; // Size of tess factor stride (in dword)
-#if LLPC_BUILD_GFX11
+        unsigned patchConstSize;     // Size of an output patch constants (in dword)
+        unsigned tessFactorStride;   // Size of tess factor stride (in dword)
         unsigned specialTfValueSize; // Size of special TF value (in dword)
-#endif
-        unsigned tessOnChipLdsSize; // On-chip LDS size (exclude off-chip LDS buffer) (in dword)
+        unsigned tessOnChipLdsSize;  // On-chip LDS size (exclude off-chip LDS buffer) (in dword)
 #if VKI_RAY_TRACING
         unsigned rayQueryLdsStackSize; // Ray query LDS stack size
 #endif
@@ -495,10 +486,8 @@ struct ResourceUsage {
 
 // Represents stream-out data
 struct StreamOutData {
-  unsigned tablePtr; // Table pointer for stream-out
-#if LLPC_BUILD_GFX11
-  unsigned controlBufPtr; // Control buffer pointer for stream-out (GFX11+)
-#endif
+  unsigned tablePtr;                                   // Table pointer for stream-out
+  unsigned controlBufPtr;                              // Control buffer pointer for stream-out (GFX11+)
   unsigned streamInfo;                                 // Stream-out info (ID, vertex count, enablement)
   unsigned writeIndex;                                 // Write index for stream-out
   unsigned streamOffsets[MaxTransformFeedbackBuffers]; // Stream-out Offset
@@ -526,11 +515,9 @@ struct InterfaceData {
   struct {
     // Geometry shader
     struct {
-      unsigned copyShaderEsGsLdsSize;    // ES -> GS ring LDS size (for copy shader)
-      unsigned copyShaderStreamOutTable; // Stream-out table (for copy shader)
-#if LLPC_BUILD_GFX11
+      unsigned copyShaderEsGsLdsSize;         // ES -> GS ring LDS size (for copy shader)
+      unsigned copyShaderStreamOutTable;      // Stream-out table (for copy shader)
       unsigned copyShaderStreamOutControlBuf; // Stream-out control buffer (for copy shader)
-#endif
     } gs;
 
     unsigned spillTable; // Spill table user data map

--- a/lgc/include/lgc/state/TargetInfo.h
+++ b/lgc/include/lgc/state/TargetInfo.h
@@ -149,7 +149,6 @@ struct WorkaroundFlags {
     unsigned u32All;
   } gfx10;
 
-#if LLPC_BUILD_GFX11
   union {
     struct {
       unsigned waUserSgprInitBug : 1;
@@ -157,7 +156,6 @@ struct WorkaroundFlags {
     };
     unsigned u32All;
   } gfx11;
-#endif
 };
 
 // =====================================================================================================================

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -141,12 +141,8 @@ struct Options {
   unsigned reserved0f;                 // Reserved for future functionality
   unsigned useResourceBindingRange;    // A resource node binding is the start of a range whose size is
                                        //  sizeInDwords/stride.
-#if LLPC_BUILD_GFX11
-  unsigned optimizeTessFactor; // If set, we can determine either send HT_TessFactor message or write to TF buffer
-                               // depending the values of tessellation factors.
-#else
-  unsigned reserved1f; // Reserved for future functionality
-#endif
+  unsigned optimizeTessFactor;    // If set, we can determine either send HT_TessFactor message or write to TF buffer
+                                  // depending the values of tessellation factors.
   unsigned enableInterpModePatch; // Enable to do per-sample interpolation for nonperspective and smooth input
   unsigned pageMigrationEnabled;  // Enable page migration
   ResourceLayoutScheme resourceLayoutScheme;     // Resource layout scheme

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -312,7 +312,6 @@ void ConfigBuilderBase::setThreadgroupDimensions(llvm::ArrayRef<unsigned> values
     arrayNode[i] = values[i];
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Set stream-out vertex strides (GFX11+)
 //
@@ -322,7 +321,6 @@ void ConfigBuilderBase::setStreamOutVertexStrides(ArrayRef<unsigned> values) {
   for (unsigned i = 0; i < values.size(); ++i)
     arrayNode[i] = values[i];
 }
-#endif
 
 // =====================================================================================================================
 /// Append a single entry to the PAL register metadata.

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -83,9 +83,7 @@ protected:
   void setEsGsLdsSize(unsigned value);
   void setNggSubgroupSize(unsigned value);
   void setThreadgroupDimensions(llvm::ArrayRef<unsigned> values);
-#if LLPC_BUILD_GFX11
   void setStreamOutVertexStrides(llvm::ArrayRef<unsigned> values);
-#endif
   unsigned setupFloatingPointMode(ShaderStage shaderStage);
 
   void appendConfig(llvm::ArrayRef<PalMetadataNoteEntry> config);

--- a/lgc/patch/Gfx9Chip.cpp
+++ b/lgc/patch/Gfx9Chip.cpp
@@ -134,10 +134,8 @@ PrimShaderRegConfig::PrimShaderRegConfig(GfxIpVersion gfxIp) {
   // Special registers, having different register IDs
   if (gfxIp.major == 9 || gfxIp.major == 10) {
     INIT_REG_GFX9_10(gfxIp.major, VGT_GS_OUT_PRIM_TYPE);
-#if LLPC_BUILD_GFX11
   } else if (gfxIp.major == 11) {
     INIT_REG_GFX11(gfxIp.major, VGT_GS_OUT_PRIM_TYPE);
-#endif
   } else {
     llvm_unreachable("Not implemented!");
   }
@@ -314,10 +312,8 @@ MeshRegConfig::MeshRegConfig(GfxIpVersion gfxIp) {
   // Special registers, having different register IDs
   if (gfxIp.major == 10) {
     INIT_REG_GFX9_10(gfxIp.major, VGT_GS_OUT_PRIM_TYPE);
-#if LLPC_BUILD_GFX11
   } else if (gfxIp.major == 11) {
     INIT_REG_GFX11(gfxIp.major, VGT_GS_OUT_PRIM_TYPE);
-#endif
   } else {
     llvm_unreachable("Not implemented!");
   }
@@ -348,10 +344,8 @@ MeshRegConfig::MeshRegConfig(GfxIpVersion gfxIp) {
   INIT_REG_GFX10_PLUS(gfxIp.major, GE_NGG_SUBGRP_CNTL);
   INIT_REG_GFX10_PLUS(gfxIp.major, SPI_SHADER_IDX_FORMAT);
 
-#if LLPC_BUILD_GFX11
   INIT_REG_GFX11(gfxIp.major, SPI_SHADER_GS_MESHLET_DIM);
   INIT_REG_GFX11(gfxIp.major, SPI_SHADER_GS_MESHLET_EXP_ALLOC);
-#endif
 }
 
 // =====================================================================================================================

--- a/lgc/patch/Gfx9Chip.h
+++ b/lgc/patch/Gfx9Chip.h
@@ -121,7 +121,6 @@ using namespace Pal::Gfx9::Chip;
     }                                                                                                                  \
   }
 
-#if LLPC_BUILD_GFX11
 // GFX11 only
 #define INIT_REG_GFX11(_gfx, _reg)                                                                                     \
   {                                                                                                                    \
@@ -132,7 +131,6 @@ using namespace Pal::Gfx9::Chip;
       INIT_REG_TO_INVALID(_reg);                                                                                       \
     }                                                                                                                  \
   }
-#endif
 
 // GFX9-GFX10 only
 #define INIT_REG_GFX9_10(_gfx, _reg)                                                                                   \
@@ -205,10 +203,8 @@ using namespace Pal::Gfx9::Chip;
 #define SET_REG_GFX10_3_PLUS_FIELD(_stage, _reg, _field, _val) (_stage)->_reg##_VAL.gfx103Plus._field = (_val);
 #define SET_REG_GFX10_3_PLUS_EXCLUSIVE_FIELD(_stage, _reg, _field, _val)                                               \
   (_stage)->_reg##_VAL.gfx103PlusExclusive._field = (_val);
-#if LLPC_BUILD_GFX11
 #define SET_REG_GFX10_4_PLUS_FIELD(_stage, _reg, _field, _val) (_stage)->_reg##_VAL.gfx104Plus._field = (_val);
 #define SET_REG_GFX11_FIELD(_stage, _reg, _field, _val) (_stage)->_reg##_VAL.gfx11._field = (_val);
-#endif
 
 // Preferred number of GS primitives per ES thread.
 constexpr unsigned GsPrimsPerEsThread = 256;
@@ -575,10 +571,8 @@ struct MeshRegConfig {
   DEF_REG(GE_NGG_SUBGRP_CNTL);
   DEF_REG(SPI_SHADER_IDX_FORMAT);
 
-#if LLPC_BUILD_GFX11
   DEF_REG(SPI_SHADER_GS_MESHLET_DIM);
   DEF_REG(SPI_SHADER_GS_MESHLET_EXP_ALLOC);
-#endif
 
   MeshRegConfig(GfxIpVersion gfxIp);
 };

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -449,13 +449,11 @@ void ConfigBuilder::buildPipelineNggVsFsRegConfig() {
 
   SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_EN, true);
   SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_PASSTHRU_EN, nggControl->passthroughMode);
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     SET_REG_GFX10_4_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_PASSTHRU_NO_MSG,
                                nggControl->passthroughMode && !m_pipelineState->enableSwXfb());
     SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, NGG_WAVE_ID_EN, m_pipelineState->enableSwXfb());
   }
-#endif
 
   if (m_pipelineState->hasShaderStage(ShaderStageVertex)) {
     buildPrimShaderRegConfig<PipelineNggVsFsRegConfig>(ShaderStageVertex, ShaderStageInvalid, &config);
@@ -518,13 +516,11 @@ void ConfigBuilder::buildPipelineNggVsTsFsRegConfig() {
 
   SET_REG_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_EN, true);
   SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_PASSTHRU_EN, nggControl->passthroughMode);
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     SET_REG_GFX10_4_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_PASSTHRU_NO_MSG,
                                nggControl->passthroughMode && !m_pipelineState->enableSwXfb());
     SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, NGG_WAVE_ID_EN, m_pipelineState->enableSwXfb());
   }
-#endif
 
   if (m_pipelineState->hasShaderStage(ShaderStageVertex) || m_pipelineState->hasShaderStage(ShaderStageTessControl)) {
     const bool hasVs = m_pipelineState->hasShaderStage(ShaderStageVertex);
@@ -608,10 +604,8 @@ void ConfigBuilder::buildPipelineNggVsGsFsRegConfig() {
   // NGG control settings. In such case, the pass-through flag means whether there is culling (different from
   // hardware pass-through).
   SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_PASSTHRU_EN, false);
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11)
     SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, NGG_WAVE_ID_EN, m_pipelineState->enableSwXfb());
-#endif
 
   if (m_pipelineState->hasShaderStage(ShaderStageVertex) || m_pipelineState->hasShaderStage(ShaderStageGeometry)) {
     const bool hasVs = m_pipelineState->hasShaderStage(ShaderStageVertex);
@@ -678,10 +672,8 @@ void ConfigBuilder::buildPipelineNggVsTsGsFsRegConfig() {
   // NGG control settings. In such case, the pass-through flag means whether there is culling (different from
   // hardware pass-through).
   SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, PRIMGEN_PASSTHRU_EN, false);
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11)
     SET_REG_GFX10_PLUS_FIELD(&config, VGT_SHADER_STAGES_EN, NGG_WAVE_ID_EN, m_pipelineState->enableSwXfb());
-#endif
 
   if (m_pipelineState->hasShaderStage(ShaderStageVertex) || m_pipelineState->hasShaderStage(ShaderStageTessControl)) {
     const bool hasVs = m_pipelineState->hasShaderStage(ShaderStageVertex);
@@ -975,10 +967,8 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
     SET_REG_GFX10_PLUS_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC1_HS, WGP_MODE, wgpMode);
     SET_REG_GFX10_PLUS_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR_MSB, userSgprMsb);
 
-#if LLPC_BUILD_NAVI31
     // The shared scratch offset is reused by HW to provide HS wave ID in group
     SET_REG_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, SCRATCH_EN, m_pipelineState->canOptimizeTessFactor());
-#endif
   } else {
     SET_REG_GFX9_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR_MSB, userSgprMsb);
   }
@@ -1005,13 +995,11 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
     SET_REG_GFX10_PLUS_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, LDS_SIZE, ldsSize);
   }
 
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     // Pixel wait sync+
     const bool useImageOp = vsResUsage->useImageOp || tcsResUsage->useImageOp;
     SET_REG_GFX11_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC4_HS, IMAGE_OP, useImageOp);
   }
-#endif
 
   setLdsSizeByteSize(Util::Abi::HardwareStage::Hs, ldsSizeInDwords * 4);
 
@@ -1350,7 +1338,6 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
   setLdsSizeByteSize(Util::Abi::HardwareStage::Gs, ldsSizeInDwords * 4);
   setEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     // Pixel wait sync+
     bool useImageOp = hasGs ? gsResUsage->useImageOp : false;
@@ -1360,7 +1347,6 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
       useImageOp |= vsResUsage->useImageOp;
     SET_REG_GFX11_FIELD(&config->primShaderRegs, SPI_SHADER_PGM_RSRC4_GS, IMAGE_OP, useImageOp);
   }
-#endif
 
   unsigned maxVertOut = std::max(1u, static_cast<unsigned>(geometryMode.outputVertices));
   SET_REG_FIELD(&config->primShaderRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
@@ -1488,7 +1474,6 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
     // the address of that table.
     SET_REG(&config->primShaderRegs, SPI_SHADER_PGM_LO_GS, static_cast<unsigned>(UserDataMapping::NggCullingData));
   }
-#if LLPC_BUILD_GFX11
 
   //
   // Build SW stream-out configuration (GFX11+)
@@ -1503,7 +1488,6 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
     }
     setStreamOutVertexStrides(xfbStridesInDwords); // Set SW stream-out vertex strides
   }
-#endif
 }
 
 // =====================================================================================================================
@@ -1539,12 +1523,10 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
     SET_REG_GFX9_FIELD(&config->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
   }
 
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     // Pixel wait sync+
     SET_REG_GFX11_FIELD(&config->psRegs, SPI_SHADER_PGM_RSRC4_PS, IMAGE_OP, resUsage->useImageOp);
   }
-#endif
 
   SET_REG_FIELD(&config->psRegs, SPI_BARYC_CNTL, FRONT_FACE_ALL_BITS, true);
   if (fragmentMode.pixelCenterInteger) {
@@ -1659,7 +1641,6 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
     // NOTE: Flat shading flag is only set for per-vertex parameter.
     spiPsInputCntl.bits.FLAT_SHADE = interpInfoElem.flat && !interpInfoElem.isPerPrimitive;
     spiPsInputCntl.bits.OFFSET = interpInfoElem.loc;
-#if LLPC_BUILD_GFX11
     if (gfxIp.major >= 11 && interpInfoElem.isPerPrimitive) {
       const auto preStage = m_pipelineState->getPrevShaderStage(ShaderStageFragment);
       if (preStage == ShaderStageMesh) {
@@ -1673,7 +1654,6 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
       }
       spiPsInputCntl.gfx11.PRIM_ATTR = true;
     }
-#endif
 
     if (interpInfoElem.custom) {
       // NOTE: Force parameter cache data to be read in passthrough mode.
@@ -1701,13 +1681,11 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
   }
 
   unsigned numInterp = resUsage->inOutUsage.fs.interpInfo.size() - numPrimInterp;
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     // NOTE: For GFX11+, vertex attributes and primitive attributes are counted together. The field
     // SPI_PS_INPUT_CNTL.PRIM_ATTR is used to differentiate them.
     numInterp = resUsage->inOutUsage.fs.interpInfo.size();
   }
-#endif
   SET_REG_FIELD(&config->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, numInterp);
   if (gfxIp.isGfx(10, 3))
     SET_REG_GFX10_3_PLUS_EXCLUSIVE_FIELD(&config->psRegs, SPI_PS_IN_CONTROL, NUM_PRIM_INTERP, numPrimInterp);
@@ -1774,15 +1752,10 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
 
   SET_REG_FIELD(&config->meshRegs, VGT_SHADER_STAGES_EN, ES_EN, ES_STAGE_REAL);
   SET_REG_FIELD(&config->meshRegs, VGT_SHADER_STAGES_EN, GS_EN, GS_STAGE_ON);
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     static constexpr unsigned NEW_FAST_LAUNCH = 0x2;
     SET_REG_GFX09_1X_PLUS_FIELD(&config->meshRegs, VGT_SHADER_STAGES_EN, GS_FAST_LAUNCH, NEW_FAST_LAUNCH);
   } else {
-#else
-  {
-#endif
-    (void(gfxIp)); // Unused
     static constexpr unsigned LEGACY_FAST_LAUNCH = 0x1;
     SET_REG_GFX09_1X_PLUS_FIELD(&config->meshRegs, VGT_SHADER_STAGES_EN, GS_FAST_LAUNCH, LEGACY_FAST_LAUNCH);
   }
@@ -1826,12 +1799,10 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
   SET_REG_FIELD(&config->meshRegs, SPI_SHADER_PGM_RSRC2_GS, LDS_SIZE, ldsSize);
   setLdsSizeByteSize(Util::Abi::HardwareStage::Gs, ldsSizeInDwords * 4);
 
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     // Pixel wait sync+
     SET_REG_GFX11_FIELD(&config->meshRegs, SPI_SHADER_PGM_RSRC4_GS, IMAGE_OP, resUsage->useImageOp);
   }
-#endif
 
   unsigned maxVertOut = std::max(1u, static_cast<unsigned>(meshMode.outputVertices));
   SET_REG_FIELD(&config->meshRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
@@ -1890,7 +1861,6 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
                 hasPrimitivePayload ? SPI_SHADER_2COMP : SPI_SHADER_1COMP);
   SET_REG_GFX10_PLUS_FIELD(&config->meshRegs, VGT_DRAW_PAYLOAD_CNTL, EN_PRIM_PAYLOAD, hasPrimitivePayload);
 
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     SET_REG_FIELD(&config->meshRegs, SPI_SHADER_GS_MESHLET_DIM, MESHLET_NUM_THREAD_X, meshMode.workgroupSizeX - 1);
     SET_REG_FIELD(&config->meshRegs, SPI_SHADER_GS_MESHLET_DIM, MESHLET_NUM_THREAD_Y, meshMode.workgroupSizeY - 1);
@@ -1905,7 +1875,6 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
     SET_REG_FIELD(&config->meshRegs, SPI_SHADER_GS_MESHLET_EXP_ALLOC, MAX_EXP_VERTS, meshMode.outputVertices);
     SET_REG_FIELD(&config->meshRegs, SPI_SHADER_GS_MESHLET_EXP_ALLOC, MAX_EXP_PRIMS, meshMode.outputPrimitives);
   }
-#endif
 
   setWaveFrontSize(Util::Abi::HardwareStage::Gs, waveSize);
 
@@ -1997,12 +1966,10 @@ void ConfigBuilder::buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *confi
     tidigCompCnt = 1;
   SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TIDIG_COMP_CNT, tidigCompCnt);
 
-#if LLPC_BUILD_GFX11
   if (gfxIp.major >= 11) {
     // Pixel wait sync+
     SET_REG_GFX11_FIELD(config, COMPUTE_PGM_RSRC3, IMAGE_OP, resUsage->useImageOp);
   }
-#endif
 
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_X, NUM_THREAD_FULL, workgroupSizes[0]);
   SET_REG_FIELD(config, COMPUTE_NUM_THREAD_Y, NUM_THREAD_FULL, workgroupSizes[1]);
@@ -2236,11 +2203,7 @@ template <typename T> void ConfigBuilder::setupPaSpecificRegisters(T *config) {
     SET_REG_FIELD(config, PA_CL_CLIP_CNTL, VTE_VPORT_PROVOKE_DISABLE, false);
   }
 
-#if LLPC_BUILD_GFX11
   SET_REG_FIELD(config, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse || m_pipelineState->enableSwXfb());
-#else
-  SET_REG_FIELD(config, VGT_REUSE_OFF, REUSE_OFF, disableVertexReuse);
-#endif
 
   bool miscExport = usePointSize;
   if (!meshPipeline) {

--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -123,9 +123,7 @@ private:
   };
   void doExport(ExportKind kind, llvm::ArrayRef<ExportInfo> exports);
 
-#if LLPC_BUILD_GFX11
   void prepareAttribRingAccess();
-#endif
 
   llvm::Value *getMeshFlatWorkgroupId();
   llvm::Value *getMeshNumWorkgroups();
@@ -168,23 +166,20 @@ private:
     llvm::Value *threadIdInWave;
     llvm::Value *threadIdInSubgroup;
     llvm::Value *primOrVertexIndex;
-#if LLPC_BUILD_GFX11
     // Following info is for GFX11+
     llvm::Value *workgroupIdX;
     llvm::Value *workgroupIdY;
     llvm::Value *workgroupIdZ;
     llvm::Value *rowInSubgroup;
-#endif
   } m_waveThreadInfo = {};
 
   bool m_accessTaskPayload = false;                // Whether task shader has payload access operations
   llvm::Value *m_shaderRingEntryIndex = nullptr;   // Shader ring entry index of current workgroup
   llvm::Value *m_payloadRingEntryOffset = nullptr; // Entry offset (in bytes) of the payload ring
-#if LLPC_BUILD_GFX11
+
   bool m_hasNoVertexAttrib = false;              // Whether mesh shader has vertex attribute export or not
   llvm::Value *m_attribRingBufDesc = nullptr;    // Attribute ring buffer descriptor
   llvm::Value *m_attribRingBaseOffset = nullptr; // Subgroup's attribute ring base offset (in bytes)
-#endif
 
   llvm::Value *m_meshFlatWorkgroupId = nullptr;       // Flat workgroupId of mesh shader
   llvm::Value *m_meshWorkgroupId = nullptr;           // Built-in WorkgroupId of mesh shader

--- a/lgc/patch/NggLdsManager.h
+++ b/lgc/patch/NggLdsManager.h
@@ -46,14 +46,10 @@ enum NggLdsRegionType {
   // LDS region for ES only (no GS)
   //
   LdsRegionDistribPrimId,     // Distributed primitive ID (VS only, for both pass-through and culling modes)
-#if LLPC_BUILD_GFX11
   LdsRegionXfbOutput,         // Transform feedback output (pass-through mode only)
-#endif
   LdsRegionVertPosData,       // Vertex position data
   LdsRegionVertCullInfo,      // Vertex cull info
-#if LLPC_BUILD_GFX11
   LdsRegionXfbStatInfo,       // Transform feedback statistics info
-#endif
   LdsRegionVertCountInWaves,  // Vertex count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionVertThreadIdMap,   // Vertex thread ID map (compacted -> uncompacted), for vertex compaction
 
@@ -65,15 +61,11 @@ enum NggLdsRegionType {
   //
   LdsRegionEsGsRing,            // ES-GS ring
   LdsRegionOutPrimData,         // GS output primitive data
-#if LLPC_BUILD_GFX11
   LdsRegionOutPrimCountInWaves, // GS output primitive count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionOutPrimThreadIdMap,  // GS output primitive thread ID map (compacted -> uncompacted)
-#endif
   LdsRegionOutVertCountInWaves, // GS output vertex count accumulated per wave (8 potential waves) and per sub-group
   LdsRegionOutVertThreadIdMap,  // GS output vertex thread ID map (compacted -> uncompacted), for vertex compaction
-#if LLPC_BUILD_GFX11
   LdsRegionGsXfbStatInfo,       // GS transform feedback statistics info
-#endif
   LdsRegionGsVsRing,            // GS-VS ring
 
   LdsRegionGsBeginRange = LdsRegionEsGsRing,

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -88,12 +88,10 @@ struct PrimShaderCbLayoutLookupTable {
 
 // Represents the layout structure of an item of vertex cull info (this acts as ES-GS ring item from HW's perspective)
 struct VertexCullInfo {
-#if LLPC_BUILD_GFX11
   //
   // Vertex transform feedback outputs
   //
   unsigned xfbOutputs[4];
-#endif
   //
   // Vertex cull data
   //
@@ -123,12 +121,10 @@ struct VertexCullInfo {
 
 // Represents a collection of LDS offsets (in bytes) within an item of vertex cull info.
 struct VertexCullInfoOffsets {
-#if LLPC_BUILD_GFX11
   //
   // Vertex transform feedback outputs
   //
   unsigned xfbOutputs;
-#endif
   //
   // Vertex cull data
   //
@@ -152,7 +148,6 @@ struct VertexCullInfoOffsets {
   unsigned relPatchId;
 };
 
-#if LLPC_BUILD_GFX11
 // Represents export info of a transform feedback output
 struct XfbOutputExport {
   unsigned xfbBuffer;   // Transform feedback buffer
@@ -164,7 +159,6 @@ struct XfbOutputExport {
     unsigned loc;      // Output location
   } locInfo;           // Output location info in GS-VS ring (just for GS)
 };
-#endif
 
 // =====================================================================================================================
 // Represents the manager of NGG primitive shader.
@@ -272,7 +266,6 @@ private:
   llvm::Value *fetchCullDistanceSignMask(llvm::Value *vertexId);
   llvm::Value *calcVertexItemOffset(unsigned streamId, llvm::Value *vertexId);
 
-#if LLPC_BUILD_GFX11
   void processVertexAttribExport(llvm::Function *&targetFunc);
 
   void processXfbOutputExport(llvm::Module *module, llvm::Argument *sysValueStart);
@@ -282,7 +275,6 @@ private:
 
   llvm::Value *readXfbOutputFromLds(llvm::Type *readDataTy, llvm::Value *vertexId, unsigned outputIndex);
   void writeXfbOutputToLds(llvm::Value *writeData, llvm::Value *vertexId, unsigned outputIndex);
-#endif
 
   // Checks if NGG culling operations are enabled
   bool enableCulling() const {
@@ -316,17 +308,13 @@ private:
     llvm::Value *threadIdInSubgroup; // Thread ID in sub-group
 
     llvm::Value *waveIdInSubgroup; // Wave ID in sub-group
-#if LLPC_BUILD_GFX11
-    llvm::Value *orderedWaveId; // Ordered wave ID
-#endif
+    llvm::Value *orderedWaveId;    // Ordered wave ID
 
     llvm::Value *primitiveId;   // Primitive ID (for VS)
     llvm::Value *vertCompacted; // Whether vertex compaction is performed (for culling mode)
 
     // System values (SGPRs)
-#if LLPC_BUILD_GFX11
-    llvm::Value *attribRingBase; // Attribute ring base for this sub-group
-#endif
+    llvm::Value *attribRingBase;          // Attribute ring base for this sub-group
     llvm::Value *primShaderTableAddrLow;  // Primitive shader table address low
     llvm::Value *primShaderTableAddrHigh; // Primitive shader table address high
 
@@ -347,9 +335,7 @@ private:
   bool m_hasTes; // Whether the pipeline has tessellation evaluation shader
   bool m_hasGs;  // Whether the pipeline has geometry shader
 
-#if LLPC_BUILD_GFX11
   bool m_enableSwXfb; // Whether SW-emulated stream-out is enabled (GFX11+)
-#endif
 
   bool m_constPositionZ; // Whether the Z channel of vertex position data is constant
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -137,24 +137,20 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
     //   void copyShader(
     //     i32 vertexIndex)
     //
-#if LLPC_BUILD_GFX11
     // GFX11+:
     //   void copyShader(
     //     i32 inreg globalTable,
     //     i32 inreg streamOutTable,
     //     i32 inreg streamOutControlBuf,
     //     i32 vertexId)
-#endif
     if (m_pipelineState->getTargetInfo().getGfxIpVersion().major <= 10) {
       argTys = {int32Ty};
       argInReg = {false};
       argNames = {"vertexId"};
-#if LLPC_BUILD_GFX11
     } else {
       argTys = {int32Ty, int32Ty, int32Ty, int32Ty};
       argInReg = {true, true, true, false};
       argNames = {"globalTable", "streamOutTable", "streamOutControlBuf", "vertexId"};
-#endif
     }
   }
 
@@ -202,10 +198,8 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
       // If NGG, esGsLdsSize is not used
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = InvalidValue;
       intfData->userDataUsage.gs.copyShaderStreamOutTable = 1;
-#if LLPC_BUILD_GFX11
       if (m_pipelineState->enableSwXfb())
         intfData->userDataUsage.gs.copyShaderStreamOutControlBuf = 2;
-#endif
     }
   }
 
@@ -303,9 +297,8 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
       //   return
       // }
       //
-#if LLPC_BUILD_GFX11
       assert(gfxIp.major >= 11); // Must be GFX11+
-#endif
+
       for (unsigned streamId = 0; streamId < MaxGsStreams; ++streamId) {
         if (resUsage->inOutUsage.gs.outLocCount[streamId] > 0)
           exportOutput(streamId, builder);
@@ -699,14 +692,12 @@ void PatchCopyShader::exportXfbOutput(Value *outputValue, const XfbOutInfo &xfbO
     }
   }
 
-#if LLPC_BUILD_GFX11
   // Collect transform feedback output export calls, used in SW-emulated stream-out.
   if (m_pipelineState->enableSwXfb()) {
     auto &inOutUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader)->inOutUsage;
     // A transform feedback output export call is expected to be <4 x dword> at most
     inOutUsage.xfbOutputExpCount += outputValue->getType()->getPrimitiveSizeInBits() > 128 ? 2 : 1;
   }
-#endif
 
   Value *args[] = {builder.getInt32(xfbOutInfo.xfbBuffer), builder.getInt32(xfbOutInfo.xfbOffset),
                    builder.getInt32(xfbOutInfo.streamId), outputValue};
@@ -736,14 +727,12 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
     auto &locInfoXfbOutInfoMap = resUsage->inOutUsage.locInfoXfbOutInfoMap;
     const auto &locInfoXfbOutInfoMapIt = locInfoXfbOutInfoMap.find(outLocInfo);
     if (locInfoXfbOutInfoMapIt != locInfoXfbOutInfoMap.end()) {
-#if LLPC_BUILD_GFX11
       // Collect transform feedback output export calls, used in SW-emulated stream-out.
       if (m_pipelineState->enableSwXfb()) {
         auto &inOutUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader)->inOutUsage;
         // A transform feedback output export call is expected to be <4 x dword> at most
         inOutUsage.xfbOutputExpCount += outputValue->getType()->getPrimitiveSizeInBits() > 128 ? 2 : 1;
       }
-#endif
 
       const auto &xfbOutInfo = locInfoXfbOutInfoMapIt->second;
       std::string instName(lgcName::OutputExportXfb);

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1018,7 +1018,6 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
     userDataIdx += dwordSize;
   }
 
-#if LLPC_BUILD_GFX11
   if (m_pipelineState->getTargetInfo().getGpuWorkarounds().gfx11.waUserSgprInitBug) {
     // Add dummy user data to bring the total to 16 SGPRS if hardware workaround
     // is required
@@ -1037,7 +1036,6 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
       }
     }
   }
-#endif
 
   intfData->userDataCount = userDataIdx;
   inRegMask = (1ull << argTys.size()) - 1;
@@ -1241,7 +1239,6 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       case ShaderStageVertex:
         userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "streamOutTable", UserDataMapping::StreamOutTable,
                                            &intfData->entryArgIdxs.vs.streamOutData.tablePtr));
-#if LLPC_BUILD_GFX11
         if (m_pipelineState->enableSwXfb()) {
           // NOTE: For GFX11+, the SW stream-out needs an additional special user data SGPR to store the
           // stream-out control buffer address.
@@ -1249,12 +1246,10 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
                                                     UserDataMapping::StreamOutControlBuf,
                                                     &intfData->entryArgIdxs.vs.streamOutData.controlBufPtr));
         }
-#endif
         break;
       case ShaderStageTessEval:
         userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "streamOutTable", UserDataMapping::StreamOutTable,
                                            &intfData->entryArgIdxs.tes.streamOutData.tablePtr));
-#if LLPC_BUILD_GFX11
         if (m_pipelineState->enableSwXfb()) {
           // NOTE: For GFX11+, the SW stream-out needs an additional special user data SGPR to store the
           // stream-out control buffer address.
@@ -1262,13 +1257,11 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
                                                     UserDataMapping::StreamOutControlBuf,
                                                     &intfData->entryArgIdxs.tes.streamOutData.controlBufPtr));
         }
-#endif
         break;
       case ShaderStageGeometry:
         if (m_pipelineState->getTargetInfo().getGfxIpVersion().major <= 10) {
           // Allocate dummy stream-out register for geometry shader
           userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "dummyStreamOut"));
-#if LLPC_BUILD_GFX11
         } else if (m_pipelineState->enableSwXfb()) {
           userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "streamOutTable", UserDataMapping::StreamOutTable,
                                              &intfData->entryArgIdxs.gs.streamOutData.tablePtr));
@@ -1277,7 +1270,6 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
           specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "streamOutControlBuf",
                                                     UserDataMapping::StreamOutControlBuf,
                                                     &intfData->entryArgIdxs.gs.streamOutData.controlBufPtr));
-#endif
         }
         break;
       default:

--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -151,7 +151,6 @@ void PatchInitializeWorkgroupMemory::initializeWithZero(GlobalVariable *lds, Bui
   Value *localInvocationId = getFunctionArgument(m_entryPoint, entryArgIdxs.cs.localInvocationId);
   const unsigned actualNumThreads = shaderMode.workgroupSizeX * shaderMode.workgroupSizeY * shaderMode.workgroupSizeZ;
 
-#if LLPC_BUILD_GFX11
   // On GFX11, it is a single VGPR and we need to extract the three components.
   if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 11) {
     assert(localInvocationId->getType() == builder.getInt32Ty());
@@ -176,7 +175,6 @@ void PatchInitializeWorkgroupMemory::initializeWithZero(GlobalVariable *lds, Bui
 
     localInvocationId = unpackedLocalInvocationId;
   }
-#endif
 
   Value *threadId = builder.CreateExtractElement(localInvocationId, uint64_t(0));
   if (shaderMode.workgroupSizeY > 1) {

--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -239,11 +239,9 @@ void PatchPreparePipelineAbi::writeTessFactors(PipelineState *pipelineState, Val
   if (pipelineState->getTargetInfo().getGfxIpVersion().major == 10) {
     bufferFormatX2 = BUF_FORMAT_32_32_FLOAT_GFX10;
     bufferFormatX4 = BUF_FORMAT_32_32_32_32_FLOAT_GFX10;
-#if LLPC_BUILD_GFX11
   } else if (pipelineState->getTargetInfo().getGfxIpVersion().major == 11) {
     bufferFormatX2 = BUF_FORMAT_32_32_FLOAT_GFX11;
     bufferFormatX4 = BUF_FORMAT_32_32_32_32_FLOAT_GFX11;
-#endif
   }
 
   auto primitiveMode = pipelineState->getShaderModes()->getTessellationMode().primitiveMode;
@@ -485,10 +483,8 @@ void PatchPreparePipelineAbi::addAbiMetadata(Module &module) {
 void PatchPreparePipelineAbi::storeTessFactors(Function *entryPoint) {
   assert(getShaderStage(entryPoint) == ShaderStageTessControl); // Must be tessellation control shader
 
-#if LLPC_BUILD_GFX11
   if (m_pipelineState->canOptimizeTessFactor())
     return; // If TF store is to be optimized, skip further processing
-#endif
 
   // Find the return instruction
   Instruction *retInst = nullptr;

--- a/lgc/patch/PatchWaveSizeAdjust.cpp
+++ b/lgc/patch/PatchWaveSizeAdjust.cpp
@@ -32,9 +32,7 @@
 #include "lgc/patch/Patch.h"
 #include "lgc/state/TargetInfo.h"
 #include "llvm/IR/InstIterator.h"
-#if LLPC_BUILD_GFX11
 #include "llvm/IR/IntrinsicInst.h"
-#endif
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/Support/Debug.h"
 
@@ -73,7 +71,6 @@ bool PatchWaveSizeAdjust::runImpl(Module &module, PipelineState *pipelineState) 
     }
   }
 
-#if LLPC_BUILD_GFX11
   if (pipelineState->getTargetInfo().getGfxIpVersion().major >= 11) {
     // Prefer Wave64 when 16-bit arithmetic is used by the shader.
     // Except when API subgroup size requirements require Wave32 or tuning option specifies wave32.
@@ -101,11 +98,10 @@ bool PatchWaveSizeAdjust::runImpl(Module &module, PipelineState *pipelineState) 
       }
     }
   }
-#endif
+
   return false;
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Check if the given instruction is a 16-bit arithmetic operation
 //
@@ -145,4 +141,3 @@ bool PatchWaveSizeAdjust::is16BitArithmeticOp(Instruction *inst) {
   }
   return false;
 }
-#endif

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -75,10 +75,8 @@ const char *ShaderInputs::getSpecialUserDataName(UserDataMapping kind) {
     return "MeshTaskRingIndex";
   case UserDataMapping::MeshPipeStatsBuf:
     return "MeshPipeStatsBuf";
-#if LLPC_BUILD_GFX11
   case UserDataMapping::StreamOutControlBuf:
     return "StreamOutControlBuf";
-#endif
   default:
     return "";
   }
@@ -163,10 +161,8 @@ Type *ShaderInputs::getInputType(ShaderInput inputKind, const LgcContext &lgcCon
   case ShaderInput::WorkgroupId:
     return FixedVectorType::get(Type::getInt32Ty(context), 3);
   case ShaderInput::LocalInvocationId:
-#if LLPC_BUILD_GFX11
     if (lgcContext.getTargetInfo().getGfxIpVersion().major >= 11)
       return Type::getInt32Ty(context);
-#endif
     return FixedVectorType::get(Type::getInt32Ty(context), 3);
 
   case ShaderInput::TessCoordX:
@@ -536,10 +532,8 @@ uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage
   uint64_t inRegMask = 0;
   auto intfData = pipelineState->getShaderInterfaceData(shaderStage);
   const auto &xfbStrides = pipelineState->getXfbBufferStrides();
-#if LLPC_BUILD_GFX11
   // NOTE: For GFX11+, stream-out is actually SW-emulated in NGG primitive shader and we doesn't have relevant shader
   // inputs for HW stream-out.
-#endif
   const unsigned gfxIp = pipelineState->getTargetInfo().getGfxIpVersion().major;
   const bool enableHwXfb = pipelineState->enableXfb() && gfxIp <= 10;
 

--- a/lgc/patch/ShaderMerger.h
+++ b/lgc/patch/ShaderMerger.h
@@ -56,10 +56,8 @@ enum SpecialSgprInput : unsigned {
   // GFX9~GFX10
   SharedScratchOffset,
 
-#if LLPC_BUILD_GFX11
   // GFX11+
   waveIdInGroup,
-#endif
 };
 } // namespace LsHs
 
@@ -80,12 +78,10 @@ enum SpecialSgprInput : unsigned {
   // GFX10+
   MergedGroupInfo, // NGG
 
-#if LLPC_BUILD_GFX11
   // GFX11+
   AttribRingBase,
   FlatScratchLow,
   FlatScratchHigh,
-#endif
 };
 } // namespace EsGs
 
@@ -126,11 +122,9 @@ private:
   void processRayQueryLdsStack(llvm::Function *entryPoint1, llvm::Function *entryPoint2) const;
 #endif
 
-#if LLPC_BUILD_GFX11
   void storeTessFactorsWithOpt(llvm::Value *threadIdInWave, llvm::IRBuilder<> &builder);
   llvm::Value *readValueFromLds(llvm::Type *readTy, llvm::Value *ldsOffset, llvm::IRBuilder<> &builder);
   void writeValueToLds(llvm::Value *writeValue, llvm::Value *ldsOffset, llvm::IRBuilder<> &builder);
-#endif
 
   PipelineState *m_pipelineState; // Pipeline state
   llvm::LLVMContext *m_context;   // LLVM context

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -99,7 +99,6 @@ Value *ShaderSystemValues::getTessFactorBufDesc() {
   return m_tfBufDesc;
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Get the descriptor for vertex attribute ring buffer (for VS, TES, and copy shader output)
 Value *ShaderSystemValues::getAttribRingBufDesc() {
@@ -115,7 +114,6 @@ Value *ShaderSystemValues::getAttribRingBufDesc() {
   return m_attribRingBufDesc;
 }
 
-#endif
 // =====================================================================================================================
 // Get the descriptor for task payload ring buffer (for task and mesh shader)
 Value *ShaderSystemValues::getTaskPayloadRingBufDesc() {
@@ -427,7 +425,6 @@ Value *ShaderSystemValues::getStreamOutBufDesc(unsigned xfbBuffer) {
   return m_streamOutBufDescs[xfbBuffer];
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Get stream-out buffer offset
 //
@@ -463,7 +460,6 @@ Value *ShaderSystemValues::getStreamOutBufOffset(unsigned xfbBuffer) {
   }
   return m_streamOutBufOffsets[xfbBuffer];
 }
-#endif
 
 // =====================================================================================================================
 // Get stream-out buffer table pointer
@@ -502,7 +498,6 @@ std::pair<Type *, Instruction *> ShaderSystemValues::getStreamOutTablePtr() {
   return std::make_pair(streamOutTableTy, m_streamOutTablePtr);
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Get stream-out control buffer pointer
 Instruction *ShaderSystemValues::getStreamOutControlBufPtr() {
@@ -543,7 +538,6 @@ Instruction *ShaderSystemValues::getStreamOutControlBufPtr() {
   }
   return m_streamOutControlBufPtr;
 }
-#endif
 
 // =====================================================================================================================
 // Make 64-bit pointer of specified type from 32-bit int, extending with the specified value, or PC if InvalidValue

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -132,9 +132,7 @@ private:
 
   static const VertexCompFormatInfo m_vertexCompFormatInfo[]; // Info table of vertex component format
   static const unsigned char m_vertexFormatMapGfx10[][8];     // Info table of vertex format mapping for GFX10
-#if LLPC_BUILD_GFX11
-  static const unsigned char m_vertexFormatMapGfx11[][8]; // Info table of vertex format mapping for GFX11
-#endif
+  static const unsigned char m_vertexFormatMapGfx11[][8];     // Info table of vertex format mapping for GFX11
 
   // Default values for vertex fetch (<4 x i32> or <8 x i32>)
   struct {
@@ -349,7 +347,6 @@ const unsigned char VertexFetchImpl::m_vertexFormatMapGfx10[][8] = {
 };
 // clang-format on
 
-#if LLPC_BUILD_GFX11
 // clang-format off
 const unsigned char VertexFetchImpl::m_vertexFormatMapGfx11[][8] = {
     // BUF_DATA_FORMAT
@@ -523,7 +520,6 @@ const unsigned char VertexFetchImpl::m_vertexFormatMapGfx11[][8] = {
      BUF_FORMAT_INVALID},
 };
 // clang-format on
-#endif
 
 // =====================================================================================================================
 // Run the lower vertex fetch pass on a module
@@ -1553,13 +1549,11 @@ unsigned VertexFetchImpl::mapVertexFormat(unsigned dfmt, unsigned nfmt) const {
     assert(nfmt < sizeof(m_vertexFormatMapGfx10[0]) / sizeof(m_vertexFormatMapGfx10[0][0]));
     format = m_vertexFormatMapGfx10[dfmt][nfmt];
     break;
-#if LLPC_BUILD_GFX11
   case 11:
     assert(dfmt < sizeof(m_vertexFormatMapGfx11) / sizeof(m_vertexFormatMapGfx11[0]));
     assert(nfmt < sizeof(m_vertexFormatMapGfx11[0]) / sizeof(m_vertexFormatMapGfx11[0][0]));
     format = m_vertexFormatMapGfx11[dfmt][nfmt];
     break;
-#endif
   }
   return format;
 }

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1279,10 +1279,8 @@ void PipelineState::setShaderDefaultWaveSize(ShaderStage stage) {
       } else if (hasShaderStage(ShaderStageGeometry)) {
         // Legacy (non-NGG) hardware path for GS does not support wave32.
         waveSize = 64;
-#if LLPC_BUILD_GFX11
         if (getTargetInfo().getGfxIpVersion().major >= 11)
           waveSize = 32;
-#endif
       }
 
       // Experimental data from performance tuning show that wave64 is more efficient than wave32 in most cases for CS
@@ -1364,7 +1362,6 @@ bool PipelineState::enableMeshRowExport() const {
   return m_meshRowExport;
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Checks if SW-emulated stream-out should be enabled.
 bool PipelineState::enableSwXfb() {
@@ -1384,7 +1381,6 @@ bool PipelineState::enableSwXfb() {
 
   return enableXfb();
 }
-#endif
 
 // =====================================================================================================================
 // Gets resource usage of the specified shader stage
@@ -1582,7 +1578,6 @@ StringRef PipelineState::getBuiltInName(BuiltInKind builtIn) {
   }
 }
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // Determine whether can use tessellation factor optimization
 bool PipelineState::canOptimizeTessFactor() {
@@ -1595,7 +1590,6 @@ bool PipelineState::canOptimizeTessFactor() {
     return false;
   return getOptions().optimizeTessFactor;
 }
-#endif
 
 // =====================================================================================================================
 // Set the packable state of generic input/output

--- a/lgc/state/TargetInfo.cpp
+++ b/lgc/state/TargetInfo.cpp
@@ -439,7 +439,6 @@ static void setGfx1034Info(TargetInfo *targetInfo) {
   targetInfo->getGpuProperty().numShaderEngines = 1;
 }
 
-#if LLPC_BUILD_GFX11
 // gfx11
 //
 // @param [in/out] targetInfo : Target info
@@ -453,9 +452,6 @@ static void setGfx11Info(TargetInfo *targetInfo) {
   targetInfo->getGpuProperty().supportIntegerDotFlag.diffSignedness = true;
 }
 
-#endif
-
-#if LLPC_BUILD_NAVI31
 // gfx1100
 //
 // @param [in/out] targetInfo : Target info
@@ -467,7 +463,6 @@ static void setGfx1100Info(TargetInfo *targetInfo) {
 
   targetInfo->getGpuProperty().numShaderEngines = 6;
 }
-#endif
 
 // =====================================================================================================================
 // Set TargetInfo. Returns false if the GPU name is not found or not supported.
@@ -480,40 +475,38 @@ bool TargetInfo::setTargetInfo(StringRef gpuName) {
   };
 
   static const GpuNameStringMap GpuNameMap[] = {
-    {"gfx600", &setGfx600Info},   // gfx600, tahiti
-    {"gfx601", &setGfx601Info},   // gfx601, pitcairn, verde
-    {"gfx602", &setGfx602Info},   // gfx601, oland, hainan
-    {"gfx700", &setGfx700Info},   // gfx700, kaveri
-    {"gfx701", &setGfx701Info},   // gfx701, hawaii
-    {"gfx702", &setGfx7Info},     // gfx702
-    {"gfx703", &setGfx703Info},   // gfx703, kabini, mullins
-    {"gfx704", &setGfx703Info},   // gfx704, bonaire
-    {"gfx705", &setGfx705Info},   // gfx705
-    {"gfx800", &setGfx800Info},   // gfx800, iceland
-    {"gfx801", &setGfx800Info},   // gfx801, carrizo
-    {"gfx802", &setGfx802Info},   // gfx802, tonga
-    {"gfx803", &setGfx803Info},   // gfx803, fiji, polaris10, polaris11
-    {"gfx804", &setGfx803Info},   // gfx804
-    {"gfx805", &setGfx802Info},   // gfx805, tongapro
-    {"gfx810", &setGfx81Info},    // gfx810, stoney
-    {"gfx900", &setGfx900Info},   // gfx900
-    {"gfx901", &setGfx9Info},     // gfx901
-    {"gfx902", &setGfx900Info},   // gfx902
-    {"gfx903", &setGfx9Info},     // gfx903
-    {"gfx904", &setGfx9Info},     // gfx904, vega12
-    {"gfx906", &setGfx906Info},   // gfx906, vega20
-    {"gfx909", &setGfx9Info},     // gfx909, raven2
-    {"gfx90c", &setGfx9Info},     // gfx90c
-    {"gfx1010", &setGfx1010Info}, // gfx1010
-    {"gfx1011", &setGfx1011Info}, // gfx1011, navi12
-    {"gfx1012", &setGfx1012Info}, // gfx1012, navi14
-    {"gfx1030", &setGfx1030Info}, // gfx1030, navi21
-    {"gfx1031", &setGfx1031Info}, // gfx1031, navi22
-    {"gfx1032", &setGfx1032Info}, // gfx1032, navi23
-    {"gfx1034", &setGfx1034Info}, // gfx1034, navi24
-#if LLPC_BUILD_NAVI31
-    {"gfx1100", &setGfx1100Info}, // gfx1100, navi31
-#endif
+      {"gfx600", &setGfx600Info},   // gfx600, tahiti
+      {"gfx601", &setGfx601Info},   // gfx601, pitcairn, verde
+      {"gfx602", &setGfx602Info},   // gfx601, oland, hainan
+      {"gfx700", &setGfx700Info},   // gfx700, kaveri
+      {"gfx701", &setGfx701Info},   // gfx701, hawaii
+      {"gfx702", &setGfx7Info},     // gfx702
+      {"gfx703", &setGfx703Info},   // gfx703, kabini, mullins
+      {"gfx704", &setGfx703Info},   // gfx704, bonaire
+      {"gfx705", &setGfx705Info},   // gfx705
+      {"gfx800", &setGfx800Info},   // gfx800, iceland
+      {"gfx801", &setGfx800Info},   // gfx801, carrizo
+      {"gfx802", &setGfx802Info},   // gfx802, tonga
+      {"gfx803", &setGfx803Info},   // gfx803, fiji, polaris10, polaris11
+      {"gfx804", &setGfx803Info},   // gfx804
+      {"gfx805", &setGfx802Info},   // gfx805, tongapro
+      {"gfx810", &setGfx81Info},    // gfx810, stoney
+      {"gfx900", &setGfx900Info},   // gfx900
+      {"gfx901", &setGfx9Info},     // gfx901
+      {"gfx902", &setGfx900Info},   // gfx902
+      {"gfx903", &setGfx9Info},     // gfx903
+      {"gfx904", &setGfx9Info},     // gfx904, vega12
+      {"gfx906", &setGfx906Info},   // gfx906, vega20
+      {"gfx909", &setGfx9Info},     // gfx909, raven2
+      {"gfx90c", &setGfx9Info},     // gfx90c
+      {"gfx1010", &setGfx1010Info}, // gfx1010
+      {"gfx1011", &setGfx1011Info}, // gfx1011, navi12
+      {"gfx1012", &setGfx1012Info}, // gfx1012, navi14
+      {"gfx1030", &setGfx1030Info}, // gfx1030, navi21
+      {"gfx1031", &setGfx1031Info}, // gfx1031, navi22
+      {"gfx1032", &setGfx1032Info}, // gfx1032, navi23
+      {"gfx1034", &setGfx1034Info}, // gfx1034, navi24
+      {"gfx1100", &setGfx1100Info}, // gfx1100, navi31
   };
 
   void (*setTargetInfoFunc)(TargetInfo * targetInfo) = nullptr;

--- a/lgc/util/GfxRegHandler.cpp
+++ b/lgc/util/GfxRegHandler.cpp
@@ -118,9 +118,7 @@ SqImgSampRegHandler::SqImgSampRegHandler(IRBuilder<> *builder, Value *reg, GfxIp
   case 8:
   case 9:
   case 10:
-#if LLPC_BUILD_GFX11
   case 11:
-#endif
     m_bitsInfo = SqImgSampRegBitsGfx9;
     break;
   default:
@@ -232,7 +230,6 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx10[static_cast<unsigned>(SqRsrcRegs
     {2, 0, 12},  // WidthHi
 };
 
-#if LLPC_BUILD_GFX11
 // =====================================================================================================================
 // SqImgSampReg Bits information look up table (Gfx11)
 // TODO: update comment when the registers file is available
@@ -254,7 +251,6 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx11[static_cast<unsigned>(SqRsrcRegs
     {1, 30, 2},  // WidthLo
     {2, 0, 12},  // WidthHi
 };
-#endif
 
 // =====================================================================================================================
 // Helper class for handling Registers defined in SQ_IMG_RSRC_WORD
@@ -278,11 +274,9 @@ SqImgRsrcRegHandler::SqImgRsrcRegHandler(IRBuilder<> *builder, Value *reg, GfxIp
   case 10:
     m_bitsInfo = SqImgRsrcRegBitsGfx10;
     break;
-#if LLPC_BUILD_GFX11
   case 11:
     m_bitsInfo = SqImgRsrcRegBitsGfx11;
     break;
-#endif
   default:
     llvm_unreachable("GFX IP is not supported!");
     break;
@@ -317,9 +311,7 @@ Value *SqImgRsrcRegHandler::getReg(SqRsrcRegs regId) {
     case 9:
       return m_builder->CreateAdd(getRegCommon(static_cast<unsigned>(regId)), m_one);
     case 10:
-#if LLPC_BUILD_GFX11
     case 11:
-#endif
       return m_builder->CreateAdd(
           getRegCombine(static_cast<unsigned>(SqRsrcRegs::WidthLo), static_cast<unsigned>(SqRsrcRegs::WidthHi)), m_one);
     default:
@@ -372,9 +364,7 @@ void SqImgRsrcRegHandler::setReg(SqRsrcRegs regId, Value *regValue) {
       setRegCommon(static_cast<unsigned>(regId), m_builder->CreateSub(regValue, m_one));
       break;
     case 10:
-#if LLPC_BUILD_GFX11
     case 11:
-#endif
       setRegCombine(static_cast<unsigned>(SqRsrcRegs::WidthLo), static_cast<unsigned>(SqRsrcRegs::WidthHi),
                     m_builder->CreateSub(regValue, m_one));
       break;


### PR DESCRIPTION
The codes are released. No need of keeping the two macros.