### PR TITLE
Fix Visual Studio solution generation with CMake

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -144,7 +144,10 @@ set_compiler_options(llpc ${LLPC_ENABLE_WERROR})
 
 ### Defines/Includes/Sources ###########################################################################################
 if(ICD_BUILD_LLPC)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm")
+    list(APPEND CMAKE_MODULE_PATH
+        "${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm"
+        "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm" # Workaround for VS generator with older LLVM.
+    )
     include(LLVMConfig)
     message(STATUS "LLVM executables: " ${LLVM_TOOLS_BINARY_DIR})
     message(STATUS "LLVM libraries: " ${LLVM_BUILD_LIBRARY_DIR})
@@ -298,8 +301,6 @@ if(UNIX)
 elseif(WIN32)
     set(BUILD_OS win)
 endif()
-
-set(LLVM_BIN_DIR "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/bin")
 
 endif()
 ### Link Libraries #####################################################################################################

--- a/llpc/test/CMakeLists.txt
+++ b/llpc/test/CMakeLists.txt
@@ -26,7 +26,6 @@
 find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
   COMPONENTS Interpreter)
 
-list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm")
 include(LLVMConfig)
 
 set(AMDLLPC_TEST_DEPS amdllpc FileCheck llvm-objdump llvm-readelf count not)

--- a/llpc/unittests/CMakeLists.txt
+++ b/llpc/unittests/CMakeLists.txt
@@ -30,7 +30,6 @@ set_target_properties(LlpcUnitTests PROPERTIES FOLDER "LLPC Tests")
 # To execute all LLPC unit tests, run:
 #   cmake --build . --target check-amdllpc-units
 
-list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm")
 include(LLVMConfig)
 
 # Required to use LIT on Windows.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,10 @@ if(NOT LLPC_IS_STANDALONE)
   find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
     COMPONENTS Interpreter)
 
-  list(APPEND CMAKE_MODULE_PATH "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm")
+  list(APPEND CMAKE_MODULE_PATH
+    "${XGL_LLVM_BUILD_PATH}/lib/cmake/llvm"
+    "${XGL_LLVM_BUILD_PATH}/${CMAKE_CFG_INTDIR}/lib/cmake/llvm" # Workaround for VS generator with older LLVM.
+  )
   include(LLVMConfig)
 
   # required by lit.site.cfg.py.in.


### PR DESCRIPTION
This stopped working due to a CMake change in LLVM.

Let's keep both paths, so that it can work with old and new versions of LLVM.

I also removed `LLVM_BIN_DIR`, it is not referenced anywhere.