### PR TITLE
Align GFX11 NGG settings with what driver does in standalone compiler

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -437,6 +437,9 @@ struct GfxIpVersion {
   bool operator>=(const GfxIpVersion &rhs) const {
     return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
   }
+  bool isGfx(unsigned rhsMajor, unsigned rhsMinor) const {
+    return std::tie(major, minor) == std::tie(rhsMajor, rhsMinor);
+  }
 };
 
 /// Represents shader binary data.

--- a/llpc/tool/amdllpc.cpp
+++ b/llpc/tool/amdllpc.cpp
@@ -374,13 +374,17 @@ static Result init(int argc, char *argv[], ICompiler *&compiler) {
   }
 
   // Change defaults of NGG options according to GFX IP
-  if (ParsedGfxIp >= GfxIpVersion{10, 3}) {
-    // For GFX10.3+, we always prefer to enable NGG. Backface culling and small primitive filter are enabled as
-    // well. Also, the compaction mode is set to compactionless.
+  if (ParsedGfxIp.isGfx(10, 3)) {
+    // For GFX10.3, we always prefer to enable NGG. Backface culling and small primitive filter are enabled as
+    // well. Also, we disable vertex compaction.
     EnableNgg.setValue(true);
     NggCompactVertex.setValue(false);
     NggEnableBackfaceCulling.setValue(true);
     NggEnableSmallPrimFilter.setValue(true);
+  } else if (ParsedGfxIp.major >= 11) {
+    // For GFX11+, NGG must be enabled because the legacy pipeline mode is removed. Still, we disable vertex compaction.
+    EnableNgg.setValue(true);
+    NggCompactVertex.setValue(false);
   }
 
   // Provide a default for -shader-cache-file-dir, as long as the environment variables below are


### PR DESCRIPTION
Disable BackfaceCulling and SmallPrimFilter since XGL driver also disables them as well. The standalone compiler must follow the same settings.