### PR TITLE
Mark image descriptor loads invariant

### DIFF
--- a/llpc/test/shaderdb/general/ImgDescLoad.comp
+++ b/llpc/test/shaderdb/general/ImgDescLoad.comp
@@ -1,0 +1,29 @@
+// The test checks whether image/sampler descriptor loads are marked with invariant.load metadata.
+
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+
+; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
+; SHADERTEST: [[SMP_DESC:%[0-9]*]] = load <4 x i32>, ptr addrspace(4) %{{[0-9]*}}, align 16, !invariant.load
+; SHADERTEST: [[IMG_DESC:%[0-9]*]] = load <8 x i32>, ptr addrspace(4) %{{[0-9]*}}, align 32, !invariant.load
+; SHADERTEST: lgc.create.image.sample.v4f32(i32 1, i32 512, <8 x i32> [[IMG_DESC]], <4 x i32> [[SMP_DESC]], i32 33, <2 x float> zeroinitializer, float 0.000000e+00) 
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+*/
+// END_SHADERTEST
+
+#version 450
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 1, std430) buffer B
+{
+    vec4 res;
+};
+
+layout(set = 1, binding = 0) uniform sampler2D s;
+
+void main()
+{
+    res = texture(s, vec2(0.0, 0.0));
+}

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -2552,7 +2552,9 @@ Value *SPIRVToLLVM::loadImageSampler(Type *elementTy, Value *base) {
     // load one descriptor; if there are any converting samplers, we load all three, and rely on later optimizations
     // to remove the unused ones (and thus stop us reading off the end of the descriptor table).
     elementTy = arrayTy->getElementType();
-    Value *oneVal = getBuilder()->CreateLoad(elementTy, ptr);
+    auto *oneVal = getBuilder()->CreateLoad(elementTy, ptr);
+    oneVal->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, {}));
+
     Value *result = getBuilder()->CreateInsertValue(UndefValue::get(arrayTy), oneVal, 0);
     // Pointer to image is represented as a struct containing {pointer, stride, planeStride, isResource}.
     if (!m_convertingSamplers.empty() && base->getType()->getStructNumElements() >= 4) {
@@ -2565,6 +2567,7 @@ Value *SPIRVToLLVM::loadImageSampler(Type *elementTy, Value *base) {
         ptr = getBuilder()->CreateGEP(getBuilder()->getInt8Ty(), ptr, planeStride);
         ptr = getBuilder()->CreateBitCast(ptr, ptrTy);
         oneVal = getBuilder()->CreateLoad(elementTy, ptr);
+        oneVal->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, {}));
         result = getBuilder()->CreateInsertValue(result, oneVal, planeIdx);
       }
     }
@@ -2572,7 +2575,9 @@ Value *SPIRVToLLVM::loadImageSampler(Type *elementTy, Value *base) {
   }
 
   // Other cases: Just load the element from the pointer.
-  return getBuilder()->CreateLoad(elementTy, ptr);
+  auto load = getBuilder()->CreateLoad(elementTy, ptr);
+  load->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(*m_context, {}));
+  return load;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Mark image/sampler descriptor loads invariant in the SPIR-V reader to allow more code motion optimizations in the middle-end.

This has a large impact on sgpr pressure. The total number of v_writelane instructions in the 10k shaders set (which is a rough indicator of excessive sgpr pressure) goes from 14702 to 8805.