### PR TITLE
Add useShadingRate and useSampleInfo

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     61.8 | Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
 //  |     61.7 | Add disableFMA to PipelineShaderOptions                                                               |
 //  |     61.6 | Add workaroundInitializeOutputsToZero to PipelineShaderOptions                                        |
 //  |     61.5 | Add RtIpVersion (including its checkers) to represent ray tracing IP                                  |
@@ -603,9 +604,11 @@ struct ShaderModuleUsage {
   bool isInternalRtShader; ///< Whether the shaderModule is a ray tracing internal shader
   bool hasTraceRay;        ///< Whether the shaderModule has OpTraceRayKHR;
 #endif
-  bool useIsNan;     ///< Whether IsNan is used
-  bool useInvariant; ///< Whether invariant variable is used
-  bool usePointSize; ///< Whether gl_PointSize is used in output
+  bool useIsNan;       ///< Whether IsNan is used
+  bool useInvariant;   ///< Whether invariant variable is used
+  bool usePointSize;   ///< Whether gl_PointSize is used in output
+  bool useShadingRate; ///< Whether shading rate is used
+  bool useSampleInfo;  ///< Whether gl_SamplePosition or InterpolateAtSample are used
 };
 
 /// Represents common part of shader module data

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -82,6 +82,13 @@ ShaderModuleUsage ShaderModuleHelper::getShaderModuleUsageInfo(const BinaryData 
       capabilities.insert(capability);
       break;
     }
+    case OpExtInst: {
+      auto extInst = static_cast<GLSLstd450>(codePos[4]);
+      if (extInst == GLSLstd450InterpolateAtSample) {
+        shaderModuleUsage.useSampleInfo = true;
+      }
+      break;
+    }
     case OpExtension: {
       StringRef extName = reinterpret_cast<const char *>(&codePos[1]);
       if (extName == "SPV_AMD_shader_ballot") {
@@ -98,8 +105,23 @@ ShaderModuleUsage ShaderModuleHelper::getShaderModuleUsageInfo(const BinaryData 
       }
       if (decoration == DecorationBuiltIn) {
         auto builtIn = (opCode == OpDecorate) ? static_cast<BuiltIn>(codePos[3]) : static_cast<BuiltIn>(codePos[4]);
-        if (builtIn == BuiltInPointSize) {
+        switch (builtIn) {
+        case BuiltInPointSize: {
           shaderModuleUsage.usePointSize = true;
+          break;
+        }
+        case BuiltInPrimitiveShadingRateKHR:
+        case BuiltInShadingRateKHR: {
+          shaderModuleUsage.useShadingRate = true;
+          break;
+        }
+        case BuiltInSamplePosition: {
+          shaderModuleUsage.useSampleInfo = true;
+          break;
+        }
+        default: {
+          break;
+        }
         }
       }
       break;


### PR DESCRIPTION
When dynamic rasterization samples or shader object is enabled, we need shading rate and sample information from shaders to finalize the pipeline states. Therefore, report useShadingRate to be true when gl_PrimitiveShadingRateEXT or gl_ShadingRateEXT were used; report useSampleInfo to be true when gl_SamplePosition or InterpolateAtSample are used

Affected CTS cases:
dEQP-VK.pipeline.shader_object_unlinked_spirv.multisample_interpolation.*
dEQP-VK.pipeline.shader_object_unlinked_spirv.multisample_with_fragment_shading_rate.mixed_attachment_samples.*
