### PR TITLE
Remove state from Builder and BuilderRecorder

### DIFF
--- a/lgc/builder/Builder.cpp
+++ b/lgc/builder/Builder.cpp
@@ -62,87 +62,8 @@ Builder *Builder::createBuilderImpl(LgcContext *context, Pipeline *pipeline) {
 //
 // @param context : LGC context
 // @param pipeline : Pipeline object, can be nullptr
-// @param omitOpcodes : Don't add opcode metadata to lgc.create.* function declarations
-Builder *Builder::createBuilderRecorder(LgcContext *context, Pipeline *pipeline, bool omitOpcodes) {
-  return new BuilderRecorder(context, pipeline, omitOpcodes);
-}
-
-// =====================================================================================================================
-//
-// @param builderContext : Builder context
-Builder::Builder(LgcContext *builderContext)
-    : BuilderCommon(builderContext->getContext()), m_builderContext(builderContext) {
-}
-
-// =====================================================================================================================
-// Set the common shader mode for the given shader stage, containing hardware FP round and denorm modes.
-//
-// @param shaderStage : Shader stage to set modes for
-// @param commonShaderMode : FP round and denorm modes
-void Builder::setCommonShaderMode(ShaderStage shaderStage, const CommonShaderMode &commonShaderMode) {
-  getShaderModes()->setCommonShaderMode(shaderStage, commonShaderMode);
-}
-
-// =====================================================================================================================
-// Get the common shader mode for the given shader stage.
-// @param shaderStage : Shader stage to get modes for
-const CommonShaderMode &Builder::getCommonShaderMode(ShaderStage shaderStage) {
-  return getShaderModes()->getCommonShaderMode(shaderStage);
-}
-
-// =====================================================================================================================
-// Set the tessellation mode
-//
-// @param tessellationMode : Tessellation mode
-void Builder::setTessellationMode(const TessellationMode &tessellationMode) {
-  getShaderModes()->setTessellationMode(tessellationMode);
-}
-
-// =====================================================================================================================
-// Set the geometry shader mode
-//
-// @param geometryShaderMode : Geometry shader mode
-void Builder::setGeometryShaderMode(const GeometryShaderMode &geometryShaderMode) {
-  getShaderModes()->setGeometryShaderMode(geometryShaderMode);
-}
-
-// =====================================================================================================================
-// Set the mesh shader mode
-//
-// @param meshShaderMode : Mesh shader mode
-void Builder::setMeshShaderMode(const MeshShaderMode &meshShaderMode) {
-  getShaderModes()->setMeshShaderMode(meshShaderMode);
-}
-
-// =====================================================================================================================
-// Set the fragment shader mode
-//
-// @param fragmentShaderMode : Fragment shader mode
-void Builder::setFragmentShaderMode(const FragmentShaderMode &fragmentShaderMode) {
-  getShaderModes()->setFragmentShaderMode(fragmentShaderMode);
-}
-
-// =====================================================================================================================
-// Set the compute shader mode (workgroup size)
-//
-// @param computeShaderMode : Compute shader mode
-void Builder::setComputeShaderMode(const ComputeShaderMode &computeShaderMode) {
-  getShaderModes()->setComputeShaderMode(computeShaderMode);
-}
-
-// =====================================================================================================================
-// Set subgroup size usage
-//
-// @param stage : Shader stage
-// @param usage : Subgroup size usage
-void Builder::setSubgroupSizeUsage(ShaderStage stage, bool usage) {
-  getShaderModes()->setSubgroupSizeUsage(stage, usage);
-}
-
-// =====================================================================================================================
-// Get the compute shader mode (workgroup size)
-const ComputeShaderMode &Builder::getComputeShaderMode() {
-  return getShaderModes()->getComputeShaderMode();
+Builder *Builder::createBuilderRecorder(LgcContext *context, Pipeline *pipeline) {
+  return new BuilderRecorder(context->getContext());
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -29,6 +29,7 @@
  ***********************************************************************************************************************
  */
 #include "lgc/builder/BuilderImpl.h"
+#include "lgc/LgcContext.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
@@ -37,6 +38,7 @@ using namespace lgc;
 using namespace llvm;
 
 // =====================================================================================================================
+// BuilderImpl constructor
 //
 // @param builderContext : LgcContext
 // @param pipeline : PipelineState (as public superclass Pipeline)
@@ -45,6 +47,14 @@ BuilderImpl::BuilderImpl(LgcContext *builderContext, Pipeline *pipeline)
       ImageBuilder(builderContext), InOutBuilder(builderContext), MatrixBuilder(builderContext),
       MiscBuilder(builderContext), SubgroupBuilder(builderContext) {
   m_pipelineState = reinterpret_cast<PipelineState *>(pipeline);
+}
+
+// =====================================================================================================================
+// BuilderImplBase constructor
+//
+// @param builderContext : LgcContext
+BuilderImplBase::BuilderImplBase(LgcContext *builderContext)
+    : Builder(builderContext->getContext()), m_builderContext(builderContext) {
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -40,7 +40,7 @@ namespace lgc {
 // Builder implementation base class
 class BuilderImplBase : public Builder {
 public:
-  BuilderImplBase(LgcContext *builderContext) : Builder(builderContext) {}
+  BuilderImplBase(LgcContext *builderContext);
 
   // Create scalar from dot product of vector
   llvm::Value *CreateDotProduct(llvm::Value *const vector1, llvm::Value *const vector2,
@@ -53,9 +53,12 @@ public:
   // Set the current shader stage, clamp shader stage to the ShaderStageCompute
   void setShaderStage(ShaderStage stage) { m_shaderStage = stage > ShaderStageCompute ? ShaderStageCompute : stage; }
 
+  // Get the LgcContext
+  LgcContext *getLgcContext() const { return m_builderContext; }
+
 protected:
   // Get the ShaderModes object.
-  ShaderModes *getShaderModes() override final;
+  ShaderModes *getShaderModes();
 
   // Get the PipelineState object.
   PipelineState *getPipelineState() const { return m_pipelineState; }
@@ -122,6 +125,8 @@ private:
   BuilderImplBase() = delete;
   BuilderImplBase(const BuilderImplBase &) = delete;
   BuilderImplBase &operator=(const BuilderImplBase &) = delete;
+
+  LgcContext *m_builderContext; // Builder context
 };
 
 // =====================================================================================================================

--- a/lgc/include/lgc/builder/BuilderRecorder.h
+++ b/lgc/include/lgc/builder/BuilderRecorder.h
@@ -238,13 +238,10 @@ public:
   static Opcode getOpcodeFromName(llvm::StringRef name);
 
   // Constructors
-  BuilderRecorder(LgcContext *builderContext, Pipeline *pipeline, bool omitOpcodes);
+  BuilderRecorder(llvm::LLVMContext &context) : Builder(context) {}
   BuilderRecorder() = delete;
   BuilderRecorder(const BuilderRecorder &) = delete;
   BuilderRecorder &operator=(const BuilderRecorder &) = delete;
-
-  // Record shader modes into IR metadata if this is a shader compile (no PipelineState).
-  void recordShaderModes(llvm::Module *module) override final;
 
   // -----------------------------------------------------------------------------------------------------------------
   // Base class operations
@@ -596,18 +593,10 @@ public:
                                              llvm::Value *const index, const llvm::Twine &instName) override final;
   llvm::Value *CreateSubgroupMbcnt(llvm::Value *const mask, const llvm::Twine &instName) override final;
 
-protected:
-  // Get the ShaderModes object.
-  ShaderModes *getShaderModes() override final;
-
 private:
   // Record one Builder call
   llvm::Instruction *record(Opcode opcode, llvm::Type *returnTy, llvm::ArrayRef<llvm::Value *> args,
                             const llvm::Twine &instName);
-
-  PipelineState *m_pipelineState;             // PipelineState; nullptr for shader compile
-  std::unique_ptr<ShaderModes> m_shaderModes; // ShaderModes for a shader compile
-  bool m_omitOpcodes;                         // Omit opcodes on lgc.create.* function declarations
 
   BuilderRecorderMetadataKinds m_mdKindIdCache;
 };

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -466,6 +466,31 @@ public:
     return readArrayOfInt32MetaNode(namedMetaNode->getOperand(0), value);
   }
 
+  // Set a named metadata node to point to its previous array of i32 values, with a new array of i32 ORed in.
+  // The array is trimmed to remove trailing zero values. If the whole array would be 0, then this function
+  // removes the named metadata node (if it existed).
+  //
+  // @param [in/out] module : IR module to record into
+  // @param value : Value to write as array of i32
+  // @param metaName : Name for named metadata node
+  template <typename T>
+  static void orNamedMetadataToArrayOfInt32(llvm::Module *module, const T &value, llvm::StringRef metaName) {
+    llvm::ArrayRef<unsigned> values(reinterpret_cast<const unsigned *>(&value), sizeof(value) / sizeof(unsigned));
+    unsigned oredValues[sizeof(value) / sizeof(unsigned)] = {};
+    auto namedMetaNode = module->getOrInsertNamedMetadata(metaName);
+    if (namedMetaNode->getNumOperands() >= 1)
+      readArrayOfInt32MetaNode(namedMetaNode->getOperand(0), oredValues);
+    for (unsigned idx = 0; idx != sizeof(value) / sizeof(unsigned); ++idx)
+      oredValues[idx] |= values[idx];
+    llvm::MDNode *arrayMetaNode = getArrayOfInt32MetaNode(module->getContext(), oredValues, false);
+    if (!arrayMetaNode) {
+      module->eraseNamedMetadata(namedMetaNode);
+      return;
+    }
+    namedMetaNode->clearOperands();
+    namedMetaNode->addOperand(arrayMetaNode);
+  }
+
 private:
   // Read shaderStageMask from IR
   void readShaderStageMask(llvm::Module *module);

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -401,6 +401,7 @@ public:
   template <typename T>
   static llvm::MDNode *getArrayOfInt32MetaNode(llvm::LLVMContext &context, const T &value, bool atLeastOneValue) {
     llvm::IRBuilder<> builder(context);
+    static_assert(sizeof(value) % sizeof(unsigned) == 0, "Bad value type");
     llvm::ArrayRef<unsigned> values(reinterpret_cast<const unsigned *>(&value), sizeof(value) / sizeof(unsigned));
 
     while (!values.empty() && values.back() == 0) {
@@ -426,6 +427,7 @@ public:
   // @param metaName : Name for named metadata node
   template <typename T>
   static void setNamedMetadataToArrayOfInt32(llvm::Module *module, const T &value, llvm::StringRef metaName) {
+    static_assert(sizeof(value) % sizeof(unsigned) == 0, "Bad value type");
     llvm::MDNode *arrayMetaNode = getArrayOfInt32MetaNode(module->getContext(), value, false);
     if (!arrayMetaNode) {
       if (auto namedMetaNode = module->getNamedMetadata(metaName))
@@ -444,6 +446,7 @@ public:
   // @param metaNode : Metadata node to read from
   // @param [out] value : Value to write into (caller must zero initialize)
   template <typename T> static unsigned readArrayOfInt32MetaNode(llvm::MDNode *metaNode, T &value) {
+    static_assert(sizeof(value) % sizeof(unsigned) == 0, "Bad value type");
     llvm::MutableArrayRef<unsigned> values(reinterpret_cast<unsigned *>(&value), sizeof(value) / sizeof(unsigned));
     unsigned count = std::min(metaNode->getNumOperands(), unsigned(values.size()));
     for (unsigned index = 0; index < count; ++index)
@@ -475,6 +478,7 @@ public:
   // @param metaName : Name for named metadata node
   template <typename T>
   static void orNamedMetadataToArrayOfInt32(llvm::Module *module, const T &value, llvm::StringRef metaName) {
+    static_assert(sizeof(value) % sizeof(unsigned) == 0, "Bad value type");
     llvm::ArrayRef<unsigned> values(reinterpret_cast<const unsigned *>(&value), sizeof(value) / sizeof(unsigned));
     unsigned oredValues[sizeof(value) / sizeof(unsigned)] = {};
     auto namedMetaNode = module->getOrInsertNamedMetadata(metaName);

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -88,6 +88,10 @@ public:
   static LgcContext *create(llvm::LLVMContext &context, llvm::StringRef gpuName, unsigned int palAbiVersion,
                             llvm::CodeGenOpt::Level optLevel);
 
+  // Get the value of the -emit-lgc option. BuilderRecorder uses this to decide whether to omit the opcode
+  // metadata when recording a Builder call.
+  static bool getEmitLgc();
+
   ~LgcContext();
 
   // Given major.minor.steppings - generate the gpuName string

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -660,6 +660,53 @@ public:
   llvm::LLVMContext &getContext() const;
 
   // -----------------------------------------------------------------------------------------------------------------
+  // Methods to set shader modes (FP modes, tessellation modes, fragment modes, workgroup size) for the current
+  // shader that come from the input language.
+
+  // Set the common shader mode for the given shader stage, containing hardware FP round and denorm modes.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  static void setCommonShaderMode(llvm::Module &module, ShaderStage shaderStage,
+                                  const CommonShaderMode &commonShaderMode);
+
+  // Get the common shader mode for the given shader stage.
+  static CommonShaderMode getCommonShaderMode(llvm::Module &module, ShaderStage shaderStage);
+
+  // Set the tessellation mode. This can be called in multiple shaders, and the values are merged
+  // together -- a zero value in one call is overridden by a non-zero value in another call. LLPC needs
+  // that because SPIR-V allows some of these execution mode items to appear in either the TCS or TES.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  static void setTessellationMode(llvm::Module &module, ShaderStage shaderStage,
+                                  const TessellationMode &tessellationMode);
+
+  // Set the geometry shader state.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  static void setGeometryShaderMode(llvm::Module &module, const GeometryShaderMode &geometryShaderMode);
+
+  // Set the mesh shader state.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  static void setMeshShaderMode(llvm::Module &module, const MeshShaderMode &meshShaderMode);
+
+  // Set the fragment shader mode.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  static void setFragmentShaderMode(llvm::Module &module, const FragmentShaderMode &fragmentShaderMode);
+
+  // Set the compute shader modes.
+  // The client should always zero-initialize the struct before setting it up, in case future versions
+  // add more fields. A local struct variable can be zero-initialized with " = {}".
+  static void setComputeShaderMode(llvm::Module &module, const ComputeShaderMode &computeShaderMode);
+
+  // Set subgroup size usage.
+  static void setSubgroupSizeUsage(llvm::Module &module, ShaderStage stage, bool usage);
+
+  // Get the compute shader mode (workgroup size)
+  static ComputeShaderMode getComputeShaderMode(llvm::Module &module);
+
+  // -----------------------------------------------------------------------------------------------------------------
   // State setting methods
 
   // Set whether pre-rasterization part has a geometry shader

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -252,6 +252,13 @@ LgcContext *LgcContext::create(LLVMContext &context, StringRef gpuName, unsigned
 }
 
 // =====================================================================================================================
+// Get the value of the -emit-lgc option. BuilderRecorder uses this to decide whether to omit the opcode
+// metadata when recording a Builder call.
+bool LgcContext::getEmitLgc() {
+  return EmitLgc;
+}
+
+// =====================================================================================================================
 //
 // @param context : LLVM context to give each Builder
 // @param palAbiVersion : PAL pipeline ABI version to compile for
@@ -278,7 +285,7 @@ Pipeline *LgcContext::createPipeline() {
 //
 // @param pipeline : Pipeline object for pipeline compile, nullptr for shader compile
 Builder *LgcContext::createBuilder(Pipeline *pipeline) {
-  return Builder::createBuilderRecorder(this, pipeline, EmitLgc);
+  return Builder::createBuilderRecorder(this, pipeline);
 }
 
 // =====================================================================================================================

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -217,6 +217,99 @@ static CompSetting computeCompSetting(BufDataFormat dfmt) {
 } // namespace
 
 // =====================================================================================================================
+// Set the common shader mode for the given shader stage, containing hardware FP round and denorm modes.
+// This records the mode into IR metadata in the given module.
+//
+// @param module : Module to record in
+// @param shaderStage : Shader stage to set modes for
+// @param commonShaderMode : FP round and denorm modes
+void Pipeline::setCommonShaderMode(Module &module, ShaderStage shaderStage, const CommonShaderMode &commonShaderMode) {
+  ShaderModes::setCommonShaderMode(module, shaderStage, commonShaderMode);
+}
+
+// =====================================================================================================================
+// Get the common shader mode for the given shader stage.
+// This reads the mode from IR metadata in the given module.
+//
+// @param module : Module to read from
+// @param shaderStage : Shader stage to get modes for
+CommonShaderMode Pipeline::getCommonShaderMode(Module &module, ShaderStage shaderStage) {
+  return ShaderModes::getCommonShaderMode(module, shaderStage);
+}
+
+// =====================================================================================================================
+// Set the tessellation mode
+// This records the mode into IR metadata in the given module.
+// Both TCS and TES can set tessellation mode, and the two get merged together by the middle end.
+//
+// @param module : Module to record in
+// @param shaderStage : Shader stage to set modes for (TCS or TES)
+// @param tessellationMode : Tessellation mode
+void Pipeline::setTessellationMode(Module &module, ShaderStage shaderStage, const TessellationMode &tessellationMode) {
+  ShaderModes::setTessellationMode(module, shaderStage, tessellationMode);
+}
+
+// =====================================================================================================================
+// Set the geometry shader mode
+// This records the mode into IR metadata in the given module.
+//
+// @param module : Module to record in
+// @param geometryShaderMode : Geometry shader mode
+void Pipeline::setGeometryShaderMode(Module &module, const GeometryShaderMode &geometryShaderMode) {
+  ShaderModes::setGeometryShaderMode(module, geometryShaderMode);
+}
+
+// =====================================================================================================================
+// Set the mesh shader mode
+// This records the mode into IR metadata in the given module.
+//
+// @param module : Module to record in
+// @param meshShaderMode : Mesh shader mode
+void Pipeline::setMeshShaderMode(Module &module, const MeshShaderMode &meshShaderMode) {
+  ShaderModes::setMeshShaderMode(module, meshShaderMode);
+}
+
+// =====================================================================================================================
+// Set the fragment shader mode
+// This records the mode into IR metadata in the given module.
+//
+// @param module : Module to record in
+// @param fragmentShaderMode : Fragment shader mode
+void Pipeline::setFragmentShaderMode(Module &module, const FragmentShaderMode &fragmentShaderMode) {
+  ShaderModes::setFragmentShaderMode(module, fragmentShaderMode);
+}
+
+// =====================================================================================================================
+// Set the compute shader mode (workgroup size)
+// This records the mode into IR metadata in the given module.
+//
+// @param module : Module to record in
+// @param computeShaderMode : Compute shader mode
+void Pipeline::setComputeShaderMode(Module &module, const ComputeShaderMode &computeShaderMode) {
+  ShaderModes::setComputeShaderMode(module, computeShaderMode);
+}
+
+// =====================================================================================================================
+// Set subgroup size usage.
+// This records the mode into IR metadata in the given module.
+//
+// @param module : Module to record in
+// @param stage : Shader stage
+// @param usage : Subgroup size usage
+void Pipeline::setSubgroupSizeUsage(Module &module, ShaderStage stage, bool usage) {
+  ShaderModes::setSubgroupSizeUsage(module, stage, usage);
+}
+
+// =====================================================================================================================
+// Get the compute shader mode (workgroup size)
+// This reads the mode from IR metadata in the given module.
+//
+// @param module : Module to read from
+ComputeShaderMode Pipeline::getComputeShaderMode(Module &module) {
+  return ShaderModes::getComputeShaderMode(module);
+}
+
+// =====================================================================================================================
 // Constructor
 //
 // @param builderContext : LGC builder context
@@ -317,7 +410,6 @@ void PipelineState::clear(Module *module) {
 //
 // @param [in/out] module : Module to record the IR metadata in
 void PipelineState::record(Module *module) {
-  getShaderModes()->record(module);
   recordOptions(module);
   recordUserDataNodes(module);
   recordDeviceIndex(module);

--- a/lgc/state/ShaderModes.cpp
+++ b/lgc/state/ShaderModes.cpp
@@ -226,12 +226,15 @@ void ShaderModes::readModesFromPipeline(Module *module) {
   TessellationMode tesMode = {};
   PipelineState::readNamedMetadataArrayOfInt32(module, TcsModeMetadataName, tcsMode);
   PipelineState::readNamedMetadataArrayOfInt32(module, TesModeMetadataName, tesMode);
-  m_tessellationMode.vertexSpacing = tcsMode.vertexSpacing != VertexSpacing::Unknown ? tcsMode.vertexSpacing
-    : tesMode.vertexSpacing != VertexSpacing::Unknown ? tesMode.vertexSpacing : VertexSpacing::Equal;
-  m_tessellationMode.vertexOrder = tcsMode.vertexOrder != VertexOrder::Unknown ? tcsMode.vertexOrder
-    : tesMode.vertexOrder != VertexOrder::Unknown ? tesMode.vertexOrder : VertexOrder::Ccw;
-  m_tessellationMode.primitiveMode = tcsMode.primitiveMode != PrimitiveMode::Unknown ? tcsMode.primitiveMode
-    : tesMode.primitiveMode != PrimitiveMode::Unknown ? tesMode.primitiveMode : PrimitiveMode::Triangles;
+  m_tessellationMode.vertexSpacing = tcsMode.vertexSpacing != VertexSpacing::Unknown   ? tcsMode.vertexSpacing
+                                     : tesMode.vertexSpacing != VertexSpacing::Unknown ? tesMode.vertexSpacing
+                                                                                       : VertexSpacing::Equal;
+  m_tessellationMode.vertexOrder = tcsMode.vertexOrder != VertexOrder::Unknown   ? tcsMode.vertexOrder
+                                   : tesMode.vertexOrder != VertexOrder::Unknown ? tesMode.vertexOrder
+                                                                                 : VertexOrder::Ccw;
+  m_tessellationMode.primitiveMode = tcsMode.primitiveMode != PrimitiveMode::Unknown   ? tcsMode.primitiveMode
+                                     : tesMode.primitiveMode != PrimitiveMode::Unknown ? tesMode.primitiveMode
+                                                                                       : PrimitiveMode::Triangles;
   m_tessellationMode.pointMode = tcsMode.pointMode | tesMode.pointMode;
   m_tessellationMode.outputVertices = tcsMode.outputVertices != 0 ? tcsMode.outputVertices : tesMode.outputVertices;
 }

--- a/lgc/test/ShaderStages.lgc
+++ b/lgc/test/ShaderStages.lgc
@@ -236,7 +236,7 @@ declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readonly }
 
-!llpc.tessellation.mode = !{!0}
+!llpc.tcs.mode = !{!0}
 !lgc.options = !{!1}
 !lgc.options.TCS = !{!2}
 !lgc.options.TES = !{!3}
@@ -294,7 +294,7 @@ declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readonly }
 
-!llpc.tessellation.mode = !{!0}
+!llpc.tcs.mode = !{!0}
 !lgc.options = !{!1}
 !lgc.options.TCS = !{!2}
 !lgc.options.TES = !{!3}
@@ -359,7 +359,7 @@ declare <4 x float> @lgc.create.read.generic.input.v4f32(...) local_unnamed_addr
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readonly }
 
-!llpc.tessellation.mode = !{!0}
+!llpc.tes.mode = !{!0}
 !lgc.options = !{!1}
 !lgc.options.TCS = !{!2}
 !lgc.options.TES = !{!3}
@@ -499,7 +499,7 @@ declare void @llvm.amdgcn.s.sendmsg(i32 immarg, i32) #0
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readonly }
 
-!llpc.tessellation.mode = !{!0}
+!llpc.tcs.mode = !{!0}
 !llpc.geometry.mode = !{!0}
 !lgc.options = !{!1}
 !lgc.options.TCS = !{!2}

--- a/lgc/test/UnlinkedTessFetches.lgc
+++ b/lgc/test/UnlinkedTessFetches.lgc
@@ -42,7 +42,7 @@ define dllexport spir_func void @lgc.shader.TES.VkMain() local_unnamed_addr #0 !
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readonly willreturn }
 
-!llpc.tessellation.mode = !{!0}
+!llpc.tcs.mode = !{!0}
 !lgc.client = !{!1}
 !lgc.unlinked = !{!2}
 !lgc.options = !{!3}

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -64,6 +64,10 @@ public:
 
 #if VKI_RAY_TRACING
   virtual bool hasRayQuery() const override { return (m_pipelineInfo->shaderLibrary.codeSize > 0); }
+
+  // Set workgroup size for compute pipeline so that rayQuery lowering can see it.
+  virtual void setWorkgroupSize(unsigned workgroupSize) override { m_workgroupSize = workgroupSize; }
+  virtual unsigned getWorkgroupSize() const override { return m_workgroupSize; }
 #endif
 
 private:
@@ -72,6 +76,9 @@ private:
   ComputeContext &operator=(const ComputeContext &) = delete;
 
   const ComputePipelineBuildInfo *m_pipelineInfo; // Info to build a compute pipeline
+#if VKI_RAY_TRACING
+  unsigned m_workgroupSize = 0;                   // Workgroup size for rayQuery lowering
+#endif
 };
 
 } // namespace Llpc

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -77,7 +77,7 @@ private:
 
   const ComputePipelineBuildInfo *m_pipelineInfo; // Info to build a compute pipeline
 #if VKI_RAY_TRACING
-  unsigned m_workgroupSize = 0;                   // Workgroup size for rayQuery lowering
+  unsigned m_workgroupSize = 0; // Workgroup size for rayQuery lowering
 #endif
 };
 

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -155,6 +155,10 @@ public:
   virtual void collectCallableDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}
   virtual void collectAttributeDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}
   virtual void collectBuiltIn(unsigned builtIn) {}
+
+  // Set workgroup size for compute pipeline so that rayQuery lowering can see it.
+  virtual void setWorkgroupSize(unsigned workgroupSize) {}
+  virtual unsigned getWorkgroupSize() const { return 0; }
 #endif
 
   static const char *getGpuNameAbbreviation(GfxIpVersion gfxIp);

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -66,7 +66,7 @@ void SpirvLowerMath::init(Module &module) {
   SpirvLower::init(&module);
   m_changed = false;
 
-  auto &commonShaderMode = m_context->getBuilder()->getCommonShaderMode(getLgcShaderStage(m_shaderStage));
+  auto commonShaderMode = Pipeline::getCommonShaderMode(module, getLgcShaderStage(m_shaderStage));
   m_fp16DenormFlush = commonShaderMode.fp16DenormMode == FpDenormMode::FlushOut ||
                       commonShaderMode.fp16DenormMode == FpDenormMode::FlushInOut;
   m_fp32DenormFlush = commonShaderMode.fp32DenormMode == FpDenormMode::FlushOut ||

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -1443,8 +1443,7 @@ unsigned SpirvLowerRayQuery::getWorkgroupSize() const {
   } else if (m_context->isGraphics()) {
     workgroupSize = m_context->getPipelineContext()->getRayTracingWaveSize();
   } else {
-    const lgc::ComputeShaderMode &computeMode = m_builder->getComputeShaderMode();
-    workgroupSize = computeMode.workgroupSizeX * computeMode.workgroupSizeY * computeMode.workgroupSizeZ;
+    workgroupSize = m_context->getPipelineContext()->getWorkgroupSize();
   }
   assert(workgroupSize != 0);
 #if VKI_BUILD_GFX11

--- a/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
@@ -86,7 +86,7 @@ bool SpirvLowerRayTracingBuiltIn::runImpl(Module &module) {
   mode.workgroupSizeX = rtState->threadGroupSizeX;
   mode.workgroupSizeY = rtState->threadGroupSizeY;
   mode.workgroupSizeZ = rtState->threadGroupSizeZ;
-  m_context->getBuilder()->setComputeShaderMode(mode);
+  lgc::Pipeline::setComputeShaderMode(module, mode);
 
   for (auto funcIt = module.begin(), funcEnd = module.end(); funcIt != funcEnd;) {
     Function *func = &*funcIt++;

--- a/llpc/lower/llpcSpirvLowerTranslator.cpp
+++ b/llpc/lower/llpcSpirvLowerTranslator.cpp
@@ -123,10 +123,6 @@ void SpirvLowerTranslator::translateSpirvToLlvm(const PipelineShaderInfo *shader
                        false);
   }
 
-  // Ensure the shader modes are recorded in IR metadata in the case that this is a shader compile
-  // rather than a pipeline compile.
-  m_context->getBuilder()->recordShaderModes(module);
-
   ShaderModuleHelper::cleanOptimizedSpirv(&optimizedSpirvBin);
 
   // NOTE: Our shader entrypoint is marked in the SPIR-V reader as dllexport. Here we tell LGC that it is the


### PR DESCRIPTION
This takes advantage of the fact that we no longer support builder direct mode; a Builder in the front-end is always a BuilderRecorder.

Most of the work here is to change BuilderRecorder so it does not hold a PipelineState object or a ShaderModes object. Now, when the front-end wants to write shader modes, it calls a static method on Pipeline, and that calls on to a static method in ShaderModes to write the values directly into IR, instead of caching in a ShaderModes object.

The middle-end still creates a ShaderModes object and reads the applicable IR metadata into it on creation.

The point of this is that having no state in Builder or BuilderRecorder (other than what is in IRBuilder) means that the front-end could just construct a local Builder object when needed, instead of having to construct a single Builder and get it into front-end passes.

Next steps in dismantling the BuilderRecorder/BuilderImpl thing would be:
- remove 'virtual' from all the methods;
- separate the class hierarchy so Builder is BuilderRecorder, and BuilderImpl is a separate thing that does not inherit from Builder.