### PR TITLE
Emit llvm.is.fpclass instead of llvm.amdgcn.class

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -674,7 +674,7 @@ Value *BuilderImpl::CreateSqrt(Value *x, const Twine &instName) {
 
     // If x is +INF, +0, or -0, use its original value
     return CreateSelect(
-        createCallAmdgcnClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), x, g,
+        createCallIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), x, g,
         instName);
   }
 
@@ -741,7 +741,7 @@ Value *BuilderImpl::CreateInverseSqrt(Value *x, const Twine &instName) {
 
     // If x is +INF, +0, or -0, use the initial value of reciprocal square root
     return CreateSelect(
-        createCallAmdgcnClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), y, h,
+        createCallIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), y, h,
         instName);
   }
 
@@ -1195,7 +1195,7 @@ Value *BuilderImpl::fDivFast(Value *numerator, Value *denominator) {
 // @param x : Input value X
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateIsInf(Value *x, const Twine &instName) {
-  return createCallAmdgcnClass(x, CmpClass::NegativeInfinity | CmpClass::PositiveInfinity, instName);
+  return createCallIsFPClass(x, CmpClass::NegativeInfinity | CmpClass::PositiveInfinity, instName);
 }
 
 // =====================================================================================================================
@@ -1205,22 +1205,18 @@ Value *BuilderImpl::CreateIsInf(Value *x, const Twine &instName) {
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateIsNaN(Value *x, const Twine &instName) {
   // 0x001: signaling NaN, 0x002: quiet NaN
-  return createCallAmdgcnClass(x, CmpClass::SignalingNaN | CmpClass::QuietNaN, instName);
+  return createCallIsFPClass(x, CmpClass::SignalingNaN | CmpClass::QuietNaN, instName);
 }
 
 // =====================================================================================================================
-// Helper method to create call to llvm.amdgcn.class, scalarizing if necessary. This is not exposed outside of
+// Helper method to create call to llvm.is.fpclass, scalarizing if necessary. This is not exposed outside of
 // ArithBuilder.
 //
 // @param value : Input value
 // @param flags : Flags for what class(es) to check for
 // @param instName : Name to give instruction(s)
-Value *BuilderImpl::createCallAmdgcnClass(Value *value, unsigned flags, const Twine &instName) {
-  Value *result = scalarize(value, [this, flags](Value *value) {
-    return CreateIntrinsic(Intrinsic::amdgcn_class, value->getType(), {value, getInt32(flags)});
-  });
-  result->setName(instName);
-  return result;
+Value *BuilderImpl::createCallIsFPClass(Value *value, unsigned flags, const Twine &instName) {
+  return CreateIntrinsic(Intrinsic::is_fpclass, value->getType(), {value, getInt32(flags)}, nullptr, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -674,7 +674,7 @@ Value *BuilderImpl::CreateSqrt(Value *x, const Twine &instName) {
 
     // If x is +INF, +0, or -0, use its original value
     return CreateSelect(
-        createCallIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), x, g,
+        createIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), x, g,
         instName);
   }
 
@@ -741,7 +741,7 @@ Value *BuilderImpl::CreateInverseSqrt(Value *x, const Twine &instName) {
 
     // If x is +INF, +0, or -0, use the initial value of reciprocal square root
     return CreateSelect(
-        createCallIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), y, h,
+        createIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), y, h,
         instName);
   }
 
@@ -1195,7 +1195,7 @@ Value *BuilderImpl::fDivFast(Value *numerator, Value *denominator) {
 // @param x : Input value X
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateIsInf(Value *x, const Twine &instName) {
-  return createCallIsFPClass(x, CmpClass::NegativeInfinity | CmpClass::PositiveInfinity, instName);
+  return createIsFPClass(x, CmpClass::NegativeInfinity | CmpClass::PositiveInfinity, instName);
 }
 
 // =====================================================================================================================
@@ -1205,7 +1205,7 @@ Value *BuilderImpl::CreateIsInf(Value *x, const Twine &instName) {
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateIsNaN(Value *x, const Twine &instName) {
   // 0x001: signaling NaN, 0x002: quiet NaN
-  return createCallIsFPClass(x, CmpClass::SignalingNaN | CmpClass::QuietNaN, instName);
+  return createIsFPClass(x, CmpClass::SignalingNaN | CmpClass::QuietNaN, instName);
 }
 
 // =====================================================================================================================
@@ -1215,7 +1215,7 @@ Value *BuilderImpl::CreateIsNaN(Value *x, const Twine &instName) {
 // @param value : Input value
 // @param flags : Flags for what class(es) to check for
 // @param instName : Name to give instruction(s)
-Value *BuilderImpl::createCallIsFPClass(Value *value, unsigned flags, const Twine &instName) {
+Value *BuilderImpl::createIsFPClass(Value *value, unsigned flags, const Twine &instName) {
   return CreateIntrinsic(Intrinsic::is_fpclass, value->getType(), {value, getInt32(flags)}, nullptr, instName);
 }
 

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -229,9 +229,8 @@ private:
   // Generate FP division, using fast fdiv for float to bypass optimization.
   llvm::Value *fDivFast(llvm::Value *numerator, llvm::Value *denominator);
 
-  // Helper method to create call to llvm.amdgcn.class, scalarizing if necessary. This is not exposed outside of
-  // ArithBuilder.
-  llvm::Value *createCallAmdgcnClass(llvm::Value *value, unsigned flags, const llvm::Twine &instName = "");
+  // Helper method to create call to llvm.is.fpclass. This is not exposed outside of ArithBuilder.
+  llvm::Value *createCallIsFPClass(llvm::Value *value, unsigned flags, const llvm::Twine &instName = "");
 
   // Methods to get various FP constants as scalar or vector. Any needed directly by a client should be moved
   // to Builder.h. Using these (rather than just using for example

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -230,7 +230,7 @@ private:
   llvm::Value *fDivFast(llvm::Value *numerator, llvm::Value *denominator);
 
   // Helper method to create call to llvm.is.fpclass. This is not exposed outside of ArithBuilder.
-  llvm::Value *createCallIsFPClass(llvm::Value *value, unsigned flags, const llvm::Twine &instName = "");
+  llvm::Value *createIsFPClass(llvm::Value *value, unsigned flags, const llvm::Twine &instName = "");
 
   // Methods to get various FP constants as scalar or vector. Any needed directly by a client should be moved
   // to Builder.h. Using these (rather than just using for example

--- a/llpc/test/shaderdb/core/OpIsInf_TestDouble_lit.frag
+++ b/llpc/test/shaderdb/core/OpIsInf_TestDouble_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; SHADERTEST: = call i1 (...) @lgc.create.isinf.i1(double
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call i1 @llvm.amdgcn.class.f64(double %{{[0-9]*}}, i32 516)
+; SHADERTEST: call i1 @llvm.is.fpclass.f64(double %{{[0-9]*}}, i32 516)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/core/OpIsInf_TestFloat_lit.frag
+++ b/llpc/test/shaderdb/core/OpIsInf_TestFloat_lit.frag
@@ -18,7 +18,7 @@ void main()
 ; SHADERTEST: = call i1 (...) @lgc.create.isinf.i1(float
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call i1 @llvm.amdgcn.class.f32(float %{{[0-9]*}}, i32 516)
+; SHADERTEST: call i1 @llvm.is.fpclass.f32(float %{{[0-9]*}}, i32 516)
 
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
@@ -51,7 +51,7 @@ void main()
 ; SHADERTEST: %[[EXP_OF_SCALE_RSQ_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_RSQ_X]])
 ; SHADERTEST: %[[TOO_SMALL_SCALE_RSQ_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_RSQ_X]], -1021
 ; SHADERTEST: %[[NEW_SCALE_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_RSQ_X]], double 0.000000e+00, double %[[SCALE_RSQ_X]]
-; SHADERTEST: %[[SPECIAL_X:[^ ,]*]] = call i1 @llvm.amdgcn.class.f64(double %[[NEW_SCALE_X]], i32 608)
+; SHADERTEST: %[[SPECIAL_X:[^ ,]*]] = call i1 @llvm.is.fpclass.f64(double %[[NEW_SCALE_X]], i32 608)
 ; SHADERTEST: %[[FINAL_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[SPECIAL_X]], double %[[Y]], double %[[NEW_SCALE_RSQ_X]]
 
 ; SHADERTEST: AMDLLPC SUCCESS


### PR DESCRIPTION
This enables more optimizations in LLVM, like combining multiple class tests or comparisons into a single llvm.is.fpclass operation.