### PR TITLE
Replace amdgcn.ldexp with llvm.ldexp

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -834,7 +834,7 @@ Value *BuilderImpl::CreateLdexp(Value *x, Value *exp, const Twine &instName) {
 
   // We need to scalarize this ourselves.
   Value *result = scalarize(x, exp, [this](Value *x, Value *exp) {
-    Value *ldexp = CreateIntrinsic(Intrinsic::amdgcn_ldexp, x->getType(), {x, exp});
+    Value *ldexp = CreateIntrinsic(x->getType(), Intrinsic::ldexp, {x, exp});
     if (x->getType()->getScalarType()->isDoubleTy()) {
       // NOTE: If LDEXP result is a denormal, we can flush it to zero. This is allowed. For double type, LDEXP
       // instruction does mantissa rounding instead of truncation, which is not expected by SPIR-V spec.

--- a/lgc/patch/PatchWaveSizeAdjust.cpp
+++ b/lgc/patch/PatchWaveSizeAdjust.cpp
@@ -129,6 +129,7 @@ bool PatchWaveSizeAdjust::is16BitArithmeticOp(Instruction *inst) {
     case Intrinsic::umax:
     case Intrinsic::smax:
     case Intrinsic::fma:
+    case Intrinsic::ldexp:
     case Intrinsic::amdgcn_fract:
     case Intrinsic::amdgcn_frexp_mant:
     case Intrinsic::amdgcn_frexp_exp:

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -383,7 +383,7 @@ void PalMetadata::mergeFromBlob(llvm::StringRef blob, bool isGlueCode) {
       if (destNode->getKind() == msgpack::Type::UInt)
         *destNode = destNode->getUInt() | srcNode.getUInt();
       else if (destNode->getKind() == msgpack::Type::Boolean)
-        *destNode = destNode->getBool() | srcNode.getBool();
+        *destNode = destNode->getBool() || srcNode.getBool();
       else
         llvm_unreachable("unsupported type to be merged!");
     }

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
@@ -28,7 +28,7 @@ void main()
 ; SHADERTEST: %[[SCALING:[^ ,]*]] = fcmp reassoc nnan nsz arcp contract olt double %[[X]], 0x1000000000000000
 ; SHADERTEST: %[[SCALE_UP:[^ ,]*]] = select i1 %[[SCALING]], i32 256, i32 0
 ; SHADERTEST: %[[SCALE_DOWN:[^ ,]*]] = select i1 %[[SCALING]], i32 128, i32 0
-; SHADERTEST: %[[SCALE_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.amdgcn.ldexp.f64(double %[[X]], i32 %[[SCALE_UP]])
+; SHADERTEST: %[[SCALE_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.ldexp.f64.i32(double %[[X]], i32 %[[SCALE_UP]])
 ; SHADERTEST: %[[EXP_OF_SCALE_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_X]])
 ; SHADERTEST: %[[TOO_SMALL_SCALE_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_X]], -1021
 ; SHADERTEST: %[[NEW_SCALE_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_X]], double 0.000000e+00, double %[[SCALE_X]]
@@ -47,7 +47,7 @@ void main()
 ; SHADERTEST: %[[R2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H2]], double %[[G2]], double 5.000000e-01)
 ; SHADERTEST: %[[H3:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H2]], double %[[R2]], double %[[H2]])
 ; SHADERTEST: %[[RSQ_X:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double 2.000000e+00, %[[H3]]
-; SHADERTEST: %[[SCALE_RSQ_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.amdgcn.ldexp.f64(double %[[RSQ_X]], i32 %[[SCALE_DOWN]])
+; SHADERTEST: %[[SCALE_RSQ_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.ldexp.f64.i32(double %[[RSQ_X]], i32 %[[SCALE_DOWN]])
 ; SHADERTEST: %[[EXP_OF_SCALE_RSQ_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_RSQ_X]])
 ; SHADERTEST: %[[TOO_SMALL_SCALE_RSQ_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_RSQ_X]], -1021
 ; SHADERTEST: %[[NEW_SCALE_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_RSQ_X]], double 0.000000e+00, double %[[SCALE_RSQ_X]]

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestLdexpDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestLdexpDouble_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract double (...) @lgc.create.ldexp.f64(double
 ; SHADERTEST: = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.ldexp.v3f64(<3 x double>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.amdgcn.ldexp.f64(double %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.amdgcn.ldexp.f64(double %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.ldexp.f64.i32(double %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract double @llvm.ldexp.f64.i32(double %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestLdexpFloat_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestLdexpFloat_lit.frag
@@ -26,8 +26,8 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float (...) @lgc.create.ldexp.f32(float %{{.*}}, i32
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.ldexp.v3f32(<3 x float> %{{.*}}, <3 x i32>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.ldexp.f32.i32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.ldexp.f32.i32(float %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestLdexpVec4_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestLdexpVec4_lit.frag
@@ -16,10 +16,10 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <4 x float> (...) @lgc.create.ldexp.v4f32(<4 x float> %{{.*}}, <4 x i32>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
-; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.amdgcn.ldexp.f32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.ldexp.f32.i32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.ldexp.f32.i32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.ldexp.f32.i32(float %{{.*}}, i32 %{{.*}})
+; SHADERTEST: %{{[0-9]*}} = call reassoc nnan nsz arcp contract afn float @llvm.ldexp.f32.i32(float %{{.*}}, i32 %{{.*}})
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
There is llvm.ldexp since https://reviews.llvm.org/D14327.
GlobalISel is failing some tests because it does not understand
amdgcn.ldexp anymore.