### PR TITLE
Fix creation of llvm.amdgcn.image.bvh.intersect.ray

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -436,6 +436,24 @@ CallInst *Builder::CreateIntrinsic(Intrinsic::ID id, ArrayRef<Type *> types, Arr
   return result;
 }
 
+// =====================================================================================================================
+// Create a call to the specified intrinsic with the specified return type and operands, mangled based on the operand
+// types. This is an override of the same method in IRBuilder<>; the difference is that this one sets fast math
+// flags from the Builder if none are specified by fmfSource.
+//
+// @param retTy : Return type
+// @param id : Intrinsic ID
+// @param args : Input values
+// @param fmfSource : Instruction to copy fast math flags from; nullptr to get from Builder
+// @param name : Name to give instruction
+CallInst *Builder::CreateIntrinsic(Type *retTy, Intrinsic::ID id, ArrayRef<Value *> args, Instruction *fmfSource,
+                                   const Twine &name) {
+  CallInst *result = IRBuilder<>::CreateIntrinsic(retTy, id, args, fmfSource, name);
+  if (!fmfSource && isa<FPMathOperator>(result))
+    result->setFastMathFlags(getFastMathFlags());
+  return result;
+}
+
 #if VKI_RAY_TRACING
 // =====================================================================================================================
 // Create a ray intersect result with specified node in BVH buffer.

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1573,7 +1573,7 @@ Value *ImageBuilder::CreateImageBvhIntersectRay(Value *nodePtr, Value *extent, V
   args.push_back(invDirection);
   args.push_back(imageDesc);
 
-  return CreateIntrinsic(Intrinsic::amdgcn_image_bvh_intersect_ray, FixedVectorType::get(getInt32Ty(), 4), args);
+  return CreateIntrinsic(FixedVectorType::get(getInt32Ty(), 4), Intrinsic::amdgcn_image_bvh_intersect_ray, args);
 }
 
 #endif

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -262,6 +262,15 @@ public:
                                   llvm::ArrayRef<llvm::Value *> args, llvm::Instruction *fmfSource = nullptr,
                                   const llvm::Twine &name = "");
 
+  //
+  // @param retTy : Return type
+  // @param id : Intrinsic ID
+  // @param args : Input values
+  // @param fmfSource : Instruction to copy fast math flags from; nullptr to get from Builder
+  // @param name : Name to give instruction
+  llvm::CallInst *CreateIntrinsic(llvm::Type *retTy, llvm::Intrinsic::ID id, llvm::ArrayRef<llvm::Value *> args,
+                                  llvm::Instruction *fmfSource = nullptr, const llvm::Twine &name = "");
+
   // -----------------------------------------------------------------------------------------------------------------
   // Arithmetic operations
 


### PR DESCRIPTION
Use the correct CreateIntrinsic overload to mangle the intrinsic based on the operand types.