### PR TITLE
Fix a regression on packing with XFB outputs

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -118,12 +118,6 @@ public:
   bool isBuiltIn() const { return m_data.bits.isBuiltIn; }
   void setBuiltIn(bool isBuiltIn) { m_data.bits.isBuiltIn = isBuiltIn; }
 
-  bool isFlat() const { return m_data.bits.isFlat; }
-  void setFlat(bool isFlat) { m_data.bits.isFlat = isFlat; }
-
-  bool isCustom() const { return m_data.bits.isCustom; }
-  void setCustom(bool isCustom) { m_data.bits.isCustom = isCustom; }
-
   unsigned getStreamId() const { return m_data.bits.streamId; }
   void setStreamId(unsigned streamId) { m_data.bits.streamId = static_cast<uint16_t>(streamId); }
 
@@ -135,10 +129,8 @@ private:
     struct {
       uint16_t isHighHalf : 1; // High half in case of 16-bit attributes
       uint16_t component : 2;  // The component index
-      uint16_t location : 8;   // The location
+      uint16_t location : 10;  // The location
       uint16_t isBuiltIn : 1;  // Whether location is actually built-in ID
-      uint16_t isFlat : 1;     // Whether is flat shading
-      uint16_t isCustom : 1;   // Whether is custom interpolation
       uint16_t streamId : 2;   // Output vertex stream ID
     } bits;
     uint16_t u16All;

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -701,34 +701,14 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           // The inputLocInfoMap of {TCS, GS, FS} maps original InOutLocationInfo to tightly compact InOutLocationInfo
           const bool isTcs = m_shaderStage == ShaderStageTessControl;
           const uint32_t elemIdxArgIdx = (isInterpolantInputImport || isTcs) ? 2 : 1;
-          bool hasDynIndex = false;
-          if (isTcs) {
-            hasDynIndex = !isa<ConstantInt>(callInst.getOperand(1)) || !isa<ConstantInt>(callInst.getOperand(2));
-            if (!hasDynIndex) {
-              // TCS input calls at the same location may have dynamic indexing or not
-              // Try the key as combination of location and component at first
-              origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue());
-              locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
-              if (locInfoMapIt == resUsage->inOutUsage.inputLocInfoMap.end()) {
-                // Try the key as the plain location
-                origLocInfo.setComponent(0);
-                hasDynIndex = true;
-              }
-            }
-          } else {
-            origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue());
-            if (m_shaderStage == ShaderStageFragment && isInterpolantInputImport) {
-              const unsigned interpMode = cast<ConstantInt>(callInst.getOperand(3))->getZExtValue();
-              origLocInfo.setFlat(interpMode == InOutInfo::InterpModeFlat);
-              origLocInfo.setCustom(interpMode == InOutInfo::InterpModeCustom);
-            }
-          }
+          // All packing of the VS-TCS interface is disabled if dynamic indexing is detected
+          assert(!isTcs || (isa<ConstantInt>(callInst.getOperand(1)) && isa<ConstantInt>(callInst.getOperand(2))));
+          origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(elemIdxArgIdx))->getZExtValue());
           locInfoMapIt = resUsage->inOutUsage.inputLocInfoMap.find(origLocInfo);
           assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
 
           loc = locInfoMapIt->second.getLocation();
-          if (!hasDynIndex)
-            elemIdx = builder.getInt32(locInfoMapIt->second.getComponent());
+          elemIdx = builder.getInt32(locInfoMapIt->second.getComponent());
           highHalf = locInfoMapIt->second.isHighHalf();
         } else {
           assert(locInfoMapIt != resUsage->inOutUsage.inputLocInfoMap.end());
@@ -1004,21 +984,10 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
                  m_shaderStage == ShaderStageTessEval);
           origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(1))->getZExtValue());
           locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
-          bool relateDynIndex = false;
-          const bool checkDynIndex =
-              (m_shaderStage == ShaderStageVertex && m_pipelineState->hasShaderStage(ShaderStageTessControl));
-          if (checkDynIndex && locInfoMapIt == resUsage->inOutUsage.outputLocInfoMap.end()) {
-            // The location in TCS may be used with dynamic indexing, try location as the key for a search
-            origLocInfo.setComponent(0);
-            locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
-            relateDynIndex = true;
-          }
 
           if (locInfoMapIt != resUsage->inOutUsage.outputLocInfoMap.end()) {
             loc = locInfoMapIt->second.getLocation();
-            // Dynamic indexing related locations just use the location for mapping
-            if (!relateDynIndex)
-              elemIdx = locInfoMapIt->second.getComponent();
+            elemIdx = locInfoMapIt->second.getComponent();
             exist = true;
           } else {
             exist = false;

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestInOutPacking.pipe
@@ -2,67 +2,80 @@
 ; RUN: amdllpc -enable-part-pipeline=0 -v %gfxip %s | FileCheck -check-prefix=SHADERTEST_PP0 %s
 ; SHADERTEST_PP0-LABEL: LLPC pipeline before-patching results
 ; SHADERTEST_PP0-LABEL: LLPC location input/output mapping results (FS shader)
-; SHADERTEST_PP0: (FS) Input:  loc = 0, comp = 0 =>  Mapped = 0, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 0, comp = 1 =>  Mapped = 0, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 1, comp = 0 =>  Mapped = 0, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 1, comp = 1 =>  Mapped = 0, 3
-; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 0 =>  Mapped = 4, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 1 =>  Mapped = 4, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 2 =>  Mapped = 4, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 2, comp = 3 =>  Mapped = 4, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 0 =>  Mapped = 4, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 1 =>  Mapped = 4, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 2 =>  Mapped = 4, 3
-; SHADERTEST_PP0: (FS) Input:  loc = 3, comp = 3 =>  Mapped = 4, 3
-; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 2 =>  Mapped = 1, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 4, comp = 3 =>  Mapped = 1, 3
-; SHADERTEST_PP0: (FS) Input:  loc = 5, comp = 0 =>  Mapped = 2, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 5, comp = 1 =>  Mapped = 2, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 6, comp = 0 =>  Mapped = 2, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 7, comp = 0 =>  Mapped = 5, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 7, comp = 1 =>  Mapped = 5, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 8, comp = 0 =>  Mapped = 5, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 8, comp = 1 =>  Mapped = 5, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 0 =>  Mapped = 5, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 1 =>  Mapped = 5, 2
-; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 2 =>  Mapped = 5, 3
-; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 3 =>  Mapped = 5, 3
-; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 0 =>  Mapped = 3, 0
-; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 1 =>  Mapped = 3, 1
-; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 2 =>  Mapped = 3, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 7, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 7, comp = 1 =>  Mapped = 0, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 8, comp = 0 =>  Mapped = 0, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 8, comp = 1 =>  Mapped = 0, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 0 =>  Mapped = 1, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 1 =>  Mapped = 1, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 2 =>  Mapped = 1, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 9, comp = 3 =>  Mapped = 1, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 0 =>  Mapped = 1, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 1 =>  Mapped = 1, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 2 =>  Mapped = 1, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 10, comp = 3 =>  Mapped = 1, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 11, comp = 0 =>  Mapped = 2, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 11, comp = 1 =>  Mapped = 2, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 11, comp = 2 =>  Mapped = 2, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 11, comp = 3 =>  Mapped = 2, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 12, comp = 0 =>  Mapped = 3, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 12, comp = 1 =>  Mapped = 3, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 13, comp = 0 =>  Mapped = 3, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 14, comp = 0 =>  Mapped = 4, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 14, comp = 1 =>  Mapped = 4, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 15, comp = 0 =>  Mapped = 4, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 15, comp = 1 =>  Mapped = 4, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 16, comp = 0 =>  Mapped = 4, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 16, comp = 1 =>  Mapped = 4, 2
+; SHADERTEST_PP0: (FS) Input:  loc = 16, comp = 2 =>  Mapped = 4, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 16, comp = 3 =>  Mapped = 4, 3
+; SHADERTEST_PP0: (FS) Input:  loc = 17, comp = 0 =>  Mapped = 5, 0
+; SHADERTEST_PP0: (FS) Input:  loc = 17, comp = 1 =>  Mapped = 5, 1
+; SHADERTEST_PP0: (FS) Input:  loc = 17, comp = 2 =>  Mapped = 5, 2
 ; SHADERTEST_PP0-LABEL: LLPC location input/output mapping results (VS shader)
-; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 0  =>  Mapped = 0, 0
-; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 1  =>  Mapped = 0, 1
-; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 0  =>  Mapped = 0, 2
-; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 1  =>  Mapped = 0, 3
-; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 0  =>  Mapped = 4, 0
-; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 1  =>  Mapped = 4, 0
-; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 2  =>  Mapped = 4, 1
-; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 3  =>  Mapped = 4, 1
-; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 0  =>  Mapped = 4, 2
-; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 1  =>  Mapped = 4, 2
-; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 2  =>  Mapped = 4, 3
-; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 3  =>  Mapped = 4, 3
-; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 0  =>  Mapped = 1, 0
-; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 1  =>  Mapped = 1, 1
-; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 2  =>  Mapped = 1, 2
-; SHADERTEST_PP0: (VS) Output: loc = 4, comp = 3  =>  Mapped = 1, 3
-; SHADERTEST_PP0: (VS) Output: loc = 5, comp = 0  =>  Mapped = 2, 0
-; SHADERTEST_PP0: (VS) Output: loc = 5, comp = 1  =>  Mapped = 2, 1
-; SHADERTEST_PP0: (VS) Output: loc = 6, comp = 0  =>  Mapped = 2, 2
-; SHADERTEST_PP0: (VS) Output: loc = 7, comp = 0  =>  Mapped = 5, 0
-; SHADERTEST_PP0: (VS) Output: loc = 7, comp = 1  =>  Mapped = 5, 0
-; SHADERTEST_PP0: (VS) Output: loc = 8, comp = 0  =>  Mapped = 5, 1
-; SHADERTEST_PP0: (VS) Output: loc = 8, comp = 1  =>  Mapped = 5, 1
-; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 0  =>  Mapped = 5, 2
-; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 1  =>  Mapped = 5, 2
-; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 2  =>  Mapped = 5, 3
-; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 3  =>  Mapped = 5, 3
-; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 0  =>  Mapped = 3, 0
-; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 1  =>  Mapped = 3, 1
-; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 2  =>  Mapped = 3, 2
+; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 0  =>  Mapped = 6, 0
+; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 1  =>  Mapped = 6, 1
+; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 2  =>  Mapped = 6, 2
+; SHADERTEST_PP0: (VS) Output: loc = 0, comp = 3  =>  Mapped = 6, 3
+; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 0  =>  Mapped = 7, 0
+; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 1  =>  Mapped = 7, 1
+; SHADERTEST_PP0: (VS) Output: loc = 1, comp = 2  =>  Mapped = 7, 2
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 0  =>  Mapped = 7, 3
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 1  =>  Mapped = 8, 0
+; SHADERTEST_PP0: (VS) Output: loc = 2, comp = 2  =>  Mapped = 8, 1
+; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 0  =>  Mapped = 8, 2
+; SHADERTEST_PP0: (VS) Output: loc = 3, comp = 1  =>  Mapped = 8, 3
+; SHADERTEST_PP0: (VS) Output: loc = 6, comp = 0  =>  Mapped = 9, 0
+; SHADERTEST_PP0: (VS) Output: loc = 7, comp = 0  =>  Mapped = 0, 0
+; SHADERTEST_PP0: (VS) Output: loc = 7, comp = 1  =>  Mapped = 0, 1
+; SHADERTEST_PP0: (VS) Output: loc = 8, comp = 0  =>  Mapped = 0, 2
+; SHADERTEST_PP0: (VS) Output: loc = 8, comp = 1  =>  Mapped = 0, 3
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 0  =>  Mapped = 1, 0
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 1  =>  Mapped = 1, 0
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 2  =>  Mapped = 1, 1
+; SHADERTEST_PP0: (VS) Output: loc = 9, comp = 3  =>  Mapped = 1, 1
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 0  =>  Mapped = 1, 2
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 1  =>  Mapped = 1, 2
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 2  =>  Mapped = 1, 3
+; SHADERTEST_PP0: (VS) Output: loc = 10, comp = 3  =>  Mapped = 1, 3
+; SHADERTEST_PP0: (VS) Output: loc = 11, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST_PP0: (VS) Output: loc = 11, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST_PP0: (VS) Output: loc = 11, comp = 2  =>  Mapped = 2, 2
+; SHADERTEST_PP0: (VS) Output: loc = 11, comp = 3  =>  Mapped = 2, 3
+; SHADERTEST_PP0: (VS) Output: loc = 12, comp = 0  =>  Mapped = 3, 0
+; SHADERTEST_PP0: (VS) Output: loc = 12, comp = 1  =>  Mapped = 3, 1
+; SHADERTEST_PP0: (VS) Output: loc = 13, comp = 0  =>  Mapped = 3, 2
+; SHADERTEST_PP0: (VS) Output: loc = 14, comp = 0  =>  Mapped = 4, 0
+; SHADERTEST_PP0: (VS) Output: loc = 14, comp = 1  =>  Mapped = 4, 0
+; SHADERTEST_PP0: (VS) Output: loc = 15, comp = 0  =>  Mapped = 4, 1
+; SHADERTEST_PP0: (VS) Output: loc = 15, comp = 1  =>  Mapped = 4, 1
+; SHADERTEST_PP0: (VS) Output: loc = 16, comp = 0  =>  Mapped = 4, 2
+; SHADERTEST_PP0: (VS) Output: loc = 16, comp = 1  =>  Mapped = 4, 2
+; SHADERTEST_PP0: (VS) Output: loc = 16, comp = 2  =>  Mapped = 4, 3
+; SHADERTEST_PP0: (VS) Output: loc = 16, comp = 3  =>  Mapped = 4, 3
+; SHADERTEST_PP0: (VS) Output: loc = 17, comp = 0  =>  Mapped = 5, 0
+; SHADERTEST_PP0: (VS) Output: loc = 17, comp = 1  =>  Mapped = 5, 1
+; SHADERTEST_PP0: (VS) Output: loc = 17, comp = 2  =>  Mapped = 5, 2
 ; SHADERTEST_PP0: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -74,69 +87,82 @@
 ; Fragment shader part-pipeline:
 ; SHADERTEST_PP1-LABEL: LLPC pipeline before-patching results
 ; SHADERTEST_PP1-LABEL: LLPC location input/output mapping results (FS shader)
-; SHADERTEST_PP1: (FS) Input:  loc = 0, comp = 0 =>  Mapped = 0, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 0, comp = 1 =>  Mapped = 0, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 1, comp = 0 =>  Mapped = 0, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 1, comp = 1 =>  Mapped = 0, 3
-; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 0 =>  Mapped = 4, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 1 =>  Mapped = 4, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 2 =>  Mapped = 4, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 2, comp = 3 =>  Mapped = 4, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 0 =>  Mapped = 4, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 1 =>  Mapped = 4, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 2 =>  Mapped = 4, 3
-; SHADERTEST_PP1: (FS) Input:  loc = 3, comp = 3 =>  Mapped = 4, 3
-; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 2 =>  Mapped = 1, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 4, comp = 3 =>  Mapped = 1, 3
-; SHADERTEST_PP1: (FS) Input:  loc = 5, comp = 0 =>  Mapped = 2, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 5, comp = 1 =>  Mapped = 2, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 6, comp = 0 =>  Mapped = 2, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 7, comp = 0 =>  Mapped = 5, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 7, comp = 1 =>  Mapped = 5, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 8, comp = 0 =>  Mapped = 5, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 8, comp = 1 =>  Mapped = 5, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 0 =>  Mapped = 5, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 1 =>  Mapped = 5, 2
-; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 2 =>  Mapped = 5, 3
-; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 3 =>  Mapped = 5, 3
-; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 0 =>  Mapped = 3, 0
-; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 1 =>  Mapped = 3, 1
-; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 2 =>  Mapped = 3, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 7, comp = 0 =>  Mapped = 0, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 7, comp = 1 =>  Mapped = 0, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 8, comp = 0 =>  Mapped = 0, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 8, comp = 1 =>  Mapped = 0, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 0 =>  Mapped = 1, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 1 =>  Mapped = 1, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 2 =>  Mapped = 1, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 9, comp = 3 =>  Mapped = 1, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 0 =>  Mapped = 1, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 1 =>  Mapped = 1, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 2 =>  Mapped = 1, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 10, comp = 3 =>  Mapped = 1, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 11, comp = 0 =>  Mapped = 2, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 11, comp = 1 =>  Mapped = 2, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 11, comp = 2 =>  Mapped = 2, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 11, comp = 3 =>  Mapped = 2, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 12, comp = 0 =>  Mapped = 3, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 12, comp = 1 =>  Mapped = 3, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 13, comp = 0 =>  Mapped = 3, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 14, comp = 0 =>  Mapped = 4, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 14, comp = 1 =>  Mapped = 4, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 15, comp = 0 =>  Mapped = 4, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 15, comp = 1 =>  Mapped = 4, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 16, comp = 0 =>  Mapped = 4, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 16, comp = 1 =>  Mapped = 4, 2
+; SHADERTEST_PP1: (FS) Input:  loc = 16, comp = 2 =>  Mapped = 4, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 16, comp = 3 =>  Mapped = 4, 3
+; SHADERTEST_PP1: (FS) Input:  loc = 17, comp = 0 =>  Mapped = 5, 0
+; SHADERTEST_PP1: (FS) Input:  loc = 17, comp = 1 =>  Mapped = 5, 1
+; SHADERTEST_PP1: (FS) Input:  loc = 17, comp = 2 =>  Mapped = 5, 2
 ; Pre-rasterization part-pipeline:
 ; SHADERTEST_PP1-LABEL: LLPC pipeline before-patching results
 ; SHADERTEST_PP1-LABEL: LLPC location input/output mapping results (VS shader)
-; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 0  =>  Mapped = 0, 0
-; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 1  =>  Mapped = 0, 1
-; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 0  =>  Mapped = 0, 2
-; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 1  =>  Mapped = 0, 3
-; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 0  =>  Mapped = 4, 0
-; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 1  =>  Mapped = 4, 0
-; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 2  =>  Mapped = 4, 1
-; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 3  =>  Mapped = 4, 1
-; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 0  =>  Mapped = 4, 2
-; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 1  =>  Mapped = 4, 2
-; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 2  =>  Mapped = 4, 3
-; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 3  =>  Mapped = 4, 3
-; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 0  =>  Mapped = 1, 0
-; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 1  =>  Mapped = 1, 1
-; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 2  =>  Mapped = 1, 2
-; SHADERTEST_PP1: (VS) Output: loc = 4, comp = 3  =>  Mapped = 1, 3
-; SHADERTEST_PP1: (VS) Output: loc = 5, comp = 0  =>  Mapped = 2, 0
-; SHADERTEST_PP1: (VS) Output: loc = 5, comp = 1  =>  Mapped = 2, 1
-; SHADERTEST_PP1: (VS) Output: loc = 6, comp = 0  =>  Mapped = 2, 2
-; SHADERTEST_PP1: (VS) Output: loc = 7, comp = 0  =>  Mapped = 5, 0
-; SHADERTEST_PP1: (VS) Output: loc = 7, comp = 1  =>  Mapped = 5, 0
-; SHADERTEST_PP1: (VS) Output: loc = 8, comp = 0  =>  Mapped = 5, 1
-; SHADERTEST_PP1: (VS) Output: loc = 8, comp = 1  =>  Mapped = 5, 1
-; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 0  =>  Mapped = 5, 2
-; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 1  =>  Mapped = 5, 2
-; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 2  =>  Mapped = 5, 3
-; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 3  =>  Mapped = 5, 3
-; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 0  =>  Mapped = 3, 0
-; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 1  =>  Mapped = 3, 1
-; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 2  =>  Mapped = 3, 2
+; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 0  =>  Mapped = 6, 0
+; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 1  =>  Mapped = 6, 1
+; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 2  =>  Mapped = 6, 2
+; SHADERTEST_PP1: (VS) Output: loc = 0, comp = 3  =>  Mapped = 6, 3
+; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 0  =>  Mapped = 7, 0
+; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 1  =>  Mapped = 7, 1
+; SHADERTEST_PP1: (VS) Output: loc = 1, comp = 2  =>  Mapped = 7, 2
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 0  =>  Mapped = 7, 3
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 1  =>  Mapped = 8, 0
+; SHADERTEST_PP1: (VS) Output: loc = 2, comp = 2  =>  Mapped = 8, 1
+; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 0  =>  Mapped = 8, 2
+; SHADERTEST_PP1: (VS) Output: loc = 3, comp = 1  =>  Mapped = 8, 3
+; SHADERTEST_PP1: (VS) Output: loc = 6, comp = 0  =>  Mapped = 9, 0
+; SHADERTEST_PP1: (VS) Output: loc = 7, comp = 0  =>  Mapped = 0, 0
+; SHADERTEST_PP1: (VS) Output: loc = 7, comp = 1  =>  Mapped = 0, 1
+; SHADERTEST_PP1: (VS) Output: loc = 8, comp = 0  =>  Mapped = 0, 2
+; SHADERTEST_PP1: (VS) Output: loc = 8, comp = 1  =>  Mapped = 0, 3
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 0  =>  Mapped = 1, 0
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 1  =>  Mapped = 1, 0
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 2  =>  Mapped = 1, 1
+; SHADERTEST_PP1: (VS) Output: loc = 9, comp = 3  =>  Mapped = 1, 1
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 0  =>  Mapped = 1, 2
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 1  =>  Mapped = 1, 2
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 2  =>  Mapped = 1, 3
+; SHADERTEST_PP1: (VS) Output: loc = 10, comp = 3  =>  Mapped = 1, 3
+; SHADERTEST_PP1: (VS) Output: loc = 11, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST_PP1: (VS) Output: loc = 11, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST_PP1: (VS) Output: loc = 11, comp = 2  =>  Mapped = 2, 2
+; SHADERTEST_PP1: (VS) Output: loc = 11, comp = 3  =>  Mapped = 2, 3
+; SHADERTEST_PP1: (VS) Output: loc = 12, comp = 0  =>  Mapped = 3, 0
+; SHADERTEST_PP1: (VS) Output: loc = 12, comp = 1  =>  Mapped = 3, 1
+; SHADERTEST_PP1: (VS) Output: loc = 13, comp = 0  =>  Mapped = 3, 2
+; SHADERTEST_PP1: (VS) Output: loc = 14, comp = 0  =>  Mapped = 4, 0
+; SHADERTEST_PP1: (VS) Output: loc = 14, comp = 1  =>  Mapped = 4, 0
+; SHADERTEST_PP1: (VS) Output: loc = 15, comp = 0  =>  Mapped = 4, 1
+; SHADERTEST_PP1: (VS) Output: loc = 15, comp = 1  =>  Mapped = 4, 1
+; SHADERTEST_PP1: (VS) Output: loc = 16, comp = 0  =>  Mapped = 4, 2
+; SHADERTEST_PP1: (VS) Output: loc = 16, comp = 1  =>  Mapped = 4, 2
+; SHADERTEST_PP1: (VS) Output: loc = 16, comp = 2  =>  Mapped = 4, 3
+; SHADERTEST_PP1: (VS) Output: loc = 16, comp = 3  =>  Mapped = 4, 3
+; SHADERTEST_PP1: (VS) Output: loc = 17, comp = 0  =>  Mapped = 5, 0
+; SHADERTEST_PP1: (VS) Output: loc = 17, comp = 1  =>  Mapped = 5, 1
+; SHADERTEST_PP1: (VS) Output: loc = 17, comp = 2  =>  Mapped = 5, 2
 ; SHADERTEST_PP1: AMDLLPC SUCCESS
 ; END_SHADERTEST
 
@@ -149,18 +175,33 @@ version = 6
 #extension GL_ARB_gpu_shader_int64 : enable
 #extension GL_AMD_gpu_shader_int16 : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
-layout(location = 0) out vec2 v2f_0;
-layout(location = 1) out vec2 v2f_1;
-layout(location = 2) out f16vec4 v4f16_0;
-layout(location = 3) out f16vec4 v4f16_1;
-layout(location = 4) out i64vec3 v3i64_0;
-layout(location = 6) out int i32_0;
-layout(location = 7) out i8vec2 v2i8_0;
-layout(location = 8) out i16vec2 v2i16_0;
-layout(location = 9) out f16vec4 v4f16_2;
-layout(location = 10) out vec3 interp;
+layout(location = 0, xfb_buffer = 0, xfb_stride = 60, xfb_offset = 0) out vec4 xfbOut1;
+layout(location = 1, xfb_buffer = 0, xfb_stride = 60, xfb_offset = 36) out vec3 xfbOut2[2];
+layout(location = 3, xfb_buffer = 0, xfb_stride = 60, xfb_offset = 24) out uvec2 xfbOut3;
+layout(location = 4) out float unused[2];
+layout(location = 6, xfb_buffer = 0, xfb_stride = 60, xfb_offset = 32) out uint xfbOut4;
+
+layout(location = 7) out vec2 v2f_0;
+layout(location = 8) out vec2 v2f_1;
+layout(location = 9) out f16vec4 v4f16_0;
+layout(location = 10) out f16vec4 v4f16_1;
+layout(location = 11) out i64vec3 v3i64_0;
+layout(location = 13) out int i32_0;
+layout(location = 14) out i8vec2 v2i8_0;
+layout(location = 15) out i16vec2 v2i16_0;
+layout(location = 16) out f16vec4 v4f16_2;
+layout(location = 17) out vec3 interp;
+
+
 void main()
 {
+    xfbOut1 = vec4(1.0);
+    xfbOut2[0] = vec3(2.0);
+    xfbOut2[1] = vec3(3.0);
+    xfbOut3 = uvec2(4);
+    unused[0] = 5.0;
+    unused[1] = 6.0;
+    xfbOut4 = 7;
     v2f_0 = vec2(1.0, 0.0);
     v2f_1 = vec2(0.0, 1.0);
     v4f16_0 = f16vec4(0.2, 0.2, 0.2, 1.0);
@@ -183,16 +224,16 @@ entryPoint = main
 #extension GL_AMD_gpu_shader_int16 : enable
 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
 #extension GL_AMD_shader_explicit_vertex_parameter : enable
-layout(location = 0) in vec2 v2f_0;
-layout(location = 1) in vec2 v2f_1;
-layout(location = 2) in f16vec4 v4f16_0;
-layout(location = 3) in f16vec4 v4f16_1;
-layout(location = 4) flat in i64vec3 v3i64_0;
-layout(location = 6) flat in int i32_0;
-layout(location = 7) flat in i8vec2 v2i8_0;
-layout(location = 8) flat in i16vec2 v2i16_0;
-layout(location = 9) flat in f16vec4 v4f16_2;
-layout(location = 10) __explicitInterpAMD in vec3 interp;
+layout(location = 7) in vec2 v2f_0;
+layout(location = 8) in vec2 v2f_1;
+layout(location = 9) in f16vec4 v4f16_0;
+layout(location = 10) in f16vec4 v4f16_1;
+layout(location = 11) flat in i64vec3 v3i64_0;
+layout(location = 13) flat in int i32_0;
+layout(location = 14) flat in i8vec2 v2i8_0;
+layout(location = 15) flat in i16vec2 v2i16_0;
+layout(location = 16) flat in f16vec4 v4f16_2;
+layout(location = 17) __explicitInterpAMD in vec3 interp;
 layout(location = 0) out vec4 fragColor;
 
 void main()

--- a/llpc/test/shaderdb/general/PipelineVsGsFs_TestDwordPacking.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsGsFs_TestDwordPacking.pipe
@@ -9,12 +9,12 @@
 ; SHADERTEST: (FS) Input:  loc = 1, comp = 1 =>  Mapped = 0, 1
 ; SHADERTEST: (FS) Input:  loc = 1, comp = 2 =>  Mapped = 0, 2
 ; SHADERTEST: (FS) Input:  loc = 1, comp = 3 =>  Mapped = 0, 3
-; SHADERTEST: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
-; SHADERTEST: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
 ; SHADERTEST: (FS) Input:  loc = 2, comp = 0 =>  Mapped = 2, 0
 ; SHADERTEST: (FS) Input:  loc = 2, comp = 1 =>  Mapped = 2, 1
 ; SHADERTEST: (FS) Input:  loc = 2, comp = 2 =>  Mapped = 2, 2
 ; SHADERTEST: (FS) Input:  loc = 2, comp = 3 =>  Mapped = 2, 3
+; SHADERTEST: (FS) Input:  loc = 4, comp = 0 =>  Mapped = 1, 0
+; SHADERTEST: (FS) Input:  loc = 4, comp = 1 =>  Mapped = 1, 1
 ; SHADERTEST-LABEL: LLPC location count results (after builtin-to-generic mapping)
 ; SHADERTEST: (FS) Input:  loc count = 3
 ; SHADERTEST: (FS) Output: loc count = 2
@@ -29,11 +29,11 @@
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 3  =>  Mapped = 2, 3
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 4, comp = 0  =>  Mapped = 1, 0
 ; SHADERTEST: (GS) Output: stream = 0,  loc = 4, comp = 1  =>  Mapped = 1, 1
-; SHADERTEST: (GS) Output: stream = 0,  loc = 5, comp = 0  =>  Mapped = 1, 2
-; SHADERTEST: (GS) Output: stream = 0,  loc = 5, comp = 1  =>  Mapped = 1, 3
+; SHADERTEST: (GS) Output: stream = 0,  loc = 5, comp = 0  =>  Mapped = 3, 0
+; SHADERTEST: (GS) Output: stream = 0,  loc = 5, comp = 1  =>  Mapped = 3, 1
 ; SHADERTEST-LABEL: LLPC location count results (after input/output matching)
 ; SHADERTEST: (GS) Input:  loc count = 2
-; SHADERTEST: (GS) Output: loc count = 3
+; SHADERTEST: (GS) Output: loc count = 4
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
Commits cd4ace7 introduces a crash on packing involving XFB and unused outputs. Unused generic output calls are added into `m_deadCalls` twice (one in `updateOutputLocInfoMapWithPack` and one in `reassembleOutputExportCalls`) that causes the null pointer dereferenced. Besides, the mapping result may be a mess if there are XFB outputs. For example:
```
VS:
layout(location=0) out vec2 o1;
layout(location=1, xfb_buffer=0,xfb_offset=0) out vec2 xfbOut;
layout(location=2) out float unused;
layout(location=3) out vec2 o2;
FS:
layout(location=0) in vec2 o1;
layout(location=3) in vec2 o2;
```
The current output map is created from the info of all output calls excluding the unused calls, see the mismatching result.
```
(VS) Output: loc = 0, comp = 0  =>  Mapped = 0, 0
(VS) Output: loc = 0, comp = 1  =>  Mapped = 0, 1
(VS) Output: loc = 1, comp = 0  =>  Mapped = 0, 2
(VS) Output: loc = 1, comp = 1  =>  Mapped = 0, 3
(VS) Output: loc = 3, comp = 0  =>  Mapped = 1, 0
(VS) Output: loc = 3, comp = 1  =>  Mapped = 1, 1

(FS) Input: loc = 0, comp = 0  =>  Mapped = 0, 0
(FS) Input: loc = 0, comp = 1  =>  Mapped = 0, 1
(FS) Input: loc = 3, comp = 0  =>  Mapped = 0, 2
(FS) Input: loc = 3, comp = 1  =>  Mapped = 0, 3
```
This change will fix the issue in two steps: firstly, reuse FS input map as the output map and caculate the location offset. Secondly, generate a map from XFB calls and append it to the output map based on the offset.The above case can be fixed as below:
```
(VS) Output: loc = 0, comp = 0  =>  Mapped = 0, 0
(VS) Output: loc = 0, comp = 1  =>  Mapped = 0, 1
(VS) Output: loc = 1, comp = 0  =>  Mapped = 1, 0
(VS) Output: loc = 1, comp = 1  =>  Mapped = 1, 1
(VS) Output: loc = 3, comp = 0  =>  Mapped = 0, 2
(VS) Output: loc = 3, comp = 1  =>  Mapped = 0, 3
```
Fixes:
[Angle]KHR-GLES31.core.program_interface_query.transform-feedback-types

Besides, this change will simplify the code of accessing input/output map in `PatchInOutImportExport` for VS-TCS if TCS has dynamic indexing.