### PR TITLE
Add support for writing client-defined metadata into the ELF

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 61
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     61.2 | Add pClientMetadata and clientMetadataSize to all PipelineBuildInfos                                  |
 //  |     61.1 | Add IPipelineDumper::GetGraphicsShaderBinaryHash                                                      |
 //  |     61.0 | Add DescriptorMutable type and ResourceMappingNode::strideInDwords to support mutable descriptors     |
 //  |     60.0 | Simplify the enum NggCompactMode to a boolean flag                                                    |
@@ -1202,6 +1203,8 @@ struct GraphicsPipelineBuildInfo {
   BinaryData shaderLibrary; ///< SPIR-V library binary data
   RtState rtState;          ///< Ray tracing state
 #endif
+  const void *pClientMetadata; ///< Pointer to (optional) client-defined data to be stored inside the ELF
+  size_t clientMetadataSize;   ///< Size (in bytes) of the client-defined data
 };
 
 /// Represents info to build a compute pipeline.
@@ -1223,6 +1226,8 @@ struct ComputePipelineBuildInfo {
   BinaryData shaderLibrary; ///< SPIR-V library binary data
   RtState rtState;          ///< Ray tracing state
 #endif
+  const void *pClientMetadata; ///< Pointer to (optional) client-defined data to be stored inside the ELF
+  size_t clientMetadataSize;   ///< Size (in bytes) of the client-defined data
 };
 
 #if VKI_RAY_TRACING
@@ -1250,6 +1255,9 @@ struct RayTracingPipelineBuildInfo {
   bool hasPipelineLibrary;                                   ///< Whether include pipeline library
   unsigned pipelineLibStageMask;                             ///< Pipeline library stage mask
   bool isReplay;                                             ///< Pipeline is created for replaying
+  const void *pClientMetadata;                               ///< Pointer to (optional) client-defined data to be
+                                                             ///  stored inside the ELF
+  size_t clientMetadataSize;                                 ///< Size (in bytes) of the client-defined data
 };
 
 /// Ray tracing max shader name length

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -193,6 +193,9 @@ public:
   // In part-pipeline compilation, copy any metadata needed from the "other" pipeline's PAL metadata into ours.
   void setOtherPartPipeline(PalMetadata &other);
 
+  // Copy client-defined metadata blob to be stored inside ELF
+  void setClientMetadata(llvm::StringRef clientMetadata);
+
   // Erase the PAL metadata for FS input mappings. Used when finalizing the PAL metadata in the link.
   void eraseFragmentInputInfo();
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -182,6 +182,9 @@ public:
   // compile of the non-FS part of the pipeline, to inherit required information from the FS part-pipeline.
   void setOtherPartPipeline(Pipeline &otherPartPipeline, llvm::Module *linkedModule = nullptr) override final;
 
+  // Set the client-defined metadata to be stored inside the ELF
+  void setClientMetadata(llvm::StringRef clientMetadata) override final;
+
   // -----------------------------------------------------------------------------------------------------------------
   // Other methods
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -727,6 +727,9 @@ public:
   //                 do an irLink() at all.
   virtual void setOtherPartPipeline(Pipeline &otherPartPipeline, llvm::Module *linkedModule = nullptr) = 0;
 
+  // Set the client-defined metadata to be stored inside the ELF
+  virtual void setClientMetadata(llvm::StringRef clientMetadata) = 0;
+
   // -----------------------------------------------------------------------------------------------------------------
   // IR link and generate pipeline/library methods
 

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -1063,6 +1063,15 @@ void PalMetadata::setOtherPartPipeline(PalMetadata &other) {
 }
 
 // =====================================================================================================================
+// Store client-defined metadata blob in a buffer node.
+//
+// @param clientMetadata : StringRef representing the client metadata blob
+void PalMetadata::setClientMetadata(StringRef clientMetadata) {
+  if (!clientMetadata.empty())
+    m_pipelineNode[Util::Abi::PipelineMetadataKey::ApiCreateInfo] = MemoryBufferRef(clientMetadata, "");
+}
+
+// =====================================================================================================================
 // Check whether we have FS input mappings, and thus whether we're doing part-pipeline compilation of the
 // pre-FS part of the pipeline.
 bool PalMetadata::haveFsInputMappings() {

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -295,6 +295,14 @@ void PipelineState::setOtherPartPipeline(Pipeline &otherPartPipeline, Module *li
 }
 
 // =====================================================================================================================
+// Copy client-defined metadata blob to be stored inside ELF.
+//
+// @param clientMetadata : StringRef representing the client metadata blob
+void PipelineState::setClientMetadata(StringRef clientMetadata) {
+  getPalMetadata()->setClientMetadata(clientMetadata);
+}
+
+// =====================================================================================================================
 // Clear the pipeline state IR metadata.
 // This does not clear PalMetadata, because we want that to persist into the back-end.
 //

--- a/llpc/context/llpcComputeContext.cpp
+++ b/llpc/context/llpcComputeContext.cpp
@@ -76,4 +76,10 @@ unsigned ComputeContext::getSubgroupSizeUsage() const {
   return moduleData->usage.useSubgroupSize ? ShaderStageComputeBit : 0;
 }
 
+// =====================================================================================================================
+// Gets client-defined metadata
+StringRef ComputeContext::getClientMetadata() const {
+  return StringRef(static_cast<const char *>(m_pipelineInfo->pClientMetadata), m_pipelineInfo->clientMetadataSize);
+}
+
 } // namespace Llpc

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -62,6 +62,9 @@ public:
   // Gets subgroup size usage
   virtual unsigned getSubgroupSizeUsage() const override;
 
+  // Gets client-defined metadata
+  virtual llvm::StringRef getClientMetadata() const override;
+
 #if VKI_RAY_TRACING
   virtual bool hasRayQuery() const override { return (m_pipelineInfo->shaderLibrary.codeSize > 0); }
 #endif

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -160,4 +160,10 @@ unsigned GraphicsContext::getSubgroupSizeUsage() const {
   return bitmask;
 }
 
+// =====================================================================================================================
+// Gets client-defined metadata
+StringRef GraphicsContext::getClientMetadata() const {
+  return StringRef(static_cast<const char *>(m_pipelineInfo->pClientMetadata), m_pipelineInfo->clientMetadataSize);
+}
+
 } // namespace Llpc

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -73,6 +73,9 @@ public:
   // Gets subgroup size usage
   virtual unsigned getSubgroupSizeUsage() const override;
 
+  // Gets client-defined metadata
+  virtual llvm::StringRef getClientMetadata() const override;
+
 #if VKI_RAY_TRACING
   virtual bool hasRayQuery() const override { return (m_pipelineInfo->shaderLibrary.codeSize > 0); }
 #endif

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -282,6 +282,9 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, Util::MetroHash64 *ha
         hasher->Update(deviceIndex);
     }
   }
+
+  if (pipeline)
+    pipeline->setClientMetadata(getClientMetadata());
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -143,6 +143,9 @@ public:
 #endif
   virtual unsigned getSubgroupSizeUsage() const = 0;
 
+  // Gets client-defined metadata
+  virtual llvm::StringRef getClientMetadata() const = 0;
+
 #if VKI_RAY_TRACING
   // Checks whether the pipeline is ray tracing
   virtual bool isRayTracing() const { return false; }

--- a/llpc/context/llpcRayTracingContext.cpp
+++ b/llpc/context/llpcRayTracingContext.cpp
@@ -222,4 +222,10 @@ unsigned RayTracingContext::getSubgroupSizeUsage() const {
   return 0;
 }
 
+// =====================================================================================================================
+// Gets client-defined metadata
+StringRef RayTracingContext::getClientMetadata() const {
+  return StringRef(static_cast<const char *>(m_pipelineInfo->pClientMetadata), m_pipelineInfo->clientMetadataSize);
+}
+
 } // namespace Llpc

--- a/llpc/context/llpcRayTracingContext.h
+++ b/llpc/context/llpcRayTracingContext.h
@@ -69,6 +69,9 @@ public:
   // Gets subgroup size usage
   virtual unsigned getSubgroupSizeUsage() const override;
 
+  // Gets client-defined metadata
+  virtual llvm::StringRef getClientMetadata() const override;
+
   // Checks whether the pipeline is ray tracing
   virtual bool isRayTracing() const override { return true; }
 


### PR DESCRIPTION
This change allows LLPC clients to store a generic memory chunk inside the ELF. Clients need this feature to query various info when handed a ELF (e.g. for hard disk caching or pipeline reinjection).