### PR TITLE
lgc: Separate LgcContext::createTargetMachine out of LgcContext::create

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -159,6 +159,8 @@ public:
   // Generate pipeline module
   bool generate(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
                 CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers) override final;
+  bool generate(llvm::Module *pipelineModule, llvm::raw_pwrite_stream &outStream,
+                CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers) override final;
 
   // Create an ELF linker object for linking unlinked shader/part-pipeline ELFs into a pipeline ELF using the
   // pipeline state

--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -79,14 +79,19 @@ public:
   // possible, this should be called in a thread-safe way.
   static void initialize();
 
-  // Create the LgcContext. Returns nullptr on failure to recognize the AMDGPU target whose name is specified
+  // Create TargetMachine. Returns nullptr on failure to recognize the AMDGPU target whose name is specified.
   //
-  // @param context : LLVM context to use on all compiles
   // @param gpuName : LLVM GPU name (e.g. "gfx900"); empty to use -mcpu option setting
+  // @param optLevel : LLVM optimization level used to initialize target machine
+  static std::unique_ptr<llvm::TargetMachine> createTargetMachine(llvm::StringRef gpuName,
+                                                                  llvm::CodeGenOpt::Level optLevel);
+
+  // Create the LgcContext.
+  //
+  // @param targetMachine : LLVM TargetMachine to use. Caller retains ownership and must free it when finished.
+  // @param context : LLVM context to give each Builder. Caller retains ownership and must free it when finished.
   // @param palAbiVersion : PAL pipeline ABI version to compile for
-  // @param optLevel : The optimization level to use.
-  static LgcContext *create(llvm::LLVMContext &context, llvm::StringRef gpuName, unsigned int palAbiVersion,
-                            llvm::CodeGenOpt::Level optLevel);
+  static LgcContext *create(llvm::TargetMachine *targetMachine, llvm::LLVMContext &context, unsigned palAbiVersion);
 
   // Get the value of the -emit-lgc option. BuilderRecorder uses this to decide whether to omit the opcode
   // metadata when recording a Builder call.

--- a/lgc/interface/lgc/PassManager.h
+++ b/lgc/interface/lgc/PassManager.h
@@ -33,6 +33,11 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/PassManager.h"
 
+namespace llvm {
+class LLVMContext;
+class TargetMachine;
+} // namespace llvm
+
 namespace lgc {
 
 class LgcContext;
@@ -51,7 +56,9 @@ public:
 // Public interface of LLPC middle-end's PassManager override
 class PassManager : public llvm::ModulePassManager {
 public:
+  // Create an LGC PassManager using the TargetMachine and LLVMContext from the given lgcContext.
   static PassManager *Create(LgcContext *lgcContext);
+
   virtual ~PassManager() {}
   template <typename PassBuilderT> bool registerFunctionAnalysis(PassBuilderT &&PassBuilder) {
     return m_functionAnalysisManager.registerPass(std::forward<PassBuilderT>(PassBuilder));

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -864,6 +864,10 @@ public:
   virtual bool generate(std::unique_ptr<llvm::Module> pipelineModule, llvm::raw_pwrite_stream &outStream,
                         CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers) = 0;
 
+  // Version of generate() that does not take ownership of the Module.
+  virtual bool generate(llvm::Module *pipelineModule, llvm::raw_pwrite_stream &outStream,
+                        CheckShaderCacheFunc checkShaderCacheFunc, llvm::ArrayRef<llvm::Timer *> timers) = 0;
+
   // Create an ELF linker object for linking unlinked shader or part-pipeline ELFs into a pipeline ELF using
   // the pipeline state. This needs to be deleted after use.
   virtual ElfLinker *createElfLinker(llvm::ArrayRef<llvm::MemoryBufferRef> elfs) = 0;

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -160,6 +160,13 @@ Module *PipelineState::irLink(ArrayRef<Module *> modules, PipelineLink pipelineL
 }
 
 // =====================================================================================================================
+// Version of generate() that takes ownership of the Module and deletes it.
+bool PipelineState::generate(std::unique_ptr<Module> pipelineModule, raw_pwrite_stream &outStream,
+                             Pipeline::CheckShaderCacheFunc checkShaderCacheFunc, ArrayRef<Timer *> timers) {
+  return generate(&*pipelineModule, outStream, checkShaderCacheFunc, timers);
+}
+
+// =====================================================================================================================
 // Generate pipeline module by running patch, middle-end optimization and backend codegen passes.
 // The output is normally ELF, but IR assembly if an option is used to stop compilation early,
 // or ISA assembly if -filetype=asm is specified.
@@ -179,7 +186,7 @@ Module *PipelineState::irLink(ArrayRef<Module *> modules, PipelineLink pipelineL
 //           module cannot be compiled that way.  The client typically then does a whole-pipeline compilation
 //           instead. The client can call getLastError() to get a textual representation of the error, for
 //           use in logging or in error reporting in a command-line utility.
-bool PipelineState::generate(std::unique_ptr<Module> pipelineModule, raw_pwrite_stream &outStream,
+bool PipelineState::generate(Module *pipelineModule, raw_pwrite_stream &outStream,
                              Pipeline::CheckShaderCacheFunc checkShaderCacheFunc, ArrayRef<Timer *> timers) {
   m_lastError.clear();
 

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -244,12 +244,12 @@ int main(int argc, char **argv) {
   }
 
   // Create the LgcContext.
-  std::unique_ptr<LgcContext> lgcContext(
-      LgcContext::create(context, gpuName, PalAbiVersion, CodeGenOpt::Level::Default));
-  if (!lgcContext) {
+  std::unique_ptr<TargetMachine> targetMachine(LgcContext::createTargetMachine(gpuName, CodeGenOpt::Level::Default));
+  if (!targetMachine) {
     errs() << progName << ": GPU type '" << gpuName << "' not recognized\n";
     return 1;
   }
+  std::unique_ptr<LgcContext> lgcContext(LgcContext::create(&*targetMachine, context, PalAbiVersion));
 
   if (VerboseOutput)
     lgcContext->setLlpcOuts(&outs());

--- a/lgc/unittests/interface/OptLevelTest.cpp
+++ b/lgc/unittests/interface/OptLevelTest.cpp
@@ -26,6 +26,7 @@
 #include "lgc/LgcContext.h"
 #include "lgc/LgcDialect.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/Target/TargetMachine.h"
 #include "gmock/gmock.h"
 
 using namespace lgc;
@@ -41,7 +42,8 @@ TEST(LgcInterfaceTests, DefaultOptLevel) {
   StringRef gpuName = "gfx802";
 
   for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
-    std::unique_ptr<LgcContext> lgcContext(LgcContext::create(context, gpuName, palAbiVersion, optLevel));
+    std::unique_ptr<TargetMachine> targetMachine = LgcContext::createTargetMachine(gpuName, optLevel);
+    std::unique_ptr<LgcContext> lgcContext(LgcContext::create(&*targetMachine, context, palAbiVersion));
     EXPECT_EQ(lgcContext->getOptimizationLevel(), optLevel);
   }
 }

--- a/llpc/context/llpcContext.h
+++ b/llpc/context/llpcContext.h
@@ -84,7 +84,8 @@ public:
   // Get (create if necessary) LgcContext
   lgc::LgcContext *getLgcContext();
 
-  llvm::CodeGenOpt::Level getOptimizationLevel() const;
+  llvm::CodeGenOpt::Level getOptimizationLevel();
+  llvm::CodeGenOpt::Level getLastOptimizationLevel() const;
 
   std::unique_ptr<llvm::Module> loadLibrary(const BinaryData *lib);
 
@@ -127,13 +128,14 @@ private:
   Context(const Context &) = delete;
   Context &operator=(const Context &) = delete;
 
-  GfxIpVersion m_gfxIp;                              // Graphics IP version info
-  PipelineContext *m_pipelineContext;                // Pipeline-specific context
-  bool m_isInUse = false;                            // Whether this context is in use
-  lgc::Builder *m_builder = nullptr;                 // LLPC builder object
-  std::unique_ptr<lgc::LgcContext> m_builderContext; // Builder context
+  GfxIpVersion m_gfxIp;                                 // Graphics IP version info
+  PipelineContext *m_pipelineContext;                   // Pipeline-specific context
+  bool m_isInUse = false;                               // Whether this context is in use
+  lgc::Builder *m_builder = nullptr;                    // LLPC builder object
+  std::unique_ptr<llvm::TargetMachine> m_targetMachine; // Target machine for LGC context
+  std::unique_ptr<lgc::LgcContext> m_builderContext;    // LGC context
 
-  std::unique_ptr<llvm::TargetMachine> m_targetMachine; // Target machine
+  std::optional<llvm::CodeGenOpt::Level> m_lastOptLevel{}; // What getOptimizationLevel() last returned
   std::unique_ptr<llvm_dialects::DialectContext> m_dialectContext;
 
   unsigned m_useCount = 0; // Number of times this context is used.


### PR DESCRIPTION
Also add a new version of lgc::Pipeline::generate that does not take ownership of the Module, so it can be run from inside a pass.

This is to allow for future front-end changes.