### PR TITLE
Complete the dialect-ification of buffer pointers

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -176,10 +176,8 @@ Type *Builder::getTransposedMatrixTy(Type *const matrixType) const {
 
 // =====================================================================================================================
 // Get the type of pointer returned by CreateLoadBufferDesc.
-//
-// @param pointeeTy : Type that the returned pointer should point to.
-PointerType *Builder::getBufferDescTy(Type *pointeeTy) {
-  return PointerType::get(pointeeTy, ADDR_SPACE_BUFFER_FAT_POINTER);
+PointerType *Builder::getBufferDescTy() {
+  return PointerType::get(getContext(), ADDR_SPACE_BUFFER_FAT_POINTER);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1085,10 +1085,9 @@ Value *BuilderRecorder::CreateFindSMsb(Value *value, const Twine &instName) {
 // @param binding : Descriptor binding
 // @param descIndex : Descriptor index
 // @param flags : BufferFlag* bit settings
-// @param pointeeTy : Type that the returned pointer should point to
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Value *descIndex, unsigned flags,
-                                             Type *pointeeTy, const Twine &instName) {
+                                             const Twine &instName) {
   return record(Opcode::LoadBufferDesc, getBufferDescTy(),
                 {
                     getInt32(descSet),

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1089,7 +1089,7 @@ Value *BuilderRecorder::CreateFindSMsb(Value *value, const Twine &instName) {
 // @param instName : Name to give instruction(s)
 Value *BuilderRecorder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Value *descIndex, unsigned flags,
                                              Type *pointeeTy, const Twine &instName) {
-  return record(Opcode::LoadBufferDesc, getBufferDescTy(pointeeTy),
+  return record(Opcode::LoadBufferDesc, getBufferDescTy(),
                 {
                     getInt32(descSet),
                     getInt32(binding),

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -397,11 +397,10 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
 
   // Replayer implementations of DescBuilder methods
   case BuilderRecorder::Opcode::LoadBufferDesc: {
-    return m_builder->CreateLoadBufferDesc(cast<ConstantInt>(args[0])->getZExtValue(), // descSet
-                                           cast<ConstantInt>(args[1])->getZExtValue(), // binding
-                                           args[2],                                    // descIndex
-                                           cast<ConstantInt>(args[3])->getZExtValue(), // flags
-                                           m_builder->getInt8Ty());                    // pointeeTy
+    return m_builder->CreateLoadBufferDesc(cast<ConstantInt>(args[0])->getZExtValue(),  // descSet
+                                           cast<ConstantInt>(args[1])->getZExtValue(),  // binding
+                                           args[2],                                     // descIndex
+                                           cast<ConstantInt>(args[3])->getZExtValue()); // flags
   }
 
   case BuilderRecorder::Opcode::GetDescStride:

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -189,7 +189,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
   // Convert to fat pointer.
   desc = CreateNamedCall(lgcName::LateLaunderFatPointer, getInt8Ty()->getPointerTo(ADDR_SPACE_BUFFER_FAT_POINTER), desc,
                          Attribute::ReadNone);
-  return CreateBitCast(desc, getBufferDescTy(pointeeTy));
+  return desc;
 }
 
 // =====================================================================================================================

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -53,10 +53,9 @@ using namespace llvm;
 // @param binding : Descriptor binding
 // @param descIndex : Descriptor index
 // @param flags : BufferFlag* bit settings
-// @param pointeeTy : Type that the returned pointer should point to.
 // @param instName : Name to give instruction(s)
 Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Value *descIndex, unsigned flags,
-                                         Type *const pointeeTy, const Twine &instName) {
+                                         const Twine &instName) {
   Value *desc = nullptr;
   bool return64Address = false;
   descIndex = scalarizeIfUniform(descIndex, flags & BufferFlagNonUniform);

--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -186,9 +186,7 @@ Value *DescBuilder::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
     desc->setName(instName);
 
   // Convert to fat pointer.
-  desc = CreateNamedCall(lgcName::LateLaunderFatPointer, getInt8Ty()->getPointerTo(ADDR_SPACE_BUFFER_FAT_POINTER), desc,
-                         Attribute::ReadNone);
-  return desc;
+  return create<BufferDescToPtrOp>(desc);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1177,8 +1177,7 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
       auto bufferDesc = CreateLoadBufferDesc(options.reverseThreadGroupBufferDescSet,
                                              options.reverseThreadGroupBufferBinding, getInt32(0), 0, getInt8Ty());
       auto controlBitPtr = CreateInBoundsGEP(getInt8Ty(), bufferDesc, getInt32(0));
-      auto controlBit = CreateTrunc(
-          CreateLoad(getInt32Ty(), CreateBitCast(controlBitPtr, getBufferDescTy(getInt32Ty()))), getInt1Ty());
+      auto controlBit = CreateTrunc(CreateLoad(getInt32Ty(), controlBitPtr), getInt1Ty());
 
       workgroupId = CreateSelect(controlBit, reversedWorkgroupId, workgroupId);
     }

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1175,7 +1175,7 @@ Value *InOutBuilder::readCsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
 
       // Load control bit from internal buffer
       auto bufferDesc = CreateLoadBufferDesc(options.reverseThreadGroupBufferDescSet,
-                                             options.reverseThreadGroupBufferBinding, getInt32(0), 0, getInt8Ty());
+                                             options.reverseThreadGroupBufferBinding, getInt32(0), 0);
       auto controlBitPtr = CreateInBoundsGEP(getInt8Ty(), bufferDesc, getInt32(0));
       auto controlBit = CreateTrunc(CreateLoad(getInt32Ty(), controlBitPtr), getInt1Ty());
 

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -292,7 +292,7 @@ public:
 
   // Create a load of a buffer descriptor.
   llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, unsigned flags,
-                                    llvm::Type *pointeeTy, const llvm::Twine &instName) override final;
+                                    const llvm::Twine &instName) override final;
 
   // Create a get of the stride (in bytes) of a descriptor.
   llvm::Value *CreateGetDescStride(ResourceNodeType concreteType, ResourceNodeType abstractType, unsigned descSet,

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -356,7 +356,7 @@ public:
   // Descriptor operations
 
   llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, unsigned flags,
-                                    llvm::Type *pointeeTy, const llvm::Twine &instName) override final;
+                                    const llvm::Twine &instName) override final;
 
   llvm::Value *CreateGetDescStride(ResourceNodeType concreteType, ResourceNodeType abstractType, unsigned descSet,
                                    unsigned binding, const llvm::Twine &instName) override final;

--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -75,7 +75,6 @@ private:
   Replacement getRemappedValue(llvm::Value *value) const;
   llvm::Value *getBaseAddressFromBufferDesc(llvm::Value *const bufferDesc) const;
   void copyMetadata(llvm::Value *const dest, const llvm::Value *const src) const;
-  llvm::PointerType *getRemappedType(llvm::Type *const type) const;
   bool removeUsersForInvariantStarts(llvm::Value *const value);
   llvm::Value *replaceLoadStore(llvm::Instruction &loadInst);
   llvm::Value *replaceICmp(llvm::ICmpInst *const iCmpInst);
@@ -93,6 +92,7 @@ private:
   llvm::SmallVector<llvm::Instruction *, 16> m_postVisitInsts; // The post process instruction set.
   llvm::IRBuilder<> *m_builder;                                // The IRBuilder.
   llvm::LLVMContext *m_context;                                // The LLVM context.
+  llvm::PointerType *m_offsetType;                             // The proxy pointer type used to accumulate offsets.
   PipelineState *m_pipelineState;                              // The pipeline state
 
   std::function<bool(const llvm::Value &)> m_isDivergent;

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -102,8 +102,6 @@ const static char SpecialUserData[] = "lgc.special.user.data.";
 // Get shader input. Arg is ShaderInput enum value.
 const static char ShaderInput[] = "lgc.shader.input.";
 
-const static char LateLaunderFatPointer[] = "lgc.late.launder.fat.pointer";
-
 // Names of global variables
 const static char ImmutableSamplerGlobal[] = "lgc.immutable.sampler";
 const static char ImmutableConvertingSamplerGlobal[] = "lgc.immutable.converting.sampler";

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -706,7 +706,7 @@ public:
   };
 
   // Get the type of pointer returned by CreateLoadBufferDesc.
-  llvm::PointerType *getBufferDescTy(llvm::Type *pointeeTy);
+  llvm::PointerType *getBufferDescTy();
 
   // Create a load of a buffer descriptor.
   //

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -717,10 +717,9 @@ public:
   // @param binding : Descriptor binding
   // @param descIndex : Descriptor index
   // @param flags : BufferFlag* bit settings
-  // @param pointeeTy : Type that the returned pointer should point to.
   // @param instName : Name to give instruction(s)
   virtual llvm::Value *CreateLoadBufferDesc(unsigned descSet, unsigned binding, llvm::Value *descIndex, unsigned flags,
-                                            llvm::Type *pointeeTy, const llvm::Twine &instName = "") = 0;
+                                            const llvm::Twine &instName = "") = 0;
 
   // Get the type of a descriptor
   //

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -30,9 +30,9 @@ def LgcDialect : Dialect {
   let cppNamespace = "lgc";
 }
 
-def BufferPointer : PointerType<7>;
+def BufferPointer : TgConstant<(PointerType 7)>, Type;
 
-def V4I32 : FixedVectorType<4, I32>;
+def V4I32 : TgConstant<(FixedVectorType I32, 4)>, Type;
 
 class LgcOp<string mnemonic_, list<Trait> traits_ = []>
     : Op<LgcDialect, mnemonic_, traits_ # [NoUnwind]>;
@@ -53,7 +53,7 @@ class LgcOp<string mnemonic_, list<Trait> traits_ = []>
 
 def BufferLengthOp : LgcOp<"buffer.length", [Memory<[]>, WillReturn]> {
   // TODO: Change to BufferPointer after we switch to opaque pointers.
-  let arguments = (ins AnyPointerType:$pointer, I32:$offset);
+  let arguments = (ins PointerType:$pointer, I32:$offset);
   let results = (outs I32:$result);
 
   let summary = "return the size of a buffer";
@@ -70,10 +70,8 @@ def BufferLengthOp : LgcOp<"buffer.length", [Memory<[]>, WillReturn]> {
 
 def BufferPtrDiffOp : LgcOp<"buffer.ptr.diff", [Memory<[]>, WillReturn]> {
   // TODO: Change to BufferPointer after we switch to opaque pointers.
-  let arguments = (ins AnyPointerType:$lhs, AnyPointerType:$rhs);
+  let arguments = (ins PointerType:$lhs, (eq $lhs):$rhs);
   let results = (outs I64:$result);
-
-  let verifier = [(SameTypes $lhs, $rhs)];
 
   let summary = "return the difference between buffer pointers in bytes";
   let description = [{

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -37,23 +37,21 @@ def V4I32 : TgConstant<(FixedVectorType I32, 4)>, Type;
 class LgcOp<string mnemonic_, list<Trait> traits_ = []>
     : Op<LgcDialect, mnemonic_, traits_ # [NoUnwind]>;
 
-// TODO: Enable this once we have made the switch to opaque pointers.
-//def BufferDescToPtrOp : LgcOp<"buffer.desc.to.ptr", [ReadNone, WillReturn]> {
-//  let arguments = (ins V4I32:$desc);
-//  let results = (outs BufferPointer:$result);
-//
-//  let summary = "convert a buffer descriptor into a buffer pointer";
-//  let description = [{
-//    Given a buffer descriptor for a storage buffer, returns a fat buffer pointer to the start of the buffer.
-//
-//    The descriptor must be a null descriptor or a valid descriptor for a storage buffer aka raw buffer, i.e. a buffer
-//    for which the indexing feature of BUFFER_LOAD_* instructions is never used.
-//  }];
-//}
+def BufferDescToPtrOp : LgcOp<"buffer.desc.to.ptr", [Memory<[]>, WillReturn]> {
+  let arguments = (ins V4I32:$desc);
+  let results = (outs BufferPointer:$result);
+
+  let summary = "convert a buffer descriptor into a buffer pointer";
+  let description = [{
+    Given a buffer descriptor for a storage buffer, returns a fat buffer pointer to the start of the buffer.
+
+    The descriptor must be a null descriptor or a valid descriptor for a storage buffer aka raw buffer, i.e. a buffer
+    for which the indexing feature of BUFFER_LOAD_* instructions is never used.
+  }];
+}
 
 def BufferLengthOp : LgcOp<"buffer.length", [Memory<[]>, WillReturn]> {
-  // TODO: Change to BufferPointer after we switch to opaque pointers.
-  let arguments = (ins PointerType:$pointer, I32:$offset);
+  let arguments = (ins BufferPointer:$pointer, I32:$offset);
   let results = (outs I32:$result);
 
   let summary = "return the size of a buffer";
@@ -69,8 +67,7 @@ def BufferLengthOp : LgcOp<"buffer.length", [Memory<[]>, WillReturn]> {
 }
 
 def BufferPtrDiffOp : LgcOp<"buffer.ptr.diff", [Memory<[]>, WillReturn]> {
-  // TODO: Change to BufferPointer after we switch to opaque pointers.
-  let arguments = (ins PointerType:$lhs, (eq $lhs):$rhs);
+  let arguments = (ins BufferPointer:$lhs, BufferPointer:$rhs);
   let results = (outs I64:$result);
 
   let summary = "return the difference between buffer pointers in bytes";

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -563,9 +563,8 @@ bool LowerVertexFetch::runImpl(Module &module, PipelineState *pipelineState) {
     std::unique_ptr<lgc::Builder> desBuilder(Builder::createBuilderImpl(pipelineState->getLgcContext(), pipelineState));
     static_cast<BuilderImplBase *>(&*desBuilder)->setShaderStage(ShaderStageVertex);
     desBuilder->SetInsertPoint(&(*vertexFetches[0]->getFunction()->front().getFirstInsertionPt()));
-    auto desc =
-        desBuilder->CreateLoadBufferDesc(InternalDescriptorSetId, FetchShaderInternalBufferBinding,
-                                         desBuilder->getInt32(0), Builder::BufferFlagAddress, desBuilder->getInt8Ty());
+    auto desc = desBuilder->CreateLoadBufferDesc(InternalDescriptorSetId, FetchShaderInternalBufferBinding,
+                                                 desBuilder->getInt32(0), Builder::BufferFlagAddress);
 
     // The size of each input descriptor is sizeof(UberFetchShaderAttribInfo). vector4
     auto uberFetchAttrType = FixedVectorType::get(builder.getInt32Ty(), 4);

--- a/lgc/test/TextureRange.lgc
+++ b/lgc/test/TextureRange.lgc
@@ -4,8 +4,8 @@
 ; CHECK: [[desc0:%[0-9]+]] = call ptr addrspace(4) @lgc.descriptor.table.addr(i32 6
 ; CHECK-NEXT: %{{.*}} = getelementptr i8, ptr addrspace(4) [[desc0]], i32 16
 ; CHECK: call <2 x i32> @lgc.root.descriptor.v2i32(i32 6)
-; CHECK: call ptr addrspace(7) @lgc.late.launder.fat.pointer(<4 x i32>
-; CHECK: [[varindex0:%[0-9]+]] = call ptr addrspace(7) @lgc.late.launder.fat.pointer(<4 x i32>
+; CHECK: call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32>
+; CHECK: [[varindex0:%[0-9]+]] = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32>
 ; CHECK: [[varindex1:%[0-9]+]] = load i32, ptr addrspace(7) [[varindex0]], align 4
 ; CHECK-NEXT: [[varindex2:%[0-9]+]] = sext i32 [[varindex1]] to i64
 ; CHECK-NEXT: getelementptr <{ [4294967295 x float] }>, ptr addrspace(7) %{{.*}}, i64 0, i32 0, i64 [[varindex2]]

--- a/lgc/test/Transforms/PatchBufferOp/simple.lgc
+++ b/lgc/test/Transforms/PatchBufferOp/simple.lgc
@@ -7,11 +7,11 @@ define amdgpu_gfx float @simple(<4 x i32> inreg %desc) !lgc.shaderstage !0 {
 ; CHECK-NEXT:    [[TMP2:%.*]] = bitcast i32 [[TMP1]] to float
 ; CHECK-NEXT:    ret float [[TMP2]]
 ;
-  %ptr = call ptr addrspace(7) @lgc.late.launder.fat.pointer(<4 x i32> %desc)
+  %ptr = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc)
   %r = load float, ptr addrspace(7) %ptr
   ret float %r
 }
 
-declare ptr addrspace(7) @lgc.late.launder.fat.pointer(<4 x i32>) nounwind readnone
+declare ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32>) nounwind readnone
 
 !0 = !{i32 7}

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -2314,8 +2314,8 @@ void SpirvLowerGlobal::lowerBufferBlock() {
             // does not change!), and has removed it.
             m_builder->SetInsertPoint(replaceInstsInfo.bitCastInst);
             unsigned bufferFlags = global.isConstant() ? 0 : lgc::Builder::BufferFlagWritten;
-            Value *const bufferDesc = m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0),
-                                                                      bufferFlags, m_builder->getInt8Ty());
+            Value *const bufferDesc =
+                m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0), bufferFlags);
 
             // If the global variable is a constant, the data it points to is invariant.
             if (global.isConstant())
@@ -2327,8 +2327,8 @@ void SpirvLowerGlobal::lowerBufferBlock() {
             // pointers are removing zero-index GEPs and BitCast with pointer to pointer cast.
             m_builder->SetInsertPoint(replaceInstsInfo.otherInst);
             unsigned bufferFlags = global.isConstant() ? 0 : lgc::Builder::BufferFlagWritten;
-            Value *const bufferDesc = m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0),
-                                                                      bufferFlags, m_builder->getInt8Ty());
+            Value *const bufferDesc =
+                m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0), bufferFlags);
 
             // If the global variable is a constant, the data it points to is invariant.
             if (global.isConstant())
@@ -2436,8 +2436,8 @@ void SpirvLowerGlobal::lowerBufferBlock() {
                 skipGlobals.insert(globals[nextGlobalIdx]);
               }
               for (unsigned idx = 0; idx < descCount; ++idx) {
-                bufferDescs[idx] = m_builder->CreateLoadBufferDesc(descSets[idx], bindings[idx], blockIndex,
-                                                                   bufferFlags, m_builder->getInt8Ty());
+                bufferDescs[idx] =
+                    m_builder->CreateLoadBufferDesc(descSets[idx], bindings[idx], blockIndex, bufferFlags);
                 // If the global variable is a constant, the data it points to is invariant.
                 if (global.isConstant())
                   m_builder->CreateInvariantStart(bufferDescs[idx]);
@@ -2482,8 +2482,8 @@ void SpirvLowerGlobal::lowerBufferBlock() {
       } else {
         m_builder->SetInsertPointPastAllocas(func);
         unsigned bufferFlags = global.isConstant() ? 0 : lgc::Builder::BufferFlagWritten;
-        Value *const bufferDesc = m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0), bufferFlags,
-                                                                  m_builder->getInt8Ty());
+        Value *const bufferDesc =
+            m_builder->CreateLoadBufferDesc(descSet, binding, m_builder->getInt32(0), bufferFlags);
 
         // If the global variable is a constant, the data it points to is invariant.
         if (global.isConstant())

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -2290,7 +2290,7 @@ Function *SpirvLowerRayTracing::getOrCreateRemapCapturedVaToReplayVaFunc() {
     auto loopIteratorPtr = m_builder->CreateAlloca(int32Ty, SPIRAS_Private);
 
     auto bufferDesc = m_builder->CreateLoadBufferDesc(Vkgc::InternalDescriptorSetId,
-                                                      Vkgc::RtCaptureReplayInternalBufferBinding, zero, 0, int8Ty);
+                                                      Vkgc::RtCaptureReplayInternalBufferBinding, zero, 0);
 
     auto numEntriesPtr = m_builder->CreateInBoundsGEP(int8Ty, bufferDesc, zero);
     auto numEntries = m_builder->CreateTrunc(m_builder->CreateLoad(int64Ty, numEntriesPtr), int32Ty);

--- a/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
@@ -194,8 +194,7 @@ Value *SpirvLowerRayTracingBuiltIn::processBuiltIn(GlobalVariable *global, Instr
     Value *rayDispatchWidthPtr =
         m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, offsetOfRayDispatchWidth, "");
     Type *int32x3Ty = FixedVectorType::get(m_builder->getInt32Ty(), 3);
-    Type *int32x3PtrTy = m_builder->getBufferDescTy(int32x3Ty);
-    input = m_builder->CreateLoad(int32x3Ty, m_builder->CreateBitCast(rayDispatchWidthPtr, int32x3PtrTy));
+    input = m_builder->CreateLoad(int32x3Ty, rayDispatchWidthPtr);
     break;
   }
   case BuiltInPrimitiveId: {
@@ -280,51 +279,49 @@ void SpirvLowerRayTracingBuiltIn::setShaderTableVariables(GlobalValue *global, S
                                                           Instruction *insertPos) {
   m_builder->SetInsertPoint(insertPos);
   Value *value = nullptr;
-  Type *int64PtrTy = m_builder->getBufferDescTy(m_builder->getInt64Ty());
-  Type *int32PtrTy = m_builder->getBufferDescTy(m_builder->getInt32Ty());
   Value *const bufferDesc = getDispatchRaysInfoDesc(insertPos);
 
   switch (tableKind) {
   case ShaderTable::RayGenTableAddr: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, rayGenerationTable);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt64Ty(), m_builder->CreateBitCast(valuePtr, int64PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt64Ty(), valuePtr);
     break;
   }
   case ShaderTable::MissTableAddr: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, missTable.baseAddress);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt64Ty(), m_builder->CreateBitCast(valuePtr, int64PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt64Ty(), valuePtr);
     break;
   }
   case ShaderTable::HitGroupTableAddr: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, hitGroupTable.baseAddress);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt64Ty(), m_builder->CreateBitCast(valuePtr, int64PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt64Ty(), valuePtr);
     break;
   }
   case ShaderTable::CallableTableAddr: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, callableTable.baseAddress);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt64Ty(), m_builder->CreateBitCast(valuePtr, int64PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt64Ty(), valuePtr);
     break;
   }
   case ShaderTable::MissTableStride: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, missTable.strideInBytes);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt32Ty(), m_builder->CreateBitCast(valuePtr, int32PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt32Ty(), valuePtr);
     break;
   }
   case ShaderTable::HitGroupTableStride: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, hitGroupTable.strideInBytes);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt32Ty(), m_builder->CreateBitCast(valuePtr, int32PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt32Ty(), valuePtr);
     break;
   }
   case ShaderTable::CallableTableStride: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, callableTable.strideInBytes);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt32Ty(), m_builder->CreateBitCast(valuePtr, int32PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt32Ty(), valuePtr);
     break;
   }
   case ShaderTable::ShaderRecordIndex: {
@@ -334,7 +331,7 @@ void SpirvLowerRayTracingBuiltIn::setShaderTableVariables(GlobalValue *global, S
   case ShaderTable::TraceRayGpuVirtAddr: {
     auto offset = offsetof(GpuRt::DispatchRaysInfoData, traceRayGpuVa);
     Value *valuePtr = m_builder->CreateInBoundsGEP(m_builder->getInt8Ty(), bufferDesc, m_builder->getInt32(offset), "");
-    value = m_builder->CreateLoad(m_builder->getInt64Ty(), m_builder->CreateBitCast(valuePtr, int64PtrTy));
+    value = m_builder->CreateLoad(m_builder->getInt64Ty(), valuePtr);
     break;
   }
   default: {

--- a/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
@@ -351,9 +351,8 @@ void SpirvLowerRayTracingBuiltIn::setShaderTableVariables(GlobalValue *global, S
 Value *SpirvLowerRayTracingBuiltIn::getDispatchRaysInfoDesc(Instruction *insertPos) {
   if (!m_dispatchRaysInfoDesc) {
     m_builder->SetInsertPoint(insertPos);
-    m_dispatchRaysInfoDesc =
-        m_builder->CreateLoadBufferDesc(TraceRayDescriptorSet, RayTracingResourceIndexDispatchRaysInfo,
-                                        m_builder->getInt32(0), 0, m_builder->getInt8Ty());
+    m_dispatchRaysInfoDesc = m_builder->CreateLoadBufferDesc(
+        TraceRayDescriptorSet, RayTracingResourceIndexDispatchRaysInfo, m_builder->getInt32(0), 0);
   }
   return m_dispatchRaysInfoDesc;
 }

--- a/llpc/test/shaderdb/general/CallInstAsUserOfGlobalVariable.spvasm
+++ b/llpc/test/shaderdb/general/CallInstAsUserOfGlobalVariable.spvasm
@@ -1,7 +1,7 @@
 ; This test checks if lowerGlobal is handling properly case with removed zero-index GEPs.
 
 ; @_ug_input23 = external addrspace(7) global [2 x <{ [4294967295 x float] }>], !spirv.Resource !2, !spirv.Block !1
-; %2 = call i32 (...) @lgc.buffer.length(ptr addrspace(7) @_ug_input23, i32 0)
+; %2 = call i32 @lgc.buffer.length(ptr addrspace(7) @_ug_input23, i32 0)
 
 
 
@@ -9,11 +9,11 @@
 
 ; CHECK-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; CHECK: @_ug_input23 = external addrspace(7) global [2 x <{ [4294967295 x float] }>], !spirv.Resource !2, !spirv.Block !1
-; CHECK: call i32 (...) @lgc.buffer.length(ptr addrspace(7) @_ug_input23, i32 0)
+; CHECK: call i32 @lgc.buffer.length(ptr addrspace(7) @_ug_input23, i32 0)
 
 ; CHECK-LABEL: {{^// LLPC}}  SPIR-V lowering results
 ; CHECK: %[[global:[0-9]+]] = call ptr addrspace(7) (...) @lgc.create.load.buffer.desc.p7(i32 2, i32 1, i32 0, i32 2)
-; CHECK: call i32 (...) @lgc.buffer.length(ptr addrspace(7) %[[global]], i32 0)
+; CHECK: call i32 @lgc.buffer.length(ptr addrspace(7) %[[global]], i32 0)
 
 ; CHECK-LABEL: {{^}}===== AMDLLPC SUCCESS =====
 

--- a/llpc/test/shaderdb/general/PipelineCs_MultipleRootInlineBuffer.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_MultipleRootInlineBuffer.pipe
@@ -30,7 +30,7 @@
 ; SHADERTEST: [[desc1_3:%[0-9]*]] = insertelement <4 x i32> [[desc1_2]], i32 151468, i64 3
 
 ; Get the "fat pointer" for the buffer
-; SHADERTEST: call ptr addrspace(7) @lgc.late.launder.fat.pointer(<4 x i32> [[desc1_3]]) #2
+; SHADERTEST: call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> [[desc1_3]])
 
 ; Get a pointer to the spill table
 ; SHADERTEST: [[spill_table0:%[0-9]*]] = call ptr addrspace(4) @lgc.spill.table() #2


### PR DESCRIPTION
Now that the transition to opaque pointers is complete, we can cleanly represent the lgc.buffer.desc.to.ptr operation and tighten up the type constraints on the other ops.

Also start using the llvm_dialects::Visitor as a type switch over operations. The idea here is that in the long run, the type switch can be optimized using something like a map lookup (this isn't implemented yet). There is still room for improvement in this part: ideally, we'd treat all instructions (native LLVM IR *and* dialect operations) as part of the same visitor, but that needs more changes in llvm-dialects.

This also updates llvm-dialects and contains a bunch of opaque pointer-related cleanups.