### PR TITLE
Move module linking from before SpirvLower to after

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1835,7 +1835,7 @@ std::unique_ptr<Module> Compiler::createGpurtShaderLibrary(Context *context) {
   bool hwIntersectRay = rtState->bvhResDesc.dataSizeInDwords > 0;
   shaderInfo.options.noContract = !hwIntersectRay;
 
-  auto module = std::make_unique<Module>("gpurt", *context);
+  auto module = std::make_unique<Module>(RtName::TraceRayKHR, *context);
   context->setModuleTargetMachine(module.get());
 
   TimerProfiler timerProfiler(context->getPipelineHashCode(), "LLPC", TimerProfiler::PipelineTimerEnableMask);
@@ -2057,20 +2057,6 @@ Result Compiler::buildRayTracingPipelineElf(Context *context, std::unique_ptr<Mo
                                             std::vector<RayTracingShaderProperty> &shaderProps,
                                             std::vector<bool> &moduleCallsTraceRay, unsigned moduleIndex,
                                             std::unique_ptr<Pipeline> &pipeline, TimerProfiler &timerProfiler) {
-  // Per-shader SPIR-V lowering passes.
-  unsigned passIndex = 0;
-  std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(context->getLgcContext()));
-  lowerPassMgr->setPassIndex(&passIndex);
-  SpirvLower::registerPasses(*lowerPassMgr);
-
-  SpirvLower::addPasses(context, ShaderStageCompute, *lowerPassMgr, timerProfiler.getTimer(TimerLower), true, false,
-                        false);
-  // Run the passes.
-  bool success = runPasses(&*lowerPassMgr, module.get());
-  if (!success) {
-    LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
-    return Result::ErrorInvalidShader;
-  }
 
   if (moduleIndex > 0) {
     auto &shaderProp = shaderProps[moduleIndex - 1];
@@ -2079,24 +2065,37 @@ Result Compiler::buildRayTracingPipelineElf(Context *context, std::unique_ptr<Mo
     strcpy(&shaderProp.name[0], funcName.data());
     shaderProp.shaderId = moduleIndex;
     shaderProp.hasTraceRay = moduleCallsTraceRay[moduleIndex - 1];
-
-    // NOTE: We need to distinguish each pipelines's cache hash from others, so that RGP can capture them correctly.
-    auto options = pipeline->getOptions();
-    uint64_t originalCacheHash = options.hash[1];
-
-    // Re-hash the cache hash with module index.
-    MetroHash64 hasher;
-    MetroHash::Hash hash = {};
-    hasher.Update(originalCacheHash);
-    hasher.Update(moduleIndex);
-    hasher.Finalize(hash.bytes);
-
-    options.hash[1] = MetroHash::compact64(&hash);
-    pipeline->setOptions(options);
   }
 
+  generatePipeline(context, moduleIndex, std::move(module), pipelineElf, pipeline.get(), timerProfiler);
+
+  if (moduleIndex > 0)
+    addRayTracingIndirectPipelineMetadata(&pipelineElf);
+
+  return Result::Success;
+}
+
+// =====================================================================================================================
+// Run lgc passes
+// @param context : Acquired context
+// @param moduleIndex : Module index
+// @param module : The module used to build Elf package
+// @param [out] pipelineElf : Output Elf package
+// @param pipeline : The pipeline object
+// @param timerProfiler : Timer profiler
+Result Compiler::generatePipeline(Context *context, unsigned moduleIndex, std::unique_ptr<Module> module,
+                                  ElfPackage &pipelineElf, Pipeline *pipeline, TimerProfiler &timerProfiler) {
   // Generate pipeline.
   std::unique_ptr<Module> pipelineModule;
+
+  auto options = pipeline->getOptions();
+  MetroHash64 hasher;
+  MetroHash::Hash hash = {};
+  hasher.Update(options.hash[1]);
+  hasher.Update(moduleIndex);
+  hasher.Finalize(hash.bytes);
+  options.hash[1] = MetroHash::compact64(&hash);
+  pipeline->setOptions(options);
 
   pipelineModule.reset(pipeline->irLink(module.release(), context->getPipelineContext()->isUnlinked()
                                                               ? PipelineLink::Unlinked
@@ -2106,8 +2105,7 @@ Result Compiler::buildRayTracingPipelineElf(Context *context, std::unique_ptr<Mo
     return Result::ErrorInvalidShader;
   }
 
-  ElfPackage *elfPackage = &pipelineElf;
-  raw_svector_ostream elfStream(*elfPackage);
+  raw_svector_ostream elfStream(pipelineElf);
 
 #if LLPC_ENABLE_EXCEPTION
   try
@@ -2126,9 +2124,6 @@ Result Compiler::buildRayTracingPipelineElf(Context *context, std::unique_ptr<Mo
     return Result::ErrorInvalidShader;
   }
 #endif
-
-  if (moduleIndex > 0)
-    addRayTracingIndirectPipelineMetadata(elfPackage);
 
   return Result::Success;
 }
@@ -2207,7 +2202,6 @@ void helperThreadBuildRayTracingPipelineElf(IHelperThreadProvider *helperThreadP
       helperThreadProvider->TaskCompleted();
       continue;
     }
-
     auto result = helperThreadPayload->compiler->buildRayTracingPipelineElf(
         context, std::move(module), helperThreadPayload->pipelineElfs[moduleIndex], helperThreadPayload->shaderProps,
         helperThreadPayload->moduleCallsTraceRay, moduleIndex, pipeline, timerProfiler);
@@ -2295,8 +2289,6 @@ Result Compiler::buildRayTracingPipelineInternal(RayTracingContext &rtContext,
   }
 
   for (unsigned shaderIndex = 0; shaderIndex < shaderInfo.size(); ++shaderIndex) {
-    ShaderStage entryStage = shaderInfo[shaderIndex]->entryStage;
-
     std::unique_ptr<lgc::PassManager> lowerPassMgr(lgc::PassManager::Create(builderContext));
     lowerPassMgr->setPassIndex(&passIndex);
     SpirvLower::registerPasses(*lowerPassMgr);
@@ -2307,12 +2299,9 @@ Result Compiler::buildRayTracingPipelineInternal(RayTracingContext &rtContext,
     // Any ray tracing shader may access shader record buffer in non-entry function, we will replace all Global SRB to a
     // combination of instructions at the beginning of entry function in SpirvLowerRayTracing pass, so we need to inline
     // all functions so that SRB is accessible throughout the shader.
-    if (entryStage != ShaderStageCompute) {
-      // Lower SPIR-V CFG merges before inlining -- don't run in the (empty) entry point module
-      lowerPassMgr->addPass(SpirvLowerCfgMerges());
-      lowerPassMgr->addPass(AlwaysInlinerPass());
-    } else
-      lowerPassMgr->addPass(SpirvProcessGpuRtLibrary());
+    // Lower SPIR-V CFG merges before inlining -- don't run in the (empty) entry point module
+    lowerPassMgr->addPass(SpirvLowerCfgMerges());
+    lowerPassMgr->addPass(AlwaysInlinerPass());
     lowerPassMgr->addPass(SpirvLowerRayTracing());
 
     // Stop timer for translate.
@@ -2326,7 +2315,7 @@ Result Compiler::buildRayTracingPipelineInternal(RayTracingContext &rtContext,
     }
   }
 
-  // Step 2: Link modules.
+  // Step 2: Link rayquery modules
   std::vector<std::unique_ptr<Module>> newModules;
   // Record which module calls TraceRay(), except the first one (For indirect mode, it is the entry function which will
   // never call TraceRay(). For inlined mode, we don't need to care).
@@ -2342,53 +2331,65 @@ Result Compiler::buildRayTracingPipelineInternal(RayTracingContext &rtContext,
   // Vulkan driver's shader group handle construction logic assume that if any shader identifier uses a VA mapping, then
   // all of them do.
   auto indirectStageMask = rtContext.getIndirectStageMask() & ShaderStageAllRayTracingBit;
-
   assert(indirectStageMask == 0 || indirectStageMask == ShaderStageAllRayTracingBit);
 
-  std::optional<Linker> linker;
-  {
-    std::unique_ptr<Module> entry = std::move(modules.back());
-    modules.pop_back();
-    shaderInfo = shaderInfo.drop_back();
+  std::unique_ptr<Module> entry = std::move(modules.back());
+  modules.pop_back();
+  shaderInfo = shaderInfo.drop_back();
 
-    if (indirectStageMask == 0)
-      linker.emplace(*entry);
-
-    setShaderStageToModule(entry.get(), ShaderStageCompute);
-    newModules.push_back(std::move(entry));
-  }
+  setShaderStageToModule(entry.get(), ShaderStageCompute);
+  newModules.push_back(std::move(entry));
 
   for (unsigned shaderIndex = 0; shaderIndex < pipelineInfo->shaderCount; ++shaderIndex) {
     const auto *shaderInfoEntry = shaderInfo[shaderIndex];
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(shaderInfoEntry->pModuleData);
     auto shaderModule = std::move(modules[shaderIndex]);
 
-    if (linker) {
-      if (linker->linkInModule(std::move(shaderModule)))
+    if (moduleData->usage.enableRayQuery) {
+      Linker linker(*shaderModule);
+      if (linker.linkInModule(CloneModule(*gpurtShaderLibrary)))
         return Result::ErrorInvalidShader;
-    } else {
-      if (moduleData->usage.enableRayQuery) {
-        Linker linker(*shaderModule);
-        if (linker.linkInModule(CloneModule(*gpurtShaderLibrary)))
-          return Result::ErrorInvalidShader;
-      }
-
-      newModules.push_back(std::move(shaderModule));
-      moduleCallsTraceRay.push_back(moduleData->usage.hasTraceRay);
     }
+
+    newModules.push_back(std::move(shaderModule));
+    moduleCallsTraceRay.push_back(moduleData->usage.hasTraceRay);
   }
 
   if (gpurtShaderLibrary) {
-    if (linker) {
-      if (linker->linkInModule(std::move(gpurtShaderLibrary)))
-        return Result::ErrorInvalidShader;
-    } else {
-      newModules.push_back(std::move(gpurtShaderLibrary));
-      moduleCallsTraceRay.push_back(false);
-    }
+    newModules.push_back(std::move(gpurtShaderLibrary));
+    moduleCallsTraceRay.push_back(false);
   }
 
   assert(moduleCallsTraceRay.size() == (newModules.size() - 1));
+
+  for (auto &module : newModules) {
+    std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(builderContext));
+    SpirvLower::registerPasses(*passMgr);
+    SpirvLower::addPasses(mainContext, ShaderStageCompute, *passMgr, timerProfiler.getTimer(TimerLower), true, false,
+                          false);
+    bool success = runPasses(&*passMgr, module.get());
+    if (!success) {
+      LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
+      return Result::ErrorInvalidShader;
+    }
+  }
+
+  if (indirectStageMask == 0) {
+    auto &mainModule = newModules[0];
+    Linker linker(*mainModule);
+    for (unsigned i = 1; i < newModules.size(); ++i) {
+      linker.linkInModule(std::move(newModules[i]));
+    }
+    std::unique_ptr<lgc::PassManager> passMgr(lgc::PassManager::Create(builderContext));
+    passMgr->addPass(AlwaysInlinerPass());
+    bool success = runPasses(&*passMgr, mainModule.get());
+    if (!success) {
+      LLPC_ERRS("Failed to translate SPIR-V or run per-shader passes\n");
+      return Result::ErrorInvalidShader;
+    }
+    clearNonEntryFunctions(mainModule.get(), "main");
+    newModules.erase(newModules.begin() + 1, newModules.end());
+  }
 
   rtContext.setLinked(true);
   pipelineElfs.resize(newModules.size());
@@ -2511,7 +2512,6 @@ void Compiler::addRayTracingIndirectPipelineMetadata(ElfPackage *pipelineElf) {
   writer.writeToBuffer(pipelineElf);
 }
 #endif
-
 // =====================================================================================================================
 // Builds hash code from compilation-options
 //

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -205,6 +205,8 @@ private:
                                      Vkgc::UnlinkedShaderStage stage, ElfPackage &elfPackage,
                                      llvm::MutableArrayRef<CacheAccessInfo> stageCacheAccesses);
   void dumpCompilerOptions(void *pipelineDumpFile);
+  Result generatePipeline(Context *context, unsigned moduleIndex, std::unique_ptr<llvm::Module> module,
+                          ElfPackage &pipelineElf, lgc::Pipeline *pipeline, TimerProfiler &timerProfiler);
 
   std::vector<std::string> m_options;           // Compilation options
   MetroHash::Hash m_optionHash;                 // Hash code of compilation options

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -56,7 +56,7 @@ extern const char *MetaNameSpirvOp;
 } // namespace SPIRV
 
 namespace RtName {
-const char *TraceRayKHR = "TraceRayKHR";
+const char *TraceRayKHR = "_cs_";
 const char *TraceRaySetTraceParams = "TraceRaySetTraceParams";
 const char *ShaderTable = "ShaderTable";
 static const char *HitAttribute = "HitAttribute";
@@ -1566,7 +1566,7 @@ void SpirvLowerRayTracing::createTraceRay() {
   bool indirect = rayTracingContext->getIndirectStageMask() & ShaderStageComputeBit;
 
   auto funcTy = getTraceRayFuncTy();
-  StringRef funcName = indirect ? m_module->getName() : RtName::TraceRayKHR;
+  StringRef funcName = RtName::TraceRayKHR;
   Function *func = Function::Create(funcTy, GlobalValue::ExternalLinkage, funcName, m_module);
   func->setCallingConv(CallingConv::SPIR_FUNC);
   if (!indirect)

--- a/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
@@ -79,7 +79,6 @@ bool SpirvLowerRayTracingBuiltIn::runImpl(Module &module) {
   m_context = static_cast<Context *>(&m_module->getContext());
   m_builder = m_context->getBuilder();
   m_shaderStage = getShaderStageFromModule(m_module);
-  auto rayTracingContext = static_cast<RayTracingContext *>(m_context->getPipelineContext());
   const auto *rtState = m_context->getPipelineContext()->getRayTracingState();
 
   lgc::ComputeShaderMode mode = {};
@@ -91,9 +90,7 @@ bool SpirvLowerRayTracingBuiltIn::runImpl(Module &module) {
   for (auto funcIt = module.begin(), funcEnd = module.end(); funcIt != funcEnd;) {
     Function *func = &*funcIt++;
     if (func->getLinkage() == GlobalValue::ExternalLinkage && !func->empty()) {
-      StringRef entryName =
-          rayTracingContext->getIndirectStageMask() == 0 ? rayTracingContext->getEntryName() : module.getName();
-      if (func->getName().startswith(entryName))
+      if (func->getName().startswith(module.getName()))
         m_entryPoint = func;
       else {
         func->dropAllReferences();

--- a/llpc/lower/llpcSpirvLowerUtil.cpp
+++ b/llpc/lower/llpcSpirvLowerUtil.cpp
@@ -101,4 +101,20 @@ BasicBlock *clearBlock(Function *func) {
   return &entryBlock;
 }
 
+// =====================================================================================================================
+// Clear non entry external functions
+// @param module : LLVM module to remove functions.
+// @param entryName : Entry Function Name
+void clearNonEntryFunctions(Module *module, StringRef entryName) {
+  for (auto funcIt = module->begin(), funcEnd = module->end(); funcIt != funcEnd;) {
+    Function *func = &*funcIt++;
+    if (func->getLinkage() == GlobalValue::ExternalLinkage && !func->empty()) {
+      if (!func->getName().startswith(entryName)) {
+        func->dropAllReferences();
+        func->eraseFromParent();
+      }
+    }
+  }
+}
+
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerUtil.h
+++ b/llpc/lower/llpcSpirvLowerUtil.h
@@ -37,6 +37,7 @@ namespace llvm {
 class Function;
 class Module;
 class BasicBlock;
+class StringRef;
 
 } // namespace llvm
 
@@ -62,5 +63,7 @@ llvm::Function *getEntryPoint(llvm::Module *module);
 
 // Clears the empty block
 llvm::BasicBlock *clearBlock(llvm::Function *func);
+// Clear non entry external functions
+void clearNonEntryFunctions(llvm::Module *module, llvm::StringRef entryName);
 
 } // namespace Llpc


### PR DESCRIPTION
This module linking position movement is required for the second stage of refactoring, when LowerRayTracing is at the end of the SpirvLower passes aka
AlwaysInlinerPass();
SpirvLowerGlobal();
LowerRayTracing();

when all the functions are inlined from combinded/linking modules if module linking before spirvLower. and
there is no functions left to lower.

Without this step, the first stage of refactoring will collect and analyse the entry functions of combined modules. however this part would be deprecated by the time of second stage refactoring.

so i think this is better to do it now.
