### PR TITLE
Disable ngg culling when there is no position fetch

### DIFF
--- a/lgc/test/NGGPassthrough.lgc
+++ b/lgc/test/NGGPassthrough.lgc
@@ -1,0 +1,21 @@
+; RUN: lgc -march=amdgcn--amdpal -mcpu=gfx1100 -o - <%s | FileCheck %s
+
+; Check that NGG passthrough mode is used for that shader. If a s_sendmsg
+; instruction is generated on GFX11, passthrough mode is not used.
+
+define dllexport spir_func void @lgc.shader.VS.main() !spirv.ExecutionModel !3 !lgc.shaderstage !4 {
+; CHECK-NOT: s_sendmsg
+  %1 = insertelement <4 x float> <float poison, float poison, float poison, float 1.000000e+00>, float 0.0, i64 0
+  call void (...) @lgc.create.write.builtin.output(<4 x float> %1, i32 0, i32 0, i32 undef, i32 undef)
+  ret void
+}
+
+declare void @lgc.create.write.builtin.output(...)
+
+!lgc.options = !{!1}
+!lgc.input.assembly.state = !{!2}
+
+!1 = !{i32 -291355731, i32 1941901057, i32 1881874640, i32 2004622469, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 272, i32 0, i32 0, i32 1, i32 256, i32 256, i32 -1, i32 0, i32 1}
+!2 = !{i32 3}
+!3 = !{i32 0}
+!4 = !{i32 1}


### PR DESCRIPTION
This patch is to disable ngg culling when there is no position fetch.