### PR TITLE
Fail compilation when node cannot be found

### DIFF
--- a/lgc/builder/DescBuilder.cpp
+++ b/lgc/builder/DescBuilder.cpp
@@ -91,10 +91,6 @@ Value *BuilderImpl::CreateLoadBufferDesc(unsigned descSet, unsigned binding, Val
       // If we can't find the node, assume mutable descriptor and search for any node.
       std::tie(topNode, node) =
           m_pipelineState->findResourceNode(ResourceNodeType::DescriptorMutable, descSet, binding);
-      if (!node) {
-        // We did not find the resource node. Return an poison value.
-        return PoisonValue::get(getBufferDescTy());
-      }
     }
     assert(node && "missing resource node");
 


### PR DESCRIPTION
As of https://github.com/GPUOpen-Drivers/llpc/commit/da8ce391372c8d036458e74b3b3c552c5af01c2e compilation succeeds when the resource node cannot be found. This change restores the pre-existing behavior (set by https://github.com/GPUOpen-Drivers/llpc/commit/ad739502e6b1a9dec8b6474fd4ee0a3fdf58cf08).