### PR TITLE
NGG coding rework: Change arguments of ES/GS/copy shader runner

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -267,11 +267,11 @@ private:
   llvm::Value *fetchCullDistanceSignMask(llvm::Value *vertxIndex);
   llvm::Value *calcVertexItemOffset(unsigned streamId, llvm::Value *vertxIndex);
 
-  void processVertexAttribExport(llvm::Function *&targetFunc);
+  void processVertexAttribExport(llvm::Function *&target);
 
-  void processSwXfb(llvm::Module *module, llvm::Argument *sysValueStart);
-  void processSwXfbWithGs(llvm::Module *module, llvm::Argument *sysValueStart);
-  llvm::Value *fetchXfbOutput(llvm::Module *module, llvm::Argument *sysValueStart,
+  void processSwXfb(llvm::Function *target, llvm::ArrayRef<llvm::Argument *> args);
+  void processSwXfbWithGs(llvm::Function *target, llvm::ArrayRef<llvm::Argument *> args);
+  llvm::Value *fetchXfbOutput(llvm::Function *target, llvm::ArrayRef<llvm::Argument *> args,
                               llvm::SmallVector<XfbOutputExport, 32> &xfbOutputExports);
 
   llvm::Value *readXfbOutputFromLds(llvm::Type *readDataTy, llvm::Value *vertxIndex, unsigned outputIndex);

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -200,18 +200,16 @@ private:
 
   void earlyExitWithDummyExport();
 
-  void runEs(llvm::Module *module, llvm::Argument *sysValueStart);
-  llvm::Value *runPartEs(llvm::Module *module, llvm::Argument *sysValueStart, llvm::Value *position = nullptr);
+  void runEs(llvm::Function *esEntryPoint, llvm::ArrayRef<llvm::Argument *> args);
+  llvm::Value *runPartEs(llvm::Function *partEs, llvm::ArrayRef<llvm::Argument *> args,
+                         llvm::Value *position = nullptr);
+  void splitEs(llvm::Function *esEntryPoint);
 
-  void splitEs(llvm::Module *module);
+  void runGs(llvm::Function *gsEntryPoint, llvm::ArrayRef<llvm::Argument *> args);
+  llvm::Function *mutateGs(llvm::Function *gsEntryPoint);
 
-  void runGs(llvm::Module *module, llvm::Argument *sysValueStart);
-
-  llvm::Function *mutateGs(llvm::Module *module);
-
-  void runCopyShader(llvm::Module *module, llvm::Argument *sysValueStart);
-
-  llvm::Function *mutateCopyShader(llvm::Module *module);
+  void runCopyShader(llvm::Function *copyShader, llvm::ArrayRef<llvm::Argument *> args);
+  llvm::Function *mutateCopyShader(llvm::Function *copyShader);
 
   void exportGsOutput(llvm::Value *output, unsigned location, unsigned compIdx, unsigned streamId,
                       llvm::Value *threadIdInSubgroup, llvm::Value *emitVerts);
@@ -303,31 +301,28 @@ private:
 
   // NGG inputs (from system values or derived from them)
   struct {
+    // SGPRs
     llvm::Value *vertCountInSubgroup; // Number of vertices in subgroup
     llvm::Value *primCountInSubgroup; // Number of primitives in subgroup
     llvm::Value *vertCountInWave;     // Number of vertices in wave
     llvm::Value *primCountInWave;     // Number of primitives in wave
 
-    llvm::Value *threadIdInWave;     // Thread ID in wave
-    llvm::Value *threadIdInSubgroup; // Thread ID in subgroup
-
     llvm::Value *waveIdInSubgroup; // Wave ID in subgroup
     llvm::Value *orderedWaveId;    // Ordered wave ID
 
-    // System values (SGPRs)
     llvm::Value *attribRingBase;          // Attribute ring base for this subgroup
     llvm::Value *primShaderTableAddrLow;  // Primitive shader table address low
     llvm::Value *primShaderTableAddrHigh; // Primitive shader table address high
 
-    // System values (VGPRs)
-    llvm::Value *primData; // Primitive connectivity data (only for non-GS NGG pass-through mode)
+    // VGPRs
+    llvm::Value *threadIdInWave;     // Thread ID in wave
+    llvm::Value *threadIdInSubgroup; // Thread ID in subgroup
 
-    llvm::Value *esGsOffset0; // ES-GS offset of vertex0
-    llvm::Value *esGsOffset1; // ES-GS offset of vertex1
-    llvm::Value *esGsOffset2; // ES-GS offset of vertex2
-    llvm::Value *esGsOffset3; // ES-GS offset of vertex3
-    llvm::Value *esGsOffset4; // ES-GS offset of vertex4
-    llvm::Value *esGsOffset5; // ES-GS offset of vertex5
+    llvm::Value *primData; // Primitive connectivity data (provided by HW)
+
+    llvm::Value *vertexIndex0; // Relative index of vertex0 in NGG subgroup
+    llvm::Value *vertexIndex1; // Relative index of vertex1 in NGG subgroup
+    llvm::Value *vertexIndex2; // Relative index of vertex2 in NGG subgroup
 
   } m_nggInputs = {};
 

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestPrimitiveID_First.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestPrimitiveID_First.pipe
@@ -4,13 +4,13 @@
 ; RUN: amdllpc -enable-opaque-pointers=true -v --gfxip=10.1.0 %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: @[[LDS:[^ ]*]] = external addrspace(3) global [{{[0-9]*}} x i32], align 4
-; SHADERTEST: define dllexport amdgpu_gs void @_amdgpu_gs_main({{.*}}, i32 %esGsOffsets01, i32 %esGsOffsets23, i32 %gsPrimitiveId,
+; SHADERTEST: define dllexport amdgpu_gs void @_amdgpu_gs_main({{.*}}, i32 %esGsOffsets01, i32 %esGsOffsets23, i32 %primitiveId,
 ; Extract bits 0 to 8 from %esGsOffsets01. These bit encode the thread ID in sub-group which will be used to
 ; calculate the address at which to store the provoking vertex.
 ; SHADERTEST: [[offset1:%[0-9]*]] = shl i32 %esGsOffsets01, 2
 ; SHADERTEST: [[offset2:%[0-9]*]] = and i32 [[offset1]], 2044
 ; SHADERTEST: [[Addr1:%[0-9]*]] = getelementptr i8, ptr addrspace(3) @[[LDS]], i32 [[offset2]]
-; SHADERTEST: store i32 %gsPrimitiveId, ptr addrspace(3) [[Addr1]], align 4
+; SHADERTEST: store i32 %primitiveId, ptr addrspace(3) [[Addr1]], align 4
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestPrimitiveID_Last.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestPrimitiveID_Last.pipe
@@ -4,13 +4,13 @@
 ; RUN: amdllpc -enable-opaque-pointers=true -v --gfxip=10.1.0 %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: @[[LDS:[^ ]*]] = external addrspace(3) global [{{[0-9]*}} x i32], align 4
-; SHADERTEST: define dllexport amdgpu_gs void @_amdgpu_gs_main({{.*}}, i32 %esGsOffsets01, i32 %esGsOffsets23, i32 %gsPrimitiveId,
+; SHADERTEST: define dllexport amdgpu_gs void @_amdgpu_gs_main({{.*}}, i32 %esGsOffsets01, i32 %esGsOffsets23, i32 %primitiveId,
 ; Extract bits 20 to 28 from %esGsOffsets01. These bit encode the thread ID in sub-group which will be used to
 ; calculate the address at which to store the provoking vertex.
 ; SHADERTEST: [[offset1:%[0-9]*]] = lshr i32 %esGsOffsets01, 18
 ; SHADERTEST: [[offset2:%[0-9]*]] = and i32 [[offset1]], 2044
 ; SHADERTEST: [[Addr1:%[0-9]*]] = getelementptr i8, ptr addrspace(3) @[[LDS]], i32 [[offset2]]
-; SHADERTEST: store i32 %gsPrimitiveId, ptr addrspace(3) [[Addr1]], align 4
+; SHADERTEST: store i32 %primitiveId, ptr addrspace(3) [[Addr1]], align 4
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
This change is to address three problems:

1. We always pass module and entry-point argument iterator to ES/GS/Copy shader runner. The arguments are inappropriate.

2. Gather primitive shader entry-point arguments to a vector. This is more readable when handling system SGPRs/VGPRs. Future generation will have new HW definitions of part of VGPRs.

3. Make recorded NGG inputs more clean. Remove esGsOffsets. They will be changed by future generations.