### PR TITLE
Fix a shaderdb task shader test where OpEmitMeshTasksEXT is missing

### DIFF
--- a/llpc/test/shaderdb/general/TestCompilationOfNestedStructTaskPayload.spvasm
+++ b/llpc/test/shaderdb/general/TestCompilationOfNestedStructTaskPayload.spvasm
@@ -66,6 +66,6 @@
          %65 = OpAccessChain %_ptr_TaskPayloadWorkgroupEXT__struct_47 %50 %int_0
          %66 = OpCopyLogical %_struct_47 %63
                OpStore %65 %66
-               OpReturn
+               OpEmitMeshTasksEXT %uint_1 %uint_1 %uint_1 %50
                OpFunctionEnd
 


### PR DESCRIPTION
Per [spec](https://github.com/KhronosGroup/Vulkan-Docs/blob/main/proposals/VK_EXT_mesh_shader.adoc#spir-v-changes):

```
OpEmitMeshTasksEXT
...
Any invocation must execute this instruction exactly once and under uniform control flow.
```

`OpEmitMeshTasksEXT` must be used in a task shader, the original shader is invalid.