### PR TITLE
Add pipeline metadata ".mesh_linear_dispath_from_task"

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -217,6 +217,7 @@ static constexpr char VgtHosMinTessLevel[] = ".vgt_hos_min_tess_level";
 static constexpr char VgtHosMaxTessLevel[] = ".vgt_hos_max_tess_level";
 static constexpr char SpiShaderGsMeshletDim[] = ".spi_shader_gs_meshlet_dim";
 static constexpr char SpiShaderGsMeshletExpAlloc[] = ".spi_shader_gs_meshlet_exp_alloc";
+static constexpr char MeshLinearDispatchFromTask[] = ".mesh_linear_dispatch_from_task";
 static constexpr char ImageOp[] = ".image_op";
 static constexpr char VgtGsMaxVertOut[] = ".vgt_gs_max_vert_out";
 static constexpr char VgtGsInstanceCnt[] = ".vgt_gs_instance_cnt";

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -173,6 +173,12 @@ struct ResourceUsage {
   struct {
     // Per-stage built-in usage
     union {
+      // Task shader
+      struct {
+        // Statement
+        unsigned meshLinearDispatch : 1; // Mesh linear dispatch from task shader when group count Y/Z are both ones
+      } task;
+
       // Vertex shader
       struct {
         // Input

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1457,6 +1457,14 @@ void MeshTaskShader::emitTaskMeshs(Value *groupCountX, Value *groupCountY, Value
   auto entryPoint = m_builder->GetInsertBlock()->getParent();
   assert(getShaderStage(entryPoint) == ShaderStageTask); // Must be task shader
 
+  // Mark the flag of mesh linear dispatch from task when the group count Y and Z are both ones
+  if (isa<ConstantInt>(groupCountY) && isa<ConstantInt>(groupCountZ)) {
+    const unsigned constGroupCountY = cast<ConstantInt>(groupCountY)->getZExtValue();
+    const unsigned constGroupCountZ = cast<ConstantInt>(groupCountZ)->getZExtValue();
+    m_pipelineState->getShaderResourceUsage(ShaderStageTask)->builtInUsage.task.meshLinearDispatch =
+        constGroupCountY == 1 && constGroupCountZ == 1;
+  }
+
   auto emitMeshsCall = m_builder->GetInsertPoint();
 
   auto checkEmitMeshsBlock = m_builder->GetInsertBlock();

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -477,6 +477,15 @@ void RegisterMetadataBuilder::buildPrimShaderRegisters() {
     // VGT_DRAW_PAYLOAD_CNTL
     getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtDrawPrimPayloadEn] = hasPrimitivePayload;
 
+    // Pipeline metadata: mesh_linear_dispatch_from_task
+    bool meshLinearDispatchFromTask = false;
+    if (m_hasTask) {
+      meshLinearDispatchFromTask =
+          m_pipelineState->getShaderResourceUsage(ShaderStageTask)->builtInUsage.task.meshLinearDispatch;
+    }
+    getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::MeshLinearDispatchFromTask] =
+        meshLinearDispatchFromTask;
+
     if (m_gfxIp.major >= 11) {
       // SPI_SHADER_GS_MESHLET_DIM
       auto spiShaderGsMeshletDim =


### PR DESCRIPTION
When we handle EmitMeshTasks, if the group count Y/Z are both ones, this is a linear dispath. We can set the new PAL metadata. PAL will set the flag and tell CP to do linear dispatch.