### PR TITLE
Add a new option to control whether fmask is enabled

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -425,9 +425,9 @@ Value *BuilderImpl::getDescPtr(ResourceNodeType concreteType, ResourceNodeType a
     // - value for high 32 bits of the pointer; HighAddrPc to use PC
     if (node || topNode || concreteType != ResourceNodeType::DescriptorFmask) {
       unsigned shadowDescriptorTable = m_pipelineState->getOptions().shadowDescriptorTable;
-      bool shadow =
-          concreteType == ResourceNodeType::DescriptorFmask && shadowDescriptorTable != ShadowDescriptorTableDisable;
-      Value *highHalf = getInt32(shadow ? shadowDescriptorTable : HighAddrPc);
+      bool enableFmask =
+          concreteType == ResourceNodeType::DescriptorFmask && m_pipelineState->getOptions().enableFmask;
+      Value *highHalf = getInt32(enableFmask ? shadowDescriptorTable : HighAddrPc);
       return CreateNamedCall(lgcName::DescriptorTableAddr, getInt8Ty()->getPointerTo(ADDR_SPACE_CONST),
                              {getInt32(unsigned(concreteType)), getInt32(unsigned(abstractType)), getInt32(descSet),
                               getInt32(binding), highHalf},
@@ -518,6 +518,9 @@ Value *BuilderImpl::getDescPtr(ResourceNodeType concreteType, ResourceNodeType a
     if (concreteType == ResourceNodeType::DescriptorSampler &&
         node->concreteType == ResourceNodeType::DescriptorCombinedTexture)
       offsetInBytes += DescriptorSizeResource;
+    else if (concreteType == ResourceNodeType::DescriptorFmask &&
+             node->concreteType == ResourceNodeType::DescriptorCombinedTexture)
+      offsetInBytes += DescriptorSizeResource + DescriptorSizeSampler;
     offset = getInt32(offsetInBytes);
   }
 

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -583,7 +583,7 @@ Value *BuilderImpl::CreateImageLoadWithFmask(Type *resultTy, unsigned dim, unsig
   }
 
   // When the shadow table is disabled, we don't need to load F-mask descriptor
-  if (m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
+  if (m_pipelineState->getOptions().enableFmask) {
     Value *fmaskTexel = CreateImageLoad(FixedVectorType::get(getInt32Ty(), 4), fmaskDim, flags, fmaskDesc, coord,
                                         nullptr, instName + ".fmaskload");
 

--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -216,7 +216,7 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
     return true;
   }
   if (name == reloc::ShadowDescriptorTableEnabled) {
-    value = m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable;
+    value = m_pipelineState->getOptions().enableFmask;
     return true;
   }
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -133,8 +133,8 @@ struct Options {
   bool fullSubgroups;                  // Use full subgroup lanes
   unsigned nggVertsPerSubgroup;        // How to determine NGG verts per subgroup
   unsigned nggPrimsPerSubgroup;        // How to determine NGG prims per subgroup
-  unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address, or
-                                       //   ShadowDescriptorTableDisable to disable shadow descriptor tables
+  unsigned shadowDescriptorTable;      // High dword of shadow descriptor table address
+  bool     enableFmask;                // Enable Fmask
   unsigned allowNullDescriptor;        // Allow and give defined behavior for null descriptor
   unsigned disableImageResourceCheck;  // Don't do image resource type check
   unsigned reserved0f;                 // Reserved for future functionality

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -560,5 +560,5 @@ unsigned ShaderSystemValues::findResourceNodeByDescSet(unsigned descSet) {
 // =====================================================================================================================
 // Test if shadow descriptor table is enabled
 bool ShaderSystemValues::isShadowDescTableEnabled() const {
-  return m_pipelineState->getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable;
+  return m_pipelineState->getOptions().enableFmask;
 }

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1003,8 +1003,7 @@ PipelineState::findResourceNode(ResourceNodeType nodeType, unsigned descSet, uns
       return {&node, &node};
   }
 
-  if (nodeType == ResourceNodeType::DescriptorFmask &&
-      getOptions().shadowDescriptorTable != ShadowDescriptorTableDisable) {
+  if (nodeType == ResourceNodeType::DescriptorFmask && getOptions().enableFmask) {
 #if defined(__GNUC__) && !defined(__clang__)
     // FIXME Newer gcc versions optimize out this if statement. The reason is either undefined behavior in lgc or a bug
     // in gcc. The following inline assembly prevents the gcc optimization.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -288,21 +288,27 @@ Options PipelineContext::computePipelineOptions() const {
   case Vkgc::ShadowDescriptorTableUsage::Auto:
     // Use default of 2 for standalone amdllpc.
     options.shadowDescriptorTable = ShadowDescTablePtrHigh;
+    options.enableFmask = true;
     break;
   case Vkgc::ShadowDescriptorTableUsage::Enable:
     options.shadowDescriptorTable = getPipelineOptions()->shadowDescriptorTablePtrHigh;
+    options.enableFmask = true;
     break;
   case Vkgc::ShadowDescriptorTableUsage::Disable:
     options.shadowDescriptorTable = ShadowDescriptorTableDisable;
+    options.enableFmask = false;
     break;
   }
 
   // Shadow descriptor command line options override pipeline options.
   if (EnableShadowDescriptorTable.getNumOccurrences() > 0) {
-    if (!EnableShadowDescriptorTable)
+    if (!EnableShadowDescriptorTable) {
       options.shadowDescriptorTable = ShadowDescriptorTableDisable;
-    else
+      options.enableFmask = false;
+    } else {
       options.shadowDescriptorTable = ShadowDescTablePtrHigh;
+      options.shadowDescriptorTable = true;
+    }
   }
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;


### PR DESCRIPTION
Currently, the option "shadowDescriptorTable" not only controls whether fmask is enabled, but also is used as high dword of shadow descriptor table address. This doesn't meet the cases that the descriptors are not in shadow table, shadowDescriptorTable will be set ~0u, and fmask is required to be enabled.