### PR TITLE
Fix for unhandled SPIRVIS-NonSemanticInfo

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4100,6 +4100,8 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpExtInst>(SPIRVValue *cons
     default:
       return nullptr;
     }
+  case SPIRVEIS_NonSemanticInfo:
+    return nullptr;
   default:
     llvm_unreachable("Should never be called!");
     return nullptr;


### PR DESCRIPTION
Changes to support new NonSemanticShaderDebugInfo meant that some CTS tests generated SPIRV with NonSemanticInfo in them.

This led to hitting an llvm_unreachable for the unhandled case. This change stops the unreachable and enables the test to pass.