### PR TITLE
Fix two issues of XFB output location handling

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -762,7 +762,7 @@ Instruction *BuilderImpl::CreateWriteXfbOutput(Value *valueToWrite, bool isBuilt
 
     if (valueToWrite->getType()->getPrimitiveSizeInBits() > 128) {
       outLocInfo.setLocation(location + 1);
-      xfbOutInfo.xfbOffset += 32;
+      xfbOutInfo.xfbOffset += 16; // <4 x dword>
       resUsage->inOutUsage.locInfoXfbOutInfoMap[outLocInfo] = xfbOutInfo;
     }
   }


### PR DESCRIPTION
1. For 64-bit vec3/vec4 output, we try to split them to two 32-bit parts occupying two consecutive locations. The corresponding XFB offset between them is 16 not 32.
2. In the above case, if the output is not written by API shader, we try to remove the export and its location/XFB info. Due to the outputs occupying two consecutive locations, we need to remove both of them.