### PR TITLE
Use default format to fill SPI_SHADER_COL_FORMAT

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -132,11 +132,15 @@ Function *ColorExportShader::createColorExportFunc() {
   // Create the function. Mark SGPR inputs as "inreg".
   Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, getGlueShaderName(), module);
   func->setCallingConv(CallingConv::AMDGPU_PS);
+  func->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
   setShaderStage(func, ShaderStageFragment);
 
   BasicBlock *block = BasicBlock::Create(func->getContext(), "", func);
   BuilderBase builder(block);
   builder.CreateRetVoid();
+  AttrBuilder attribBuilder(func->getContext());
+  attribBuilder.addAttribute("InitialPSInputAddr", std::to_string(0xFFFFFFFF));
+  func->addFnAttrs(attribBuilder);
   return func;
 }
 
@@ -153,4 +157,5 @@ void ColorExportShader::updatePalMetadata(PalMetadata &palMetadata) {
     }
   }
   palMetadata.updateSpiShaderColFormat(m_exports, hasDepthExpFmtZero, m_killEnabled);
+  palMetadata.updateCbShaderMask(m_exports);
 }

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -62,7 +62,7 @@ public:
   FragColorExport(llvm::LLVMContext *context, PipelineState *pipelineState);
 
   llvm::Value *handleColorExportInstructions(llvm::Value *output, unsigned int hwColorTarget, BuilderBase &builder,
-                                             ExportFormat expFmt, const bool signedness, uint8_t* pNumUndefiedTarget);
+                                             ExportFormat expFmt, const bool signedness, uint8_t *pNumUndefinedTarget);
 
   void generateExportInstructions(llvm::ArrayRef<lgc::ColorExportInfo> info, llvm::ArrayRef<llvm::Value *> values,
                                   llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -62,7 +62,7 @@ public:
   FragColorExport(llvm::LLVMContext *context, PipelineState *pipelineState);
 
   llvm::Value *handleColorExportInstructions(llvm::Value *output, unsigned int hwColorTarget, BuilderBase &builder,
-                                             ExportFormat expFmt, const bool signedness);
+                                             ExportFormat expFmt, const bool signedness, uint8_t* pNumUndefiedTarget);
 
   void generateExportInstructions(llvm::ArrayRef<lgc::ColorExportInfo> info, llvm::ArrayRef<llvm::Value *> values,
                                   llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -170,6 +170,9 @@ public:
   // Updates the PS register information that depends on the exports.
   void updateSpiShaderColFormat(llvm::ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled);
 
+  // Updates the CB shader mask information that depends on the exports.
+  void updateCbShaderMask(llvm::ArrayRef<ColorExportInfo> exps);
+
   // Sets the finalized 128-bit cache hash.  The version identifies the version of LLPC used to generate the hash.
   void setFinalized128BitCacheHash(const lgc::Hash128 &finalizedCacheHash, const llvm::VersionTuple &version);
 

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -94,7 +94,7 @@ static void extractElements(Value *input, BuilderBase &builder, SmallVectorImpl<
 // @param signedness: If output should be interpreted as a signed integer
 Value *FragColorExport::handleColorExportInstructions(Value *output, unsigned hwColorTarget, BuilderBase &builder,
                                                       ExportFormat expFmt, const bool signedness,
-                                                      uint8_t *pNumUndefiedTarget) {
+                                                      uint8_t *pNumUndefinedTarget) {
   Type *outputTy = output->getType();
   const unsigned bitWidth = outputTy->getScalarSizeInBits();
   unsigned compCount = outputTy->isVectorTy() ? cast<FixedVectorType>(outputTy)->getNumElements() : 1;
@@ -113,9 +113,8 @@ Value *FragColorExport::handleColorExportInstructions(Value *output, unsigned hw
       floatTy, //  EXP_FORMAT_32_ABGR = 9,
   };
 
-  if (expFmt == EXP_FORMAT_ZERO)
-  {
-    *pNumUndefiedTarget += 1;
+  if (expFmt == EXP_FORMAT_ZERO) {
+    *pNumUndefinedTarget += 1;
     return nullptr;
   }
 
@@ -262,14 +261,14 @@ Value *FragColorExport::handleColorExportInstructions(Value *output, unsigned hw
         comps[i] = undefFloat;
 
       Value *args[] = {
-          builder.getInt32(EXP_TARGET_MRT_0 + hwColorTarget - *pNumUndefiedTarget), // tgt
-          builder.getInt32((1 << compCount) - 1),                                   // en
-          comps[0],                                                                 // src0
-          comps[1],                                                                 // src1
-          comps[2],                                                                 // src2
-          comps[3],                                                                 // src3
-          builder.getFalse(),                                                       // done
-          builder.getTrue()                                                         // vm
+          builder.getInt32(EXP_TARGET_MRT_0 + hwColorTarget - *pNumUndefinedTarget), // tgt
+          builder.getInt32((1 << compCount) - 1),                                    // en
+          comps[0],                                                                  // src0
+          comps[1],                                                                  // src1
+          comps[2],                                                                  // src2
+          comps[3],                                                                  // src3
+          builder.getFalse(),                                                        // done
+          builder.getTrue()                                                          // vm
       };
 
       return builder.CreateNamedCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_context), args, {});
@@ -294,14 +293,14 @@ Value *FragColorExport::handleColorExportInstructions(Value *output, unsigned hw
       comps[i] = undefFloat;
 
     Value *args[] = {
-        builder.getInt32(EXP_TARGET_MRT_0 + hwColorTarget - *pNumUndefiedTarget), // tgt
-        builder.getInt32((1 << compCount) - 1),                                   // en
-        comps[0],                                                                 // src0
-        comps[1],                                                                 // src1
-        comps[2],                                                                 // src2
-        comps[3],                                                                 // src3
-        builder.getFalse(),                                                       // done
-        builder.getTrue()                                                         // vm
+        builder.getInt32(EXP_TARGET_MRT_0 + hwColorTarget - *pNumUndefinedTarget), // tgt
+        builder.getInt32((1 << compCount) - 1),                                    // en
+        comps[0],                                                                  // src0
+        comps[1],                                                                  // src1
+        comps[2],                                                                  // src2
+        comps[3],                                                                  // src3
+        builder.getFalse(),                                                        // done
+        builder.getTrue()                                                          // vm
     };
 
     exportCall = builder.CreateNamedCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_context), args, {});

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -900,7 +900,6 @@ llvm::Type *PalMetadata::getLlvmType(StringRef tyName) const {
 void PalMetadata::updateSpiShaderColFormat(ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled) {
   unsigned spiShaderColFormat = 0;
   unsigned undefinedTargets = 0;
-  unsigned cbShaderMask = 0;
   for (auto &exp : exps) {
     if (exp.hwColorTarget == MaxColorTargets)
       continue;


### PR DESCRIPTION
Failures observed when running CTS cases 
dEQP-_VK.shader_object.rendering.color_attachment_count_4.none.extra_output_before_2.\*.random_color_formats.\*_

Those cases randomly insert dummy attachment with format **VK_FORMAT_UNDEFINED** into the valid attachment set.

According to the hardware spec on **SPI_SHADER_COL_FORMAT**, it cannot have holes i.e. if COL2_EXPORT_FORMAT is non-zero, COL0_EXPORT_FORMAT and COL1_EXPORT_FORMAT must also be non-zero.

Thus, use a default value **EXP_FORMAT_FP16_ABGR** instead of **EXP_FORMAT_ZERO** to avoid the above issue. Not quite sure if we need extra check here, thus any suggestion would be appreciated.