### PR TITLE
Allow future generation to build compact buffer descriptor like GFX11

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -593,7 +593,7 @@ Value *BuilderImpl::buildBufferCompactDesc(Value *desc) {
     sqBufRsrcWord3.gfx10.resourceLevel = 1;
     sqBufRsrcWord3.gfx10.oobSelect = 2;
     assert(sqBufRsrcWord3.u32All == 0x21014FAC);
-  } else if (gfxIp.major == 11) {
+  } else if (gfxIp.major >= 11) {
     sqBufRsrcWord3.gfx11.format = BUF_FORMAT_32_UINT;
     sqBufRsrcWord3.gfx11.oobSelect = 2;
     assert(sqBufRsrcWord3.u32All == 0x20014FAC);


### PR DESCRIPTION
The layout of the fourth dword of a buffer descriptor ought to keep similar from GFX11.