### PR TITLE
Fix unused-but-set-variable warning

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1054,11 +1054,6 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
 
   if (m_pipelineState->useRegisterFieldFormat()) {
     constexpr unsigned NumUserSgprs = 32;
-    unsigned numUserDataSgprs = 16;
-    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9 && m_shaderStage != ShaderStageCompute &&
-        m_shaderStage != ShaderStageTask)
-      numUserDataSgprs = 32;
-
     constexpr unsigned InvalidMapVal = static_cast<unsigned>(UserDataMapping::Invalid);
     SmallVector<unsigned, NumUserSgprs> userDataMap;
     userDataMap.resize(NumUserSgprs, InvalidMapVal);


### PR DESCRIPTION
Clang warned:
PatchEntryPointMutate.cpp:1049:14: warning: variable 'numUserDataSgprs' set but not used [-Wunused-but-set-variable]

Caused by "RegisterMetadata: support compute pipeline and task shader pipeline"