### PR TITLE
Refactor the rayquery library stack functions processing

### DIFF
--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -76,12 +76,16 @@ if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/interface/lgc)
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/interface/lgc")
 endif()
 tablegen(LGC interface/lgc/LgcDialect.h.inc -gen-dialect-decls --dialect lgc
-    EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../imported/llvm-dialects/include)
+    EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../imported/llvm-dialects/include
+    EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/interface/lgc
+    )
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/state)
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/state")
 endif()
 tablegen(LGC state/LgcDialect.cpp.inc -gen-dialect-defs --dialect lgc
-    EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../imported/llvm-dialects/include)
+    EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../imported/llvm-dialects/include
+    EXTRA_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/interface/lgc
+    )
 add_public_tablegen_target(LgcDialectTableGen)
 
 add_dependencies(LLVMlgc LgcDialectTableGen)

--- a/lgc/interface/lgc/GpurtDialect.td
+++ b/lgc/interface/lgc/GpurtDialect.td
@@ -1,0 +1,79 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+
+def GpurtGetStackSize : LgcOp<"gpurt.get.stack.size", [Memory<[]>, WillReturn]> {
+  let arguments = (ins);
+  let results = (outs I32:$result);
+  let summary = "return the gpurt stack size in dword";
+  let description = [{
+    The dialect will return total stack size in dword of workgroup
+  }];
+}
+
+def GpurtStackRead : LgcOp<"gpurt.stack.read", [Memory<[(read)]>, WillReturn]> {
+  let arguments = (ins I32:$index);
+  let results = (outs I32:$result);
+  let summary = "read a dword from stack";
+  let description = [{
+    Read a dword from lds/(scratch buffer) stack at index position
+  }];
+}
+
+def GpurtStackWrite : LgcOp<"gpurt.stack.write", [Memory<[(write)]>, WillReturn]> {
+  let arguments = (ins I32:$index, I32:$value);
+  let results = (outs I32:$result);
+  let summary = "write a dword to stack";
+  let description = [{
+    Write a dword to lds/(scratch buffer) stack at index position
+  }];
+}
+
+def GpurtGetStackBase : LgcOp<"gpurt.get.stack.base", [Memory<[]>, WillReturn]> {
+  let arguments = (ins);
+  let results = (outs I32:$result);
+  let summary = "this returns the stack base position in dword";
+}
+
+def GpurtGetStackStride : LgcOp<"gpurt.get.stack.stride", [Memory<[]>, WillReturn]> {
+  let arguments = (ins);
+  let results = (outs I32:$result);
+  let summary = "return the gpurt stack stride in dword";
+}
+
+def GpurtLdsStackInit : LgcOp<"gpurt.lds.stack.init", [Memory<[]>, WillReturn]> {
+  let arguments = (ins);
+  let results = (outs I32:$result);
+  let summary = "return the initial stack dword position for use with lds.stack.store";
+}
+
+def GpurtLdsStackStore : LgcOp<"gpurt.lds.stack.store", [Memory<[(write)]>, WillReturn]> {
+  let arguments = (ins PrivatePointer:$new_pos, I32:$old_pos, V4I32:$data);
+  let results = (outs I32:$result);
+  let summary = "perform a combined lds stack push and pop operation.";
+  let description = [{
+    this pushes $data and pops a dword from the stack, and data and positions are interpreted according to the ds_bvh_stack_rtn instruction.
+  }];
+}
+

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -30,6 +30,7 @@ def LgcDialect : Dialect {
   let cppNamespace = "lgc";
 }
 
+def PrivatePointer : TgConstant<(PointerType 5)>, Type;
 def BufferPointer : TgConstant<(PointerType 7)>, Type;
 
 def V4I32 : TgConstant<(FixedVectorType I32, 4)>, Type;
@@ -157,7 +158,7 @@ def InputImportInterpolatedOp : LgcOp<"input.import.interpolated", [Memory<[]>, 
     Only used in PS for per-vertex/interpolated inputs. Use `input.import.generic` for per-primitive inputs.
 
     `interpMode` is one of:
-    
+
     - InterpModeSmooth for interpolation using the `<2 x float>` barycentrics in `interpValue`
     - InterpModeFlat for flat shading; `interpValue` is ignored and is recommended to be `poison`
     - InterpModeCustom to retrieve the attribute of the vertex with the `i32` index `interpValue` (which must be 0, 1,
@@ -165,3 +166,5 @@ def InputImportInterpolatedOp : LgcOp<"input.import.interpolated", [Memory<[]>, 
       this operation to map between HW and API.
   }];
 }
+
+include "GpurtDialect.td"

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -242,6 +242,8 @@ if(VKI_RAY_TRACING)
         lower/llpcSpirvLowerRayTracing.cpp
         lower/llpcSpirvLowerRayTracingBuiltIn.cpp
         lower/llpcSpirvLowerRayTracingIntrinsics.cpp
+        lower/llpcSpirvProcessGpuRtLibrary.cpp
+        lower/LowerGpuRt.cpp
     )
 endif()
 #endif

--- a/llpc/context/llpcComputeContext.h
+++ b/llpc/context/llpcComputeContext.h
@@ -67,12 +67,6 @@ public:
   // Gets client-defined metadata
   virtual llvm::StringRef getClientMetadata() const override;
 
-#if VKI_RAY_TRACING
-  // Set workgroup size for compute pipeline so that rayQuery lowering can see it.
-  virtual void setWorkgroupSize(unsigned workgroupSize) override { m_workgroupSize = workgroupSize; }
-  virtual unsigned getWorkgroupSize() const override { return m_workgroupSize; }
-#endif
-
 private:
   ComputeContext() = delete;
   ComputeContext(const ComputeContext &) = delete;

--- a/llpc/context/llpcPipelineContext.h
+++ b/llpc/context/llpcPipelineContext.h
@@ -163,10 +163,6 @@ public:
   virtual void collectCallableDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}
   virtual void collectAttributeDataSize(llvm::Type *type, const llvm::DataLayout &dataLayout) {}
   virtual void collectBuiltIn(unsigned builtIn) {}
-
-  // Set workgroup size for compute pipeline so that rayQuery lowering can see it.
-  virtual void setWorkgroupSize(unsigned workgroupSize) {}
-  virtual unsigned getWorkgroupSize() const { return 0; }
 #endif
 
   static const char *getGpuNameAbbreviation(GfxIpVersion gfxIp);

--- a/llpc/lower/LowerGpuRt.cpp
+++ b/llpc/lower/LowerGpuRt.cpp
@@ -1,0 +1,264 @@
+/*
+************************************************************************************************************************
+*
+*  Copyright (C) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+*
+***********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  LowerGpuRt.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::LowerGpuRt.
+ ***********************************************************************************************************************
+ */
+#include "LowerGpuRt.h"
+#include "llpcContext.h"
+#include "lgc/Builder.h"
+#include "lgc/LgcDialect.h"
+#include "llvm-dialects/Dialect/Visitor.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
+#define DEBUG_TYPE "llpc-gpurt"
+using namespace lgc;
+using namespace llvm;
+using namespace Llpc;
+
+namespace RtName {
+static const char *LdsStack = "LdsStack";
+} // namespace RtName
+
+namespace Llpc {
+// =====================================================================================================================
+LowerGpuRt::LowerGpuRt() : m_stack(nullptr), m_stackTy(nullptr), m_lowerStack(false) {
+}
+// =====================================================================================================================
+// Executes this SPIR-V lowering pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+PreservedAnalyses LowerGpuRt::run(Module &module, ModuleAnalysisManager &analysisManager) {
+  LLVM_DEBUG(dbgs() << "Run the pass Lower-gpurt\n");
+  SpirvLower::init(&module);
+  auto gfxip = m_context->getPipelineContext()->getGfxIpVersion();
+  // NOTE: rayquery of sect and ahit can reuse lds.
+  m_lowerStack = (m_entryPoint->getName().startswith("_ahit") || m_entryPoint->getName().startswith("_sect")) &&
+                 (gfxip.major < 11);
+  createGlobalStack();
+  static auto visitor = llvm_dialects::VisitorBuilder<LowerGpuRt>()
+                            .setStrategy(llvm_dialects::VisitorStrategy::ByFunctionDeclaration)
+                            .add(&LowerGpuRt::getStackSize)
+                            .add(&LowerGpuRt::getStackBase)
+                            .add(&LowerGpuRt::getStackStride)
+                            .add(&LowerGpuRt::stackWrite)
+                            .add(&LowerGpuRt::stackRead)
+                            .add(&LowerGpuRt::ldsStackInit)
+                            .add(&LowerGpuRt::ldsStackStore)
+                            .build();
+
+  visitor.visit(*this, *m_module);
+
+  for (Instruction *call : m_callsToLower) {
+    call->dropAllReferences();
+    call->eraseFromParent();
+  }
+
+  for (Function *func : m_funcsToLower) {
+    func->dropAllReferences();
+    func->eraseFromParent();
+  }
+
+  if (m_callsToLower.size())
+    return PreservedAnalyses::all();
+  return PreservedAnalyses::none();
+}
+
+// =====================================================================================================================
+// Get pipeline workgroup size for stack size calculation
+unsigned LowerGpuRt::getWorkgroupSize() const {
+  unsigned workgroupSize = 0;
+  if (m_context->getPipelineType() == PipelineType::Graphics) {
+    workgroupSize = m_context->getPipelineContext()->getRayTracingWaveSize();
+  } else {
+    ComputeShaderMode mode = lgc::Pipeline::getComputeShaderMode(*m_module);
+    workgroupSize = mode.workgroupSizeX * mode.workgroupSizeY * mode.workgroupSizeZ;
+  }
+  assert(workgroupSize != 0);
+  if (m_context->getPipelineContext()->getGfxIpVersion().major >= 11) {
+    // Round up to multiple of 32, as the ds_bvh_stack swizzle as 32 threads
+    workgroupSize = alignTo(workgroupSize, 32);
+  }
+  return workgroupSize;
+}
+
+// =====================================================================================================================
+// Get flat thread id in work group/wave
+Value *LowerGpuRt::getThreadIdInGroup() const {
+  // Todo: for graphics shader, subgroupId * waveSize + subgroupLocalInvocationId()
+  unsigned builtIn = m_context->getPipelineType() == PipelineType::Graphics ? lgc::BuiltInSubgroupLocalInvocationId
+                                                                            : lgc::BuiltInLocalInvocationIndex;
+  lgc::InOutInfo inputInfo = {};
+  return m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(builtIn), inputInfo, nullptr, nullptr, "");
+}
+
+// =====================================================================================================================
+// Create global variable for the stack
+void LowerGpuRt::createGlobalStack() {
+  auto ldsStackSize = getWorkgroupSize() * MaxLdsStackEntries;
+  // Double anyhit and intersection shader lds size, these shader use lower part of stack to read/write value
+  if (m_lowerStack)
+    ldsStackSize = ldsStackSize << 1;
+
+  m_stackTy = ArrayType::get(m_builder->getInt32Ty(), ldsStackSize);
+  auto ldsStack = new GlobalVariable(*m_module, m_stackTy, false, GlobalValue::ExternalLinkage, nullptr,
+                                     RtName::LdsStack, nullptr, GlobalValue::NotThreadLocal, 3);
+
+  ldsStack->setAlignment(MaybeAlign(4));
+  m_stack = ldsStack;
+}
+
+// =====================================================================================================================
+// Create to get stack size
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::getStackSize(GpurtGetStackSize &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *size = nullptr;
+  size = m_builder->getInt32(MaxLdsStackEntries * getWorkgroupSize());
+  inst.replaceAllUsesWith(size);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Create to get stack base
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::getStackBase(GpurtGetStackBase &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *base = getThreadIdInGroup();
+  inst.replaceAllUsesWith(base);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Create to get stack stride, this function
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::getStackStride(GpurtGetStackStride &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *stride = m_builder->getInt32(getWorkgroupSize());
+  inst.replaceAllUsesWith(stride);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Create to read stack
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::stackRead(GpurtStackRead &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *stackIndex = inst.getIndex();
+  Type *stackTy = PointerType::get(m_builder->getInt32Ty(), 3);
+  if (m_lowerStack) {
+    auto ldsStackSize = m_builder->getInt32(getWorkgroupSize() * MaxLdsStackEntries);
+    stackIndex = m_builder->CreateAdd(stackIndex, ldsStackSize);
+  }
+
+  Value *stackAddr = m_builder->CreateGEP(stackTy, m_stack, {stackIndex});
+  Value *stackData = m_builder->CreateLoad(m_builder->getInt32Ty(), stackAddr);
+
+  inst.replaceAllUsesWith(stackData);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Create to write stack
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::stackWrite(GpurtStackWrite &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *stackIndex = inst.getIndex();
+  Value *stackData = inst.getValue();
+  Type *stackTy = PointerType::get(m_builder->getInt32Ty(), 3);
+  if (m_lowerStack) {
+    auto ldsStackSize = m_builder->getInt32(getWorkgroupSize() * MaxLdsStackEntries);
+    stackIndex = m_builder->CreateAdd(stackIndex, ldsStackSize);
+  }
+
+  auto stackArrayAddr = m_builder->CreateGEP(stackTy, m_stack, {stackIndex});
+  m_builder->CreateStore(stackData, stackArrayAddr);
+
+  inst.replaceAllUsesWith(m_builder->getInt32(0));
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Create to init stack LDS
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::ldsStackInit(GpurtLdsStackInit &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *stackBasePerThread = getThreadIdInGroup();
+
+  // From Navi3x on, Hardware has decided that the stacks are only swizzled across every 32 threads,
+  // with stacks for every set of 32 threads stored after all the stack data for the previous 32 threads.
+  if (getWorkgroupSize() > 32) {
+    // localThreadId = (LinearLocalThreadID%32)
+    // localGroupId = (LinearLocalThreadID/32)
+    // stackSize = STACK_SIZE * 32 = m_stackEntries * 32
+    // groupOf32ThreadSize = (LinearLocalThreadID/32) * stackSize
+    // stackBasePerThread (in DW) = (LinearLocalThreadID%32)+(LinearLocalThreadID/32)*STACK_SIZE*32
+    //                            = localThreadId + groupOf32ThreadSize
+    Value *localThreadId = m_builder->CreateAnd(stackBasePerThread, m_builder->getInt32(31));
+    Value *localGroupId = m_builder->CreateLShr(stackBasePerThread, m_builder->getInt32(5));
+    Value *stackSize = m_builder->getInt32(MaxLdsStackEntries * 32);
+    Value *groupOf32ThreadSize = m_builder->CreateMul(localGroupId, stackSize);
+    stackBasePerThread = m_builder->CreateAdd(localThreadId, groupOf32ThreadSize);
+  }
+
+  Value *stackBaseAsInt = m_builder->CreatePtrToInt(
+      m_builder->CreateGEP(m_stackTy, m_stack, {m_builder->getInt32(0), stackBasePerThread}), m_builder->getInt32Ty());
+
+  // stack_addr[31:18] = stack_base[15:2]
+  // stack_addr[17:0] = stack_index[17:0]
+  // The low 18 bits of stackAddr contain stackIndex which we always initialize to 0.
+  // Note that this relies on stackAddr being a multiple of 4, so that bits 17 and 16 are 0.
+  Value *stackAddr = m_builder->CreateShl(stackBaseAsInt, 16);
+  inst.replaceAllUsesWith(stackAddr);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Create to store stack LDS
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::ldsStackStore(GpurtLdsStackStore &inst) {
+  m_builder->SetInsertPoint(&inst);
+  Value *stackAddr = inst.getNewPos();
+  Value *stackAddrVal = m_builder->CreateLoad(m_builder->getInt32Ty(), stackAddr);
+  Value *lastVisited = inst.getOldPos();
+  Value *data = inst.getData();
+  // OFFSET = {OFFSET1, OFFSET0}
+  // stack_size[1:0] = OFFSET1[5:4]
+  // Stack size is encoded in the offset argument as:
+  // 8 -> {0x00, 0x00}
+  // 16 -> {0x10, 0x00}
+  // 32 -> {0x20, 0x00}
+  // 64 -> {0x30, 0x00}
+  assert(MaxLdsStackEntries == 16);
+  Value *offset = m_builder->getInt32((Log2_32(MaxLdsStackEntries) - 3) << 12);
+
+  Value *result =
+      m_builder->CreateIntrinsic(Intrinsic::amdgcn_ds_bvh_stack_rtn, {}, {stackAddrVal, lastVisited, data, offset});
+
+  m_builder->CreateStore(m_builder->CreateExtractValue(result, 1), stackAddr);
+  Value *ret = m_builder->CreateExtractValue(result, 0);
+  inst.replaceAllUsesWith(ret);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+} // namespace Llpc

--- a/llpc/lower/LowerGpuRt.h
+++ b/llpc/lower/LowerGpuRt.h
@@ -1,0 +1,58 @@
+/*
+************************************************************************************************************************
+*
+*  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+*
+***********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcLowerGpuRt.h
+ * @brief LLPC header file: contains declaration of Llpc::LowerGpuRt
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcSpirvLower.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/IR/PassManager.h"
+
+namespace lgc {
+class GpurtGetStackSize;
+class GpurtGetStackBase;
+class GpurtGetStackStride;
+class GpurtStackWrite;
+class GpurtStackRead;
+class GpurtLdsStackInit;
+class GpurtLdsStackStore;
+} // namespace lgc
+
+namespace llvm {
+class AllocaInst;
+}
+
+namespace Llpc {
+class LowerGpuRt : public SpirvLower, public llvm::PassInfoMixin<LowerGpuRt> {
+public:
+  LowerGpuRt();
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+
+private:
+  typedef void (LowerGpuRt::*LibraryFuncPtr)(llvm::Function *, unsigned);
+  const static unsigned MaxLdsStackEntries = 16;
+  uint32_t getWorkgroupSize() const;
+  llvm::Value *getThreadIdInGroup() const;
+  void createGlobalStack();
+  void getStackSize(lgc::GpurtGetStackSize &inst);
+  void getStackBase(lgc::GpurtGetStackBase &inst);
+  void getStackStride(lgc::GpurtGetStackStride &inst);
+  void stackWrite(lgc::GpurtStackWrite &inst);
+  void stackRead(lgc::GpurtStackRead &inst);
+  void ldsStackInit(lgc::GpurtLdsStackInit &inst);
+  void ldsStackStore(lgc::GpurtLdsStackStore &inst);
+  llvm::Value *m_stack;                                  // Stack array to hold stack value
+  llvm::Type *m_stackTy;                                 // Stack type
+  bool m_lowerStack;                                     // If it is lowerStack
+  llvm::SmallVector<llvm::Instruction *> m_callsToLower; // Call instruction to lower
+  llvm::SmallSet<llvm::Function *, 4> m_funcsToLower;    // Functions to lower
+};
+} // namespace Llpc

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -39,6 +39,7 @@
 #include "llpcSpirvLowerMath.h"
 #include "llpcSpirvLowerMemoryOp.h"
 #if VKI_RAY_TRACING
+#include "LowerGpuRt.h"
 #include "llpcSpirvLowerRayQueryPostInline.h"
 #include "llpcSpirvLowerRayTracingBuiltIn.h"
 #include "llpcSpirvLowerRayTracingIntrinsics.h"
@@ -255,6 +256,11 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 
   // Lower SPIR-V instruction metadata remove
   passMgr.addPass(SpirvLowerInstMetaRemove());
+
+#if VKI_RAY_TRACING
+  if (rayTracing || rayQuery)
+    passMgr.addPass(LowerGpuRt());
+#endif
 
   // Stop timer for lowering passes.
   if (lowerTimer)

--- a/llpc/lower/llpcSpirvLower.h
+++ b/llpc/lower/llpcSpirvLower.h
@@ -39,7 +39,6 @@ namespace llvm {
 class Constant;
 class GlobalVariable;
 class Timer;
-
 } // namespace llvm
 
 namespace lgc {

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -53,7 +53,6 @@ const char *PrevRayQueryObj = "PrevRayQueryObj";
 const char *RayQueryObjGen = "RayQueryObjGen";
 const char *StaticId = "StaticId";
 static const char *LibraryEntryFuncName = "libraryEntry";
-static const char *LdsStack = "LdsStack";
 extern const char *LoadDwordAtAddr;
 extern const char *LoadDwordAtAddrx2;
 extern const char *LoadDwordAtAddrx4;
@@ -64,21 +63,12 @@ static const char *IntersectBvh = "AmdExtD3DShaderIntrinsics_IntersectInternal";
 #endif
 extern const char *ConvertF32toF16NegInf;
 extern const char *ConvertF32toF16PosInf;
-static const char *GetStackSize = "AmdTraceRayGetStackSize";
-static const char *LdsRead = "AmdTraceRayLdsRead";
-static const char *LdsWrite = "AmdTraceRayLdsWrite";
-static const char *GetStackBase = "AmdTraceRayGetStackBase";
-static const char *GetStackStride = "AmdTraceRayGetStackStride";
 static const char *GetStaticFlags = "AmdTraceRayGetStaticFlags";
 static const char *GetTriangleCompressionMode = "AmdTraceRayGetTriangleCompressionMode";
 static const char *SetHitTokenData = "AmdTraceRaySetHitTokenData";
 static const char *GetBoxSortHeuristicMode = "AmdTraceRayGetBoxSortHeuristicMode";
 static const char *SampleGpuTimer = "AmdTraceRaySampleGpuTimer";
 static const char *GetStaticId = "AmdTraceRayGetStaticId";
-#if VKI_BUILD_GFX11
-static const char *LdsStackInit = "AmdTraceRayLdsStackInit";
-static const char *LdsStackStore = "AmdTraceRayLdsStackStore";
-#endif
 static const char *FetchTrianglePositionFromRayQuery = "FetchTrianglePositionFromRayQuery";
 } // namespace RtName
 
@@ -308,8 +298,8 @@ SpirvLowerRayQuery::SpirvLowerRayQuery() : SpirvLowerRayQuery(false) {
 
 // =====================================================================================================================
 SpirvLowerRayQuery::SpirvLowerRayQuery(bool rayQueryLibrary)
-    : m_rayQueryLibrary(rayQueryLibrary), m_spirvOpMetaKindId(0), m_ldsStack(nullptr), m_prevRayQueryObj(nullptr),
-      m_rayQueryObjGen(nullptr), m_nextTraceRayId(0) {
+    : m_rayQueryLibrary(rayQueryLibrary), m_spirvOpMetaKindId(0), m_prevRayQueryObj(nullptr), m_rayQueryObjGen(nullptr),
+      m_nextTraceRayId(0) {
 }
 
 // =====================================================================================================================
@@ -333,7 +323,6 @@ bool SpirvLowerRayQuery::runImpl(Module &module) {
   createGlobalLdsUsage();
   createGlobalTraceRayStaticId();
   if (m_rayQueryLibrary) {
-    createGlobalStack();
     for (auto funcIt = module.begin(), funcEnd = module.end(); funcIt != funcEnd;) {
       Function *func = &*funcIt++;
       processLibraryFunction(func);
@@ -389,30 +378,6 @@ void SpirvLowerRayQuery::processLibraryFunction(Function *&func) {
     createConvertF32toF16(func, 2);
   } else if (mangledName.startswith(RtName::ConvertF32toF16PosInf)) {
     createConvertF32toF16(func, 3);
-  } else if (mangledName.startswith(RtName::GetStackSize)) {
-    eraseFunctionBlocks(func);
-    BasicBlock *entryBlock = BasicBlock::Create(*m_context, "", func);
-    m_builder->SetInsertPoint(entryBlock);
-    m_builder->CreateRet(m_builder->getInt32(MaxLdsStackEntries * getWorkgroupSize()));
-    func->setName(RtName::GetStackSize);
-  } else if (mangledName.startswith(RtName::LdsRead)) {
-    createReadLdsStack(func);
-    func->setName(RtName::LdsRead);
-  } else if (mangledName.startswith(RtName::LdsWrite)) {
-    createWriteLdsStack(func);
-    func->setName(RtName::LdsWrite);
-  } else if (mangledName.startswith(RtName::GetStackBase)) {
-    eraseFunctionBlocks(func);
-    BasicBlock *entryBlock = BasicBlock::Create(*m_context, "", func);
-    m_builder->SetInsertPoint(entryBlock);
-    m_builder->CreateRet(getThreadIdInGroup());
-    func->setName(RtName::GetStackBase);
-  } else if (mangledName.startswith(RtName::GetStackStride)) {
-    eraseFunctionBlocks(func);
-    BasicBlock *entryBlock = BasicBlock::Create(*m_context, "", func);
-    m_builder->SetInsertPoint(entryBlock);
-    m_builder->CreateRet(m_builder->getInt32(getWorkgroupSize()));
-    func->setName(RtName::GetStackStride);
   } else if (mangledName.startswith(RtName::GetStaticFlags)) {
     eraseFunctionBlocks(func);
     BasicBlock *entryBlock = BasicBlock::Create(*m_context, "", func);
@@ -441,15 +406,7 @@ void SpirvLowerRayQuery::processLibraryFunction(Function *&func) {
     m_builder->SetInsertPoint(entryBlock);
     m_builder->CreateRet(m_builder->CreateLoad(m_builder->getInt32Ty(), m_traceRayStaticId));
     func->setName(RtName::GetStaticId);
-  }
-#if VKI_BUILD_GFX11
-  else if (mangledName.startswith(RtName::LdsStackInit)) {
-    createLdsStackInit(func);
-  } else if (mangledName.startswith(RtName::LdsStackStore)) {
-    createLdsStackStore(func);
-  }
-#endif
-  else if (mangledName.startswith(RtName::FetchTrianglePositionFromRayQuery)) {
+  } else if (mangledName.startswith(RtName::FetchTrianglePositionFromRayQuery)) {
     func->setName(RtName::FetchTrianglePositionFromRayQuery);
     func->setLinkage(GlobalValue::ExternalLinkage);
   } else {
@@ -1346,96 +1303,6 @@ void SpirvLowerRayQuery::processShaderFunction(Function *func, unsigned opcode) 
 }
 
 // =====================================================================================================================
-// Return read value from LDS stack
-//
-// @param func : The function to create
-void SpirvLowerRayQuery::createReadLdsStack(Function *func) {
-  eraseFunctionBlocks(func);
-  BasicBlock *entryBlock = BasicBlock::Create(*m_context, "", func);
-  m_builder->SetInsertPoint(entryBlock);
-  auto argIt = func->arg_begin();
-  Value *stackOffset = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt);
-
-  auto stageMask = m_context->getPipelineContext()->getShaderStageMask();
-  bool isGraphics = stageMask < ShaderStageComputeBit;
-  bool hasAnyHitStage = stageMask & ShaderStageRayTracingAnyHitBit;
-  if (isGraphics || hasAnyHitStage) {
-    Value *ldsUsage = m_builder->CreateLoad(m_builder->getInt32Ty(), m_ldsUsage);
-    auto isLds = m_builder->CreateICmpEQ(ldsUsage, m_builder->getInt32(1));
-
-    BasicBlock *tempArrayBlock = BasicBlock::Create(*m_context, ".tempArray", func);
-    BasicBlock *ldsArrayBlock = BasicBlock::Create(*m_context, ".lds", func);
-    m_builder->CreateCondBr(isLds, ldsArrayBlock, tempArrayBlock);
-    m_builder->SetInsertPoint(tempArrayBlock);
-    auto stackArrayIdx = getStackArrayIndex(stackOffset);
-    Type *stackArrayEltTy = m_stackArray->getValueType();
-    auto stackArrayAddr = m_builder->CreateGEP(stackArrayEltTy, m_stackArray, {m_builder->getInt32(0), stackArrayIdx});
-    Value *stackArrayData = m_builder->CreateLoad(m_builder->getInt32Ty(), stackArrayAddr);
-    m_builder->CreateRet(stackArrayData);
-    m_builder->SetInsertPoint(ldsArrayBlock);
-  }
-  Type *ldsStackEltTy = m_ldsStack->getValueType();
-  Value *stackAddr = m_builder->CreateGEP(ldsStackEltTy, m_ldsStack, {m_builder->getInt32(0), stackOffset});
-  Value *stackData = m_builder->CreateLoad(m_builder->getInt32Ty(), stackAddr);
-  m_builder->CreateRet(stackData);
-}
-
-// =====================================================================================================================
-// Write value to LDS stack
-//
-// @param func : The function to create
-void SpirvLowerRayQuery::createWriteLdsStack(Function *func) {
-  eraseFunctionBlocks(func);
-  BasicBlock *entryBlock = BasicBlock::Create(*m_context, "", func);
-  m_builder->SetInsertPoint(entryBlock);
-
-  auto argIt = func->arg_begin();
-  Value *stackOffset = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt++);
-  Value *stackData = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt);
-
-  auto stageMask = m_context->getPipelineContext()->getShaderStageMask();
-  bool isGraphics = stageMask < ShaderStageComputeBit;
-  bool hasAnyHitStage = stageMask & ShaderStageRayTracingAnyHitBit;
-  if (isGraphics || hasAnyHitStage) {
-    Value *ldsUsage = m_builder->CreateLoad(m_builder->getInt32Ty(), m_ldsUsage);
-    auto isLds = m_builder->CreateICmpEQ(ldsUsage, m_builder->getInt32(1));
-
-    BasicBlock *tempArrayBlock = BasicBlock::Create(*m_context, ".tempArray", func);
-    BasicBlock *ldsArrayBlock = BasicBlock::Create(*m_context, ".lds", func);
-    m_builder->CreateCondBr(isLds, ldsArrayBlock, tempArrayBlock);
-    m_builder->SetInsertPoint(tempArrayBlock);
-    auto stackArrayIdx = getStackArrayIndex(stackOffset);
-    Type *stackArrayEltTy = m_stackArray->getValueType();
-    auto stackArrayAddr = m_builder->CreateGEP(stackArrayEltTy, m_stackArray, {m_builder->getInt32(0), stackArrayIdx});
-    m_builder->CreateStore(stackData, stackArrayAddr);
-    m_builder->CreateRet(m_builder->getInt32(0));
-    m_builder->SetInsertPoint(ldsArrayBlock);
-  }
-
-  Type *ldsStackEltTy = m_ldsStack->getValueType();
-  Value *stackAddr = m_builder->CreateGEP(ldsStackEltTy, m_ldsStack, {m_builder->getInt32(0), stackOffset});
-  m_builder->CreateStore(stackData, stackAddr);
-  m_builder->CreateRet(m_builder->getInt32(0));
-}
-
-// =====================================================================================================================
-// Create global variable for the LDS stack and stack array
-void SpirvLowerRayQuery::createGlobalStack() {
-  auto ldsStackSize = getWorkgroupSize() * MaxLdsStackEntries;
-
-  auto ldsStackTy = ArrayType::get(m_builder->getInt32Ty(), ldsStackSize);
-  m_ldsStack = new GlobalVariable(*m_module, ldsStackTy, false, GlobalValue::ExternalLinkage, nullptr, RtName::LdsStack,
-                                  nullptr, GlobalValue::NotThreadLocal, SPIRAS_Local);
-
-  m_ldsStack->setAlignment(MaybeAlign(4));
-
-  auto arrayStackTy = ArrayType::get(m_builder->getInt32Ty(), MaxLdsStackEntries);
-  m_stackArray = new GlobalVariable(*m_module, arrayStackTy, false, GlobalValue::ExternalLinkage, nullptr,
-                                    RtName::LdsStack, nullptr, GlobalValue::NotThreadLocal, SPIRAS_Private);
-  m_stackArray->setAlignment(MaybeAlign(4));
-}
-
-// =====================================================================================================================
 // Create global variable for the LDS stack
 void SpirvLowerRayQuery::createGlobalLdsUsage() {
   m_ldsUsage =
@@ -1554,37 +1421,6 @@ Value *SpirvLowerRayQuery::createTransformMatrix(unsigned builtInId, Value *acce
 }
 
 // =====================================================================================================================
-// Get raytracing workgroup size for LDS stack size calculation
-unsigned SpirvLowerRayQuery::getWorkgroupSize() const {
-  unsigned workgroupSize = 0;
-  if (m_context->getPipelineType() == PipelineType::RayTracing) {
-    const auto *rtState = m_context->getPipelineContext()->getRayTracingState();
-    workgroupSize = rtState->threadGroupSizeX * rtState->threadGroupSizeY * rtState->threadGroupSizeZ;
-  } else if (m_context->getPipelineType() == PipelineType::Graphics) {
-    workgroupSize = m_context->getPipelineContext()->getRayTracingWaveSize();
-  } else {
-    workgroupSize = m_context->getPipelineContext()->getWorkgroupSize();
-  }
-  assert(workgroupSize != 0);
-#if VKI_BUILD_GFX11
-  if (m_context->getPipelineContext()->getGfxIpVersion().major >= 11) {
-    // Round up to multiple of 32, as the ds_bvh_stack swizzle as 32 threads
-    workgroupSize = alignTo(workgroupSize, 32);
-  }
-#endif
-  return workgroupSize;
-}
-
-// =====================================================================================================================
-// Get flat thread id in work group/wave
-Value *SpirvLowerRayQuery::getThreadIdInGroup() const {
-  unsigned builtIn = m_context->getPipelineType() == PipelineType::Graphics ? BuiltInSubgroupLocalInvocationId
-                                                                            : BuiltInLocalInvocationIndex;
-  lgc::InOutInfo inputInfo = {};
-  return m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(builtIn), inputInfo, nullptr, nullptr, "");
-}
-
-// =====================================================================================================================
 // Create function to return bvh node intersection result
 //
 // @param func : The function to create
@@ -1699,23 +1535,6 @@ void SpirvLowerRayQuery::generateTraceRayStaticId() {
 // @param stage : Shader stage
 bool SpirvLowerRayQuery::stageNotSupportLds(ShaderStage stage) {
   return stage == ShaderStageRayTracingAnyHit;
-}
-
-// =====================================================================================================================
-// Get stack array index from stackoffset
-
-// @param stackOffset : Stack offset
-Value *SpirvLowerRayQuery::getStackArrayIndex(Value *stackOffset) {
-  // offset = (rayQuery.stackPtr - AmdTraceRayGetStackBase()) % AmdTraceRayGetStackSize();
-  // index = offset / AmdTraceRayGetStackStride();
-
-  // From rayquery.hlsl : stackOffset = rayQuery.stackPtr % AmdTraceRayGetStackSize()
-  // so offset = (stackOffset - AmdTraceRayGetStackBase() + AmdTraceRayGetStackSize()) % AmdTraceRayGetStackSize()
-  Value *offset = m_builder->CreateSub(stackOffset, getThreadIdInGroup());
-  Value *stackSize = m_builder->getInt32(MaxLdsStackEntries * getWorkgroupSize());
-  offset = m_builder->CreateAdd(offset, stackSize);
-  offset = m_builder->CreateURem(offset, stackSize);
-  return m_builder->CreateUDiv(offset, m_builder->getInt32(getWorkgroupSize()));
 }
 
 // =====================================================================================================================
@@ -1853,84 +1672,12 @@ Value *SpirvLowerRayQuery::createLoadMatrixFromAddr(Value *matrixAddr) {
   return matrix;
 }
 
-#if VKI_BUILD_GFX11
-// =====================================================================================================================
-// Init LDS stack address
-//
-// @param func : The function to create
-void SpirvLowerRayQuery::createLdsStackInit(Function *func) {
-  eraseFunctionBlocks(func);
-  BasicBlock *block = BasicBlock::Create(*m_context, "", func);
-  m_builder->SetInsertPoint(block);
-
-  // The initial stack index is 0 currently.
-  // stackIndex = 0
-  // stackBase = AmdTraceRayGetStackBase()
-  // stackAddr = ((stackBase << 18u) | startIndex)
-  Type *ldsStackElemTy = m_ldsStack->getValueType();
-  Value *stackBasePerThread = getThreadIdInGroup();
-
-  // From Navi3x on, Hardware has decided that the stacks are only swizzled across every 32 threads,
-  // with stacks for every set of 32 threads stored after all the stack data for the previous 32 threads.
-  if (getWorkgroupSize() > 32) {
-    // localThreadId = (LinearLocalThreadID%32)
-    // localGroupId = (LinearLocalThreadID/32)
-    // stackSize = STACK_SIZE * 32 = m_stackEntries * 32
-    // groupOf32ThreadSize = (LinearLocalThreadID/32) * stackSize
-    // stackBasePerThread (in DW) = (LinearLocalThreadID%32)+(LinearLocalThreadID/32)*STACK_SIZE*32
-    //                            = localThreadId + groupOf32ThreadSize
-    Value *localThreadId = m_builder->CreateAnd(stackBasePerThread, m_builder->getInt32(31));
-    Value *localGroupId = m_builder->CreateLShr(stackBasePerThread, m_builder->getInt32(5));
-    Value *stackSize = m_builder->getInt32(MaxLdsStackEntries * 32);
-    Value *groupOf32ThreadSize = m_builder->CreateMul(localGroupId, stackSize);
-    stackBasePerThread = m_builder->CreateAdd(localThreadId, groupOf32ThreadSize);
-  }
-
-  Value *stackBaseAsInt = m_builder->CreatePtrToInt(
-      m_builder->CreateGEP(ldsStackElemTy, m_ldsStack, {m_builder->getInt32(0), stackBasePerThread}),
-      m_builder->getInt32Ty());
-
-  // stack_addr[31:18] = stack_base[15:2]
-  // stack_addr[17:0] = stack_index[17:0]
-  // The low 18 bits of stackAddr contain stackIndex which we always initialize to 0.
-  // Note that this relies on stackAddr being a multiple of 4, so that bits 17 and 16 are 0.
-  Value *stackAddr = m_builder->CreateShl(stackBaseAsInt, 16);
-
-  m_builder->CreateRet(stackAddr);
+Value *SpirvLowerRayQuery::getThreadIdInGroup() const {
+  // Todo: for graphics shader, subgroupId * waveSize + subgroupLocalInvocationId()
+  unsigned builtIn = m_context->getPipelineType() == PipelineType::Graphics ? BuiltInSubgroupLocalInvocationId
+                                                                            : BuiltInLocalInvocationIndex;
+  lgc::InOutInfo inputInfo = {};
+  return m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(builtIn), inputInfo, nullptr, nullptr, "");
 }
-
-// =====================================================================================================================
-// Store to LDS stack
-//
-// @param func : The function to create
-void SpirvLowerRayQuery::createLdsStackStore(Function *func) {
-  eraseFunctionBlocks(func);
-  BasicBlock *block = BasicBlock::Create(*m_context, "", func);
-  m_builder->SetInsertPoint(block);
-
-  auto int32x4Ty = FixedVectorType::get(m_builder->getInt32Ty(), 4);
-
-  auto argIt = func->arg_begin();
-  Value *stackAddr = argIt++;
-  Value *stackAddrVal = m_builder->CreateLoad(m_builder->getInt32Ty(), stackAddr);
-  Value *lastVisited = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt++);
-  Value *data = m_builder->CreateLoad(int32x4Ty, argIt);
-  // OFFSET = {OFFSET1, OFFSET0}
-  // stack_size[1:0] = OFFSET1[5:4]
-  // Stack size is encoded in the offset argument as:
-  // 8 -> {0x00, 0x00}
-  // 16 -> {0x10, 0x00}
-  // 32 -> {0x20, 0x00}
-  // 64 -> {0x30, 0x00}
-  assert(MaxLdsStackEntries == 16);
-  Value *offset = m_builder->getInt32((Log2_32(MaxLdsStackEntries) - 3) << 12);
-
-  Value *result =
-      m_builder->CreateIntrinsic(Intrinsic::amdgcn_ds_bvh_stack_rtn, {}, {stackAddrVal, lastVisited, data, offset});
-
-  m_builder->CreateStore(m_builder->CreateExtractValue(result, 1), stackAddr);
-  m_builder->CreateRet(m_builder->CreateExtractValue(result, 0));
-}
-#endif
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerRayQuery.h
+++ b/llpc/lower/llpcSpirvLowerRayQuery.h
@@ -116,6 +116,7 @@ public:
   SpirvLowerRayQuery(bool rayQueryLibrary);
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
   virtual bool runImpl(llvm::Module &module);
+  llvm::Value *getThreadIdInGroup() const;
 
   static llvm::StringRef name() { return "Lower SPIR-V RayQuery operations"; }
 
@@ -124,7 +125,6 @@ public:
 protected:
   void processLibraryFunction(llvm::Function *&func);
   void processShaderFunction(llvm::Function *func, unsigned opcode);
-  void createGlobalStack();
   void createGlobalLdsUsage();
   void createGlobalRayQueryObj();
   void createGlobalTraceRayStaticId();
@@ -132,7 +132,6 @@ protected:
   void generateTraceRayStaticId();
   llvm::Value *createTransformMatrix(unsigned builtInId, llvm::Value *accelStruct, llvm::Value *instanceId,
                                      llvm::Instruction *insertPos);
-  llvm::Value *getThreadIdInGroup() const;
   void eraseFunctionBlocks(llvm::Function *func);
   unsigned getFuncOpcode(llvm::Function *func);
   llvm::Value *createLoadInstanceIndex(llvm::Value *instNodeAddr);
@@ -146,22 +145,14 @@ private:
   template <spv::Op> void createRayQueryFunc(llvm::Function *func);
   void createRayQueryProceedFunc(llvm::Function *func);
   llvm::Value *createIntersectSystemValue(llvm::Function *func, unsigned raySystem);
-  void createWriteLdsStack(llvm::Function *func);
-  void createReadLdsStack(llvm::Function *func);
   void createIntersectMatrix(llvm::Function *func, unsigned builtInId);
   void createIntersectBvh(llvm::Function *func);
   void createSampleGpuTime(llvm::Function *func);
-#if VKI_BUILD_GFX11
-  void createLdsStackInit(llvm::Function *func);
-  void createLdsStackStore(llvm::Function *func);
-#endif
-  llvm::Value *getStackArrayIndex(llvm::Value *stackOffset);
-  uint32_t getWorkgroupSize() const;
   llvm::Value *createGetInstanceNodeAddr(llvm::Value *instNodePtr, llvm::Value *rayQuery);
   llvm::Value *getDispatchId();
   llvm::Value *createGetBvhSrd(llvm::Value *expansion, llvm::Value *boxSortMode);
   bool stageNotSupportLds(ShaderStage stage);
-  llvm::GlobalVariable *m_ldsStack;        // LDS to hold stack value
+
   llvm::GlobalVariable *m_ldsUsage;        // LDS usage
   llvm::GlobalVariable *m_stackArray;      // Stack array to hold stack value
   llvm::GlobalVariable *m_prevRayQueryObj; // Previous ray query Object

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -486,7 +486,6 @@ bool SpirvLowerRayTracing::runImpl(Module &module) {
 
   // Process traceRays module
   if (m_shaderStage == ShaderStageCompute) {
-    createGlobalStack();
     for (auto funcIt = module.begin(), funcEnd = module.end(); funcIt != funcEnd;) {
       Function *func = &*funcIt++;
       SpirvLowerRayQuery::processLibraryFunction(func);

--- a/llpc/lower/llpcSpirvLowerUtil.cpp
+++ b/llpc/lower/llpcSpirvLowerUtil.cpp
@@ -87,4 +87,18 @@ void setShaderStageToModule(Module *module, ShaderStage shaderStage) {
   func->setMetadata(gSPIRVMD::ExecutionModel, execModelMetaNode);
 }
 
+// =====================================================================================================================
+// Clear the block before patching the function
+//
+// @param func : The function to clear
+BasicBlock *clearBlock(Function *func) {
+  assert(func->size() == 1);
+  BasicBlock &entryBlock = func->getEntryBlock();
+  for (auto instIt = entryBlock.begin(); instIt != entryBlock.end();) {
+    auto &inst = *instIt++;
+    inst.eraseFromParent();
+  }
+  return &entryBlock;
+}
+
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerUtil.h
+++ b/llpc/lower/llpcSpirvLowerUtil.h
@@ -36,6 +36,7 @@ namespace llvm {
 
 class Function;
 class Module;
+class BasicBlock;
 
 } // namespace llvm
 
@@ -58,5 +59,8 @@ void setShaderStageToModule(llvm::Module *module, ShaderStage shaderStage);
 
 // Gets the entry point (valid for AMD GPU) of a LLVM module.
 llvm::Function *getEntryPoint(llvm::Module *module);
+
+// Clears the empty block
+llvm::BasicBlock *clearBlock(llvm::Function *func);
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -1,0 +1,168 @@
+/*
+************************************************************************************************************************
+*
+*  Copyright (C) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+*
+***********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcSpirvLowerExecutionGraph.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::SpirvLowerExecutionGraph.
+ ***********************************************************************************************************************
+ */
+#include "llpcSpirvProcessGpuRtLibrary.h"
+#include "llpcContext.h"
+#include "llpcSpirvLowerUtil.h"
+#include "lgc/Builder.h"
+#include "lgc/LgcContext.h"
+#include "lgc/LgcDialect.h"
+
+#define DEBUG_TYPE "llpc-spirv-lower-gpurt-library"
+using namespace lgc;
+using namespace llvm;
+
+namespace RtName {
+static const char *AmdLibraryNames[] = {
+    "AmdTraceRayGetStackSize",   "AmdTraceRayLdsRead",      "AmdTraceRayLdsWrite",      "AmdTraceRayGetStackBase",
+    "AmdTraceRayGetStackStride", "AmdTraceRayLdsStackInit", "AmdTraceRayLdsStackStore",
+
+};
+} // namespace RtName
+
+namespace AmdLibraryFunc {
+enum : unsigned {
+  GetStackSize = 0, // Get stack size
+  LdsRead,          // Read from LDS
+  LdsWrite,         // Write to LDS
+  GetStackBase,     // Get stack base
+  GetStackStride,   // Get stack stride
+  LdsStackInit,     // Lds stack init
+  LdsStackStore,    // Lds stack store
+  Count
+};
+} // namespace AmdLibraryFunc
+
+namespace Llpc {
+SpirvProcessGpuRtLibrary::SpirvProcessGpuRtLibrary() {
+}
+
+// =====================================================================================================================
+// Executes this SPIR-V lowering pass on the specified LLVM module.
+//
+// @param [in/out] module : LLVM module to be run on
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+PreservedAnalyses SpirvProcessGpuRtLibrary::run(Module &module, ModuleAnalysisManager &analysisManager) {
+  LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-gpurt\n");
+  SpirvLower::init(&module);
+  for (auto funcIt = module.begin(), funcEnd = module.end(); funcIt != funcEnd;) {
+    Function *func = &*funcIt++;
+    processLibraryFunction(func);
+  }
+  return PreservedAnalyses::none();
+}
+
+// =====================================================================================================================
+// Initialize library function pointer table
+SpirvProcessGpuRtLibrary::LibraryFunctionTable::LibraryFunctionTable() {
+  LibraryFuncPtr amdLibraryFuncs[] = {
+      &SpirvProcessGpuRtLibrary::createGetStackSize,   &SpirvProcessGpuRtLibrary::createLdsRead,
+      &SpirvProcessGpuRtLibrary::createLdsWrite,       &SpirvProcessGpuRtLibrary::createGetStackBase,
+      &SpirvProcessGpuRtLibrary::createGetStackStride, &SpirvProcessGpuRtLibrary::createLdsStackInit,
+      &SpirvProcessGpuRtLibrary::createLdsStackStore,
+
+  };
+  for (unsigned i = 0; i < AmdLibraryFunc::Count; ++i) {
+    m_libFuncPtrs[RtName::AmdLibraryNames[i]] = amdLibraryFuncs[i];
+  }
+}
+
+// =====================================================================================================================
+// Clear the block before patching the function
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::processLibraryFunction(Function *&func) {
+  auto &funcTable = LibraryFunctionTable::get().m_libFuncPtrs;
+
+  auto funcIt = funcTable.find(func->getName());
+  if (funcIt != funcTable.end()) {
+    auto funcPtr = funcIt->second;
+    (this->*funcPtr)(func);
+  }
+}
+
+// =====================================================================================================================
+// Create to get stack size
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createGetStackSize(llvm::Function *func) {
+  m_builder->SetInsertPoint(clearBlock(func));
+  m_builder->CreateRet(m_builder->create<GpurtGetStackSize>());
+}
+
+// =====================================================================================================================
+// Create to get stack base
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createGetStackBase(llvm::Function *func) {
+  m_builder->SetInsertPoint(clearBlock(func));
+  m_builder->CreateRet(m_builder->create<GpurtGetStackBase>());
+}
+
+// =====================================================================================================================
+// Create to write LDS stack
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createLdsWrite(llvm::Function *func) {
+  m_builder->SetInsertPoint(clearBlock(func));
+  auto argIt = func->arg_begin();
+  auto int32ty = m_builder->getInt32Ty();
+  Value *stackOffset = m_builder->CreateLoad(int32ty, argIt++);
+  Value *stackData = m_builder->CreateLoad(int32ty, argIt);
+  m_builder->CreateRet(m_builder->create<GpurtStackWrite>(stackOffset, stackData));
+}
+
+// =====================================================================================================================
+// Create to read LDS stack
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createLdsRead(llvm::Function *func) {
+  m_builder->SetInsertPoint(clearBlock(func));
+  Value *stackIndex = func->arg_begin();
+  stackIndex = m_builder->CreateLoad(m_builder->getInt32Ty(), stackIndex);
+  m_builder->CreateRet(m_builder->create<GpurtStackRead>(stackIndex));
+}
+
+// =====================================================================================================================
+// Create to get stack stride
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createGetStackStride(llvm::Function *func) {
+
+  m_builder->SetInsertPoint(clearBlock(func));
+  m_builder->CreateRet(m_builder->create<GpurtGetStackStride>());
+}
+
+// =====================================================================================================================
+// Create to init stack LDS
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createLdsStackInit(llvm::Function *func) {
+  m_builder->SetInsertPoint(clearBlock(func));
+  m_builder->CreateRet(m_builder->create<GpurtLdsStackInit>());
+}
+
+// =====================================================================================================================
+// Create to store stack LDS
+//
+// @param func : The function to process
+void SpirvProcessGpuRtLibrary::createLdsStackStore(llvm::Function *func) {
+  m_builder->SetInsertPoint(clearBlock(func));
+  auto argIt = func->arg_begin();
+  Value *stackAddr = argIt++;
+  Value *lastVisited = m_builder->CreateLoad(m_builder->getInt32Ty(), argIt++);
+  auto int32x4Ty = FixedVectorType::get(m_builder->getInt32Ty(), 4);
+  Value *data = m_builder->CreateLoad(int32x4Ty, argIt);
+  m_builder->CreateRet(m_builder->create<GpurtLdsStackStore>(stackAddr, lastVisited, data));
+}
+
+} // namespace Llpc

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.h
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.h
@@ -1,0 +1,42 @@
+/*
+************************************************************************************************************************
+*
+*  Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+*
+***********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcSpirvProcessGpuRtLibrary.h
+ * @brief LLPC header file: contains declaration of Llpc::SpirvProcessGpuRtLibrary
+ ***********************************************************************************************************************
+ */
+#pragma once
+
+#include "llpcSpirvLower.h"
+#include "llvm/IR/PassManager.h"
+namespace Llpc {
+class SpirvProcessGpuRtLibrary : public SpirvLower, public llvm::PassInfoMixin<SpirvProcessGpuRtLibrary> {
+public:
+  SpirvProcessGpuRtLibrary();
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+
+private:
+  typedef void (SpirvProcessGpuRtLibrary::*LibraryFuncPtr)(llvm::Function *);
+  struct LibraryFunctionTable {
+    llvm::DenseMap<llvm::StringRef, LibraryFuncPtr> m_libFuncPtrs;
+    LibraryFunctionTable();
+    static const LibraryFunctionTable &get() {
+      static LibraryFunctionTable instance;
+      return instance;
+    }
+  };
+  void processLibraryFunction(llvm::Function *&func);
+  void createGetStackSize(llvm::Function *func);
+  void createGetStackBase(llvm::Function *func);
+  void createLdsWrite(llvm::Function *func);
+  void createLdsRead(llvm::Function *func);
+  void createGetStackStride(llvm::Function *func);
+  void createLdsStackInit(llvm::Function *func);
+  void createLdsStackStore(llvm::Function *func);
+};
+} // namespace Llpc

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7665,15 +7665,6 @@ bool SPIRVToLLVM::transMetadata() {
           computeMode.workgroupSizeZ = workgroupSizeZ;
         }
         Pipeline::setComputeShaderMode(*m_m, computeMode);
-#if VKI_RAY_TRACING
-        // We also need to set the overall workgroup size on the PipelineContext so that the LowerRayQuery
-        // pass running on the rayQuery library module (a different module to this compute shader) can see it.
-        unsigned workgroupSize = workgroupSizeX == 0 ? 1 : workgroupSizeX;
-        workgroupSize *= workgroupSizeY == 0 ? 1 : workgroupSizeY;
-        workgroupSize *= workgroupSizeZ == 0 ? 1 : workgroupSizeZ;
-        Llpc::Context *llpcContext = static_cast<Llpc::Context *>(m_context);
-        llpcContext->getPipelineContext()->setWorkgroupSize(workgroupSize);
-#endif
 
       } else
         llvm_unreachable("Invalid execution model");


### PR DESCRIPTION
Moving the stack library functions processing from SpirvLowerRayQuery to the LowerGpurt

Now the stack operation lowering is postpone to the Lowergpurt after module inlining with
exlicit workgroup size knowledge.

Use dialect to refactor rayquery module
Add intersect lds check

Double lds size of the anyhit and intersection shader. and anyhit and intersection shader user lower part of the stack to read/write values