### PR TITLE
lgc: Add ModuleBunch infrastructure

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -243,6 +243,8 @@ target_sources(LLVMlgc PRIVATE
     util/GfxRegHandlerBase.cpp
     util/GfxRegHandler.cpp
     util/Internal.cpp
+    util/MbStandardInstrumentations.cpp
+    util/ModuleBunch.cpp
     util/PassManager.cpp
     util/StartStopTimer.cpp
     util/TypeLowering.cpp

--- a/lgc/interface/lgc/MbStandardInstrumentations.h
+++ b/lgc/interface/lgc/MbStandardInstrumentations.h
@@ -1,0 +1,131 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+// An alternative to LLVM's StandardInstrumentations that (partly) patches
+// things up so they work on ModuleBunch passes.
+// Most code here is copied from LLVM's StandardInstrumentations.cpp and
+// edited.
+
+#pragma once
+
+#include "lgc/ModuleBunch.h"
+#include "llvm/Passes/StandardInstrumentations.h"
+
+namespace llvm {
+
+// Copy of PrintIRInstrumentation with edits for ModuleBunch.
+/// Instrumentation to print IR before/after passes.
+///
+/// Needs state to be able to print module after pass that invalidates IR unit
+/// (typically Loop or SCC).
+class MbPrintIRInstrumentation {
+public:
+  ~MbPrintIRInstrumentation();
+
+  void registerCallbacks(PassInstrumentationCallbacks &PIC);
+
+private:
+  void printBeforePass(StringRef PassID, Any IR);
+  void printAfterPass(StringRef PassID, Any IR);
+  void printAfterPassInvalidated(StringRef PassID);
+
+  bool shouldPrintBeforePass(StringRef PassID);
+  bool shouldPrintAfterPass(StringRef PassID);
+
+  using PrintModuleDesc = std::tuple<Any, std::string, StringRef>;
+
+  void pushModuleDesc(StringRef PassID, Any IR);
+  PrintModuleDesc popModuleDesc(StringRef PassID);
+
+  PassInstrumentationCallbacks *PIC;
+  /// Stack of Module description, enough to print the module after a given
+  /// pass.
+  SmallVector<PrintModuleDesc, 2> ModuleDescStack;
+};
+
+// Debug logging for transformation and analysis passes.
+class MbPrintPassInstrumentation {
+  raw_ostream &print();
+
+public:
+  MbPrintPassInstrumentation(bool Enabled, PrintPassOptions Opts) : Enabled(Enabled), Opts(Opts) {}
+  void registerCallbacks(PassInstrumentationCallbacks &PIC);
+
+private:
+  bool Enabled;
+  PrintPassOptions Opts;
+  int Indent = 0;
+};
+
+// Copy of VerifyInstrumentation with edits for ModuleBunch.
+class MbVerifyInstrumentation {
+  bool DebugLogging;
+
+public:
+  MbVerifyInstrumentation(bool DebugLogging) : DebugLogging(DebugLogging) {}
+  void registerCallbacks(PassInstrumentationCallbacks &PIC);
+};
+
+/// This class provides an interface to register all the standard pass
+/// instrumentations and manages their state (if any).
+/// Ones that have not yet been adapted for use with a ModuleBunch pass manager (ones without an Mb prefix)
+/// may well be broken.
+class MbStandardInstrumentations {
+  MbPrintIRInstrumentation PrintIR;
+  MbPrintPassInstrumentation PrintPass;
+  TimePassesHandler TimePasses;
+  TimeProfilingPassesHandler TimeProfilingPasses;
+  OptNoneInstrumentation OptNone;
+  // OptPassGateInstrumentation OptPassGate; // Cannot even attempt to use this as it needs LLVMContext
+  PreservedCFGCheckerInstrumentation PreservedCFGChecker;
+  IRChangedPrinter PrintChangedIR;
+  PseudoProbeVerifier PseudoProbeVerification;
+  InLineChangePrinter PrintChangedDiff;
+  DotCfgChangeReporter WebsiteChangeReporter;
+  PrintCrashIRInstrumentation PrintCrashIR;
+  IRChangedTester ChangeTester;
+  MbVerifyInstrumentation Verify;
+
+  bool VerifyEach;
+
+public:
+  MbStandardInstrumentations(bool DebugLogging, bool VerifyEach = false,
+                             PrintPassOptions PrintPassOpts = PrintPassOptions());
+
+  // Register all the standard instrumentation callbacks. If \p FAM is nullptr
+  // then PreservedCFGChecker is not enabled.
+  void registerCallbacks(PassInstrumentationCallbacks &PIC,
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 454783
+                         // Old version of the code
+                         FunctionAnalysisManager *FAM = nullptr);
+#else
+                         // New version of the code (also handles unknown version, which we treat as latest)
+                         ModuleAnalysisManager *MAM = nullptr);
+#endif
+
+  TimePassesHandler &getTimePasses() { return TimePasses; }
+};
+
+} // namespace llvm

--- a/lgc/interface/lgc/ModuleBunch.h
+++ b/lgc/interface/lgc/ModuleBunch.h
@@ -1,0 +1,301 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+// The ModuleBunch class, representing a bunch of modules, and a pass manager
+// and analysis manager for it allowing you to run passes on it.
+
+#pragma once
+
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/PassBuilder.h"
+
+namespace llvm {
+
+class ModuleBunch;
+
+using ModuleBunchPassManager = PassManager<ModuleBunch>;
+using ModuleBunchAnalysisManager = AnalysisManager<ModuleBunch>;
+using ModuleAnalysisManagerModuleBunchProxy = InnerAnalysisManagerProxy<ModuleAnalysisManager, ModuleBunch>;
+using ModuleBunchAnalysisManagerModuleProxy = OuterAnalysisManagerProxy<ModuleBunchAnalysisManager, Module>;
+
+/// A pointer encapsulated as random access iterator, so that it can be subclassed to handle dereferences differently.
+template <typename T> class PointerAsIterator : public std::iterator<std::random_access_iterator_tag, T> {
+public:
+  using value_type = T;
+  using difference_type = size_t;
+  PointerAsIterator(value_type *ptr) : ptr(ptr) {}
+
+  const value_type &operator*() const { return *ptr; }
+  const value_type *operator->() const { return ptr; }
+  PointerAsIterator &operator+=(size_t offset) {
+    ptr += offset;
+    return *this;
+  }
+  PointerAsIterator operator+(size_t offset) const { return PointerAsIterator(ptr + offset); }
+  friend PointerAsIterator operator+(size_t offset, const PointerAsIterator &it) {
+    return PointerAsIterator(it.ptr + offset);
+  }
+  PointerAsIterator &operator++() {
+    ++ptr;
+    return *this;
+  }
+  PointerAsIterator &operator-=(size_t offset) {
+    ptr -= offset;
+    return *this;
+  }
+  PointerAsIterator operator-(size_t offset) const { return PointerAsIterator(ptr - offset); }
+  size_t operator-(const PointerAsIterator &rhs) const { return ptr - rhs.ptr; }
+  PointerAsIterator &operator--() {
+    --ptr;
+    return *this;
+  }
+  value_type &operator[](size_t idx) { return *(*this + idx); }
+  bool operator==(const PointerAsIterator &rhs) const { return ptr == rhs.ptr; }
+  bool operator!=(const PointerAsIterator &rhs) const { return ptr != rhs.ptr; }
+  bool operator<(const PointerAsIterator &rhs) const { return ptr < rhs.ptr; }
+  bool operator>(const PointerAsIterator &rhs) const { return ptr > rhs.ptr; }
+  bool operator<=(const PointerAsIterator &rhs) const { return ptr <= rhs.ptr; }
+  bool operator>=(const PointerAsIterator &rhs) const { return ptr >= rhs.ptr; }
+
+private:
+  value_type *ptr = nullptr;
+};
+
+/// ModuleBunch is a pseudo-IR construct for a bunch of modules that we want to run passes on.
+class ModuleBunch {
+public:
+  // Iterator for accessing the Modules in the ModuleBunch, without being able to free or replace
+  // any Module. The iterator does a "double dereference" from pointer-to-unique-ptr-to-Module
+  // down to Module &.
+  class iterator : public PointerAsIterator<const std::unique_ptr<Module>> {
+  public:
+    using Parent = PointerAsIterator<const std::unique_ptr<Module>>;
+    using value_type = Module;
+    iterator(const std::unique_ptr<Module> *ptr) : Parent(ptr) {}
+    // Override methods that access the iterator's contents.
+    value_type &operator*() const { return **static_cast<Parent>(*this); }
+    const value_type *operator->() const { return &**static_cast<Parent>(*this); }
+    value_type &operator[](size_t idx) const { return *static_cast<Parent>(*this)[idx]; }
+  };
+
+  // Access the Modules in the ModuleBunch, without erasing/removing/replacing them.
+  iterator begin() const { return iterator(Modules.begin()); }
+  iterator end() const { return iterator(Modules.end()); }
+  size_t size() const { return end() - begin(); }
+  bool empty() const { return size() == 0; }
+
+  // Access the array of Modules in the ModuleBunch, directly accessing the unique_ptrs
+  // for erasing/removing/replacing them.
+  // After doing that, call renormalize() to remove any holes.
+  MutableArrayRef<std::unique_ptr<Module>> getMutableModules() {
+    assert(isNormalized());
+    return Modules;
+  }
+
+  // Add Module to ModuleBunch, taking ownership. Invalidates modules() iterator.
+  void addModule(std::unique_ptr<Module> module);
+
+  // Renormalize ModuleBunch's array of Modules after manipulation by user.
+  // Invalidates modules() iterator.
+  void renormalize();
+
+  // Check that Modules list has been renormalized since caller removed/freed modules.
+  bool isNormalized() const;
+
+private:
+  SmallVector<std::unique_ptr<Module>> Modules;
+};
+
+extern template class PassManager<ModuleBunch>;
+extern template class AnalysisManager<ModuleBunch>;
+extern template class AllAnalysesOn<ModuleBunch>;
+
+/// Trivial adaptor that maps from a ModuleBunch to its modules.
+///
+/// Designed to allow composition of a ModulePass(Manager) and
+/// a ModuleBunchPassManager, by running the ModulePass(Manager) over every
+/// module in the ModuleBunch.
+///
+/// Module passes run within this adaptor can rely on having exclusive access
+/// to the module they are run over. They should not read or modify any other
+/// modules! Other threads or systems may be manipulating other functions in
+/// the ModuleBunch, and so their state should never be relied on.
+///
+/// Module passes can also read the ModuleBunch containing the module, but they
+/// should not modify that ModuleBunch.
+/// For example, a module pass is not permitted to add modules to the
+/// ModuleBunch.
+///
+/// Note that although module passes can access ModuleBunch analyses, ModuleBunch
+/// analyses are not invalidated while the module passes are running, so they
+/// may be stale.  Module analyses will not be stale.
+class ModuleBunchToModulePassAdaptor : public PassInfoMixin<ModuleBunchToModulePassAdaptor> {
+public:
+  using PassConceptT = detail::PassConcept<Module, ModuleAnalysisManager>;
+
+  /// Construct with a function that returns a pass. It can then parallelize compilation by calling
+  /// the function once for each parallel thread.
+  explicit ModuleBunchToModulePassAdaptor(function_ref<std::unique_ptr<PassConceptT>()> PassMaker,
+                                          bool EagerlyInvalidate = false)
+      : PassMaker(PassMaker), EagerlyInvalidate(EagerlyInvalidate) {}
+
+  /// Construct with a pass. It can then not parallelize compilation.
+  explicit ModuleBunchToModulePassAdaptor(std::unique_ptr<PassConceptT> pass, bool eagerlyInvalidate)
+      : Pass(std::move(pass)), EagerlyInvalidate(eagerlyInvalidate) {}
+
+  /// Runs the module pass across every module in the ModuleBunch.
+  PreservedAnalyses run(ModuleBunch &moduleBunch, ModuleBunchAnalysisManager &analysisMgr);
+  void printPipeline(raw_ostream &os, function_ref<StringRef(StringRef)> mapClassName2PassName);
+
+  static bool isRequired() { return true; }
+
+private:
+  std::unique_ptr<PassConceptT> Pass;
+  function_ref<std::unique_ptr<PassConceptT>()> PassMaker;
+  bool EagerlyInvalidate;
+};
+
+// A function to deduce a module pass type and create a unique_ptr of it for returning from the PassMaker
+// function.
+template <typename ModulePassT>
+std::unique_ptr<ModuleBunchToModulePassAdaptor::PassConceptT>
+createForModuleBunchToModulePassAdaptor(ModulePassT Pass) {
+  using PassModelT = detail::PassModel<Module, ModulePassT, PreservedAnalyses, ModuleAnalysisManager>;
+  return std::unique_ptr<ModuleBunchToModulePassAdaptor::PassConceptT>(new PassModelT(std::forward<ModulePassT>(Pass)));
+}
+
+// A function to deduce a module pass type and wrap it in the templated adaptor.
+template <typename ModulePassT>
+ModuleBunchToModulePassAdaptor createModuleBunchToModulePassAdaptor(ModulePassT Pass, bool EagerlyInvalidate = false) {
+  return ModuleBunchToModulePassAdaptor(createForModuleBunchToModulePassAdaptor(std::move(Pass)), EagerlyInvalidate);
+}
+
+/// This class provides access to building LLVM's passes.
+///
+/// Currently implemented as a subclass of LLVM's PassBuilder. If we merge ModuleBunch
+/// into LLVM, then the functionality here would be merged into PassBuilder.
+class MbPassBuilder : public PassBuilder {
+public:
+  explicit MbPassBuilder(TargetMachine *TM = nullptr, PipelineTuningOptions PTO = PipelineTuningOptions(),
+                         std::optional<PGOOptions> PGOOpt = std::nullopt, PassInstrumentationCallbacks *PIC = nullptr)
+      : PassBuilder(TM, PTO, PGOOpt, PIC) {}
+
+  /// Parse a textual pass pipeline description into a \c
+  /// ModulePassManager.
+  ///
+  /// The format of the textual pass pipeline description looks something like:
+  ///
+  ///   modulebunch(module(function(instcombine,sroa),dce,cgscc(inliner,function(...)),...))
+  ///
+  /// Pass managers have ()s describing the nest structure of passes. All passes
+  /// are comma separated. As a special shortcut, if the very first pass is not
+  /// a modulebunch pass (as a modulebunch pass manager is), this will automatically form
+  /// the shortest stack of pass managers that allow inserting that first pass.
+  /// So, assuming module passes 'mpassN', function passes 'fpassN', CGSCC passes
+  /// 'cgpassN', and loop passes 'lpassN', all of these are valid:
+  ///
+  ///   mpass1,mpass2,mpass3
+  ///   fpass1,fpass2,fpass3
+  ///   cgpass1,cgpass2,cgpass3
+  ///   lpass1,lpass2,lpass3
+  ///
+  /// And they are equivalent to the following (resp.):
+  ///
+  ///   modulebunch(module(mpass1,mpass2,mpass3))
+  ///   modulebunch(module(function(fpass1,fpass2,fpass3)))
+  ///   modulebunch(module(cgscc(cgpass1,cgpass2,cgpass3)))
+  ///   modulebunch(module(function(loop(lpass1,lpass2,lpass3))))
+  ///
+  /// This shortcut is especially useful for debugging and testing small pass
+  /// combinations.
+  ///
+  /// The sequence of passes aren't necessarily the exact same kind of pass.
+  /// You can mix different levels implicitly if adaptor passes are defined to
+  /// make them work. For example,
+  ///
+  ///   mpass1,fpass1,fpass2,mpass2,lpass1
+  ///
+  /// This pipeline uses only one pass manager: the top-level modulebunch manager.
+  /// fpass1,fpass2 and lpass1 are added into the the top-level modulebunch manager
+  /// using only adaptor passes. No nested function/loop pass managers are
+  /// added. The purpose is to allow easy pass testing when the user
+  /// specifically want the pass to run under a adaptor directly. This is
+  /// preferred when a pipeline is largely of one type, but one or just a few
+  /// passes are of different types(See PassBuilder.cpp for examples).
+  Error parsePassPipeline(ModuleBunchPassManager &passMgr, StringRef pipelineText);
+
+  /// Register pipeline parsing callbacks with this pass builder instance.
+  /// Using these callbacks, callers can parse both a single pass name, as well
+  /// as entire sub-pipelines, and populate the PassManager instance
+  /// accordingly.
+  void registerPipelineParsingCallback(
+      const std::function<bool(StringRef Name, ModuleBunchPassManager &, ArrayRef<PipelineElement>)> &C) {
+    ModuleBunchPipelineParsingCallbacks.push_back(C);
+  }
+
+  // Forward other overloads of registerPipelineParsingCallback to PassBuilder.
+  void registerPipelineParsingCallback(
+      const std::function<bool(StringRef Name, ModulePassManager &, ArrayRef<PipelineElement>)> &C) {
+    PassBuilder::registerPipelineParsingCallback(C);
+  }
+
+  void registerPipelineParsingCallback(
+      const std::function<bool(StringRef Name, FunctionPassManager &, ArrayRef<PipelineElement>)> &C) {
+    PassBuilder::registerPipelineParsingCallback(C);
+  }
+
+  void registerPipelineParsingCallback(
+      const std::function<bool(StringRef Name, LoopPassManager &, ArrayRef<PipelineElement>)> &C) {
+    PassBuilder::registerPipelineParsingCallback(C);
+  }
+
+private:
+  static std::optional<std::vector<PipelineElement>> parsePipelineText(StringRef Text);
+
+  Error parseModuleBunchPassPipeline(ModuleBunchPassManager &MBPM, ArrayRef<PipelineElement> Pipeline);
+
+  Error parseModuleBunchPass(ModuleBunchPassManager &MBPM, const PipelineElement &E);
+
+  SmallVector<std::function<bool(StringRef, ModuleBunchPassManager &, ArrayRef<PipelineElement>)>, 2>
+      ModuleBunchPipelineParsingCallbacks;
+};
+
+// Copied from PrintModulePass in IRPrintingPasses.h and edited.
+/// ModuleBunch pass to print the IR of the modules.
+class PrintModuleBunchPass : public llvm::PassInfoMixin<PrintModuleBunchPass> {
+  raw_ostream &OS;
+  std::string Banner;
+  bool ShouldPreserveUseListOrder;
+
+public:
+  PrintModuleBunchPass() : OS(dbgs()) {}
+  PrintModuleBunchPass(raw_ostream &OS, const std::string &Banner, bool ShouldPreserveUseListOrder)
+      : OS(OS), Banner(Banner), ShouldPreserveUseListOrder(ShouldPreserveUseListOrder) {}
+
+  PreservedAnalyses run(ModuleBunch &MB, AnalysisManager<ModuleBunch> &);
+  static bool isRequired() { return true; }
+};
+
+} // namespace llvm

--- a/lgc/util/MbStandardInstrumentations.cpp
+++ b/lgc/util/MbStandardInstrumentations.cpp
@@ -1,0 +1,485 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+// An alternative to LLVM's StandardInstrumentations that (partly) patches
+// things up so they work on ModuleBunch passes.
+// Most code here is copied from LLVM's StandardInstrumentations.cpp and
+// edited.
+
+#include "lgc/MbStandardInstrumentations.h"
+#include "llvm/IR/PrintPasses.h"
+#include "llvm/IR/Verifier.h"
+
+using namespace llvm;
+
+namespace {
+
+/// Extract the outermost IR unit out of \p IR unit. May return wrapped nullptr if \p IR does not match
+/// certain global filters. Will never return wrapped nullptr if \p Force is true.
+Any unwrapOuter(Any IR, bool Force = false) {
+  if (const auto **MB = any_cast<const ModuleBunch *>(&IR))
+    return *MB;
+  if (const auto **M = any_cast<const Module *>(&IR))
+    return *M;
+
+  if (const auto **F = any_cast<const Function *>(&IR)) {
+    if (!Force && !isFunctionInPrintList((*F)->getName()))
+      return nullptr;
+
+    return (*F)->getParent();
+  }
+
+  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR)) {
+    for (const LazyCallGraph::Node &N : **C) {
+      const Function &F = N.getFunction();
+      if (Force || (!F.isDeclaration() && isFunctionInPrintList(F.getName()))) {
+        return F.getParent();
+      }
+    }
+    assert(!Force && "Expected a module");
+    return nullptr;
+  }
+
+  if (const auto **L = any_cast<const Loop *>(&IR)) {
+    const Function *F = (*L)->getHeader()->getParent();
+    if (!Force && !isFunctionInPrintList(F->getName()))
+      return nullptr;
+    return F->getParent();
+  }
+
+  llvm_unreachable("Unknown IR unit");
+}
+
+void printIR(raw_ostream &OS, const Function *F) {
+  if (!isFunctionInPrintList(F->getName()))
+    return;
+  OS << *F;
+}
+
+void printIR(raw_ostream &OS, const Module *M) {
+  if (isFunctionInPrintList("*") || forcePrintModuleIR()) {
+    M->print(OS, nullptr);
+  } else {
+    for (const auto &F : M->functions()) {
+      printIR(OS, &F);
+    }
+  }
+}
+
+void printIR(raw_ostream &OS, const ModuleBunch *MB) {
+  for (Module &M : *MB)
+    printIR(OS, &M);
+}
+
+void printIR(raw_ostream &OS, const LazyCallGraph::SCC *C) {
+  for (const LazyCallGraph::Node &N : *C) {
+    const Function &F = N.getFunction();
+    if (!F.isDeclaration() && isFunctionInPrintList(F.getName())) {
+      F.print(OS);
+    }
+  }
+}
+
+void printIR(raw_ostream &OS, const Loop *L) {
+  const Function *F = L->getHeader()->getParent();
+  if (!isFunctionInPrintList(F->getName()))
+    return;
+  printLoop(const_cast<Loop &>(*L), OS);
+}
+
+std::string getIRName(Any IR) {
+  if (any_cast<const ModuleBunch *>(&IR))
+    return "[moduleBunch]";
+
+  if (any_cast<const Module *>(&IR))
+    return "[module]";
+
+  if (const auto **F = any_cast<const Function *>(&IR))
+    return (*F)->getName().str();
+
+  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+    return (*C)->getName();
+
+  if (const auto **L = any_cast<const Loop *>(&IR))
+    return (*L)->getName().str();
+
+  llvm_unreachable("Unknown wrapped IR type");
+}
+
+bool moduleContainsFilterPrintFunc(const Module &M) {
+  return any_of(M.functions(), [](const Function &F) { return isFunctionInPrintList(F.getName()); }) ||
+         isFunctionInPrintList("*");
+}
+
+bool sccContainsFilterPrintFunc(const LazyCallGraph::SCC &C) {
+  return any_of(C, [](const LazyCallGraph::Node &N) { return isFunctionInPrintList(N.getName()); }) ||
+         isFunctionInPrintList("*");
+}
+
+bool shouldPrintIR(Any IR) {
+  if (const auto **MB = any_cast<const ModuleBunch *>(&IR)) {
+    bool ShouldPrint = false;
+    for (Module &M : **MB)
+      ShouldPrint |= moduleContainsFilterPrintFunc(M);
+    return ShouldPrint;
+  }
+
+  if (const auto **M = any_cast<const Module *>(&IR))
+    return moduleContainsFilterPrintFunc(**M);
+
+  if (const auto **F = any_cast<const Function *>(&IR))
+    return isFunctionInPrintList((*F)->getName());
+
+  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+    return sccContainsFilterPrintFunc(**C);
+
+  if (const auto **L = any_cast<const Loop *>(&IR))
+    return isFunctionInPrintList((*L)->getHeader()->getParent()->getName());
+  llvm_unreachable("Unknown wrapped IR type");
+}
+
+/// Generic IR-printing helper that unpacks a pointer to IRUnit wrapped into
+/// Any and does actual print job.
+void unwrapAndPrint(raw_ostream &OS, Any IR) {
+  if (!shouldPrintIR(IR))
+    return;
+
+  if (forcePrintModuleIR())
+    IR = unwrapOuter(IR);
+
+  if (const auto **MB = any_cast<const ModuleBunch *>(&IR)) {
+    printIR(OS, *MB);
+    return;
+  }
+
+  if (const auto **M = any_cast<const Module *>(&IR)) {
+    printIR(OS, *M);
+    return;
+  }
+
+  if (const auto **F = any_cast<const Function *>(&IR)) {
+    printIR(OS, *F);
+    return;
+  }
+
+  if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR)) {
+    printIR(OS, *C);
+    return;
+  }
+
+  if (const auto **L = any_cast<const Loop *>(&IR)) {
+    printIR(OS, *L);
+    return;
+  }
+  llvm_unreachable("Unknown wrapped IR type");
+}
+
+// Return true when this is a pass for which changes should be ignored
+bool isIgnored(StringRef PassID) {
+  return isSpecialPass(PassID, {"PassManager", "PassAdaptor", "AnalysisManagerProxy", "DevirtSCCRepeatedPass",
+                                "ModuleInlinerWrapperPass"});
+}
+
+} // anonymous namespace
+
+MbPrintIRInstrumentation::~MbPrintIRInstrumentation() {
+  assert(ModuleDescStack.empty() && "ModuleDescStack is not empty at exit");
+}
+
+void MbPrintIRInstrumentation::pushModuleDesc(StringRef PassID, Any IR) {
+  ModuleDescStack.emplace_back(unwrapOuter(IR), getIRName(IR), PassID);
+}
+
+MbPrintIRInstrumentation::PrintModuleDesc MbPrintIRInstrumentation::popModuleDesc(StringRef PassID) {
+  assert(!ModuleDescStack.empty() && "empty ModuleDescStack");
+  PrintModuleDesc ModuleDesc = ModuleDescStack.pop_back_val();
+  assert(std::get<2>(ModuleDesc).equals(PassID) && "malformed ModuleDescStack");
+  return ModuleDesc;
+}
+
+void MbPrintIRInstrumentation::printBeforePass(StringRef PassID, Any IR) {
+  if (isIgnored(PassID))
+    return;
+
+  // Saving Module for AfterPassInvalidated operations.
+  // Note: here we rely on a fact that we do not change modules while
+  // traversing the pipeline, so the latest captured module is good
+  // for all print operations that has not happen yet.
+  if (shouldPrintAfterPass(PassID))
+    pushModuleDesc(PassID, IR);
+
+  if (!shouldPrintBeforePass(PassID))
+    return;
+
+  if (!shouldPrintIR(IR))
+    return;
+
+  dbgs() << "*** IR Dump Before " << PassID << " on " << getIRName(IR) << " ***\n";
+  unwrapAndPrint(dbgs(), IR);
+}
+
+void MbPrintIRInstrumentation::printAfterPass(StringRef PassID, Any IR) {
+  if (isIgnored(PassID))
+    return;
+
+  if (!shouldPrintAfterPass(PassID))
+    return;
+
+  Any OuterIR;
+  std::string IRName;
+  StringRef StoredPassID;
+  std::tie(OuterIR, IRName, StoredPassID) = popModuleDesc(PassID);
+  assert(StoredPassID == PassID && "mismatched PassID");
+
+  if (!shouldPrintIR(IR))
+    return;
+
+  dbgs() << "*** IR Dump After " << PassID << " on " << IRName << " ***\n";
+  unwrapAndPrint(dbgs(), IR);
+}
+
+void MbPrintIRInstrumentation::printAfterPassInvalidated(StringRef PassID) {
+  StringRef PassName = PIC->getPassNameForClassName(PassID);
+  if (!shouldPrintAfterPass(PassName))
+    return;
+
+  if (isIgnored(PassID))
+    return;
+
+  Any OuterIR;
+  std::string IRName;
+  StringRef StoredPassID;
+  std::tie(OuterIR, IRName, StoredPassID) = popModuleDesc(PassID);
+  assert(StoredPassID == PassID && "mismatched PassID");
+  // Additional filtering (e.g. -filter-print-func) can lead to module
+  // printing being skipped.
+  if (!*any_cast<const void *>(&OuterIR))
+    return;
+
+  SmallString<20> Banner = formatv("*** IR Dump After {0} on {1} (invalidated) ***", PassID, IRName);
+  dbgs() << Banner << "\n";
+  unwrapAndPrint(dbgs(), OuterIR);
+}
+
+bool MbPrintIRInstrumentation::shouldPrintBeforePass(StringRef PassID) {
+  if (shouldPrintBeforeAll())
+    return true;
+
+  StringRef PassName = PIC->getPassNameForClassName(PassID);
+  return is_contained(printBeforePasses(), PassName);
+}
+
+bool MbPrintIRInstrumentation::shouldPrintAfterPass(StringRef PassID) {
+  if (shouldPrintAfterAll())
+    return true;
+
+  StringRef PassName = PIC->getPassNameForClassName(PassID);
+  return is_contained(printAfterPasses(), PassName);
+}
+
+void MbPrintIRInstrumentation::registerCallbacks(PassInstrumentationCallbacks &PIC) {
+  this->PIC = &PIC;
+
+  // BeforePass callback is not just for printing, it also saves a Module
+  // for later use in AfterPassInvalidated.
+  if (shouldPrintBeforeSomePass() || shouldPrintAfterSomePass())
+    PIC.registerBeforeNonSkippedPassCallback([this](StringRef P, Any IR) { this->printBeforePass(P, IR); });
+
+  if (shouldPrintAfterSomePass()) {
+    PIC.registerAfterPassCallback(
+        [this](StringRef P, Any IR, const PreservedAnalyses &) { this->printAfterPass(P, IR); });
+    PIC.registerAfterPassInvalidatedCallback(
+        [this](StringRef P, const PreservedAnalyses &) { this->printAfterPassInvalidated(P); });
+  }
+}
+
+void MbVerifyInstrumentation::registerCallbacks(PassInstrumentationCallbacks &PIC) {
+  PIC.registerAfterPassCallback([this](StringRef P, Any IR, const PreservedAnalyses &PassPA) {
+    if (isIgnored(P) || P == "VerifierPass")
+      return;
+    const Function **FPtr = any_cast<const Function *>(&IR);
+    const Function *F = FPtr ? *FPtr : nullptr;
+    if (!F) {
+      if (const auto **L = any_cast<const Loop *>(&IR))
+        F = (*L)->getHeader()->getParent();
+    }
+
+    if (F) {
+      if (DebugLogging)
+        dbgs() << "Verifying function " << F->getName() << "\n";
+
+      if (verifyFunction(*F, &errs()))
+        report_fatal_error("Broken function found, compilation aborted!");
+    } else if (const ModuleBunch **MB = any_cast<const ModuleBunch *>(&IR)) {
+      for (Module &M : **MB) {
+        if (DebugLogging)
+          dbgs() << "Verifying module " << M.getName() << "\n";
+
+        if (verifyModule(M, &errs()))
+          report_fatal_error("Broken module found, compilation aborted!");
+      }
+    } else {
+      const Module **MPtr = any_cast<const Module *>(&IR);
+      const Module *M = MPtr ? *MPtr : nullptr;
+      if (!M) {
+        if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR))
+          M = (*C)->begin()->getFunction().getParent();
+      }
+
+      if (M) {
+        if (DebugLogging)
+          dbgs() << "Verifying module " << M->getName() << "\n";
+
+        if (verifyModule(*M, &errs()))
+          report_fatal_error("Broken module found, compilation aborted!");
+      }
+    }
+  });
+}
+
+raw_ostream &MbPrintPassInstrumentation::print() {
+  if (Opts.Indent) {
+    assert(Indent >= 0);
+    dbgs().indent(Indent);
+  }
+  return dbgs();
+}
+
+void MbPrintPassInstrumentation::registerCallbacks(PassInstrumentationCallbacks &PIC) {
+  if (!Enabled)
+    return;
+
+  std::vector<StringRef> SpecialPasses;
+  if (!Opts.Verbose) {
+    SpecialPasses.emplace_back("PassManager");
+    SpecialPasses.emplace_back("PassAdaptor");
+  }
+
+  PIC.registerBeforeSkippedPassCallback([this, SpecialPasses](StringRef PassID, Any IR) {
+    assert(!isSpecialPass(PassID, SpecialPasses) && "Unexpectedly skipping special pass");
+
+    print() << "Skipping pass: " << PassID << " on " << getIRName(IR) << "\n";
+  });
+  PIC.registerBeforeNonSkippedPassCallback([this, SpecialPasses](StringRef PassID, Any IR) {
+    if (isSpecialPass(PassID, SpecialPasses))
+      return;
+
+    auto &OS = print();
+    OS << "Running pass: " << PassID << " on " << getIRName(IR);
+    if (const auto **F = any_cast<const Function *>(&IR)) {
+      unsigned Count = (*F)->getInstructionCount();
+      OS << " (" << Count << " instruction";
+      if (Count != 1)
+        OS << 's';
+      OS << ')';
+    } else if (const auto **C = any_cast<const LazyCallGraph::SCC *>(&IR)) {
+      int Count = (*C)->size();
+      OS << " (" << Count << " node";
+      if (Count != 1)
+        OS << 's';
+      OS << ')';
+    }
+    OS << "\n";
+    Indent += 2;
+  });
+  PIC.registerAfterPassCallback([this, SpecialPasses](StringRef PassID, Any IR, const PreservedAnalyses &) {
+    if (isSpecialPass(PassID, SpecialPasses))
+      return;
+
+    Indent -= 2;
+  });
+  PIC.registerAfterPassInvalidatedCallback([this, SpecialPasses](StringRef PassID, Any IR) {
+    if (isSpecialPass(PassID, SpecialPasses))
+      return;
+
+    Indent -= 2;
+  });
+
+  if (!Opts.SkipAnalyses) {
+    PIC.registerBeforeAnalysisCallback([this](StringRef PassID, Any IR) {
+      print() << "Running analysis: " << PassID << " on " << getIRName(IR) << "\n";
+      Indent += 2;
+    });
+    PIC.registerAfterAnalysisCallback([this](StringRef PassID, Any IR) { Indent -= 2; });
+    PIC.registerAnalysisInvalidatedCallback([this](StringRef PassID, Any IR) {
+      print() << "Invalidating analysis: " << PassID << " on " << getIRName(IR) << "\n";
+    });
+    PIC.registerAnalysesClearedCallback(
+        [this](StringRef IRName) { print() << "Clearing all analysis results for: " << IRName << "\n"; });
+  }
+}
+
+MbStandardInstrumentations::MbStandardInstrumentations(bool DebugLogging, bool VerifyEach,
+                                                       PrintPassOptions PrintPassOpts)
+    : PrintPass(DebugLogging, PrintPassOpts), OptNone(DebugLogging),
+      PrintChangedIR(PrintChanged == ChangePrinter::Verbose),
+      PrintChangedDiff(PrintChanged == ChangePrinter::DiffVerbose || PrintChanged == ChangePrinter::ColourDiffVerbose,
+                       PrintChanged == ChangePrinter::ColourDiffVerbose ||
+                           PrintChanged == ChangePrinter::ColourDiffQuiet),
+      WebsiteChangeReporter(PrintChanged == ChangePrinter::DotCfgVerbose), Verify(DebugLogging),
+      VerifyEach(VerifyEach) {
+}
+
+// Copied from LLVM's StandardInstrumentations.cpp and edited.
+void MbStandardInstrumentations::registerCallbacks(
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 454783
+    // Old version of the code
+    PassInstrumentationCallbacks &PIC, FunctionAnalysisManager *FAM) {
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    PassInstrumentationCallbacks &PIC, ModuleAnalysisManager *MAM) {
+#endif
+  PrintIR.registerCallbacks(PIC);
+  PrintPass.registerCallbacks(PIC);
+  TimePasses.registerCallbacks(PIC);
+  OptNone.registerCallbacks(PIC);
+  // OptPassGate.registerCallbacks(PIC);
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 454783
+  // Old version of the code
+  if (FAM)
+    PreservedCFGChecker.registerCallbacks(PIC, *FAM);
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  if (MAM)
+    PreservedCFGChecker.registerCallbacks(PIC, *MAM);
+#endif
+  PrintChangedIR.registerCallbacks(PIC);
+  PseudoProbeVerification.registerCallbacks(PIC);
+  if (VerifyEach)
+    Verify.registerCallbacks(PIC);
+  PrintChangedDiff.registerCallbacks(PIC);
+  WebsiteChangeReporter.registerCallbacks(PIC);
+
+  ChangeTester.registerCallbacks(PIC);
+
+  PrintCrashIR.registerCallbacks(PIC);
+  // TimeProfiling records the pass running time cost.
+  // Its 'BeforePassCallback' can be appended at the tail of all the
+  // BeforeCallbacks by calling `registerCallbacks` in the end.
+  // Its 'AfterPassCallback' is put at the front of all the
+  // AfterCallbacks by its `registerCallbacks`. This is necessary
+  // to ensure that other callbacks are not included in the timings.
+  TimeProfilingPasses.registerCallbacks(PIC);
+}

--- a/lgc/util/ModuleBunch.cpp
+++ b/lgc/util/ModuleBunch.cpp
@@ -1,0 +1,399 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+// The ModuleBunch class, representing a bunch of modules, and a pass manager
+// and analysis manager for it allowing you to run passes on it.
+
+#include "lgc/ModuleBunch.h"
+#include "llvm/IR/PassManagerImpl.h"
+#include "llvm/IR/PrintPasses.h"
+
+namespace llvm {
+
+template class PassManager<ModuleBunch>;
+template class AnalysisManager<ModuleBunch>;
+template class AllAnalysesOn<ModuleBunch>;
+
+} // namespace llvm
+
+using namespace llvm;
+
+// Add Module to ModuleBunch, taking ownership.
+void ModuleBunch::addModule(std::unique_ptr<Module> module) {
+  Modules.push_back(std::move(module));
+}
+
+// Renormalize ModuleBunch's array of Modules after manipulation by user.
+// Invalidates modules() iterator.
+void ModuleBunch::renormalize() {
+  // Remove holes from where caller freed/released modules.
+  Modules.erase(std::remove(Modules.begin(), Modules.end(), nullptr), Modules.end());
+}
+
+// Check that Modules list has been renormalized since caller removed/freed modules.
+// Checks that there are no holes.
+bool ModuleBunch::isNormalized() const {
+  for (const std::unique_ptr<Module> &entry : Modules) {
+    if (!entry)
+      return false;
+  }
+  return true;
+}
+
+// Copied from IRPrintingPasses.cpp and edited.
+PreservedAnalyses PrintModuleBunchPass::run(ModuleBunch &MB, ModuleBunchAnalysisManager &AM) {
+  if (llvm::isFunctionInPrintList("*")) {
+    if (!Banner.empty())
+      OS << Banner << "\n";
+    for (const Module &M : MB)
+      M.print(OS, nullptr, ShouldPreserveUseListOrder);
+  } else {
+    bool BannerPrinted = false;
+    for (const Module &M : MB) {
+      for (const auto &F : M.functions()) {
+        if (llvm::isFunctionInPrintList(F.getName())) {
+          if (!BannerPrinted && !Banner.empty()) {
+            OS << Banner << "\n";
+            BannerPrinted = true;
+          }
+          F.print(OS);
+        }
+      }
+    }
+  }
+
+  return PreservedAnalyses::all();
+}
+
+// Copied from FunctionAnalysisManagerModuleProxy in llvm/lib/IR/PassManager.cpp and edited.
+template <>
+bool ModuleAnalysisManagerModuleBunchProxy::Result::invalidate(ModuleBunch &Bunch, const PreservedAnalyses &PA,
+                                                               ModuleBunchAnalysisManager::Invalidator &Inv) {
+  // If literally everything is preserved, we're done.
+  if (PA.areAllPreserved())
+    return false; // This is still a valid proxy.
+
+  // If this proxy isn't marked as preserved, then even if the result remains
+  // valid, the key itself may no longer be valid, so we clear everything.
+  //
+  // Note that in order to preserve this proxy, a ModuleBunch pass must ensure that
+  // the MAM has been completely updated to handle the deletion of modules.
+  // Specifically, any MAM-cached results for those modules need to have been
+  // forcibly cleared. When preserved, this proxy will only invalidate results
+  // cached on modules *still in the ModuleBunch* at the end of the ModuleBunch pass.
+  auto PAC = PA.getChecker<ModuleAnalysisManagerModuleBunchProxy>();
+  if (!PAC.preserved() && !PAC.preservedSet<AllAnalysesOn<ModuleBunch>>()) {
+    InnerAM->clear();
+    return true;
+  }
+
+  // Directly check if the relevant set is preserved.
+  bool AreModuleAnalysesPreserved = PA.allAnalysesInSetPreserved<AllAnalysesOn<Module>>();
+
+  // Now walk all the modules to see if any inner analysis invalidation is
+  // necessary.
+  for (Module &M : Bunch) {
+    std::optional<PreservedAnalyses> ModulePA;
+
+    // Check to see whether the preserved set needs to be pruned based on
+    // module-level analysis invalidation that triggers deferred invalidation
+    // registered with the outer analysis manager proxy for this module.
+    if (auto *OuterProxy = InnerAM->getCachedResult<ModuleBunchAnalysisManagerModuleProxy>(M))
+      for (const auto &OuterInvalidationPair : OuterProxy->getOuterInvalidations()) {
+        AnalysisKey *OuterAnalysisID = OuterInvalidationPair.first;
+        const auto &InnerAnalysisIDs = OuterInvalidationPair.second;
+        if (Inv.invalidate(OuterAnalysisID, Bunch, PA)) {
+          if (!ModulePA)
+            ModulePA = PA;
+          for (AnalysisKey *InnerAnalysisID : InnerAnalysisIDs)
+            ModulePA->abandon(InnerAnalysisID);
+        }
+      }
+
+    // Check if we needed a custom PA set, and if so we'll need to run the
+    // inner invalidation.
+    if (ModulePA) {
+      InnerAM->invalidate(M, *ModulePA);
+      continue;
+    }
+
+    // Otherwise we only need to do invalidation if the original PA set didn't
+    // preserve all module analyses.
+    if (!AreModuleAnalysesPreserved)
+      InnerAM->invalidate(M, PA);
+  }
+
+  // Return false to indicate that this result is still a valid proxy.
+  return false;
+}
+
+// Copied from ModuleToFunctionPassAdaptor::printPipeline in llvm/lib/IR/PassManager.cpp and edited.
+void ModuleBunchToModulePassAdaptor::printPipeline(raw_ostream &OS,
+                                                   function_ref<StringRef(StringRef)> MapClassName2PassName) {
+  OS << "module";
+  if (EagerlyInvalidate)
+    OS << "<eager-inv>";
+  OS << "(";
+  Pass->printPipeline(OS, MapClassName2PassName);
+  OS << ")";
+}
+
+// Copied from ModuleToFunctionPassAdaptor::run in llvm/lib/IR/PassManager.cpp and edited.
+PreservedAnalyses ModuleBunchToModulePassAdaptor::run(ModuleBunch &Bunch, ModuleBunchAnalysisManager &AM) {
+  ModuleAnalysisManager &MAM = AM.getResult<ModuleAnalysisManagerModuleBunchProxy>(Bunch).getManager();
+
+  // Request PassInstrumentation from analysis manager, will use it to run
+  // instrumenting callbacks for the passes later.
+  PassInstrumentation PI = AM.getResult<PassInstrumentationAnalysis>(Bunch);
+
+  PreservedAnalyses PA = PreservedAnalyses::all();
+
+  // TODO: Add real parallelism, with an API to provide threads to run module passes.
+  // For now, run each distinct LLVMContext in a separate copy of the module pass manager,
+  // so we can at least test users adding identical copies of the module pass manager.
+  SmallPtrSet<LLVMContext *, 16> DoneContexts;
+  for (unsigned StartIdx = 0; StartIdx != Bunch.size(); ++StartIdx) {
+    LLVMContext *Context = &Bunch.begin()[StartIdx].getContext();
+    if (!DoneContexts.insert(Context).second)
+      continue;
+
+    // Use the single Pass if it was set. Otherwise call PassMaker to create a Pass each time
+    // round the outer per-LLVMContext loop.
+    std::unique_ptr<PassConceptT> AllocatedPass;
+    PassConceptT *ThisPass = &*Pass;
+    if (!ThisPass) {
+      AllocatedPass = PassMaker();
+      ThisPass = &*AllocatedPass;
+    }
+
+    for (unsigned Idx = StartIdx; Idx != Bunch.size(); ++Idx) {
+      Module &M = Bunch.begin()[Idx];
+      if (&M.getContext() != Context)
+        continue;
+
+      // Check the PassInstrumentation's BeforePass callbacks before running the
+      // pass, skip its execution completely if asked to (callback returns
+      // false).
+      if (!PI.runBeforePass<Module>(*ThisPass, M))
+        continue;
+
+      PreservedAnalyses PassPA = ThisPass->run(M, MAM);
+      PI.runAfterPass(*ThisPass, M, PassPA);
+
+      // TODO: With real parallelism, the next two statements need to be under a mutex.
+      // We know that the module pass couldn't have invalidated any other
+      // module's analyses (that's the contract of a module pass), so
+      // directly handle the module analysis manager's invalidation here.
+      MAM.invalidate(M, EagerlyInvalidate ? PreservedAnalyses::none() : PassPA);
+
+      // Then intersect the preserved set so that invalidation of module
+      // analyses will eventually occur when the module pass completes.
+      PA.intersect(std::move(PassPA));
+    }
+  }
+
+  // The ModuleAnalysisManagerModuleBunchProxy is preserved because (we assume)
+  // the module passes we ran didn't add or remove any modules.
+  //
+  // We also preserve all analyses on Modules, because we did all the
+  // invalidation we needed to do above.
+  PA.preserveSet<AllAnalysesOn<Module>>();
+  PA.preserve<ModuleAnalysisManagerModuleBunchProxy>();
+  return PA;
+}
+
+// Copied from lib/Passes/PassBuilder.cpp because it is private there.
+std::optional<std::vector<PassBuilder::PipelineElement>> MbPassBuilder::parsePipelineText(StringRef Text) {
+  std::vector<PipelineElement> ResultPipeline;
+
+  SmallVector<std::vector<PipelineElement> *, 4> PipelineStack = {&ResultPipeline};
+  for (;;) {
+    std::vector<PipelineElement> &Pipeline = *PipelineStack.back();
+    size_t Pos = Text.find_first_of(",()");
+    Pipeline.push_back({Text.substr(0, Pos), {}});
+
+    // If we have a single terminating name, we're done.
+    if (Pos == Text.npos)
+      break;
+
+    char Sep = Text[Pos];
+    Text = Text.substr(Pos + 1);
+    if (Sep == ',')
+      // Just a name ending in a comma, continue.
+      continue;
+
+    if (Sep == '(') {
+      // Push the inner pipeline onto the stack to continue processing.
+      PipelineStack.push_back(&Pipeline.back().InnerPipeline);
+      continue;
+    }
+
+    assert(Sep == ')' && "Bogus separator!");
+    // When handling the close parenthesis, we greedily consume them to avoid
+    // empty strings in the pipeline.
+    do {
+      // If we try to pop the outer pipeline we have unbalanced parentheses.
+      if (PipelineStack.size() == 1)
+        return std::nullopt;
+
+      PipelineStack.pop_back();
+    } while (Text.consume_front(")"));
+
+    // Check if we've finished parsing.
+    if (Text.empty())
+      break;
+
+    // Otherwise, the end of an inner pipeline always has to be followed by
+    // a comma, and then we can continue.
+    if (!Text.consume_front(","))
+      return std::nullopt;
+  }
+
+  if (PipelineStack.size() > 1)
+    // Unbalanced paretheses.
+    return std::nullopt;
+
+  assert(PipelineStack.back() == &ResultPipeline && "Wrong pipeline at the bottom of the stack!");
+  return {std::move(ResultPipeline)};
+}
+
+// Copied from PassBuilder.cpp.
+static std::optional<int> parseRepeatPassName(StringRef Name) {
+  if (!Name.consume_front("repeat<") || !Name.consume_back(">"))
+    return std::nullopt;
+  int Count;
+  if (Name.getAsInteger(0, Count) || Count <= 0)
+    return std::nullopt;
+  return Count;
+}
+
+// Copied from PassBuilder.cpp.
+/// Tests whether registered callbacks will accept a given pass name.
+///
+/// When parsing a pipeline text, the type of the outermost pipeline may be
+/// omitted, in which case the type is automatically determined from the first
+/// pass name in the text. This may be a name that is handled through one of the
+/// callbacks. We check this through the oridinary parsing callbacks by setting
+/// up a dummy PassManager in order to not force the client to also handle this
+/// type of query.
+template <typename PassManagerT, typename CallbacksT>
+static bool callbacksAcceptPassName(StringRef Name, CallbacksT &Callbacks) {
+  if (!Callbacks.empty()) {
+    PassManagerT DummyPM;
+    for (auto &CB : Callbacks)
+      if (CB(Name, DummyPM, {}))
+        return true;
+  }
+  return false;
+}
+
+// Copied from isModulePassName in PassBuilder.cpp and edited.
+template <typename CallbacksT> static bool isModuleBunchPassName(StringRef Name, CallbacksT &Callbacks) {
+  // Explicitly handle pass manager names.
+  if (Name == "modulebunch")
+    return true;
+  if (Name == "module")
+    return true;
+  if (Name == "cgscc")
+    return true;
+  if (Name == "function" || Name == "function<eager-inv>")
+    return true;
+  if (Name == "coro-cond")
+    return true;
+
+  // Explicitly handle custom-parsed pass names.
+  if (parseRepeatPassName(Name))
+    return true;
+  return callbacksAcceptPassName<ModuleBunchPassManager>(Name, Callbacks);
+}
+
+// Copied from the ModulePassManager overload in llvm/lib/Passes/PassBuilder.cpp and edited.
+// Primary pass pipeline description parsing routine for a \c ModuleBunchPassManager
+// FIXME: Should this routine accept a TargetMachine or require the caller to
+// pre-populate the analysis managers with target-specific stuff?
+Error MbPassBuilder::parsePassPipeline(ModuleBunchPassManager &MBPM, StringRef PipelineText) {
+  auto Pipeline = parsePipelineText(PipelineText);
+  if (!Pipeline || Pipeline->empty())
+    return make_error<StringError>(formatv("invalid pipeline '{0}'", PipelineText).str(), inconvertibleErrorCode());
+
+  // If the first name isn't at the modulebunch layer, wrap the pipeline up
+  // automatically.
+  StringRef FirstName = Pipeline->front().Name;
+
+  if (!isModuleBunchPassName(FirstName, ModuleBunchPipelineParsingCallbacks)) {
+    ModulePassManager MPM;
+    if (Error Err = PassBuilder::parsePassPipeline(MPM, PipelineText))
+      return Err;
+    MBPM.addPass(createModuleBunchToModulePassAdaptor(std::move(MPM)));
+    return Error::success();
+  }
+
+  if (auto Err = parseModuleBunchPassPipeline(MBPM, *Pipeline))
+    return Err;
+  return Error::success();
+}
+
+// Copied from PassBuilder::parseModulePassPipeline and edited.
+Error MbPassBuilder::parseModuleBunchPassPipeline(ModuleBunchPassManager &MBPM, ArrayRef<PipelineElement> Pipeline) {
+  for (const auto &Element : Pipeline) {
+    if (auto Err = parseModuleBunchPass(MBPM, Element))
+      return Err;
+  }
+  return Error::success();
+}
+
+// Copied from PassBuilder::parseModulePass and edited.
+Error MbPassBuilder::parseModuleBunchPass(ModuleBunchPassManager &MBPM, const PipelineElement &E) {
+  auto &Name = E.Name;
+  auto &InnerPipeline = E.InnerPipeline;
+
+  // First handle complex passes like the pass managers which carry pipelines.
+  if (!InnerPipeline.empty()) {
+    if (Name == "modulebunch") {
+      ModuleBunchPassManager NestedMBPM;
+      if (auto Err = parseModuleBunchPassPipeline(NestedMBPM, InnerPipeline))
+        return Err;
+      MBPM.addPass(std::move(NestedMBPM));
+      return Error::success();
+    }
+    if (auto Count = parseRepeatPassName(Name)) {
+      ModuleBunchPassManager NestedMBPM;
+      if (auto Err = parseModuleBunchPassPipeline(NestedMBPM, InnerPipeline))
+        return Err;
+      MBPM.addPass(createRepeatedPass(*Count, std::move(NestedMBPM)));
+      return Error::success();
+    }
+    // TODO:
+    // For any other nested pass manager ("module", "function" etc) we want to invoke
+    // parseModulePassPipeline etc, but we can't as it is private in PassBuilder. So
+    // instead we need to reconstruct a text string and call parsePipelineText.
+    report_fatal_error("Nested pipeline spec not handled yet");
+  }
+
+  for (auto &C : ModuleBunchPipelineParsingCallbacks)
+    if (C(Name, MBPM, InnerPipeline))
+      return Error::success();
+  return make_error<StringError>(formatv("unknown modulebunch pass '{0}'", Name).str(), inconvertibleErrorCode());
+}


### PR DESCRIPTION
This adds a pseudo-IR unit "ModuleBunch" (a bunch of modules), and the pass manager infrastructure to allow module bunch passes and analysis.

In the same way as a module pass manager can have an adaptor to run (e.g.) function passes, a module bunch pass manager can have an adaptor to run module passes.

Currently that adaptor runs multiple modules sequentially, but the design allows for a future change where modules can be run in parallel, as long as they are created in separate LLVMContexts. If that happens, a ModuleBunch pass that wants to move code from one module to another would need to be aware of that possibility.

To run in parallel, there needs to be a separate copy of the ModulePassManager inside the adaptor per thread. To enable that, there is a constructor that takes a PassMaker function instead of a pass, and the adaptor calls that once per distinct LLVMContext. There is no actual parallelism yet.

The normal PassBuilder does not know about module bunch passes, so you must instead use MbPassBuilder (added here).

Unlike for other real IR units, there is no way to directly get the parent ModuleBunch from a Module. A user of this feature could provide its own local way to do that for its passes, perhaps via a thread-local variable.

LLVM's standard instrumentations unfortunately blow up in some places when they see a novel IR unit they haven't heard of. This commit adds a new MbStandardInstrumentations that contains copies of a few of the standard instrumentations fixed up to cope with ModuleBunches. In particular, -print-after etc and -verify-ir work.