### PR TITLE
Keep allocas at the start of the function

### DIFF
--- a/lgc/elfLinker/FetchShader.cpp
+++ b/lgc/elfLinker/FetchShader.cpp
@@ -212,7 +212,7 @@ Value *FetchShader::getReplacementForVertexIdBuiltIn(CallInst *call) const {
 // @param function : The function from which to get the argument.
 // @returns : The value of the argument as a 32-bit integer.
 Value *FetchShader::getVgprArgumentAsAnInt32(unsigned vgpr, Function *function) const {
-  BuilderBase builder(&*function->front().getFirstInsertionPt());
+  BuilderBase builder(&*function->front().getFirstNonPHIOrDbgOrAlloca());
   Value *vertexId = getVpgrArgument(vgpr, builder);
   return builder.CreateBitCast(vertexId, builder.getInt32Ty());
 }
@@ -265,7 +265,7 @@ Value *FetchShader::getReplacementForVertexBufferTableBuiltIn(CallInst *call) co
   Function *callerFunction = call->getFunction();
   AddressExtender extender(callerFunction);
   Value *highAddr = call->getArgOperand(1);
-  BuilderBase builder(&*callerFunction->front().getFirstInsertionPt());
+  BuilderBase builder(&*callerFunction->front().getFirstNonPHIOrDbgOrAlloca());
   Argument *vertexBufferTable = callerFunction->getArg(m_vsEntryRegInfo.vertexBufferTable);
   return extender.extend(vertexBufferTable, highAddr, call->getType(), builder);
 }

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3615,11 +3615,18 @@ void NggPrimShader::mutateGs() {
   Value *outVertsPtrs[MaxGsStreams] = {};
 
   for (int i = 0; i < MaxGsStreams; ++i) {
-    auto emitVertsPtr = m_builder.CreateAlloca(m_builder.getInt32Ty());
+    Value *emitVertsPtr = nullptr;
+    Value *outVertsPtr = nullptr;
+    {
+      IRBuilder<>::InsertPointGuard allocaGuard(m_builder);
+      m_builder.SetInsertPointPastAllocas(m_gsHandlers.main);
+      emitVertsPtr = m_builder.CreateAlloca(m_builder.getInt32Ty());
+      outVertsPtr = m_builder.CreateAlloca(m_builder.getInt32Ty());
+    }
+
     m_builder.CreateStore(m_builder.getInt32(0), emitVertsPtr); // emitVerts = 0
     emitVertsPtrs[i] = emitVertsPtr;
 
-    auto outVertsPtr = m_builder.CreateAlloca(m_builder.getInt32Ty());
     m_builder.CreateStore(m_builder.getInt32(0), outVertsPtr); // outVerts = 0
     outVertsPtrs[i] = outVertsPtr;
   }

--- a/lgc/patch/PatchInitializeWorkgroupMemory.cpp
+++ b/lgc/patch/PatchInitializeWorkgroupMemory.cpp
@@ -94,8 +94,7 @@ bool PatchInitializeWorkgroupMemory::runImpl(Module &module, PipelineShadersResu
   m_shaderStage = ShaderStageCompute;
   m_entryPoint = pipelineShaders.getEntryPoint(static_cast<ShaderStage>(m_shaderStage));
   BuilderBase builder(*m_context);
-  Instruction *insertPos = &*m_entryPoint->front().getFirstInsertionPt();
-  builder.SetInsertPoint(insertPos);
+  builder.SetInsertPointPastAllocas(m_entryPoint);
 
   // Fill the map of each variable with zeroinitializer and calculate its corresponding offset on LDS
   unsigned offset = 0;
@@ -135,7 +134,7 @@ bool PatchInitializeWorkgroupMemory::runImpl(Module &module, PipelineShadersResu
 // @param lds : The LDS variable to be initialized
 // @param builder : BuilderBase to use for instruction constructing
 void PatchInitializeWorkgroupMemory::initializeWithZero(GlobalVariable *lds, BuilderBase &builder) {
-  auto entryInsertPos = &*m_entryPoint->front().getFirstInsertionPt();
+  auto entryInsertPos = &*m_entryPoint->front().getFirstNonPHIOrDbgOrAlloca();
   auto originBlock = entryInsertPos->getParent();
   auto endInitBlock = originBlock->splitBasicBlock(entryInsertPos);
   endInitBlock->setName(".endInit");

--- a/lgc/patch/VertexFetch.cpp
+++ b/lgc/patch/VertexFetch.cpp
@@ -567,7 +567,7 @@ bool LowerVertexFetch::runImpl(Module &module, PipelineState *pipelineState) {
     // NOTE: The 10_10_10_2 formats are not supported by the uber fetch shader on gfx9 and older.
     // We rely on the driver to fallback to not using the uber fetch shader when those formats are used.
     builder.setShaderStage(ShaderStageVertex);
-    builder.SetInsertPoint(&(*vertexFetches[0]->getFunction()->front().getFirstInsertionPt()));
+    builder.SetInsertPointPastAllocas(vertexFetches[0]->getFunction());
     auto desc = builder.CreateLoadBufferDesc(InternalDescriptorSetId, FetchShaderInternalBufferBinding,
                                              builder.getInt32(0), Builder::BufferFlagAddress);
 
@@ -941,13 +941,13 @@ Value *VertexFetchImpl::fetchVertex(InputImportGenericOp *inst, llvm::Value *des
 
   if (!m_vertexIndex) {
     IRBuilderBase::InsertPointGuard ipg(builder);
-    builder.SetInsertPoint(&*inst->getFunction()->front().getFirstInsertionPt());
+    builder.SetInsertPointPastAllocas(inst->getFunction());
     m_vertexIndex = ShaderInputs::getVertexIndex(builder, *m_lgcContext);
   }
 
   if (!m_instanceIndex) {
     IRBuilderBase::InsertPointGuard ipg(builder);
-    builder.SetInsertPoint(&*inst->getFunction()->front().getFirstInsertionPt());
+    builder.SetInsertPointPastAllocas(inst->getFunction());
     m_instanceIndex = ShaderInputs::getInstanceIndex(builder, *m_lgcContext);
   }
 
@@ -955,7 +955,7 @@ Value *VertexFetchImpl::fetchVertex(InputImportGenericOp *inst, llvm::Value *des
   Type *vbDescTy = FixedVectorType::get(Type::getInt32Ty(*m_context), 4);
   if (!m_vertexBufTablePtr) {
     IRBuilderBase::InsertPointGuard ipg(builder);
-    builder.SetInsertPoint(&*inst->getFunction()->front().getFirstInsertionPt());
+    builder.SetInsertPointPastAllocas(inst->getFunction());
     m_vertexBufTablePtr =
         ShaderInputs::getSpecialUserDataAsPointer(UserDataMapping::VertexBufferTable, vbDescTy, builder);
   }

--- a/lgc/util/AddressExtender.cpp
+++ b/lgc/util/AddressExtender.cpp
@@ -43,7 +43,7 @@ using namespace llvm;
 Instruction *AddressExtender::getFirstInsertionPt() {
   if (m_pc)
     return m_pc->getNextNode();
-  return &*m_func->front().getFirstInsertionPt();
+  return &*m_func->front().getFirstNonPHIOrDbgOrAlloca();
 }
 
 // =====================================================================================================================
@@ -78,7 +78,7 @@ Instruction *AddressExtender::getPc() {
     // This uses its own builder, as it wants to insert at the start of the function, whatever the caller
     // is doing.
     IRBuilder<> builder(m_func->getContext());
-    builder.SetInsertPoint(&*m_func->front().getFirstInsertionPt());
+    builder.SetInsertPointPastAllocas(m_func);
     Value *pc = builder.CreateIntrinsic(llvm::Intrinsic::amdgcn_s_getpc, {}, {});
     pc = cast<Instruction>(builder.CreateBitCast(pc, FixedVectorType::get(builder.getInt32Ty(), 2)));
     m_pc = cast<Instruction>(pc);

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -328,7 +328,7 @@ bool SpirvLowerRayQuery::runImpl(Module &module) {
       processLibraryFunction(func);
     }
   } else {
-    Instruction *insertPos = &*(m_entryPoint->begin()->getFirstInsertionPt());
+    Instruction *insertPos = &*(m_entryPoint->begin()->getFirstNonPHIOrDbgOrAlloca());
     m_builder->SetInsertPoint(insertPos);
     initGlobalVariable();
     m_spirvOpMetaKindId = m_context->getMDKindID(MetaNameSpirvOp);

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -480,7 +480,7 @@ bool SpirvLowerRayTracing::runImpl(Module &module) {
     rayTracingContext->setEntryName("main");
     return true;
   }
-  Instruction *insertPos = &*(m_entryPoint->begin()->getFirstInsertionPt());
+  Instruction *insertPos = &*(m_entryPoint->begin()->getFirstNonPHIOrDbgOrAlloca());
 
   // Process traceRays module
   if (m_shaderStage == ShaderStageCompute) {
@@ -1928,8 +1928,7 @@ void SpirvLowerRayTracing::createEntryFunc(Function *func) {
   m_entryPoint = newFunc;
   m_entryPoint->addFnAttr(Attribute::NoUnwind);
   m_entryPoint->addFnAttr(Attribute::AlwaysInline);
-  Instruction *insertPos = &*(newFunc->begin()->getFirstInsertionPt());
-  m_builder->SetInsertPoint(insertPos);
+  m_builder->SetInsertPointPastAllocas(newFunc);
   auto argIt = newFunc->arg_begin();
 
   // Save the function input parameter value to the global payloads and builtIns
@@ -2102,8 +2101,7 @@ void SpirvLowerRayTracing::createCallableShaderEntryFunc(Function *func) {
   m_entryPoint = newFunc;
   m_entryPoint->addFnAttr(Attribute::NoUnwind);
   m_entryPoint->addFnAttr(Attribute::AlwaysInline);
-  Instruction *insertPos = &*(newFunc->begin()->getFirstInsertionPt());
-  m_builder->SetInsertPoint(insertPos);
+  m_builder->SetInsertPointPastAllocas(newFunc);
 
   auto argIt = newFunc->arg_begin();
 

--- a/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracingBuiltIn.cpp
@@ -103,7 +103,7 @@ bool SpirvLowerRayTracingBuiltIn::runImpl(Module &module) {
 
   auto traceParamstrLen = strlen(RtName::TraceRaySetTraceParams);
   auto shaderTableStrLen = strlen(RtName::ShaderTable);
-  Instruction *insertPos = &*(m_entryPoint->begin()->getFirstInsertionPt());
+  Instruction *insertPos = &*(m_entryPoint->begin()->getFirstNonPHIOrDbgOrAlloca());
   for (auto globalIt = m_module->global_begin(), end = m_module->global_end(); globalIt != end;) {
     GlobalVariable *global = &*globalIt++;
     if (global->getType()->getAddressSpace() != SPIRAS_Private)


### PR DESCRIPTION
All inserted code should come after allocas. If an alloca ends up outside of the entry block, LLVM consideres it dynamically allocated stack and the scratch size in PAL metadata does not include it anymore.

Fixes dEQP-VK.subgroups.ballot_broadcast.mesh.subgroupbroadcast_dvec2_mesh in combination with D150609.