### PR TITLE
Fix assert/trap in GS emit counter code

### DIFF
--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -329,7 +329,7 @@ std::pair<Type *, ArrayRef<Value *>> ShaderSystemValues::getEmitCounterPtr() {
       m_emitCounterPtrs.push_back(emitCounterPtr);
     }
   }
-  return std::make_pair(emitCounterTy, m_emitCounterPtrs);
+  return std::make_pair(emitCounterTy, ArrayRef<Value *>(m_emitCounterPtrs));
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
I only saw a problem on Mac, not Linux, and then not on the first time through this code. I think the problem was that the std::make_pair did a copy of the m_emitCounterPtrs vector into a local temp, then the return cast that by taking an ArrayRef of its contents. That would then become invalid as soon as we returned from the function. I'm surprised it worked as well as it did.