### PR TITLE
Handle the case where m_blendSources[1] is empty when dual source blend is enabled

### DIFF
--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -843,7 +843,6 @@ Value *FragColorExport::dualSourceSwizzle(BuilderBase &builder) {
         builder.getFalse(),                                 // done
         builder.getTrue()                                   // vm
     };
-
     return builder.CreateNamedCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_context), args, {});
   } else {
     Value *result0[4], *result1[4];


### PR DESCRIPTION
CTS cases _dEQP-VK.shader_object.pipeline_interaction.*_ enable dual source blend but only set one output color in the fragment shader. If that behavior is legal, need to handle this case by issuing a normal export to MRT0 when m_blendSources[1] is empty.

Affected CTS list:
dEQP-VK.shader_object.pipeline_interaction.*