### PR TITLE
Fix latent issues of mesh shader implementation

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1648,16 +1648,14 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
     spiPsInputCntl.bits.FLAT_SHADE = interpInfoElem.flat && !interpInfoElem.isPerPrimitive;
     spiPsInputCntl.bits.OFFSET = interpInfoElem.loc;
     if (gfxIp.major >= 11 && interpInfoElem.isPerPrimitive) {
-      const auto preStage = m_pipelineState->getPrevShaderStage(ShaderStageFragment);
-      if (preStage == ShaderStageMesh) {
-        // NOTE: HW allocates and manages attribute ring based on the register fields: VS_EXPORT_COUNT and
-        // PRIM_EXPORT_COUNT. When VS_EXPORT_COUNT = 0, HW assumes there is still a vertex attribute exported even
-        // though this is not what we want. Hence, we should reserve param0 as a dummy vertex attribute and all
-        // primitive attributes are moved after it.
-        bool hasNoVertexAttrib = m_pipelineState->getShaderResourceUsage(ShaderStageMesh)->inOutUsage.expCount == 0;
-        if (hasNoVertexAttrib)
-          ++spiPsInputCntl.bits.OFFSET;
-      }
+      // NOTE: HW allocates and manages attribute ring based on the register fields: VS_EXPORT_COUNT and
+      // PRIM_EXPORT_COUNT. When VS_EXPORT_COUNT = 0, HW assumes there is still a vertex attribute exported even
+      // though this is not what we want. Hence, we should reserve param0 as a dummy vertex attribute and all
+      // primitive attributes are moved after it.
+      const bool hasNoVertexAttrib = resUsage->inOutUsage.inputMapLocCount == 0; // No vertex attribute
+      if (hasNoVertexAttrib)
+        ++spiPsInputCntl.bits.OFFSET;
+
       spiPsInputCntl.gfx11.PRIM_ATTR = true;
     }
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1386,6 +1386,10 @@ bool PipelineState::enableSwXfb() {
   if (getTargetInfo().getGfxIpVersion().major < 11)
     return false;
 
+  // Mesh pipeline doesn't support stream-out
+  if (hasShaderStage(ShaderStageTask) || hasShaderStage(ShaderStageMesh))
+    return false;
+
   auto lastVertexStage = getLastVertexProcessingStage();
   lastVertexStage = lastVertexStage == ShaderStageCopyShader ? ShaderStageGeometry : lastVertexStage;
 

--- a/lgc/test/TaskShaderOps.lgc
+++ b/lgc/test/TaskShaderOps.lgc
@@ -46,13 +46,13 @@
 ; CHECK-NEXT: [[wrapMask:%[0-9]*]] = add nuw nsw i32 [[numEntries]], 268435455
 ; CHECK-NEXT: [[wrappedEntryIndex:%[0-9]*]] = and i32 [[entryIndex]], [[wrapMask]]
 ; CHECK-NEXT: [[entryOffset:%[0-9]*]] = shl i32 [[wrappedEntryIndex]], 4
+; CHECK-NEXT: call void @llvm.amdgcn.raw.buffer.store.v3i32(<3 x i32> <i32 3, i32 1, i32 1>, <4 x i32> [[drawDataRingDesc]], i32 0, i32 [[entryOffset]], i32 0)
 ; CHECK: [[ringSize:%[0-9]*]] = extractelement <4 x i32> [[drawDataRingDesc]], i64 2
 ; CHECK-NEXT: [[numEntries:%[0-9]*]] = lshr i32 [[ringSize]], 4
 ; CHECK-NEXT: [[checkReadyBit:%[0-9]*]] = and i32 [[entryIndex]], [[numEntries]]
 ; CHECK-NEXT: [[readyBit:%[0-9]*]] = icmp ne i32 [[checkReadyBit]], 0
-; CHECK-NEXT: [[readyBit32:%[0-9]*]] = zext i1 [[readyBit]] to i32
-; CHECK-NEXT: [[drawData:%[0-9]*]] = insertelement <4 x i32> <i32 3, i32 1, i32 1, i32 poison>, i32 [[readyBit32]], i64 3
-; CHECK: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> [[drawData]], <4 x i32> [[drawDataRingDesc]], i32 0, i32 [[entryOffset]], i32 0)
+; CHECK-NEXT: [[readyBit8:%[0-9]*]] = zext i1 [[readyBit]] to i8
+; CHECK-NEXT: call void @llvm.amdgcn.raw.buffer.store.i8(i8 [[readyBit8]], <4 x i32> [[drawDataRingDesc]], i32 12, i32 [[entryOffset]], i32 0)
 ; CHECK-NEXT: br label %.endEmitMeshs
 ;
 ; CHECK: .endEmitMeshs:

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7580,12 +7580,14 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
 
     } else if (as == SPIRAS_Uniform || as == SPIRAS_TaskPayload) {
       // Translate decorations of blocks
-      // Remove array dimensions, it is useless for block metadata building
-      SPIRVType *blockTy = nullptr;
-
-      blockTy = bv->getType()->getPointerElementType();
-      while (blockTy->isTypeArray())
-        blockTy = blockTy->getArrayElementType();
+      SPIRVType *blockTy = bv->getType()->getPointerElementType();
+      // If not task payload, try to remove block array dimensions. Note that task
+      // payload doesn't have such dimensions.
+      if (as != SPIRAS_TaskPayload) {
+        // Remove array dimensions, it is useless for block metadata building
+        while (blockTy->isTypeArray())
+          blockTy = blockTy->getArrayElementType();
+      }
       bool isStructTy = blockTy->isTypeStruct();
 #if VKI_RAY_TRACING
       isStructTy = isStructTy || blockTy->isTypeAccelerationStructureKHR();


### PR DESCRIPTION
1. The enableSwXfb function should return false if mesh pipeline is found. XFB is only applied to traditional graphics pipeline.

2. When checking hasNoVertexAttrib in PS reg config, we should rely on the exsitence of per-vertex inputs in fragment shader. This is because we could encounter part pipeline compilation of mesh pipeline. In such cases, fragment shader is compiled without the knowlegde of previous stages.

3. The ready bit of draw data is supposed to be written by task shader with the lowest 8 bits of the dword (last dword). Other bits of the dword have other purposes.

4. Task payload could have such usage:

     taskpayloadSharedEXT uint outVar[32];

   In this case, we incorrectly handle the array dimension of task payload. The original logic is to handle block array by eliminating its array dimension (see the block array as folow):

     layout(binding = 0) buffer Data {
       uint outVar;
     } data[32];

   For task payload, this is meaningless since task payload doesn't defined as block array.