### PR TITLE
RegisterMetadaBuilder: fix setting for VGT_STRMOUT_VTX_STRIDE

### DIFF
--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -618,10 +618,11 @@ void RegisterMetadataBuilder::buildHwVsRegisters() {
   getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VsSoBase3En] = xfbStrides[3] > 0;
 
   // VGT_STRMOUT_VTX_STRIDE_*
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride0] = xfbStrides[0] / sizeof(unsigned);
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride1] = xfbStrides[1] / sizeof(unsigned);
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride2] = xfbStrides[2] / sizeof(unsigned);
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride3] = xfbStrides[3] / sizeof(unsigned);
+  const unsigned sizeInByte = static_cast<unsigned>(sizeof(unsigned));
+  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride0] = xfbStrides[0] / sizeInByte;
+  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride1] = xfbStrides[1] / sizeInByte;
+  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride2] = xfbStrides[2] / sizeInByte;
+  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtStrmoutVtxStride3] = xfbStrides[3] / sizeInByte;
 
   // VGT_STRMOUT_BUFFER_CONFIG
   auto vgtStrmoutBufferConfig =


### PR DESCRIPTION
The use of `sizeof(unsigned)` should be manually casted from unsigned long to unsigned.