### PR TITLE
RegisterMetadata: refine the contorl of using new PAL metadata

### DIFF
--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -51,7 +51,7 @@ void GlueShader::compile(raw_pwrite_stream &outStream) {
   m_pipelineState->record(&*module);
 
   // Add empty PAL metadata, to ensure that the back-end writes its PAL metadata in MsgPack format.
-  PalMetadata *palMetadata = new PalMetadata(nullptr);
+  PalMetadata *palMetadata = new PalMetadata(nullptr, m_pipelineState->useRegisterFieldFormat());
   palMetadata->record(&*module);
   delete palMetadata;
 

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -102,9 +102,9 @@ struct FsInputMappings {
 class PalMetadata {
 public:
   // Constructors
-  PalMetadata(PipelineState *pipelineState);
-  PalMetadata(PipelineState *pipelineState, llvm::StringRef blob);
-  PalMetadata(PipelineState *pipelineState, llvm::Module *module);
+  PalMetadata(PipelineState *pipelineState, bool useRegisterFieldFormat);
+  PalMetadata(PipelineState *pipelineState, llvm::StringRef blob, bool useRegisterFieldFormat);
+  PalMetadata(PipelineState *pipelineState, llvm::Module *module, bool useRegisterFieldFormat);
   PalMetadata(const PalMetadata &) = delete;
   PalMetadata &operator=(const PalMetadata &) = delete;
 
@@ -271,6 +271,7 @@ private:
   llvm::msgpack::DocNode *m_userDataLimit;    // Maximum so far number of user data dwords used
   llvm::msgpack::DocNode *m_spillThreshold;   // Minimum so far dword offset used in user data spill table
   llvm::SmallString<0> m_fsInputMappingsBlob; // Buffer for returning FS input mappings blob to LGC client
+  bool m_useRegisterFieldFormat;              // Whether to use new PAL metadata in ELF
 };
 
 } // namespace lgc


### PR DESCRIPTION
This a follow-up change of 51f9847. To avoid changing the value of `cl::opt` (`UseRegisterFieldFormat`) to control new or old PAL metadata code path for GlueShader, we add an explict `bool useRegisterFieldFormat` in `PalMetadata` constructor.