### PR TITLE
Remove an unnecessary assert when MatrixStride is missing for matrix

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -8455,12 +8455,8 @@ Constant *SPIRVToLLVM::buildShaderBlockMetadata(SPIRVType *bt, ShaderBlockDecora
     } else {
       blockDec.IsMatrix = true;
       stride = blockDec.MatrixStride;
-      if (stride == 0) {
-        if (deriveStride)
-          stride = bt->getDerivedMatrixStride();
-        else
-          llvm_unreachable("Missing matrix stride decoration");
-      }
+      if (stride == 0 && deriveStride)
+        stride = bt->getDerivedMatrixStride();
       elemTy = bt->getMatrixColumnType();
     }
 


### PR DESCRIPTION
We already encounter some SPIR-V binaries generated from HLSL. The missing decoration MatrixStride for matrix type is handled so this assert is not necessary. Of course, regular SPIR-V binaries from GLSL always have such decoration.