### PR TITLE
Add dualSourceBlendDynamic and set it in SPIRVReader

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -1192,8 +1192,9 @@ struct GraphicsPipelineBuildInfo {
                                                   ///  are passed to the PS.
   } rsState;                                      ///< Rasterizer State
   struct {
-    bool alphaToCoverageEnable; ///< Enable alpha to coverage
-    bool dualSourceBlendEnable; ///< Blend state bound at draw time will use a dual source blend mode
+    bool alphaToCoverageEnable;  ///< Enable alpha to coverage
+    bool dualSourceBlendEnable;  ///< Blend state bound at draw time will use a dual source blend mode
+    bool dualSourceBlendDynamic; ///< Dual source blend mode is dynamically set
 
     ColorTarget target[MaxColorTargets]; ///< Per-MRT color target info
   } cbState;                             ///< Color target state

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -65,7 +65,11 @@ GraphicsContext::GraphicsContext(GfxIpVersion gfxIp, const GraphicsPipelineBuild
                       &pipelineInfo->rtState
 #endif
                       ),
-      m_pipelineInfo(pipelineInfo), m_stageMask(0), m_preRasterHasGs(false), m_activeStageCount(0) {
+      m_pipelineInfo(pipelineInfo),
+      m_stageMask(0),
+      m_preRasterHasGs(false),
+      m_useDualSourceBlend(false),
+      m_activeStageCount(0) {
 
   setUnlinked(pipelineInfo->unlinked);
   // clang-format off
@@ -292,7 +296,8 @@ void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 
   SmallVector<ColorExportFormat, MaxColorTargets> formats;
 
   state.alphaToCoverageEnable = cbState.alphaToCoverageEnable;
-  state.dualSourceBlendEnable = cbState.dualSourceBlendEnable;
+  state.dualSourceBlendEnable = cbState.dualSourceBlendEnable ||
+                                (cbState.dualSourceBlendDynamic && getUseDualSourceBlend());
 
   for (unsigned targetIndex = 0; targetIndex < MaxColorTargets; ++targetIndex) {
     if (cbState.target[targetIndex].format != VK_FORMAT_UNDEFINED) {

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -58,6 +58,12 @@ public:
   // Sets the mask of active shader stages bound to this pipeline
   virtual void setShaderStageMask(unsigned mask) override { m_stageMask = mask; }
 
+  // Sets whether dual source blend is used in fragment shader
+  virtual void setUseDualSourceBlend(bool useDualSourceBlend) override { m_useDualSourceBlend = useDualSourceBlend; }
+
+  // Gets whether dual source blend is used in fragment shader
+  virtual bool getUseDualSourceBlend() const override { return m_useDualSourceBlend; }
+
   // Sets whether pre-rasterization part has a geometry shader
   virtual void setPreRasterHasGs(bool preRasterHasGs) override { m_preRasterHasGs = preRasterHasGs; }
 
@@ -104,6 +110,7 @@ private:
 
   unsigned m_stageMask;        // Mask of active shader stages bound to this graphics pipeline
   bool m_preRasterHasGs;       // Whether pre-rasterization part has a geometry shader
+  bool m_useDualSourceBlend;   // Whether dual source blend is used in fragment shader
   unsigned m_activeStageCount; // Count of active shader stages
 };
 

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -126,6 +126,14 @@ public:
   // Sets the mask of active shader stages bound to this pipeline
   virtual void setShaderStageMask(unsigned mask) = 0;
 
+  // Sets whether dual source blend is used in fragment shader
+  // NOTE: Only applicable in the part pipeline compilation mode.
+  virtual void setUseDualSourceBlend(bool useDualSourceBlend) { llvm_unreachable("Should never be called!"); }
+
+  // Gets whether dual source blend is used in fragment shader
+  // NOTE: Only applicable in the part pipeline compilation mode.
+  virtual bool getUseDualSourceBlend() const { return false; }
+
   // Sets whether pre-rasterization part has a geometry shader.
   // NOTE: Only applicable in the part pipeline compilation mode.
   virtual void setPreRasterHasGs(bool preRasterHasGs) { llvm_unreachable("Should never be called!"); }


### PR DESCRIPTION
This PR is a revised version of https://github.com/GPUOpen-Drivers/llpc/pull/2467

CTS cases *dEQP-VK.shader_object.pipeline_interaction.\** enables dual source blend **dynamically** but only set one output color in the fragment shader. Thus. the test would crash since it tried to access **m_blendSources[1]** in **dualSourceSwizzle()** when **m_blendSources[1]** is empty.

To handle that case, add a flag **dualSourceBlendDynamic**. When **dualSourceBlendDynamic** is true i.e. dual source blend is dynamically set, check whether the fragment shader has a output at Location 0, Index 1 in SPIRVReader.

Affected CTS list:
dEQP-VK.shader_object.pipeline_interaction.*