### PR TITLE
Support non-zero index component outputs exported to XFB

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1507,18 +1507,19 @@ Instruction *BuilderRecorder::CreateWriteGenericOutput(Value *valueToWrite, unsi
 // Create a write to an XFB (transform feedback / streamout) buffer.
 //
 // @param valueToWrite : Value to write
-// @param isBuiltIn : True for built-in, false for user output (ignored if not GS)
-// @param location : Location (row) or built-in kind of output (ignored if not GS)
+// @param isBuiltIn : True for built-in, false for user output
+// @param location : Location (row) or built-in kind of output
+// @param component : Component offset of inputs and outputs (ignored if built-in)
 // @param xfbBuffer : XFB buffer ID
 // @param xfbStride : XFB stride
 // @param xfbOffset : XFB byte offset
 // @param outputInfo : Extra output info (GS stream ID)
 Instruction *BuilderRecorder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                                   unsigned xfbBuffer, unsigned xfbStride, Value *xfbOffset,
-                                                   InOutInfo outputInfo) {
+                                                   unsigned component, unsigned xfbBuffer, unsigned xfbStride,
+                                                   Value *xfbOffset, InOutInfo outputInfo) {
   return record(Opcode::WriteXfbOutput, nullptr,
-                {valueToWrite, getInt1(isBuiltIn), getInt32(location), getInt32(xfbBuffer), getInt32(xfbStride),
-                 xfbOffset, getInt32(outputInfo.getData())},
+                {valueToWrite, getInt1(isBuiltIn), getInt32(location), getInt32(component), getInt32(xfbBuffer),
+                 getInt32(xfbStride), xfbOffset, getInt32(outputInfo.getData())},
                 "");
 }
 

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -605,13 +605,14 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   }
 
   case BuilderRecorder::Opcode::WriteXfbOutput: {
-    InOutInfo outputInfo(cast<ConstantInt>(args[6])->getZExtValue());
+    InOutInfo outputInfo(cast<ConstantInt>(args[7])->getZExtValue());
     return m_builder->CreateWriteXfbOutput(args[0],                                    // Value to write
                                            cast<ConstantInt>(args[1])->getZExtValue(), // IsBuiltIn
                                            cast<ConstantInt>(args[2])->getZExtValue(), // Location/builtIn
-                                           cast<ConstantInt>(args[3])->getZExtValue(), // XFB buffer ID
-                                           cast<ConstantInt>(args[4])->getZExtValue(), // XFB stride
-                                           args[5],                                    // XFB byte offset
+                                           cast<ConstantInt>(args[3])->getZExtValue(), // Component
+                                           cast<ConstantInt>(args[4])->getZExtValue(), // XFB buffer ID
+                                           cast<ConstantInt>(args[5])->getZExtValue(), // XFB stride
+                                           args[6],                                    // XFB byte offset
                                            outputInfo);
   }
 

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -714,15 +714,16 @@ Value *InOutBuilder::adjustIj(Value *value, Value *offset) {
 // of those correspondences is actually used when writing to XFB for each affected vertex.
 //
 // @param valueToWrite : Value to write
-// @param isBuiltIn : True for built-in, false for user output (ignored if not GS)
-// @param location : Location (row) or built-in kind of output (ignored if not GS)
+// @param isBuiltIn : True for built-in, false for user output
+// @param location : Location (row) or built-in kind of output
+// @param component : Component offset of inputs and outputs (ignored if built-in)
 // @param xfbBuffer : XFB buffer ID
 // @param xfbStride : XFB stride
 // @param xfbOffset : XFB byte offset
 // @param outputInfo : Extra output info (GS stream ID)
 Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                                unsigned xfbBuffer, unsigned xfbStride, Value *xfbOffset,
-                                                InOutInfo outputInfo) {
+                                                unsigned component, unsigned xfbBuffer, unsigned xfbStride,
+                                                Value *xfbOffset, InOutInfo outputInfo) {
   // xfbStride must be a non-zero value
   assert(xfbStride > 0);
   // Can currently only cope with constant xfbOffset.
@@ -771,7 +772,7 @@ Instruction *InOutBuilder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuil
       InOutLocationInfo outLocInfo;
       outLocInfo.setLocation(location);
       outLocInfo.setStreamId(streamId);
-      outLocInfo.setComponent(i);
+      outLocInfo.setComponent(component + i);
       outLocInfo.setBuiltIn(isBuiltIn);
       if (i >= 4) {
         outLocInfo.setLocation(location + 1);

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -509,8 +509,8 @@ public:
 
   // Create a write to an XFB (transform feedback / streamout) buffer.
   llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                          unsigned xfbBuffer, unsigned xfbStride, llvm::Value *xfbOffset,
-                                          InOutInfo outputInfo) override final;
+                                          unsigned component, unsigned xfbBuffer, unsigned xfbStride,
+                                          llvm::Value *xfbOffset, InOutInfo outputInfo) override final;
 
   // Create a read of barycoord input value.
   llvm::Value *CreateReadBaryCoord(BuiltInKind builtIn, InOutInfo inputInfo, llvm::Value *auxInterpValue,

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -454,8 +454,8 @@ public:
 
   // Create a write to an XFB (transform feedback / streamout) buffer.
   llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                          unsigned xfbBuffer, unsigned xfbStride, llvm::Value *xfbOffset,
-                                          InOutInfo outputInfo) override final;
+                                          unsigned component, unsigned xfbBuffer, unsigned xfbStride,
+                                          llvm::Value *xfbOffset, InOutInfo outputInfo) override final;
 
   // Create a read of barycoord input value.
   llvm::Value *CreateReadBaryCoord(BuiltInKind builtIn, InOutInfo inputInfo, llvm::Value *auxInterpValue,

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1198,15 +1198,16 @@ public:
   // of those correspondences is actually used when writing to XFB for each affected vertex.
   //
   // @param valueToWrite : Value to write
-  // @param isBuiltIn : True for built-in, false for user output (ignored if not GS)
-  // @param location : Location (row) or built-in kind of output (ignored if not GS)
+  // @param isBuiltIn : True for built-in, false for user output
+  // @param location : Location (row) or built-in kind of output
+  // @param component : Component offset of inputs and outputs (ignored if built-in)
   // @param xfbBuffer : XFB buffer ID
   // @param xfbStride : XFB stride
   // @param xfbOffset : XFB byte offset
   // @param outputInfo : Extra output info (GS stream ID)
   virtual llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                                  unsigned xfbBuffer, unsigned xfbStride, llvm::Value *xfbOffset,
-                                                  InOutInfo outputInfo) = 0;
+                                                  unsigned component, unsigned xfbBuffer, unsigned xfbStride,
+                                                  llvm::Value *xfbOffset, InOutInfo outputInfo) = 0;
 
   // Get the type of a built-in -- static edition of the method below, so you can use it without a Builder object.
   //

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -404,7 +404,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
     // Export XFB output
     if (m_pipelineState->canPackOutput(ShaderStageGeometry)) {
       // With packing locations, we should collect the XFB output value at an original location
-      DenseMap<unsigned, SmallVector<Value *, 4>> origLocElemsMap;
+      DenseMap<unsigned, std::pair<unsigned, SmallVector<Value *, 4>>> origLocCompElemsMap;
       for (const auto &locInfoXfbInfoPair : locInfoXfbOutInfoMap) {
         const InOutLocationInfo &origLocInfo = locInfoXfbInfoPair.first;
         if (origLocInfo.getStreamId() != streamId || origLocInfo.isBuiltIn())
@@ -418,12 +418,13 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
                           ? builder.CreateExtractElement(packedOutValue, newLocInfo.getComponent())
                           : packedOutValue;
 
-        auto &elements = origLocElemsMap[origLocInfo.getLocation()];
+        auto &elements = origLocCompElemsMap[origLocInfo.getLocation()].second;
         elements.push_back(elem);
+        origLocCompElemsMap[origLocInfo.getLocation()].first = origLocInfo.getComponent();
       }
       // Construct original XFB output value and export it
-      for (const auto &locElemsPair : origLocElemsMap) {
-        auto &elements = locElemsPair.second;
+      for (const auto &entry : origLocCompElemsMap) {
+        auto &elements = entry.second.second;
         const unsigned elemCount = elements.size();
         Value *xfbOutValue = nullptr;
         if (elemCount > 1) {
@@ -436,7 +437,8 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
 
         // Get the XFB out info at the original location info
         InOutLocationInfo origLocInfo;
-        origLocInfo.setLocation(locElemsPair.first);
+        origLocInfo.setLocation(entry.first);
+        origLocInfo.setComponent(entry.second.first);
         origLocInfo.setStreamId(streamId);
         assert(locInfoXfbOutInfoMap.count(origLocInfo) > 0);
         auto &xfbInfo = locInfoXfbOutInfoMap[origLocInfo];

--- a/llpc/test/shaderdb/core/TestXfbStateMetadata.vert
+++ b/llpc/test/shaderdb/core/TestXfbStateMetadata.vert
@@ -23,7 +23,7 @@ void main()
 // CHECK-NEXT:    [[TMP0:%.*]] = call float (...) @lgc.create.read.generic.input.f32(i32 1, i32 0, i32 0, i32 0, i32 0, i32 undef)
 // CHECK-NEXT:    [[TMP1:%.*]] = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
 // CHECK-NEXT:    call void (...) @lgc.create.write.builtin.output(<4 x float> [[TMP1]], i32 0, i32 0, i32 undef, i32 undef)
-// CHECK-NEXT:    call void (...) @lgc.create.write.xfb.output(float [[TMP0]], i1 true, i32 1, i32 0, i32 4, i32 0, i32 0)
+// CHECK-NEXT:    call void (...) @lgc.create.write.xfb.output(float [[TMP0]], i1 true, i32 1, i32 0, i32 0, i32 4, i32 0, i32 0)
 // CHECK-NEXT:    call void (...) @lgc.create.write.builtin.output(float [[TMP0]], i32 1, i32 0, i32 undef, i32 undef)
 // CHECK-NEXT:    ret void
 //

--- a/llpc/test/shaderdb/general/PipelineGsTess_TestInOutPacking.pipe
+++ b/llpc/test/shaderdb/general/PipelineGsTess_TestInOutPacking.pipe
@@ -1,5 +1,27 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} transform feedback export info (geometry shader)
+; SHADERTEST: <2 x i32> (loc = 0, comp = 0), xfbBuffer = 1, xfbStride = 40, xfbOffset = 0, streamID = 0
+; SHADERTEST: <3 x double> (loc = 1, comp = 0), xfbBuffer = 1, xfbStride = 40, xfbOffset = 16, streamID = 0
+; SHADERTEST: <2 x float> (loc = 4, comp = 0), xfbBuffer = 2, xfbStride = 8, xfbOffset = 0, streamID = 0
+; SHADERTEST: <2 x double> (loc = 3, comp = 0), xfbBuffer = 0, xfbStride = 16, xfbOffset = 0, streamID = 1
+; SHADERTEST: float (loc = 4, comp = 3), xfbBuffer = 3, xfbStride = 4, xfbOffset = 0, streamID = 1
+; SHADERTEST-LABEL: {{^// LLPC}} location input/output mapping results (GS shader)
+; SHADERTEST: (GS) Output: stream = 0,  loc = 0, comp = 0  =>  Mapped = 0, 0
+; SHADERTEST: (GS) Output: stream = 0,  loc = 0, comp = 1  =>  Mapped = 0, 1
+; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 0  =>  Mapped = 0, 2
+; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 1  =>  Mapped = 0, 3
+; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 2  =>  Mapped = 1, 0
+; SHADERTEST: (GS) Output: stream = 0,  loc = 1, comp = 3  =>  Mapped = 1, 1
+; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 0  =>  Mapped = 1, 2
+; SHADERTEST: (GS) Output: stream = 0,  loc = 2, comp = 1  =>  Mapped = 1, 3
+; SHADERTEST: (GS) Output: stream = 0,  loc = 4, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST: (GS) Output: stream = 0,  loc = 4, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST: (GS) Output: stream = 1,  loc = 3, comp = 0  =>  Mapped = 2, 0
+; SHADERTEST: (GS) Output: stream = 1,  loc = 3, comp = 1  =>  Mapped = 2, 1
+; SHADERTEST: (GS) Output: stream = 1,  loc = 3, comp = 2  =>  Mapped = 2, 2
+; SHADERTEST: (GS) Output: stream = 1,  loc = 3, comp = 3  =>  Mapped = 2, 3
+; SHADERTEST: (GS) Output: stream = 1,  loc = 4, comp = 3  =>  Mapped = 3, 0
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 32, i32 15
 ; SHADERTEST: call void @llvm.amdgcn.exp.f32(i32 33, i32 15
@@ -86,10 +108,11 @@ layout(location = 1) in vec2 in2[];
 layout(stream = 0) out;
 layout(location = 0, xfb_buffer=1, xfb_offset=0) out ivec2 out1;
 layout(location = 1, xfb_buffer=1, xfb_offset=16) out dvec3 out2;
-
+layout(location = 4, component = 0, xfb_buffer = 2, xfb_offset = 0) out vec2 out4;
 
 layout(stream=1) out;
 layout(location = 3,xfb_buffer=0, xfb_offset=0) out dvec2 out3;
+layout(location = 4, component = 3, xfb_buffer = 3, xfb_offset = 0) out float out5;
 
 void main()
 {
@@ -98,11 +121,14 @@ void main()
         gl_Position = gl_in[i].gl_Position;
         out1 = ivec2(in1[i]);
         out2 = dvec3(in1[i].xy, in2[i].x);
+        out4 = in1[i];
         EmitStreamVertex(0);
+        EndStreamPrimitive(0);
         out3 = dvec2(in2[i]);
+        out5 = in2[i].x;
         EmitStreamVertex(1);
+        EndStreamPrimitive(1);
     }
-    EndPrimitive();
 }
 
 
@@ -115,13 +141,12 @@ entryPoint = main
 
 layout(location = 0) in flat ivec2 in1;
 layout(location = 1) in flat dvec3 in2;
-layout(location = 3) in flat dvec2 in3;
 
 layout(location = 0) out vec4 fragColor;
 
 void main(void)
 {
-    vec2 v = vec2(in1.xy) + vec2(in2.xy) + vec2(in3.xy);
+    vec2 v = vec2(in1.xy) + vec2(in2.xy);
     fragColor =  vec4(v.xy, float(in2.z), 1.0);
 }
 


### PR DESCRIPTION
The component index of an output is also allowed to be non-zero when exporting to a transform feedback buffer. But we assume the index is zero-based. This case triggers the assertion
`assert(outputLocInfoMap.count(origLocInfo));` in the output packing path in `PatchCopyShader::exportOutput`. The reason is that the keys of the two output maps are not equal any more. `outputLocInfoMap` is build from the generic output calls that include the info of the component index, while `locInfoXfbOutInfoMap` is built from xfb output calls that lack the info of component index. In order to get component index for `locInfoXfbOutInfoMap`, we need modify the interface `CreateWriteXfbOutput` to pass the component index through function argmument.
Update PipelineGsTess_TestInOutPacking.pipe to cover this case.