### PR TITLE
NGG coding rework: Don't conditionally create blocks

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -215,6 +215,7 @@ private:
 
   void initWaveThreadInfo(llvm::Value *mergedGroupInfo, llvm::Value *mergedWaveInfo);
   void loadStreamOutBufferInfo(llvm::Value *userData);
+  void distributePrimitiveId(llvm::Value *primitiveId);
 
   llvm::Value *doCulling(llvm::Module *module, llvm::Value *vertxIndex0, llvm::Value *vertxIndex1,
                          llvm::Value *vertxIndex2);


### PR DESCRIPTION
This change is to create all possible blocks unconditionally and make
some of them empty if the processing should be skipped. The empty blocks
will be removed by SimplifyCFG. The finally generated codes are the
same.

The reason for this is the conditonal block creation makes the processing
duplicated and unclear. This is very error-prone when we have multiple
conditions that controlling block creation and their branching
relationship.

The function buildPassthroughPrimShader is modified in this change. Will
continue to change buildPrimShader and buildPrimShaderWithGs in separate
changes.