### PR TITLE
PipelineOption: Disable FMA intrinsic

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 61
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 5
+#define LLPC_INTERFACE_MINOR_VERSION 7
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     61.7 | Add disableFMA to PipelineOptions                                                                     |
 //  |     61.6 | Add workaroundInitializeOutputsToZero to PipelineShaderOptions                                        |
 //  |     61.5 | Add RtIpVersion (including its checkers) to represent ray tracing IP                                  |
 //  |     61.4 | Add workaroundStorageImageFormats to PipelineShaderOptions                                            |
@@ -562,6 +563,7 @@ struct PipelineOptions {
 #endif
   unsigned forceNonUniformResourceIndexStageMask; ///< Mask of the stage to force using non-uniform resource index.
   bool reserved16;
+  bool disableFMA; ///< Disable to use FMA intrinsic and use FMUL + FADD instead.
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -256,6 +256,12 @@ Value *BuilderImpl::CreateFMod(Value *dividend, Value *divisor, const Twine &ins
 // @param c : The value to add to the product of A and B
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateFma(Value *a, Value *b, Value *c, const Twine &instName) {
+  if (getPipelineState()->getOptions().disableFMA) {
+    // Using FMUL + FADD
+    FMF.setAllowContract(false);
+    return CreateFAdd(CreateFMul(a, b), c, instName);
+  }
+
   if (getPipelineState()->getTargetInfo().getGfxIpVersion().major <= 8) {
     // Pre-GFX9 version: Use fmuladd.
     return CreateIntrinsic(Intrinsic::fmuladd, a->getType(), {a, b, c}, nullptr, instName);

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -156,6 +156,7 @@ struct Options {
 #endif
   bool enableUberFetchShader; // Enable UberShader
   bool reserved16;
+  bool disableFMA; // Disable to use FMA intrinsic and use FMUL + FADD instead.
 };
 
 /// Represent a pipeline option which can be automatic as well as explicitly set.

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -133,6 +133,10 @@ static cl::opt<bool> ScalarizeWaterfallDescriptorLoads("scalarize-waterfall-desc
                                                        cl::desc("Try to scalarize non-uniform descriptor loads"),
                                                        cl::init(false));
 
+// -disable-fma: disable fma intrinsic
+static cl::opt<bool> DisableFMA("disable-fma", cl::desc("Disable FMA intrinsic and use 'FMUL + FADD' instead"),
+                                cl::init(false));
+
 namespace Llpc {
 
 // =====================================================================================================================
@@ -325,6 +329,8 @@ Options PipelineContext::computePipelineOptions() const {
 #if VKI_RAY_TRACING
   options.internalRtShaders = getPipelineOptions()->internalRtShaders;
 #endif
+
+  options.disableFMA = getPipelineOptions()->disableFMA | DisableFMA;
   return options;
 }
 

--- a/llpc/test/shaderdb/general/PipelineVsFs_DisableFMA.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_DisableFMA.pipe
@@ -1,0 +1,91 @@
+// Disable FMA
+
+; BEGIN_SHADERTEST
+; RUN: amdllpc --gfxip=10.3.0 -v %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
+; SHADERTEST: call reassoc nnan nsz arcp contract afn float (...) @lgc.create.fma.f32
+; SHADERTEST-LABEL: _amdgpu_vs_main:
+; SHADERTEST-NOT: fma
+; SHADERTEST: s_endpgm
+; END_SHADERTEST
+
+[Version]
+version = 46
+
+[VsGlsl]
+#version 450
+
+layout(binding = 0, std140) uniform _37_39
+{
+    float _m0;
+    float _m1;
+} _39;
+
+void main()
+{
+    gl_Position = vec4(fma(_39._m0, _39._m0, _39._m1),0, 0, 1.0);
+}
+
+[VsInfo]
+entryPoint = main
+
+
+[FsGlsl]
+#version 450
+layout(early_fragment_tests) in;
+
+layout(location = 0, component = 0) out vec4 _9;
+
+void main()
+{
+    _9 = vec4(0.0,1.0,0.0,1.0);
+}
+
+[FsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].visibility = 1
+userDataNode[0].type = StreamOutTableVaPtr
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 1
+userDataNode[1].visibility = 17
+userDataNode[1].type = DescriptorBuffer
+userDataNode[1].offsetInDwords = 1
+userDataNode[1].sizeInDwords = 4
+userDataNode[1].set = 0
+userDataNode[1].binding = 0
+userDataNode[2].visibility = 17
+userDataNode[2].type = DescriptorBuffer
+userDataNode[2].offsetInDwords = 5
+userDataNode[2].sizeInDwords = 4
+userDataNode[2].set = 1
+userDataNode[2].binding = 0
+userDataNode[3].visibility = 17
+userDataNode[3].type = DescriptorBuffer
+userDataNode[3].offsetInDwords = 9
+userDataNode[3].sizeInDwords = 4
+userDataNode[3].set = 1
+userDataNode[3].binding = 1
+userDataNode[4].visibility = 1
+userDataNode[4].type = IndirectUserDataVaPtr
+userDataNode[4].offsetInDwords = 13
+userDataNode[4].sizeInDwords = 1
+userDataNode[4].indirectUserDataCount = 4
+
+[GraphicsPipelineState]
+colorBuffer[0].format = VK_FORMAT_B8G8R8A8_UNORM
+colorBuffer[0].channelWriteMask = 15
+colorBuffer[0].blendEnable = 0
+colorBuffer[0].blendSrcAlphaToColor = 0
+options.disableFMA = 1
+
+[VertexInputState]
+binding[0].binding = 0
+binding[0].stride = 2
+binding[0].inputRate = VK_VERTEX_INPUT_RATE_VERTEX
+attribute[0].location = 0
+attribute[0].binding = 0
+attribute[0].format = VK_FORMAT_R8G8_SNORM
+attribute[0].offset = 0
+dynamicVertexStride = 0

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -839,6 +839,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
 
   dumpFile << "options.forceNonUniformResourceIndexStageMask = " << options->forceNonUniformResourceIndexStageMask
            << "\n";
+  dumpFile << "options.disableFMA = " << options->disableFMA << "\n";
 }
 
 // =====================================================================================================================
@@ -1589,6 +1590,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
   hasher->Update(options->internalRtShaders);
 #endif
   hasher->Update(options->forceNonUniformResourceIndexStageMask);
+  hasher->Update(options->disableFMA);
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -378,6 +378,7 @@ private:
       INIT_MEMBER_NAME_TO_ADDR(SectionPipelineOption, m_extendedRobustness, MemberTypeExtendedRobustness, true);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, forceNonUniformResourceIndexStageMask, MemberTypeInt,
                                      false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, disableFMA, MemberTypeBool, false);
       // One internal member
 #if VKI_RAY_TRACING
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);


### PR DESCRIPTION
In some cases, apps expect that FMA(a,b,c) equals (a*b+c), so we have

to use fmul + fadd to replace fma intrinsic. The option will be set by

detecting application information.