### PR TITLE
Set new LLVM atomic optimizer strategy option

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -149,11 +149,17 @@ void LgcContext::initialize() {
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
   setOptionDefault("amdgpu-atomic-optimizations", "1");
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 463788
+  // Old version of the code
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  setOptionDefault("amdgpu-atomic-optimizer-strategy", "DPP");
+#endif
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 458033
   // Old version of the code
   setOptionDefault("use-gpu-divergence-analysis", "1");
 #else
-// New version of the code (also handles unknown version, which we treat as latest)
+  // New version of the code (also handles unknown version, which we treat as latest)
 #endif
   setOptionDefault("structurizecfg-skip-uniform-regions", "1");
   setOptionDefault("spec-exec-max-speculation-cost", "10");


### PR DESCRIPTION
See: https://reviews.llvm.org/D147408#4394537
The LLVM AMDGPU atomic optimizer pass has a new command line option -amdgpu-atomic-optimizer-strategy= which currently defaults to DPP, but the plan is to change the default to Iterative. Set it to DPP explicitly so that LLPC will not be affected by that change.