### PR TITLE
lgc: correctly pack color exports in color export shaders

### DIFF
--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -61,9 +61,6 @@ class FragColorExport {
 public:
   FragColorExport(llvm::LLVMContext *context, PipelineState *pipelineState);
 
-  llvm::Value *handleColorExportInstructions(llvm::Value *output, unsigned int hwColorTarget, BuilderBase &builder,
-                                             ExportFormat expFmt, const bool signedness);
-
   void generateExportInstructions(llvm::ArrayRef<lgc::ColorExportInfo> info, llvm::ArrayRef<llvm::Value *> values,
                                   llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);
   static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
@@ -76,6 +73,9 @@ private:
   FragColorExport() = delete;
   FragColorExport(const FragColorExport &) = delete;
   FragColorExport &operator=(const FragColorExport &) = delete;
+
+  llvm::Value *handleColorExportInstructions(llvm::Value *output, unsigned int hwColorExport, BuilderBase &builder,
+                                             ExportFormat expFmt, const bool signedness);
 
   llvm::Value *convertToHalf(llvm::Value *value, bool signedness, BuilderBase &builder) const;
   llvm::Value *convertToFloat(llvm::Value *value, bool signedness, BuilderBase &builder) const;

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -38,6 +38,7 @@
 #include "lgc/CommonDefs.h"
 #include "lgc/Pipeline.h"
 #include "lgc/state/AbiMetadata.h"
+#include "lgc/state/IntrinsDefs.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 #include <map>
 
@@ -167,8 +168,11 @@ public:
   // Finalize PAL metadata for pipeline, part-pipeline or shader compilation.
   void finalizePipeline(bool isWholePipeline);
 
-  // Updates the PS register information that depends on the exports.
-  void updateSpiShaderColFormat(llvm::ArrayRef<ColorExportInfo> exps, bool hasDepthExpFmtZero, bool killEnabled);
+  // Sets the PS register information that depends on the exports.
+  void setSpiShaderColFormat(llvm::ArrayRef<ExportFormat> expFormats);
+
+  // Updates the CB shader mask information that depends on the exports.
+  void updateCbShaderMask(llvm::ArrayRef<ColorExportInfo> exps);
 
   // Sets the finalized 128-bit cache hash.  The version identifies the version of LLPC used to generate the hash.
   void setFinalized128BitCacheHash(const lgc::Hash128 &finalizedCacheHash, const llvm::VersionTuple &version);


### PR DESCRIPTION
When color export shaders are used, a color export shader may be compiled for a pipeline state in which one or more color targets are missing that the underlying shader exports to.

In that case, we need to ensure that:

* the VGPR interface between the fragment shader and the color export shader lines up correctly
* the range of mrtN export targets that are used in export instructions is compacted accordingly
* SPI_SHADER_COL_FORMAT and CB_SHADER_MASK must reflect these changes as well

This change should hopefully fix the issues we were seeing while simplifying PalMetadata::updateSpiShaderColFormat (renamed to setSpiShaderColFormat because it completely overwrites the register.)