### PR TITLE
RegisterMetadata: support compute pipeline and task shader pipeline

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -186,6 +186,14 @@ static constexpr char ApiShaderHash[] = ".api_shader_hash";
 static constexpr char HardwareMapping[] = ".hardware_mapping";
 }; // namespace ShaderMetadataKey
 
+namespace ComputeRegisterMetadataKey {
+static constexpr char TgidXEn[] = ".tgid_x_en";
+static constexpr char TgidYEn[] = ".tgid_y_en";
+static constexpr char TgidZEn[] = ".tgid_z_en";
+static constexpr char TgSizeEn[] = ".tg_size_en";
+static constexpr char TidigCompCnt[] = ".tidig_comp_cnt";
+}; // namespace ComputeRegisterMetadataKey
+
 namespace GraphicsRegisterMetadataKey {
 static constexpr char NggCullingDataReg[] = ".ngg_culling_data_reg";
 static constexpr char LsVgprCompCnt[] = ".ls_vgpr_comp_cnt";

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -67,7 +67,11 @@ ConfigBuilderBase::ConfigBuilderBase(Module *module, PipelineState *pipelineStat
       m_document->getRoot().getMap(true)[Util::Abi::PalCodeObjectMetadataKey::Pipelines].getArray(true)[0].getMap(true);
 
   if (m_pipelineState->useRegisterFieldFormat()) {
-    m_graphicsRegistersNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters].getMap(true);
+    if (m_pipelineState->isGraphics())
+      m_graphicsRegistersNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters].getMap(true);
+
+    if (m_pipelineState->hasShaderStage(ShaderStageCompute) || m_pipelineState->hasShaderStage(ShaderStageTask))
+      m_computeRegistersNode = m_pipelineNode[Util::Abi::PipelineMetadataKey::ComputeRegisters].getMap(true);
   }
 
   setApiName(pipelineState->getClient());

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -64,6 +64,7 @@ public:
 
   void writePalMetadata();
   llvm::msgpack::MapDocNode &getGraphicsRegNode() { return m_graphicsRegistersNode; }
+  llvm::msgpack::MapDocNode &getComputeRegNode() { return m_computeRegistersNode; }
   // Get the MsgPack map node for the specified HW shader in the ".hardware_stages" map
   llvm::msgpack::MapDocNode getHwShaderNode(Util::Abi::HardwareStage hwStage);
 
@@ -129,6 +130,9 @@ private:
   llvm::msgpack::MapDocNode m_graphicsRegistersNode;
   // MsgPack map node for graphics registers metadata
   // ".graphics_registers"
+  llvm::msgpack::MapDocNode m_computeRegistersNode;
+  // MsgPack map node for graphics registers metadata
+  // ".compute_registers"
 
   llvm::SmallVector<PalMetadataNoteEntry, 128> m_config; // Register/metadata configuration
 };

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1049,15 +1049,19 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
   inRegMask |= shaderInputs->getShaderArgTys(m_pipelineState, m_shaderStage, argTys, argNames, argOffset);
 
   if (m_pipelineState->useRegisterFieldFormat()) {
+    constexpr unsigned NumUserSgprs = 32;
     unsigned numUserDataSgprs = 16;
     if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 && m_shaderStage != ShaderStageCompute &&
         m_shaderStage != ShaderStageTask)
       numUserDataSgprs = 32;
-    std::vector<unsigned> userDataMap(numUserDataSgprs, static_cast<unsigned>(UserDataMapping::Invalid));
+
+    constexpr unsigned InvalidMapVal = static_cast<unsigned>(UserDataMapping::Invalid);
+    SmallVector<unsigned, NumUserSgprs> userDataMap;
+    userDataMap.resize(NumUserSgprs, InvalidMapVal);
     userDataIdx = 0;
     for (const auto &userDataArg : unspilledArgs) {
       unsigned dwordSize = userDataArg.argDwordSize;
-      if (userDataArg.userDataValue != static_cast<unsigned>(UserDataMapping::Invalid)) {
+      if (userDataArg.userDataValue != InvalidMapVal) {
         bool isSystemUserData = isSystemUserDataValue(userDataArg.userDataValue);
         unsigned numEntries = isSystemUserData ? 1 : dwordSize;
         unsigned userDataValue = userDataArg.userDataValue;

--- a/lgc/patch/RegisterMetadataBuilder.h
+++ b/lgc/patch/RegisterMetadataBuilder.h
@@ -51,7 +51,7 @@ private:
   void buildPrimShaderRegisters();
   void buildHwVsRegisters();
   void buildPsRegisters();
-  void buildCsRegisters();
+  void buildCsRegisters(ShaderStage shaderStage);
 
   void buildShaderExecutionRegisters(Util::Abi::HardwareStage hwStageId, ShaderStage apiStage1, ShaderStage apiStage2);
   void buildPaSpecificRegisters();


### PR DESCRIPTION
Implement `buildCsRegister()` and modify `buildShaderExecutionRegisters` to support `HardwareStages::Cs`.