### PR TITLE
Fix issues in new PAL ELF metatdata

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -298,10 +298,6 @@ static constexpr char ZOffsetEna[] = ".z_offset_ena";
 static constexpr char VtxW0Fmt[] = ".vtx_w0_fmt";
 }; // namespace PaClVteCntlMetadataKey
 
-namespace PaScModeCntl1MetadataKey {
-static constexpr char PsIterSample[] = ".per_iter_sample";
-}; // namespace PaScModeCntl1MetadataKey
-
 namespace VgtShaderStagesEnMetadataKey {
 static constexpr char LsStageEn[] = ".ls_stage_en";
 static constexpr char HsStageEn[] = ".hs_stage_en";
@@ -513,6 +509,17 @@ namespace SpiShaderGsMeshletExpAllocMetadataKey {
 static constexpr char MaxExpVerts[] = ".max_exp_verts";
 static constexpr char MaxExpPrims[] = ".max_exp_prims";
 }; // namespace SpiShaderGsMeshletExpAllocMetadataKey
+
+namespace CbShaderMaskMetadataKey {
+static constexpr char Output0Enable[] = ".output0_enable";
+static constexpr char Output1Enable[] = ".output1_enable";
+static constexpr char Output2Enable[] = ".output2_enable";
+static constexpr char Output3Enable[] = ".output3_enable";
+static constexpr char Output4Enable[] = ".output4_enable";
+static constexpr char Output5Enable[] = ".output5_enable";
+static constexpr char Output6Enable[] = ".output6_enable";
+static constexpr char Output7Enable[] = ".output7_enable";
+}; // namespace CbShaderMaskMetadataKey
 
 } // namespace Abi
 

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -214,6 +214,9 @@ public:
   // Serialize Util::Abi::GsOutPrimType to a string
   llvm::StringRef serializeEnum(Util::Abi::GsOutPrimType value);
 
+  // Get the MapDocNode of .amdpal.pipelines
+  llvm::msgpack::MapDocNode &getPipelineNode() { return m_pipelineNode; }
+
 private:
   // Initialize the PalMetadata object after reading in already-existing PAL metadata if any
   void initialize();


### PR DESCRIPTION
There are some incorrect settings in new PAL ELF metadata:
1. Get SPI_SHADER_COL_FORMAT from the old ELF metadata to set "amdgpu-color-export" attribute.
2. Missing the setting of ".cb_shader_mask"
3. ".vgt_gs_vert_itemsize" need a scaler value not an array for Prim shader.
4. The type of ".outprim_type*" is string not unsigned.
5. Remove duplicate declaration for ".ps_iter_sample".
6. Convert `ShaderStageCopyShader` to `ShaderStageGeomety` for
   `addApiHwShaderMapping()