### PR TITLE
Remove an unnecessary branch that handles generic FS outputs

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1027,11 +1027,6 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
           patchMeshGenericOutputExport(output, loc, locOffset, elemIdx, vertexOrPrimitiveIdx, isPerPrimitive, builder);
           break;
         }
-        case ShaderStageFragment: {
-          assert(callInst.arg_size() == 3);
-          llvm_unreachable("Fragment shader export should have been handled by the LowerFragColorExport pass");
-          break;
-        }
         case ShaderStageCopyShader: {
           patchCopyShaderGenericOutputExport(output, loc, &callInst);
           break;


### PR DESCRIPTION
As the assert says, generic FS outputs are handled by the pass LowerFragColorExport. There is no need of checking here.