### PR TITLE
[RT] Get base address of AS resource instead of reading from it

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2423,6 +2423,25 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpLoad>(SPIRVValue *const s
         (void(loadType)); // unused
         return ConstantVector::get({m_builder->getInt32(0), m_builder->getInt32(0)});
       }
+#if GPURT_CLIENT_INTERFACE_MAJOR_VERSION >= 34
+      else {
+        // From now on, AS header may start at a non-zero offset, GPURT now request base offset of the resource, and it
+        // will calculate the actual GPUVA, instead of compiler providing one loaded from offset 0.
+        unsigned binding = 0u;
+        unsigned descSet = 0u;
+        bool valid = spvLoad->getSrc()->hasDecorate(DecorationBinding, 0, &binding);
+        valid &= spvLoad->getSrc()->hasDecorate(DecorationDescriptorSet, 0, &descSet);
+        assert(valid);
+
+        auto descTy = ResourceNodeType::DescriptorBuffer;
+        auto descPtr = getBuilder()->CreateGetDescPtr(descTy, descTy, descSet, binding);
+        // Base address is the first 48-bit of descriptor.
+        Value *accelAddr = getBuilder()->CreateLoad(FixedVectorType::get(getBuilder()->getInt32Ty(), 2), descPtr);
+        accelAddr = getBuilder()->CreateInsertElement(
+            accelAddr, getBuilder()->CreateAnd(getBuilder()->CreateExtractElement(accelAddr, 1), 0xFFFF), 1);
+        return accelAddr;
+      }
+#endif
       break;
     }
 #endif


### PR DESCRIPTION
The AS offset isn't synced between the builder and traversal when dumping rayhistory tokens.
So instead GPURT should read in the base address and handle computing the offset instead of compiler.