### PR TITLE
lgc: Use DivergenceAnalysis conditional on slightly older LLVM

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -38,6 +38,15 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/PassManager.h"
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 458033
+// Old version of the code
+namespace llvm {
+class DivergenceInfo;
+}
+#else
+// New version of the code (also handles unknown version, which we treat as latest)
+#endif
+
 namespace lgc {
 
 class BufferDescToPtrOp;
@@ -67,7 +76,13 @@ class BufferOpLowering {
   };
 
 public:
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 458033
+  // Old version of the code
+  BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::DivergenceInfo &divergenceInfo);
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
   BufferOpLowering(TypeLowering &typeLowering, PipelineState &pipelineState, llvm::UniformityInfo &uniformityInfo);
+#endif
 
   static void registerVisitors(llvm_dialects::VisitorBuilder<BufferOpLowering> &builder);
 
@@ -106,7 +121,13 @@ private:
   llvm::IRBuilder<> m_builder;
 
   PipelineState &m_pipelineState;
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 458033
+  // Old version of the code
+  llvm::DivergenceInfo &m_uniformityInfo;
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
   llvm::UniformityInfo &m_uniformityInfo;
+#endif
 
   // The proxy pointer type used to accumulate offsets.
   llvm::PointerType *m_offsetType = nullptr;

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -149,6 +149,12 @@ void LgcContext::initialize() {
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 458033
+  // Old version of the code
+  setOptionDefault("use-gpu-divergence-analysis", "1");
+#else
+// New version of the code (also handles unknown version, which we treat as latest)
+#endif
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
   setOptionDefault("spec-exec-max-speculation-cost", "10");
 #if !defined(LLVM_HAVE_BRANCH_AMD_GFX)


### PR DESCRIPTION
UniformityAnalysis didn't gain its isDivergentUse method until recently, so this change conditionally goes back to DivergenceAnalysis so I can use LLPC on a slightly older LLVM.