### PR TITLE
NGG coding rework: Small rework of exporting primitive

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -195,8 +195,9 @@ private:
   llvm::Value *doCulling(llvm::Module *module, llvm::Value *vertxIndex0, llvm::Value *vertxIndex1,
                          llvm::Value *vertxIndex2);
   void sendGsAllocReqMessage();
-  void doPrimitiveExportWithoutGs(llvm::Value *cullFlag = nullptr);
-  void doPrimitiveExportWithGs(llvm::Value *vertxIndex);
+  void exportPassthroughPrimitive();
+  void exportPrimitive(llvm::Value *primitiveCulled);
+  void exportPrimitiveWithGs(llvm::Value *startingVertexIndex);
 
   void earlyExitWithDummyExport();
 


### PR DESCRIPTION
Add a new function to export passthrough primitive. This is more clear. Also, rename the primitive export function. The original names are not straightforward. This change also considers the new layout of primitive connectivity data of future generations.