### PR TITLE
Use i64 in tests for upstream change

### DIFF
--- a/llpc/test/shaderdb/core/OpVectorTimesScalar_TestDoublexDvec4_lit.frag
+++ b/llpc/test/shaderdb/core/OpVectorTimesScalar_TestDoublexDvec4_lit.frag
@@ -17,7 +17,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = insertelement <4 x double> {{undef|poison}}, double %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = insertelement <4 x double> {{undef|poison}}, double %{{.*}}, i{{32|64}} 0
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> {{undef|poison}}, <4 x i32> zeroinitializer
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract <4 x double> %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/core/OpVectorTimesScalar_TestDvec4xDouble_lit.frag
+++ b/llpc/test/shaderdb/core/OpVectorTimesScalar_TestDvec4xDouble_lit.frag
@@ -21,7 +21,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = insertelement <4 x double> {{undef|poison}}, double %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = insertelement <4 x double> {{undef|poison}}, double %{{.*}}, i{{32|64}} 0
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> {{undef|poison}}, <4 x i32> zeroinitializer
 ; SHADERTEST: %{{.*}} = fmul reassoc nnan nsz arcp contract <4 x double> %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
[D140983](https://reviews.llvm.org/D140983) changed insertelements to always use i64 instead of i32.