### PR TITLE
Rework of writing XFB output

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1502,17 +1502,15 @@ Instruction *Builder::CreateWriteGenericOutput(Value *valueToWrite, unsigned loc
 // @param valueToWrite : Value to write
 // @param isBuiltIn : True for built-in, false for user output
 // @param location : Location (row) or built-in kind of output
-// @param component : Component offset of inputs and outputs (ignored if built-in)
 // @param xfbBuffer : XFB buffer ID
 // @param xfbStride : XFB stride
 // @param xfbOffset : XFB byte offset
 // @param outputInfo : Extra output info (GS stream ID)
-Instruction *Builder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuiltIn, unsigned location, unsigned component,
-                                           unsigned xfbBuffer, unsigned xfbStride, Value *xfbOffset,
-                                           InOutInfo outputInfo) {
+Instruction *Builder::CreateWriteXfbOutput(Value *valueToWrite, bool isBuiltIn, unsigned location, unsigned xfbBuffer,
+                                           unsigned xfbStride, Value *xfbOffset, InOutInfo outputInfo) {
   return record(BuilderOpcode::WriteXfbOutput, nullptr,
-                {valueToWrite, getInt1(isBuiltIn), getInt32(location), getInt32(component), getInt32(xfbBuffer),
-                 getInt32(xfbStride), xfbOffset, getInt32(outputInfo.getData())},
+                {valueToWrite, getInt1(isBuiltIn), getInt32(location), getInt32(xfbBuffer), getInt32(xfbStride),
+                 xfbOffset, getInt32(outputInfo.getData())},
                 "");
 }
 

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -585,14 +585,13 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   }
 
   case BuilderOpcode::WriteXfbOutput: {
-    InOutInfo outputInfo(cast<ConstantInt>(args[7])->getZExtValue());
+    InOutInfo outputInfo(cast<ConstantInt>(args[6])->getZExtValue());
     return m_builder->CreateWriteXfbOutput(args[0],                                    // Value to write
                                            cast<ConstantInt>(args[1])->getZExtValue(), // IsBuiltIn
                                            cast<ConstantInt>(args[2])->getZExtValue(), // Location/builtIn
-                                           cast<ConstantInt>(args[3])->getZExtValue(), // Component
-                                           cast<ConstantInt>(args[4])->getZExtValue(), // XFB buffer ID
-                                           cast<ConstantInt>(args[5])->getZExtValue(), // XFB stride
-                                           args[6],                                    // XFB byte offset
+                                           cast<ConstantInt>(args[3])->getZExtValue(), // XFB buffer ID
+                                           cast<ConstantInt>(args[4])->getZExtValue(), // XFB stride
+                                           args[5],                                    // XFB byte offset
                                            outputInfo);
   }
 

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -479,8 +479,8 @@ public:
 
   // Create a write to an XFB (transform feedback / streamout) buffer.
   llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                          unsigned component, unsigned xfbBuffer, unsigned xfbStride,
-                                          llvm::Value *xfbOffset, InOutInfo outputInfo);
+                                          unsigned xfbBuffer, unsigned xfbStride, llvm::Value *xfbOffset,
+                                          InOutInfo outputInfo);
 
   // Create a read of barycoord input value.
   llvm::Value *CreateReadBaryCoord(BuiltInKind builtIn, InOutInfo inputInfo, llvm::Value *auxInterpValue,

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -110,7 +110,10 @@ public:
   void setHighHalf(bool isHighHalf) { m_data.bits.isHighHalf = isHighHalf; }
 
   unsigned getComponent() const { return m_data.bits.component; }
-  void setComponent(unsigned compIdx) { m_data.bits.component = static_cast<uint16_t>(compIdx); }
+  void setComponent(unsigned compIdx) {
+    assert(compIdx < 4); // Valid component offsets are 0~3
+    m_data.bits.component = static_cast<uint16_t>(compIdx);
+  }
 
   unsigned getLocation() const { return m_data.bits.location; }
   void setLocation(unsigned loc) { m_data.bits.location = static_cast<uint16_t>(loc); }

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -104,6 +104,12 @@ public:
   bool isPerPrimitive() const { return m_data.bits.perPrimitive; }
   void setPerPrimitive(bool perPrimitive = true) { m_data.bits.perPrimitive = perPrimitive; }
 
+  unsigned getComponent() const { return m_data.bits.component; }
+  void setComponent(unsigned component) {
+    assert(component < 4); // Valid component offsets are 0~3
+    m_data.bits.component = component;
+  }
+
 private:
   union {
     struct {
@@ -118,6 +124,7 @@ private:
                                  //    a read or write of ClipDistance or CullDistance that is of the
                                  //    whole array or of an element with a variable index.
       unsigned perPrimitive : 1; // Mesh shader output: whether it is a per-primitive output
+      unsigned component : 2;    // Component offset, specifying which components within a location is consumed
     } bits;
     unsigned u32All;
   } m_data;
@@ -1153,14 +1160,13 @@ public:
   // @param valueToWrite : Value to write
   // @param isBuiltIn : True for built-in, false for user output
   // @param location : Location (row) or built-in kind of output
-  // @param component : Component offset of inputs and outputs (ignored if built-in)
   // @param xfbBuffer : XFB buffer ID
   // @param xfbStride : XFB stride
   // @param xfbOffset : XFB byte offset
   // @param outputInfo : Extra output info (GS stream ID)
   llvm::Instruction *CreateWriteXfbOutput(llvm::Value *valueToWrite, bool isBuiltIn, unsigned location,
-                                          unsigned component, unsigned xfbBuffer, unsigned xfbStride,
-                                          llvm::Value *xfbOffset, InOutInfo outputInfo);
+                                          unsigned xfbBuffer, unsigned xfbStride, llvm::Value *xfbOffset,
+                                          InOutInfo outputInfo);
 
   // Create a read of barycoord input value.
   // The type of the returned value is the fixed type of the specified built-in (see BuiltInDefs.h),

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -957,8 +957,11 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
         loc = value;
       } else {
         if (m_pipelineState->canPackOutput(m_shaderStage)) {
+          // Generic output exports of FS should have been handled by the LowerFragColorExport pass
           assert(m_shaderStage == ShaderStageVertex || m_shaderStage == ShaderStageGeometry ||
                  m_shaderStage == ShaderStageTessEval);
+
+          // Check component offset and search the location info map once again
           origLocInfo.setComponent(cast<ConstantInt>(callInst.getOperand(1))->getZExtValue());
           locInfoMapIt = resUsage->inOutUsage.outputLocInfoMap.find(origLocInfo);
 

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2916,9 +2916,9 @@ void PatchResourceCollect::updateOutputLocInfoMapWithUnpack() {
 }
 
 // =====================================================================================================================
-// Returns true if the locations for the Gs output can be compressed.
+// Returns true if the locations for the GS output can be compressed.
 bool PatchResourceCollect::canChangeOutputLocationsForGs() {
-  // The Gs outputs can only be changed if LGC has access to the fragment shader's inputs.
+  // The GS outputs can only be changed if LGC has access to the fragment shader's inputs.
   if (!m_pipelineState->isUnlinked())
     return true;
   if (m_pipelineState->getPalMetadata()->haveFsInputMappings())

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1308,7 +1308,7 @@ void SpirvLowerGlobal::addCallInstForOutputExport(Value *outputValue, Constant *
 
           auto xfbOffset = m_builder->getInt32(outputMeta.XfbOffset + outputMeta.XfbExtraOffset + byteSize * idx);
           m_builder->CreateWriteXfbOutput(elem,
-                                          /*isBuiltIn=*/true, builtInId, 0, outputMeta.XfbBuffer, outputMeta.XfbStride,
+                                          /*isBuiltIn=*/true, builtInId, outputMeta.XfbBuffer, outputMeta.XfbStride,
                                           xfbOffset, outputInfo);
 
           if (!static_cast<bool>(EnableXfb)) {
@@ -1390,6 +1390,7 @@ void SpirvLowerGlobal::addCallInstForOutputExport(Value *outputValue, Constant *
       outputInfo.setStreamId(emitStreamId);
     outputInfo.setIsSigned(outputMeta.Signedness);
     outputInfo.setPerPrimitive(outputMeta.PerPrimitive);
+    outputInfo.setComponent(outputMeta.Component);
 
     if (outputMeta.IsBuiltIn) {
       auto builtInId = static_cast<lgc::BuiltInKind>(outputMeta.Value);
@@ -1399,7 +1400,7 @@ void SpirvLowerGlobal::addCallInstForOutputExport(Value *outputValue, Constant *
         assert(xfbOffsetAdjust == 0 && xfbBufferAdjust == 0); // Unused for built-ins
         auto xfbOffset = m_builder->getInt32(outputMeta.XfbOffset + outputMeta.XfbExtraOffset);
         m_builder->CreateWriteXfbOutput(outputValue,
-                                        /*isBuiltIn=*/true, builtInId, 0, outputMeta.XfbBuffer, outputMeta.XfbStride,
+                                        /*isBuiltIn=*/true, builtInId, outputMeta.XfbBuffer, outputMeta.XfbStride,
                                         xfbOffset, outputInfo);
 
         if (!static_cast<bool>(EnableXfb)) {
@@ -1445,8 +1446,8 @@ void SpirvLowerGlobal::addCallInstForOutputExport(Value *outputValue, Constant *
       Value *xfbOffset = m_builder->getInt32(outputMeta.XfbOffset + outputMeta.XfbExtraOffset + xfbOffsetAdjust);
       m_builder->CreateWriteXfbOutput(outputValue,
                                       /*isBuiltIn=*/false, location + cast<ConstantInt>(locOffset)->getZExtValue(),
-                                      outputMeta.Component, outputMeta.XfbBuffer + xfbBufferAdjust,
-                                      outputMeta.XfbStride, xfbOffset, outputInfo);
+                                      outputMeta.XfbBuffer + xfbBufferAdjust, outputMeta.XfbStride, xfbOffset,
+                                      outputInfo);
 
       if (!static_cast<bool>(EnableXfb)) {
         LLPC_OUTS("\n===============================================================================\n");

--- a/llpc/test/shaderdb/core/TestXfbStateMetadata.vert
+++ b/llpc/test/shaderdb/core/TestXfbStateMetadata.vert
@@ -23,7 +23,7 @@ void main()
 // CHECK-NEXT:    [[TMP0:%.*]] = call float (...) @lgc.create.read.generic.input.f32(i32 1, i32 0, i32 0, i32 0, i32 0, i32 undef)
 // CHECK-NEXT:    [[TMP1:%.*]] = call <4 x float> (...) @lgc.create.read.generic.input.v4f32(i32 0, i32 0, i32 0, i32 0, i32 0, i32 undef)
 // CHECK-NEXT:    call void (...) @lgc.create.write.builtin.output(<4 x float> [[TMP1]], i32 0, i32 0, i32 undef, i32 undef)
-// CHECK-NEXT:    call void (...) @lgc.create.write.xfb.output(float [[TMP0]], i1 true, i32 1, i32 0, i32 0, i32 4, i32 0, i32 0)
+// CHECK-NEXT:    call void (...) @lgc.create.write.xfb.output(float [[TMP0]], i1 true, i32 1, i32 0, i32 4, i32 0, i32 0)
 // CHECK-NEXT:    call void (...) @lgc.create.write.builtin.output(float [[TMP0]], i32 1, i32 0, i32 undef, i32 undef)
 // CHECK-NEXT:    ret void
 //


### PR DESCRIPTION
This is a follow-up change of
https://github.com/GPUOpen-Drivers/llpc/pull/2299. We don't need to pass component as an argument. Rather, this could be passed via InOutInfo. Add corresponding setter and getter.