### PR TITLE
Use new ballot intrinsics to replace old ballot implementation

### DIFF
--- a/lgc/builder/SubgroupBuilder.cpp
+++ b/lgc/builder/SubgroupBuilder.cpp
@@ -1457,7 +1457,7 @@ Value *BuilderImpl::createGroupBallot(Value *const value) {
 
   // If we have a 32-bit subgroup size, we need to turn the 32-bit ballot result into a 64-bit result.
   if (waveSize <= 32)
-    result = CreateZExt(result, getInt64Ty(), "");
+    result = CreateZExt(result, getInt64Ty());
 
   return result;
 }

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -5972,20 +5972,7 @@ Value *NggPrimShader::ballot(Value *value) {
   const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageGeometry);
   assert(waveSize == 32 || waveSize == 64);
 
-  value = m_builder.CreateSelect(value, m_builder.getInt32(1), m_builder.getInt32(0));
-
-  auto inlineAsmTy = FunctionType::get(m_builder.getInt32Ty(), m_builder.getInt32Ty(), false);
-  auto inlineAsm = InlineAsm::get(inlineAsmTy, "; %1", "=v,0", true);
-  value = m_builder.CreateCall(inlineAsm, value);
-
-  static const unsigned PredicateNE = 33; // 33 = predicate NE
-  Value *result = m_builder.CreateIntrinsic(Intrinsic::amdgcn_icmp,
-                                            {
-                                                m_builder.getIntNTy(waveSize), // Return type
-                                                m_builder.getInt32Ty()         // Argument type
-                                            },
-                                            {value, m_builder.getInt32(0), m_builder.getInt32(PredicateNE)});
-
+  Value *result = m_builder.CreateIntrinsic(Intrinsic::amdgcn_ballot, m_builder.getIntNTy(waveSize), value);
   if (waveSize == 32)
     result = m_builder.CreateZExt(result, m_builder.getInt64Ty());
 


### PR DESCRIPTION
This will generate better code to avoid v_cmp_ne.