### PR TITLE
Simplify some bits around rayquery handling

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -598,7 +598,7 @@ struct ShaderModuleUsage {
   bool useSpecConstant;        ///< Whether specialization constant is used
   bool keepUnusedFunctions;    ///< Whether to keep unused function
 #if VKI_RAY_TRACING
-  bool enableRayQuery;     ///< Whether to enable "RayQueryProvisionalKHR" capability
+  bool enableRayQuery;     ///< Whether the "RayQueryKHR" capability is used
   bool rayQueryLibrary;    ///< Whether the shaderModule is rayQueryLibrary
   bool isInternalRtShader; ///< Whether the shaderModule is a ray tracing internal shader
   bool hasTraceRay;        ///< Whether the shaderModule has OpTraceRayKHR;

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -810,7 +810,7 @@ Result Compiler::buildUnlinkedShaderInternal(Context *context, ArrayRef<const Pi
 
   // Check the cache for the relocatable shader for this stage.
   MetroHash::Hash cacheHash = {};
-  if (context->isGraphics()) {
+  if (context->getPipelineType() == PipelineType::Graphics) {
     auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
     cacheHash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo, true, true, stage);
   } else {
@@ -1184,7 +1184,8 @@ Result Compiler::buildPipelineInternal(Context *context, ArrayRef<const Pipeline
 
   // Only enable per stage cache for full graphics pipeline (traditional pipeline or mesh pipeline)
   bool checkPerStageCache =
-      cl::EnablePerStageCache && !cl::EnablePartPipeline && context->isGraphics() && !buildingRelocatableElf &&
+      cl::EnablePerStageCache && !cl::EnablePartPipeline && context->getPipelineType() == PipelineType::Graphics &&
+      !buildingRelocatableElf &&
       (context->getShaderStageMask() & (ShaderStageVertexBit | ShaderStageMeshBit | ShaderStageFragmentBit));
 
   if (!checkPerStageCache)

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -71,8 +71,6 @@ public:
   virtual llvm::StringRef getClientMetadata() const override;
 
 #if VKI_RAY_TRACING
-  virtual bool hasRayQuery() const override { return (m_pipelineInfo->shaderLibrary.codeSize > 0); }
-
   // Set workgroup size for compute pipeline so that rayQuery lowering can see it.
   virtual void setWorkgroupSize(unsigned workgroupSize) override { m_workgroupSize = workgroupSize; }
   virtual unsigned getWorkgroupSize() const override { return m_workgroupSize; }

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -42,6 +42,8 @@ public:
                  MetroHash::Hash *cacheHash);
   virtual ~ComputeContext() {}
 
+  virtual PipelineType getPipelineType() const override { return PipelineType::Compute; }
+
   // Gets pipeline shader info of the specified shader stage
   virtual const PipelineShaderInfo *getPipelineShaderInfo(unsigned shaderId) const override;
 

--- a/llpc/context/llpcContext.h
+++ b/llpc/context/llpcContext.h
@@ -90,10 +90,7 @@ public:
   std::unique_ptr<llvm::Module> loadLibrary(const BinaryData *lib);
 
   // Wrappers of interfaces of pipeline context
-  bool isGraphics() const { return m_pipelineContext->isGraphics(); }
-#if VKI_RAY_TRACING
-  bool isRayTracing() const { return m_pipelineContext->isRayTracing(); }
-#endif
+  PipelineType getPipelineType() const { return m_pipelineContext->getPipelineType(); }
   const PipelineShaderInfo *getPipelineShaderInfo(ShaderStage shaderId) const {
     return m_pipelineContext->getPipelineShaderInfo(shaderId);
   }

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -44,7 +44,7 @@ public:
                   MetroHash::Hash *cacheHash);
   virtual ~GraphicsContext();
 
-  virtual bool isGraphics() const override { return true; }
+  virtual PipelineType getPipelineType() const override { return PipelineType::Graphics; }
 
   // Gets pipeline shader info of the specified shader stage
   virtual const PipelineShaderInfo *getPipelineShaderInfo(unsigned shaderId) const override;

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -82,10 +82,6 @@ public:
   // Gets client-defined metadata
   virtual llvm::StringRef getClientMetadata() const override;
 
-#if VKI_RAY_TRACING
-  virtual bool hasRayQuery() const override { return (m_pipelineInfo->shaderLibrary.codeSize > 0); }
-#endif
-
 protected:
   // Give the pipeline options to the middle-end, and/or hash them.
   virtual lgc::Options computePipelineOptions() const override;

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -624,9 +624,16 @@ ShaderOptions PipelineContext::computeShaderOptions(const PipelineShaderInfo &sh
   }
 #if VKI_RAY_TRACING
   // NOTE: WaveSize of raytracing usually be 32
-  if (hasRayQuery() || getPipelineType() == PipelineType::RayTracing) {
-    shaderOptions.waveSize = getRayTracingWaveSize();
+  bool useRayTracingWaveSize = false;
+  if (getPipelineType() == PipelineType::RayTracing) {
+    useRayTracingWaveSize = true;
+  } else {
+    const auto *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfo.pModuleData);
+    if (moduleData->usage.enableRayQuery)
+      useRayTracingWaveSize = true;
   }
+  if (useRayTracingWaveSize)
+    shaderOptions.waveSize = getRayTracingWaveSize();
 #endif
 
   // Use a static cast from Vkgc WaveBreakSize to LGC WaveBreak, and static assert that

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -624,7 +624,7 @@ ShaderOptions PipelineContext::computeShaderOptions(const PipelineShaderInfo &sh
   }
 #if VKI_RAY_TRACING
   // NOTE: WaveSize of raytracing usually be 32
-  if (hasRayQuery() || isRayTracing()) {
+  if (hasRayQuery() || getPipelineType() == PipelineType::RayTracing) {
     shaderOptions.waveSize = getRayTracingWaveSize();
   }
 #endif
@@ -714,7 +714,7 @@ ShaderOptions PipelineContext::computeShaderOptions(const PipelineShaderInfo &sh
 // =====================================================================================================================
 // Get wave size used for raytracing
 unsigned PipelineContext::getRayTracingWaveSize() const {
-  if ((m_gfxIp.major >= 10) && !isGraphics())
+  if ((m_gfxIp.major >= 10) && getPipelineType() != PipelineType::Graphics)
     return 32;
   return 64;
 }

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -94,6 +94,13 @@ struct ShaderFpMode {
   unsigned roundingModeRTZ : 4;          // Bitmask of roundingModeRTZ flags
 };
 
+// Pipeline type enumeration
+enum class PipelineType {
+  Graphics,
+  Compute,
+  RayTracing,
+};
+
 // =====================================================================================================================
 // Represents pipeline-specific context for pipeline compilation, it is a part of LLPC context
 class PipelineContext {
@@ -107,8 +114,8 @@ public:
   );
   virtual ~PipelineContext();
 
-  // Checks whether the pipeline is graphics or compute
-  virtual bool isGraphics() const { return false; }
+  // Returns the pipeline type
+  virtual PipelineType getPipelineType() const = 0;
 
   // Gets pipeline shader info of the specified shader stage
   virtual const PipelineShaderInfo *getPipelineShaderInfo(unsigned shaderId) const = 0;
@@ -153,9 +160,6 @@ public:
   virtual llvm::StringRef getClientMetadata() const = 0;
 
 #if VKI_RAY_TRACING
-  // Checks whether the pipeline is ray tracing
-  virtual bool isRayTracing() const { return false; }
-
   virtual bool hasRayQuery() const { return false; }
 
   virtual void setIndirectStage(ShaderStage stage) {}

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -160,8 +160,6 @@ public:
   virtual llvm::StringRef getClientMetadata() const = 0;
 
 #if VKI_RAY_TRACING
-  virtual bool hasRayQuery() const { return false; }
-
   virtual void setIndirectStage(ShaderStage stage) {}
 
   virtual void collectPayloadSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}

--- a/llpc/context/llpcRayTracingContext.h
+++ b/llpc/context/llpcRayTracingContext.h
@@ -49,6 +49,8 @@ public:
                     MetroHash::Hash *cacheHash, unsigned indirectStageMask);
   virtual ~RayTracingContext() {}
 
+  virtual PipelineType getPipelineType() const override { return PipelineType::RayTracing; }
+
   virtual const PipelineShaderInfo *getPipelineShaderInfo(unsigned shaderId) const override;
 
   // Gets pipeline build info
@@ -74,9 +76,6 @@ public:
 
   // Gets client-defined metadata
   virtual llvm::StringRef getClientMetadata() const override;
-
-  // Checks whether the pipeline is ray tracing
-  virtual bool isRayTracing() const override { return true; }
 
   // Set the raytracing shader stages inline/indirect status
   virtual void setIndirectStage(ShaderStage stage) override { m_indirectStageMask |= shaderStageToMask(stage); }

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -821,7 +821,7 @@ void SpirvLowerGlobal::lowerInput() {
 void SpirvLowerGlobal::lowerOutput() {
 #if VKI_RAY_TRACING
   // Note: indirect raytracing does not have output to lower and must return payload value
-  if (m_context->isRayTracing())
+  if (m_context->getPipelineType() == PipelineType::RayTracing)
     return;
 #endif
 

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -1464,10 +1464,10 @@ Value *SpirvLowerRayQuery::createTransformMatrix(unsigned builtInId, Value *acce
 // Get raytracing workgroup size for LDS stack size calculation
 unsigned SpirvLowerRayQuery::getWorkgroupSize() const {
   unsigned workgroupSize = 0;
-  if (m_context->isRayTracing()) {
+  if (m_context->getPipelineType() == PipelineType::RayTracing) {
     const auto *rtState = m_context->getPipelineContext()->getRayTracingState();
     workgroupSize = rtState->threadGroupSizeX * rtState->threadGroupSizeY * rtState->threadGroupSizeZ;
-  } else if (m_context->isGraphics()) {
+  } else if (m_context->getPipelineType() == PipelineType::Graphics) {
     workgroupSize = m_context->getPipelineContext()->getRayTracingWaveSize();
   } else {
     workgroupSize = m_context->getPipelineContext()->getWorkgroupSize();
@@ -1485,7 +1485,8 @@ unsigned SpirvLowerRayQuery::getWorkgroupSize() const {
 // =====================================================================================================================
 // Get flat thread id in work group/wave
 Value *SpirvLowerRayQuery::getThreadIdInGroup() const {
-  unsigned builtIn = m_context->isGraphics() ? BuiltInSubgroupLocalInvocationId : BuiltInLocalInvocationIndex;
+  unsigned builtIn = m_context->getPipelineType() == PipelineType::Graphics ? BuiltInSubgroupLocalInvocationId
+                                                                            : BuiltInLocalInvocationIndex;
   lgc::InOutInfo inputInfo = {};
   return m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(builtIn), inputInfo, nullptr, nullptr, "");
 }

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7096,10 +7096,11 @@ bool SPIRVToLLVM::translate(ExecutionModel entryExecModel, const char *entryName
   unsigned subgroupSizeUsage = pipelineContext->getSubgroupSizeUsage();
 #if VKI_RAY_TRACING
   // NOTE: setCommonShaderMode() supports the graphics and compute stage, does not support raytracing stage
-  shaderMode.useSubgroupSize = pipelineContext->isRayTracing() ? subgroupSizeUsage : shaderMode.useSubgroupSize;
+  shaderMode.useSubgroupSize =
+      pipelineContext->getPipelineType() == PipelineType::RayTracing ? subgroupSizeUsage : shaderMode.useSubgroupSize;
 #endif
 
-  if (pipelineContext->isGraphics() && subgroupSizeUsage) {
+  if (pipelineContext->getPipelineType() == PipelineType::Graphics && subgroupSizeUsage) {
     for (lgc::ShaderStage stage : lgc::enumRange<lgc::ShaderStage>()) {
       if (subgroupSizeUsage & (1 << stage)) {
         Pipeline::setSubgroupSizeUsage(*m_m, stage, true);

--- a/llpc/util/llpcCacheAccessor.cpp
+++ b/llpc/util/llpcCacheAccessor.cpp
@@ -53,7 +53,7 @@ namespace Llpc {
 // @param internalCaches : The internal caches to check.
 CacheAccessor::CacheAccessor(Context *context, MetroHash::Hash &cacheHash, CachePair internalCaches) {
   assert(context);
-  if (context->isGraphics()) {
+  if (context->getPipelineType() == PipelineType::Graphics) {
     const auto *pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(context->getPipelineBuildInfo());
     initializeUsingBuildInfo(pipelineInfo, cacheHash, internalCaches);
   } else {


### PR DESCRIPTION
The two commits are self-contained, but the point here is to remove the `hasRayQuery` virtual method which wasn't implemented consistently.