### PR TITLE
Mesh shader: Use GFX11 native HW localInvocationId

### DIFF
--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -595,6 +595,7 @@ struct InterfaceData {
         unsigned baseRingEntryIndex; // Base entry index (first workgroup) of mesh/task shader ring for current dispatch
         unsigned pipeStatsBuf;       // Pipeline statistics buffer
         unsigned flatWorkgroupId;    // Flat workgroup ID (emulated by HW vertex ID)
+        unsigned localInvocationId;  // Local invocation ID (GFX11+, packed)
       } mesh;
 
       // Fragment shader

--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -166,11 +166,13 @@ private:
     llvm::Value *threadIdInWave;
     llvm::Value *threadIdInSubgroup;
     llvm::Value *primOrVertexIndex;
-    // Following info is for GFX11+
+    llvm::Value *rowInSubgroup;
     llvm::Value *workgroupIdX;
     llvm::Value *workgroupIdY;
     llvm::Value *workgroupIdZ;
-    llvm::Value *rowInSubgroup;
+    llvm::Value *localInvocationIdX;
+    llvm::Value *localInvocationIdY;
+    llvm::Value *localInvocationIdZ;
   } m_waveThreadInfo = {};
 
   bool m_accessTaskPayload = false;                // Whether task shader has payload access operations


### PR DESCRIPTION
On GFX11+, GE passes local invocation ID to shader. The VGPR0 has the packed local invocation ID.

Also, remove some unnecessary mesh shader settings.