### PR TITLE
Optimize unspecified channel to 0.0 when exporting vertex attributes

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     61.3 | Add workaroundInitializeOutputsToZero to PipelineShaderOptions                                        |
 //  |     61.2 | Add pClientMetadata and clientMetadataSize to all PipelineBuildInfos                                  |
 //  |     61.1 | Add IPipelineDumper::GetGraphicsShaderBinaryHash                                                      |
 //  |     61.0 | Add DescriptorMutable type and ResourceMappingNode::strideInDwords to support mutable descriptors     |
@@ -839,6 +840,9 @@ struct PipelineShaderOptions {
 
   /// Aggressively mark shader loads as invariant (where it is safe to do so).
   InvariantLoads aggressiveInvariantLoads;
+
+  /// Initialize outputs to zero if it is true
+  bool workaroundInitializeOutputsToZero;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -86,10 +86,11 @@ struct FsInterpInfo {
   bool attr0Valid;     // Whether the location has a valid low half
   bool attr1Valid;     // Wheterh the location has a valid high half
   bool isPerPrimitive; // Whether it is per-primitive
+  bool isDefaultVal;   // Whether it is default value
 };
 
 // Invalid interpolation info
-static const FsInterpInfo InvalidFsInterpInfo = {InvalidValue, false, false, false, false, false, false};
+static const FsInterpInfo InvalidFsInterpInfo = {InvalidValue, false, false, false, false, false, false, false};
 
 // Represents the location information on an input or output
 class InOutLocationInfo {

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1608,7 +1608,7 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
 
   // NOTE: PAL expects at least one mmSPI_PS_INPUT_CNTL_0 register set, so we always patch it at least one if none
   // were identified in the shader.
-  const std::vector<FsInterpInfo> dummyInterpInfo{{0, false, false, false, false, false, false}};
+  const std::vector<FsInterpInfo> dummyInterpInfo{{0, false, false, false, false, false, false, false}};
   const auto &fsInterpInfo = resUsage->inOutUsage.fs.interpInfo;
   const auto *interpInfo = fsInterpInfo.size() == 0 ? &dummyInterpInfo : &fsInterpInfo;
 
@@ -1661,6 +1661,8 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
       // NOTE: Set the offset value to force hardware to select input defaults (no VS match).
       spiPsInputCntl.bits.OFFSET = UseDefaultVal;
     }
+    if (interpInfoElem.isDefaultVal)
+      spiPsInputCntl.bits.OFFSET = UseDefaultVal; // VS doesn't write the outputs
 
     // NOTE: Set SPI_PS_INPUT_CNTL_* here, but the register can still be changed later,
     // when it becomes known that gl_ViewportIndex is not used and fields OFFSET and FLAT_SHADE

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -788,7 +788,7 @@ void RegisterMetadataBuilder::buildPsRegisters() {
 
   msgpack::ArrayDocNode spiPsInputCnt =
       getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::SpiPsInputCntl].getArray(true);
-  const std::vector<FsInterpInfo> dummyInterpInfo{{0, false, false, false, false, false, false}};
+  const std::vector<FsInterpInfo> dummyInterpInfo{{0, false, false, false, false, false, false, false}};
   const auto &fsInterpInfo = resUsage->inOutUsage.fs.interpInfo;
   const auto *interpInfo = fsInterpInfo.size() == 0 ? &dummyInterpInfo : &fsInterpInfo;
 
@@ -838,6 +838,8 @@ void RegisterMetadataBuilder::buildPsRegisters() {
       // NOTE: Set the offset value to force hardware to select input defaults (no VS match).
       spiPsInputCntlInfo.offset = UseDefaultVal;
     }
+    if (interpInfoElem.isDefaultVal)
+      spiPsInputCntlInfo.offset = UseDefaultVal; // VS doesn't write the outputs
 
     spiPsInputCntElem[Util::Abi::SpiPsInputCntlMetadataKey::FlatShade] = spiPsInputCntlInfo.flatShade;
     spiPsInputCntElem[Util::Abi::SpiPsInputCntlMetadataKey::Offset] = spiPsInputCntlInfo.offset;

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4210,14 +4210,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpVariable>(SPIRVValue *con
     }
     if (!isBuiltIn) {
       // Initializize user-defined output variable to zero
-      if (varType->isAggregateType() || varType->isVectorTy())
-        initializer = ConstantAggregateZero::get(varType);
-      else if (varType->isIntegerTy())
-        initializer = ConstantInt::get(varType, uint64_t(0));
-      else if (varType->isFloatTy())
-        initializer = ConstantFP::getZero(varType);
-      else
-        llvm_unreachable("should never be called");
+      initializer = Constant::getNullValue(varType);
     }
   }
 


### PR DESCRIPTION
This pr gives a workaround to fix the corruption in vk_timeline_semaphore in nvpro-sample. The root cause is that FS reads an input which is not exported by VS. We need initialize the output to zero when the workaround flag is enabled.