### PR TITLE
Fix issue that llvm-dialects-tblgen can not be found while cross-compiling

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -68,7 +68,7 @@ set_compiler_options(LLVMlgc ${LLPC_ENABLE_WERROR})
 
 ### TableGen for LGC dialect ###########################################################################################
 
-set(LGC_TABLEGEN_EXE llvm-dialects-tblgen)
+set(LGC_TABLEGEN_EXE ${LLVM_TOOLS_BINARY_DIR}/llvm-dialects-tblgen)
 set(LGC_TABLEGEN_TARGET llvm-dialects-tblgen)
 set(LLVM_TARGET_DEFINITIONS interface/lgc/LgcDialect.td)
 


### PR DESCRIPTION
The parameter LGC_TABLEGEN_EXE is used as the 'tablegen_exe' parameter in the 'tablegen' function within the 'llvm-project/llvm/cmake/modules/TableGen.cmake' file, and eventually passed as the 'COMMAND' parameter in the 'add_custom_command' function.

Refer to the CMake specification for more information about the 'COMMAND' parameter in the 'add_custom_command' function: https://cmake.org/cmake/help/latest/command/add_custom_command.html
Please note that in cross-compiling, the executable target name will not be automatically replaced by the path of the target created at build time. Therefore, we need to manually assign the target path.
