### PR TITLE
dumper: add missing workaroundInitializeOutputsToZero

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1647,6 +1647,7 @@ void PipelineDumper::updateHashForPipelineShaderInfo(ShaderStage stage, const Pi
       hasher->Update(options.nsaThreshold);
       hasher->Update(options.aggressiveInvariantLoads);
       hasher->Update(options.workaroundStorageImageFormats);
+      hasher->Update(options.workaroundInitializeOutputsToZero);
       hasher->Update(options.disableFMA);
     }
   }


### PR DESCRIPTION
Fixes: 7902703 (Add a workaround of initializing outputs to zero #2401)