### PR TITLE
Remove a unnecessary check condition when handling XFB export calls

### DIFF
--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1330,17 +1330,15 @@ void PatchResourceCollect::visitCallInst(CallInst &callInst) {
           }
         }
 
-        // For GS, we remove transform feedback location info as well if it exists
-        if (m_shaderStage == ShaderStageGeometry) {
-          outLocInfo.setLocation(location);
-          auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.locInfoXfbOutInfoMap;
-          if (locInfoXfbOutInfoMap.count(outLocInfo) > 0) {
+        // Remove transform feedback location info as well if it exists
+        outLocInfo.setLocation(location);
+        auto &locInfoXfbOutInfoMap = m_resUsage->inOutUsage.locInfoXfbOutInfoMap;
+        if (locInfoXfbOutInfoMap.count(outLocInfo) > 0) {
+          locInfoXfbOutInfoMap.erase(outLocInfo);
+          if (outputValue->getType()->getPrimitiveSizeInBits() > 128) {
+            // NOTE: For any data that is larger than <4 x dword>, there are two consecutive locations occupied.
+            outLocInfo.setLocation(location + 1);
             locInfoXfbOutInfoMap.erase(outLocInfo);
-            if (outputValue->getType()->getPrimitiveSizeInBits() > 128) {
-              // NOTE: For any data that is larger than <4 x dword>, there are two consecutive locations occupied.
-              outLocInfo.setLocation(location + 1);
-              locInfoXfbOutInfoMap.erase(outLocInfo);
-            }
           }
         }
       }


### PR DESCRIPTION
If XFB export call is specified with undefine values, the XFB export info should be removed just like what we are doing for output locations.