### PR TITLE
Opaque Pointer: Remove enable-opaque-pointers flag from cli

### DIFF
--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -103,7 +103,6 @@ cl::opt<unsigned> PalAbiVersion("pal-abi-version", cl::init(0xFFFFFFFF), cl::cat
 // -v: enable verbose output
 cl::opt<bool> VerboseOutput("v", cl::cat(LgcCategory), cl::desc("Enable verbose output"), cl::init(false));
 
-cl::opt<bool> OpaquePointers("enable-opaque-pointers", cl::desc("Enable opaque-pointers in LGC"), cl::init(true));
 } // anonymous namespace
 
 // =====================================================================================================================

--- a/llpc/util/llpcDebug.cpp
+++ b/llpc/util/llpcDebug.cpp
@@ -64,11 +64,6 @@ opt<std::string> LogFileDbgs("log-file-dbgs", desc("Name of the file to log info
 opt<std::string> LogFileOuts("log-file-outs", desc("Name of the file to log info from LLPC_OUTS() and LLPC_ERRS()"),
                              value_desc("filename"), init(""));
 
-// TODO: Remove this when LLPC will switch fully to opaque pointers.
-// opaque-pointers flag which is implemented in LLVM is by default enabled. Right now we do not want
-// to enable by default this flag for LLPC, but we need to have some flag to use for transition and for LIT tests.
-opt<bool> OpaquePointers("enable-opaque-pointers", desc("Enable opaque-pointers for LLPC"), init(true));
-
 } // namespace cl
 
 } // namespace llvm
@@ -76,9 +71,6 @@ opt<bool> OpaquePointers("enable-opaque-pointers", desc("Enable opaque-pointers 
 using namespace llvm;
 
 namespace Llpc {
-bool GetOpaquePointersFlag() {
-  return cl::OpaquePointers;
-}
 // =====================================================================================================================
 // Gets the value of option "allow-out".
 bool EnableOuts() {

--- a/llpc/util/llpcDebug.h
+++ b/llpc/util/llpcDebug.h
@@ -66,6 +66,4 @@ void redirectLogOutput(bool restoreToDefault, unsigned optionCount, const char *
 // Enable/disable the output for debugging.
 void enableDebugOutput(bool restore);
 
-bool GetOpaquePointersFlag();
-
 } // namespace Llpc


### PR DESCRIPTION
Flag is no longer needed since Opaque Pointers are enabled by default now.