### PR TITLE
Fix an improper assert in copy shader

### DIFF
--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -193,8 +193,7 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = 2;
       intfData->userDataUsage.gs.copyShaderStreamOutTable = 3;
     } else {
-      // If NGG (SW stream-out), both esGsLdsSize and streamOutTable are not used
-      assert(m_pipelineState->enableSwXfb());
+      // If NGG, both esGsLdsSize and streamOutTable are not used
       intfData->userDataUsage.gs.copyShaderEsGsLdsSize = InvalidValue;
       intfData->userDataUsage.gs.copyShaderStreamOutTable = InvalidValue;
     }


### PR DESCRIPTION
This was introduced by
https://github.com/GPUOpen-Drivers/llpc/pull/2463. Actually, it was mistaken.