### PR TITLE
IPipelineDumper: Add GetGraphicsShaderBinaryHash

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 61
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     61.1 | Add IPipelineDumper::GetGraphicsShaderBinaryHash                                                      |
 //  |     61.0 | Add DescriptorMutable type and ResourceMappingNode::strideInDwords to support mutable descriptors     |
 //  |     60.0 | Simplify the enum NggCompactMode to a boolean flag                                                    |
 //  |     59.0 | Remove the option enableVertexReuse from NggState                                                     |
@@ -1353,6 +1354,15 @@ public:
   ///
   /// @returns : Hash code associated this shader module.
   static uint64_t VKAPI_CALL GetShaderHash(const void *pModuleData);
+
+  /// Calculates graphics shader binary hash code.
+  ///
+  /// @param [in]  pPipelineInfo  Info to build this partial graphics pipeline
+  /// @param [in]  stage          The shader stage for which the code is calculated
+  ///
+  /// @returns : Hash code associated to this shader binary compilation
+  static uint64_t VKAPI_CALL GetGraphicsShaderBinaryHash(const GraphicsPipelineBuildInfo *pPipelineInfo,
+                                                         ShaderStage stage);
 
   /// Calculates graphics pipeline hash code.
   ///

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -190,6 +190,22 @@ uint64_t VKAPI_CALL IPipelineDumper::GetShaderHash(const void *moduleData) {
 }
 
 // =====================================================================================================================
+// Calculates graphics shader binary hash code.
+//
+// @param pipelineInfo : Info to build this partial graphics pipeline
+// @param stage : The shader stage for which the code is calculated
+uint64_t VKAPI_CALL IPipelineDumper::GetGraphicsShaderBinaryHash(const GraphicsPipelineBuildInfo *pipelineInfo,
+                                                                 ShaderStage stage) {
+  UnlinkedShaderStage unlinkedStage;
+  if (stage < ShaderStageFragment)
+    unlinkedStage = UnlinkedStageVertexProcess;
+  else
+    unlinkedStage = UnlinkedStageFragment;
+  auto hash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo, false, false, unlinkedStage);
+  return MetroHash::compact64(&hash);
+}
+
+// =====================================================================================================================
 // Calculates graphics pipeline hash code.
 //
 // @param pipelineInfo : Info to build this graphics pipeline


### PR DESCRIPTION
Suitable for computing dump hash codes for generating pipeline dumps for graphics pipeline library compiles.

A corresponding driver change is pending.