### PR TITLE
Add support for mutable descriptors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "imported/llvm-dialects"]
 	path = imported/llvm-dialects
-	url = git@github.com:GPUOpen-Drivers/llvm-dialects.git
+	url = ../llvm-dialects

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "imported/llvm-dialects"]
 	path = imported/llvm-dialects
-	url = ../llvm-dialects
+	url = git@github.com:GPUOpen-Drivers/llvm-dialects.git

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -368,6 +368,8 @@ struct ResourceMappingNode {
 
   unsigned sizeInDwords;   ///< Size of this node in dword
   unsigned offsetInDwords; ///< Offset of this node (from the beginning of the resource mapping table) in dword
+  unsigned strideInDwords; ///< Stride of elements in a descriptor array (used for mutable descriptors)
+                           ///  a stride of zero will use the type of the node to determine the stride
 
   union {
     /// Info for generic descriptor nodes (DescriptorResource, DescriptorSampler, DescriptorCombinedTexture,

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -351,6 +351,7 @@ enum class ResourceMappingNodeType : unsigned {
   DescriptorImage,              ///< Generic descriptor: storageImage, including image, input attachment
   DescriptorConstTexelBuffer,   ///< Generic descriptor: constTexelBuffer, including uniform texel buffer
   InlineBuffer,                 ///< Push constant with binding
+  DescriptorMutable,            ///< Mutable descriptor type
   Count,                        ///< Count of resource mapping node types.
 };
 
@@ -368,15 +369,15 @@ struct ResourceMappingNode {
 
   unsigned sizeInDwords;   ///< Size of this node in dword
   unsigned offsetInDwords; ///< Offset of this node (from the beginning of the resource mapping table) in dword
-  unsigned strideInDwords; ///< Stride of elements in a descriptor array (used for mutable descriptors)
-                           ///  a stride of zero will use the type of the node to determine the stride
 
   union {
     /// Info for generic descriptor nodes (DescriptorResource, DescriptorSampler, DescriptorCombinedTexture,
     /// DescriptorTexelBuffer, DescriptorBuffer and DescriptorBufferCompact)
     struct {
-      unsigned set;     ///< Descriptor set
-      unsigned binding; ///< Descriptor binding
+      unsigned set;            ///< Descriptor set
+      unsigned binding;        ///< Descriptor binding
+      unsigned strideInDwords; ///< Stride of elements in a descriptor array (used for mutable descriptors)
+                               ///  a stride of zero will use the type of the node to determine the stride
       unsigned reserv0;
       unsigned reserv1;
       unsigned reserv2;

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -90,7 +90,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
     if (!node) {
       // If we can't find the node, assume mutable descriptor and search for any node.
       std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
-      if(!node) {
+      if (!node) {
         // We did not find the resource node. Return an undef value.
         return UndefValue::get(getBufferDescTy(pointeeTy));
       }
@@ -112,9 +112,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
         dwordOffset += node->offsetInDwords;
         dwordOffset += (binding - node->binding) * node->stride;
         desc = CreateNamedCall(callName, descTy, getInt32(dwordOffset), Attribute::ReadNone);
-      }
-      else
-      {
+      } else {
         // Handle a descriptor in the root table (a "dynamic descriptor") specially, as long as it is not variably
         // indexed and is not an InlineBuffer. This lgc.root.descriptor call is by default lowered in
         // PatchEntryPointMutate into a load from the spill table, but it might be able to "unspill" it to
@@ -148,12 +146,10 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
       ResourceNodeType abstractType = node->abstractType;
 
       // Handle mutable descriptors
-      if(resType == ResourceNodeType::Unknown)
-      {
+      if (resType == ResourceNodeType::Unknown) {
         resType = ResourceNodeType::DescriptorBuffer;
       }
-      if(abstractType == ResourceNodeType::Unknown)
-      {
+      if (abstractType == ResourceNodeType::Unknown) {
         abstractType = ResourceNodeType::DescriptorBuffer;
       }
 
@@ -244,19 +240,20 @@ Value *DescBuilder::CreateGetDescStride(ResourceNodeType concreteType, ResourceN
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
     if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
       if (!node) {
-      // If we can't find the node, assume mutable descriptor and search for any node.
-      std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
-      if (!node) {
-        // We did not find the resource node. Return an undef value.
-        return UndefValue::get(getInt32Ty());
+        // If we can't find the node, assume mutable descriptor and search for any node.
+        std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
+        if (!node) {
+          // We did not find the resource node. Return an undef value.
+          return UndefValue::get(getInt32Ty());
+        }
+        if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
+          // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
+          // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
+          // expect the caller to handle it.
+          return UndefValue::get(getInt32Ty());
+        }
+        assert(node && "missing resource node");
       }
-      if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
-        // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
-        // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
-        // expect the caller to handle it.
-        return UndefValue::get(getInt32Ty());
-      }
-      assert(node && "missing resource node");
     }
     assert(node && "missing resource node");
   }
@@ -283,19 +280,20 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType concreteType, ResourceNode
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
     if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
       if (!node) {
-      // If we can't find the node, assume mutable descriptor and search for any node.
-      std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
-      if (!node) {
-        // We did not find the resource node. Return an undef value.
-        return UndefValue::get(getDescPtrTy(concreteType));
+        // If we can't find the node, assume mutable descriptor and search for any node.
+        std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
+        if (!node) {
+          // We did not find the resource node. Return an undef value.
+          return UndefValue::get(getDescPtrTy(concreteType));
+        }
+        if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
+          // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
+          // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
+          // expect the caller to handle it.
+          return UndefValue::get(getDescPtrTy(concreteType));
+        }
+        assert(node && "missing resource node");
       }
-      if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
-        // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
-        // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
-        // expect the caller to handle it.
-        return UndefValue::get(getDescPtrTy(concreteType));
-      }
-      assert(node && "missing resource node");
     }
     assert(node && "missing resource node");
   }

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -87,31 +87,53 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
       abstractType = ResourceNodeType::DescriptorBufferCompact;
 
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
+    if (!node) {
+      // If we can't find the node, assume mutable descriptor and search for any node.
+      std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
+      if(!node) {
+        // We did not find the resource node. Return an undef value.
+        return UndefValue::get(getBufferDescTy(pointeeTy));
+      }
+    }
     assert(node && "missing resource node");
 
     if (node == topNode && isa<Constant>(descIndex) && node->concreteType != ResourceNodeType::InlineBuffer) {
-      // Handle a descriptor in the root table (a "dynamic descriptor") specially, as long as it is not variably
-      // indexed and is not an InlineBuffer. This lgc.root.descriptor call is by default lowered in
-      // PatchEntryPointMutate into a load from the spill table, but it might be able to "unspill" it to
-      // directly use shader entry SGPRs.
-      // TODO: Handle root InlineBuffer specially in a similar way to PushConst. The default handling is
-      // suboptimal as it always loads from the spill table.
-      Type *descTy = getDescTy(node->concreteType);
-      std::string callName = lgcName::RootDescriptor;
-      addTypeMangling(descTy, {}, callName);
-      unsigned dwordSize = descTy->getPrimitiveSizeInBits() / 32;
-      unsigned dwordOffset = cast<ConstantInt>(descIndex)->getZExtValue() * dwordSize;
-      if (dwordOffset + dwordSize > node->sizeInDwords) {
-        // Index out of range
-        desc = UndefValue::get(descTy);
-      } else {
+      if (return64Address) {
+        assert(node->concreteType == ResourceNodeType::DescriptorBufferCompact);
+        return CreateBitCast(desc, getInt64Ty());
+      }
+      // If the node is a mutable descriptor create call
+      if (node->concreteType == ResourceNodeType::Unknown) {
+        Type *descTy = getInt8Ty()->getPointerTo(ADDR_SPACE_BUFFER_FAT_POINTER);
+        std::string callName = lgcName::RootDescriptor;
+        addTypeMangling(descTy, {}, callName);
+        unsigned dwordSize = 2;
+        unsigned dwordOffset = cast<ConstantInt>(descIndex)->getZExtValue() * dwordSize;
         dwordOffset += node->offsetInDwords;
         dwordOffset += (binding - node->binding) * node->stride;
         desc = CreateNamedCall(callName, descTy, getInt32(dwordOffset), Attribute::ReadNone);
       }
-      if (return64Address) {
-        assert(node->concreteType == ResourceNodeType::DescriptorBufferCompact);
-        return CreateBitCast(desc, getInt64Ty());
+      else
+      {
+        // Handle a descriptor in the root table (a "dynamic descriptor") specially, as long as it is not variably
+        // indexed and is not an InlineBuffer. This lgc.root.descriptor call is by default lowered in
+        // PatchEntryPointMutate into a load from the spill table, but it might be able to "unspill" it to
+        // directly use shader entry SGPRs.
+        // TODO: Handle root InlineBuffer specially in a similar way to PushConst. The default handling is
+        // suboptimal as it always loads from the spill table.
+        Type *descTy = getDescTy(node->concreteType);
+        std::string callName = lgcName::RootDescriptor;
+        addTypeMangling(descTy, {}, callName);
+        unsigned dwordSize = descTy->getPrimitiveSizeInBits() / 32;
+        unsigned dwordOffset = cast<ConstantInt>(descIndex)->getZExtValue() * dwordSize;
+        if (dwordOffset + dwordSize > node->sizeInDwords) {
+          // Index out of range
+          desc = UndefValue::get(descTy);
+        } else {
+          dwordOffset += node->offsetInDwords;
+          dwordOffset += (binding - node->binding) * node->stride;
+          desc = CreateNamedCall(callName, descTy, getInt32(dwordOffset), Attribute::ReadNone);
+        }
       }
     } else if (node->concreteType == ResourceNodeType::InlineBuffer) {
       // Handle an inline buffer specially. Get a pointer to it, then expand to a descriptor.
@@ -124,6 +146,17 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
     if (node) {
       ResourceNodeType resType = node->concreteType;
       ResourceNodeType abstractType = node->abstractType;
+
+      // Handle mutable descriptors
+      if(resType == ResourceNodeType::Unknown)
+      {
+        resType = ResourceNodeType::DescriptorBuffer;
+      }
+      if(abstractType == ResourceNodeType::Unknown)
+      {
+        abstractType = ResourceNodeType::DescriptorBuffer;
+      }
+
       Value *descPtr = getDescPtr(resType, abstractType, descSet, binding, topNode, node);
       // Index it.
       if (descIndex != getInt32(0)) {
@@ -210,10 +243,20 @@ Value *DescBuilder::CreateGetDescStride(ResourceNodeType concreteType, ResourceN
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
     if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
-      // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
-      // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
-      // expect the caller to handle it.
-      return UndefValue::get(getInt32Ty());
+      if (!node) {
+      // If we can't find the node, assume mutable descriptor and search for any node.
+      std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
+      if (!node) {
+        // We did not find the resource node. Return an undef value.
+        return UndefValue::get(getInt32Ty());
+      }
+      if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
+        // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
+        // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
+        // expect the caller to handle it.
+        return UndefValue::get(getInt32Ty());
+      }
+      assert(node && "missing resource node");
     }
     assert(node && "missing resource node");
   }
@@ -239,10 +282,20 @@ Value *DescBuilder::CreateGetDescPtr(ResourceNodeType concreteType, ResourceNode
   if (!m_pipelineState->isUnlinked() || !m_pipelineState->getUserDataNodes().empty()) {
     std::tie(topNode, node) = m_pipelineState->findResourceNode(abstractType, descSet, binding);
     if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
-      // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
-      // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
-      // expect the caller to handle it.
-      return UndefValue::get(getDescPtrTy(concreteType));
+      if (!node) {
+      // If we can't find the node, assume mutable descriptor and search for any node.
+      std::tie(topNode, node) = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding);
+      if (!node) {
+        // We did not find the resource node. Return an undef value.
+        return UndefValue::get(getDescPtrTy(concreteType));
+      }
+      if (!node && m_pipelineState->findResourceNode(ResourceNodeType::Unknown, descSet, binding).second) {
+        // NOTE: Resource node may be DescriptorTexelBuffer, but it is defined as OpTypeSampledImage in SPIRV,
+        // In this case, a caller may search for the DescriptorSampler and not find it. We return nullptr and
+        // expect the caller to handle it.
+        return UndefValue::get(getDescPtrTy(concreteType));
+      }
+      assert(node && "missing resource node");
     }
     assert(node && "missing resource node");
   }

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -130,7 +130,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
   }
 
   if (!desc) {
-    if (node || node->concreteType == ResourceNodeType::DescriptorMutable) {
+    if (node) {
       ResourceNodeType resType = node->concreteType;
       ResourceNodeType abstractType = node->abstractType;
       // Handle mutable descriptors

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -92,7 +92,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
       std::tie(topNode, node) =
           m_pipelineState->findResourceNode(ResourceNodeType::DescriptorMutable, descSet, binding);
       if (!node) {
-        // We did not find the resource node. Return an undef value.
+        // We did not find the resource node. Return an poison value.
         return PoisonValue::get(getBufferDescTy(pointeeTy));
       }
     }

--- a/lgc/interface/lgc/CommonDefs.h
+++ b/lgc/interface/lgc/CommonDefs.h
@@ -91,6 +91,7 @@ enum class ResourceNodeType : unsigned {
   InlineBuffer,                 ///< Inline buffer, with descriptor set and binding
   DescriptorConstBuffer,        ///< Generic descriptor: constant buffer
   DescriptorConstBufferCompact, ///< Compact buffer descriptor, only contains the buffer address
+  DescriptorMutable,            ///< Mutable descriptor type
   Count,                        ///< Count of resource mapping node types.
 };
 

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -358,7 +358,7 @@ void PatchEntryPointMutate::gatherUserDataUsage(Module *module) {
           // index.
           const ResourceNode *node;
           node = m_pipelineState->findResourceNode(searchType, set, binding).first;
-          if(!node) {
+          if (!node) {
             // Handle mutable descriptors
             node = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, set, binding).first;
           }

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -358,6 +358,10 @@ void PatchEntryPointMutate::gatherUserDataUsage(Module *module) {
           // index.
           const ResourceNode *node;
           node = m_pipelineState->findResourceNode(searchType, set, binding).first;
+          if(!node) {
+            // Handle mutable descriptors
+            node = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, set, binding).first;
+          }
           assert(node && "Could not find resource node");
           uint32_t descTableIndex = node - &m_pipelineState->getUserDataNodes().front();
           descriptorTable.resize(std::max(descriptorTable.size(), size_t(descTableIndex + 1)));

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -360,7 +360,7 @@ void PatchEntryPointMutate::gatherUserDataUsage(Module *module) {
           node = m_pipelineState->findResourceNode(searchType, set, binding).first;
           if (!node) {
             // Handle mutable descriptors
-            node = m_pipelineState->findResourceNode(ResourceNodeType::Unknown, set, binding).first;
+            node = m_pipelineState->findResourceNode(ResourceNodeType::DescriptorMutable, set, binding).first;
           }
           assert(node && "Could not find resource node");
           uint32_t descTableIndex = node - &m_pipelineState->getUserDataNodes().front();

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -788,7 +788,7 @@ const ResourceNode *PipelineState::findPushConstantResourceNode() const {
 // @param candidateType : Resource node candidate type
 static bool isNodeTypeCompatible(ResourceNodeType nodeType, ResourceNodeType candidateType) {
   if (nodeType == ResourceNodeType::Unknown || candidateType == nodeType ||
-    candidateType == ResourceNodeType::DescriptorMutable)
+      candidateType == ResourceNodeType::DescriptorMutable)
     return true;
 
   if ((nodeType == ResourceNodeType::DescriptorConstBuffer || nodeType == DescriptorAnyBuffer) &&

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -787,7 +787,8 @@ const ResourceNode *PipelineState::findPushConstantResourceNode() const {
 // @param nodeType : Resource node type
 // @param candidateType : Resource node candidate type
 static bool isNodeTypeCompatible(ResourceNodeType nodeType, ResourceNodeType candidateType) {
-  if (nodeType == ResourceNodeType::Unknown || candidateType == nodeType)
+  if (nodeType == ResourceNodeType::Unknown || candidateType == nodeType ||
+    candidateType == ResourceNodeType::DescriptorMutable)
     return true;
 
   if ((nodeType == ResourceNodeType::DescriptorConstBuffer || nodeType == DescriptorAnyBuffer) &&
@@ -1537,6 +1538,7 @@ const char *PipelineState::getResourceNodeTypeName(ResourceNodeType type) {
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, InlineBuffer)
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, DescriptorConstBuffer)
     CASE_CLASSENUM_TO_STRING(ResourceNodeType, DescriptorConstBufferCompact)
+    CASE_CLASSENUM_TO_STRING(ResourceNodeType, DescriptorMutable)
     break;
   default:
     llvm_unreachable("Should never be called!");

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -747,15 +747,12 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
         destNode.stride = 2;
         break;
       default:
-        if(node.strideInDwords > 0)
-        {
-          // Normally we know the stride of items in a desriptor array. However in specific circumstances
+        if (node.strideInDwords > 0) {
+          // Normally we know the stride of items in a descriptor array. However in specific circumstances
           // the type is not known by llpc. This is the case with mutable descriptors where we need the
           // stride to be explicitly specified.
           destNode.stride = node.strideInDwords;
-        }
-        else
-        {
+        } else {
           destNode.stride = DescriptorSizeBuffer / sizeof(uint32_t);
         }
         break;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -747,7 +747,17 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
         destNode.stride = 2;
         break;
       default:
-        destNode.stride = DescriptorSizeBuffer / sizeof(uint32_t);
+        if(node.strideInDwords > 0)
+        {
+          // Normally we know the stride of items in a desriptor array. However in specific circumstances
+          // the type is not known by llpc. This is the case with mutable descriptors where we need the
+          // stride to be explicitly specified.
+          destNode.stride = node.strideInDwords;
+        }
+        else
+        {
+          destNode.stride = DescriptorSizeBuffer / sizeof(uint32_t);
+        }
         break;
       }
 

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -722,16 +722,12 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
       destNode.immutableValue = nullptr;
       destNode.immutableSize = 0;
 
-
-      // Normally we know the stride of items in a desriptor array. However in specific circumstances
+      // Normally we know the stride of items in a descriptor array. However in specific circumstances
       // the type is not known by llpc. This is the case with mutable descriptors where we need the
       // stride to be explicitly specified.
-      if(node.srdRange.strideInDwords > 0)
-      {
+      if (node.srdRange.strideInDwords > 0) {
         destNode.stride = node.srdRange.strideInDwords;
-      }
-      else
-      {
+      } else {
         switch (node.type) {
         case ResourceMappingNodeType::DescriptorImage:
         case ResourceMappingNodeType::DescriptorResource:
@@ -760,7 +756,7 @@ void PipelineContext::setUserDataNodesTable(Pipeline *pipeline, ArrayRef<Resourc
           destNode.stride = 2;
           break;
         default:
-            destNode.stride = DescriptorSizeBuffer / sizeof(uint32_t);
+          destNode.stride = DescriptorSizeBuffer / sizeof(uint32_t);
           break;
         }
       }

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -497,6 +497,7 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
   dumpFile << prefix << ".type = " << userDataNode->type << "\n";
   dumpFile << prefix << ".offsetInDwords = " << userDataNode->offsetInDwords << "\n";
   dumpFile << prefix << ".sizeInDwords = " << userDataNode->sizeInDwords << "\n";
+  dumpFile << prefix << ".strideInDwords = " << userDataNode->strideInDwords << "\n";
 
   switch (userDataNode->type) {
   case ResourceMappingNodeType::DescriptorResource:
@@ -532,6 +533,10 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
     break;
   }
   case ResourceMappingNodeType::StreamOutTableVaPtr: {
+    break;
+  }
+  case ResourceMappingNodeType::Unknown: {
+    // Mutable descriptors
     break;
   }
   default: {
@@ -1714,6 +1719,7 @@ void PipelineDumper::updateHashForResourceMappingNode(const ResourceMappingNode 
   hasher->Update(userDataNode->type);
   hasher->Update(userDataNode->sizeInDwords);
   hasher->Update(userDataNode->offsetInDwords);
+  hasher->Update(userDataNode->strideInDwords);
   switch (userDataNode->type) {
   case ResourceMappingNodeType::DescriptorResource:
   case ResourceMappingNodeType::DescriptorSampler:

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -497,7 +497,6 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
   dumpFile << prefix << ".type = " << userDataNode->type << "\n";
   dumpFile << prefix << ".offsetInDwords = " << userDataNode->offsetInDwords << "\n";
   dumpFile << prefix << ".sizeInDwords = " << userDataNode->sizeInDwords << "\n";
-  dumpFile << prefix << ".strideInDwords = " << userDataNode->strideInDwords << "\n";
 
   switch (userDataNode->type) {
   case ResourceMappingNodeType::DescriptorResource:
@@ -514,10 +513,12 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
   case ResourceMappingNodeType::DescriptorConstBufferCompact:
   case ResourceMappingNodeType::DescriptorImage:
   case ResourceMappingNodeType::DescriptorConstTexelBuffer: {
+  case ResourceMappingNodeType::DescriptorMutable:
     char setHexvalue[64] = {};
     snprintf(setHexvalue, 64, "0x%08" PRIX32, userDataNode->srdRange.set);
     dumpFile << prefix << ".set = " << setHexvalue << "\n";
     dumpFile << prefix << ".binding = " << userDataNode->srdRange.binding << "\n";
+    dumpFile << prefix << ".strideInDwords = " << userDataNode->srdRange.strideInDwords << "\n";
     break;
   }
   case ResourceMappingNodeType::DescriptorTableVaPtr: {
@@ -533,10 +534,6 @@ void PipelineDumper::dumpResourceMappingNode(const ResourceMappingNode *userData
     break;
   }
   case ResourceMappingNodeType::StreamOutTableVaPtr: {
-    break;
-  }
-  case ResourceMappingNodeType::Unknown: {
-    // Mutable descriptors
     break;
   }
   default: {
@@ -1719,7 +1716,6 @@ void PipelineDumper::updateHashForResourceMappingNode(const ResourceMappingNode 
   hasher->Update(userDataNode->type);
   hasher->Update(userDataNode->sizeInDwords);
   hasher->Update(userDataNode->offsetInDwords);
-  hasher->Update(userDataNode->strideInDwords);
   switch (userDataNode->type) {
   case ResourceMappingNodeType::DescriptorResource:
   case ResourceMappingNodeType::DescriptorSampler:
@@ -1732,7 +1728,8 @@ void PipelineDumper::updateHashForResourceMappingNode(const ResourceMappingNode 
   case ResourceMappingNodeType::DescriptorConstBuffer:
   case ResourceMappingNodeType::DescriptorConstBufferCompact:
   case ResourceMappingNodeType::DescriptorImage:
-  case ResourceMappingNodeType::DescriptorConstTexelBuffer: {
+  case ResourceMappingNodeType::DescriptorConstTexelBuffer:
+  case ResourceMappingNodeType::DescriptorMutable: {
     hasher->Update(userDataNode->srdRange);
     break;
   }

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -60,6 +60,7 @@ public:
     ADD_CLASS_ENUM_MAP(ResourceMappingNodeType, DescriptorImage)
     ADD_CLASS_ENUM_MAP(ResourceMappingNodeType, DescriptorConstTexelBuffer)
     ADD_CLASS_ENUM_MAP(ResourceMappingNodeType, InlineBuffer)
+    ADD_CLASS_ENUM_MAP(ResourceMappingNodeType, DescriptorMutable)
     ADD_CLASS_ENUM_MAP(NggSubgroupSizingType, Auto)
     ADD_CLASS_ENUM_MAP(NggSubgroupSizingType, MaximumSize)
     ADD_CLASS_ENUM_MAP(NggSubgroupSizingType, HalfSize)

--- a/util/vkgcUtil.cpp
+++ b/util/vkgcUtil.cpp
@@ -157,6 +157,7 @@ const char *getResourceMappingNodeTypeName(ResourceMappingNodeType type) {
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorBufferCompact)
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, StreamOutTableVaPtr)
     CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, InlineBuffer)
+    CASE_CLASSENUM_TO_STRING(ResourceMappingNodeType, DescriptorMutable)
     break;
   default:
     llvm_unreachable("Should never be called!");


### PR DESCRIPTION
Code to add support for the extension VK_EXT_mutable_descriptor_type. This extension allows a descriptor to be specified as being one of a number of different descriptor types. Since this type can change we need to keep track of the stride for arrays of descriptors.