### PR TITLE
Use PipelineSystemValues in copy shader handling

### DIFF
--- a/lgc/include/lgc/patch/PatchCopyShader.h
+++ b/lgc/include/lgc/patch/PatchCopyShader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "lgc/patch/Patch.h"
+#include "lgc/patch/SystemValues.h"
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/util/BuilderBase.h"
@@ -56,8 +57,6 @@ private:
   llvm::Value *loadValueFromGsVsRing(llvm::Type *loadTy, unsigned location, unsigned component, unsigned streamId,
                                      BuilderBase &builder);
 
-  llvm::Value *loadGsVsRingBufferDescriptor(BuilderBase &builder);
-
   void exportGenericOutput(llvm::Value *outputValue, unsigned location, BuilderBase &builder);
   void exportXfbOutput(llvm::Value *outputValue, const XfbOutInfo &XfbOutInfo, BuilderBase &builder);
   void exportBuiltInOutput(llvm::Value *outputValue, BuiltInKind builtInId, unsigned streamId, BuilderBase &builder);
@@ -65,7 +64,8 @@ private:
   // Low part of global internal table pointer
   static const unsigned EntryArgIdxInternalTablePtrLow = 0;
 
-  PipelineState *m_pipelineState;           // Pipeline state
+  PipelineState *m_pipelineState = nullptr; // Pipeline state
+  PipelineSystemValues m_pipelineSysValues; // Cache of ShaderSystemValues objects
   llvm::GlobalVariable *m_lds = nullptr;    // Global variable representing LDS
   llvm::Value *m_gsVsRingBufDesc = nullptr; // Descriptor for GS-VS ring
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -81,12 +81,18 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
   LLVM_DEBUG(dbgs() << "Run the pass Patch-Copy-Shader\n");
 
   Patch::init(&module);
+
   m_pipelineState = pipelineState;
+  m_pipelineSysValues.initialize(m_pipelineState);
+
   auto gsEntryPoint = pipelineShaders.getEntryPoint(ShaderStageGeometry);
   if (!gsEntryPoint) {
-    // No geometry shader -- copy shader not required.
+    // Skip copy shader generation if GS is absent
     return false;
   }
+
+  // Tell pipeline state there is a copy shader.
+  m_pipelineState->setShaderStageMask(m_pipelineState->getShaderStageMask() | (1U << ShaderStageCopyShader));
 
   // Gather GS generic export details.
   collectGsGenericOutputInfo(gsEntryPoint);
@@ -159,6 +165,9 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
   entryPoint->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
   entryPoint->setCallingConv(CallingConv::AMDGPU_VS);
 
+  // Set the shader stage on the new function.
+  setShaderStage(entryPoint, ShaderStageCopyShader);
+
   auto insertPos = module.getFunctionList().end();
   auto fsEntryPoint = pipelineShaders.getEntryPoint(ShaderStageFragment);
   if (fsEntryPoint)
@@ -218,8 +227,6 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
 
   if (m_pipelineState->isGsOnChip())
     m_lds = Patch::getLdsVariable(m_pipelineState, &module);
-  else
-    m_gsVsRingBufDesc = loadGsVsRingBufferDescriptor(builder);
 
   unsigned outputStreamCount = 0;
   unsigned outputStreamId = InvalidValue;
@@ -307,12 +314,6 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
     exportOutput(outputStreamId, builder);
     builder.CreateBr(endBlock);
   }
-
-  // Set the shader stage on the new function.
-  setShaderStage(entryPoint, ShaderStageCopyShader);
-
-  // Tell pipeline state there is a copy shader.
-  m_pipelineState->setShaderStageMask(m_pipelineState->getShaderStageMask() | (1U << ShaderStageCopyShader));
 
   return true;
 }
@@ -558,6 +559,8 @@ Value *PatchCopyShader::calcGsVsRingOffsetForInput(unsigned location, unsigned c
 // @param builder : BuilderBase to use for instruction constructing
 Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, unsigned component, unsigned streamId,
                                               BuilderBase &builder) {
+  auto entryPoint = builder.GetInsertBlock()->getParent();
+
   unsigned elemCount = 1;
   Type *elemTy = loadTy;
 
@@ -598,7 +601,6 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
 
     return builder.CreateAlignedLoad(loadTy, loadPtr, m_lds->getAlign());
   }
-  assert(m_gsVsRingBufDesc);
 
   CoherentFlag coherent = {};
   if (m_pipelineState->getTargetInfo().getGfxIpVersion().major <= 11) {
@@ -610,12 +612,13 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
 
   for (unsigned i = 0; i < elemCount; ++i) {
     Value *ringOffset = calcGsVsRingOffsetForInput(location + i / 4, component + i % 4, streamId, builder);
-    auto loadElem = builder.CreateIntrinsic(Intrinsic::amdgcn_raw_buffer_load, elemTy,
-                                            {
-                                                m_gsVsRingBufDesc, ringOffset,
-                                                builder.getInt32(0),              // soffset
-                                                builder.getInt32(coherent.u32All) // glc, slc
-                                            });
+    auto loadElem =
+        builder.CreateIntrinsic(Intrinsic::amdgcn_raw_buffer_load, elemTy,
+                                {
+                                    m_pipelineSysValues.get(entryPoint)->getGsVsRingBufDesc(streamId), ringOffset,
+                                    builder.getInt32(0),              // soffset
+                                    builder.getInt32(coherent.u32All) // glc, slc
+                                });
 
     if (loadTy->isArrayTy())
       loadValue = builder.CreateInsertValue(loadValue, loadElem, i);
@@ -628,38 +631,6 @@ Value *PatchCopyShader::loadValueFromGsVsRing(Type *loadTy, unsigned location, u
   }
 
   return loadValue;
-}
-
-// =====================================================================================================================
-// Load GS-VS ring buffer descriptor.
-//
-// @param builder : BuilderBase to use for instruction constructing
-Value *PatchCopyShader::loadGsVsRingBufferDescriptor(BuilderBase &builder) {
-  Function *entryPoint = builder.GetInsertBlock()->getParent();
-  Value *internalTablePtrLow = getFunctionArgument(entryPoint, EntryArgIdxInternalTablePtrLow);
-
-  Value *pc = builder.CreateIntrinsic(Intrinsic::amdgcn_s_getpc, {}, {});
-  pc = builder.CreateBitCast(pc, FixedVectorType::get(builder.getInt32Ty(), 2));
-
-  auto internalTablePtrHigh = builder.CreateExtractElement(pc, 1);
-
-  auto undef = UndefValue::get(FixedVectorType::get(builder.getInt32Ty(), 2));
-  Value *internalTablePtr = builder.CreateInsertElement(undef, internalTablePtrLow, uint64_t(0));
-  internalTablePtr = builder.CreateInsertElement(internalTablePtr, internalTablePtrHigh, 1);
-  internalTablePtr = builder.CreateBitCast(internalTablePtr, builder.getInt64Ty());
-
-  auto gsVsRingBufDescPtr = builder.CreateAdd(internalTablePtr, builder.getInt64(SiDrvTableVsRingInOffs << 4));
-
-  auto int32x4Ty = FixedVectorType::get(builder.getInt32Ty(), 4);
-  auto int32x4PtrTy = PointerType::get(int32x4Ty, ADDR_SPACE_CONST);
-  gsVsRingBufDescPtr = builder.CreateIntToPtr(gsVsRingBufDescPtr, int32x4PtrTy);
-  cast<Instruction>(gsVsRingBufDescPtr)
-      ->setMetadata(MetaNameUniform, MDNode::get(gsVsRingBufDescPtr->getContext(), {}));
-
-  auto gsVsRingBufDesc = builder.CreateLoad(int32x4Ty, gsVsRingBufDescPtr);
-  gsVsRingBufDesc->setMetadata(LLVMContext::MD_invariant_load, MDNode::get(gsVsRingBufDesc->getContext(), {}));
-
-  return gsVsRingBufDesc;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -53,7 +53,12 @@ void ShaderSystemValues::initialize(PipelineState *pipelineState, Function *entr
     m_pipelineState = pipelineState;
 
     assert(m_shaderStage != ShaderStageInvalid);
-    assert(m_pipelineState->getShaderInterfaceData(m_shaderStage)->entryArgIdxs.initialized);
+    if (m_shaderStage != ShaderStageCopyShader) {
+      // NOTE: For shader stages other than copy shader, make sure their entry-points are mutated with proper arguments.
+      // For copy shader, we don't need such check because entry-point mutation is not applied to copy shader. Copy
+      // shader is completely generated.
+      assert(m_pipelineState->getShaderInterfaceData(m_shaderStage)->entryArgIdxs.initialized);
+    }
   }
 }
 
@@ -305,7 +310,6 @@ Value *ShaderSystemValues::getGsVsRingBufDesc(unsigned streamId) {
       m_gsVsRingBufDescs[streamId] = desc;
     } else {
       // Copy shader, using GS-VS ring for input.
-      assert(streamId == 0);
       m_gsVsRingBufDescs[streamId] = loadDescFromDriverTable(SiDrvTableVsRingInOffs, builder);
     }
   }


### PR DESCRIPTION
PipelineSystemValues does support copy shader but we didn't use it and wrote some redundant getters.