### PR TITLE
Add a workaround of initializing outputs to zero

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     61.6 | Add workaroundInitializeOutputsToZero to PipelineShaderOptions                                        |
 //  |     61.5 | Add RtIpVersion (including its checkers) to represent ray tracing IP                                  |
 //  |     61.4 | Add workaroundStorageImageFormats to PipelineShaderOptions                                            |
 //  |     61.2 | Add pClientMetadata and clientMetadataSize to all PipelineBuildInfos                                  |
@@ -856,6 +857,9 @@ struct PipelineShaderOptions {
   /// Disable an optimization that relies on trusting shaders to specify the correct image format to reduce the number
   /// of written channels.
   bool workaroundStorageImageFormats;
+
+  /// Initialize outputs to zero if it is true
+  bool workaroundInitializeOutputsToZero;
 };
 
 /// Represents YCbCr sampler meta data in resource descriptor

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4255,10 +4255,28 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpVariable>(SPIRVValue *con
   Constant *initializer = nullptr;
 
   // If the type has an initializer, re-create the SPIR-V initializer in LLVM.
-  if (spvInitializer)
+  if (spvInitializer) {
     initializer = transInitializer(spvInitializer, varType);
-  else if (storageClass == SPIRVStorageClassKind::StorageClassWorkgroup)
+  } else if (storageClass == SPIRVStorageClassKind::StorageClassWorkgroup) {
     initializer = UndefValue::get(varType);
+  } else if (m_shaderOptions->workaroundInitializeOutputsToZero &&
+             storageClass == SPIRVStorageClassKind::StorageClassOutput) {
+    bool isBuiltIn = false;
+    if (spvVarType->hasDecorate(DecorationBuiltIn)) {
+      isBuiltIn = true;
+    } else if (spvVarType->isTypeStruct()) {
+      for (unsigned memberId = 0; memberId < spvVarType->getStructMemberCount(); ++memberId) {
+        if (spvVarType->hasMemberDecorate(memberId, DecorationBuiltIn)) {
+          isBuiltIn = true;
+          break;
+        }
+      }
+    }
+    if (!isBuiltIn) {
+      // Initializize user-defined output variable to zero
+      initializer = Constant::getNullValue(varType);
+    }
+  }
 
   bool readOnly = false;
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -607,6 +607,7 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   }
 
   // Output pipeline shader options
+  // clang-format off
   dumpFile << "options.trapPresent = " << shaderInfo->options.trapPresent << "\n";
   dumpFile << "options.debugMode = " << shaderInfo->options.debugMode << "\n";
   dumpFile << "options.enablePerformanceData = " << shaderInfo->options.enablePerformanceData << "\n";
@@ -645,7 +646,9 @@ void PipelineDumper::dumpPipelineShaderInfo(const PipelineShaderInfo *shaderInfo
   dumpFile << "options.nsaThreshold = " << shaderInfo->options.nsaThreshold << "\n";
   dumpFile << "options.aggressiveInvariantLoads = " << shaderInfo->options.aggressiveInvariantLoads << "\n";
   dumpFile << "options.workaroundStorageImageFormats = " << shaderInfo->options.workaroundStorageImageFormats << "\n";
+  dumpFile << "options.workaroundInitializeOutputsToZero = " << shaderInfo->options.workaroundInitializeOutputsToZero << "\n";
   dumpFile << "\n";
+  // clang-format on
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -168,6 +168,7 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, nsaThreshold, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, aggressiveInvariantLoads, MemberTypeEnum, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, workaroundStorageImageFormats, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionShaderOption, workaroundInitializeOutputsToZero, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};


### PR DESCRIPTION
This change makes a workaround to fix the corruption in vk_timeline_semaphore in nvpro-sample. The root cause is that FS reads an input which is not exported by VS. We need initialize the output to zero when the workaround flag is enabled.

