### PR TITLE
amdllpc: Print error and exit, instead of asserting on error

### DIFF
--- a/tool/vfx/vfxError.h
+++ b/tool/vfx/vfxError.h
@@ -47,8 +47,9 @@
     int pos = vfxSnprintf(errorBuf, 4096, "Parse error at line %u: ", lineNum);                                        \
     pos += vfxSnprintf(errorBuf + pos, 4096 - pos, __VA_ARGS__);                                                       \
     pos += vfxSnprintf(errorBuf + pos, 4096 - pos, "\n");                                                              \
-    VFX_NEVER_CALLED();                                                                                                \
     errorMsg += errorBuf;                                                                                              \
+    fputs(errorBuf, stderr);                                                                                           \
+    exit(1);                                                                                                           \
   }
 
 #define PARSE_WARNING(errorMsg, lineNum, ...)                                                                          \


### PR DESCRIPTION
Previously a parse error (including not finding a shader file) caused it to abort at a VFX_NEVER_CALLED, and not show you the error message.