### PR TITLE
Add 'component' argument to loadValueFromGsVsRing

### DIFF
--- a/lgc/include/lgc/patch/PatchCopyShader.h
+++ b/lgc/include/lgc/patch/PatchCopyShader.h
@@ -53,7 +53,8 @@ private:
 
   llvm::Value *calcGsVsRingOffsetForInput(unsigned location, unsigned compIdx, unsigned streamId, BuilderBase &builder);
 
-  llvm::Value *loadValueFromGsVsRing(llvm::Type *loadTy, unsigned location, unsigned streamId, BuilderBase &builder);
+  llvm::Value *loadValueFromGsVsRing(llvm::Type *loadTy, unsigned location, unsigned component, unsigned streamId,
+                                     BuilderBase &builder);
 
   llvm::Value *loadGsVsRingBufferDescriptor(BuilderBase &builder);
 

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -153,9 +153,10 @@ struct XfbOutputExport {
   unsigned numElements; // Number of output elements, valid range is [1,4]
   bool is16bit;         // Whether the output is 16-bit
   struct {
-    unsigned streamId; // Output stream ID
-    unsigned loc;      // Output location
-  } locInfo;           // Output location info in GS-VS ring (just for GS)
+    unsigned streamId;  // Output stream ID
+    unsigned location;  // Output location
+    unsigned component; // Output component within a location
+  } locInfo;            // Output location info in GS-VS ring (just for GS)
 };
 
 // Enumerates the LDS regions used by primitive shader
@@ -244,9 +245,10 @@ private:
   void appendUserData(llvm::SmallVectorImpl<llvm::Value *> &args, llvm::Function *target, llvm::Value *userData,
                       unsigned userDataCount);
 
-  void writeGsOutput(llvm::Value *output, unsigned location, unsigned compIdx, unsigned streamId,
+  void writeGsOutput(llvm::Value *output, unsigned location, unsigned component, unsigned streamId,
                      llvm::Value *primitiveIndex, llvm::Value *emitVerts);
-  llvm::Value *readGsOutput(llvm::Type *outputTy, unsigned location, unsigned streamId, llvm::Value *vertexOffset);
+  llvm::Value *readGsOutput(llvm::Type *outputTy, unsigned location, unsigned component, unsigned streamId,
+                            llvm::Value *vertexOffset);
 
   void processGsEmit(unsigned streamId, llvm::Value *primitiveIndex, llvm::Value *emitVertsPtr,
                      llvm::Value *outVertsPtr);


### PR DESCRIPTION
The reason is that we ought to be able to load component value from a specific output location. Currently, we always load the whole value of a specific output location. In the future, we want to just load the necessary component value.

Will have more work on PatchCopyShader::exportOutput in follow-up changes. This is just a preparation change.