### PR TITLE
Prepare llpc test for upstream change to inbounds

### DIFF
--- a/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
+++ b/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
@@ -9,39 +9,39 @@
 ; SHADERTEST: @[[LDS1:[^ ]*]] = addrspace(3) global <{ [4 x i32] }> undef, align 4
 ; SHADERTEST: @[[LDS2:[^ ]*]] = addrspace(3) global <{ [16 x i8], [4 x i32] }> undef, align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) @[[LDS1]], align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds ([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 1), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds ([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 2), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds ([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 3), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1, i32 1), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1, i32 2), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1, i32 3), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 2), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 3), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1, i32 2), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [16 x i8], [4 x i32] }>, ptr addrspace(3) @[[LDS2]], i32 0, i32 1, i32 3), align 4
 ; SHADERTEST: load i32, ptr addrspace(3) @[[LDS0]], align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 1), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 2), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 3), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 4), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 5), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 6), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds ([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 7), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 1), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 2), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 3), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 4), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 5), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 6), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 7), align 4
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: @[[LDS:[^ ]*]] = local_unnamed_addr addrspace(3) global <{ [8 x i32] }> undef, align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) @[[LDS]], align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 1), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 2), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 3), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 4), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 5), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 6), align 4
-; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 7), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 1), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 2), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 3), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 4), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 5), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 6), align 4
+; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 7), align 4
 ; SHADERTEST: load i32, ptr addrspace(3) @[[LDS]], align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 1), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 2), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 3), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 4), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 5), align 4
-; SHADERTEST: load i32, ptr addrspace(3) getelementptr inbounds (<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 6), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 1), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 2), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 3), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 4), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 5), align 4
+; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 6), align 4
 ; index = 7 is optimized.
 
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
Upstream change removes inbounds flag in some cases. Modify test to accept either with or without inbounds.