### PR TITLE
Update amdpal.version and move .graphics_registers up a level

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -43,7 +43,11 @@ namespace Util {
 namespace Abi {
 
 constexpr unsigned PipelineMetadataMajorVersion = 2; // Pipeline Metadata Major Version
-constexpr unsigned PipelineMetadataMinorVersion = 3; // Pipeline Metadata Minor Version
+constexpr unsigned PipelineMetadataMinorVersion = 6; // Pipeline Metadata Minor Version
+
+// TODO: Remove and update the version to [3,0] after switching to new register metadata layout
+constexpr unsigned PipelineMetadataMajorVersionNew = 3; // Pipeline Metadata Major Version
+constexpr unsigned PipelineMetadataMinorVersionNew = 0; // Pipeline Metadata Minor Version
 
 constexpr unsigned PipelineMetadataBase = 0x10000000; // Pipeline Metadata base value to be OR'd with the
                                                       //  PipelineMetadataEntry value when saving to ELF.

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -302,7 +302,7 @@ public:
   bool enableMeshRowExport() const;
 
   // Checks if register field value format is used or not
-  bool useRegisterFieldFormat() const;
+  bool useRegisterFieldFormat() const { return m_registerFieldFormat; }
 
   // Checks if SW-emulated stream-out should be enabled
   bool enableSwXfb();

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -67,9 +67,7 @@ ConfigBuilderBase::ConfigBuilderBase(Module *module, PipelineState *pipelineStat
       m_document->getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0].getMap(true);
 
   if (m_pipelineState->useRegisterFieldFormat()) {
-    m_graphicsRegistersNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::Registers]
-                                  .getMap(true)[Util::Abi::PipelineMetadataKey::GraphicsRegisters]
-                                  .getMap(true);
+    m_graphicsRegistersNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters].getMap(true);
   }
 
   setApiName(pipelineState->getClient());

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -99,7 +99,7 @@ void RegisterMetadataBuilder::buildPalMetadata() {
     for (const auto &entry : apiHwShaderMap) {
       const auto apiStage = static_cast<ShaderStage>(entry.first);
       hwStageMask |= entry.second;
-      addApiHwShaderMapping(apiStage, hwStageMask);
+      addApiHwShaderMapping(apiStage, entry.second);
     }
 
     if (hwStageMask & Util::Abi::HwShaderHs) {

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -603,7 +603,7 @@ void PalMetadata::finalizeUserDataLimit() {
 void PalMetadata::finalizeRegisterSettings(bool isWholePipeline) {
   assert(m_pipelineState->isGraphics());
   if (m_pipelineState->useRegisterFieldFormat()) {
-    auto graphicsRegNode = m_registers[Util::Abi::PipelineMetadataKey::GraphicsRegisters].getMap(true);
+    auto graphicsRegNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters].getMap(true);
 
     if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 &&
         m_pipelineState->getColorExportState().alphaToCoverageEnable) {
@@ -985,7 +985,7 @@ void PalMetadata::updateSpiShaderColFormat(ArrayRef<ColorExportInfo> exps, bool 
   }
 
   if (m_pipelineState->useRegisterFieldFormat()) {
-    auto spiShaderColFormatNode = m_registers[Util::Abi::PipelineMetadataKey::GraphicsRegisters]
+    auto spiShaderColFormatNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters]
                                       .getMap(true)[Util::Abi::GraphicsRegisterMetadataKey::SpiShaderColFormat]
                                       .getMap(true);
     spiShaderColFormatNode[Util::Abi::SpiShaderColFormatMetadataKey::Col_0ExportFormat] = spiShaderColFormat & 0xF;

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -41,12 +41,15 @@
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/VersionTuple.h"
 
 #define DEBUG_TYPE "lgc-pal-metadata"
 
 using namespace lgc;
 using namespace llvm;
+
+extern cl::opt<bool> UseRegisterFieldFormat;
 
 namespace {
 
@@ -154,8 +157,13 @@ void PalMetadata::initialize() {
 void PalMetadata::record(Module *module) {
   // Add the metadata version number.
   auto versionNode = m_document->getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Version].getArray(true);
-  versionNode[0] = Util::Abi::PipelineMetadataMajorVersion;
-  versionNode[1] = Util::Abi::PipelineMetadataMinorVersion;
+  if (UseRegisterFieldFormat) {
+    versionNode[0] = Util::Abi::PipelineMetadataMajorVersionNew;
+    versionNode[1] = Util::Abi::PipelineMetadataMinorVersionNew;
+  } else {
+    versionNode[0] = Util::Abi::PipelineMetadataMajorVersion;
+    versionNode[1] = Util::Abi::PipelineMetadataMinorVersion;
+  }
 
   // Write the MsgPack document into an IR metadata node.
   // The IR named metadata node contains an MDTuple containing an MDString containing the msgpack data.

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -54,9 +54,8 @@ static cl::opt<bool> EnableTessOffChip("enable-tess-offchip", cl::desc("Enable t
 static cl::opt<bool> EnableRowExport("enable-row-export", cl::desc("Enable row export for mesh shader"),
                                      cl::init(false));
 
-// -use-register-field-format: use register field format in pipeline ELF
-static cl::opt<bool> UseRegisterFieldFormat("use-register-field-format",
-                                            cl::desc("Use register field format in pipeline ELF"), cl::init(false));
+cl::opt<bool> UseRegisterFieldFormat("use-register-field-format", cl::desc("Use register field format in pipeline ELF"),
+                                     cl::init(false));
 
 // Names for named metadata nodes when storing and reading back pipeline state
 static const char UnlinkedMetadataName[] = "lgc.unlinked";

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -327,6 +327,12 @@ void PipelineState::record(Module *module) {
   recordGraphicsState(module);
   if (m_palMetadata)
     m_palMetadata->record(module);
+
+  if (UseRegisterFieldFormat) {
+    const bool isFieldSupported =
+        getTargetInfo().getGfxIpVersion().major >= 11 && (m_pipelineLink == PipelineLink::WholePipeline);
+    UseRegisterFieldFormat.setValue(isFieldSupported);
+  }
 }
 
 // =====================================================================================================================
@@ -1365,14 +1371,6 @@ bool PipelineState::enableMeshRowExport() const {
     return false; // Row export is not supported by HW
 
   return m_meshRowExport;
-}
-
-// =====================================================================================================================
-// Checks if register field value format is used or not
-bool PipelineState::useRegisterFieldFormat() const {
-  if (getTargetInfo().getGfxIpVersion().major < 11)
-    return false; // Register field format is not supported pre-GFX11 by now
-  return m_registerFieldFormat;
 }
 
 // =====================================================================================================================

--- a/lgc/test/BuiltIns/cs-numworkgroups.lgc
+++ b/lgc/test/BuiltIns/cs-numworkgroups.lgc
@@ -76,5 +76,5 @@ attributes #0 = { nounwind }
 ; CHECK-NEXT:     .user_data_limit: 0x3
 ; CHECK-NEXT: amdpal.version:
 ; CHECK-NEXT:   - 0x2
-; CHECK-NEXT:   - 0x3
+; CHECK-NEXT:   - 0x6
 ; CHECK-NEXT: ...

--- a/lgc/test/BuiltIns/cs-workgroupid.lgc
+++ b/lgc/test/BuiltIns/cs-workgroupid.lgc
@@ -75,5 +75,5 @@ attributes #0 = { nounwind }
 ; CHECK-NEXT:     .user_data_limit: 0x3
 ; CHECK-NEXT: amdpal.version:
 ; CHECK-NEXT:   - 0x2
-; CHECK-NEXT:   - 0x3
+; CHECK-NEXT:   - 0x6
 ; CHECK-NEXT: ...

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
@@ -120,5 +120,5 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:       .llpc_version: {{.*}}
 ; CHECK-NEXT: amdpal.version:
 ; CHECK-NEXT:   - 0x2
-; CHECK-NEXT:   - 0x3
+; CHECK-NEXT:   - 0x6
 ; CHECK-NEXT: ...


### PR DESCRIPTION
1. Move .graphics_registers section out of .registers
2. Update setting `PipelineState::m_isRegisterFieldFormat` to block unsupported cases, such as pre-gfx11, unlinked shaders and relocatable shader ELF.
3. Modify `.amdpal.version` to 3.0 for the new register metadata layout to identify the new mode in backend.