### PR TITLE
Revert the optimiaztion for the issue exposed by VK_EXT_image_sliced_…

### DIFF
--- a/lgc/include/lgc/util/GfxRegHandler.h
+++ b/lgc/include/lgc/util/GfxRegHandler.h
@@ -145,10 +145,6 @@ enum class SqRsrcRegs {
   Depth,
   Pitch,
   BcSwizzle,
-  BaseLevel,
-  LastLevel,
-  BaseArray,
-  LastArray, // only gfx6, gfx7 and gfx8
 
   // The following are introduced in gfx10.
   WidthLo,

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -31,16 +31,12 @@
 ; GFX900: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 ; GFX1010: %.lod = call <2 x float> @llvm.amdgcn.image.getlod.2d.v2f32.f32(i32 3, float 0.000000e+00, float 0.000000e+00, <8 x i32> %{{[0-9]+}}, <4 x i32> %{{[0-9]+}}, i1 false, i32 0, i32 0)
 
-; CHECK: [[WFDESC:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.readfirstlane
-; GFX900: [[WFDESC1:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.last.use.v8i32(i32 %{{[0-9]+}}, <8 x i32> [[WFDESC]])
-; GFX900: call void @llvm.amdgcn.image.store.2d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, i32 0, <8 x i32> [[WFDESC1]], i32 0, i32 0)
-; GFX1010: extractelement <8 x i32> [[WFDESC]], i64 3
-; GFX1010-NEXT: icmp sge i32
-; GFX1010-NEXT: and i32
-; GFX1010-NEXT: select i1
-; GFX1010-NEXT: [[PATCHED_DESC1:%[.a-zA-Z0-9]+]] = insertelement <8 x i32> [[WFDESC]]
-; GFX1010: [[WFDESC1:%[0-9]+]] = call <8 x i32> @llvm.amdgcn.waterfall.last.use.v8i32(i32 %{{[0-9]+}}, <8 x i32> [[PATCHED_DESC1]])
-; GFX1010: call void @llvm.amdgcn.image.store.1d.v4f32.i32(<4 x float> zeroinitializer, i32 15, i32 0, <8 x i32> [[WFDESC1]], i32 0, i32 0)
+; GFX900: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> %.desc, i32 0, i32 0)
+; GFX1010: call <4 x float> @llvm.amdgcn.image.getresinfo.2d.v4f32.i32(i32 15, i32 0, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
+
+; GFX900: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> %.desc, i32 0, i32 0)
+; GFX1010: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef, <8 x i32> [[PATCHED_DESC0]], i32 0, i32 0)
+
 ; ModuleID = 'lgcPipeline'
 source_filename = "lgcPipeline"
 target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7"

--- a/lgc/util/GfxRegHandler.cpp
+++ b/lgc/util/GfxRegHandler.cpp
@@ -178,10 +178,6 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx6[static_cast<unsigned>(SqRsrcRegs:
     {4, 0, 13},  // Depth
     {4, 13, 14}, // Pitch
     {},          // BcSwizzle
-    {3, 12, 4},  // BaseLevel
-    {3, 16, 4},  // LastLevel
-    {5, 0, 13},  // BaseArray
-    {5, 13, 13}, // LastArray
     {},          // WidthLo
     {},          // WidthHi
 };
@@ -200,10 +196,6 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx9[static_cast<unsigned>(SqRsrcRegs:
     {4, 0, 13},  // Depth
     {4, 13, 12}, // Pitch
     {4, 29, 3},  // BcSwizzle
-    {3, 12, 4},  // BaseLevel
-    {3, 16, 4},  // LastLevel
-    {5, 0, 13},  // BaseArray
-    {},          // LastArray
     {},          // WidthLo
     {},          // WidthHi
 };
@@ -222,10 +214,6 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx10[static_cast<unsigned>(SqRsrcRegs
     {4, 0, 13},  // Depth
     {},          // Pitch
     {3, 25, 3},  // BcSwizzle
-    {3, 12, 4},  // BaseLevel
-    {3, 16, 4},  // LastLevel
-    {4, 16, 13}, // BaseArray
-    {},          // LastArray
     {1, 30, 2},  // WidthLo
     {2, 0, 12},  // WidthHi
 };
@@ -244,10 +232,6 @@ static constexpr BitsInfo SqImgRsrcRegBitsGfx11[static_cast<unsigned>(SqRsrcRegs
     {4, 0, 13},  // Depth
     {},          // Pitch
     {3, 25, 3},  // BcSwizzle
-    {3, 12, 4},  // BaseLevel
-    {3, 16, 4},  // LastLevel
-    {4, 16, 13}, // BaseArray
-    {},          // LastArray
     {1, 30, 2},  // WidthLo
     {2, 0, 12},  // WidthHi
 };
@@ -294,12 +278,9 @@ Value *SqImgRsrcRegHandler::getReg(SqRsrcRegs regId) {
   case SqRsrcRegs::Format:
   case SqRsrcRegs::DstSelXYZW:
   case SqRsrcRegs::SwizzleMode:
-  case SqRsrcRegs::BcSwizzle:
-  case SqRsrcRegs::BaseLevel:
-  case SqRsrcRegs::LastLevel:
-  case SqRsrcRegs::BaseArray:
-    return getRegCommon(static_cast<unsigned>(regId));
   case SqRsrcRegs::Depth:
+  case SqRsrcRegs::BcSwizzle:
+    return getRegCommon(static_cast<unsigned>(regId));
   case SqRsrcRegs::Height:
   case SqRsrcRegs::Pitch:
     return m_builder->CreateAdd(getRegCommon(static_cast<unsigned>(regId)), m_one);
@@ -314,16 +295,6 @@ Value *SqImgRsrcRegHandler::getReg(SqRsrcRegs regId) {
     case 11:
       return m_builder->CreateAdd(
           getRegCombine(static_cast<unsigned>(SqRsrcRegs::WidthLo), static_cast<unsigned>(SqRsrcRegs::WidthHi)), m_one);
-    default:
-      llvm_unreachable("GFX IP is not supported!");
-      break;
-    }
-  case SqRsrcRegs::LastArray:
-    switch (m_gfxIpVersion->major) {
-    case 6:
-    case 7:
-    case 8:
-      return getRegCommon(static_cast<unsigned>(regId));
     default:
       llvm_unreachable("GFX IP is not supported!");
       break;

--- a/llpc/test/shaderdb/core/OpImageQueryLevels_TestBasic_lit.comp
+++ b/llpc/test/shaderdb/core/OpImageQueryLevels_TestBasic_lit.comp
@@ -76,6 +76,20 @@ void main()
 ; SHADERTEST: call i32 (...) @lgc.create.image.query.levels.i32(i32 8, i32 512, {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.3d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2darray.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQueryLevels_TestTextureQueryLevels_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQueryLevels_TestTextureQueryLevels_lit.frag
@@ -36,6 +36,10 @@ void main()
 ; SHADERTEST: call i32 (...) @lgc.create.image.query.levels.i32(i32 8, i32 128, <8 x {{.*}})
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 8, i32 undef,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQuerySizeLod_TestTextureSize_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQuerySizeLod_TestTextureSize_lit.frag
@@ -31,6 +31,9 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 2, i32 512, {{.*}}, i32 5)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 3,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 4,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.3d.v3f32.i32(i32 7, i32 5,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQuerySize_TestBasic_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQuerySize_TestBasic_lit.frag
@@ -111,6 +111,21 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 7, i32 512, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.3d.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.1darray.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darray.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQuerySize_TestImageSize_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQuerySize_TestImageSize_lit.frag
@@ -40,6 +40,10 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 8, i32 128, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.2dmsaa.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.cube.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQuerySize_TestImage_lit.comp
+++ b/llpc/test/shaderdb/core/OpImageQuerySize_TestImage_lit.comp
@@ -63,6 +63,16 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.i32(i32 0, i32 512, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call float @llvm.amdgcn.image.getresinfo.1d.f32.i32(i32 1, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.3d.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.cube.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.1darray.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darray.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <{{3|4}} x float> @llvm.amdgcn.image.getresinfo.cube.v{{3|4}}f32.i32(i32 {{7|15}}, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQuerySize_TestSeparated_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQuerySize_TestSeparated_lit.frag
@@ -19,6 +19,7 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v2i32(i32 1, i32 512, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpImageQuerySize_TestTextureSize_lit.frag
+++ b/llpc/test/shaderdb/core/OpImageQuerySize_TestTextureSize_lit.frag
@@ -34,6 +34,9 @@ void main()
 ; SHADERTEST: call {{.*}} @lgc.create.image.query.size.v3i32(i32 7, i32 128, {{.*}}, i32 0)
 
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2d.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <2 x float> @llvm.amdgcn.image.getresinfo.2dmsaa.v2f32.i32(i32 3, i32 0,{{.*}}, i32 0, i32 0)
+; SHADERTEST: call <3 x float> @llvm.amdgcn.image.getresinfo.2darraymsaa.v3f32.i32(i32 7, i32 0,{{.*}}, i32 0, i32 0)
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
…view_of_3d

    This issue has been exposed by the new extension: VK_EXT_image_sliced_view_of_3d.There are some cases failed on LLPC:

    Taking the shader codes for example:

        layout (local_size_x=8, local_size_y=8, local_size_z=1) in;
        layout (rgba8ui, set=0, binding=0) uniform uimage3D slicedImage;
        layout (rgba8ui, set=0, binding=1) uniform uimage3D auxiliarImage;
        void main (void) {
            const ivec3 coords = ivec3(ivec2(gl_LocalInvocationID.xy), int(gl_WorkGroupID.x));
            const ivec3 size = imageSize(slicedImage);
            const uvec4 badColor = uvec4(0, 0, 0, 0);
            const uvec4 goodColor = imageLoad(slicedImage, coords);
            const uvec4 storedColor = ((size.z == 1) ? goodColor : badColor);
            imageStore(auxiliarImage, coords, storedColor);
        }
    With current optimization, LLPC will extract related bits from SRD in ImageBuilder::CreateImageQuerySize.  Two issues here:
        1.      The calculation logic for “depth”  is different between LLPC and driver side,
                especially for Dim3D, more variables are used under the driver side and the calculation logic is hard to replay on CreateImageQuerySize。
        2.      About mipLevel: for some failed cases on this extension, there isn’t any OpImageQueryLod in the shader, so even the image has some mipLevel info, it hasn’t been queried.
                Then “depth = CreateLShr(depth, CreateAdd(baseLevel, lod));” will be failed as lod is always zero.