### PR TITLE
DebugPrintf: various cleanups and add documentation

### DIFF
--- a/docs/DdnDebugPrintf.md
+++ b/docs/DdnDebugPrintf.md
@@ -1,0 +1,274 @@
+# Support of NonSemantics.DebugPrintf
+
+## Summary
+
+The `NonSemantics.DebugPrintf` extended instruction enables `printf`-style
+functionality in SPIR-V modules.
+
+Khronos validation has a `debugPrintf` layer which implements the instruction by
+hooking `vkCreateShaderModule`, among other things. However, we have quite a lot
+of internal SPIR-V code (e.g. for ray tracing) which is never seen by any
+Vulkan layers.
+
+Our internal print debug capability allows us to use `printf` in internal
+SPIR-V applications that are head-scratching hard to debug.
+
+
+## Interfaces
+
+This section describes interfaces between major components:
+
+* Various components need to be aware of [format string identifiers](#format-string-identifiers)
+  which are used to refer to format strings.
+
+* The [printf buffer](#printf-buffer) is setup by the driver at runtime, written
+  to by the shader to capture uses of the `DebugPrintf` extended instruction,
+  and then read and interpreted by the driver afterwards.
+
+* The [ELF extension](#elf-extension) describes how format strings and their
+  identifiers are stored in PAL metadata.
+
+### Format string identifiers
+
+At runtime, the shader does not touch format strings. Each use of `DebugPrintf`
+merely writes a numeric ID of the relevant format string to the printf buffer.
+
+Format string IDs must be unique at least on a per-device (`Pal::IDevice`)
+basis.
+
+Format string IDs are 48-bit numbers.
+
+Instead of attempting to coordinate the assignment of IDs between multiple
+shader compilations, the compiler simply computes a hash of the format string
+and uses that as the format string ID.
+
+48-bit hashes can collide, but the likelihood is very low and acceptable for a
+debug feature. When loading a pipeline, the driver should check whether an ID
+has been seen before with a different corresponding format string and issue a
+warning in that case.
+
+To avoid having to coordinate hashing algorithms between different software
+components, the compiler writes the ID to ELF metadata, and other components
+(PAL, driver) use the ID as an opaque number. They need not be aware of the
+hashing algorithm.
+
+### ELF extension
+
+Format strings are placed inside a new `amdpal.format_strings` map in the PAL
+metadata. This new map is a sibling of the existing `amdpal.version` and
+`amdpal.pipelines` entries.
+
+The `amdpal.format_strings` map contains:
+
+* An element with key `.version` whose value is the integer `1`.
+* An element with key `.strings` whose value is an array of maps, each of
+  which contains:
+  * An element with key `.index` whose value is the format string identifier
+    as an integer.
+  * An element with key `.string` whose value is the format string.
+  * An element with key `.argument_count` whose value is the number of arguments
+    passed into `DebugPrintf`
+  * An element with key `.64bit_arguments` whose value is an array of 64-bit
+    integers that serve as a bitmask of arguments that are 64-bit sized
+
+An example in JSON-ified form:
+```json
+{
+    "amdpal.version": [ .. ],
+    "amdpal.pipelines": [ .. ],
+    "amdpal.format_strings": {
+        ".version": 1,
+        ".strings": [
+            {
+              ".index": 12345678,
+              ".string": "Sample %i format %f",
+              ".argument_count": 2,
+              ".64bit_arguments": [0]
+            },
+            {
+              ".index": 31415926,
+              ".string": "Another format string: %f %f",
+              ".argument_count": 2,
+              ".64bit_arguments": [0]
+            }
+        ]
+    }
+}
+```
+
+### Printf buffer
+
+The driver sets up a buffer into which `printf` invocations are logged. The
+buffer contains an overall header that is initialized by the driver, followed
+immediately by space into which buffer entries are written by the shader.
+
+```c++
+// The header is followed by entries. Reserved fields must be initialized to 0
+// by the driver.
+struct PrintfBufferHeader {
+    // Offset into the buffer in dwords, **excluding** this header. Points at
+    // the next free space. Note that only buffers up to 2GiB are supported;
+    // if this value is larger, the buffer has overrun and anything beyond 2GiB
+    // may be garbage.
+    uint64_t bufferOffset;
+
+    uint32_t reserved0;
+    uint32_t reserved1;
+};
+static_assert(sizeof(PrintfBufferHeader) == 16, "header size changed");
+
+// Each entry is followed by entry-specific payload. The driver uses the
+// formatStringId to interpret the payload.
+struct PrintfBufferEntryHeader {
+    // Size of the entry in dwords, including this header.
+    uint64_t entrySize : 16;
+
+    // Identifies the format string that is used by this entry.
+    uint64_t formatStringId : 48;
+};
+static_assert(sizeof(PrintfBufferEntryHeader) == 8, "entry header size changed");
+```
+
+The 64-bit address pointing at `PrintfBufferHeader` is passed to the shader via
+a binding with:
+
+* `set = InternalDescriptorSetId`
+* `binding = InternalBinding::PrintfBufferBindingId`
+
+**Payload packing:** Payload arguments to `NonSemantic.DebugPrintf` are packed
+as follows:
+
+* integer values are first zero-extended to be at least 32-bits wide and are
+  then written with 4-byte alignment
+* half-precision floating point values are widened to single-precision
+  floating point values
+* float and double values are written with 4-byte alignment
+* vector values are written as a sequence of component scalar values
+
+**Buffer overflow protection:** The shader uses a 64-bit atomic add on
+`bufferOffset` to allocate space in the buffer and retrieve the offset at which
+to write into the buffer. To prevent overwriting older data, the 64-bit value is
+clamped to a value corresponding to at most 2GiB before using the clamped result
+as an offset of `buffer_store` instructions.
+
+We do _not_ guard against wraparound of `bufferOffset` itself ([rationale](#overflow-of-bufferoffset)).
+
+**Format string safety:** If a shader's use of `DebugPrintf` is incorrect, it is
+possible for the payload to be too short for the underlying format string. It is
+up to the parser integrated in the driver to guard against such errors.
+
+
+## Implementation
+
+### Vulkan driver
+
+During pipeline creation, the printf buffer descriptor is added to the pipeline
+resource mapping.
+
+Most of the implementation is in xgl/icd/api/debug_printf.cpp.
+
+> **Note/Todo:** At time of writing, the implementation is limited to handling
+> only a single pipeline at a time.
+
+
+### LLPC
+
+#### lgc: debug printf operation
+
+The `@lgc.debug.printf` operation represents a printf call for debug purposes.
+It is declared as follows:
+```llvm
+declare void @lgc.debug.printf(ptr addrspace(7) %buffer, ptr addrspace(4) %format, ...)
+                               memory(inaccessible) nosync nounwind alwaysreturn
+```
+`%buffer` is a (fat) pointer to the printf buffer.
+
+`%format` is the format string, which must point at a non-external global
+constant of type `[n x i8]`.
+
+Allowed types for the variable argument operands are:
+
+* `i8, i16, i32, i64, half, float, double`
+* Vectors of the above
+
+#### SPIRVReader
+
+The SPIRVReader emits the format string as a global variable in the constant
+address space and produces a call to `@lgc.debug.printf`.
+
+Example:
+```llvm
+  @debugString.0 = private addrspace(4) constant [11 x i8] c"the arg: %i", align 1
+
+  ...
+  call void (...) @lgc.debug.printf(ptr addrspace(7) %printfBuffer, ptr addrspace(4) @debugString.0, i32 %arg)
+  ...
+```
+
+**Note:** Builder record/replay is not used.
+
+#### lgc::LowerDebugPrintf
+
+The module pass `LowerDebugPrintf` runs just before `PatchEntryPointMutate`.
+It collects all calls to `@lgc.debug.printf` in the entire module and:
+
+* Collects the format strings and adds the `amdpal.format_strings` entry to the
+  PAL metadata document.
+* Lowers the calls to the required lower-level instructions.
+
+#### Linker support
+
+The LLPC-internal ELF linker must be able to:
+
+* Combine the `amdpal.format_strings.strings` arrays from all source ELF files.
+
+> **Note/Todo:** This is currently not implemented.
+
+## Appendix
+
+### Format string identifier rationales
+
+We use 48-bit identifiers to keep the printf buffer entry encoding reasonably
+compact.
+
+Two alternatives were considered:
+
+We considered assigning IDs after compilation, using ELF relocation. This
+alternative was rejected because it is more complicated.
+
+We also considered splitting the identifier namespace into (pipeline/module,
+string) pairs at the architectural level. This introduces a number of
+complications:
+
+* Require either a fixed bit split which may end up causing surprising
+  limitations, or grow the ID to at least 64 bits.
+* Additional implementation cost for partial pipeline compilation / partial
+  pipeline caching. Consider vertex and fragment shaders that both use
+  `DebugPrintf`, are first compiled separately, and then linked together in the
+  compiler. We would either have to re-assign string IDs during the static
+  linking in the compiler or extend the metadata format such a single `.elf`
+  can define multiple "modules".
+
+In contrast, the genuine benefits of such a split are unclear:
+
+* Allocation of IDs in the driver may be cheaper. However, for the debugging
+  scenario, a simple bump allocator is most likely sufficient anyway.
+* Tying an ID back to a pipeline when parsing the printf buffer is possible
+  either way by storing a link back to the pipeline together with the format
+  string.
+
+Therefore, we currently do not propose such a split.
+
+### Overflow of bufferOffset
+
+It is theoretically possible for `PrintfBufferHeader::bufferOffset` to
+overflow. Once we've overflown the buffer, increments to `bufferOffset` are
+no longer limited by the external memory bandwidth; they're only limited by how
+fast we can do the atomic adds.
+
+Assuming a maximum entry size of `128 B`, a wave may attempt to allocate up to
+`8 kB` in a single atomic transaction (one chunk of `128 B` per lane). As one
+atomic transaction can be handled per clock, this means that `~2**44` bytes can
+be allocated per second, which would lead to a wraparound in `~2**20` seconds,
+or just over 12 days. It seems safe to ignore this overflow scenario.
+

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -1866,7 +1866,7 @@ Value *Builder::createFMix(Value *x, Value *y, Value *a, const Twine &instName) 
 // @vars: Printf variable parameters
 // @instName : Instance Name
 Value *Builder::CreateDebugPrintf(ArrayRef<Value *> vars, const Twine &instName) {
-  return record(BuilderOpcode::DebugPrintf, getInt64Ty(), vars, instName);
+  return record(BuilderOpcode::DebugPrintf, getVoidTy(), vars, instName);
 }
 
 // =====================================================================================================================

--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -66,8 +66,6 @@ StringRef BuilderRecorder::getCallName(BuilderOpcode opcode) {
   switch (opcode) {
   case BuilderOpcode::Nop:
     return "nop";
-  case BuilderOpcode::DebugPrintf:
-    return "debug.printf";
   case BuilderOpcode::DotProduct:
     return "dot.product";
   case BuilderOpcode::IntegerDotProduct:
@@ -1862,14 +1860,6 @@ Value *Builder::createFMix(Value *x, Value *y, Value *a, const Twine &instName) 
 }
 
 // =====================================================================================================================
-// Create debug printf operation, and write to the output debug buffer
-// @vars: Printf variable parameters
-// @instName : Instance Name
-Value *Builder::CreateDebugPrintf(ArrayRef<Value *> vars, const Twine &instName) {
-  return record(BuilderOpcode::DebugPrintf, getVoidTy(), vars, instName);
-}
-
-// =====================================================================================================================
 // Create a subgroup shuffle.
 //
 // @param value : The value to shuffle
@@ -2086,7 +2076,6 @@ Instruction *Builder::record(BuilderOpcode opcode, Type *resultTy, ArrayRef<Valu
     case BuilderOpcode::CrossProduct:
     case BuilderOpcode::CubeFaceCoord:
     case BuilderOpcode::CubeFaceIndex:
-    case BuilderOpcode::DebugPrintf:
     case BuilderOpcode::Derivative:
     case BuilderOpcode::DotProduct:
     case BuilderOpcode::IntegerDotProduct:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -161,7 +161,6 @@ enum BuilderOpcode : unsigned {
   Barrier,
   Kill,
   ReadClock,
-  DebugPrintf,
   Derivative,
   DemoteToHelperInvocation,
   IsHelperInvocation,

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -729,14 +729,6 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   case BuilderOpcode::DotProduct: {
     return m_builder->CreateDotProduct(args[0], args[1]);
   }
-  case BuilderOpcode::DebugPrintf: {
-    SmallVector<Value *> vars;
-    vars.reserve(args.size());
-    for (const auto &arg : args) {
-      vars.push_back(arg);
-    }
-    return m_builder->CreateDebugPrintf(vars);
-  }
   case BuilderOpcode::IntegerDotProduct: {
     Value *vector1 = args[0];
     Value *vector2 = args[1];

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1466,7 +1466,7 @@ Value *BuilderImpl::CreateDebugPrintf(ArrayRef<Value *> args, const Twine &instN
   for (auto arg : args)
     argTys.push_back(arg->getType());
 
-  auto funcTy = FunctionType::get(getInt64Ty(), argTys, false);
+  auto funcTy = FunctionType::get(getVoidTy(), argTys, false);
   auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::LowerDebugPrintf, module);
   func->addFnAttr(Attribute::NoUnwind);
   return CreateCall(func, args, instName);

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1456,23 +1456,6 @@ Value *BuilderImpl::CreateTaskPayloadAtomicCompareSwap(AtomicOrdering ordering, 
 }
 
 // =====================================================================================================================
-// Create debug printf operation, and write to the output debug buffer
-// @args : Printf variable parameters
-// @instName : Instance Name
-Value *BuilderImpl::CreateDebugPrintf(ArrayRef<Value *> args, const Twine &instName) {
-  Module *module = GetInsertPoint()->getModule();
-  SmallVector<Type *> argTys;
-  argTys.reserve(args.size());
-  for (auto arg : args)
-    argTys.push_back(arg->getType());
-
-  auto funcTy = FunctionType::get(getVoidTy(), argTys, false);
-  auto func = Function::Create(funcTy, GlobalValue::InternalLinkage, lgcName::LowerDebugPrintf, module);
-  func->addFnAttr(Attribute::NoUnwind);
-  return CreateCall(func, args, instName);
-}
-
-// =====================================================================================================================
 // Get the type of a built-in. This overrides the one in Builder to additionally recognize the internal built-ins.
 //
 // @param builtIn : Built-in kind

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -519,9 +519,6 @@ public:
                                                   llvm::Value *comparatorValue, llvm::Value *byteOffset,
                                                   const llvm::Twine &instName = "");
 
-  // Create debug printf operation, and write to the output debug buffer
-  llvm::Value *CreateDebugPrintf(llvm::ArrayRef<llvm::Value *> vars, const llvm::Twine &instName = "");
-
 private:
   // Read (a part of) a generic (user) input/output value.
   llvm::Value *readGenericInputOutput(bool isOutput, llvm::Type *resultTy, unsigned location,

--- a/lgc/include/lgc/patch/LowerDebugPrintf.h
+++ b/lgc/include/lgc/patch/LowerDebugPrintf.h
@@ -39,6 +39,9 @@
 #include "llvm/IR/Function.h"
 
 namespace lgc {
+
+class DebugPrintfOp;
+
 // =====================================================================================================================
 // Pass to lower debug.printf calls
 class LowerDebugPrintf : public llvm::PassInfoMixin<LowerDebugPrintf> {
@@ -52,12 +55,12 @@ public:
   static llvm::StringRef name() { return "Lower debug printf calls"; }
 
 private:
-  void createDebugPrintf(llvm::Value *debugPrintfBuffer, llvm::Value *formatStr,
-                         llvm::iterator_range<llvm::User::op_iterator> vars, lgc::BuilderBase &builder);
+  void visitDebugPrintf(DebugPrintfOp &op);
   void getDwordValues(llvm::Value *val, llvm::SmallVectorImpl<llvm::Value *> &output,
                       llvm::SmallBitVector &output64Bits, BuilderBase &builder);
   void setupElfsPrintfStrings();
   llvm::DenseMap<uint64_t, ElfInfo> m_elfInfos;
+  llvm::SmallVector<llvm::Instruction *> m_toErase;
   PipelineState *m_pipelineState = nullptr;
 };
 

--- a/lgc/include/lgc/patch/LowerDebugPrintf.h
+++ b/lgc/include/lgc/patch/LowerDebugPrintf.h
@@ -41,7 +41,7 @@
 namespace lgc {
 // =====================================================================================================================
 // Pass to lower debug.printf calls
-class LowerDebugPrintf : public Patch, public llvm::PassInfoMixin<LowerDebugPrintf> {
+class LowerDebugPrintf : public llvm::PassInfoMixin<LowerDebugPrintf> {
   struct ElfInfo {
     llvm::StringRef formatString;  // Printf format string
     llvm::SmallBitVector bit64Pos; // 64bit position records output variable 32bit/64bit condition.
@@ -52,8 +52,8 @@ public:
   static llvm::StringRef name() { return "Lower debug printf calls"; }
 
 private:
-  llvm::Value *createDebugPrintf(llvm::Value *debugPrintfBuffer, llvm::Value *formatStr,
-                                 llvm::iterator_range<llvm::User::op_iterator> vars, lgc::BuilderBase &builder);
+  void createDebugPrintf(llvm::Value *debugPrintfBuffer, llvm::Value *formatStr,
+                         llvm::iterator_range<llvm::User::op_iterator> vars, lgc::BuilderBase &builder);
   void getDwordValues(llvm::Value *val, llvm::SmallVectorImpl<llvm::Value *> &output,
                       llvm::SmallBitVector &output64Bits, BuilderBase &builder);
   void setupElfsPrintfStrings();

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -96,7 +96,6 @@ const static char NggPrimShaderEntryPoint[] = "lgc.shader.PRIM.main";
 const static char EntryPointPrefix[] = "lgc.shader.";
 const static char CopyShaderEntryPoint[] = "lgc.shader.COPY.main";
 const static char NullFsEntryPoint[] = "lgc.shader.FS.null.main";
-const static char LowerDebugPrintf[] = "lgc.debug.printf";
 
 } // namespace lgcName
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -216,6 +216,12 @@ public:
   // Record pipeline state into IR metadata of specified module.
   void record(llvm::Module *module);
 
+  // Print pipeline state
+  void print(llvm::raw_ostream &out) const;
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+  LLVM_DUMP_METHOD void dump() const { print(llvm::dbgs()); }
+#endif
+
   // Accessors for shader stage mask
   unsigned getShaderStageMask();
   bool getPreRasterHasGs() const { return m_preRasterHasGs; }
@@ -616,6 +622,25 @@ public:
   bool runImpl(llvm::Module &module, PipelineState *pipelineState);
 
   static llvm::StringRef name() { return "LLPC pipeline state clearer"; }
+};
+
+// =====================================================================================================================
+// Pass to print the pipeline state in a human-readable way
+class PipelineStatePrinter : public llvm::PassInfoMixin<PipelineStatePrinter> {
+public:
+  explicit PipelineStatePrinter(llvm::raw_ostream &out = llvm::dbgs()) : m_out(out) {}
+
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
+
+private:
+  llvm::raw_ostream &m_out;
+};
+
+// =====================================================================================================================
+// Pass to record the pipeline state back into the IR if present
+class PipelineStateRecorder : public llvm::PassInfoMixin<PipelineStateRecorder> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
 };
 
 } // namespace lgc

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1430,10 +1430,6 @@ public:
   llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount, // NOLINT
                                           const llvm::Twine &instName = "");
 
-  // Create debug printf operation, and write to the output debug buffer
-  // @vars: Printf variable parameters
-  // @instName : Instance Name
-  llvm::Value *CreateDebugPrintf(llvm::ArrayRef<llvm::Value *> vars, const llvm::Twine &instName = "");
   // -----------------------------------------------------------------------------------------------------------------
   // Subgroup operations
 

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -30,6 +30,7 @@ def LgcDialect : Dialect {
   let cppNamespace = "lgc";
 }
 
+def ConstantPointer : TgConstant<(PointerType 4)>, Type;
 def PrivatePointer : TgConstant<(PointerType 5)>, Type;
 def BufferPointer : TgConstant<(PointerType 7)>, Type;
 
@@ -78,6 +79,19 @@ def BufferPtrDiffOp : LgcOp<"buffer.ptr.diff", [Memory<[]>, WillReturn]> {
     If `lhs` and `rhs` have different pointer provenance, the result is poison.
 
     If `lhs` and `rhs` are both null, the result is 0.
+  }];
+}
+
+def DebugPrintfOp : LgcOp<"debug.printf", [Memory<[(readwrite InaccessibleMem)]>, WillReturn]> {
+  let arguments = (ins BufferPointer:$buffer, ConstantPointer:$format, varargs:$args);
+  let results = (outs);
+
+  let summary = "print a formatted message";
+  let description = [{
+    Writes an entry to the debug printf buffer pointed to by `buffer`. No-op if `buffer` is literal constant poison.
+
+    `format` must be a non-external global variable in the constant address space of type `[n x i8]` (not
+    null-terminated).
   }];
 }
 

--- a/lgc/patch/LowerDebugPrintf.cpp
+++ b/lgc/patch/LowerDebugPrintf.cpp
@@ -53,22 +53,19 @@ namespace lgc {
 PreservedAnalyses LowerDebugPrintf::run(Module &module, ModuleAnalysisManager &analysisManager) {
   LLVM_DEBUG(dbgs() << "Run the pass Lower-debug-printf\n");
   PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
-  Patch::init(&module);
   m_pipelineState = pipelineState;
   SmallVector<CallInst *> callees;
-  BuilderBase builder(*m_context);
+  BuilderBase builder(module.getContext());
   for (auto &func : module) {
     auto name = func.getName();
     if (name.startswith(lgcName::LowerDebugPrintf)) {
       for (auto user : func.users()) {
         if (CallInst *callInst = dyn_cast<CallInst>(user)) {
-          Value *resultVal = builder.getInt64(0);
-          if (!isa<UndefValue>(callInst->getArgOperand(0)) && !isa<PoisonValue>(callInst->getArgOperand(0))) {
+          if (!isa<PoisonValue>(callInst->getArgOperand(0))) {
             builder.SetInsertPoint(callInst);
-            resultVal = createDebugPrintf(callInst->getArgOperand(0), callInst->getArgOperand(1),
-                                          make_range(callInst->arg_begin() + 2, callInst->arg_end()), builder);
+            createDebugPrintf(callInst->getArgOperand(0), callInst->getArgOperand(1),
+                              make_range(callInst->arg_begin() + 2, callInst->arg_end()), builder);
           }
-          callInst->replaceAllUsesWith(resultVal);
           callees.push_back(callInst);
         }
       }
@@ -92,8 +89,8 @@ PreservedAnalyses LowerDebugPrintf::run(Module &module, ModuleAnalysisManager &a
 // @formatStr : Printf format string
 // @vars : Printf variable parameters
 // @builder : BuilderBase to build instruction
-Value *LowerDebugPrintf::createDebugPrintf(Value *debugPrintfBuffer, Value *formatStr,
-                                           iterator_range<User::op_iterator> vars, BuilderBase &builder) {
+void LowerDebugPrintf::createDebugPrintf(Value *debugPrintfBuffer, Value *formatStr,
+                                         iterator_range<User::op_iterator> vars, BuilderBase &builder) {
 
   // Printf output variables in DWORDs
 
@@ -122,23 +119,17 @@ Value *LowerDebugPrintf::createDebugPrintf(Value *debugPrintfBuffer, Value *form
   uint32_t loEntryheader = uint32_t(header);
   uint32_t hiEntryheader = uint32_t(header >> 32);
 
-  auto offsetTy = PointerType::get(builder.getInt64Ty(), ADDR_SPACE_BUFFER_FAT_POINTER);
-  Value *bufferPtr = builder.CreateBitCast(debugPrintfBuffer, offsetTy);
   // uint64_t offset = AtomicAdd64(offsetPtr, entrySize);
-  // maxOffset = 1<<31;
+  // maxOffset = 1 << 29; // corresponds to 2GiB
   // offset = offset < maxOffset ? offset : maxOffset;
-  Value *entryOffset = builder.CreateAtomicRMW(AtomicRMWInst::Add, bufferPtr, builder.getInt64(entrySize), MaybeAlign(),
-                                               AtomicOrdering::Monotonic, SyncScope::SingleThread);
-  Value *maxOffset = builder.getInt64(1U << 31);
+  Value *entryOffset = builder.CreateAtomicRMW(AtomicRMWInst::Add, debugPrintfBuffer, builder.getInt64(entrySize),
+                                               MaybeAlign(8), AtomicOrdering::Monotonic, SyncScope::System);
+  Value *maxOffset = builder.getInt64(1U << 29);
   entryOffset = builder.CreateBinaryIntrinsic(Intrinsic::umin, entryOffset, maxOffset);
+  entryOffset = builder.CreateTrunc(entryOffset, builder.getInt32Ty());
 
-  // Buffer Header is {BufferOffset_Loword, BufferOffset_Hiword, reserved0, reserved1};
-  Type *bufferHeaderType = ArrayType::get(builder.getInt32Ty(), 4);
-  Type *runtimeArrayType = ArrayType::get(builder.getInt32Ty(), ~0U);
-  Type *bufferType = StructType::get(*m_context, {bufferHeaderType, runtimeArrayType});
-  Type *bufferPtrType = PointerType::get(bufferType, ADDR_SPACE_BUFFER_FAT_POINTER);
-
-  bufferPtr = builder.CreateBitCast(debugPrintfBuffer, bufferPtrType);
+  // Skip buffer Header, which is {BufferOffset_Loword, BufferOffset_Hiword, reserved0, reserved1};
+  entryOffset = builder.CreateAdd(entryOffset, builder.getInt32(4));
 
   SmallVector<Value *> outputVals = {builder.getInt32(loEntryheader), builder.getInt32(hiEntryheader)};
   outputVals.reserve(printArgs.size() + 2);
@@ -148,13 +139,10 @@ Value *LowerDebugPrintf::createDebugPrintf(Value *debugPrintfBuffer, Value *form
 
   // Write the payload to debug buffer
   for (auto outValue : outputVals) {
-    Value *bufferOutputPos =
-        builder.CreateGEP(bufferType, bufferPtr, {builder.getInt32(0), builder.getInt32(1), entryOffset});
+    Value *bufferOutputPos = builder.CreateGEP(builder.getInt32Ty(), debugPrintfBuffer, entryOffset);
     builder.CreateStore(outValue, bufferOutputPos);
-    entryOffset = builder.CreateAdd(entryOffset, builder.getInt64(1));
+    entryOffset = builder.CreateAdd(entryOffset, builder.getInt32(1));
   }
-
-  return entryOffset;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/PassRegistry.inc
+++ b/lgc/patch/PassRegistry.inc
@@ -50,6 +50,8 @@
 #endif
 
 LLPC_MODULE_ANALYSIS("lgc-pipeline-state", PipelineStateWrapper)
+LLPC_MODULE_PASS("print<lgc-pipeline-state>", PipelineStatePrinter)
+LLPC_MODULE_PASS("lgc-pipeline-state-recorder", PipelineStateRecorder)
 
 LLPC_MODULE_PASS("lgc-builder-replayer", BuilderReplayer)
 LLPC_MODULE_PASS("lgc-patch-resource-collect", PatchResourceCollect)

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1886,6 +1886,18 @@ void PipelineState::setXfbStateMetadata(Module *module) {
 }
 
 // =====================================================================================================================
+// Print the pipeline state
+//
+// @param out : output stream
+void PipelineState::print(llvm::raw_ostream &out) const {
+  if (m_palMetadata) {
+    out << "PAL metadata:\n";
+    m_palMetadata->getDocument()->toYAML(out);
+  }
+  out << "(pipeline state printing is incomplete)\n";
+}
+
+// =====================================================================================================================
 // Execute this analysis on the specified LLVM module.
 //
 // @param [in/out] module : LLVM module to be run on
@@ -1943,4 +1955,30 @@ PipelineStateWrapper::PipelineStateWrapper(LgcContext *builderContext) : m_build
 //
 // @param pipelineState : Pipeline state to wrap
 PipelineStateWrapper::PipelineStateWrapper(PipelineState *pipelineState) : m_pipelineState(pipelineState) {
+}
+
+// =====================================================================================================================
+// Print the pipeline state in a human-readable way
+//
+// @param [in/out] module : IR module
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+// @returns : The preserved analyses (The analyses that are still valid after this pass)
+PreservedAnalyses PipelineStatePrinter::run(Module &module, ModuleAnalysisManager &analysisManager) {
+  PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
+  pipelineState->print(m_out);
+  return PreservedAnalyses::all();
+}
+
+// =====================================================================================================================
+// Record the PipelineState back into the IR, if present
+//
+// @param [in/out] module : IR module
+// @param [in/out] analysisManager : Analysis manager to use for this transformation
+// @returns : The preserved analyses (The analyses that are still valid after this pass)
+PreservedAnalyses PipelineStateRecorder::run(Module &module, ModuleAnalysisManager &analysisManager) {
+  if (auto *psw = analysisManager.getCachedResult<PipelineStateWrapper>(module)) {
+    PipelineState *pipelineState = psw->getPipelineState();
+    pipelineState->record(&module);
+  }
+  return PreservedAnalyses::none();
 }

--- a/lgc/test/CMakeLists.txt
+++ b/lgc/test/CMakeLists.txt
@@ -23,7 +23,7 @@
  #
  #######################################################################################################################
 
-set(LGC_TEST_DEPENDS lgc lgcdis FileCheck count not llvm-mc)
+set(LGC_TEST_DEPENDS lgc lgcdis FileCheck count not llvm-mc llvm-readelf llvm-objdump)
 add_custom_target(lgc-test-depends DEPENDS ${LGC_TEST_DEPENDS})
 set_target_properties(lgc-test-depends PROPERTIES FOLDER "Tests")
 

--- a/lgc/test/CsLowerDebugPrintf.lgc
+++ b/lgc/test/CsLowerDebugPrintf.lgc
@@ -26,12 +26,12 @@ define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !spi
   %11 = insertelement <2 x i32> poison, i32 0, i64 0
   %12 = insertelement <2 x i32> %11, i32 0, i64 1
   %13 = bitcast <2 x i32> %12 to i64
-  %" " = call i64 @lgc.debug.printf(ptr addrspace(7) %10, ptr addrspace(4) @str.1, i32 %__llpc_input_proxy_gl_GlobalInvocationID.0.vec.extract, i64 %13)
+  call void (...) @lgc.debug.printf(ptr addrspace(7) %10, ptr addrspace(4) @str.1, i32 %__llpc_input_proxy_gl_GlobalInvocationID.0.vec.extract, i64 %13)
   ret void
 }
 
 ; Function Attrs: nounwind
-declare i64 @lgc.debug.printf(ptr addrspace(7), ptr addrspace(4), i32) #0
+declare void @lgc.debug.printf(...) #0
 
 ; Function Attrs: nounwind memory(none)
 declare <3 x i32> @lgc.shader.input.WorkgroupId(i32) #1
@@ -88,22 +88,24 @@ attributes #2 = { nounwind willreturn memory(none) }
 ; CHECK-NEXT:    [[TMP14:%.*]] = trunc i64 [[TMP13]] to i32
 ; CHECK-NEXT:    [[TMP15:%.*]] = lshr i64 [[TMP13]], 32
 ; CHECK-NEXT:    [[TMP16:%.*]] = trunc i64 [[TMP15]] to i32
-; CHECK-NEXT:    [[TMP17:%.*]] = atomicrmw add ptr addrspace(7) [[TMP10]], i64 5 syncscope("singlethread") monotonic, align 8
-; CHECK-NEXT:    [[TMP18:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP17]], i64 2147483648)
-; CHECK-NEXT:    [[TMP19:%.*]] = getelementptr { [4 x i32], [4294967295 x i32] }, ptr addrspace(7) [[TMP10]], i32 0, i32 1, i64 [[TMP18]]
-; CHECK-NEXT:    store i32 {{-*[0-9]+}}, ptr addrspace(7) [[TMP19]], align 4
-; CHECK-NEXT:    [[TMP20:%.*]] = add i64 [[TMP18]], 1
-; CHECK-NEXT:    [[TMP21:%.*]] = getelementptr { [4 x i32], [4294967295 x i32] }, ptr addrspace(7) [[TMP10]], i32 0, i32 1, i64 [[TMP20]]
-; CHECK-NEXT:    store i32 {{-*[0-9]+}}, ptr addrspace(7) [[TMP21]], align 4
-; CHECK-NEXT:    [[TMP22:%.*]] = add i64 [[TMP20]], 1
-; CHECK-NEXT:    [[TMP23:%.*]] = getelementptr { [4 x i32], [4294967295 x i32] }, ptr addrspace(7) [[TMP10]], i32 0, i32 1, i64 [[TMP22]]
-; CHECK-NEXT:    store i32 [[__LLPC_INPUT_PROXY_GL_GLOBALINVOCATIONID_0_VEC_EXTRACT]], ptr addrspace(7) [[TMP23]], align 4
-; CHECK-NEXT:    [[TMP24:%.*]] = add i64 [[TMP22]], 1
-; CHECK-NEXT:    [[TMP25:%.*]] = getelementptr { [4 x i32], [4294967295 x i32] }, ptr addrspace(7) [[TMP10]], i32 0, i32 1, i64 [[TMP24]]
-; CHECK-NEXT:    store i32 [[TMP14]], ptr addrspace(7) [[TMP25]], align 4
-; CHECK-NEXT:    [[TMP26:%.*]] = add i64 [[TMP24]], 1
-; CHECK-NEXT:    [[TMP27:%.*]] = getelementptr { [4 x i32], [4294967295 x i32] }, ptr addrspace(7) [[TMP10]], i32 0, i32 1, i64 [[TMP26]]
-; CHECK-NEXT:    store i32 [[TMP16]], ptr addrspace(7) [[TMP27]], align 4
-; CHECK-NEXT:    [[TMP28:%.*]] = add i64 [[TMP26]], 1
+; CHECK-NEXT:    [[TMP17:%.*]] = atomicrmw add ptr addrspace(7) [[TMP10]], i64 5 monotonic, align 8
+; CHECK-NEXT:    [[TMP18:%.*]] = call i64 @llvm.umin.i64(i64 [[TMP17]], i64 536870912)
+; CHECK-NEXT:    [[TMP19:%.*]] = trunc i64 [[TMP18]] to i32
+; CHECK-NEXT:    [[TMP20:%.*]] = add i32 [[TMP19]], 4
+; CHECK-NEXT:    [[TMP21:%.*]] = getelementptr i32, ptr addrspace(7) [[TMP10]], i32 [[TMP20]]
+; CHECK-NEXT:    store i32 {{-?[0-9]+}}, ptr addrspace(7) [[TMP21]], align 4
+; CHECK-NEXT:    [[TMP22:%.*]] = add i32 [[TMP20]], 1
+; CHECK-NEXT:    [[TMP23:%.*]] = getelementptr i32, ptr addrspace(7) [[TMP10]], i32 [[TMP22]]
+; CHECK-NEXT:    store i32 {{-?[0-9]+}}, ptr addrspace(7) [[TMP23]], align 4
+; CHECK-NEXT:    [[TMP24:%.*]] = add i32 [[TMP22]], 1
+; CHECK-NEXT:    [[TMP25:%.*]] = getelementptr i32, ptr addrspace(7) [[TMP10]], i32 [[TMP24]]
+; CHECK-NEXT:    store i32 [[__LLPC_INPUT_PROXY_GL_GLOBALINVOCATIONID_0_VEC_EXTRACT]], ptr addrspace(7) [[TMP25]], align 4
+; CHECK-NEXT:    [[TMP26:%.*]] = add i32 [[TMP24]], 1
+; CHECK-NEXT:    [[TMP27:%.*]] = getelementptr i32, ptr addrspace(7) [[TMP10]], i32 [[TMP26]]
+; CHECK-NEXT:    store i32 [[TMP14]], ptr addrspace(7) [[TMP27]], align 4
+; CHECK-NEXT:    [[TMP28:%.*]] = add i32 [[TMP26]], 1
+; CHECK-NEXT:    [[TMP29:%.*]] = getelementptr i32, ptr addrspace(7) [[TMP10]], i32 [[TMP28]]
+; CHECK-NEXT:    store i32 [[TMP16]], ptr addrspace(7) [[TMP29]], align 4
+; CHECK-NEXT:    [[TMP30:%.*]] = add i32 [[TMP28]], 1
 ; CHECK-NEXT:    ret void
 ;

--- a/lgc/test/Transforms/LowerDebugPrintf/basic.lgc
+++ b/lgc/test/Transforms/LowerDebugPrintf/basic.lgc
@@ -1,0 +1,26 @@
+; RUN: lgc -o - -passes='require<lgc-pipeline-state>,lgc-lower-debug-printf' %s | FileCheck --check-prefixes=IR %s
+; RUN: lgc -o - -passes='require<lgc-pipeline-state>,lgc-lower-debug-printf,print<lgc-pipeline-state>' %s -o /dev/null 2>&1 | FileCheck --check-prefixes=PALMD %s
+
+@str = internal addrspace(4) global [8 x i8] c"Test: %u"
+
+define spir_func void @simple(ptr addrspace(7) %buffer) !lgc.shaderstage !0 {
+; IR-LABEL: @simple(
+; IR-NOT: call {{.*}} @lgc.debug.printf
+  call void (...) @lgc.debug.printf(ptr addrspace(7) %buffer, ptr addrspace(4) @str, i32 42)
+  ret void
+}
+
+; IR: !amdgpu.pal.metadata.msgpack =
+
+; PALMD:      amdpal.format_strings:
+; PALMD-NEXT:   .strings:
+; PALMD-NEXT:     - .64bit_arguments:
+; PALMD-NEXT:         - 0
+; PALMD-NEXT:       .argument_count: 1
+; PALMD-NEXT:       .index:
+; PALMD-NEXT:       .string:         'Test: %u'
+; PALMD-NEXT:   .version:        1
+
+declare void @lgc.debug.printf(...)
+
+!0 = !{i32 7}

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -159,6 +159,7 @@ static bool runPassPipeline(Pipeline &pipeline, Module &module, raw_pwrite_strea
   // This mode of the tool is only ever used for development and testing, so unconditionally run the verifier on the
   // final output.
   passMgr->addPass(VerifierPass());
+  passMgr->addPass(PipelineStateRecorder());
 
   switch (codegen::getFileType()) {
   case CGFT_AssemblyFile:

--- a/llpc/test/shaderdb/general/PipelineCs_DebugPrintf.pipe
+++ b/llpc/test/shaderdb/general/PipelineCs_DebugPrintf.pipe
@@ -24,8 +24,10 @@ userDataNode[0].next[0].set = 0xFFFFFFFF
 userDataNode[0].next[0].binding = 6
 ; CHECK-LABEL: @lgc.shader.CS.main(
 ; CHECK-NEXT:  .entry:
-; CHECK:         [[TMP1:%.*]] = call ptr addrspace(7) (...) @lgc.create.load.buffer.desc.p7(i64 4294967295, i32 6, i32 0, i32 2)
-; CHECK:         [[TMP2:%.*]] = call i64 (...) @lgc.create.debug.printf.i64(ptr addrspace(7) [[TMP1]], ptr addrspace(4) @str.1, i32 %{{.*}})
-; CHECK-NEXT:    [[TMP3:%.*]] = call i64 (...) @lgc.create.debug.printf.i64(ptr addrspace(7) [[TMP1]], ptr addrspace(4) @str.2, double 1.000000e+00, double 1.000000e+00)
+; CHECK-NEXT:    [[TMP0:%.*]] = call ptr addrspace(7) (...) @lgc.create.load.buffer.desc.p7(i64 4294967295, i32 6, i32 0, i32 2)
+; CHECK-NEXT:    [[TMP1:%.*]] = call <3 x i32> (...) @lgc.create.read.builtin.input.v3i32(i32 28, i32 0, i32 poison, i32 poison)
+; CHECK-NEXT:    [[__LLPC_INPUT_PROXY_GL_GLOBALINVOCATIONID_0_VEC_EXTRACT:%.*]] = extractelement <3 x i32> [[TMP1]], i64 0
+; CHECK-NEXT:    call void (...) @lgc.debug.printf(ptr addrspace(7) [[TMP0]], ptr addrspace(4) @str.1, i32 [[__LLPC_INPUT_PROXY_GL_GLOBALINVOCATIONID_0_VEC_EXTRACT]])
+; CHECK-NEXT:    call void (...) @lgc.debug.printf(ptr addrspace(7) [[TMP0]], ptr addrspace(4) @str.2, double 1.000000e+00, double 1.000000e+00)
 ; CHECK-NEXT:    ret void
 ;

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4162,11 +4162,11 @@ Value *SPIRVToLLVM::transDebugPrintf(SPIRVInstruction *bi, const ArrayRef<SPIRVV
 
   auto spvValueItr = spvValues.begin();
   Value *formatStr = mapEntry(*spvValueItr++, nullptr);
-  SmallVector<Value *> args = {m_debugOutputBuffer, formatStr};
+  SmallVector<Value *> args;
   for (; spvValueItr != spvValues.end(); ++spvValueItr) {
     args.push_back(transValue(*spvValueItr, func, bb));
   }
-  return getBuilder()->CreateDebugPrintf(args);
+  return getBuilder()->create<lgc::DebugPrintfOp>(m_debugOutputBuffer, formatStr, args);
 }
 
 // Translate an initializer. This has special handling for the case where the type to initialize to does not match the


### PR DESCRIPTION
Series of separate commits around cleaning up DebugPrintf support.

One unrelated addition is the patch "lgc: add initial pipeline state printer and recorder facilities" whose purpose is to improve the testability of the LowerDebugPrintf pass and potentially other passes.

Note that this depends on https://github.com/GPUOpen-Drivers/llvm-dialects/pull/54 (merged)