### PR TITLE
Remove an unnecessary workaround to handle dvec3/dvec4 XFB export

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -135,7 +135,7 @@ private:
                             llvm::Instruction *insertPos);
 
   void storeValueToStreamOutBuffer(llvm::Value *storeValue, unsigned xfbBuffer, unsigned xfbOffset, unsigned xfbStride,
-                                   unsigned streamId, llvm::Value *streamOutBufDesc, llvm::Instruction *insertPos);
+                                   unsigned streamId, llvm::Instruction *insertPos);
 
   void createStreamOutBufferStoreFunction(llvm::Value *storeValue, unsigned xfbStrde, std::string &funcName);
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -193,7 +193,8 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = 2;
       intfData->userDataUsage.gs.copyShaderStreamOutTable = 3;
     } else {
-      // If NGG, both esGsLdsSize and streamOutTable are not used
+      // If NGG (SW stream-out), both esGsLdsSize and streamOutTable are not used
+      assert(m_pipelineState->enableSwXfb());
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = InvalidValue;
       intfData->userDataUsage.gs.copyShaderStreamOutTable = InvalidValue;
     }


### PR DESCRIPTION
By the work of https://github.com/GPUOpen-Drivers/llpc/pull/2439, copy
shader will generate <4 x dword> XFB export value. dvec3/dvec4 are split
to vec4+vec2 and vec4+vec4. Therefore, we don't need such workaround to
handle dvec3/dvec4 XFB export for GFX11 SW stream-out.

Also, simplify the function storeValueToStreamOutBuffer by removing an
unnecessary parameter streamOutBufDesc. It can be deduced from
xfbBuffer.