### PR TITLE
Replace deprecated FloatToBits with bit_cast

### DIFF
--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -548,8 +548,8 @@ template <typename T> void ConfigBuilder::buildHsRegConfig(ShaderStage shaderSta
   // Minimum and maximum tessellation factors supported by the hardware.
   constexpr float minTessFactor = 1.0f;
   constexpr float maxTessFactor = 64.0f;
-  SET_REG(&config->hsRegs, VGT_HOS_MIN_TESS_LEVEL, FloatToBits(minTessFactor));
-  SET_REG(&config->hsRegs, VGT_HOS_MAX_TESS_LEVEL, FloatToBits(maxTessFactor));
+  SET_REG(&config->hsRegs, VGT_HOS_MIN_TESS_LEVEL, bit_cast<uint32_t>(minTessFactor));
+  SET_REG(&config->hsRegs, VGT_HOS_MAX_TESS_LEVEL, bit_cast<uint32_t>(maxTessFactor));
 
   // Set VGT_LS_HS_CONFIG
   SET_REG_FIELD(&config->hsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1012,8 +1012,8 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   // Minimum and maximum tessellation factors supported by the hardware.
   constexpr float minTessFactor = 1.0f;
   constexpr float maxTessFactor = 64.0f;
-  SET_REG(&config->lsHsRegs, VGT_HOS_MIN_TESS_LEVEL, FloatToBits(minTessFactor));
-  SET_REG(&config->lsHsRegs, VGT_HOS_MAX_TESS_LEVEL, FloatToBits(maxTessFactor));
+  SET_REG(&config->lsHsRegs, VGT_HOS_MIN_TESS_LEVEL, bit_cast<uint32_t>(minTessFactor));
+  SET_REG(&config->lsHsRegs, VGT_HOS_MAX_TESS_LEVEL, bit_cast<uint32_t>(maxTessFactor));
 
   // Set VGT_LS_HS_CONFIG
   SET_REG_FIELD(&config->lsHsRegs, VGT_LS_HS_CONFIG, NUM_PATCHES, calcFactor.patchCountPerThreadGroup);

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -162,8 +162,8 @@ void RegisterMetadataBuilder::buildLsHsRegisters() {
   // Minimum and maximum tessellation factors supported by the hardware.
   constexpr float minTessFactor = 1.0f;
   constexpr float maxTessFactor = 64.0f;
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtHosMinTessLevel] = FloatToBits(minTessFactor);
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtHosMaxTessLevel] = FloatToBits(maxTessFactor);
+  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtHosMinTessLevel] = bit_cast<uint32_t>(minTessFactor);
+  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VgtHosMaxTessLevel] = bit_cast<uint32_t>(maxTessFactor);
 
   // VGT_LS_HS_CONFIG
   const auto &calcFactor = m_pipelineState->getShaderResourceUsage(ShaderStageTessControl)->inOutUsage.tcs.calcFactor;


### PR DESCRIPTION
FloatToBits is now deprecated.
Replaced uses with the recommended llvm::bit_cast<uint32_t> instead.