### PR TITLE
Replace divergence analysis with uniformity analysis

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -33,13 +33,10 @@
 #include "lgc/patch/Patch.h"
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Analysis/UniformityAnalysis.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/PassManager.h"
-
-namespace llvm {
-class DivergenceInfo;
-}
 
 namespace lgc {
 
@@ -70,7 +67,7 @@ class BufferOpLowering {
   };
 
 public:
-  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::DivergenceInfo &divergenceInfo);
+  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::UniformityInfo &uniformityInfo);
 
   static void registerVisitors(llvm_dialects::VisitorBuilder<BufferOpLowering> &builder);
 
@@ -109,7 +106,7 @@ private:
   llvm::IRBuilder<> m_builder;
 
   PipelineState &m_pipelineState;
-  llvm::DivergenceInfo &m_divergenceInfo;
+  llvm::UniformityInfo &m_uniformityInfo;
 
   // The proxy pointer type used to accumulate offsets.
   llvm::PointerType *m_offsetType = nullptr;

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -395,7 +395,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
                                   .needCanonicalLoops(true)
                                   .sinkCommonInsts(true)));
   fpm.addPass(LoopUnrollPass(LoopUnrollOptions(optLevel)));
-  // uses DivergenceAnalysis
+  // uses UniformityAnalysis
   fpm.addPass(PatchReadFirstLane());
   fpm.addPass(InstCombinePass(instCombineOpt));
   passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));

--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -38,7 +38,6 @@
 #include "lgc/util/TypeLowering.h"
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/ADT/PostOrderIterator.h"
-#include "llvm/Analysis/DivergenceAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
@@ -55,7 +54,7 @@ using namespace lgc;
 namespace {
 
 struct PatchBufferOpImpl {
-  PatchBufferOpImpl(LLVMContext &context, PipelineState &pipelineState, DivergenceInfo &divergenceInfo);
+  PatchBufferOpImpl(LLVMContext &context, PipelineState &pipelineState, UniformityInfo &uniformityInfo);
 
   bool run(Function &function);
 
@@ -78,9 +77,9 @@ PreservedAnalyses PatchBufferOp::run(Function &function, FunctionAnalysisManager
   const auto &moduleAnalysisManager = analysisManager.getResult<ModuleAnalysisManagerFunctionProxy>(function);
   PipelineState *pipelineState =
       moduleAnalysisManager.getCachedResult<PipelineStateWrapper>(*function.getParent())->getPipelineState();
-  DivergenceInfo &divergenceInfo = analysisManager.getResult<DivergenceAnalysis>(function);
+  UniformityInfo &uniformityInfo = analysisManager.getResult<UniformityInfoAnalysis>(function);
 
-  PatchBufferOpImpl impl(function.getContext(), *pipelineState, divergenceInfo);
+  PatchBufferOpImpl impl(function.getContext(), *pipelineState, uniformityInfo);
   if (!impl.run(function))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();
@@ -88,8 +87,8 @@ PreservedAnalyses PatchBufferOp::run(Function &function, FunctionAnalysisManager
 
 // =====================================================================================================================
 // Construct the per-run temporaries of the PatchBufferOp pass.
-PatchBufferOpImpl::PatchBufferOpImpl(LLVMContext &context, PipelineState &pipelineState, DivergenceInfo &divergenceInfo)
-    : m_typeLowering(context), m_bufferOpLowering(m_typeLowering, pipelineState, divergenceInfo) {
+PatchBufferOpImpl::PatchBufferOpImpl(LLVMContext &context, PipelineState &pipelineState, UniformityInfo &uniformityInfo)
+    : m_typeLowering(context), m_bufferOpLowering(m_typeLowering, pipelineState, uniformityInfo) {
 }
 
 // =====================================================================================================================
@@ -135,11 +134,11 @@ static SmallVector<Type *> convertBufferPointer(TypeLowering &typeLowering, Type
 //
 // @param typeLowering : the TypeLowering object to be used
 // @param pipelineState : the PipelineState object
-// @param divergenceInfo : the divergence analysis result
+// @param uniformityInfo : the uniformity analysis result
 BufferOpLowering::BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState,
-                                   DivergenceInfo &divergenceInfo)
+                                   UniformityInfo &uniformityInfo)
     : m_typeLowering(typeLowering), m_builder(typeLowering.getContext()), m_pipelineState(pipelineState),
-      m_divergenceInfo(divergenceInfo) {
+      m_uniformityInfo(uniformityInfo) {
   m_typeLowering.addRule(&convertBufferPointer);
 
   m_offsetType = m_builder.getPtrTy(ADDR_SPACE_CONST_32BIT);
@@ -176,6 +175,7 @@ void BufferOpLowering::finish() {
   // divergence, and the new phi should be divergent as well.
   //
   // TODO: DivergenceAnalysis should really be updatable/preservable (but switch to new uniform analysis first)
+
   for (PHINode *originalPhi : m_divergentPhis) {
     auto values = m_typeLowering.getValue(originalPhi);
     if (auto *newPhi = dyn_cast<PHINode>(values[0])) {
@@ -227,7 +227,7 @@ BufferOpLowering::DescriptorInfo BufferOpLowering::getDescriptorInfo(Value *desc
             searchWorklist.push_back(incoming);
         } else if (auto *select = dyn_cast<SelectInst>(current)) {
           assert(select->getOperandUse(0).get() == select->getCondition());
-          if (m_divergenceInfo.isDivergentUse(select->getOperandUse(0)))
+          if (m_uniformityInfo.isDivergentUse(select->getOperandUse(0)))
             di.divergent = true;
 
           if (!di.invariant.has_value() || !di.divergent.has_value()) {
@@ -622,7 +622,7 @@ void BufferOpLowering::visitBufferDescToPtr(BufferDescToPtrOp &descToPtr) {
 
   auto &di = m_descriptors[descToPtr.getDesc()];
   di.invariant = removeUsersForInvariantStarts(&descToPtr);
-  di.divergent = m_divergenceInfo.isDivergent(*descToPtr.getDesc());
+  di.divergent = m_uniformityInfo.isDivergent(descToPtr.getDesc());
 }
 
 // =====================================================================================================================
@@ -828,7 +828,7 @@ void BufferOpLowering::visitPhiInst(llvm::PHINode &phi) {
   if (!phi.getType()->isPointerTy() || phi.getType()->getPointerAddressSpace() != ADDR_SPACE_BUFFER_FAT_POINTER)
     return;
 
-  if (m_divergenceInfo.isDivergent(phi))
+  if (m_uniformityInfo.isDivergent(&phi))
     m_divergentPhis.push_back(&phi);
 }
 

--- a/lgc/patch/PatchReadFirstLane.cpp
+++ b/lgc/patch/PatchReadFirstLane.cpp
@@ -31,8 +31,8 @@
 #include "lgc/patch/PatchReadFirstLane.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/PipelineState.h"
-#include "llvm/Analysis/DivergenceAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Analysis/UniformityAnalysis.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
@@ -89,8 +89,8 @@ PatchReadFirstLane::PatchReadFirstLane() : m_targetTransformInfo(nullptr) {
 PreservedAnalyses PatchReadFirstLane::run(Function &function, FunctionAnalysisManager &analysisManager) {
   TargetTransformInfo &targetTransformInfo = analysisManager.getResult<TargetIRAnalysis>(function);
 
-  DivergenceInfo &divergenceInfo = analysisManager.getResult<DivergenceAnalysis>(function);
-  auto isDivergentUse = [&](const Use &use) { return divergenceInfo.isDivergentUse(use); };
+  UniformityInfo &uniformityInfo = analysisManager.getResult<UniformityInfoAnalysis>(function);
+  auto isDivergentUse = [&](const Use &use) { return uniformityInfo.isDivergentUse(use); };
   if (runImpl(function, isDivergentUse, &targetTransformInfo))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -149,7 +149,6 @@ void LgcContext::initialize() {
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
-  setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
   setOptionDefault("spec-exec-max-speculation-cost", "10");
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)

--- a/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
+++ b/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
@@ -6,7 +6,6 @@
 ;
 ; OVERRIDDEN-LABEL: --robust-buffer-access = 1 (default: 0)
 ; OVERRIDDEN-NOT:   --scalar-block-layout = {{.*}}
-; OVERRIDDEN-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
 
 ; 2. Check that all options gets printed with `--print-all-options`.
 ; RUN: amdllpc %gfxip %s --robust-buffer-access --print-all-options \
@@ -14,7 +13,6 @@
 ;
 ; ALL-LABEL: --robust-buffer-access = 1 (default: 0)
 ; ALL-LABEL: --scalar-block-layout = {{.*}}
-; ALL-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
 
 
                OpCapability Shader


### PR DESCRIPTION
The old divergence analysis is deprecated in favor of the new uniformity analysis and is going to be removed from upstream LLVM soon.