### PR TITLE
Fix implicit-fallthrough warning

### DIFF
--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -1498,6 +1498,7 @@ VertexFormatInfo VertexFetchImpl::getVertexFormatInfo(const VertexInputDescripti
   case BufDataFormat8_8_8:
     info.dfmt = BufDataFormat8_8_8;
     info.numChannels = 3;
+    break;
   default:
     break;
   }


### PR DESCRIPTION
Clang warned:
VertexFetch.cpp:1471:3: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]

Caused by "Support 'R8G8B8' vertex attribute formats"