### PR TITLE
Add rasterStream to vkgcDefs.h

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -47,7 +47,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 61
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 10
+#define LLPC_INTERFACE_MINOR_VERSION 14
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -82,7 +82,8 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
-//  |     61.11| Add dualSourceBlendDynamic to cbState                                                                 |
+//  |     61.14| Add rasterStream to rsState                                                                           |
+//  |     61.13| Add dualSourceBlendDynamic to cbState                                                                 |
 //  |     61.10| Add useShadingRate and useSampleInfoto ShaderModuleUsage                                              |
 //  |     61.8 | Add enableImplicitInvariantExports to PipelineOptions                                                 |
 //  |     61.7 | Add disableFMA to PipelineShaderOptions                                                               |
@@ -1187,7 +1188,7 @@ struct GraphicsPipelineBuildInfo {
     unsigned samplePatternIdx;    ///< Index into the currently bound MSAA sample pattern table that
                                   ///  matches the sample pattern used by the rasterizer when rendering
                                   ///  with this pipeline.
-
+    unsigned rasterStream;        ///< Which vertex stream to rasterize
     VkProvokingVertexModeEXT provokingVertexMode; ///< Specifies which vertex of a primitive is the _provoking
                                                   ///  vertex_, this impacts which vertex's "flat" VS outputs
                                                   ///  are passed to the PS.

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1892,9 +1892,6 @@ void BuilderImpl::markBuiltInOutputUsage(BuiltInKind builtIn, unsigned arraySize
     default:
       break;
     }
-    // Collect raster stream ID for the export of built-ins
-    if (streamId != InvalidValue)
-      getPipelineState()->getShaderResourceUsage(m_shaderStage)->inOutUsage.gs.rasterStream = streamId;
     break;
   }
 

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -437,9 +437,6 @@ struct ResourceUsage {
       //   <location, <component, byteSize>>
       std::unordered_map<unsigned, std::vector<unsigned>> genericOutByteSizes[MaxGsStreams];
 
-      // ID of the vertex stream sent to rasterizer
-      unsigned rasterStream = 0;
-
       struct {
         unsigned esGsRingItemSize;   // Size of each vertex written to the ES -> GS Ring, in dwords.
         unsigned gsVsRingItemSize;   // Size of each primitive written to the GS -> VS Ring, in dwords.

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -470,17 +470,17 @@ enum ProvokingVertexMode : unsigned {
 
 // Struct to pass to SetRasterizerState
 struct RasterizerState {
-  unsigned rasterizerDiscardEnable; // Kill all rasterized pixels. This is implicitly true if stream out
-                                    //  is enabled and no streams are rasterized
-  unsigned innerCoverage;           // Related to conservative rasterization.  Must be false if
-                                    //  conservative rasterization is disabled.
-  unsigned perSampleShading;        // Enable per sample shading
-  unsigned numSamples;              // Number of coverage samples used when rendering with this pipeline
-  unsigned samplePatternIdx;        // Index into the currently bound MSAA sample pattern table that
-                                    //  matches the sample pattern used by the rasterizer when rendering
-                                    //  with this pipeline.
-  unsigned usrClipPlaneMask;        // Mask to indicate the enabled user defined clip planes
-
+  unsigned rasterizerDiscardEnable;        // Kill all rasterized pixels. This is implicitly true if stream out
+                                           //  is enabled and no streams are rasterized
+  unsigned innerCoverage;                  // Related to conservative rasterization.  Must be false if
+                                           //  conservative rasterization is disabled.
+  unsigned perSampleShading;               // Enable per sample shading
+  unsigned numSamples;                     // Number of coverage samples used when rendering with this pipeline
+  unsigned samplePatternIdx;               // Index into the currently bound MSAA sample pattern table that
+                                           //  matches the sample pattern used by the rasterizer when rendering
+                                           //  with this pipeline.
+  unsigned usrClipPlaneMask;               // Mask to indicate the enabled user defined clip planes
+  unsigned rasterStream;                   // Which vertex stream to rasterize
   ProvokingVertexMode provokingVertexMode; // Specifies which vertex of a primitive is the _provoking vertex_,
                                            // this impacts which vertex's "flat" VS outputs are passed to the PS.
 };

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -353,7 +353,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
     SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN, streamXfbBuffers[1] > 0);
     SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN, streamXfbBuffers[2] > 0);
     SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN, streamXfbBuffers[3] > 0);
-    SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM, resUsage->inOutUsage.gs.rasterStream);
+    SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM, m_pipelineState->getRasterizerState().rasterStream);
   } else {
     const auto &shaderOptions = m_pipelineState->getShaderOptions(shaderStage);
     SET_REG_FIELD(&config->vsRegs, SPI_SHADER_PGM_RSRC1_VS, DEBUG_MODE, shaderOptions.debugMode);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -847,7 +847,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
     SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_1_EN, streamXfbBuffers[1] > 0);
     SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_2_EN, streamXfbBuffers[2] > 0);
     SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, STREAMOUT_3_EN, streamXfbBuffers[3] > 0);
-    SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM, resUsage->inOutUsage.gs.rasterStream);
+    SET_REG_FIELD(&config->vsRegs, VGT_STRMOUT_CONFIG, RAST_STREAM, m_pipelineState->getRasterizerState().rasterStream);
   } else {
     const auto &shaderOptions = m_pipelineState->getShaderOptions(shaderStage);
     SET_REG_FIELD(&config->vsRegs, SPI_SHADER_PGM_RSRC1_VS, DEBUG_MODE, shaderOptions.debugMode);

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -434,7 +434,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
   }
 
   // Following non-XFB output exports are only for rasterization stream
-  if (resUsage->inOutUsage.gs.rasterStream != streamId)
+  if (m_pipelineState->getRasterizerState().rasterStream != streamId)
     return;
 
   // Reconstruct output value at the new mapped location
@@ -723,7 +723,7 @@ void PatchCopyShader::exportBuiltInOutput(Value *outputValue, BuiltInKind builtI
     }
   }
 
-  if (resUsage->inOutUsage.gs.rasterStream == streamId) {
+  if (m_pipelineState->getRasterizerState().rasterStream == streamId) {
     std::string callName = lgcName::OutputExportBuiltIn;
     callName += PipelineState::getBuiltInName(builtInId);
     Value *args[] = {builder.getInt32(builtInId), outputValue};

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -2571,8 +2571,8 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
     const unsigned loc = builtInMap.second;
 
     if (m_shaderStage == ShaderStageGeometry) {
-      LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: stream = " << inOutUsage.gs.rasterStream
-                    << " , "
+      LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage)
+                    << ") Output: stream = " << m_pipelineState->getRasterizerState().rasterStream << " , "
                     << "builtin = " << PipelineState::getBuiltInName(builtInId) << "  =>  Mapped = " << loc << "\n");
     } else {
       LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: builtin = "
@@ -2651,7 +2651,7 @@ void PatchResourceCollect::mapGsBuiltInOutput(unsigned builtInId, unsigned elemC
   assert(m_shaderStage == ShaderStageGeometry);
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageGeometry);
   auto &inOutUsage = resUsage->inOutUsage.gs;
-  unsigned streamId = inOutUsage.rasterStream;
+  unsigned streamId = m_pipelineState->getRasterizerState().rasterStream;
 
   resUsage->inOutUsage.builtInOutputLocMap[builtInId] = inOutUsage.outLocCount[streamId]++;
 
@@ -3086,7 +3086,7 @@ void PatchResourceCollect::updateOutputLocInfoMapWithPack() {
     if (m_shaderStage == ShaderStageGeometry) {
       // NOTE: The output location info from next shader stage (FS) doesn't contain raster stream ID. We have to
       // reconstruct it.
-      const auto rasterStream = m_pipelineState->getShaderResourceUsage(m_shaderStage)->inOutUsage.gs.rasterStream;
+      const auto rasterStream = m_pipelineState->getRasterizerState().rasterStream;
       for (auto &entry : nextStageInputLocInfoMap) {
         InOutLocationInfo origLocInfo(entry.first);
         origLocInfo.setStreamId(rasterStream);

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -664,7 +664,8 @@ void RegisterMetadataBuilder::buildHwVsRegisters() {
   vgtStrmoutConfig[Util::Abi::VgtStrmoutConfigMetadataKey::Streamout_2En] = streamXfbBuffers[2] > 0;
   vgtStrmoutConfig[Util::Abi::VgtStrmoutConfigMetadataKey::Streamout_3En] = streamXfbBuffers[3] > 0;
   if (shaderStage == ShaderStageCopyShader)
-    vgtStrmoutConfig[Util::Abi::VgtStrmoutConfigMetadataKey::RastStream] = resUsage->inOutUsage.gs.rasterStream;
+    vgtStrmoutConfig[Util::Abi::VgtStrmoutConfigMetadataKey::RastStream] =
+        m_pipelineState->getRasterizerState().rasterStream;
 
   // Set some field of SPI_SHADER_PGM_RSRC2_VS
   getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VsSoEn] = enableXfb;

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -45,7 +45,6 @@ ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
   } else if (shaderStage == ShaderStageTessControl) {
     inOutUsage.tcs.calcFactor = {};
   } else if (shaderStage == ShaderStageGeometry) {
-    inOutUsage.gs.rasterStream = 0;
     inOutUsage.gs.calcFactor = {};
   } else if (shaderStage == ShaderStageFragment) {
     for (uint32_t i = 0; i < MaxColorTargets; ++i) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -471,6 +471,7 @@ void GraphicsContext::setGraphicsStateInPipeline(Pipeline *pipeline, Util::Metro
     rasterizerState.rasterizerDiscardEnable = inputRsState.rasterizerDiscardEnable;
     rasterizerState.usrClipPlaneMask = inputRsState.usrClipPlaneMask;
     rasterizerState.provokingVertexMode = static_cast<ProvokingVertexMode>(inputRsState.provokingVertexMode);
+    rasterizerState.rasterStream = inputRsState.rasterStream;
   }
 
   if (isShaderStageInMask(ShaderStageFragment, stageMask)) {

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -883,6 +883,7 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
   dumpFile << "numSamples = " << pipelineInfo->rsState.numSamples << "\n";
   dumpFile << "pixelShaderSamples = " << pipelineInfo->rsState.pixelShaderSamples << "\n";
   dumpFile << "samplePatternIdx = " << pipelineInfo->rsState.samplePatternIdx << "\n";
+  dumpFile << "rasterStream = " << pipelineInfo->rsState.rasterStream << "\n";
   dumpFile << "usrClipPlaneMask = " << static_cast<unsigned>(pipelineInfo->rsState.usrClipPlaneMask) << "\n";
   dumpFile << "alphaToCoverageEnable = " << pipelineInfo->cbState.alphaToCoverageEnable << "\n";
   dumpFile << "dualSourceBlendEnable = " << pipelineInfo->cbState.dualSourceBlendEnable << "\n";
@@ -1451,6 +1452,7 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
   if (updateHashFromRs) {
     auto rsState = &pipeline->rsState;
     hasher->Update(rsState->usrClipPlaneMask);
+    hasher->Update(rsState->rasterStream);
   }
 
   if (isCacheHash) {
@@ -1496,6 +1498,7 @@ void PipelineDumper::updateHashForFragmentState(const GraphicsPipelineBuildInfo 
     hasher->Update(rsState->innerCoverage);
     hasher->Update(rsState->numSamples);
     hasher->Update(rsState->samplePatternIdx);
+    hasher->Update(rsState->rasterStream);
 
     auto cbState = &pipeline->cbState;
     hasher->Update(cbState->alphaToCoverageEnable);

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -509,6 +509,7 @@ struct GraphicsPipelineState {
   unsigned numSamples;                          // Number of coverage samples used when rendering with this pipeline
   unsigned pixelShaderSamples;                  // Controls the pixel shader execution rate
   unsigned samplePatternIdx;                    // Index into the currently bound MSAA sample pattern table
+  unsigned rasterStream;                        // Which vertex stream to rasterize
   unsigned usrClipPlaneMask;                    // Mask to indicate the enabled user defined clip planes
   unsigned alphaToCoverageEnable;               // Enable alpha to coverage
   unsigned dualSourceBlendEnable;               // Blend state bound at draw time will use a dual source blend mode

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -119,6 +119,7 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
     gfxPipelineInfo->rsState.numSamples = graphicState.numSamples;
     gfxPipelineInfo->rsState.pixelShaderSamples = graphicState.pixelShaderSamples;
     gfxPipelineInfo->rsState.samplePatternIdx = graphicState.samplePatternIdx;
+    gfxPipelineInfo->rsState.rasterStream = graphicState.rasterStream;
     gfxPipelineInfo->rsState.usrClipPlaneMask = static_cast<uint8_t>(graphicState.usrClipPlaneMask);
 
     gfxPipelineInfo->cbState.alphaToCoverageEnable = graphicState.alphaToCoverageEnable != 0;

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -654,6 +654,7 @@ public:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, numSamples, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, pixelShaderSamples, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, samplePatternIdx, MemberTypeInt, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, rasterStream, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, usrClipPlaneMask, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, alphaToCoverageEnable, MemberTypeInt, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, dualSourceBlendEnable, MemberTypeInt, false);


### PR DESCRIPTION
The rasterization stream ID is supposed to be set by driver. This is not simply checked by detecting the stream qualifier for GS built-in output. Rather, this can be missing.

In this change, we add the rasterStream to the member of rsState. In the future, driver will pass this info to compiler.