### PR TITLE
Add flag dualSourceBlendDynamic to cbState

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,6 +82,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     62.1 | Add dualSourceBlendDynamic to cbState                                                                 |
 //  |     62.0 | Add enableImplicitInvariantExports to PipelineOptions                                                 |
 //  |     61.8 | Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
 //  |     61.7 | Add disableFMA to PipelineShaderOptions                                                               |
@@ -1192,8 +1193,9 @@ struct GraphicsPipelineBuildInfo {
                                                   ///  are passed to the PS.
   } rsState;                                      ///< Rasterizer State
   struct {
-    bool alphaToCoverageEnable; ///< Enable alpha to coverage
-    bool dualSourceBlendEnable; ///< Blend state bound at draw time will use a dual source blend mode
+    bool alphaToCoverageEnable;  ///< Enable alpha to coverage
+    bool dualSourceBlendEnable;  ///< Blend state bound at draw time will use a dual source blend mode
+    bool dualSourceBlendDynamic; ///< Dual source blend mode is dynamically set.
 
     ColorTarget target[MaxColorTargets]; ///< Per-MRT color target info
   } cbState;                             ///< Color target state
@@ -1202,7 +1204,6 @@ struct GraphicsPipelineBuildInfo {
   PipelineOptions options;     ///< Per pipeline tuning/debugging options
   bool unlinked;               ///< True to build an "unlinked" half-pipeline ELF
   bool dynamicVertexStride;    ///< Dynamic Vertex input Stride is enabled.
-  bool dynamicDualSourceBlend; ///< Dynamic dual source blend mode is set.
   bool enableUberFetchShader;  ///< Use uber fetch shader
   bool enableEarlyCompile;     ///< Whether enable early compile
 #if VKI_RAY_TRACING

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -82,9 +82,9 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
-//  |     61.11 | Add dualSourceBlendDynamic to cbState                                                                |
+//  |     61.11| Add dualSourceBlendDynamic to cbState                                                                 |
 //  |     61.10| Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
-//  |     61.8 | Add enableImplicitInvariantExports to PipelineOptions                                                 |
+//  |     61.8 | Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
 //  |     61.7 | Add disableFMA to PipelineShaderOptions                                                               |
 //  |     61.6 | Add workaroundInitializeOutputsToZero to PipelineShaderOptions                                        |
 //  |     61.5 | Add RtIpVersion (including its checkers) to represent RT IP                                           |
@@ -1200,12 +1200,12 @@ struct GraphicsPipelineBuildInfo {
     ColorTarget target[MaxColorTargets]; ///< Per-MRT color target info
   } cbState;                             ///< Color target state
 
-  NggState nggState;           ///< NGG state used for tuning and debugging
-  PipelineOptions options;     ///< Per pipeline tuning/debugging options
-  bool unlinked;               ///< True to build an "unlinked" half-pipeline ELF
-  bool dynamicVertexStride;    ///< Dynamic Vertex input Stride is enabled.
-  bool enableUberFetchShader;  ///< Use uber fetch shader
-  bool enableEarlyCompile;     ///< Whether enable early compile
+  NggState nggState;          ///< NGG state used for tuning and debugging
+  PipelineOptions options;    ///< Per pipeline tuning/debugging options
+  bool unlinked;              ///< True to build an "unlinked" half-pipeline ELF
+  bool dynamicVertexStride;   ///< Dynamic Vertex input Stride is enabled.
+  bool enableUberFetchShader; ///< Use uber fetch shader
+  bool enableEarlyCompile;    ///< Whether enable early compile
 #if VKI_RAY_TRACING
   BinaryData shaderLibrary; ///< SPIR-V library binary data
   RtState rtState;          ///< Ray tracing state

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -1198,12 +1198,13 @@ struct GraphicsPipelineBuildInfo {
     ColorTarget target[MaxColorTargets]; ///< Per-MRT color target info
   } cbState;                             ///< Color target state
 
-  NggState nggState;          ///< NGG state used for tuning and debugging
-  PipelineOptions options;    ///< Per pipeline tuning/debugging options
-  bool unlinked;              ///< True to build an "unlinked" half-pipeline ELF
-  bool dynamicVertexStride;   ///< Dynamic Vertex input Stride is enabled.
-  bool enableUberFetchShader; ///< Use uber fetch shader
-  bool enableEarlyCompile;    ///< Whether enable early compile
+  NggState nggState;           ///< NGG state used for tuning and debugging
+  PipelineOptions options;     ///< Per pipeline tuning/debugging options
+  bool unlinked;               ///< True to build an "unlinked" half-pipeline ELF
+  bool dynamicVertexStride;    ///< Dynamic Vertex input Stride is enabled.
+  bool dynamicDualSourceBlend; ///< Dynamic dual source blend mode is set.
+  bool enableUberFetchShader;  ///< Use uber fetch shader
+  bool enableEarlyCompile;     ///< Whether enable early compile
 #if VKI_RAY_TRACING
   BinaryData shaderLibrary; ///< SPIR-V library binary data
   RtState rtState;          ///< Ray tracing state

--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -84,7 +84,7 @@
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
 //  |     61.11| Add dualSourceBlendDynamic to cbState                                                                 |
 //  |     61.10| Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
-//  |     61.8 | Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
+//  |     61.8 | Add enableImplicitInvariantExports to PipelineOptions                                                 |
 //  |     61.7 | Add disableFMA to PipelineShaderOptions                                                               |
 //  |     61.6 | Add workaroundInitializeOutputsToZero to PipelineShaderOptions                                        |
 //  |     61.5 | Add RtIpVersion (including its checkers) to represent RT IP                                           |

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -296,7 +296,7 @@ void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 
 
   state.alphaToCoverageEnable = cbState.alphaToCoverageEnable;
   state.dualSourceBlendEnable =
-      cbState.dualSourceBlendEnable || (pipelineInfo->cbstate.dualSourceBlendDynamic && getUseDualSourceBlend());
+      cbState.dualSourceBlendEnable || (pipelineInfo->cbState.dualSourceBlendDynamic && getUseDualSourceBlend());
 
   for (unsigned targetIndex = 0; targetIndex < MaxColorTargets; ++targetIndex) {
     if (cbState.target[targetIndex].format != VK_FORMAT_UNDEFINED) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -296,7 +296,7 @@ void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 
 
   state.alphaToCoverageEnable = cbState.alphaToCoverageEnable;
   state.dualSourceBlendEnable =
-      cbState.dualSourceBlendEnable || (pipelineInfo->dynamicDualSourceBlend && getUseDualSourceBlend());
+      cbState.dualSourceBlendEnable || (pipelineInfo->cbstate.dualSourceBlendDynamic && getUseDualSourceBlend());
 
   for (unsigned targetIndex = 0; targetIndex < MaxColorTargets; ++targetIndex) {
     if (cbState.target[targetIndex].format != VK_FORMAT_UNDEFINED) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -65,7 +65,11 @@ GraphicsContext::GraphicsContext(GfxIpVersion gfxIp, const GraphicsPipelineBuild
                       &pipelineInfo->rtState
 #endif
                       ),
-      m_pipelineInfo(pipelineInfo), m_stageMask(0), m_preRasterHasGs(false), m_activeStageCount(0) {
+      m_pipelineInfo(pipelineInfo),
+      m_stageMask(0),
+      m_preRasterHasGs(false),
+      m_useDualSourceBlend(false),
+      m_activeStageCount(0) {
 
   setUnlinked(pipelineInfo->unlinked);
   // clang-format off
@@ -282,7 +286,9 @@ Options GraphicsContext::computePipelineOptions() const {
 // @param [in/out] pipeline : Middle-end pipeline object; nullptr if only hashing
 // @param [in/out] hasher : Hasher object; nullptr if only setting LGC pipeline state
 void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 *hasher) const {
-  const auto &cbState = static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->cbState;
+  auto pipelineInfo = reinterpret_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo());
+  const auto &cbState = pipelineInfo->cbState;
+
   if (hasher)
     hasher->Update(cbState);
   if (!pipeline)
@@ -292,7 +298,8 @@ void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 
   SmallVector<ColorExportFormat, MaxColorTargets> formats;
 
   state.alphaToCoverageEnable = cbState.alphaToCoverageEnable;
-  state.dualSourceBlendEnable = cbState.dualSourceBlendEnable;
+  state.dualSourceBlendEnable = cbState.dualSourceBlendEnable ||
+                                (pipelineInfo->dynamicDualSourceBlend && getUseDualSourceBlend());
 
   for (unsigned targetIndex = 0; targetIndex < MaxColorTargets; ++targetIndex) {
     if (cbState.target[targetIndex].format != VK_FORMAT_UNDEFINED) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -65,10 +65,7 @@ GraphicsContext::GraphicsContext(GfxIpVersion gfxIp, const GraphicsPipelineBuild
                       &pipelineInfo->rtState
 #endif
                       ),
-      m_pipelineInfo(pipelineInfo),
-      m_stageMask(0),
-      m_preRasterHasGs(false),
-      m_useDualSourceBlend(false),
+      m_pipelineInfo(pipelineInfo), m_stageMask(0), m_preRasterHasGs(false), m_useDualSourceBlend(false),
       m_activeStageCount(0) {
 
   setUnlinked(pipelineInfo->unlinked);
@@ -298,8 +295,8 @@ void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 
   SmallVector<ColorExportFormat, MaxColorTargets> formats;
 
   state.alphaToCoverageEnable = cbState.alphaToCoverageEnable;
-  state.dualSourceBlendEnable = cbState.dualSourceBlendEnable ||
-                                (pipelineInfo->dynamicDualSourceBlend && getUseDualSourceBlend());
+  state.dualSourceBlendEnable =
+      cbState.dualSourceBlendEnable || (pipelineInfo->dynamicDualSourceBlend && getUseDualSourceBlend());
 
   for (unsigned targetIndex = 0; targetIndex < MaxColorTargets; ++targetIndex) {
     if (cbState.target[targetIndex].format != VK_FORMAT_UNDEFINED) {

--- a/llpc/context/llpcGraphicsContext.h
+++ b/llpc/context/llpcGraphicsContext.h
@@ -58,6 +58,12 @@ public:
   // Sets the mask of active shader stages bound to this pipeline
   virtual void setShaderStageMask(unsigned mask) override { m_stageMask = mask; }
 
+  // Sets whether dual source blend is used in fragment shader
+  virtual void setUseDualSourceBlend(bool useDualSourceBlend) override { m_useDualSourceBlend = useDualSourceBlend; }
+
+  // Gets whether dual source blend is used in fragment shader
+  virtual bool getUseDualSourceBlend() const override { return m_useDualSourceBlend; }
+
   // Sets whether pre-rasterization part has a geometry shader
   virtual void setPreRasterHasGs(bool preRasterHasGs) override { m_preRasterHasGs = preRasterHasGs; }
 
@@ -104,6 +110,7 @@ private:
 
   unsigned m_stageMask;        // Mask of active shader stages bound to this graphics pipeline
   bool m_preRasterHasGs;       // Whether pre-rasterization part has a geometry shader
+  bool m_useDualSourceBlend;   // Whether dual source blend is used in fragment shader
   unsigned m_activeStageCount; // Count of active shader stages
 };
 

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -126,6 +126,14 @@ public:
   // Sets the mask of active shader stages bound to this pipeline
   virtual void setShaderStageMask(unsigned mask) = 0;
 
+  // Sets whether dual source blend is used in fragment shader
+  // NOTE: Only applicable in the part pipeline compilation mode.
+  virtual void setUseDualSourceBlend(bool useDualSourceBlend) { llvm_unreachable("Should never be called!"); }
+
+  // Gets whether dual source blend is used in fragment shader
+  // NOTE: Only applicable in the part pipeline compilation mode.
+  virtual bool getUseDualSourceBlend() const { return false; }
+
   // Sets whether pre-rasterization part has a geometry shader.
   // NOTE: Only applicable in the part pipeline compilation mode.
   virtual void setPreRasterHasGs(bool preRasterHasGs) { llvm_unreachable("Should never be called!"); }

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7794,6 +7794,20 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
         inOutDec.XfbOffset = xfbOffset;
       }
 
+      // If dual source blend is dynamically set, need to confirm whether the fragment shader actually uses
+      // dual-source blending by checking if there is an output at Location 0, Index 1
+      Llpc::Context *llpcContext = static_cast<Llpc::Context *>(m_context);
+      if ((llpcContext->getPipelineType() == PipelineType::Graphics) &&
+          (m_execModule == spv::ExecutionModelFragment)) {
+        auto *buildInfo = static_cast<const Vkgc::GraphicsPipelineBuildInfo *>(llpcContext->getPipelineBuildInfo());
+        if (buildInfo->dynamicDualSourceBlend &&
+            (as == SPIRAS_Output) &&
+            (inOutDec.Value.Loc == 0) &&
+            (inOutDec.Index == 1)) {
+          llpcContext->getPipelineContext()->setUseDualSourceBlend(true);
+        }
+      }
+
       Type *mdTy = nullptr;
       SPIRVType *bt = bv->getType()->getPointerElementType();
       auto md = buildShaderInOutMetadata(bt, inOutDec, mdTy);

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7797,12 +7797,9 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
       // If dual source blend is dynamically set, need to confirm whether the fragment shader actually uses
       // dual-source blending by checking if there is an output at Location 0, Index 1
       Llpc::Context *llpcContext = static_cast<Llpc::Context *>(m_context);
-      if ((llpcContext->getPipelineType() == PipelineType::Graphics) &&
-          (m_execModule == spv::ExecutionModelFragment)) {
+      if ((llpcContext->getPipelineType() == PipelineType::Graphics) && (m_execModule == spv::ExecutionModelFragment)) {
         auto *buildInfo = static_cast<const Vkgc::GraphicsPipelineBuildInfo *>(llpcContext->getPipelineBuildInfo());
-        if (buildInfo->dynamicDualSourceBlend &&
-            (as == SPIRAS_Output) &&
-            (inOutDec.Value.Loc == 0) &&
+        if (buildInfo->dynamicDualSourceBlend && (as == SPIRAS_Output) && (inOutDec.Value.Loc == 0) &&
             (inOutDec.Index == 1)) {
           llpcContext->getPipelineContext()->setUseDualSourceBlend(true);
         }

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7799,7 +7799,7 @@ bool SPIRVToLLVM::transShaderDecoration(SPIRVValue *bv, Value *v) {
       Llpc::Context *llpcContext = static_cast<Llpc::Context *>(m_context);
       if ((llpcContext->getPipelineType() == PipelineType::Graphics) && (m_execModule == spv::ExecutionModelFragment)) {
         auto *buildInfo = static_cast<const Vkgc::GraphicsPipelineBuildInfo *>(llpcContext->getPipelineBuildInfo());
-        if (buildInfo->dynamicDualSourceBlend && (as == SPIRAS_Output) && (inOutDec.Value.Loc == 0) &&
+        if (buildInfo->cbState.dualSourceBlendDynamic && (as == SPIRAS_Output) && (inOutDec.Value.Loc == 0) &&
             (inOutDec.Index == 1)) {
           llpcContext->getPipelineContext()->setUseDualSourceBlend(true);
         }

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -886,6 +886,7 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
   dumpFile << "usrClipPlaneMask = " << static_cast<unsigned>(pipelineInfo->rsState.usrClipPlaneMask) << "\n";
   dumpFile << "alphaToCoverageEnable = " << pipelineInfo->cbState.alphaToCoverageEnable << "\n";
   dumpFile << "dualSourceBlendEnable = " << pipelineInfo->cbState.dualSourceBlendEnable << "\n";
+  dumpFile << "dualSourceBlendDynamic = " << pipelineInfo->cbState.dualSourceBlendDynamic << "\n";
 
   for (unsigned i = 0; i < MaxColorTargets; ++i) {
     if (pipelineInfo->cbState.target[i].format != VK_FORMAT_UNDEFINED) {
@@ -1499,6 +1500,7 @@ void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo 
     auto cbState = &pipeline->cbState;
     hasher->Update(cbState->alphaToCoverageEnable);
     hasher->Update(cbState->dualSourceBlendEnable);
+    hasher->Update(cbState->dualSourceBlendDynamic);
     for (unsigned i = 0; i < MaxColorTargets; ++i) {
       hasher->Update(cbState->target[i].channelWriteMask);
       hasher->Update(cbState->target[i].blendEnable);

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -512,6 +512,7 @@ struct GraphicsPipelineState {
   unsigned usrClipPlaneMask;                    // Mask to indicate the enabled user defined clip planes
   unsigned alphaToCoverageEnable;               // Enable alpha to coverage
   unsigned dualSourceBlendEnable;               // Blend state bound at draw time will use a dual source blend mode
+  unsigned dualSourceBlendDynamic;              // Dual source blend mode is dynamically set
   unsigned switchWinding;                       // reverse the TCS declared output primitive vertex order
   unsigned enableMultiView;                     // Whether to enable multi-view support
   Vkgc::PipelineOptions options;                // Pipeline options

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -123,6 +123,7 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
 
     gfxPipelineInfo->cbState.alphaToCoverageEnable = graphicState.alphaToCoverageEnable != 0;
     gfxPipelineInfo->cbState.dualSourceBlendEnable = graphicState.dualSourceBlendEnable != 0;
+    gfxPipelineInfo->cbState.dualSourceBlendDynamic = graphicState.dualSourceBlendDynamic != 0;
     for (unsigned i = 0; i < MaxColorTargets; ++i) {
       gfxPipelineInfo->cbState.target[i].format = graphicState.colorBuffer[i].format;
       gfxPipelineInfo->cbState.target[i].channelWriteMask =

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -657,6 +657,7 @@ public:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, usrClipPlaneMask, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, alphaToCoverageEnable, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendEnable, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendDynamic, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, switchWinding, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableMultiView, MemberTypeInt, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_options, MemberTypePipelineOption, true);


### PR DESCRIPTION
This PR is a revised version of https://github.com/GPUOpen-Drivers/llpc/pull/2467

CTS cases *dEQP-VK.shader_object.pipeline_interaction.\** enables dual source blend **dynamically** but only set one output color in the fragment shader. Thus. the test would crash since it tried to access **m_blendSources[1]** in **dualSourceSwizzle()** when **m_blendSources[1]** is empty.

To handle that case, add a flag **dualSourceBlendDynamic**. When **dualSourceBlendDynamic** is true i.e. dual source blend is dynamically set, check whether the fragment shader has a output at Location 0, Index 1 in SPIRVReader.

Affected CTS list:
_dEQP-VK.shader_object.pipeline_interaction.\*_