### PR TITLE
LLPC code refine

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1964,6 +1964,7 @@ unsigned BuilderImpl::getBuiltInValidMask(BuiltInKind builtIn, bool isOutput) {
     C = shaderStageToMask(ShaderStageCompute),
     D = shaderStageToMask(ShaderStageTessEval),
     H = shaderStageToMask(ShaderStageTessControl),
+    G = shaderStageToMask(ShaderStageGeometry),
     HD = shaderStageToMask(ShaderStageTessControl, ShaderStageTessEval),
     HDG = shaderStageToMask(ShaderStageTessControl, ShaderStageTessEval, ShaderStageGeometry),
     HDGP = shaderStageToMask(ShaderStageTessControl, ShaderStageTessEval, ShaderStageGeometry, ShaderStageFragment),

--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -105,7 +105,7 @@ Module *ColorExportShader::generate() {
   // Create the function.
   Function *colorExportFunc = createColorExportFunc();
 
-  // Process each vertex input.
+  // Process each fragment output.
   std::unique_ptr<FragColorExport> fragColorExport(new FragColorExport(&getContext(), m_pipelineState));
   auto ret = cast<ReturnInst>(colorExportFunc->back().getTerminator());
   BuilderBase builder(ret);
@@ -121,7 +121,7 @@ Module *ColorExportShader::generate() {
 }
 
 // =====================================================================================================================
-// Create module with function for the fetch shader. On return, the function contains only the code to copy the
+// Create module with function for the color export shader. On return, the function contains only the code to copy the
 // wave dispatch SGPRs and VGPRs to the return value.
 Function *ColorExportShader::createColorExportFunc() {
   // Create the module

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -34,25 +34,6 @@
 
 namespace lgc {
 
-// Internal built-ins for fragment input interpolation (I/J)
-static const BuiltInKind BuiltInInterpPerspSample = static_cast<BuiltInKind>(0x10000000);
-static const BuiltInKind BuiltInInterpPerspCenter = static_cast<BuiltInKind>(0x10000001);
-static const BuiltInKind BuiltInInterpPerspCentroid = static_cast<BuiltInKind>(0x10000002);
-static const BuiltInKind BuiltInInterpPullMode = static_cast<BuiltInKind>(0x10000003);
-static const BuiltInKind BuiltInInterpLinearSample = static_cast<BuiltInKind>(0x10000004);
-static const BuiltInKind BuiltInInterpLinearCenter = static_cast<BuiltInKind>(0x10000005);
-static const BuiltInKind BuiltInInterpLinearCentroid = static_cast<BuiltInKind>(0x10000006);
-
-// Internal built-ins for sample position emulation
-static const BuiltInKind BuiltInSamplePosOffset = static_cast<BuiltInKind>(0x10000007);
-static const BuiltInKind BuiltInNumSamples = static_cast<BuiltInKind>(0x10000008);
-static const BuiltInKind BuiltInSamplePatternIdx = static_cast<BuiltInKind>(0x10000009);
-static const BuiltInKind BuiltInGsWaveId = static_cast<BuiltInKind>(0x1000000A);
-
-// Internal builts-ins for compute input when thread id is swizzled
-static const BuiltInKind BuiltInUnswizzledLocalInvocationId = static_cast<BuiltInKind>(0x1000000B);
-static const BuiltInKind BuiltInUnswizzledLocalInvocationIndex = static_cast<BuiltInKind>(0x1000000C);
-
 // Names used for calls added to IR to represent various actions internally.
 namespace lgcName {
 const static char InternalCallPrefix[] = "lgc.";

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -129,7 +129,6 @@ BUILTIN(NumSamples, BuiltInInternalBase + 8, N, P, i32)
 BUILTIN(SamplePatternIdx, BuiltInInternalBase + 9, N, P, i32)
 BUILTIN(GsWaveId, BuiltInInternalBase + 10, N, G, i32)
 
-// Internal builts-ins for compute input when thread id is swizzled
+// Internal built-ins for compute input when thread id is swizzled
 BUILTIN(UnswizzledLocalInvocationId, BuiltInInternalBase + 11, N, C, i32)
 BUILTIN(UnswizzledLocalInvocationIndex, BuiltInInternalBase + 12, N, C, i32)
-

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -113,3 +113,23 @@ BUILTIN(VertexId, 5, N, V, i32)                          // Index of current ver
 BUILTIN(InstanceId, 6, N, V, i32)                        // Index of current primitive
 
 // Reserved LGC internal built-ins
+
+// Internal built-ins for fragment input interpolation (I/J)
+BUILTIN(InterpPerspSample, BuiltInInternalBase + 0, N, P, v2f32)
+BUILTIN(InterpPerspCenter, BuiltInInternalBase + 1, N, P, v2f32)
+BUILTIN(InterpPerspCentroid, BuiltInInternalBase + 2, N, P, v2f32)
+BUILTIN(InterpPullMode, BuiltInInternalBase + 3, N, P, v3f32)
+BUILTIN(InterpLinearSample, BuiltInInternalBase + 4, N, P, v2f32)
+BUILTIN(InterpLinearCenter, BuiltInInternalBase + 5, N, P, v2f32)
+BUILTIN(InterpLinearCentroid, BuiltInInternalBase + 6, N, P, v2f32)
+
+// Internal built-ins for sample position emulation
+BUILTIN(SamplePosOffset, BuiltInInternalBase + 7, N, P, i32)
+BUILTIN(NumSamples, BuiltInInternalBase + 8, N, P, i32)
+BUILTIN(SamplePatternIdx, BuiltInInternalBase + 9, N, P, i32)
+BUILTIN(GsWaveId, BuiltInInternalBase + 10, N, G, i32)
+
+// Internal builts-ins for compute input when thread id is swizzled
+BUILTIN(UnswizzledLocalInvocationId, BuiltInInternalBase + 11, N, C, i32)
+BUILTIN(UnswizzledLocalInvocationIndex, BuiltInInternalBase + 12, N, C, i32)
+

--- a/lgc/interface/lgc/BuiltIns.h
+++ b/lgc/interface/lgc/BuiltIns.h
@@ -32,6 +32,9 @@
 #pragma once
 
 namespace lgc {
+// Max spirv builtIn value
+static constexpr unsigned BuiltInInternalBase = 0x10000000;
+
 // Define built-in kind enum.
 enum BuiltInKind : unsigned {
 #define BUILTIN(name, number, out, in, type) BuiltIn##name = number,

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1690,24 +1690,6 @@ StringRef PipelineState::getBuiltInName(BuiltInKind builtIn) {
     return #name;
 #include "lgc/BuiltInDefs.h"
 #undef BUILTIN
-
-  // Internal built-ins.
-  case BuiltInSamplePosOffset:
-    return "SamplePosOffset";
-  case BuiltInInterpLinearCenter:
-    return "InterpLinearCenter";
-  case BuiltInInterpPullMode:
-    return "InterpPullMode";
-  case BuiltInInterpPerspCenter:
-    return "InterpPerspCenter";
-  case BuiltInInterpPerspCentroid:
-    return "InterpPerspCentroid";
-  case BuiltInInterpLinearCentroid:
-    return "InterpLinearCentroid";
-  case BuiltInInterpPerspSample:
-    return "InterpPerspSample";
-  case BuiltInInterpLinearSample:
-    return "InterpLinearSample";
   default:
     llvm_unreachable("Should never be called!");
     return "unknown";

--- a/llpc/test/shaderdb/general/VertexOptimizationLevelTest.spvasm
+++ b/llpc/test/shaderdb/general/VertexOptimizationLevelTest.spvasm
@@ -25,7 +25,7 @@
 ; PIPE-DAG:  options.optimizationLevel = 2
 
 ; Check that we can compile with the pipeline dump as input and get the same optimization level
-; RUN: grep -l "options.optimizationLevel = 1" %t/dump/PipelineVsFs_0x*.pipe \
+; RUN: grep -l "options.optimizationLevel = 1" %t/dump/PipelineLibVs_0x*.pipe \
 ; RUN:   | xargs amdllpc -v %gfxip -o %t.recompile.elf \
 ; RUN:   | FileCheck --match-full-lines -check-prefix=RECOMPILE %s
 ; RECOMPILE-LABEL: TargetMachine optimization level = 1

--- a/llpc/test/shaderdb/general/VertexPipelineDumpTest.spvasm
+++ b/llpc/test/shaderdb/general/VertexPipelineDumpTest.spvasm
@@ -11,14 +11,14 @@
 
 ; Check that all the expected dump files are in place.
 ; RUN: ls -1 %t/dump | FileCheck -check-prefix=FILES %s
-; FILES:     {{^}}PipelineVsFs_0x[[PIPE_HASH:[0-9A-F]+]].elf{{$}}
-; FILES:     {{^}}PipelineVsFs_0x[[PIPE_HASH]].pipe{{$}}
+; FILES:     {{^}}PipelineLibVs_0x[[PIPE_HASH:[0-9A-F]+]].elf{{$}}
+; FILES:     {{^}}PipelineLibVs_0x[[PIPE_HASH]].pipe{{$}}
 ; FILES-NOT: {{^}}Pipeline
 ; FILES:     {{^}}Shader_0x{{[0-9A-F]+}}.spv{{$}}
 ; FILES-NOT: {{^}}Shader_
 
 ; Check that we can compile with the pipeline dump as input.
-; RUN: amdllpc -v %gfxip %t/dump/PipelineVsFs_0x*.pipe -o %t.recompile.elf \
+; RUN: amdllpc -v %gfxip %t/dump/PipelineLibVs_0x*.pipe -o %t.recompile.elf \
 ; RUN:   | FileCheck -check-prefix=RECOMPILE %s
 ; RECOMPILE-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; RECOMPILE-LABEL: ==== AMDLLPC SUCCESS ====

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -384,8 +384,7 @@ std::string PipelineDumper::getPipelineInfoFileName(PipelineBuildInfo pipelineIn
         fileNamePrefix = "PipelineLibMesh";
       else
         fileNamePrefix = "PipelineLibFs";
-    }
-    else if (pipelineInfo.pGraphicsInfo->tes.pModuleData && pipelineInfo.pGraphicsInfo->gs.pModuleData)
+    } else if (pipelineInfo.pGraphicsInfo->tes.pModuleData && pipelineInfo.pGraphicsInfo->gs.pModuleData)
       fileNamePrefix = "PipelineGsTess";
     else if (pipelineInfo.pGraphicsInfo->gs.pModuleData)
       fileNamePrefix = "PipelineGs";

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -131,7 +131,14 @@ void *VKAPI_CALL IPipelineDumper::BeginPipelineDump(const PipelineDumpOptions *d
 #endif
   else {
     assert(pipelineInfo.pGraphicsInfo);
-    hash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo.pGraphicsInfo, false, false);
+    UnlinkedShaderStage unlinkedStage = UnlinkedStageCount;
+    if (pipelineInfo.pGraphicsInfo->unlinked) {
+      if (pipelineInfo.pGraphicsInfo->fs.pModuleData)
+        unlinkedStage = UnlinkedStageFragment;
+      else
+        unlinkedStage = UnlinkedStageVertexProcess;
+    }
+    hash = PipelineDumper::generateHashForGraphicsPipeline(pipelineInfo.pGraphicsInfo, false, false, unlinkedStage);
   }
 
   return PipelineDumper::BeginPipelineDump(dumpOptions, pipelineInfo, MetroHash::compact64(&hash));
@@ -362,7 +369,23 @@ std::string PipelineDumper::getPipelineInfoFileName(PipelineBuildInfo pipelineIn
   else {
     assert(pipelineInfo.pGraphicsInfo);
     const char *fileNamePrefix = nullptr;
-    if (pipelineInfo.pGraphicsInfo->tes.pModuleData && pipelineInfo.pGraphicsInfo->gs.pModuleData)
+    if (pipelineInfo.pGraphicsInfo->unlinked) {
+      if (pipelineInfo.pGraphicsInfo->task.pModuleData)
+        fileNamePrefix = "PipelineLibTask";
+      else if (pipelineInfo.pGraphicsInfo->vs.pModuleData)
+        fileNamePrefix = "PipelineLibVs";
+      else if (pipelineInfo.pGraphicsInfo->tcs.pModuleData)
+        fileNamePrefix = "PipelineLibTcs";
+      else if (pipelineInfo.pGraphicsInfo->tes.pModuleData)
+        fileNamePrefix = "PipelineLibTes";
+      else if (pipelineInfo.pGraphicsInfo->gs.pModuleData)
+        fileNamePrefix = "PipelineLibGs";
+      else if (pipelineInfo.pGraphicsInfo->mesh.pModuleData)
+        fileNamePrefix = "PipelineLibMesh";
+      else
+        fileNamePrefix = "PipelineLibFs";
+    }
+    else if (pipelineInfo.pGraphicsInfo->tes.pModuleData && pipelineInfo.pGraphicsInfo->gs.pModuleData)
       fileNamePrefix = "PipelineGsTess";
     else if (pipelineInfo.pGraphicsInfo->gs.pModuleData)
       fileNamePrefix = "PipelineGs";


### PR DESCRIPTION
1. Move all internal builtin to BuiltInDefs.h to fix the warning in VC build
2. Fix a typoes in colorExportShader.cpp and vkgcPipelineDumper.cpp
3. Refine pipeline dump file name and modify related tests.