### PR TITLE
Reenable some tests

### DIFF
--- a/lgc/test/FetchShaderSingleInput.lgc
+++ b/lgc/test/FetchShaderSingleInput.lgc
@@ -1,5 +1,4 @@
 ; Test building the vertex shader by itself.
-; REQUIRES: do-not-run-me
 
 ; RUN: lgc -mcpu=gfx802 -extract=2 - <%s | FileCheck --check-prefixes=VS-ISA,VS-NOTNGG-ISA %s
 ; RUN: lgc -mcpu=gfx900 -extract=2 - <%s | FileCheck --check-prefixes=VS-ISA,VS-NOTNGG-ISA %s

--- a/lgc/test/IntVectorVertexInput.lgc
+++ b/lgc/test/IntVectorVertexInput.lgc
@@ -1,5 +1,4 @@
 ; Test with a vector of integers are a vertex attribute input.
-; REQUIRES: do-not-run-me
 
 ; RUN: lgc -mcpu=gfx802 -extract=2 -filetype=obj -o %t.vs.elf - <%s && lgc -mcpu=gfx802 -extract=3 -filetype=obj -o %t.fs.elf - <%s && lgc -mcpu=gfx802 -extract=1 -o - -l -glue=1 %s %t.vs.elf %t.fs.elf | FileCheck -check-prefixes=FETCH-ISA %s
 ; FETCH-ISA: tbuffer_load_format_xyzw v[4:7],

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -1,5 +1,4 @@
 ; Test that a fetch shader for 1 input is handled correctly.
-; REQUIRES: do-not-run-me
 
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -use-relocatable-shader-elf -auto-layout-desc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s


### PR DESCRIPTION
These were temporarily disabled by #2394 to cope with updating to a new version of llvm.