### PR TITLE
Uber fetch shader: Fix the default value

### DIFF
--- a/lgc/test/UberFetchShader.lgc
+++ b/lgc/test/UberFetchShader.lgc
@@ -41,8 +41,6 @@
 ; Whether is BGRA format (attr & 0x100000)
 ; CHECK: and i32 [[attr]], 1048576
 
-; fetch vertex function
-; CHECK-LABEL: define internal <4 x i32> @FetchVertex32
 ; Load the whole vertex
 ; CHECK: call <4 x i32> @llvm.amdgcn.struct.buffer.load.format.v4i32(<4 x i32>
 ; Load per channel, 4 channels

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestUberShader.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestUberShader.pipe
@@ -10,7 +10,8 @@
 ; SHADERTEST: [[UBERINFO:%[0-9]*]] = load <4 x i32>, ptr addrspace(4) [[INTDESCPTR]], align 16
 
 ; Load vertex
-; SHADERTEST-COUNT-5: call i32 @llvm.amdgcn.struct.buffer.load.format
+; SHADERTEST-COUNT-1: call <3 x i32> @llvm.amdgcn.struct.buffer.load.format.v3i32
+; SHADERTEST-COUNT-2: call i32 @llvm.amdgcn.struct.buffer.load.format.i32
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestUberShader.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestUberShader.pipe
@@ -10,8 +10,7 @@
 ; SHADERTEST: [[UBERINFO:%[0-9]*]] = load <4 x i32>, ptr addrspace(4) [[INTDESCPTR]], align 16
 
 ; Load vertex
-; SHADERTEST-COUNT-1: call <3 x i32> @llvm.amdgcn.struct.buffer.load.format.v3i32
-; SHADERTEST-COUNT-2: call i32 @llvm.amdgcn.struct.buffer.load.format.i32
+; SHADERTEST-COUNT-3: call i32 @llvm.amdgcn.struct.buffer.load.format.i32
 ; SHADERTEST: AMDLLPC SUCCESS
 ; END_SHADERTEST
 


### PR DESCRIPTION
1. Set the default value for per-component fetches. When per-component fetches is needed, we should initialize the vertex to (0,0,0,1), then fill related channel according to swizzle.

2. Vertex fetch function is no longer created, replaced with 'splitBasicBlock'