### PR TITLE
revert 'Replace divergence analysis with uniformity analysis'

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -33,10 +33,13 @@
 #include "lgc/patch/Patch.h"
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/Analysis/UniformityAnalysis.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/PassManager.h"
+
+namespace llvm {
+class DivergenceInfo;
+}
 
 namespace lgc {
 
@@ -67,7 +70,7 @@ class BufferOpLowering {
   };
 
 public:
-  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::UniformityInfo &uniformityInfo);
+  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::DivergenceInfo &divergenceInfo);
 
   static void registerVisitors(llvm_dialects::VisitorBuilder<BufferOpLowering> &builder);
 
@@ -106,7 +109,7 @@ private:
   llvm::IRBuilder<> m_builder;
 
   PipelineState &m_pipelineState;
-  llvm::UniformityInfo &m_uniformityInfo;
+  llvm::DivergenceInfo &m_divergenceInfo;
 
   // The proxy pointer type used to accumulate offsets.
   llvm::PointerType *m_offsetType = nullptr;

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -395,7 +395,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
                                   .needCanonicalLoops(true)
                                   .sinkCommonInsts(true)));
   fpm.addPass(LoopUnrollPass(LoopUnrollOptions(optLevel)));
-  // uses UniformityAnalysis
+  // uses DivergenceAnalysis
   fpm.addPass(PatchReadFirstLane());
   fpm.addPass(InstCombinePass(instCombineOpt));
   passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));

--- a/lgc/patch/PatchReadFirstLane.cpp
+++ b/lgc/patch/PatchReadFirstLane.cpp
@@ -31,8 +31,8 @@
 #include "lgc/patch/PatchReadFirstLane.h"
 #include "lgc/patch/Patch.h"
 #include "lgc/state/PipelineState.h"
+#include "llvm/Analysis/DivergenceAnalysis.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
-#include "llvm/Analysis/UniformityAnalysis.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
@@ -89,8 +89,8 @@ PatchReadFirstLane::PatchReadFirstLane() : m_targetTransformInfo(nullptr) {
 PreservedAnalyses PatchReadFirstLane::run(Function &function, FunctionAnalysisManager &analysisManager) {
   TargetTransformInfo &targetTransformInfo = analysisManager.getResult<TargetIRAnalysis>(function);
 
-  UniformityInfo &uniformityInfo = analysisManager.getResult<UniformityInfoAnalysis>(function);
-  auto isDivergentUse = [&](const Use &use) { return uniformityInfo.isDivergentUse(use); };
+  DivergenceInfo &divergenceInfo = analysisManager.getResult<DivergenceAnalysis>(function);
+  auto isDivergentUse = [&](const Use &use) { return divergenceInfo.isDivergentUse(use); };
   if (runImpl(function, isDivergentUse, &targetTransformInfo))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -149,6 +149,7 @@ void LgcContext::initialize() {
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
+  setOptionDefault("use-gpu-divergence-analysis", "1");
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
   setOptionDefault("spec-exec-max-speculation-cost", "10");
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)

--- a/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
+++ b/llpc/test/shaderdb/general/PrintOptionsTest.spvasm
@@ -6,6 +6,7 @@
 ;
 ; OVERRIDDEN-LABEL: --robust-buffer-access = 1 (default: 0)
 ; OVERRIDDEN-NOT:   --scalar-block-layout = {{.*}}
+; OVERRIDDEN-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
 
 ; 2. Check that all options gets printed with `--print-all-options`.
 ; RUN: amdllpc %gfxip %s --robust-buffer-access --print-all-options \
@@ -13,6 +14,7 @@
 ;
 ; ALL-LABEL: --robust-buffer-access = 1 (default: 0)
 ; ALL-LABEL: --scalar-block-layout = {{.*}}
+; ALL-LABEL: --use-gpu-divergence-analysis = 1 (default: 0)
 
 
                OpCapability Shader


### PR DESCRIPTION
Revert 'https://github.com/GPUOpen-Drivers/llpc/commit/b9879b93cea3e9d4b9cb8d87f0dcbf8c48a44b09' due to this commit have broken two build