### PR TITLE
GlueShader: fix the missing disassemble code in ELF

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -42,7 +42,7 @@ using namespace llvm;
 // Constructor. This is where we store all the information needed to generate the export shader; other methods
 // do not need to look at PipelineState.
 ColorExportShader::ColorExportShader(PipelineState *pipelineState, ArrayRef<ColorExportInfo> exports)
-    : GlueShader(pipelineState->getLgcContext()), m_pipelineState(pipelineState) {
+    : GlueShader(pipelineState->getLgcContext(), pipelineState) {
   m_exports.append(exports.begin(), exports.end());
 
   memset(m_exportFormat, 0, sizeof(m_exportFormat));

--- a/lgc/elfLinker/ColorExportShader.h
+++ b/lgc/elfLinker/ColorExportShader.h
@@ -79,7 +79,6 @@ private:
   ExportFormat m_exportFormat[MaxColorTargets] = {}; // The export format for each hw color target.
   // The encoded or hashed (in some way) single string version of the above.
   std::string m_shaderString;
-  PipelineState *m_pipelineState; // The pipeline state.  Used to set meta data information.
   bool m_killEnabled;             // True if this fragment shader has kill enabled.
 };
 

--- a/lgc/elfLinker/FetchShader.cpp
+++ b/lgc/elfLinker/FetchShader.cpp
@@ -51,7 +51,7 @@ constexpr uint32_t LsHsSysValueMergedWaveInfo = 3;
 // @param vsEntryRegInfo : The information about the contents of the parameters to the vertex shader.
 FetchShader::FetchShader(PipelineState *pipelineState, ArrayRef<VertexFetchInfo> fetches,
                          const VsEntryRegInfo &vsEntryRegInfo)
-    : GlueShader(pipelineState->getLgcContext()), m_vsEntryRegInfo(vsEntryRegInfo) {
+    : GlueShader(pipelineState->getLgcContext(), pipelineState), m_vsEntryRegInfo(vsEntryRegInfo) {
   m_fetches.append(fetches.begin(), fetches.end());
   for (const auto &fetch : m_fetches)
     m_fetchDescriptions.push_back(pipelineState->findVertexInputDescription(fetch.location));

--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -47,6 +47,9 @@ void GlueShader::compile(raw_pwrite_stream &outStream) {
   // Generate the glue shader IR module.
   std::unique_ptr<Module> module(generate());
 
+  // Record pipeline state
+  m_pipelineState->record(&*module);
+
   // Add empty PAL metadata, to ensure that the back-end writes its PAL metadata in MsgPack format.
   PalMetadata *palMetadata = new PalMetadata(nullptr);
   palMetadata->record(&*module);

--- a/lgc/elfLinker/GlueShader.h
+++ b/lgc/elfLinker/GlueShader.h
@@ -89,7 +89,8 @@ public:
   virtual void updatePalMetadata(PalMetadata &palMetadata) = 0;
 
 protected:
-  GlueShader(LgcContext *lgcContext) : m_lgcContext(lgcContext) {}
+  GlueShader(LgcContext *lgcContext, PipelineState* pipelineState)
+      : m_lgcContext(lgcContext), m_pipelineState(pipelineState){}
 
   // Compile the glue shader
   void compile(llvm::raw_pwrite_stream &outStream);
@@ -100,6 +101,9 @@ protected:
   llvm::LLVMContext &getContext() const { return m_lgcContext->getContext(); }
 
   LgcContext *m_lgcContext;
+
+  // The pipeline state.  Used to set meta data information.
+  PipelineState* m_pipelineState;
 
 private:
   llvm::SmallString<0> m_elfBlob;

--- a/lgc/elfLinker/NullFragmentShader.h
+++ b/lgc/elfLinker/NullFragmentShader.h
@@ -40,7 +40,7 @@ namespace lgc {
 // The class to generate the null fragment shader when linking.
 class NullFragmentShader : public GlueShader {
 public:
-  NullFragmentShader(PipelineState *pipelineState) : GlueShader(pipelineState->getLgcContext()) {}
+  NullFragmentShader(PipelineState *pipelineState) : GlueShader(pipelineState->getLgcContext(), pipelineState) {}
 
   // Get the string for this glue shader. This is some encoding or hash of the inputs to the create*Shader function
   // that the front-end client can use as a cache key to avoid compiling the same glue shader more than once.


### PR DESCRIPTION
Pipeline option is ignored when compiling glue shader, so some

informations are missing, like disassemble code which is handled by

the option 'includeDisassembly'.