### PR TITLE
GlueShader: Support "include IR"

### DIFF
--- a/lgc/patch/PatchLlvmIrInclusion.cpp
+++ b/lgc/patch/PatchLlvmIrInclusion.cpp
@@ -30,6 +30,7 @@
  */
 #include "lgc/patch/PatchLlvmIrInclusion.h"
 #include "lgc/state/Abi.h"
+#include "lgc/state/PipelineState.h"
 #include "llvm/IR/Constants.h"
 
 #define DEBUG_TYPE "lgc-patch-llvm-ir-inclusion"
@@ -46,7 +47,9 @@ namespace lgc {
 // @param [in/out] analysisManager : Analysis manager to use for this transformation
 // @returns : The preserved analyses (The analyses that are still valid after this pass)
 PreservedAnalyses PatchLlvmIrInclusion::run(Module &module, ModuleAnalysisManager &analysisManager) {
-  runImpl(module);
+  PipelineState *pipelineState = analysisManager.getResult<PipelineStateWrapper>(module).getPipelineState();
+  if (pipelineState->getOptions().includeIr)
+    runImpl(module);
   return PreservedAnalyses::none();
 }
 

--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -30,6 +30,7 @@
  */
 #include "lgc/state/PassManagerCache.h"
 #include "lgc/LgcContext.h"
+#include "lgc/patch/PatchLlvmIrInclusion.h"
 #include "lgc/patch/PatchSetupTargetFeatures.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 442438
@@ -110,6 +111,8 @@ std::pair<lgc::PassManager &, LegacyPassManager &> PassManagerCache::getPassMana
   fpm.addPass(EarlyCSEPass(true));
   passManagers.first->addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
   passManagers.first->addPass(PatchSetupTargetFeatures());
+  passManagers.first->addPass(PatchLlvmIrInclusion());
+
   // Add one last pass that does nothing, but invalidates all the analyses.
   // This is required to avoid the pass manager to use results of analyses from
   // previous runs which is causing random crashes.


### PR DESCRIPTION
Add the pass "PatchLlvmIrInclusion" to PassManager when compiling glue

shader.