### PR TITLE
RegisterMetadata: fix UserDataLimit/AlphaToMaskDisable/CullDistanceMas…

### DIFF
--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -220,6 +220,9 @@ public:
   // Get the MapDocNode of .amdpal.pipelines
   llvm::msgpack::MapDocNode &getPipelineNode() { return m_pipelineNode; }
 
+  // Set userDataLimit to the given value
+  void setUserDataLimit(unsigned value);
+
 private:
   // Initialize the PalMetadata object after reading in already-existing PAL metadata if any
   void initialize();


### PR DESCRIPTION
…k/VgtGsOutPrimType

This PR will fix multiply issues in the bellow metadata:
- `UserDataLimit` is not updated to the maximum value when filling in the user data map.
- Add PalMatadata::setUserDataLimit utility function.
- The code of accessing 'AlphaToMaskDisable` node is wrong.
- The calculation of `cullDistanceMask` lacks a left shift operation.
- Add the support of new pal metadata for `VgtGsOutPrimType` in `fixupRegisters`.