### PR TITLE
RegisterMetadataBuilder: optimize the metadata of Tgid{X,Y,Z}En for c…

### DIFF
--- a/lgc/patch/PatchPreparePipelineAbi.cpp
+++ b/lgc/patch/PatchPreparePipelineAbi.cpp
@@ -474,7 +474,7 @@ void PatchPreparePipelineAbi::addAbiMetadata(Module &module) {
     configBuilder.buildPalMetadata();
   } else {
     if (m_pipelineState->useRegisterFieldFormat()) {
-      Gfx9::RegisterMetadataBuilder regMetadataBuilder(&module, m_pipelineState);
+      Gfx9::RegisterMetadataBuilder regMetadataBuilder(&module, m_pipelineState, m_pipelineShaders);
       regMetadataBuilder.buildPalMetadata();
     } else {
       Gfx9::ConfigBuilder configBuilder(&module, m_pipelineState);

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -901,10 +901,20 @@ void RegisterMetadataBuilder::buildPsRegisters() {
 // Builds register configuration for compute/task shader.
 void RegisterMetadataBuilder::buildCsRegisters(ShaderStage shaderStage) {
   assert(shaderStage == ShaderStageCompute || shaderStage == ShaderStageTask);
+  auto entryPoint = m_pipelineShaders->getEntryPoint(shaderStage);
+  if (shaderStage == ShaderStageCompute) {
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidXEn] =
+        !entryPoint->hasFnAttribute("amdgpu-no-workgroup-id-x");
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidYEn] =
+        !entryPoint->hasFnAttribute("amdgpu-no-workgroup-id-y");
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidZEn] =
+        !entryPoint->hasFnAttribute("amdgpu-no-workgroup-id-z");
 
-  getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidXEn] = true;
-  getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidYEn] = true;
-  getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidZEn] = true;
+  } else {
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidXEn] = true;
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidYEn] = true;
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidZEn] = true;
+  }
   getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgSizeEn] = true;
 
   const auto resUsage = m_pipelineState->getShaderResourceUsage(shaderStage);

--- a/lgc/patch/RegisterMetadataBuilder.h
+++ b/lgc/patch/RegisterMetadataBuilder.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "ConfigBuilderBase.h"
+#include "lgc/state/PipelineShaders.h"
 #include "llvm/ADT/DenseSet.h"
 
 namespace lgc {
@@ -40,8 +41,8 @@ namespace Gfx9 {
 // Represents the builder to generate register configurations for GFX11 plus chips.
 class RegisterMetadataBuilder : public ConfigBuilderBase {
 public:
-  RegisterMetadataBuilder(llvm::Module *module, PipelineState *PipelineState)
-      : ConfigBuilderBase(module, PipelineState) {}
+  RegisterMetadataBuilder(llvm::Module *module, PipelineState *PipelineState, PipelineShadersResult *pipelineShaders)
+      : ConfigBuilderBase(module, PipelineState), m_pipelineShaders(pipelineShaders) {}
 
   void buildPalMetadata();
 
@@ -62,6 +63,7 @@ private:
   unsigned calcLdsSize(unsigned ldsSizeInDwords);
 
   bool m_isNggMode = false;
+  PipelineShadersResult *m_pipelineShaders; // API shaders in the pipeline
 };
 
 } // namespace Gfx9


### PR DESCRIPTION
…ompute shader

Currently, Tgid{X,Y,Z}En are hard-coded as true unconditionally. There is room for improvement if compute shader never reads some components of gl_WorkgroupId, then that part could be set false. The part is identified by the existence of ExtractElementInst as the user of WorkgroupId input, and the result is recorded in term of function attribute "amdgcn-no-workgroup-id-{x,y,z}".