### PR TITLE
LLPC frontend SPIR-V reader: Change UndefValue to PoisonValue

### DIFF
--- a/llpc/test/shaderdb/core/OpCopyMemory_TestStruct_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpCopyMemory_TestStruct_lit.spvasm
@@ -5,7 +5,7 @@
 ; SHADERTEST: load <4 x float>,
 ; SHADERTEST: load <4 x float>,
 ; SHADERTEST: load <4 x float>,
-; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> } undef
+; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> } poison
 ; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> }
 ; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> }
 ; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> }
@@ -21,7 +21,7 @@
 ; SHADERTEST: load <4 x float>,
 ; SHADERTEST: load <4 x float>,
 ; SHADERTEST: load <4 x float>,
-; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> } undef
+; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> } poison
 ; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> }
 ; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> }
 ; SHADERTEST: insertvalue { <4 x float>, <4 x float>, <4 x float>, <4 x float> }

--- a/llpc/test/shaderdb/core/OpPtrDiff_Workgroup_mem.spvasm
+++ b/llpc/test/shaderdb/core/OpPtrDiff_Workgroup_mem.spvasm
@@ -15,7 +15,7 @@
 ; SHADERTEST: [[d:%[0-9]+]] = sdiv exact i64 [[c]], ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64)
 ; SHADERTEST: [[e:%[0-9]+]] = trunc i64 [[d]] to i32
 
-; SHADERTEST: [[i:%[0-9a-zA-Z.]+]] = insertelement <2 x i32> undef, i32 [[e1]], i32 0
+; SHADERTEST: [[i:%[0-9a-zA-Z.]+]] = insertelement <2 x i32> poison, i32 [[e1]], i32 0
 ; SHADERTEST: {{%[0-9]+}} = insertelement <2 x i32> [[i]], i32 [[e]], i32 1
 
 ; SHADERTEST-LABEL: }

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDifferentInputVecSizes_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDifferentInputVecSizes_lit.spvasm
@@ -5,12 +5,12 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> undef, <4 x double> %1, <2 x i32> <i32 7, i32 6>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> <double poison, double poison, double undef, double undef>, <4 x double> %1, <2 x i32> <i32 7, i32 6>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <2 x i32> <i32 3, i32 2>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> <double poison, double poison, double undef, double undef>, <2 x i32> <i32 3, i32 2>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UndefVariable_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UndefVariable_lit.spvasm
@@ -2,11 +2,11 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> undef, <4 x double> %1, <2 x i32> <i32 7, i32 6>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> <double poison, double poison, double undef, double undef>, <4 x double> %1, <2 x i32> <i32 7, i32 6>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> [[TEMP_VEC]], <4 x i32> <i32 4, i32 5, i32 2, i32 3>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <2 x i32> <i32 3, i32 2>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> <double poison, double poison, double undef, double undef>, <2 x i32> <i32 3, i32 2>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 6, i32 7>
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/core/OpVectorTimesScalar_TestIvec2xInt_lit.frag
+++ b/llpc/test/shaderdb/core/OpVectorTimesScalar_TestIvec2xInt_lit.frag
@@ -16,7 +16,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = insertelement <2 x i32> undef, i32 %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = insertelement <2 x i32> poison, i32 %{{.*}}, i32 0
 ; SHADERTEST: %{{.*}} = insertelement <2 x i32> %{{.*}}, i32 %{{.*}}, i32 1
 ; SHADERTEST: %{{.*}} = mul <2 x i32> %{{.*}}, %{{.*}}
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/core/OpVectorTimesScalar_TestUvec4xUint_lit.frag
+++ b/llpc/test/shaderdb/core/OpVectorTimesScalar_TestUvec4xUint_lit.frag
@@ -16,7 +16,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = insertelement <4 x i32> undef, i32 %{{.*}}, i32 0
+; SHADERTEST: %{{.*}} = insertelement <4 x i32> poison, i32 %{{.*}}, i32 0
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 1
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 2
 ; SHADERTEST: %{{.*}} = insertelement <4 x i32> %{{.*}}, i32 %{{.*}}, i32 3

--- a/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
+++ b/llpc/test/shaderdb/general/TestWorkgroupMemoryLayout.spvasm
@@ -5,9 +5,9 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @[[LDS0:[^ ]*]] = addrspace(3) global <{ [8 x i32] }> undef, align 4
-; SHADERTEST: @[[LDS1:[^ ]*]] = addrspace(3) global <{ [4 x i32] }> undef, align 4
-; SHADERTEST: @[[LDS2:[^ ]*]] = addrspace(3) global <{ [16 x i8], [4 x i32] }> undef, align 4
+; SHADERTEST: @[[LDS0:[^ ]*]] = addrspace(3) global <{ [8 x i32] }> poison, align 4
+; SHADERTEST: @[[LDS1:[^ ]*]] = addrspace(3) global <{ [4 x i32] }> poison, align 4
+; SHADERTEST: @[[LDS2:[^ ]*]] = addrspace(3) global <{ [16 x i8], [4 x i32] }> poison, align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) @[[LDS1]], align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 1), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}([4 x i32], ptr addrspace(3) @[[LDS1]], i32 0, i32 2), align 4
@@ -26,7 +26,7 @@
 ; SHADERTEST: load i32, ptr addrspace(3) getelementptr {{.*}}([8 x i32], ptr addrspace(3) @[[LDS0]], i32 0, i32 7), align 4
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: @[[LDS:[^ ]*]] = local_unnamed_addr addrspace(3) global <{ [8 x i32] }> undef, align 4
+; SHADERTEST: @[[LDS:[^ ]*]] = local_unnamed_addr addrspace(3) global <{ [8 x i32] }> poison, align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) @[[LDS]], align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 1), align 4
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr {{.*}}(<{ [8 x i32] }>, ptr addrspace(3) @[[LDS]], i32 0, i32 0, i32 2), align 4

--- a/llpc/test/shaderdb/object/ObjSharedVariable_TestArray_lit.comp
+++ b/llpc/test/shaderdb/object/ObjSharedVariable_TestArray_lit.comp
@@ -19,7 +19,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global [16 x i32] undef
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global [16 x i32] poison
 ; SHADERTEST: %{{[0-9]*}} = getelementptr [16 x i32], ptr addrspace(3) @[[LDS]], i32 0, i32 %{{[0-9]*}}
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) %{{[0-9]*}}
 ; SHADERTEST: store i32 %{{[0-9]*}}, ptr addrspace(3) getelementptr inbounds ([16 x i32], ptr addrspace(3) @[[LDS]], i32 0, i32 3)

--- a/llpc/test/shaderdb/object/ObjSharedVariable_TestBasic_lit.comp
+++ b/llpc/test/shaderdb/object/ObjSharedVariable_TestBasic_lit.comp
@@ -22,7 +22,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global <4 x float> undef
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global <4 x float> poison
 ; SHADERTEST: store <4 x float> %{{[0-9]*}}, ptr addrspace(3) @[[LDS]]
 ; SHADERTEST: %{{[0-9]*}} = load <4 x float>, ptr addrspace(3) @[[LDS]]
 

--- a/llpc/test/shaderdb/object/ObjSharedVariable_TestMatrix_lit.comp
+++ b/llpc/test/shaderdb/object/ObjSharedVariable_TestMatrix_lit.comp
@@ -22,7 +22,7 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global [4 x <4 x float>] undef
+; SHADERTEST: @[[LDS:[^ ]*]] = addrspace(3) global [4 x <4 x float>] poison
 ; SHADERTEST: store <4 x float> %{{[0-9]*}}, ptr addrspace(3) @[[LDS]]
 ; SHADERTEST: %{{[0-9]*}} = load <4 x float>, ptr addrspace(3) @[[LDS]]
 


### PR DESCRIPTION
To follow the upcoming LLVM change: https://reviews.llvm.org/D152658.