### PR TITLE
Rework of transform feedback on GFX11

### DIFF
--- a/lgc/include/lgc/patch/SystemValues.h
+++ b/lgc/include/lgc/patch/SystemValues.h
@@ -107,18 +107,12 @@ public:
   // Get stream-out buffer descriptor
   llvm::Value *getStreamOutBufDesc(unsigned xfbBuffer);
 
-  // Get stream-out buffer offset
-  llvm::Value *getStreamOutBufOffset(unsigned xfbBuffer);
-
   // Test if shadow descriptor table is enabled
   bool isShadowDescTableEnabled() const;
 
 private:
   // Get stream-out buffer table pointer
   std::pair<llvm::Type *, llvm::Instruction *> getStreamOutTablePtr();
-
-  // Get stream-out control buffer pointer
-  std::pair<llvm::Type *, llvm::Instruction *> getStreamOutControlBufPtr();
 
   // Make 64-bit pointer of specified type from 32-bit int, extending with the specified value, or PC if InvalidValue
   llvm::Instruction *makePointer(llvm::Value *lowValue, llvm::Type *ptrTy, unsigned highValue);
@@ -142,8 +136,7 @@ private:
   llvm::Value *m_taskDrawDataRingBufDesc = nullptr; // Descriptor for task draw data ring buffer (task and mesh shader)
   llvm::SmallVector<llvm::Value *, MaxGsStreams>
       m_gsVsRingBufDescs; // GS -> VS ring buffer descriptor (GS out and copy shader in)
-  llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufDescs;   // Stream-out buffer descriptors
-  llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufOffsets; // Stream-out buffer offsets
+  llvm::SmallVector<llvm::Value *, MaxTransformFeedbackBuffers> m_streamOutBufDescs; // Stream-out buffer descriptors
 
   llvm::Value *m_primitiveId = nullptr;                             // PrimitiveId (TCS)
   llvm::Value *m_invocationId = nullptr;                            // InvocationId (TCS)
@@ -158,7 +151,6 @@ private:
   llvm::Value *m_meshPipeStatsBufPtr = nullptr;              // Mesh pipeline statistics buffer pointer
   llvm::Value *m_internalPerShaderTablePtr = nullptr;        // Internal per shader table pointer
   llvm::Instruction *m_streamOutTablePtr = nullptr;          // Stream-out buffer table pointer
-  llvm::Instruction *m_streamOutControlBufPtr = nullptr;     // Stream-out control buffer pointer
   llvm::Instruction *m_pc = nullptr;                         // Program counter as <2 x i32>
 };
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -515,9 +515,8 @@ struct InterfaceData {
   struct {
     // Geometry shader
     struct {
-      unsigned copyShaderEsGsLdsSize;         // ES -> GS ring LDS size (for copy shader)
-      unsigned copyShaderStreamOutTable;      // Stream-out table (for copy shader)
-      unsigned copyShaderStreamOutControlBuf; // Stream-out control buffer (for copy shader)
+      unsigned copyShaderEsGsLdsSize;    // ES -> GS ring LDS size (for copy shader)
+      unsigned copyShaderStreamOutTable; // Stream-out table (for copy shader)
     } gs;
 
     unsigned spillTable; // Spill table user data map

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -190,6 +190,7 @@ private:
   void buildPrimShaderWithGs(llvm::Function *entryPoint);
 
   void initWaveThreadInfo(llvm::Value *mergedGroupInfo, llvm::Value *mergedWaveInfo);
+  void loadStreamOutBufferInfo(llvm::Value *userData);
 
   llvm::Value *doCulling(llvm::Module *module, llvm::Value *vertexId0, llvm::Value *vertexId1, llvm::Value *vertexId2);
   void doParamCacheAllocRequest();
@@ -333,6 +334,9 @@ private:
   bool m_hasVs = false;  // Whether the pipeline has vertex shader
   bool m_hasTes = false; // Whether the pipeline has tessellation evaluation shader
   bool m_hasGs = false;  // Whether the pipeline has geometry shader
+
+  llvm::Value *m_streamOutBufDescs[MaxTransformFeedbackBuffers];   // Stream-out buffer descriptors
+  llvm::Value *m_streamOutBufOffsets[MaxTransformFeedbackBuffers]; // Stream-out buffer offsets
 
   bool m_constPositionZ = false; // Whether the Z channel of vertex position data is constant
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -140,17 +140,15 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
     // GFX11+:
     //   void copyShader(
     //     i32 inreg globalTable,
-    //     i32 inreg streamOutTable,
-    //     i32 inreg streamOutControlBuf,
     //     i32 vertexId)
     if (m_pipelineState->getTargetInfo().getGfxIpVersion().major <= 10) {
       argTys = {int32Ty};
       argInReg = {false};
       argNames = {"vertexId"};
     } else {
-      argTys = {int32Ty, int32Ty, int32Ty, int32Ty};
-      argInReg = {true, true, true, false};
-      argNames = {"globalTable", "streamOutTable", "streamOutControlBuf", "vertexId"};
+      argTys = {int32Ty, int32Ty};
+      argInReg = {true, false};
+      argNames = {"globalTable", "vertexId"};
     }
   }
 
@@ -195,11 +193,9 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = 2;
       intfData->userDataUsage.gs.copyShaderStreamOutTable = 3;
     } else {
-      // If NGG, esGsLdsSize is not used
+      // If NGG, both esGsLdsSize and streamOutTable are not used
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = InvalidValue;
-      intfData->userDataUsage.gs.copyShaderStreamOutTable = 1;
-      if (m_pipelineState->enableSwXfb())
-        intfData->userDataUsage.gs.copyShaderStreamOutControlBuf = 2;
+      intfData->userDataUsage.gs.copyShaderStreamOutTable = InvalidValue;
     }
   }
 

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -69,6 +69,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+#include <optional>
 
 #define DEBUG_TYPE "lgc-patch-entry-point-mutate"
 
@@ -363,7 +364,10 @@ void PatchEntryPointMutate::gatherUserDataUsage(Module *module) {
           descriptorTable[descTableIndex].users.push_back(call);
         }
       }
-    } else if (func.getName().startswith(lgcName::OutputExportXfb) && !func.use_empty()) {
+    } else if ((func.getName().startswith(lgcName::OutputExportXfb) && !func.use_empty()) ||
+               m_pipelineState->enableSwXfb()) {
+      // NOTE: For GFX11+, SW emulated stream-out will always use stream-out buffer descriptors and stream-out buffer
+      // offsets to calculate numbers of written primitives/dwords and update the counters.  auto lastVertexStage =
       auto lastVertexStage = m_pipelineState->getLastVertexProcessingStage();
       lastVertexStage = lastVertexStage == ShaderStageCopyShader ? ShaderStageGeometry : lastVertexStage;
       getUserDataUsage(lastVertexStage)->usesStreamOutTable = true;

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1065,21 +1065,21 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
   LLPC_OUTS("\n");
 
   if (hasGs) {
-    LLPC_OUTS("GS stream item size:\n");
+    LLPC_OUTS("GS stream item sizes (in dwords):\n");
     for (unsigned i = 0; i < MaxGsStreams; ++i) {
       unsigned streamItemSize = gsResUsage->inOutUsage.gs.outLocCount[i] * geometryMode.outputVertices * 4;
-      LLPC_OUTS("    stream " << i << " = " << streamItemSize);
+      LLPC_OUTS("    stream[" << i << "] = " << streamItemSize);
 
       if (m_pipelineState->enableXfb()) {
-        LLPC_OUTS(", XFB buffer = ");
         const auto &streamXfbBuffers = m_pipelineState->getStreamXfbBuffers();
-        for (unsigned j = 0; j < MaxTransformFeedbackBuffers; ++j) {
-          if ((streamXfbBuffers[i] & (1 << j)) != 0) {
-            LLPC_OUTS(j);
-            if (j != MaxTransformFeedbackBuffers - 1)
-              LLPC_OUTS(", ");
+        LLPC_OUTS(", XFB buffers = { ");
+        if (streamXfbBuffers[i] != 0) {
+          for (unsigned j = 0; j < MaxTransformFeedbackBuffers; ++j) {
+            if ((streamXfbBuffers[i] & (1 << j)) != 0)
+              LLPC_OUTS(j << " ");
           }
         }
+        LLPC_OUTS("}");
       }
 
       LLPC_OUTS("\n");

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1365,7 +1365,9 @@ bool PipelineState::enableMeshRowExport() const {
 // =====================================================================================================================
 // Checks if SW-emulated stream-out should be enabled.
 bool PipelineState::enableSwXfb() {
-  assert(isGraphics());
+  // Not graphics pipeline
+  if (!isGraphics())
+    return false;
 
   // SW-emulated stream-out is enabled on GFX11+
   if (getTargetInfo().getGfxIpVersion().major < 11)

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -37,6 +37,7 @@
 #include "vkgcElfReader.h"
 #include "vkgcMetroHash.h"
 #include "lgc/CommonDefs.h"
+#include <optional>
 
 namespace llvm {
 

--- a/llpc/tool/llpcCompilationUtils.h
+++ b/llpc/tool/llpcCompilationUtils.h
@@ -62,6 +62,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Error.h"
+#include <optional>
 
 namespace Llpc {
 namespace StandaloneCompiler {


### PR DESCRIPTION
This is to address the new CTS:
dEQP-VK.transform_feedback.simple.omit_write.

The new CTS group adds such cases:

```
  layout(points) in;
  layout(location = 0) in vec4 in0[];

  layout(points, max_vertices = 1) out;
  layout(xfb_buffer = 0, xfb_offset = 0, xfb_stride = 16, location = 0)
  out vec4 out0;

  void main(void) {
    EmitVertex();
    EndPrimitive();
  }

```
In the cases, we don't actually write transform feedback outputs to buffers. Rather, the tests only verify the transform feedback counters.

Previously, on GFX11, the counters are triggered by transform feedback outputs. The stream-out buffer descriptors and buffer offsets are bound to such outputs and are handled by NGG stream-out logic. This should be revised. Those info could be obtained directly from user data and are independent of transform feedback outputs. This change does those actions as a GFX11 follow-up one of
https://github.com/GPUOpen-Drivers/llpc/pull/2138:

1. Load stream-out info directly in NGG logic. Don't handle them in separate shaders.

2. The stream-out buffer offsets are no longer part of system value getters. They are handled in NGG.

3. The mutation of GS and ES in transform feedback is modified to only handle transform feedback outputs. The stream-out buffer descriptors and buffer offsets are handled and loaded globally.