### PR TITLE
TypeLowering: return SmallVector instead of ArrayRef

### DIFF
--- a/lgc/include/lgc/util/TypeLowering.h
+++ b/lgc/include/lgc/util/TypeLowering.h
@@ -134,8 +134,8 @@ public:
 
   static void registerVisitors(llvm_dialects::VisitorBuilder<TypeLowering> &builder);
 
-  llvm::ArrayRef<llvm::Value *> getValue(llvm::Value *value);
-  llvm::ArrayRef<llvm::Value *> getValueOptional(llvm::Value *value);
+  llvm::SmallVector<llvm::Value *> getValue(llvm::Value *value);
+  llvm::SmallVector<llvm::Value *> getValueOptional(llvm::Value *value);
   void replaceInstruction(llvm::Instruction *inst, llvm::ArrayRef<llvm::Value *> mapping);
   void eraseInstruction(llvm::Instruction *inst);
 

--- a/lgc/util/TypeLowering.cpp
+++ b/lgc/util/TypeLowering.cpp
@@ -162,7 +162,7 @@ void TypeLowering::registerVisitors(llvm_dialects::VisitorBuilder<TypeLowering> 
 // post-order, and phi nodes are fixed up at the end. Therefore, this method should be preferred over getValueOptional.
 //
 // @param value : the value
-ArrayRef<Value *> TypeLowering::getValue(Value *value) {
+SmallVector<Value *> TypeLowering::getValue(Value *value) {
   auto values = getValueOptional(value);
   assert(!values.empty());
   return values;
@@ -177,7 +177,7 @@ ArrayRef<Value *> TypeLowering::getValue(Value *value) {
 // Note that constant conversion is invoked on-the-fly as needed.
 //
 // @param value : the value
-ArrayRef<Value *> TypeLowering::getValueOptional(Value *value) {
+SmallVector<Value *> TypeLowering::getValueOptional(Value *value) {
   auto valueIt = m_valueMap.find(value);
   if (valueIt == m_valueMap.end()) {
     auto *constant = dyn_cast<Constant>(value);
@@ -208,15 +208,15 @@ ArrayRef<Value *> TypeLowering::getValueOptional(Value *value) {
     assert(valueIt != m_valueMap.end());
   }
 
-  if ((valueIt->second & 1) == 0)
-    return reinterpret_cast<Value *>(valueIt->second);
+  if ((valueIt->second & 1) == 0) {
+    return SmallVector<Value *>(ArrayRef(reinterpret_cast<Value *>(valueIt->second)));
+  }
 
   size_t begin = valueIt->second >> 1;
   auto typeIt = m_multiTypeConversions.find(value->getType());
   assert(typeIt != m_multiTypeConversions.end());
   size_t count = typeIt->second.size();
-
-  return {&m_convertedValueList[begin], count};
+  return SmallVector<Value *>(ArrayRef(&m_convertedValueList[begin], count));
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
An ArrayRef to `m_convertedValueList` is dangerous. As we will constantly push new values into the vector, new values may cause memory reallocation. Then the returned ArrayRef will reference to a stale buffer. Just return SmallVector to fix the issue.