### PR TITLE
NGG coding rework: Some changes of primitive shader entry-point

### DIFF
--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -204,8 +204,7 @@ private:
   static unsigned calcVertexCullInfoSizeAndOffsets(PipelineState *pipelineState,
                                                    VertexCullInfoOffsets &vertCullInfoOffsets);
 
-  llvm::FunctionType *generatePrimShaderEntryPointType(llvm::Module *module, uint64_t *inRegMask);
-  llvm::Function *generatePrimShaderEntryPoint(llvm::Module *module);
+  llvm::FunctionType *getPrimShaderType(uint64_t &inRegMask);
 
   void buildPrimShaderCbLayoutLookupTable();
 


### PR DESCRIPTION
The primitive shader generation is splitted by 'generate' and 'generatePrimShaderEntryPoint'. It is better to merge them together. Also, apply those change:
- Remove 'generatePrimShaderEntryPoint'. Move the implementation to 'generate'.
- Rename 'generatePrimShaderEntryPointType' to 'getPrimShaderType'.