### PR TITLE
Opaque Pointers: Override opaque pointers flag in LLVM context to TRUE

### DIFF
--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -220,9 +220,8 @@ int main(int argc, char **argv) {
                                    " LLVM and LGC can be used.\n";
   cl::ParseCommandLineOptions(argc, argv, commandDesc);
 
-  // Temporarily disable opaque pointers (llvm is making opaque the default).
   // TODO: Remove this once work complete on transition to opaque pointers.
-  context.setOpaquePointers(OpaquePointers);
+  context.setOpaquePointers(true);
 
   // Find the -mcpu option and get its value.
   auto mcpu = opts.find("mcpu");

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -68,9 +68,8 @@ Context::Context(GfxIpVersion gfxIp) : LLVMContext(), m_gfxIp(gfxIp) {
   m_dialectContext = llvm_dialects::DialectContext::make<LgcDialect>(*this);
 
   reset();
-  // Temporarily disable opaque pointers (llvm is making opaque the default).
   // TODO: Remove this once work complete on transition to opaque pointers.
-  setOpaquePointers(GetOpaquePointersFlag());
+  setOpaquePointers(true);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
This change will be removed when all internal llvm branches will we up to date with llvm-project/main or all tests in LLVM/LGC will be re-written to not use typed pointers as input llvm-ir for tests.