### PR TITLE
Enable sample shading whenever gl_sampleId/gl_samplePostion is declared

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -107,6 +107,7 @@ enum class ThreadGroupSwizzleMode : unsigned {
 static const unsigned ShadowDescriptorTableDisable = ~0U;
 
 static const char XfbStateMetadataName[] = "lgc.xfb.state";
+static const char SampleShadingMetaName[] = "lgc.sample.shading";
 
 // Middle-end per-pipeline options to pass to SetOptions.
 // The front-end should zero-initialize it with "= {}" in case future changes add new fields.

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1134,9 +1134,9 @@ void PatchResourceCollect::processShader() {
   }
 
   if (m_shaderStage == ShaderStageFragment) {
-    if (m_resUsage->builtInUsage.fs.fragCoord || m_resUsage->builtInUsage.fs.pointCoord ||
-        m_resUsage->builtInUsage.fs.sampleMaskIn) {
-      if (m_pipelineState->getRasterizerState().perSampleShading)
+    if (m_pipelineState->getRasterizerState().perSampleShading) {
+      if (m_resUsage->builtInUsage.fs.fragCoord || m_resUsage->builtInUsage.fs.pointCoord ||
+          m_resUsage->builtInUsage.fs.sampleMaskIn || m_resUsage->resourceWrite)
         m_resUsage->builtInUsage.fs.runAtSampleRate = true;
     }
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1262,6 +1262,10 @@ void PipelineState::recordGraphicsState(Module *module) {
 void PipelineState::readGraphicsState(Module *module) {
   readNamedMetadataArrayOfInt32(module, IaStateMetadataName, m_inputAssemblyState);
   readNamedMetadataArrayOfInt32(module, RsStateMetadataName, m_rasterizerState);
+
+  auto nameMeta = module->getNamedMetadata(SampleShadingMetaName);
+  if (nameMeta)
+    m_rasterizerState.perSampleShading |= 1;
 }
 
 // =====================================================================================================================

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7692,6 +7692,19 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
       if (bv->hasDecorate(DecorationBuiltIn, 0, &builtIn)) {
         inOutDec.IsBuiltIn = true;
         inOutDec.Value.BuiltIn = builtIn;
+
+        // NOTE: According to the vulkan spec, sample shading is enabled if the fragment shader's entry point
+        // interface includes input variables decorated with a BuiltIn of SampleId or SamplePosition built-ins.
+        // If gl_sampleId or gl_samplePosition is declared but not used in a fragment shader, it will be removed
+        // in lower stage, in those cases, we need to add metadata and use it later.
+        if ((m_execModule == ExecutionModelFragment) &&
+            (builtIn == spv::BuiltInSampleId || builtIn == spv::BuiltInSamplePosition)) {
+          auto nameMeta = m_m->getNamedMetadata(lgc::SampleShadingMetaName);
+          if (!nameMeta) {
+            nameMeta = m_m->getOrInsertNamedMetadata(lgc::SampleShadingMetaName);
+            nameMeta->addOperand(MDNode::get(*m_context, MDString::get(*m_context, lgc::SampleShadingMetaName)));
+          }
+        }
 #if VKI_RAY_TRACING
         Llpc::Context *llpcContext = static_cast<Llpc::Context *>(m_context);
         llpcContext->getPipelineContext()->collectBuiltIn(builtIn);


### PR DESCRIPTION
According to the vulkan spec, sample shading is enabled if the fragment

shader's entry point interface includes input variables decorated with a

BuiltIn of SampleId or SamplePosition built-ins.

If gl_sampleId or gl_samplePosition is declared but not used in a fragment

shader, it will be removed in lower stage, in those cases, we need to add

metadata and use it later.