### PR TITLE
Obtain the GPURT shader library directly from GPURT by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ endif()
 
 #if VKI_RAY_TRACING
 if(VKI_RAY_TRACING)
+    if(NOT LLPC_IS_STANDALONE)
+        target_compile_definitions(vkgc_headers INTERFACE HAVE_GPURT_SHIM)
+    endif()
+
     target_compile_definitions(vkgc_headers INTERFACE VKI_RAY_TRACING)
     target_compile_definitions(vkgc_headers INTERFACE GPURT_CLIENT_INTERFACE_MAJOR_VERSION=${GPURT_CLIENT_INTERFACE_MAJOR_VERSION})
 endif()
@@ -124,11 +128,11 @@ if(EXISTS ${XGL_SPVGEN_PATH})
     add_subdirectory(${XGL_SPVGEN_PATH} ${XGL_SPVGEN_BUILD_PATH} EXCLUDE_FROM_ALL)
 endif()
 
+endif(LLPC_BUILD_TOOLS)
+
 if(ICD_BUILD_LLPC)
     # Generate Strings for LLPC standalone tool
     add_subdirectory(util ${PROJECT_BINARY_DIR}/util)
-endif()
-
 endif()
 
 ### VKGC build LLPC ################################################################

--- a/include/vkgcBase.h
+++ b/include/vkgcBase.h
@@ -1,0 +1,96 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2020-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  vkgcBase.h
+ * @brief Minimal subset of the vkgc interface that avoids including vulkan.h
+ ***********************************************************************************************************************
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+namespace Vkgc {
+
+/// Represents graphics IP version info. See https://llvm.org/docs/AMDGPUUsage.html#processors for more
+/// details.
+struct GfxIpVersion {
+  unsigned major;    ///< Major version
+  unsigned minor;    ///< Minor version
+  unsigned stepping; ///< Stepping info
+
+  // GFX IP checkers
+  bool operator==(const GfxIpVersion &rhs) const {
+    return std::tie(major, minor, stepping) == std::tie(rhs.major, rhs.minor, rhs.stepping);
+  }
+  bool operator>=(const GfxIpVersion &rhs) const {
+    return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
+  }
+  bool isGfx(unsigned rhsMajor, unsigned rhsMinor) const {
+    return std::tie(major, minor) == std::tie(rhsMajor, rhsMinor);
+  }
+};
+
+/// Represents RT IP version
+struct RtIpVersion {
+  unsigned major; ///< Major version
+  unsigned minor; ///< Minor version
+
+  // RT IP checkers
+  bool operator==(const RtIpVersion &rhs) const { return std::tie(major, minor) == std::tie(rhs.major, rhs.minor); }
+  bool operator>=(const RtIpVersion &rhs) const { return std::tie(major, minor) >= std::tie(rhs.major, rhs.minor); }
+  bool isRtIp(unsigned rhsMajor, unsigned rhsMinor) const {
+    return std::tie(major, minor) == std::tie(rhsMajor, rhsMinor);
+  }
+};
+
+// =====================================================================================================================
+// Raytracing entry function indices
+enum RAYTRACING_ENTRY_FUNC : unsigned {
+  RT_ENTRY_TRACE_RAY,
+  RT_ENTRY_TRACE_RAY_INLINE,
+  RT_ENTRY_TRACE_RAY_HIT_TOKEN,
+  RT_ENTRY_RAY_QUERY_PROCEED,
+  RT_ENTRY_INSTANCE_INDEX,
+  RT_ENTRY_INSTANCE_ID,
+  RT_ENTRY_OBJECT_TO_WORLD_TRANSFORM,
+  RT_ENTRY_WORLD_TO_OBJECT_TRANSFORM,
+  RT_ENTRY_RESERVE1,
+  RT_ENTRY_RESERVE2,
+  RT_ENTRY_FETCH_HIT_TRIANGLE_FROM_NODE_POINTER,
+  RT_ENTRY_FETCH_HIT_TRIANGLE_FROM_RAY_QUERY,
+  RT_ENTRY_FUNC_COUNT,
+};
+
+/// Represents GPURT function table
+struct GpurtFuncTable {
+  static constexpr size_t MaxFunctionNameLength = 255;
+
+  char pFunc[RT_ENTRY_FUNC_COUNT][MaxFunctionNameLength + 1]; ///< Function names
+};
+
+} // namespace Vkgc

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -30,6 +30,7 @@
  */
 #pragma once
 
+#include "vkgcBase.h"
 #include "vulkan.h"
 #include <cassert>
 #include <tuple>
@@ -437,38 +438,6 @@ struct ResourceMappingData {
 
   const StaticDescriptorValue *pStaticDescriptorValues; ///< An array of static descriptors
   unsigned staticDescriptorValueCount;                  ///< Count of static descriptors
-};
-
-/// Represents graphics IP version info. See https://llvm.org/docs/AMDGPUUsage.html#processors for more
-/// details.
-struct GfxIpVersion {
-  unsigned major;    ///< Major version
-  unsigned minor;    ///< Minor version
-  unsigned stepping; ///< Stepping info
-
-  // GFX IP checkers
-  bool operator==(const GfxIpVersion &rhs) const {
-    return std::tie(major, minor, stepping) == std::tie(rhs.major, rhs.minor, rhs.stepping);
-  }
-  bool operator>=(const GfxIpVersion &rhs) const {
-    return std::tie(major, minor, stepping) >= std::tie(rhs.major, rhs.minor, rhs.stepping);
-  }
-  bool isGfx(unsigned rhsMajor, unsigned rhsMinor) const {
-    return std::tie(major, minor) == std::tie(rhsMajor, rhsMinor);
-  }
-};
-
-/// Represents RT IP version
-struct RtIpVersion {
-  unsigned major; ///< Major version
-  unsigned minor; ///< Minor version
-
-  // RT IP checkers
-  bool operator==(const RtIpVersion &rhs) const { return std::tie(major, minor) == std::tie(rhs.major, rhs.minor); }
-  bool operator>=(const RtIpVersion &rhs) const { return std::tie(major, minor) >= std::tie(rhs.major, rhs.minor); }
-  bool isRtIp(unsigned rhsMajor, unsigned rhsMinor) const {
-    return std::tie(major, minor) == std::tie(rhsMajor, rhsMinor);
-  }
 };
 
 /// Represents shader binary data.
@@ -1007,24 +976,6 @@ enum RayTracingRayFlag : uint32_t {
 };
 
 // =====================================================================================================================
-// Raytracing entry function indices
-enum RAYTRACING_ENTRY_FUNC : unsigned {
-  RT_ENTRY_TRACE_RAY,
-  RT_ENTRY_TRACE_RAY_INLINE,
-  RT_ENTRY_TRACE_RAY_HIT_TOKEN,
-  RT_ENTRY_RAY_QUERY_PROCEED,
-  RT_ENTRY_INSTANCE_INDEX,
-  RT_ENTRY_INSTANCE_ID,
-  RT_ENTRY_OBJECT_TO_WORLD_TRANSFORM,
-  RT_ENTRY_WORLD_TO_OBJECT_TRANSFORM,
-  RT_ENTRY_RESERVE1,
-  RT_ENTRY_RESERVE2,
-  RT_ENTRY_FETCH_HIT_TRIANGLE_FROM_NODE_POINTER,
-  RT_ENTRY_FETCH_HIT_TRIANGLE_FROM_RAY_QUERY,
-  RT_ENTRY_FUNC_COUNT,
-};
-
-// =====================================================================================================================
 // raytracing system value usage flags
 union RayTracingSystemValueUsage {
   struct {
@@ -1081,11 +1032,6 @@ struct RayTracingShaderExportConfig {
   bool readsDispatchRaysIndex;        // Shader reads dispatchRaysIndex
   bool enableDynamicLaunch;           // Enable dynamic launch
   bool emitRaytracingShaderDataToken; // Emitting Raytracing ShaderData SQTT Token
-};
-
-/// Represents GPURT function table
-struct GpurtFuncTable {
-  char pFunc[RT_ENTRY_FUNC_COUNT][256]; ///< Function names
 };
 
 /// Enumerates the method of mapping from ray tracing launch ID to native thread ID

--- a/include/vkgcGpurtShim.h
+++ b/include/vkgcGpurtShim.h
@@ -1,0 +1,47 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  vkgcGpurtShim.h
+ * @brief Contains declarations for the GPURT shim library
+ ***********************************************************************************************************************
+ */
+
+#pragma once
+
+#include "vkgcBase.h"
+#include <cstddef>
+
+namespace Vkgc {
+namespace gpurt {
+
+#ifdef HAVE_GPURT_SHIM
+void getShaderLibrarySpirv(unsigned featureFlags, const void *&code, size_t &size);
+void getFuncTable(Vkgc::RtIpVersion rtIpVersion, Vkgc::GpurtFuncTable &table);
+Vkgc::RtIpVersion getRtIpVersion(Vkgc::GfxIpVersion gfxIpVersion);
+#endif
+
+} // namespace gpurt
+} // namespace Vkgc

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -311,6 +311,10 @@ target_link_libraries(llpcinternal PUBLIC
     khronos_spirv_interface
 )
 
+if(VKI_RAY_TRACING AND NOT LLPC_IS_STANDALONE)
+    target_link_libraries(llpcinternal PRIVATE vkgc_gpurtshim)
+endif()
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(llpcinternal PRIVATE Threads::Threads)

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -192,6 +192,7 @@ private:
   bool canUseRelocatableGraphicsShaderElf(const llvm::ArrayRef<const PipelineShaderInfo *> &shaderInfo,
                                           const GraphicsPipelineBuildInfo *pipelineInfo);
   bool canUseRelocatableComputeShaderElf(const ComputePipelineBuildInfo *pipelineInfo);
+  std::unique_ptr<llvm::Module> createGpurtShaderLibrary(Context *context);
 #if VKI_RAY_TRACING
   Result buildRayTracingPipelineInternal(RayTracingContext &rtContext,
                                          llvm::ArrayRef<const PipelineShaderInfo *> shaderInfo, bool unlinked,

--- a/llpc/context/llpcComputeContext.cpp
+++ b/llpc/context/llpcComputeContext.cpp
@@ -46,13 +46,13 @@ namespace Llpc {
 // @param cacheHash : Cache hash code
 ComputeContext::ComputeContext(GfxIpVersion gfxIp, const ComputePipelineBuildInfo *pipelineInfo,
                                MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash)
-    : PipelineContext(gfxIp, pipelineHash, cacheHash
-#if VKI_RAY_TRACING
-                      ,
-                      &pipelineInfo->rtState
+    : PipelineContext(gfxIp, pipelineHash, cacheHash), m_pipelineInfo(pipelineInfo) {
+  const Vkgc::BinaryData *gpurtShaderLibrary = nullptr;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
+  gpurtShaderLibrary = &pipelineInfo->shaderLibrary;
 #endif
-                      ),
-      m_pipelineInfo(pipelineInfo) {
+  setRayTracingState(pipelineInfo->rtState, gpurtShaderLibrary);
+
   setUnlinked(pipelineInfo->unlinked);
   m_resourceMapping = pipelineInfo->resourceMapping;
   m_pipelineLayoutApiHash = pipelineInfo->pipelineLayoutApiHash;

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -59,14 +59,13 @@ static cl::opt<bool> DisableColorExportShader("disable-color-export-shader", cl:
 // @param cacheHash : Cache hash code
 GraphicsContext::GraphicsContext(GfxIpVersion gfxIp, const GraphicsPipelineBuildInfo *pipelineInfo,
                                  MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash)
-    : PipelineContext(gfxIp, pipelineHash, cacheHash
-#if VKI_RAY_TRACING
-                      ,
-                      &pipelineInfo->rtState
+    : PipelineContext(gfxIp, pipelineHash, cacheHash), m_pipelineInfo(pipelineInfo), m_stageMask(0),
+      m_preRasterHasGs(false), m_activeStageCount(0) {
+  const Vkgc::BinaryData *gpurtShaderLibrary = nullptr;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
+  gpurtShaderLibrary = &pipelineInfo->shaderLibrary;
 #endif
-                      ),
-      m_pipelineInfo(pipelineInfo), m_stageMask(0), m_preRasterHasGs(false), m_useDualSourceBlend(false),
-      m_activeStageCount(0) {
+  setRayTracingState(pipelineInfo->rtState, gpurtShaderLibrary);
 
   setUnlinked(pipelineInfo->unlinked);
   // clang-format off

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -105,13 +105,7 @@ enum class PipelineType {
 // Represents pipeline-specific context for pipeline compilation, it is a part of LLPC context
 class PipelineContext {
 public:
-  PipelineContext(GfxIpVersion gfxIp, MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash
-#if VKI_RAY_TRACING
-                  ,
-                  const Vkgc::RtState *rtState
-
-#endif
-  );
+  PipelineContext(GfxIpVersion gfxIp, MetroHash::Hash *pipelineHash, MetroHash::Hash *cacheHash);
   virtual ~PipelineContext();
 
   // Returns the pipeline type
@@ -192,7 +186,7 @@ public:
   llvm::StringRef getRayTracingFunctionName(unsigned funcType);
 
   // Gets ray tracing state info
-  const Vkgc::RtState *getRayTracingState() { return m_rtState; }
+  const Vkgc::RtState *getRayTracingState() { return &m_rtState; }
 #endif
 
   // Gets the finalized 128-bit cache hash code.
@@ -238,6 +232,9 @@ public:
   lgc::ShaderOptions computeShaderOptions(const PipelineShaderInfo &shaderInfo) const;
 
 protected:
+  // Set the raytracing state
+  void setRayTracingState(const Vkgc::RtState &rtState, const Vkgc::BinaryData *shaderLibrary = nullptr);
+
   // Gets dummy vertex input create info
   virtual VkPipelineVertexInputStateCreateInfo *getDummyVertexInputInfo() { return nullptr; }
 
@@ -255,9 +252,6 @@ protected:
   MetroHash::Hash m_cacheHash;           // Cache hash code
   ResourceMappingData m_resourceMapping; // Contains resource mapping nodes and static descriptor values
   uint64_t m_pipelineLayoutApiHash;      // Pipeline Layout Api Hash
-#if VKI_RAY_TRACING
-  const Vkgc::RtState *m_rtState; // Ray tracing state
-#endif
 
 private:
   PipelineContext() = delete;
@@ -278,6 +272,7 @@ private:
 
   ShaderFpMode m_shaderFpModes[ShaderStageCountInternal] = {};
   bool m_unlinked = false; // Whether we are building an "unlinked" shader ELF
+  Vkgc::RtState m_rtState = {};
 };
 
 } // namespace Llpc

--- a/llpc/context/llpcRayTracingContext.cpp
+++ b/llpc/context/llpcRayTracingContext.cpp
@@ -46,10 +46,16 @@ namespace Llpc {
 RayTracingContext::RayTracingContext(GfxIpVersion gfxIP, const RayTracingPipelineBuildInfo *pipelineInfo,
                                      const PipelineShaderInfo *representativeShaderInfo, MetroHash::Hash *pipelineHash,
                                      MetroHash::Hash *cacheHash, unsigned indirectStageMask)
-    : PipelineContext(gfxIP, pipelineHash, cacheHash, &pipelineInfo->rtState), m_pipelineInfo(pipelineInfo),
-      m_representativeShaderInfo(), m_linked(false), m_indirectStageMask(indirectStageMask), m_entryName(""),
+    : PipelineContext(gfxIP, pipelineHash, cacheHash), m_pipelineInfo(pipelineInfo), m_representativeShaderInfo(),
+      m_linked(false), m_indirectStageMask(indirectStageMask), m_entryName(""),
       m_payloadMaxSize(pipelineInfo->payloadSizeMaxInLib), m_callableDataMaxSize(0),
       m_attributeDataMaxSize(pipelineInfo->attributeSizeMaxInLib) {
+  const Vkgc::BinaryData *gpurtShaderLibrary = nullptr;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
+  gpurtShaderLibrary = &pipelineInfo->shaderTraceRay;
+#endif
+  setRayTracingState(pipelineInfo->rtState, gpurtShaderLibrary);
+
   m_resourceMapping = pipelineInfo->resourceMapping;
   m_pipelineLayoutApiHash = pipelineInfo->pipelineLayoutApiHash;
 

--- a/llpc/tool/llpcCompilationUtils.cpp
+++ b/llpc/tool/llpcCompilationUtils.cpp
@@ -418,19 +418,19 @@ Error processInputPipeline(ICompiler *compiler, CompileInfo &compileInfo, const 
     }
   }
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
   const BinaryData *shaderLibrary = nullptr;
-  if (pipelineState->pipelineType == VfxPipelineTypeRayTracing)
+  if (pipelineState->pipelineType == VfxPipelineTypeRayTracing) {
     shaderLibrary = &pipelineState->rayPipelineInfo.shaderTraceRay;
-  else if (pipelineState->pipelineType == VfxPipelineTypeCompute)
+  } else if (pipelineState->pipelineType == VfxPipelineTypeCompute) {
     shaderLibrary = &pipelineState->compPipelineInfo.shaderLibrary;
-#endif
-#if VKI_RAY_TRACING
-  else {
+  } else {
     assert(pipelineState->pipelineType == VfxPipelineTypeGraphics);
     shaderLibrary = &pipelineState->gfxPipelineInfo.shaderLibrary;
   }
   if (shaderLibrary->codeSize > 0 && EnableOuts())
     disassembleSpirv(shaderLibrary->codeSize, shaderLibrary->pCode, "Ray tracing library");
+#endif
 #endif
 
   const bool isGraphics = compileInfo.pipelineType == VfxPipelineTypeGraphics;

--- a/tool/dumper/vkgcPipelineDumper.h
+++ b/tool/dumper/vkgcPipelineDumper.h
@@ -76,7 +76,7 @@ public:
 #if VKI_RAY_TRACING
   static MetroHash::Hash generateHashForRayTracingPipeline(const RayTracingPipelineBuildInfo *pipeline,
                                                            bool isCacheHash);
-  static void dumpRayTracingRtState(const RtState *rtState, std::ostream &dumpFile);
+  static void dumpRayTracingRtState(const RtState *rtState, const char *dumpDir, std::ostream &dumpFile);
   static void dumpRayTracingPipelineMetadata(PipelineDumpFile *binaryFile, const BinaryData *pipelineBin);
 #endif
 
@@ -129,7 +129,7 @@ private:
 
   static void dumpRayTracingStateInfo(const RayTracingPipelineBuildInfo *pipelineInfo, const char *dumpDir,
                                       std::ostream &dumpFile);
-  static void updateHashForRtState(const RtState *rtState, MetroHash64 *hasher);
+  static void updateHashForRtState(const RtState *rtState, MetroHash64 *hasher, bool isCacheHash);
 #endif
 
   static void dumpVersionInfo(std::ostream &dumpFile);

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -522,8 +522,10 @@ struct GraphicsPipelineState {
 
   ColorBuffer colorBuffer[Vkgc::MaxColorTargets]; // Color target state.
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
   Vkgc::BinaryData shaderLibrary; // Shader library SPIR-V binary
-  Vkgc::RtState rtState;          // Ray tracing state
+#endif
+  Vkgc::RtState rtState; // Ray tracing state
 #endif
   bool dynamicVertexStride;   // Dynamic Vertex input Stride is enabled.
   bool enableUberFetchShader; // Use uber fetch shader
@@ -536,8 +538,10 @@ struct ComputePipelineState {
   unsigned deviceIndex;          // Device index for device group
   Vkgc::PipelineOptions options; // Pipeline options
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
   Vkgc::BinaryData shaderLibrary; // Shader library SPIR-V binary
-  Vkgc::RtState rtState;          // Ray tracing state
+#endif
+  Vkgc::RtState rtState; // Ray tracing state
 #endif
 };
 
@@ -549,14 +553,19 @@ struct RayTracingPipelineState {
   Vkgc::PipelineOptions options;                       // Pipeline options
   unsigned shaderGroupCount;                           // Count of shader groups
   VkRayTracingShaderGroupCreateInfoKHR *pShaderGroups; // An array of shader groups
-  Vkgc::BinaryData shaderTraceRay;                     // Trace-ray SPIR-V binary
-  unsigned maxRecursionDepth;                          // Ray tracing max recursion depth
-  unsigned indirectStageMask;                          // Trace-ray indirect stage mask
-  Vkgc::RtState rtState;                               // Ray tracing state
-  unsigned payloadSizeMaxInLib;                        // Pipeline library maxPayloadSize
-  unsigned attributeSizeMaxInLib;                      // Pipeline library maxAttributeSize
-  bool hasPipelineLibrary;                             // Whether has pipeline library
-  unsigned pipelineLibStageMask;                       // Pipeline library stage mask
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
+  Vkgc::BinaryData shaderTraceRay; // Trace-ray SPIR-V binary
+#endif
+  unsigned maxRecursionDepth;     // Ray tracing max recursion depth
+  unsigned indirectStageMask;     // Trace-ray indirect stage mask
+  Vkgc::RtState rtState;          // Ray tracing state
+  unsigned payloadSizeMaxInLib;   // Pipeline library maxPayloadSize
+  unsigned attributeSizeMaxInLib; // Pipeline library maxAttributeSize
+  bool hasPipelineLibrary;        // Whether has pipeline library
+  unsigned pipelineLibStageMask;  // Pipeline library stage mask
+
+  /// Combination of GpuRt::ShaderLibraryFeatureFlag
+  unsigned gpurtFeatureFlags;
 };
 #endif
 

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -139,7 +139,9 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
     gfxPipelineInfo->enableUberFetchShader = graphicState.enableUberFetchShader;
     gfxPipelineInfo->enableEarlyCompile = graphicState.enableEarlyCompile;
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     gfxPipelineInfo->shaderLibrary = graphicState.shaderLibrary;
+#endif
     gfxPipelineInfo->rtState = graphicState.rtState;
 #endif
   }
@@ -155,7 +157,9 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
     computePipelineInfo->options = computeState.options;
     computePipelineInfo->cs.entryStage = Vkgc::ShaderStageCompute;
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     computePipelineInfo->shaderLibrary = computeState.shaderLibrary;
+#endif
     computePipelineInfo->rtState = computeState.rtState;
 #endif
   }
@@ -172,7 +176,9 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
     rayTracingPipelineInfo->options = rayTracingState.options;
     rayTracingPipelineInfo->shaderGroupCount = rayTracingState.shaderGroupCount;
     rayTracingPipelineInfo->pShaderGroups = rayTracingState.pShaderGroups;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     rayTracingPipelineInfo->shaderTraceRay = rayTracingState.shaderTraceRay;
+#endif
     rayTracingPipelineInfo->maxRecursionDepth = rayTracingState.maxRecursionDepth;
     rayTracingPipelineInfo->indirectStageMask = rayTracingState.indirectStageMask;
     rayTracingPipelineInfo->rtState = rayTracingState.rtState;

--- a/tool/vfx/vfxVkSection.cpp
+++ b/tool/vfx/vfxVkSection.cpp
@@ -104,5 +104,28 @@ void initVkSections() {
   static VkSectionParserInit init;
 }
 
+// =====================================================================================================================
+// Parse the RT IP version
+bool SectionRtState::parseRtIpVersion(RtIpVersion *rtIpVersion) {
+  if (m_rtIpVersion.empty())
+    return true;
+
+  const char *p = m_rtIpVersion.c_str();
+  if (!isdigit(*p))
+    return false;
+
+  char *np;
+  rtIpVersion->major = strtol(p, &np, 10);
+  if (p == np || *np != '.')
+    return false;
+
+  p = np + 1;
+  if (!isdigit(*p))
+    return false;
+
+  rtIpVersion->minor = strtol(p, &np, 10);
+  return *np == 0;
+}
+
 } // namespace Vfx
 #endif

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -571,18 +571,33 @@ public:
   typedef Vkgc::RtState SubState;
   SectionRtState() : Section(getAddrTable(), SectionTypeUnset, "rtState") { memset(&m_state, 0, sizeof(m_state)); }
 
-  void getSubState(SubState &state) {
+  void getSubState(const std::string &docFilename, SubState &state, std::string *errorMsg) {
     state = m_state;
     state.bvhResDesc.dataSizeInDwords = m_bvhResDescSize;
     for (unsigned i = 0; i < m_bvhResDesc.size(); ++i)
       state.bvhResDesc.descriptorData[i] = m_bvhResDesc[i];
     m_exportConfig.getSubState(state.exportConfig);
     m_gpurtFuncTable.getSubState(state.gpurtFuncTable);
+
+    if (!parseRtIpVersion(&state.rtIpVersion)) {
+      PARSE_ERROR(*errorMsg, 0, "Failed to parse rtIpVersion\n");
+    }
+
+    std::string dummySource;
+    if (!m_gpurtShaderLibrary.empty()) {
+      bool ret = readFile(docFilename, m_gpurtShaderLibrary, true, &m_gpurtShaderLibraryBinary, &dummySource, errorMsg);
+      if (ret) {
+        state.gpurtShaderLibrary.codeSize = m_gpurtShaderLibraryBinary.size();
+        state.gpurtShaderLibrary.pCode = &m_gpurtShaderLibraryBinary[0];
+      }
+    }
   }
 
   SubState &getSubStateRef() { return m_state; }
 
 private:
+  bool parseRtIpVersion(Vkgc::RtIpVersion *rtIpVersion);
+
   static StrToMemberAddrArrayRef getAddrTable() {
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
@@ -616,7 +631,12 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, enableOptimalLdsStackSizeForUnified, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, maxRayLength, MemberTypeFloat, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_exportConfig, MemberTypeRayTracingShaderExportConfig, true);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, gpurtFeatureFlags, MemberTypeInt, false);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtShaderLibrary, MemberTypeString, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_gpurtFuncTable, MemberTypeGpurtFuncTable, true);
+      INIT_MEMBER_NAME_TO_ADDR(SectionRtState, m_rtIpVersion, MemberTypeString, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, gpurtOverride, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRtState, rtIpOverride, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -624,8 +644,11 @@ private:
 
   SubState m_state;
   SectionRayTracingShaderExportConfig m_exportConfig;
+  std::string m_gpurtShaderLibrary;
+  std::vector<uint8_t> m_gpurtShaderLibraryBinary;
   SectionGpurtFuncTable m_gpurtFuncTable;
-  unsigned m_bvhResDescSize;
+  std::string m_rtIpVersion;
+  unsigned m_bvhResDescSize = 0;
   std::vector<unsigned> m_bvhResDesc;
 };
 #endif
@@ -686,6 +709,7 @@ public:
     m_nggState.getSubState(m_state.nggState);
     state = m_state;
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     std::string dummySource;
     if (!m_shaderLibrary.empty()) {
       bool ret = readFile(docFilename, m_shaderLibrary, true, &m_shaderLibraryBytes, &dummySource, errorMsg);
@@ -693,8 +717,9 @@ public:
         state.shaderLibrary.codeSize = m_shaderLibraryBytes.size();
         state.shaderLibrary.pCode = &m_shaderLibraryBytes[0];
       }
-      m_rtState.getSubState(state.rtState);
     }
+#endif
+    m_rtState.getSubState(docFilename, state.rtState, errorMsg);
 #endif
   };
   SubState &getSubStateRef() { return m_state; };
@@ -739,6 +764,7 @@ public:
     m_options.getSubState(m_state.options);
     state = m_state;
 #if VKI_RAY_TRACING
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     std::string dummySource;
     if (!m_shaderLibrary.empty()) {
       bool ret = readFile(docFilename, m_shaderLibrary, true, &m_shaderLibraryBytes, &dummySource, errorMsg);
@@ -746,11 +772,12 @@ public:
         state.shaderLibrary.codeSize = m_shaderLibraryBytes.size();
         state.shaderLibrary.pCode = &m_shaderLibraryBytes[0];
       }
-      m_rtState.getSubState(state.rtState);
     }
 #endif
-  };
-  SubState &getSubStateRef() { return m_state; };
+    m_rtState.getSubState(docFilename, state.rtState, errorMsg);
+#endif
+  }
+  SubState &getSubStateRef() { return m_state; }
 
 private:
   SubState m_state;
@@ -779,7 +806,9 @@ public:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, deviceIndex, MemberTypeInt, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_options, MemberTypePipelineOption, true);
       INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionRayTracingState, m_groups, MemberTypeShaderGroup, true);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
       INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_shaderTraceRay, MemberTypeString, false);
+#endif
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, maxRecursionDepth, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, indirectStageMask, MemberTypeInt, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionRayTracingState, m_rtState, MemberTypeRtState, true);
@@ -787,6 +816,7 @@ public:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, attributeSizeMaxInLib, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, hasPipelineLibrary, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, pipelineLibStageMask, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionRayTracingState, gpurtFeatureFlags, MemberTypeInt, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -800,6 +830,7 @@ public:
       m_groups[i].getSubState(m_vkShaderGroups[i]);
 
     m_state.pShaderGroups = (m_state.shaderGroupCount) > 0 ? &m_vkShaderGroups[0] : nullptr;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     std::string dummySource;
     if (!m_shaderTraceRay.empty()) {
       bool ret = readFile(docFilename, m_shaderTraceRay, true, &m_traceRayBinary, &dummySource, errorMsg);
@@ -808,7 +839,8 @@ public:
         m_state.shaderTraceRay.pCode = &m_traceRayBinary[0];
       }
     }
-    m_rtState.getSubState(m_state.rtState);
+#endif
+    m_rtState.getSubState(docFilename, m_state.rtState, errorMsg);
     state = m_state;
   };
   SubState &getSubStateRef() { return m_state; };
@@ -817,7 +849,9 @@ private:
   SubState m_state;
   SectionPipelineOption m_options;
   SectionRtState m_rtState;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
   std::string m_shaderTraceRay;
+#endif
   std::vector<SectionShaderGroup> m_groups;
   std::vector<VkRayTracingShaderGroupCreateInfoKHR> m_vkShaderGroups;
   std::vector<uint8_t> m_traceRayBinary;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -23,6 +23,8 @@
  #
  #######################################################################################################################
 
+add_subdirectory(gpurtshim)
+
 add_library(vkgc_util
     vkgcExtension.cpp
     vkgcCapability.h

--- a/util/gpurtshim/CMakeLists.txt
+++ b/util/gpurtshim/CMakeLists.txt
@@ -1,0 +1,36 @@
+########################################################################################################################
+#
+#  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+#
+########################################################################################################################
+
+if(VKI_RAY_TRACING AND NOT LLPC_IS_STANDALONE)
+    # The shim is built as a separate miniature library so that the GPURT include path doesn't "leak" into the main
+    # LLPC compile.
+    add_library(vkgc_gpurtshim STATIC GpurtShim.cpp)
+
+    include(../../cmake/CompilerFlags.cmake)
+    set_compiler_options(vkgc_gpurtshim ${LLPC_ENABLE_WERROR})
+
+    # Link against vkgc_headers to pull in the necessary include directories and all the VKI_* defines
+    target_link_libraries(vkgc_gpurtshim PUBLIC vkgc_headers)
+    target_link_libraries(vkgc_gpurtshim PRIVATE gpurt)
+endif()

--- a/util/gpurtshim/GpurtShim.cpp
+++ b/util/gpurtshim/GpurtShim.cpp
@@ -1,0 +1,106 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  GpurtShim.cpp
+ * @brief Fetch the shader library code directly from the GPURT component.
+ *
+ * This is not built in standalone LLPC builds (meaning builds that don't have the driver repository available).
+ ***********************************************************************************************************************
+ */
+
+#include "gpurt/gpurt.h"
+#include "vkgcGpurtShim.h"
+#include <cassert>
+
+using namespace Vkgc;
+
+void gpurt::getShaderLibrarySpirv(unsigned featureFlags, const void *&code, size_t &size) {
+  auto libCode = GpuRt::GetShaderLibraryCode(featureFlags);
+  code = libCode.pSpvCode;
+  size = libCode.spvSize;
+}
+
+RtIpVersion gpurt::getRtIpVersion(GfxIpVersion gfxIpVersion) {
+  if (gfxIpVersion.major >= 11)
+    return {2, 0};
+  if (gfxIpVersion >= GfxIpVersion{10, 3})
+    return {1, 1};
+  return {0, 0};
+}
+
+static Pal::RayTracingIpLevel getRtIpLevel(RtIpVersion rtIpVersion) {
+  // clang-format off
+  static const std::pair<RtIpVersion, Pal::RayTracingIpLevel> map[] = {
+      {{0, 0}, Pal::RayTracingIpLevel::_None},
+      {{1, 0}, Pal::RayTracingIpLevel::RtIp1_0},
+      {{1, 1}, Pal::RayTracingIpLevel::RtIp1_0},
+#if PAL_BUILD_GFX11
+      {{2, 0}, Pal::RayTracingIpLevel::RtIp2_0},
+#endif
+  };
+  // clang-format on
+
+  for (const auto &entry : map) {
+    if (entry.first == rtIpVersion)
+      return entry.second;
+  }
+
+  abort();
+}
+
+static void unmangleDxilName(char *dst, const char *src) {
+  // input  "\01?RayQueryProceed1_1@@YA_NURayQueryInternal@@IV?$vector@I$02@@@Z"
+  // output "RayQueryProceed1_1"
+  assert(src[0] == '\01' && src[1] == '?');
+
+  src += 2;
+
+  const char *end = strstr(src, "@@");
+  assert(end != nullptr);
+
+  size_t len = end - src;
+  assert(len <= GpurtFuncTable::MaxFunctionNameLength);
+
+  memcpy(dst, src, len);
+  dst[len] = 0;
+}
+
+void gpurt::getFuncTable(RtIpVersion rtIpVersion, GpurtFuncTable &table) {
+  memset(&table, 0, sizeof(table));
+
+  Pal::RayTracingIpLevel rtIpLevel = getRtIpLevel(rtIpVersion);
+  GpuRt::EntryFunctionTable gpurtTable;
+  GpuRt::QueryRayTracingEntryFunctionTable(rtIpLevel, &gpurtTable);
+
+  unmangleDxilName(table.pFunc[RT_ENTRY_TRACE_RAY], gpurtTable.traceRay.pTraceRay);
+  unmangleDxilName(table.pFunc[RT_ENTRY_TRACE_RAY_INLINE], gpurtTable.rayQuery.pTraceRayInline);
+  unmangleDxilName(table.pFunc[RT_ENTRY_TRACE_RAY_HIT_TOKEN], gpurtTable.traceRay.pTraceRayUsingHitToken);
+  unmangleDxilName(table.pFunc[RT_ENTRY_RAY_QUERY_PROCEED], gpurtTable.rayQuery.pProceed);
+  unmangleDxilName(table.pFunc[RT_ENTRY_INSTANCE_INDEX], gpurtTable.intrinsic.pGetInstanceIndex);
+  unmangleDxilName(table.pFunc[RT_ENTRY_INSTANCE_ID], gpurtTable.intrinsic.pGetInstanceID);
+  unmangleDxilName(table.pFunc[RT_ENTRY_OBJECT_TO_WORLD_TRANSFORM], gpurtTable.intrinsic.pGetObjectToWorldTransform);
+  unmangleDxilName(table.pFunc[RT_ENTRY_WORLD_TO_OBJECT_TRANSFORM], gpurtTable.intrinsic.pGetWorldToObjectTransform);
+}


### PR DESCRIPTION
This is on top of #2477; only the last two commits really belong to this PR.

Patch 1 ("Add vkgc_gpurtshim library") primarily deals with CMake and plumbing minutiae.

Patch 2 ("vkgc/llpc: obtain the GPURT shader library from GPURT by default") contains the Vkgc interface changes and bulk of refactoring in LLPC. See its commit message for more details.