### PR TITLE
Opaque Pointers: Enable opaque pointers in LLPC and LGC

### DIFF
--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -102,7 +102,7 @@ cl::opt<unsigned> PalAbiVersion("pal-abi-version", cl::init(0xFFFFFFFF), cl::cat
 // -v: enable verbose output
 cl::opt<bool> VerboseOutput("v", cl::cat(LgcCategory), cl::desc("Enable verbose output"), cl::init(false));
 
-cl::opt<bool> OpaquePointers("enable-opaque-pointers", cl::desc("Enable opaque-pointers in LGC"), cl::init(false));
+cl::opt<bool> OpaquePointers("enable-opaque-pointers", cl::desc("Enable opaque-pointers in LGC"), cl::init(true));
 } // anonymous namespace
 
 // =====================================================================================================================

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -67,7 +67,7 @@ opt<std::string> LogFileOuts("log-file-outs", desc("Name of the file to log info
 // TODO: Remove this when LLPC will switch fully to opaque pointers.
 // opaque-pointers flag which is implemented in LLVM is by default enabled. Right now we do not want
 // to enable by default this flag for LLPC, but we need to have some flag to use for transition and for LIT tests.
-opt<bool> OpaquePointers("enable-opaque-pointers", desc("Enable opaque-pointers for LLPC"), init(false));
+opt<bool> OpaquePointers("enable-opaque-pointers", desc("Enable opaque-pointers for LLPC"), init(true));
 
 } // namespace cl
 


### PR DESCRIPTION
All known tests are working without any performance degradation.