### PR TITLE
Opaque Pointers: Try to add missing zero-indexs between GEP and Globa…

### DIFF
--- a/llpc/lower/llpcSpirvLowerAccessChain.h
+++ b/llpc/lower/llpcSpirvLowerAccessChain.h
@@ -32,6 +32,7 @@
 
 #include "llpcSpirvLower.h"
 #include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Operator.h"
 #include "llvm/IR/PassManager.h"
 
 namespace Llpc {
@@ -44,6 +45,8 @@ class SpirvLowerAccessChain : public SpirvLower,
 public:
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
   virtual void visitGetElementPtrInst(llvm::GetElementPtrInst &getElemPtrInst);
+  virtual void visitLoadInst(llvm::LoadInst &loadInst);
+  virtual void visitStoreInst(llvm::StoreInst &storeInst);
 
   bool runImpl(llvm::Module &module);
 
@@ -53,6 +56,8 @@ private:
   llvm::GetElementPtrInst *tryToCoalesceChain(llvm::GetElementPtrInst *getElemPtr, unsigned addrSpace);
   void appendZeroIndexToMatchTypes(llvm::SmallVectorImpl<llvm::Value *> &indexOperands, llvm::Type *typeToMatch,
                                    llvm::Type *baseType);
+
+  void tryToAddMissingIndicesBetweenGVandGEP(llvm::GEPOperator *gep);
 };
 
 } // namespace Llpc

--- a/llpc/test/shaderdb/general/TestCompilationOfNestedStructTaskPayload.spvasm
+++ b/llpc/test/shaderdb/general/TestCompilationOfNestedStructTaskPayload.spvasm
@@ -1,0 +1,71 @@
+; RUN: amdllpc -v -gfxip=11.0 %s | FileCheck %s
+
+; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
+
+; SPIR-V
+; Version: 1.4
+; Generator: Khronos Glslang Reference Front End; 10
+; Bound: 114
+; Schema: 0
+               OpCapability Int64
+               OpCapability Int64Atomics
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint TaskEXT %4 "main" %50 %60
+               OpExecutionMode %4 LocalSize 32 1 1
+               OpDecorate %_arr_long_uint_16_0 ArrayStride 8
+               OpDecorate %_arr_long_uint_32_0 ArrayStride 8
+               OpDecorate %_arr_long_uint_32_1 ArrayStride 8
+               OpDecorate %_arr_long_uint_32_2 ArrayStride 8
+               OpDecorate %_arr_int_uint_32_0 ArrayStride 4
+               OpMemberDecorate %_struct_57 0 Offset 0
+               OpMemberDecorate %_struct_57 1 Offset 128
+               OpMemberDecorate %_struct_57 2 Offset 384
+               OpMemberDecorate %_struct_57 3 Offset 640
+               OpMemberDecorate %_struct_57 4 Offset 896
+               OpMemberDecorate %_struct_57 5 Offset 1024
+               OpMemberDecorate %_struct_58 0 Offset 0
+               OpDecorate %_struct_58 Block
+               OpDecorate %60 DescriptorSet 1
+               OpDecorate %60 Binding 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+       %long = OpTypeInt 64 1
+    %uint_16 = OpConstant %uint 16
+%_arr_long_uint_16 = OpTypeArray %long %uint_16
+    %uint_32 = OpConstant %uint 32
+%_arr_long_uint_32 = OpTypeArray %long %uint_32
+        %int = OpTypeInt 32 1
+%_arr_int_uint_32 = OpTypeArray %int %uint_32
+ %_struct_47 = OpTypeStruct %_arr_long_uint_16 %_arr_long_uint_32 %_arr_long_uint_32 %_arr_long_uint_32 %_arr_int_uint_32 %int
+ %_struct_48 = OpTypeStruct %_struct_47
+%_ptr_TaskPayloadWorkgroupEXT__struct_48 = OpTypePointer TaskPayloadWorkgroupEXT %_struct_48
+         %50 = OpVariable %_ptr_TaskPayloadWorkgroupEXT__struct_48 TaskPayloadWorkgroupEXT
+      %int_0 = OpConstant %int 0
+%_arr_long_uint_16_0 = OpTypeArray %long %uint_16
+%_arr_long_uint_32_0 = OpTypeArray %long %uint_32
+%_arr_long_uint_32_1 = OpTypeArray %long %uint_32
+%_arr_long_uint_32_2 = OpTypeArray %long %uint_32
+%_arr_int_uint_32_0 = OpTypeArray %int %uint_32
+ %_struct_57 = OpTypeStruct %_arr_long_uint_16_0 %_arr_long_uint_32_0 %_arr_long_uint_32_1 %_arr_long_uint_32_2 %_arr_int_uint_32_0 %int
+ %_struct_58 = OpTypeStruct %_struct_57
+%_ptr_StorageBuffer__struct_58 = OpTypePointer StorageBuffer %_struct_58
+         %60 = OpVariable %_ptr_StorageBuffer__struct_58 StorageBuffer
+%_ptr_StorageBuffer__struct_57 = OpTypePointer StorageBuffer %_struct_57
+%_ptr_TaskPayloadWorkgroupEXT__struct_47 = OpTypePointer TaskPayloadWorkgroupEXT %_struct_47
+          %4 = OpFunction %void None %3
+          %5 = OpLabel
+         %62 = OpAccessChain %_ptr_StorageBuffer__struct_57 %60 %int_0
+         %63 = OpLoad %_struct_57 %62
+         %65 = OpAccessChain %_ptr_TaskPayloadWorkgroupEXT__struct_47 %50 %int_0
+         %66 = OpCopyLogical %_struct_47 %63
+               OpStore %65 %66
+               OpReturn
+               OpFunctionEnd
+


### PR DESCRIPTION
…l Value

While doing translation to LLVM-IR for OpStore or OpLoad which are doing store/load of the whole structure:

example with OpLoad
%_struct_57 = OpTypeStruct %_arr_long_uint_16_0 %_arr_long_uint_32_0 OpLoad %_struct_57 %62

LLPC is creating multiple store/load instructions to handle each single element of the structure. This is done by recursively unpacking structure type, until basic type is not found (i32, i64, float, ...). While unpacking each level of the structure, the GEP instruction is created. In case of nested strutures LLPC is trying to create zero-index GEP which will not be created for opaque pointers, since it is not changing the pointer address. GEP instruction will just fold to Global Variable instruction.

Later while doing Lowering of Global Variables, LLPC is using these indices from GEP to unpack Global Variable type and it's metadata. If types of GV and GEP are different (which means that some of the zero-index elements where removed) then we are accessing wrong places of Global Value's type and metadata.

This change is creating new GEP instruction with _correct_ number of indices so that types of GEP and GV are the same.