### PR TITLE
Patch SampleMask when SampleId or SamplePosition were used

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2431,8 +2431,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
                                             {ancillary, builder.getInt32(8), builder.getInt32(4)});
 
     Value *sampleMaskIn = sampleCoverage;
-    if (m_pipelineState->getRasterizerState().perSampleShading || builtInUsage.runAtSampleRate)
-    {
+    if (m_pipelineState->getRasterizerState().perSampleShading || builtInUsage.runAtSampleRate) {
       // gl_SampleMaskIn[0] = (SampleCoverage & (1 << gl_SampleID))
       sampleMaskIn = builder.CreateShl(builder.getInt32(1), sampleId);
       sampleMaskIn = builder.CreateAnd(sampleCoverage, sampleMaskIn);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2431,7 +2431,8 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
                                             {ancillary, builder.getInt32(8), builder.getInt32(4)});
 
     Value *sampleMaskIn = sampleCoverage;
-    if (m_pipelineState->getRasterizerState().perSampleShading) {
+    if (m_pipelineState->getRasterizerState().perSampleShading || builtInUsage.runAtSampleRate)
+    {
       // gl_SampleMaskIn[0] = (SampleCoverage & (1 << gl_SampleID))
       sampleMaskIn = builder.CreateShl(builder.getInt32(1), sampleId);
       sampleMaskIn = builder.CreateAnd(sampleCoverage, sampleMaskIn);


### PR DESCRIPTION
Quoting from Vulkan spec *Sample Shading* section:

> If a fragment shader entry point [statically uses](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#shaders-staticuse) an input variable decorated with a BuiltIn of SampleId or SamplePosition, sample shading is enabled and a value of 1.0 is used instead of minSampleShading.

Therefore, patch **BuiltInSampleMask** when **perSampleShading** is enable or **runAtSampleRate** is true i.e.  **SampleId** or **SamplePosition** were used.