### PR TITLE
Set wave size for color export shader

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -132,6 +132,7 @@ Function *ColorExportShader::createColorExportFunc() {
   // Create the function. Mark SGPR inputs as "inreg".
   Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, getGlueShaderName(), module);
   func->setCallingConv(CallingConv::AMDGPU_PS);
+  setShaderStage(func, ShaderStageFragment);
 
   BasicBlock *block = BasicBlock::Create(func->getContext(), "", func);
   BuilderBase builder(block);

--- a/lgc/elfLinker/FetchShader.cpp
+++ b/lgc/elfLinker/FetchShader.cpp
@@ -308,10 +308,7 @@ Function *FetchShader::createFetchFunc() {
   func->getArg(m_vsEntryRegInfo.sgprCount + m_vsEntryRegInfo.vertexId)->setName("VertexId");
   func->getArg(m_vsEntryRegInfo.sgprCount + m_vsEntryRegInfo.instanceId)->setName("InstanceId");
 
-  if (m_lgcContext->getTargetInfo().getGfxIpVersion().major >= 10) {
-    // Set up wave32 or wave64 to match the vertex shader.
-    func->addFnAttr("target-features", m_vsEntryRegInfo.wave32 ? "+wavefrontsize32" : "+wavefrontsize64");
-  }
+  setShaderStage(func, ShaderStageVertex);
 
   BasicBlock *block = BasicBlock::Create(func->getContext(), "", func);
   BuilderBase builder(block);

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -498,10 +498,15 @@ void PalMetadata::fixUpRegisters() {
         size_t descSet = node.innerTable[0].set;
         descSetNodes.resize(std::max(descSetNodes.size(), descSet + 1));
         descSetNodes[descSet] = &node;
-      } else if (node.concreteType == ResourceNodeType::DescriptorBuffer) {
+      } else if ((node.concreteType == ResourceNodeType::DescriptorBuffer) ||
+                 (node.concreteType == ResourceNodeType::DescriptorConstBuffer) ||
+                 (node.concreteType == ResourceNodeType::DescriptorBufferCompact) ||
+                 (node.concreteType == ResourceNodeType::DescriptorConstBufferCompact)) {
         size_t descSet = node.set;
-        descSetNodes.resize(std::max(descSetNodes.size(), descSet + 1));
-        descSetNodes[descSet] = &node;
+        if (descSet != InvalidValue) {
+          descSetNodes.resize(std::max(descSetNodes.size(), descSet + 1));
+          descSetNodes[descSet] = &node;
+        }
       } else if (node.concreteType == ResourceNodeType::PushConst) {
         pushConstNode = &node;
       }

--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -30,6 +30,7 @@
  */
 #include "lgc/state/PassManagerCache.h"
 #include "lgc/LgcContext.h"
+#include "lgc/patch/PatchSetupTargetFeatures.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 442438
 // Old version of the code
@@ -90,6 +91,7 @@ std::pair<lgc::PassManager &, LegacyPassManager &> PassManagerCache::getPassMana
 
   passManagers.first.reset(PassManager::Create(m_lgcContext));
   passManagers.first->registerFunctionAnalysis([&] { return m_lgcContext->getTargetMachine()->getTargetIRAnalysis(); });
+  passManagers.first->registerModuleAnalysis([&] { return PipelineStateWrapper(m_lgcContext); });
 
   // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
   m_lgcContext->preparePassManager(*passManagers.first);
@@ -100,6 +102,7 @@ std::pair<lgc::PassManager &, LegacyPassManager &> PassManagerCache::getPassMana
   fpm.addPass(InstSimplifyPass());
   fpm.addPass(EarlyCSEPass(true));
   passManagers.first->addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
+  passManagers.first->addPass(PatchSetupTargetFeatures());
   // Add one last pass that does nothing, but invalidates all the analyses.
   // This is required to avoid the pass manager to use results of analyses from
   // previous runs which is causing random crashes.

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_16BitInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_16BitInput.pipe
@@ -15,7 +15,7 @@
 ; corresponds to the vertex shader.
 ; SHADERTEST-LABEL: // LGC glue shader results
 ; SHADERTEST: define amdgpu_vs {{.*}}
-; SHADERTEST: [[ld:%[0-9]+]] = call half @llvm.amdgcn.struct.tbuffer.load.f16({{.*}}) #1
+; SHADERTEST: [[ld:%[0-9]+]] = call half @llvm.amdgcn.struct.tbuffer.load.f16({{.*}}
 ; SHADERTEST: [[cast:%[0-9]+]] = bitcast half [[ld]] to i16
 ; SHADERTEST: [[zext:%[0-9]+]] = zext i16 [[cast]] to i32
 ; SHADERTEST: [[result:%[0-9]+]] = bitcast i32 [[zext]] to float


### PR DESCRIPTION
1. If enable dual source blend, color export shader will depends on wavesize.

2. Fix an issue that when ResourceNodeType::DescriptorBufferCompact is root node, we also need to fix up the register.