### PR TITLE
llpc/raytracing: yet further cleanups and simplifications

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -606,7 +606,8 @@ struct ShaderModuleUsage {
   bool enableRayQuery;     ///< Whether the "RayQueryKHR" capability is used
   bool rayQueryLibrary;    ///< Whether the shaderModule is rayQueryLibrary
   bool isInternalRtShader; ///< Whether the shaderModule is a GPURT internal shader (e.g. BVH build)
-  bool hasTraceRay;        ///< Whether the shaderModule has OpTraceRayKHR;
+  bool hasTraceRay;        ///< Whether the shaderModule has OpTraceRayKHR
+  bool hasExecuteCallable; ///< Whether the shaderModule has OpExecuteCallableKHR
 #endif
   bool useIsNan;       ///< Whether IsNan is used
   bool useInvariant;   ///< Whether invariant variable is used

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2501,7 +2501,7 @@ Result Compiler::buildRayTracingPipelineInternal(RayTracingContext &rtContext,
     }
   }
 
-  return Result::Success;
+  return hasError ? Result::ErrorInvalidShader : Result::Success;
 }
 
 // =====================================================================================================================

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -165,8 +165,6 @@ public:
   virtual llvm::StringRef getClientMetadata() const = 0;
 
 #if VKI_RAY_TRACING
-  virtual void setIndirectStage(ShaderStage stage) {}
-
   virtual void collectPayloadSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}
   virtual void collectCallableDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}
   virtual void collectAttributeDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}

--- a/llpc/context/llpcRayTracingContext.cpp
+++ b/llpc/context/llpcRayTracingContext.cpp
@@ -219,6 +219,16 @@ unsigned RayTracingContext::getSubgroupSizeUsage() const {
 }
 
 // =====================================================================================================================
+// Set the raytracing pipeline as indirect shader
+void RayTracingContext::setIndirectPipeline() {
+  m_indirectStageMask |=
+      shaderStageToMask(Vkgc::ShaderStageRayTracingClosestHit) | shaderStageToMask(Vkgc::ShaderStageRayTracingAnyHit) |
+      shaderStageToMask(Vkgc::ShaderStageCompute) | shaderStageToMask(Vkgc::ShaderStageRayTracingRayGen) |
+      shaderStageToMask(Vkgc::ShaderStageRayTracingIntersect) | shaderStageToMask(Vkgc::ShaderStageRayTracingMiss) |
+      shaderStageToMask(Vkgc::ShaderStageRayTracingCallable);
+}
+
+// =====================================================================================================================
 // Set pipeline state in Pipeline object for middle-end and/or calculate the hash for the state to be added.
 // Doing both these things in the same code ensures that we hash and use the same pipeline state in all situations.
 // For graphics, we use the shader stage mask to decide which parts of graphics state to use, omitting

--- a/llpc/context/llpcRayTracingContext.h
+++ b/llpc/context/llpcRayTracingContext.h
@@ -75,8 +75,8 @@ public:
   // Gets client-defined metadata
   virtual llvm::StringRef getClientMetadata() const override;
 
-  // Set the raytracing shader stages inline/indirect status
-  virtual void setIndirectStage(ShaderStage stage) override { m_indirectStageMask |= shaderStageToMask(stage); }
+  // Override to force an indirect compile
+  void setIndirectPipeline();
 
   virtual void collectPayloadSize(llvm::Type *type, const llvm::DataLayout &dataLayout) override;
   virtual void collectCallableDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) override;

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -140,6 +140,10 @@ ShaderModuleUsage ShaderModuleHelper::getShaderModuleUsageInfo(const BinaryData 
       shaderModuleUsage.hasTraceRay = true;
       break;
     }
+    case OpExecuteCallableNV:
+    case OpExecuteCallableKHR:
+      shaderModuleUsage.hasExecuteCallable = true;
+      break;
 #endif
     case OpIsNan: {
       shaderModuleUsage.useIsNan = true;


### PR DESCRIPTION
This is another sequence of smaller commits. The main point is the last commit:

We've only ever really supported the cases of either all shaders using
indirect calls or all shaders using direct (inlined) calls. Simplify the
linking by making this totally explicit.

There are a number of reasons for that, but ultimately they boil down to
how shader group identifiers are handled (or rather, how they are not
handled). The outer BuildRayTracingPipeline method assumes a 1:1 mapping
between LLVM modules and input shader infos, for example. More importantly,
the Vulkan driver also makes this assumption when it sets up shader group
identifiers.

And if anything, the decision of which shaders to pack together and how
shader calls work should be far more driven by shader groups (e.g.,
restrict the switch table to only shaders with matching payload / hit
attribute types).

By pruning complexity here, the code becomes more maintainable and if we
do decide to do something like inline intersection and AHS shader
together, we have a cleaner starting point from which to do so.