### PR TITLE
Fix enum-compare warning

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1596,7 +1596,7 @@ protected:
     GcnShaderAMDExtOpKind ExtOpGcnShaderAMD;
     ShaderTrinaryMinMaxAMDExtOpKind ExtOpShaderTrinaryMinMaxAMD;
     NonSemanticInfoExtOpKind ExtOpNonSemanticInfo;
-    SPIRVDebugExtOpKind ExtOpDebug;
+    NonSemanticShaderDebugInfo100Instructions ExtOpDebug;
   };
   SPIRVExtInstSetKind ExtSetKind;
 };


### PR DESCRIPTION
Use NonSemanticShaderDebugInfo100Instructions type as definition of ExtOpDebug