### PR TITLE
Some modification of GFX11 stream-out

### DIFF
--- a/lgc/include/lgc/state/Abi.h
+++ b/lgc/include/lgc/state/Abi.h
@@ -33,6 +33,7 @@
  */
 #pragma once
 
+#include "Defs.h"
 #include <stdint.h>
 
 namespace lgc {
@@ -129,6 +130,11 @@ struct PrimShaderCbLayout {
   PrimShaderVportCb viewportStateCb;
   PrimShaderScissorCb scissorStateCb;
   PrimShaderRenderCb renderStateCb;
+};
+
+/// Constant buffer used by SW stream-out processing (GFX11+).
+struct StreamOutControlCb {
+  unsigned bufOffsets[MaxTransformFeedbackBuffers];
 };
 
 } // namespace Abi


### PR DESCRIPTION
1. Add a helper readValueFromCb to read value from constant buffer.
2. Add stream-out control buffer layout to ABI definition. In the future, more data will be added by PAL other than stream-out buffer offsets.
3. Gate all GDS operations with GFX IP check. The operations will be updated for future generations.