### PR TITLE
Change constant arrays to be non-zero

### DIFF
--- a/llpc/test/shaderdb/object/ObjConstant_TestMatrix_lit.frag
+++ b/llpc/test/shaderdb/object/ObjConstant_TestMatrix_lit.frag
@@ -9,11 +9,11 @@ layout(location = 0) out vec4 fragColor;
 
 void main()
 {
-    const vec3 f3 = vec3(0.0);
+    const vec3 f3 = vec3(0.0, 1.0, 0.0);
 
-    const mat4 m4 = mat4(0.0);
+    const mat4 m4 = mat4(vec4(0.0), vec4(1.0), vec4(1.0), vec4(0.0));
 
-    const bool b1[3] = { false, false, false };
+    const bool b1[3] = { false, true, false };
 
     fragColor = b1[i] ? vec4(f3[i]) : m4[i];
 }
@@ -24,7 +24,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: @{{.*}} = {{.*}} addrspace(4) constant [4 x <4 x float>] zeroinitializer
+; SHADERTEST: @{{.*}} = {{.*}} addrspace(4) constant [4 x <4 x float>] [<4 x float> zeroinitializer,
 ; SHADERTEST: getelementptr [4 x <4 x float>], ptr addrspace(4) @{{.*}}, i64 0, i64 %{{[0-9]*}}
 ; SHADERTEST: AMDLLPC SUCCESS
 */


### PR DESCRIPTION
After this upstream LLVM commit, a load from a constant zero array will be optimized away: be88b5814d9e [InstCombine] Call simplifyLoadInst()

To keep this test testing something useful, change the constant arrays to be non-zero.