### PR TITLE
RegisterMetadata: add missing code for new metadata

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -54,9 +54,16 @@ ColorExportShader::ColorExportShader(PipelineState *pipelineState, ArrayRef<Colo
   }
 
   PalMetadata *metadata = pipelineState->getPalMetadata();
-  DB_SHADER_CONTROL shaderControl = {};
-  shaderControl.u32All = metadata->getRegister(mmDB_SHADER_CONTROL);
-  m_killEnabled = shaderControl.bits.KILL_ENABLE;
+  if (pipelineState->useRegisterFieldFormat()) {
+    auto dbShaderControl = metadata->getPipelineNode()[Util::Abi::PipelineMetadataKey::GraphicsRegisters]
+                               .getMap(true)[Util::Abi::GraphicsRegisterMetadataKey::DbShaderControl]
+                               .getMap(true);
+    m_killEnabled = dbShaderControl[Util::Abi::DbShaderControlMetadataKey::KillEnable].getBool();
+  } else {
+    DB_SHADER_CONTROL shaderControl = {};
+    shaderControl.u32All = metadata->getRegister(mmDB_SHADER_CONTROL);
+    m_killEnabled = shaderControl.bits.KILL_ENABLE;
+  }
 }
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -524,6 +524,25 @@ static constexpr char Output6Enable[] = ".output6_enable";
 static constexpr char Output7Enable[] = ".output7_enable";
 }; // namespace CbShaderMaskMetadataKey
 
+namespace SpiPsInputAddrMetadataKey {
+static constexpr char PerspSampleEna[] = ".persp_sample_ena";
+static constexpr char PerspCenterEna[] = ".persp_center_ena";
+static constexpr char PerspCentroidEna[] = ".persp_centroid_ena";
+static constexpr char PerspPullModelEna[] = ".persp_pull_model_ena";
+static constexpr char LinearSampleEna[] = ".linear_sample_ena";
+static constexpr char LinearCenterEna[] = ".linear_center_ena";
+static constexpr char LinearCentroidEna[] = ".linear_centroid_ena";
+static constexpr char LineStippleTexEna[] = ".line_stipple_tex_ena";
+static constexpr char PosXFloatEna[] = ".pos_x_float_ena";
+static constexpr char PosYFloatEna[] = ".pos_y_float_ena";
+static constexpr char PosZFloatEna[] = ".pos_z_float_ena";
+static constexpr char PosWFloatEna[] = ".pos_w_float_ena";
+static constexpr char FrontFaceEna[] = ".front_face_ena";
+static constexpr char AncillaryEna[] = ".ancillary_ena";
+static constexpr char SampleCoverageEna[] = ".sample_coverage_ena";
+static constexpr char PosFixedPtEna[] = ".pos_fixed_pt_ena";
+}; // namespace SpiPsInputAddrMetadataKey
+
 } // namespace Abi
 
 } // namespace Util

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -252,11 +252,12 @@ private:
   static constexpr uint64_t MAX_SPILL_THRESHOLD = UINT_MAX;
 
   unsigned getUserDataCount(unsigned callingConv);
-  unsigned getCallingConventionForFirstHardwareShaderStage();
+  unsigned getCallingConventionForFirstHardwareShaderStage(std::string &hwStageName);
   unsigned getFirstUserDataReg(unsigned callingConv);
   unsigned getNumberOfSgprsBeforeUserData(unsigned conv);
   unsigned getOffsetOfUserDataReg(std::map<llvm::msgpack::DocNode, llvm::msgpack::DocNode>::iterator firstUserDataNode,
                                   UserDataMapping userDataMapping);
+  unsigned getOffsetOfUserDataReg(llvm::msgpack::ArrayDocNode &userDataReg, UserDataMapping userDataRegMapping);
   unsigned getNumberOfSgprsAfterUserData(unsigned callingConv);
   unsigned getVertexIdOffset(unsigned callingConv);
   unsigned getInstanceIdOffset(unsigned callingConv);

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -752,7 +752,7 @@ void RegisterMetadataBuilder::buildPsRegisters() {
 
   auto dbShaderControl = getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::DbShaderControl].getMap(true);
   dbShaderControl[Util::Abi::DbShaderControlMetadataKey::ZOrder] = zOrder;
-  dbShaderControl[Util::Abi::DbShaderControlMetadataKey::KillEnable] = builtInUsage.discard;
+  dbShaderControl[Util::Abi::DbShaderControlMetadataKey::KillEnable] = builtInUsage.discard == 1;
   dbShaderControl[Util::Abi::DbShaderControlMetadataKey::ZExportEnable] = builtInUsage.fragDepth;
   dbShaderControl[Util::Abi::DbShaderControlMetadataKey::StencilTestValExportEnable] = builtInUsage.fragStencilRef;
   dbShaderControl[Util::Abi::DbShaderControlMetadataKey::MaskExportEnable] = builtInUsage.sampleMask == 1;

--- a/lgc/patch/RegisterMetadataBuilder.h
+++ b/lgc/patch/RegisterMetadataBuilder.h
@@ -42,7 +42,7 @@ namespace Gfx9 {
 class RegisterMetadataBuilder : public ConfigBuilderBase {
 public:
   RegisterMetadataBuilder(llvm::Module *module, PipelineState *PipelineState, PipelineShadersResult *pipelineShaders)
-      : ConfigBuilderBase(module, PipelineState), m_pipelineShaders(pipelineShaders) {}
+      : ConfigBuilderBase(module, PipelineState) {}
 
   void buildPalMetadata();
 
@@ -63,7 +63,6 @@ private:
   unsigned calcLdsSize(unsigned ldsSizeInDwords);
 
   bool m_isNggMode = false;
-  PipelineShadersResult *m_pipelineShaders; // API shaders in the pipeline
 };
 
 } // namespace Gfx9


### PR DESCRIPTION
This PR is going to add the missing support of new metadata in the
functions used for glue shader in PalMetadata, such as `mergeFromBlob`
and `getVsEntryRegInfo`. Besides, we add the check to prevent going
through old metadata path if new style is adopted.