### PR TITLE
llpc/rt: be less conservative about when indirect mode is needed

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3614,7 +3614,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpTraceRayKHR>(SPIRVValue *
 //
 // @param spvValue : A SPIR-V value.
 template <> Value *SPIRVToLLVM::transValueWithOpcode<OpExecuteCallableKHR>(SPIRVValue *const spvValue) {
-  if (m_execModule != ExecutionModelRayGenerationKHR) {
+  if (m_execModule == ExecutionModelCallableKHR) {
     Llpc::Context *llpcContext = static_cast<Llpc::Context *>(m_context);
     auto *pipelineContext = static_cast<Llpc::RayTracingContext *>(llpcContext->getPipelineContext());
     pipelineContext->setIndirectPipeline();


### PR DESCRIPTION
Callable shaders cannot contain OpTraceRay, so we can't get recursion from a call to a callable shader _unless_ it happens in a callable shader.

Fixes: performance regression in SaschaWillems raytracingcallable
Fixes: 157d91902a71 ("llpc/raytracing: simplify shader linking")