### PR TITLE
Stop using llvm.fmuladd

### DIFF
--- a/llpc/test/shaderdb/extensions/OpExtInst_TestFmaDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestFmaDouble_lit.frag
@@ -20,8 +20,10 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract double @llvm.fmuladd.f64(double
-; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> @llvm.fmuladd.v3f64(<3 x double>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract double
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract double
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract <3 x double>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x double>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestFmaFloat_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestFmaFloat_lit.frag
@@ -20,8 +20,10 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.fmuladd.f32(float
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.fmuladd.v3f32(<3 x float>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn float
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn float
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <3 x float>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn <3 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestFmaVec4Const_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestFmaVec4Const_lit.frag
@@ -16,8 +16,9 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.fmuladd.v4f32(<4 x float>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.fmuladd.v4f32(<4 x float> <float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000, float 0x3FE6666660000000>, <4 x float> <float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000, float 0x3FC99999A0000000>, <4 x float> <float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000, float 0x3FB99999A0000000>)
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn <4 x float>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn <4 x float> {{.*}}, <float 0x3FCEB85200000000, float 0x3FCEB85200000000, float 0x3FCEB85200000000, float 0x3FCEB85200000000>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestMixBasic_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestMixBasic_lit.frag
@@ -19,7 +19,8 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = fsub reassoc nnan nsz arcp contract afn <4 x float>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.fmuladd.v4f32(<4 x float>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn <4 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestMixLinearBlendDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestMixLinearBlendDouble_lit.frag
@@ -22,9 +22,11 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = fsub reassoc nnan nsz arcp contract <3 x double>
-; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> @llvm.fmuladd.v3f64(<3 x double>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract <3 x double>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract <3 x double>
 ; SHADERTEST: = fsub reassoc nnan nsz arcp contract <4 x double>
-; SHADERTEST: = call reassoc nnan nsz arcp contract <4 x double> @llvm.fmuladd.v4f64(<4 x double>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract <4 x double>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract <4 x double>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestMixLinearBlendFloat_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestMixLinearBlendFloat_lit.frag
@@ -22,9 +22,11 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = fsub reassoc nnan nsz arcp contract afn <3 x float>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.fmuladd.v3f32(<3 x float>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <3 x float>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn <3 x float>
 ; SHADERTEST: = fsub reassoc nnan nsz arcp contract afn <4 x float>
-; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.fmuladd.v4f32(<4 x float>
+; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn <4 x float>
+; SHADERTEST: = fadd reassoc nnan nsz arcp contract afn <4 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
The llvm.fmuladd instrinsic represents an fmul and an fadd that may be fused with each other but may not be fused with other instructions. This is overly restrictive for SPIR-V. Using separate fmul and fadd instructions and marking them both as contractable gives LLVM more flexibility to optimize.