### PR TITLE
eliminate compile warning on Linux

### DIFF
--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -19,7 +19,6 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
             -Wall
             -Wno-delete-incomplete
             -Wno-delete-non-virtual-dtor
-            -Wno-invalid-offsetof
             -Wno-missing-braces
             -Wno-missing-field-initializers
             -Wno-parentheses
@@ -42,7 +41,6 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
             -fno-aligned-new
             -Wno-ignored-qualifiers
             -Wno-missing-field-initializers
-            -Wno-invalid-offsetof           # offsetof within non-standard-layout type 'x' is undefined
         >)
 
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -41,6 +41,7 @@ function(set_compiler_options PROJECT_NAME ENABLE_WERROR)
             -fno-aligned-new
             -Wno-ignored-qualifiers
             -Wno-missing-field-initializers
+            -Wno-invalid-offsetof           # offsetof within non-standard-layout type 'x' is undefined
         >)
 
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -822,8 +822,8 @@ Value *BuilderImpl::CreateSubgroupClusteredExclusive(GroupArithOp groupArithOp, 
       Value *const threadMask = createThreadMask();
 
       // Shift right within each row:
-      // ‭0b0110,0101,0100,0011,0010,0001,0000,1111‬ = 0x‭‭6543210F‬
-      // ‭0b1110,1101,1100,1011,1010,1001,1000,0111‬ = 0xEDCBA987
+      // 0b0110,0101,0100,0011,0010,0001,0000,1111 = 0x6543210F
+      // 0b1110,1101,1100,1011,1010,1001,1000,0111 = 0xEDCBA987
       shiftRight = createPermLane16(setInactive, setInactive, 0x6543210F, 0xEDCBA987, true, false);
 
       // Only needed for wave size 64.

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1396,8 +1396,9 @@ void PatchEntryPointMutate::addUserDataArgs(SmallVectorImpl<UserDataArg> &userDa
   // We do have user data layout.
   // Add entries from the root user data layout (not vertex buffer or streamout, and not unused ones).
 
-  for (unsigned userDataNodeIdx = 0; userDataNodeIdx != m_pipelineState->getUserDataNodes().size(); ++userDataNodeIdx) {
-    const ResourceNode &node = m_pipelineState->getUserDataNodes()[userDataNodeIdx];
+  llvm::ArrayRef<ResourceNode> userDataNodes = m_pipelineState->getUserDataNodes();
+  for (unsigned userDataNodeIdx = 0; userDataNodeIdx != userDataNodes.size(); ++userDataNodeIdx) {
+    const ResourceNode &node = userDataNodes[userDataNodeIdx];
     switch (node.concreteType) {
 
     case ResourceNodeType::IndirectUserDataVaPtr:

--- a/llpc/tool/llpcInputUtils.cpp
+++ b/llpc/tool/llpcInputUtils.cpp
@@ -312,7 +312,7 @@ static void findAllMatchFiles(const std::string &inFile, std::vector<std::string
 // @param [out] expandedFilenames : Returned expanded input filenames.
 // @returns : Result::Success on success, Result::ErrorInvalidValue when expansion fails.
 Result expandInputFilenames(ArrayRef<std::string> inputSpecs, std::vector<std::string> &expandedFilenames) {
-  unsigned i = 0;
+  [[maybe_unused]] unsigned i = 0;
   for (const auto &inFile : inputSpecs) {
     // Handle any optional entry point after the filename.
     // inputSpecs can be of the form <filename>,<entrypoint> and <filename>

--- a/tool/vfx/vfxParser.cpp
+++ b/tool/vfx/vfxParser.cpp
@@ -1365,8 +1365,9 @@ bool Document::macroSubstituteLine(char *line, unsigned lineNum, const MacroDefi
         break;
       }
 
-      sprintf(namePos, "%s%s", value, lineRest);
-      lineRest = namePos + nameLen + valueLen;
+      memmove(namePos + valueLen, lineRest, restLen);
+      memcpy(namePos, value, valueLen);
+      lineRest = namePos + valueLen;
       MacroDefinition macros2;
       macros2[iter->first] = iter->second;
       result =

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -490,13 +490,17 @@ private:
     return {addrTable.data(), addrTable.size()};
   }
 
+  static const size_t ExportConfigOffset;
   template <size_t Offset> static void *GetExportConfigMember(void *pObj) {
-    constexpr size_t ExportConfigOffset = offsetof(SectionIndirectCalleeSavedRegs, m_state);
     return reinterpret_cast<uint8_t *>(pObj) + ExportConfigOffset + Offset;
   }
 
   SubState m_state;
 };
+
+// Inline may allow the compiler to conveniently optimize at compile time
+inline const size_t SectionIndirectCalleeSavedRegs::ExportConfigOffset =
+  reinterpret_cast<size_t>(&reinterpret_cast<SectionIndirectCalleeSavedRegs*>(0)->m_state);
 
 // =====================================================================================================================
 // Represents the sub section RayTracingShaderExportConfig state

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -500,7 +500,7 @@ private:
 
 // Inline may allow the compiler to conveniently optimize at compile time
 inline const size_t SectionIndirectCalleeSavedRegs::ExportConfigOffset =
-  reinterpret_cast<size_t>(&reinterpret_cast<SectionIndirectCalleeSavedRegs*>(0)->m_state);
+    reinterpret_cast<size_t>(&reinterpret_cast<SectionIndirectCalleeSavedRegs *>(0)->m_state);
 
 // =====================================================================================================================
 // Represents the sub section RayTracingShaderExportConfig state

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -490,17 +490,12 @@ private:
     return {addrTable.data(), addrTable.size()};
   }
 
-  static const size_t ExportConfigOffset;
   template <size_t Offset> static void *GetExportConfigMember(void *pObj) {
-    return reinterpret_cast<uint8_t *>(pObj) + ExportConfigOffset + Offset;
+    return reinterpret_cast<uint8_t *>(&reinterpret_cast<SectionIndirectCalleeSavedRegs *>(pObj)->m_state) + Offset;
   }
 
   SubState m_state;
 };
-
-// Inline may allow the compiler to conveniently optimize at compile time
-inline const size_t SectionIndirectCalleeSavedRegs::ExportConfigOffset =
-    reinterpret_cast<size_t>(&reinterpret_cast<SectionIndirectCalleeSavedRegs *>(0)->m_state);
 
 // =====================================================================================================================
 // Represents the sub section RayTracingShaderExportConfig state


### PR DESCRIPTION
### Warning List

 + lgc/builder/SubgroupBuilder.cpp:825:63: warning: unpaired UTF-8 bidirectional control character detected [-Wbidi-chars=]
 + lgc/patch/PatchEntryPointMutate.cpp:1399:25: warning: possibly dangling reference to a temporary [-Wdangling-reference]
 + llpc/tool/llpcInputUtils.cpp:315:12: warning: variable 'i' set but not used [-Wunused-but-set-variable]
 + tool/vfx/vfxParser.cpp:1368:15: warning: `sprintf` argument 4 may overlap destination object `namePos` [-Wrestrict]
 + tool/vfx/vfxVkSection.h:494:52: warning: `offsetof` within non-standard-layout type `Vfx::SectionIndirectCalleeSavedRegs` is conditionally-supported [-Winvalid-offsetof]

### Explanation about tool/vfx/vfxParser.cpp:1368

Currently this function never run it, because macroDefinition is always empty.
In fact, lineRest may OVERLAP with the first parameter (namePos).

The C standard and POSIX specify that the behavior of sprintf and its variants
is undefined when an argument overlaps with the destination buffer.

Reference: https://en.cppreference.com/w/c/io/fprintf

### Explanation about tool/vfx/vfxVkSection.h:494

If type is not a standard layout type, the result of offsetof is undefined.
Reason:
 + has virtual base classes,
 + has non-standard-layout base classes, and
 + multiple classes in the hierarchy has non-static data members.

Reference: https://en.cppreference.com/w/cpp/language/classes#Standard-layout_class

We often use the following code in C language to calculate the offset of a
member. That is, address of member is offset!
```c
((size_t) &((TYPE *)0)->MEMBER)
```