### PR TITLE
Add support of OpDecorateId

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -70,6 +70,11 @@ SPIRVWord SPIRVDecorateGeneric::getLiteral(size_t I) const {
   return Literals[I];
 }
 
+SPIRVEntry *SPIRVDecorateGeneric::getEntry(size_t I) const {
+  assert(I <= Ids.size() && "Out of bounds");
+  return Module->getEntry(Ids[I]);
+}
+
 size_t SPIRVDecorateGeneric::getLiteralCount() const {
   return Literals.size();
 }
@@ -145,6 +150,18 @@ void SPIRVGroupMemberDecorate::decorateTargets() {
       }
     }
   }
+}
+
+void SPIRVDecorateId::setWordCount(SPIRVWord Count) {
+  WordCount = Count;
+  Ids.resize(WordCount - FixedWC);
+}
+
+void SPIRVDecorateId::decode(std::istream &I) {
+  SPIRVDecoder Decoder = getDecoder(I);
+  Decoder >> Target >> Dec;
+  Decoder >> Ids;
+  getOrCreateTarget()->addDecorate(this);
 }
 
 bool SPIRVDecorateGeneric::Comparator::operator()(const SPIRVDecorateGeneric *A, const SPIRVDecorateGeneric *B) const {

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -59,6 +59,7 @@ public:
   SPIRVDecorateGeneric(Op OC);
 
   SPIRVWord getLiteral(size_t) const;
+  SPIRVEntry *getEntry(size_t) const;
   const char *getLiteralString() const {
     assert(!Literals.empty());
     return reinterpret_cast<const char *>(Literals.data());
@@ -91,6 +92,7 @@ public:
 protected:
   Decoration Dec;
   std::vector<SPIRVWord> Literals;
+  std::vector<SPIRVId> Ids;
   SPIRVDecorationGroup *Owner; // Owning decorate group
 };
 
@@ -124,6 +126,19 @@ public:
   void validate() const override {
     SPIRVDecorateGeneric::validate();
     assert(WordCount == Literals.size() + FixedWC);
+  }
+};
+
+class SPIRVDecorateId : public SPIRVDecorate {
+public:
+  static const Op OC = OpDecorateId;
+  static const SPIRVWord FixedWC = 3;
+
+  _SPIRV_DCL_DECODE
+  void setWordCount(SPIRVWord) override;
+  void validate() const override {
+    SPIRVDecorateGeneric::validate();
+    assert(WordCount == Ids.size() + FixedWC);
   }
 };
 

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -276,6 +276,15 @@ bool SPIRVEntry::hasDecorate(Decoration Kind, size_t Index, SPIRVWord *Result) c
   return true;
 }
 
+// Check if an entry has Kind of decorationId
+SPIRVEntry *SPIRVEntry::getDecorateId(Decoration Kind, size_t Index) const {
+  DecorateMapType::const_iterator Loc = Decorates.find(Kind);
+  if (Loc == Decorates.end())
+    return nullptr;
+
+  return Loc->second->getEntry(Index);
+}
+
 const char *SPIRVEntry::getDecorateString(Decoration kind) const {
   DecorateMapType::const_iterator loc = Decorates.find(kind);
   if (loc == Decorates.end())

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -210,6 +210,7 @@ public:
   virtual SPIRVCapVec getRequiredCapability() const { return SPIRVCapVec(); }
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0, SPIRVWord *Result = 0) const;
+  SPIRVEntry *getDecorateId(Decoration Kind, size_t Index) const;
   const char *getDecorateString(Decoration kind) const;
   bool hasMemberDecorate(SPIRVWord MemberIndex, Decoration Kind, size_t Index = 0, SPIRVWord *Result = 0) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
@@ -670,7 +671,6 @@ template <spv::Op OC> bool isa(SPIRVEntry *E) {
 // This is also an indication of how much work is left.
 #define _SPIRV_OP(x, ...) typedef SPIRVEntryOpCodeOnly<Op##x> SPIRV##x;
 _SPIRV_OP(SizeOf)
-_SPIRV_OP(DecorateId)
 // NOTE: These 4 OpCodes are reserved by SPIR-V spec, they are invalid unless
 // some extensions expose them.
 _SPIRV_OP(ImageSparseSampleProjImplicitLod)


### PR DESCRIPTION
The diffferent with OpDecorate is OpDecorateId does not use literal values, but the spirv result id as decoration.