### PR TITLE
RegisterMetadata: support new elf metadata in mergeElfNote

### DIFF
--- a/llpc/util/llpcElfWriter.h
+++ b/llpc/util/llpcElfWriter.h
@@ -131,6 +131,8 @@ private:
 
   static void mergeMapItem(llvm::msgpack::MapDocNode &destMap, llvm::msgpack::MapDocNode &srcMap, unsigned key);
 
+  static void mergeMapItem(llvm::msgpack::MapDocNode &destMap, llvm::msgpack::MapDocNode &srcMap, llvm::StringRef key);
+
   LLPC_NODISCARD size_t getRequiredBufferSizeBytes();
 
   void calcSectionHeaderOffset();


### PR DESCRIPTION
The new elf metadata is missing in `mergeMetaNote` that will break cache hit cases. This change will add the support of replacing fragment shader related registers with new metadata mode.