### PR TITLE
Fix a regression of XFB export

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -3489,6 +3489,7 @@ void PatchInOutImportExport::patchXfbOutputExport(Value *output, unsigned xfbBuf
       assert(compCount <= 8);
       Type *loadTy = FixedVectorType::get(Type::getFloatTy(*m_context), 4);
       Value *args[] = {ConstantInt::get(Type::getInt32Ty(*m_context), location),
+                       ConstantInt::get(Type::getInt32Ty(*m_context), 0),
                        ConstantInt::get(Type::getInt32Ty(*m_context), streamId)};
       output = emitCall(lgcName::NggReadGsOutput + getTypeName(loadTy), loadTy, args,
                         {Attribute::Speculatable, Attribute::ReadOnly, Attribute::WillReturn}, insertPos);


### PR DESCRIPTION
This change is to fix a regression caused by
https://github.com/GPUOpen-Drivers/llpc/commit/2b08ebc. We add component support when handling XFB export. The component is missing when handling XFB export on Navi3x.