### PR TITLE
Do not explicitly enable the LLVM atomic optimizer pass

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -148,7 +148,12 @@ void LgcContext::initialize() {
   setOptionDefault("enable-phi-of-ops", "0");
   setOptionDefault("simplifycfg-sink-common", "0");
   setOptionDefault("amdgpu-vgpr-index-mode", "1"); // force VGPR indexing on GFX8
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 464446
+  // Old version of the code
   setOptionDefault("amdgpu-atomic-optimizations", "1");
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+#endif
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 463788
   // Old version of the code
 #else


### PR DESCRIPTION
See: https://reviews.llvm.org/D152649
The LLVM AMDGPU atomic optimizer pass is now enabled by default, and the existing option to enable or disable it will be removed in favour of setting the strategy to "None".