### PR TITLE
[CMake] Apply compiler options to vfx

### DIFF
--- a/tool/vfx/CMakeLists.txt
+++ b/tool/vfx/CMakeLists.txt
@@ -46,3 +46,4 @@ target_compile_definitions(vfx PRIVATE VFX_SUPPORT_VK_PIPELINE SH_EXPORTING)
 target_include_directories(vfx PUBLIC ${PROJECT_SOURCE_DIR})
 
 target_link_libraries(vfx PRIVATE spvgen_static vkgc_headers khronos_vulkan_interface khronos_spirv_interface)
+set_compiler_options(vfx ${VFX_ENABLE_WERROR})

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -241,7 +241,6 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
       auto shaderSection = reinterpret_cast<SectionShader *>(m_sections[SectionTypeShader][i]);
       auto shaderInfoSection = reinterpret_cast<SectionShaderInfo *>(m_sections[SectionTypeShaderInfo][i]);
       VFX_ASSERT(shaderSection->getShaderStage() == shaderInfoSection->getShaderStage());
-      auto stage = shaderSection->getShaderStage();
 
       shaderSections[m_sections[SectionTypeShader][i]->getLineNum()] =
           std::pair<SectionShader *, SectionShaderInfo *>(shaderSection, shaderInfoSection);
@@ -518,6 +517,7 @@ void PipelineDocument::DeduplicateResourceMappingData(Vkgc::ResourceMappingData 
     auto iter = staticMap.find(key);
     if (iter == staticMap.end()) {
       auto result = staticMap.insert({key, descriptorRangeValue});
+      (void)result;
       VFX_ASSERT(result.second);
     } else {
       iter->second.visibility |= descriptorRangeValue.visibility;


### PR DESCRIPTION
Apply the default llpc compiler options to vfx.
This gives colorful error messages and silences some warnings that are disabled in llpc.
Fix a (now) error from an unused variable.