### PR TITLE
Revert "[LLPC] Freeze undef switch conditions in SPIRVReader"

### DIFF
--- a/llpc/test/shaderdb/core/OpAny_TestBvec2_lit.frag
+++ b/llpc/test/shaderdb/core/OpAny_TestBvec2_lit.frag
@@ -30,8 +30,7 @@ void main()
 // CHECK-NEXT:    [[TMP4:%.*]] = extractelement <2 x i1> [[TMP3]], i64 0
 // CHECK-NEXT:    [[TMP5:%.*]] = extractelement <2 x i1> [[TMP3]], i64 1
 // CHECK-NEXT:    [[TMP6:%.*]] = or i1 [[TMP4]], [[TMP5]]
-// CHECK-NEXT:    [[TMP7:%.*]] = freeze i1 [[TMP6]]
-// CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[TMP7]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, <4 x float> <float 5.000000e-01, float 5.000000e-01, float 5.000000e-01, float 5.000000e-01>
+// CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[TMP6]], <4 x float> <float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00>, <4 x float> <float 5.000000e-01, float 5.000000e-01, float 5.000000e-01, float 5.000000e-01>
 // CHECK-NEXT:    call void (...) @lgc.create.write.generic.output(<4 x float> [[SPEC_SELECT]], i32 0, i32 0, i32 0, i32 0, i32 0, i32 poison)
 // CHECK-NEXT:    ret void
 //

--- a/llpc/test/shaderdb/core/OpAtomicCompareExchange_TestStrongCompare.spvasm
+++ b/llpc/test/shaderdb/core/OpAtomicCompareExchange_TestStrongCompare.spvasm
@@ -3,10 +3,7 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: %[[RESULT:[0-9]*]] = call i32 @llvm.amdgcn.raw.buffer.atomic.cmpswap.i32(i32 %{{[0-9]*}}, i32 %[[COMPARE:[0-9]*]]
 ; SHADERTEST: %[[IS_EQUAL:[0-9]*]] = icmp eq i32 %[[RESULT]], %[[COMPARE]]
-; SHADERTEST: %[[INS1:[0-9]*]] = insertvalue { i32, i1 } %{{[0-9]*}}, i1 %[[IS_EQUAL]], 1
-; SHADERTEST: %[[FR:.*]] = freeze { i32, i1 } %[[INS1]]
-; SHADERTEST: %[[RES:[0-9]*]] = extractvalue { i32, i1 } %[[FR]], 1
-; SHADERTEST: br i1 %[[RES]]
+; SHADERTEST: br i1 %[[IS_EQUAL]]
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/core/OpFDiv_TestVector_lit.frag
+++ b/llpc/test/shaderdb/core/OpFDiv_TestVector_lit.frag
@@ -25,7 +25,7 @@ void main()
 ; SHADERTEST-COUNT-1: fdiv reassoc nnan nsz arcp contract afn <4 x float>
 ; SHADERTEST-COUNT-1: fdiv reassoc nnan nsz arcp contract <2 x double>
 ; SHADERTEST-LABEL: {{^// LLPC}}  pipeline patching results
-; SHADERTEST: fdiv reassoc nnan nsz arcp contract double
+; SHADERTEST: fdiv reassoc nnan nsz arcp contract afn float
 ; SHADERTEST-COUNT-2: fdiv reassoc nnan nsz arcp contract double
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/test/shaderdb/core/OpSwitch_TestFallThrough_lit.frag
+++ b/llpc/test/shaderdb/core/OpSwitch_TestFallThrough_lit.frag
@@ -27,7 +27,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: switch i32 %{{.*}}, label %{{[0-9]*}} [
+; SHADERTEST: switch i32 %{{[0-9]*}}, label %{{[0-9]*}} [
 ; SHADERTEST:    i32 0, label %{{[0-9]*}}
 ; SHADERTEST:    i32 1, label %{{[0-9]*}}
 ; SHADERTEST:  ]

--- a/llpc/test/shaderdb/core/OpSwitch_TestGeneral_lit.frag
+++ b/llpc/test/shaderdb/core/OpSwitch_TestGeneral_lit.frag
@@ -30,7 +30,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: switch i32 %{{.*}}, label %{{[0-9]*}} [
+; SHADERTEST: switch i32 %{{[0-9]*}}, label %{{[0-9]*}} [
 ; SHADERTEST:    i32 0, label %{{[0-9]*}}
 ; SHADERTEST:    i32 1, label %{{[0-9]*}}
 ; SHADERTEST:  ]

--- a/llpc/test/shaderdb/core/OpSwitch_TestMergedBranches_lit.frag
+++ b/llpc/test/shaderdb/core/OpSwitch_TestMergedBranches_lit.frag
@@ -26,7 +26,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: switch i32 %{{.*}}, label %{{[0-9]*}} [
+; SHADERTEST: switch i32 %{{[0-9]*}}, label %{{[0-9]*}} [
 ; SHADERTEST:    i32 0, label %{{[0-9]*}}
 ; SHADERTEST:    i32 1, label %{{[0-9]*}}
 ; SHADERTEST:  ]

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestLog2_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestLog2_lit.frag
@@ -23,7 +23,7 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.log2.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.log2.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: = call reassoc nsz arcp contract afn float @llvm.log2.f32(float
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.log2.f32(float
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> @llvm.log2.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.log2.f32(float

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestLog_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestLog_lit.frag
@@ -27,7 +27,7 @@ void main()
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn <3 x float> (...) @lgc.create.log.v3f32(<3 x float>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.log2.f32(float
-; SHADERTEST: = fmul reassoc nnan nsz arcp contract afn float %{{.*}}, 0x3FE62E4300000000
+; SHADERTEST: = call reassoc nnan nsz arcp contract afn float @llvm.log2.f32(float
 ; SHADERTEST-NOT: = call{{.*}} @llvm.log2.f32(float
 ; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4821,14 +4821,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
 
     auto trueSuccessor = cast<BasicBlock>(transValue(br->getTrueLabel(), f, bb));
     auto falseSuccessor = cast<BasicBlock>(transValue(br->getFalseLabel(), f, bb));
-
-    // OpBranchConditional can branch with OpUndef as condition. The selected jump target is undefined.
-    // In LLVM IR, BranchInst with undef value is fully UB.
-    // LLVM will mark the successors as unreachable, so later SimplifyCFG passes will cause
-    // unwanted removal of branches. By using a freeze instruction as condition, we make sure that LLVM
-    // will always operate on a fixed value.
-    c = new FreezeInst(c, "cond.freeze", bb);
-
     auto bc = BranchInst::Create(trueSuccessor, falseSuccessor, c, bb);
     auto lm = static_cast<SPIRVLoopMerge *>(br->getPrevious());
     if (lm && lm->getOpCode() == OpLoopMerge)
@@ -4920,14 +4912,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     auto select = transValue(bs->getSelect(), f, bb);
     auto defaultSuccessor = dyn_cast<BasicBlock>(transValue(bs->getDefault(), f, bb));
     recordBlockPredecessor(defaultSuccessor, bb);
-
-    // OpSwitch can branch with OpUndef as condition. The selected jump target is undefined.
-    // In LLVM IR, SwitchInst with undef value is fully UB.
-    // LLVM will mark the successors as unreachable, so later SimplifyCFG passes will cause
-    // unwanted removal of branches. By using a freeze instruction as condition, we make sure that LLVM
-    // will always operate on a fixed value.
-    select = new FreezeInst(select, "cond.freeze", bb);
-
     auto ls = SwitchInst::Create(select, defaultSuccessor, bs->getNumPairs(), bb);
     bs->foreachPair([&](SPIRVSwitch::LiteralTy literals, SPIRVBasicBlock *label) {
       assert(!literals.empty() && "Literals should not be empty");


### PR DESCRIPTION
This reverts commit 9f0652d43e773919cfb3358213c35a605fb945fe.
The commit causes some performance regressions.