### PR TITLE
Fix for InstCombinePass options

### DIFF
--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -98,7 +98,14 @@ std::pair<lgc::PassManager &, LegacyPassManager &> PassManagerCache::getPassMana
 
   // Add a few optimizations.
   FunctionPassManager fpm;
-  fpm.addPass(InstCombinePass(5));
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 452298
+  // Old version of the code
+  unsigned instCombineOpt = 5;
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  auto instCombineOpt = InstCombineOptions().setMaxIterations(5);
+#endif
+  fpm.addPass(InstCombinePass(instCombineOpt));
   fpm.addPass(InstSimplifyPass());
   fpm.addPass(EarlyCSEPass(true));
   passManagers.first->addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -239,7 +239,14 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 #endif
   passMgr.addPass(GlobalOptPass());
   passMgr.addPass(createModuleToFunctionPassAdaptor(ADCEPass()));
-  passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(2)));
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 452298
+  // Old version of the code
+  unsigned instCombineOpt = 2;
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  auto instCombineOpt = InstCombineOptions().setMaxIterations(2);
+#endif
+  passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(instCombineOpt)));
   passMgr.addPass(createModuleToFunctionPassAdaptor(SimplifyCFGPass()));
   passMgr.addPass(createModuleToFunctionPassAdaptor(EarlyCSEPass()));
 


### PR DESCRIPTION
Upstream LLVM patch https://reviews.llvm.org/D144199 changed InstCombinePass to take a struct containing options instead of a plain unsigned integer.