### PR TITLE
Fix acceleration structure access

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -1618,6 +1618,26 @@ void SpirvLowerRayTracing::createTraceRay() {
   Value *sceneAddLow = m_builder->CreateExtractElement(arg, uint64_t(0));
   Value *sceneAddHigh = m_builder->CreateExtractElement(arg, 1);
 
+#if GPURT_CLIENT_INTERFACE_MAJOR_VERSION < 34
+  {
+    // For GPURT major version < 34, GPURT expect base address of acceleration structure being passed, which is stored
+    // at offset 0 of the resource.
+    auto gpuLowAddr = m_builder->CreateZExt(sceneAddLow, m_builder->getInt64Ty());
+    auto gpuHighAddr = m_builder->CreateZExt(sceneAddHigh, m_builder->getInt64Ty());
+    gpuHighAddr = m_builder->CreateShl(gpuHighAddr, m_builder->getInt64(32));
+    auto gpuAddr = m_builder->CreateOr(gpuLowAddr, gpuHighAddr);
+
+    Type *gpuAddrAsPtrTy = PointerType::get(*m_context, SPIRAS_Global);
+    auto loadPtr = m_builder->CreateIntToPtr(gpuAddr, gpuAddrAsPtrTy);
+
+    auto loadTy = FixedVectorType::get(Type::getInt32Ty(*m_context), 2);
+    auto loadValue = m_builder->CreateLoad(loadTy, loadPtr);
+
+    sceneAddLow = m_builder->CreateExtractElement(loadValue, uint64_t(0));
+    sceneAddHigh = m_builder->CreateExtractElement(loadValue, 1);
+  }
+#endif
+
   m_builder->CreateStore(sceneAddLow, traceRaysArgs[TraceRayLibFuncParam::AcceleStructLo]);
   m_builder->CreateStore(sceneAddHigh, traceRaysArgs[TraceRayLibFuncParam::AcceleStructHi]);
 

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -1629,9 +1629,45 @@ void SpirvLowerRayTracing::createTraceRay() {
 
     Type *gpuAddrAsPtrTy = PointerType::get(*m_context, SPIRAS_Global);
     auto loadPtr = m_builder->CreateIntToPtr(gpuAddr, gpuAddrAsPtrTy);
-
     auto loadTy = FixedVectorType::get(Type::getInt32Ty(*m_context), 2);
-    auto loadValue = m_builder->CreateLoad(loadTy, loadPtr);
+
+    Value *loadValue = nullptr;
+
+    if (m_context->getPipelineContext()->getPipelineOptions()->extendedRobustness.nullDescriptor) {
+      // We should not load from a null descriptor (if it is allowed).
+      // We do:
+      // .entry:
+      //   ...
+      //   %gpuAddr = ...
+      //   %loadPtr = inttoptr %gpuAddr
+      //   %isDescValid = icmp ne %gpuAddr, 0
+      //   br %isDescValid, label %.loadDescriptor, label %.continue
+      //
+      // .loadDescriptor:
+      //   %AS = load %loadPtr
+      //
+      // .continue:
+      //   %loadVal = phi [ %AS, %.loadDescriptor ], [ 0, %.entry ]
+
+      BasicBlock *loadDescriptorBlock = BasicBlock::Create(*m_context, ".loadDescriptor", func);
+      BasicBlock *continueBlock = BasicBlock::Create(*m_context, ".continue", func);
+
+      auto isDescValid = m_builder->CreateICmpNE(gpuAddr, m_builder->getInt64(0));
+      m_builder->CreateCondBr(isDescValid, loadDescriptorBlock, continueBlock);
+
+      m_builder->SetInsertPoint(loadDescriptorBlock);
+      auto accelerationStructureAddr = m_builder->CreateLoad(loadTy, loadPtr);
+      m_builder->CreateBr(continueBlock);
+
+      m_builder->SetInsertPoint(continueBlock);
+      auto phi = m_builder->CreatePHI(loadTy, 2);
+      phi->addIncoming(accelerationStructureAddr, loadDescriptorBlock);
+      auto zero = m_builder->getInt32(0);
+      phi->addIncoming(ConstantVector::get({zero, zero}), entryBlock);
+      loadValue = phi;
+    } else {
+      loadValue = m_builder->CreateLoad(loadTy, loadPtr);
+    }
 
     sceneAddLow = m_builder->CreateExtractElement(loadValue, uint64_t(0));
     sceneAddHigh = m_builder->CreateExtractElement(loadValue, 1);

--- a/llpc/translator/lib/SPIRV/SPIRVInternal.h
+++ b/llpc/translator/lib/SPIRV/SPIRVInternal.h
@@ -454,18 +454,19 @@ struct ShaderInOutDecorate {
 /// Metadata for shader block.
 union ShaderBlockMetadata {
   struct {
-    unsigned offset : 32;      // Offset (bytes) in block
-    unsigned IsMatrix : 1;     // Whether it is a matrix
-    unsigned IsRowMajor : 1;   // Whether it is a "row_major" qualified matrix
-    unsigned MatrixStride : 6; // Matrix stride, valid for matrix
-    unsigned Restrict : 1;     // Whether "restrict" qualifier is present
-    unsigned Coherent : 1;     // Whether "coherent" qualifier is present
-    unsigned Volatile : 1;     // Whether "volatile" qualifier is present
-    unsigned NonWritable : 1;  // Whether "readonly" qualifier is present
-    unsigned NonReadable : 1;  // Whether "writeonly" qualifier is present
-    unsigned IsPointer : 1;    // Whether it is a pointer
-    unsigned IsStruct : 1;     // Whether it is a structure
-    unsigned Unused : 17;
+    unsigned offset : 32;                 // Offset (bytes) in block
+    unsigned IsMatrix : 1;                // Whether it is a matrix
+    unsigned IsRowMajor : 1;              // Whether it is a "row_major" qualified matrix
+    unsigned MatrixStride : 6;            // Matrix stride, valid for matrix
+    unsigned Restrict : 1;                // Whether "restrict" qualifier is present
+    unsigned Coherent : 1;                // Whether "coherent" qualifier is present
+    unsigned Volatile : 1;                // Whether "volatile" qualifier is present
+    unsigned NonWritable : 1;             // Whether "readonly" qualifier is present
+    unsigned NonReadable : 1;             // Whether "writeonly" qualifier is present
+    unsigned IsPointer : 1;               // Whether it is a pointer
+    unsigned IsStruct : 1;                // Whether it is a structure
+    unsigned IsAccelerationStructure : 1; // Whether it is an acceleration structure
+    unsigned Unused : 16;
   };
   uint64_t U64All;
 };


### PR DESCRIPTION
Previous change for GPURT version 34 is incorrect, it only handles OpLoad of an AS, but there are other use cases such as passing AS as function parameter, or array of AS.

This commit makes the address space of AS pointer to be SPIRAS_Constant(4), and lower the global variable to get.desc.ptr in llpcLowerGlobal.

The SPIRAS_Constant is needed because get.desc.ptr returns pointer with addrspace(4).

Then any load (or GEP->load) of the AS will get its GPUVA correctly.