### PR TITLE
Update tests to expect poisoned shufflevector masks instead of undef ones.

### DIFF
--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDifferentInputVecSizes_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDifferentInputVecSizes_lit.spvasm
@@ -6,12 +6,12 @@
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> undef, <4 x double> %1, <2 x i32> <i32 7, i32 6>
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <2 x i32> <i32 3, i32 2>
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UndefVariable_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UndefVariable_lit.spvasm
@@ -3,11 +3,11 @@
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> undef, <4 x double> %1, <2 x i32> <i32 7, i32 6>
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> [[TEMP_VEC]], <4 x i32> <i32 4, i32 5, i32 2, i32 3>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <2 x i32> <i32 3, i32 2>
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 6, i32 7>
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UnspecifiedChannel_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UnspecifiedChannel_lit.spvasm
@@ -2,12 +2,12 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> %{{.*}}, <2 x i32> <i32 3, i32 undef>
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> %{{.*}}, <2 x i32> <i32 3, i32 {{undef|poison}}>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> [[TEMP_VEC]], <4 x i32> <i32 4, i32 5, i32 2, i32 3>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <4 x double> %{{.*}}, <4 x double> poison, <4 x i32> <i32 3, i32 undef, i32 undef, i32 undef>
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 undef, i32 6, i32 7>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <4 x double> %{{.*}}, <4 x double> {{undef|poison}}, <4 x i32> <i32 3, i32 {{undef|poison}}, i32 {{undef|poison}}, i32 {{undef|poison}}>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 {{undef|poison}}, i32 6, i32 7>
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec_lit.frag
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec_lit.frag
@@ -31,8 +31,8 @@ void main()
 ; SHADERTEST: %{{.*}} = shufflevector <3 x double> %{{.*}}, <3 x double> %{{.*}}, <2 x i32> <i32 1, i32 0>
 ; SHADERTEST: %{{.*}} = shufflevector <3 x double> %{{.*}}, <3 x double> %{{.*}}, <2 x i32> <i32 2, i32 2>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = shufflevector <3 x double> %{{.*}}, <3 x double> {{undef|poison}}, <4 x i32> <i32 undef, i32 undef, i32 2, i32 undef>
-; SHADERTEST: %{{.*}} = shufflevector <3 x double> %{{.*}}, <3 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: %{{.*}} = shufflevector <3 x double> %{{.*}}, <3 x double> {{undef|poison}}, <4 x i32> <i32 {{undef|poison}}, i32 {{undef|poison}}, i32 2, i32 {{undef|poison}}>
+; SHADERTEST: %{{.*}} = shufflevector <3 x double> %{{.*}}, <3 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestVec4UnspecifiedChannel_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestVec4UnspecifiedChannel_lit.spvasm
@@ -2,12 +2,12 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = shufflevector <4 x float> %{{.*}}, <4 x float> %{{.*}}, <2 x i32> <i32 undef, i32 2>
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x float> %{{.*}}, <2 x float> poison, <4 x i32> <i32 0, i32 1, i32 undef, i32 undef>
+; SHADERTEST: %{{.*}} = shufflevector <4 x float> %{{.*}}, <4 x float> %{{.*}}, <2 x i32> <i32 {{undef|poison}}, i32 2>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x float> %{{.*}}, <2 x float> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x float> %{{.*}}, <4 x float> [[TEMP_VEC]], <4 x i32> <i32 4, i32 5, i32 2, i32 3>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <4 x float> %{{.*}}, <4 x float> poison, <4 x i32> <i32 undef, i32 2, i32 undef, i32 undef>
-; SHADERTEST: %{{.*}} = shufflevector <4 x float> [[TEMP_VEC]], <4 x float> %{{.*}}, <4 x i32> <i32 undef, i32 1, i32 6, i32 7>
+; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <4 x float> %{{.*}}, <4 x float> {{undef|poison}}, <4 x i32> <i32 {{undef|poison}}, i32 2, i32 {{undef|poison}}, i32 {{undef|poison}}>
+; SHADERTEST: %{{.*}} = shufflevector <4 x float> [[TEMP_VEC]], <4 x float> %{{.*}}, <4 x i32> <i32 {{undef|poison}}, i32 1, i32 6, i32 7>
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
Fixes passing tests after:
[IR] Change shufflevector undef mask to poison
https://reviews.llvm.org/D149210