### PR TITLE
Replace divergence analysis with uniformity analysis

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -106,7 +106,7 @@ private:
   llvm::IRBuilder<> m_builder;
 
   PipelineState &m_pipelineState;
-  UniformityInfo &m_uniformityInfo;
+  llvm::UniformityInfo &m_uniformityInfo;
 
   // The proxy pointer type used to accumulate offsets.
   llvm::PointerType *m_offsetType = nullptr;

--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -33,13 +33,10 @@
 #include "lgc/patch/Patch.h"
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Analysis/UniformityAnalysis.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/PassManager.h"
-
-namespace llvm {
-class DivergenceInfo;
-}
 
 namespace lgc {
 
@@ -70,7 +67,7 @@ class BufferOpLowering {
   };
 
 public:
-  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::DivergenceInfo &divergenceInfo);
+  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::UniformityInfo &uniformityInfo);
 
   static void registerVisitors(llvm_dialects::VisitorBuilder<BufferOpLowering> &builder);
 
@@ -109,7 +106,7 @@ private:
   llvm::IRBuilder<> m_builder;
 
   PipelineState &m_pipelineState;
-  llvm::DivergenceInfo &m_divergenceInfo;
+  UniformityInfo &m_uniformityInfo;
 
   // The proxy pointer type used to accumulate offsets.
   llvm::PointerType *m_offsetType = nullptr;

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -395,7 +395,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
                                   .needCanonicalLoops(true)
                                   .sinkCommonInsts(true)));
   fpm.addPass(LoopUnrollPass(LoopUnrollOptions(optLevel)));
-  // uses DivergenceAnalysis
+  // uses UniformityAnalysis
   fpm.addPass(PatchReadFirstLane());
   fpm.addPass(InstCombinePass(instCombineOpt));
   passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));

--- a/lgc/patch/PatchReadFirstLane.cpp
+++ b/lgc/patch/PatchReadFirstLane.cpp
@@ -31,7 +31,7 @@
 #include "lgc/patch/PatchReadFirstLane.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/PipelineState.h"
-#include "llvm/Analysis/DivergenceAnalysis.h"
+#include "llvm/Analysis/UniformityAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InstVisitor.h"
@@ -89,8 +89,8 @@ PatchReadFirstLane::PatchReadFirstLane() : m_targetTransformInfo(nullptr) {
 PreservedAnalyses PatchReadFirstLane::run(Function &function, FunctionAnalysisManager &analysisManager) {
   TargetTransformInfo &targetTransformInfo = analysisManager.getResult<TargetIRAnalysis>(function);
 
-  DivergenceInfo &divergenceInfo = analysisManager.getResult<DivergenceAnalysis>(function);
-  auto isDivergentUse = [&](const Use &use) { return divergenceInfo.isDivergentUse(use); };
+  UniformityInfo &uniformityInfo = analysisManager.getResult<UniformityInfoAnalysis>(function);
+  auto isDivergentUse = [&](const Use &use) { return uniformityInfo.isDivergentUse(use); };
   if (runImpl(function, isDivergentUse, &targetTransformInfo))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -149,7 +149,6 @@ void LgcContext::initialize() {
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
-  setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
   setOptionDefault("spec-exec-max-speculation-cost", "10");
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)

--- a/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
+++ b/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
@@ -6,7 +6,6 @@
 ;
 ; OVERRIDDEN-LABEL: --robust-buffer-access = 1 (default: 0)
 ; OVERRIDDEN-NOT:   --scalar-block-layout = {{.*}}
-; OVERRIDDEN-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
 
 ; 2. Check that all options gets printed with `--print-all-options`.
 ; RUN: amdllpc %gfxip %s --robust-buffer-access --print-all-options \
@@ -14,7 +13,6 @@
 ;
 ; ALL-LABEL: --robust-buffer-access = 1 (default: 0)
 ; ALL-LABEL: --scalar-block-layout = {{.*}}
-; ALL-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
 
 
                OpCapability Shader


### PR DESCRIPTION
The old divergence analysis is deprecated in favor of the new uniformity analysis and is going to be removed from upstream LLVM soon.