### PR TITLE
Fix tests to cope with upstream change to smem instructions used

### DIFF
--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocCombinedTextureSampler.pipe
@@ -9,9 +9,9 @@
   // Matching the relocation entry for the sampler descriptor
 ; SHADERTEST-DAG: s_mov_b32 s[[RELOREG_SAMPLER:[0-9]+]], 48 //{{.*}}
   // Loading the resource descriptor
-; SHADERTEST-DAG: s_load_dwordx8 s[[RESOURCE_REG:\[[0-9]+:[0-9]+\]]], s[{{.*}}:{{.*}}], s[[RELOREG_RESOURCE]] //{{.*}}
+; SHADERTEST-DAG: s_load_dwordx8 s[[RESOURCE_REG:\[[0-9]+:[0-9]+\]]], s[{{.*}}:{{.*}}], s[[RELOREG_RESOURCE]] {{(offset:0x0 )?}}//{{.*}}
   // Loading the sampler descriptor
-; SHADERTEST-DAG: s_load_dwordx4 s[[SAMPLER_REG:\[[0-9]+:[0-9]+\]]], s[{{.*}}:{{.*}}], s[[RELOREG_SAMPLER]] //{{.*}}
+; SHADERTEST-DAG: s_load_dwordx4 s[[SAMPLER_REG:\[[0-9]+:[0-9]+\]]], s[{{.*}}:{{.*}}], s[[RELOREG_SAMPLER]] {{(offset:0x0 )?}}//{{.*}}
   // Sampling the texture
 ; SHADERTEST: image_sample_lz v[0:3], v0, s[[RESOURCE_REG]], s[[SAMPLER_REG]] {{.*}}
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineCs_RelocConst.pipe
@@ -3,7 +3,7 @@
 ; RUN: amdllpc -enable-relocatable-shader-elf -o %t.elf %gfxip %s && llvm-objdump --arch=amdgcn --mcpu=gfx900 -d %t.elf | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: 0000000000000000 <_amdgpu_cs_main>:
 ; SHADERTEST: s_mov_b32 s[[RELOREG:[0-9]+]], 16 {{.*}}
-; SHADERTEST: s_load_dwordx2 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] //{{.*}}
+; SHADERTEST: s_load_dwordx2 s[{{.*}}:{{.*}}], s[{{.*}}:{{.*}}], s[[RELOREG]] {{(offset:0x0 )?}}//{{.*}}
 ; END_SHADERTEST
 
 ; BEGIN_SHADERTEST


### PR DESCRIPTION
Upstream change:
[AMDGPU] Don't select _SGPR forms of SMEM instructions on GFX9+

Update tests to allow for an optional "offset:0x0" which appears after the change.