### PR TITLE
Add more logging functionality for GPURT

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayQuery.h
+++ b/llpc/lower/llpcSpirvLowerRayQuery.h
@@ -127,7 +127,9 @@ protected:
   void createGlobalStack();
   void createGlobalLdsUsage();
   void createGlobalRayQueryObj();
+  void createGlobalTraceRayStaticId();
   void initGlobalVariable();
+  void generateTraceRayStaticId();
   llvm::Value *createTransformMatrix(unsigned builtInId, llvm::Value *accelStruct, llvm::Value *instanceId,
                                      llvm::Instruction *insertPos);
   llvm::Value *getThreadIdInGroup() const;
@@ -136,6 +138,7 @@ protected:
   llvm::Value *createLoadInstanceIndex(llvm::Value *instNodeAddr);
   llvm::Value *createLoadInstanceId(llvm::Value *instNodeAddr);
   llvm::Value *createLoadMatrixFromAddr(llvm::Value *matrixAddr);
+  llvm::GlobalVariable *m_traceRayStaticId; // Static trace ray call site identifier
 
   bool m_rayQueryLibrary;       // Whether the module is ray query library
   unsigned m_spirvOpMetaKindId; // Metadata kind ID for "spirv.op"
@@ -163,6 +166,7 @@ private:
   llvm::GlobalVariable *m_stackArray;      // Stack array to hold stack value
   llvm::GlobalVariable *m_prevRayQueryObj; // Previous ray query Object
   llvm::GlobalVariable *m_rayQueryObjGen;  // Ray query Object Id generator
+  unsigned m_nextTraceRayId;               // Next trace ray ID to be used for ray history
 };
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -53,6 +53,7 @@ enum : unsigned {
   DuplicateAnyHit,       // Indication of calling behavior on any hit shader,
   GeometryIndex,         // Geometry Index
   HitAttributes,         // Hit attributes
+  ParentRayId,           // Ray ID of the parent TraceRay call
   Count                  // Count of the trace attributes
 };
 }


### PR DESCRIPTION
GPURT adds 3 intrinsic functions:
`AmdTraceRayGetParentId` to get a previously set parent ray ID.
`AmdTraceRaySetParentId` to set a parent ray ID.
`AmdTraceRayGetStaticId` to get a unique ID generated by client for each TraceRay call.

This change adds LLPC support for those.

Note that the GPURT change is still under review (but almost done) internally when
this PR is posted.