### PR TITLE
BuilderRecorderMetadataKinds: turn into a cache

### DIFF
--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -42,27 +42,6 @@ using namespace lgc;
 using namespace llvm;
 
 // =====================================================================================================================
-// Constructor
-//
-// @param pipeline : Pipeline object
-BuilderReplayer::BuilderReplayer(Pipeline *pipeline)
-    : BuilderRecorderMetadataKinds(static_cast<LLVMContext &>(pipeline->getContext())) {
-}
-
-// =====================================================================================================================
-// Parser callback for adding this pass from a textually described pass pipeline.
-//
-// @param params : Parameters to the pass (in angle brackets)
-// @param passMgr : The pass manager to which the pass should be added
-bool BuilderReplayer::parsePass(llvm::StringRef params, llvm::ModulePassManager &passMgr) {
-  if (!params.empty())
-    return false;
-
-  passMgr.addPass(BuilderReplayer(nullptr));
-  return true;
-}
-
-// =====================================================================================================================
 // Run the BuilderReplayer pass on a module
 //
 // @param [in/out] module : LLVM module to be run on
@@ -100,7 +79,7 @@ bool BuilderReplayer::runImpl(Module &module, PipelineState *pipelineState) {
     // (in the case that there is no metadata because we are running the lgc command-line tool on the
     // output from "amdllpc -emit-lgc") from the name with string searching.
     unsigned opcode = 0;
-    if (const MDNode *funcMeta = func.getMetadata(opcodeMetaKindId)) {
+    if (const MDNode *funcMeta = func.getMetadata(m_mdKindIdCache.getOpcodeMetaKindId(m_builder->getContext()))) {
       const ConstantAsMetadata *metaConst = cast<ConstantAsMetadata>(funcMeta->getOperand(0));
       opcode = cast<ConstantInt>(metaConst->getValue())->getZExtValue();
       assert(func.getName().startswith(BuilderCallPrefix));

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -49,17 +49,23 @@ static const char BuilderCallOpcodeMetadataName[] = "lgc.create.opcode";
 // A class that caches the metadata kind IDs used by BuilderRecorder and BuilderReplayer.
 class BuilderRecorderMetadataKinds {
 public:
-  BuilderRecorderMetadataKinds() {}
-  BuilderRecorderMetadataKinds(llvm::LLVMContext &context);
+  unsigned getOpcodeMetaKindId(llvm::LLVMContext &context) {
+    if (!m_opcodeMetaKindId)
+      init(context);
+    return m_opcodeMetaKindId;
+  }
 
-  unsigned opcodeMetaKindId; // Cached metadata kinds for opcode
+private:
+  void init(llvm::LLVMContext &context);
+
+  unsigned m_opcodeMetaKindId = 0; // Cached metadata kinds for opcode
 };
 
 // =====================================================================================================================
 // Builder recorder, to record all Builder calls as intrinsics
 // Each call to a Builder method causes the insertion of a call to lgc.call.*, so the Builder calls can be replayed
 // later on.
-class BuilderRecorder final : public Builder, BuilderRecorderMetadataKinds {
+class BuilderRecorder final : public Builder {
   friend LgcContext;
 
 public:
@@ -602,6 +608,8 @@ private:
   PipelineState *m_pipelineState;             // PipelineState; nullptr for shader compile
   std::unique_ptr<ShaderModes> m_shaderModes; // ShaderModes for a shader compile
   bool m_omitOpcodes;                         // Omit opcodes on lgc.create.* function declarations
+
+  BuilderRecorderMetadataKinds m_mdKindIdCache;
 };
 
 } // namespace lgc

--- a/lgc/include/lgc/builder/BuilderReplayer.h
+++ b/lgc/include/lgc/builder/BuilderReplayer.h
@@ -38,17 +38,13 @@ namespace lgc {
 
 // =====================================================================================================================
 // Pass to replay Builder calls recorded by BuilderRecorder
-class BuilderReplayer final : public BuilderRecorderMetadataKinds, public llvm::PassInfoMixin<BuilderReplayer> {
+class BuilderReplayer final : public llvm::PassInfoMixin<BuilderReplayer> {
 public:
-  BuilderReplayer(Pipeline *pipeline);
-
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
 
   bool runImpl(llvm::Module &module, PipelineState *pipelineState);
 
   static llvm::StringRef name() { return "Replay LLPC builder calls"; }
-
-  static bool parsePass(llvm::StringRef params, llvm::ModulePassManager &passMgr);
 
 private:
   void replayCall(unsigned opcode, llvm::CallInst *call);
@@ -60,6 +56,8 @@ private:
   std::map<llvm::Function *, ShaderStage> m_shaderStageMap; // Map function -> shader stage
   llvm::Function *m_enclosingFunc = nullptr;                // Last function written with current
                                                             //  shader stage
+
+  BuilderRecorderMetadataKinds m_mdKindIdCache;
 };
 
 } // namespace lgc

--- a/lgc/patch/PassRegistry.inc
+++ b/lgc/patch/PassRegistry.inc
@@ -49,10 +49,9 @@
 #define LLPC_MODULE_ANALYSIS(name, class)
 #endif
 
-LLPC_MODULE_PASS_WITH_PARSER("lgc-builder-replayer", BuilderReplayer)
-
 LLPC_MODULE_ANALYSIS("lgc-pipeline-state", PipelineStateWrapper)
 
+LLPC_MODULE_PASS("lgc-builder-replayer", BuilderReplayer)
 LLPC_MODULE_PASS("lgc-patch-resource-collect", PatchResourceCollect)
 LLPC_MODULE_PASS("lgc-patch-initialize-workgroup-memory", PatchInitializeWorkgroupMemory)
 LLPC_MODULE_PASS("lgc-patch-image-derivatives", PatchImageDerivatives)

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -122,7 +122,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, T
     LgcContext::createAndAddStartStopTimer(passMgr, patchTimer, true);
 
   // We're using BuilderRecorder; replay the Builder calls now
-  passMgr.addPass(BuilderReplayer(pipelineState));
+  passMgr.addPass(BuilderReplayer());
 
   if (raw_ostream *outs = getLgcOuts()) {
     passMgr.addPass(PrintModulePass(*outs,
@@ -282,6 +282,7 @@ void Patch::registerPasses(PassBuilder &passBuilder) {
       return false;
     return true;
   };
+  (void)checkNameWithParams;
 
 #define HANDLE_PASS_WITH_PARSER(NAME, CLASS)                                                                           \
   if (innerPipeline.empty() && checkNameWithParams(name, NAME, params))                                                \
@@ -290,6 +291,7 @@ void Patch::registerPasses(PassBuilder &passBuilder) {
   passBuilder.registerPipelineParsingCallback(
       [=](StringRef name, ModulePassManager &passMgr, ArrayRef<PassBuilder::PipelineElement> innerPipeline) {
         StringRef params;
+        (void)params;
 #define LLPC_PASS(NAME, CLASS) /* */
 #define LLPC_MODULE_PASS HANDLE_PASS
 #define LLPC_MODULE_PASS_WITH_PARSER HANDLE_PASS_WITH_PARSER


### PR DESCRIPTION
The pass infrastructure is generally built to not assume an LLVMContext when a pass manager is built. In particular, we can't provide an LLVMContext to the constructor of BuilderReplayer from the pass pipeline parsing infrastructure.

With this change, we instead obtain the metadata ID when it is first requested.