### PR TITLE
Remove per-shader table

### DIFF
--- a/lgc/include/lgc/patch/SystemValues.h
+++ b/lgc/include/lgc/patch/SystemValues.h
@@ -101,9 +101,6 @@ public:
   // Load descriptor from driver table
   llvm::Instruction *loadDescFromDriverTable(unsigned tableOffset, BuilderBase &builder);
 
-  // Get internal per shader table pointer as pointer to i8.
-  llvm::Value *getInternalPerShaderTablePtr();
-
   // Get stream-out buffer descriptor
   llvm::Value *getStreamOutBufDesc(unsigned xfbBuffer);
 
@@ -149,7 +146,6 @@ private:
   llvm::SmallVector<llvm::Value *, 8> m_shadowDescTablePtrs; // Shadow descriptor table pointers
   llvm::Instruction *m_internalGlobalTablePtr = nullptr;     // Internal global table pointer
   llvm::Value *m_meshPipeStatsBufPtr = nullptr;              // Mesh pipeline statistics buffer pointer
-  llvm::Value *m_internalPerShaderTablePtr = nullptr;        // Internal per shader table pointer
   llvm::Instruction *m_streamOutTablePtr = nullptr;          // Stream-out buffer table pointer
   llvm::Instruction *m_pc = nullptr;                         // Program counter as <2 x i32>
 };

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -133,6 +133,5 @@ static const unsigned MaxRayQueryLdsStackEntries = 16; // Max number of ray quer
 
 // Internal resource table's virtual descriptor sets
 static const unsigned InternalResourceTable = 0x10000000;
-static const unsigned InternalPerShaderTable = 0x10000001;
 
 } // namespace lgc

--- a/lgc/include/lgc/state/IntrinsDefs.h
+++ b/lgc/include/lgc/state/IntrinsDefs.h
@@ -65,19 +65,19 @@ static const unsigned GsEmitCutStreamIdMask = 0x300; // Mask of STREAM_ID of the
 static const unsigned GetRealTime = 0x83; // [7] = 1, [6:0] = 3
 
 // Count of user SGPRs used in copy shader
-static const unsigned CopyShaderUserSgprCount = 4;
+static const unsigned CopyShaderUserSgprCount = 3;
 
 // User SGPR index for the stream info in copy shader
-static const unsigned CopyShaderUserSgprIdxStreamInfo = 4;
+static const unsigned CopyShaderUserSgprIdxStreamInfo = 3;
 
 // User SGPR index for the stream-out write index in copy shader
-static const unsigned CopyShaderUserSgprIdxWriteIndex = 5;
+static const unsigned CopyShaderUserSgprIdxWriteIndex = 4;
 
 // User SGPR index for the stream offsets in copy shader
-static const unsigned CopyShaderUserSgprIdxStreamOffset = 6;
+static const unsigned CopyShaderUserSgprIdxStreamOffset = 5;
 
 // Start offset of currently-processed vertex in GS-VS ring buffer
-static const unsigned CopyShaderUserSgprIdxVertexOffset = 10;
+static const unsigned CopyShaderUserSgprIdxVertexOffset = 9;
 
 // Enumerates address spaces valid for AMD GPU (similar to LLVM header AMDGPU.h)
 enum AddrSpace {

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -162,7 +162,6 @@ struct ResourceUsage {
   std::unordered_set<uint64_t> descPairs;  // Pairs of descriptor set/binding
   bool resourceWrite = false;              // Whether shader does resource-write operations (UAV)
   bool resourceRead = false;               // Whether shader does resource-read operations (UAV)
-  bool perShaderTable = false;             // Whether per shader stage table is used
   unsigned numSgprsAvailable = UINT32_MAX; // Number of available SGPRs
   unsigned numVgprsAvailable = UINT32_MAX; // Number of available VGPRs
   bool useImages = false;                  // Whether images are used

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -110,7 +110,6 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
     //
     //   void copyShader(
     //     i32 inreg globalTable,
-    //     i32 inreg perShaderTable,
     //     i32 inreg streamOutTable (GFX6-GFX8) / esGsLdsSize (GFX9+),
     //     i32 inreg esGsLdsSize (GFX6-GFX8) / streamOutTable (GFX9+),
     //     i32 inreg streamOutInfo,
@@ -121,10 +120,9 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
     //     i32 inreg streamOutOffset3,
     //     i32 vertexOffset)
     //
-    argTys = {int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty};
-    argInReg = {true, true, true, true, true, true, true, true, true, true, false};
+    argTys = {int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty, int32Ty};
+    argInReg = {true, true, true, true, true, true, true, true, true, false};
     argNames = {"globalTable",
-                "perShaderTable",
                 gfxIp.major <= 8 ? "streamOutTable" : "esGsLdsSize",
                 gfxIp.major <= 8 ? "esGsLdsSize" : "streamOutTable",
                 "streamOutInfo",

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -961,7 +961,6 @@ void PatchEntryPointMutate::setFuncAttrs(Function *entryPoint) {
 // * The "user data" SGPRs, up to 32 (GFX9+ non-compute shader) or 16 (compute shader or <=GFX8). Many of the values
 //   here are pointers, but are passed as a single 32-bit register and then expanded to 64-bit in the shader code:
 //   - The "global information table", containing various descriptors such as the inter-shader rings
-//   - The "per-shader table", which is added here but appears to be unused
 //   - The streamout table if needed
 //   - Nodes from the root user data layout, including pointers to descriptor sets.
 //   - Various other system values set up by PAL, such as the vertex buffer table and the vertex base index
@@ -989,7 +988,7 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
   entryArgIdxs.initialized = true;
 
   // First we collect the user data args in two vectors:
-  // - userDataArgs: global table, per-shader table and streamout table, followed by the nodes from the root user
+  // - userDataArgs: global table and streamout table, followed by the nodes from the root user
   //   data layout (excluding vertex buffer and streamout tables). Some of them may need to be spilled due to
   //   running out of entry SGPRs
   // - specialUserDataArgs: special values that go at the end, such as ViewId.
@@ -1005,11 +1004,6 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
 
   // Global internal table
   userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "globalTable", UserDataMapping::GlobalTable));
-
-  // Per-shader table
-  // TODO: We need add per shader table per real usage after switch to PAL new interface.
-  // if (pResUsage->perShaderTable)
-  userDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "perShaderTable"));
 
   addSpecialUserDataArgs(userDataArgs, specialUserDataArgs, builder);
 

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -47,8 +47,6 @@ const char *ShaderInputs::getSpecialUserDataName(UserDataMapping kind) {
   switch (kind) {
   case UserDataMapping::GlobalTable:
     return "GlobalTable";
-  case UserDataMapping::PerShaderTable:
-    return "PerShaderTable";
   case UserDataMapping::SpillTable:
     return "SpillTable";
   case UserDataMapping::BaseVertex:

--- a/lgc/patch/SystemValues.cpp
+++ b/lgc/patch/SystemValues.cpp
@@ -352,22 +352,6 @@ Instruction *ShaderSystemValues::getInternalGlobalTablePtr() {
 }
 
 // =====================================================================================================================
-// Get internal per shader table pointer as pointer to i8.
-Value *ShaderSystemValues::getInternalPerShaderTablePtr() {
-  if (!m_internalPerShaderTablePtr) {
-    auto ptrTy = Type::getInt8Ty(*m_context)->getPointerTo(ADDR_SPACE_CONST);
-    // Per shader table is always the second function argument (separate shader) or the ninth function argument (merged
-    // shader). And mesh shader is actually mapped to ES-GS merged shader.
-    m_internalPerShaderTablePtr =
-        makePointer(getFunctionArgument(m_entryPoint,
-                                        getShaderStage(m_entryPoint) == ShaderStageMesh ? NumSpecialSgprInputs + 1 : 1,
-                                        "perShaderTable"),
-                    ptrTy, InvalidValue);
-  }
-  return m_internalPerShaderTablePtr;
-}
-
-// =====================================================================================================================
 // Get the mesh pipeline statistics buffer pointer as pointer to i8
 Value *ShaderSystemValues::getMeshPipeStatsBufPtr() {
   assert(m_pipelineState->getTargetInfo().getGfxIpVersion() >= GfxIpVersion({10, 3})); // Must be GFX10.3+

--- a/llpc/test/shaderdb/general/PipelineCs_LdsSpillLimitDwordsOption.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_LdsSpillLimitDwordsOption.pipe
@@ -5,7 +5,7 @@
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: "amdgpu-lds-spill-limit-dwords"="1024"
-; SHADERTEST: "amdgpu-work-group-info-arg-no"="3"
+; SHADERTEST: "amdgpu-work-group-info-arg-no"="2"
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/general/PipelineCs_TestMultiEntryPoint_lit.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_TestMultiEntryPoint_lit.pipe
@@ -6,7 +6,7 @@
 ; SHADERTEST: !llpc.compute.mode = !{![[COMPUTEMODE:[0-9]+]]}
 ; SHADERTEST: ![[COMPUTEMODE]] = !{i32 1, i32 1, i32 1}
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg %globalTable, i32 inreg %perShaderTable, i32 inreg %descTable0, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId)
+; SHADERTEST: define {{.*}} void @_amdgpu_cs_main(i32 inreg %globalTable, i32 inreg %descTable0, <3 x i32> inreg %WorkgroupId, i32 inreg %MultiDispatchInfo, <3 x i32> %LocalInvocationId)
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/general/PipelineVsFs_MultiTableDescSet.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_MultiTableDescSet.pipe
@@ -13,20 +13,21 @@
 ; SHADERTEST: s_mov_b32
 ; SHADERTEST: s_mov_b32
 ; SHADERTEST: s_load_dwordx4
+; SHADERTEST: s_mov_b32 s[[TO_ADDR_LO:[0-9]*]], s[[table0:[0-9]*]]
 ; SHADERTEST: s_mov_b32 s[[TO_ADDR_HI:[0-9]*]], s[[VS_PC_HI]]
-; SHADERTEST: s_load_dwordx4 s{{\[}}[[T0_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[table0:[0-9]*]]:[[TO_ADDR_HI]]], 0x0
+; SHADERTEST: s_load_dwordx4 s{{\[}}[[T0_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[TO_ADDR_LO]]:[[TO_ADDR_HI]]], 0x0
 ; SHADERTEST: s_buffer_load_dwordx8 s[0:7], s{{\[}}[[T0_DESC]]:{{[0-9]*}}], 0x0
 ; SHADERTEST: s_buffer_load_dwordx8 s[8:15], s{{\[}}[[T0_DESC]]:{{[0-9]*}}], 0x20
 ; Now check that the image sample in the pixel shader uses the correct
 ; descriptors.  The high half of the descriptor load should come from the PC.
 ; The low half should come from the user data node at offset 1 and 2.
 ; SHADERTEST-LABEL: _amdgpu_ps_main:
-; SHADERTEST: s_getpc_b64 s{{\[}}[[VS_PC_LO:[0-9]*]]:[[VS_PC_HI:[0-9]*]]]
-; SHADERTEST: s_mov_b32 s[[T2_ADDR_LO:[0-9]*]], s[[table2:[0-9]*]]
-; SHADERTEST: s_mov_b32 s[[T2_ADDR_HI:[0-9]*]], s[[VS_PC_HI]]
-; SHADERTEST: s_mov_b32 s[[T1_ADDR_HI:[0-9]*]], s[[VS_PC_HI]]
-; SHADERTEST: s_load_dwordx8 s{{\[}}[[T1_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[table1:[0-9]*]]:[[T1_ADDR_HI]]], 0x0
-; SHADERTEST: s_load_dwordx4 s{{\[}}[[T2_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T2_ADDR_LO]]:[[T2_ADDR_HI]]], 0x0
+; SHADERTEST: s_getpc_b64 s{{\[}}[[PS_PC_LO:[0-9]*]]:[[PS_PC_HI:[0-9]*]]]
+; SHADERTEST: s_mov_b32 s[[T1_ADDR_LO:[0-9]*]], s[[table1:[0-9]*]]
+; SHADERTEST: s_mov_b32 s[[T2_ADDR_HI:[0-9]*]], s[[PS_PC_HI]]
+; SHADERTEST: s_mov_b32 s[[T1_ADDR_HI:[0-9]*]], s[[PS_PC_HI]]
+; SHADERTEST: s_load_dwordx8 s{{\[}}[[T1_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[T1_ADDR_LO]]:[[T1_ADDR_HI]]], 0x0
+; SHADERTEST: s_load_dwordx4 s{{\[}}[[T2_DESC:[0-9]*]]:{{[0-9]*}}], s{{\[}}[[table2:[0-9]*]]:[[T2_ADDR_HI]]], 0x0
 ; SHADERTEST: image_sample v[{{[0-9]*:[0-9]*}}], v[{{[0-9]*:[0-9]*}}], s{{\[}}[[T1_DESC]]:{{[0-9]*}}], s{{\[}}[[T2_DESC]]:{{[0-9]*}}]
 ; SHADERTEST-LABEL: PalMetadata
 ; SHADERTEST-LABEL: .registers:

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_line_list.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_line_list.pipe
@@ -3,7 +3,7 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 // barycentric coordinate: (1 - i - j, i + j, 0)
-; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,
+; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable,
 ; SHADERTEST: %[[jCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 1
 ; SHADERTEST: %[[iCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 0
 ; SHADERTEST: %[[subICoord:[0-9]*]] = fsub float 1.000000e+00, %[[iCoord]]

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
@@ -143,7 +143,7 @@ attribute[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
 attribute[1].offset = 16
 
 ; SHADERTEST-LABEL: amdgpu_ps_main:
-; SHADERTEST:         s_mov_b32 m0, s2
+; SHADERTEST:         s_mov_b32 m0, s1
 ; SHADERTEST-NEXT:    v_interp_mov_f32_e32 v3, p0, attr0.x
 ; SHADERTEST-NEXT:    v_sub_f32_e32 v2, 1.0, v0
 ; SHADERTEST-NEXT:    v_and_b32_e32 v3, 1, v3

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_list.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_list.pipe
@@ -3,7 +3,7 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 // barycentric coordinate: (i ,j , 1 - i - j)
-; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable, i32 inreg %perShaderTable,
+; SHADERTEST-LABEL: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %globalTable,
 ; SHADERTEST: %[[jCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 1
 ; SHADERTEST: %[[iCoord:[^,]*]] = extractelement <2 x float> %PerspInterpCenter, i64 0
 ; SHADERTEST: %[[subICoord:[0-9]*]] = fsub float 1.000000e+00, %[[iCoord]]

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
@@ -13,7 +13,7 @@
 ; SHADERTEST: call void @lgc.output.export.generic.i32.i32.v4f32(i32 0, i32 0, <4 x float> [[Value]])
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %{{[^,]*}}, i32 inreg %descTable1,
+; SHADERTEST: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %descTable1,
 ; SHADERTEST: [[Addr0:%[0-9]*]] = zext i32 %descTable1 to i64
 ; SHADERTEST: [[Addr1:%[0-9]*]] = or i64 %{{[0-9]*}}, [[Addr0]]
 ; SHADERTEST: [[Addr2:%[0-9]*]] = inttoptr i64 [[Addr1]] to ptr addrspace(4)

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
@@ -36,7 +36,7 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:       .ps:
 ; CHECK-NEXT:         .entry_point:    _amdgpu_ps_main
 ; CHECK-NEXT:         .scratch_memory_size: 0
-; CHECK-NEXT:         .sgpr_count:     0x3
+; CHECK-NEXT:         .sgpr_count:     0x2
 ; CHECK-NEXT:         .sgpr_limit:     0x6a
 ; CHECK-NEXT:         .vgpr_count:     0x2
 ; CHECK-NEXT:         .vgpr_limit:     0x100
@@ -44,7 +44,7 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:       .vs:
 ; CHECK-NEXT:         .entry_point:    _amdgpu_vs_main
 ; CHECK-NEXT:         .scratch_memory_size: 0
-; CHECK-NEXT:         .sgpr_count:     0x4
+; CHECK-NEXT:         .sgpr_count:     0x3
 ; CHECK-NEXT:         .sgpr_limit:     0x6a
 ; CHECK-NEXT:         .vgpr_count:     0x4
 ; CHECK-NEXT:         .vgpr_limit:     0x100
@@ -56,14 +56,14 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:       0x2c01:          0
 ; CHECK-NEXT:       0x2c06 (SPI_SHADER_PGM_CHKSUM_PS): {{.*}}
 ; CHECK-NEXT:       0x2c0a (SPI_SHADER_PGM_RSRC1_PS): 0x22c0000
-; CHECK-NEXT:       0x2c0b (SPI_SHADER_PGM_RSRC2_PS): 0x4
+; CHECK-NEXT:       0x2c0b (SPI_SHADER_PGM_RSRC2_PS): 0x2
 ; CHECK-NEXT:       0x2c0c (SPI_SHADER_USER_DATA_PS_0): 0x10000000
 ; CHECK-NEXT:       0x2c45 (SPI_SHADER_PGM_CHKSUM_VS): {{.*}}
 ; CHECK-NEXT:       0x2c4a (SPI_SHADER_PGM_RSRC1_VS): 0x82c0000
-; CHECK-NEXT:       0x2c4b (SPI_SHADER_PGM_RSRC2_VS): 0x8
+; CHECK-NEXT:       0x2c4b (SPI_SHADER_PGM_RSRC2_VS): 0x6
 ; CHECK-NEXT:       0x2c4c (SPI_SHADER_USER_DATA_VS_0): 0x10000000
-; CHECK-NEXT:       0x2c4e (SPI_SHADER_USER_DATA_VS_2): 0x10000003
-; CHECK-NEXT:       0x2c4f (SPI_SHADER_USER_DATA_VS_3): 0x10000004
+; CHECK-NEXT:       0x2c4d (SPI_SHADER_USER_DATA_VS_1): 0x10000003
+; CHECK-NEXT:       0x2c4e (SPI_SHADER_USER_DATA_VS_2): 0x10000004
 ; CHECK-NEXT:       0xa08f (CB_SHADER_MASK): 0
 ; CHECK-NEXT:       0xa191 (SPI_PS_INPUT_CNTL_0): 0
 ; CHECK-NEXT:       0xa1b1 (SPI_VS_OUT_CONFIG): 0x80

--- a/llpc/test/shaderdb/general/TestResourceLayout_Buffer.frag
+++ b/llpc/test/shaderdb/general/TestResourceLayout_Buffer.frag
@@ -8,7 +8,7 @@
 
 // SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 // %descTable2 is for uniform buf, it should be %descTable1 in compact mode.
-// SHADERTEST: define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %{{[^,]*}}, i32 inreg %descTable2,
+// SHADERTEST: define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %descTable2,
 // SHADERTEST: AMDLLPC SUCCESS
 // END_SHADERTEST
 

--- a/llpc/test/shaderdb/general/TestResourceLayout_Pushconst.frag
+++ b/llpc/test/shaderdb/general/TestResourceLayout_Pushconst.frag
@@ -13,7 +13,7 @@
 // SHADERTEST: call void @lgc.output.export.generic.i32.i32.v4f32(i32 0, i32 0, <4 x float> [[Value]])
 
 // SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-// SHADERTEST: define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %{{[^,]*}}, i32 inreg %descTable0,
+// SHADERTEST: define dllexport amdgpu_ps { <4 x float> } @_amdgpu_ps_main(i32 inreg %{{[^,]*}}, i32 inreg %descTable0,
 // SHADERTEST: [[Addr0:%[0-9]*]] = zext i32 %descTable0 to i64
 // SHADERTEST: [[Addr1:%[0-9]*]] = or i64 %{{[0-9]*}}, [[Addr0]]
 // SHADERTEST: [[Addr2:%[0-9]*]] = inttoptr i64 [[Addr1]] to ptr addrspace(4)

--- a/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
+++ b/llpc/test/shaderdb/gfx9/PipelineVsFs_TestFetchSingleInput.pipe
@@ -5,13 +5,13 @@
 ; Skip to the patching results for the fetch shader
 ; SHADERTEST-LABEL: LLPC pipeline patching results
 ; Check the inputs to the vertex shader.  This should be all of the regular inputs.  There is one vertex attribute being passed in: The vector at the end.
-; SHADERTEST: define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %globalTable, i32 inreg %perShaderTable, i32 inreg %descTable0, i32 inreg %vertexBufferTable, i32 inreg %baseVertex, i32 inreg %baseInstance, i32 inreg %spillTable, i32 %VertexId, i32 %RelVertexId, i32 %PrimitiveId, i32 %InstanceId, <4 x float> %vertex0.0)
+; SHADERTEST: define dllexport amdgpu_vs void @_amdgpu_vs_main_fetchless(i32 inreg %globalTable, i32 inreg %descTable0, i32 inreg %vertexBufferTable, i32 inreg %baseVertex, i32 inreg %baseInstance, i32 inreg %spillTable, i32 %VertexId, i32 %RelVertexId, i32 %PrimitiveId, i32 %InstanceId, <4 x float> %vertex0.0)
 ; SHADERTEST-LABEL: LGC glue shader results
 ; Check the inputs to the fetch shader.  This should match the vertex shader except:
 ; - there are extra inreg inputs because its determination of how many SGPR inputs
 ;   are conservative;
 ; - there is no VGPR input for the vertex input that the fetch shader generates.
-; SHADERTEST: define amdgpu_vs { i32,{{.*}}, i32, float, float, float, float, <4 x float> } @_amdgpu_vs_main(i32 inreg %0, i32 inreg %1, i32 inreg %2, i32 inreg %VertexBufferTable, i32 inreg %BaseVertex, i32 inreg %BaseInstance,{{.*}}, i32 inreg %{{.*}}, float %VertexId, float %{{.*}}, float %{{.*}}, float %InstanceId)
+; SHADERTEST: define amdgpu_vs { i32,{{.*}}, i32, float, float, float, float, <4 x float> } @_amdgpu_vs_main(i32 inreg %0, i32 inreg %1, i32 inreg %VertexBufferTable, i32 inreg %BaseVertex, i32 inreg %BaseInstance, {{.*}}, i32 inreg %{{.*}}, float %VertexId, float %{{.*}}, float %{{.*}}, float %InstanceId)
 ; Check that the attribute is loaded.
 ; SHADERTEST:  [[f0:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 0, i32 0, i32 immarg 116, i32 immarg 0)
 ; SHADERTEST:  [[f1:%.*]] = call i32 @llvm.amdgcn.struct.tbuffer.load.i32(<4 x i32> [[addr:%[0-9]*]], i32 %VertexIndex, i32 4, i32 0, i32 immarg 116, i32 immarg 0)

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_16BitInput.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_16BitInput.pipe
@@ -19,7 +19,7 @@
 ; SHADERTEST: [[cast:%[0-9]+]] = bitcast half [[ld]] to i16
 ; SHADERTEST: [[zext:%[0-9]+]] = zext i16 [[cast]] to i32
 ; SHADERTEST: [[result:%[0-9]+]] = bitcast i32 [[zext]] to float
-; SHADERTEST: [[ret:%[0-9]+]] = insertvalue { {{.*}} } {{%[0-9]+}}, float [[result]], 19
+; SHADERTEST: [[ret:%[0-9]+]] = insertvalue { {{.*}} } {{%[0-9]+}}, float [[result]], 18
 ; SHADERTEST: ret { {{.*}} } [[ret]]
 ; SHADERTEST: =====  AMDLLPC SUCCESS  =====
 ; END_SHADERTEST

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultiDwordPushConst.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_MultiDwordPushConst.pipe
@@ -17,13 +17,13 @@
 ; SHADERTEST-LABEL: _amdgpu_ps_main:
 ; SHADERTEST-NEXT: BB0_0
 ; SHADERTEST: v_mov_b32_e32 v0, 0
-; SHADERTEST-NEXT: v_mov_b32_e32 v5, s2
-; SHADERTEST-NEXT: v_mov_b32_e32 v6, s3
+; SHADERTEST-NEXT: v_mov_b32_e32 v5, s1
+; SHADERTEST-NEXT: v_mov_b32_e32 v6, s2
 ; SHADERTEST: image_gather4_lz v[0:4], v[5:6]
 
 ; Check that the PAL metadata will place the correct values in those registers.
-; SHADERTEST: SPI_SHADER_USER_DATA_PS_2                     0x0000000000000003
-; SHADERTEST: SPI_SHADER_USER_DATA_PS_3                     0x0000000000000004
+; SHADERTEST: SPI_SHADER_USER_DATA_PS_1                     0x0000000000000003
+; SHADERTEST: SPI_SHADER_USER_DATA_PS_2                     0x0000000000000004
 
 ; END_SHADERTEST
 [Version]

--- a/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
+++ b/llpc/test/shaderdb/relocatable_shaders/RelocShadowDesc.frag
@@ -14,12 +14,13 @@ void main()
 // BEGIN_SHADERTEST
 /*
 ; RUN: amdllpc -o %t.elf %gfxip %s && llvm-objdump --triple=amdgcn --mcpu=gfx900 -d -r %t.elf | FileCheck -check-prefix=SHADERTEST %s
-; SHADERTEST: s_getpc_b64 s[0:1]
+; SHADERTEST: s_mov_b32 s8, s1
+; SHADERTEST: s_getpc_b64 s[10:11]
 ; SHADERTEST: s_cmp_eq_u32 0, 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowenabled
-; SHADERTEST: s_cselect_b32 s[[addrhi:[0-9]+]], s1, 0
+; SHADERTEST: s_cselect_b32 s[[addrhi:[0-9]+]], s11, 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 $shadowdesctable
-; SHADERTEST: s_mov_b32 s[[addrlo:[0-9]+]], s2
+; SHADERTEST: s_mov_b32 s[[addrlo:[0-9]+]], s8
 ; SHADERTEST: s_mov_b32 [[offset:s[0-9]*]], 0
 ; SHADERTEST-NEXT: R_AMDGPU_ABS32 doff_0_0_f
 ; SHADERTEST: s_load_dwordx8 s[{{[0-9]*:[0-9]*}}], s{{\[}}[[addrlo]]:[[addrhi]]], [[offset]]


### PR DESCRIPTION
Per-shader table occupies the second user data SGPR. However, it is
unused. This SGPR is wasted and sometime cause push constants to use
spill table because of the oversizing of SGPR usage.