### PR TITLE
Fix issue that llvm-dialects-tblgen can not be found while compile lgcrt on cross-compiling

### DIFF
--- a/shared/lgcrt/CMakeLists.txt
+++ b/shared/lgcrt/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(LLVMLgcRt PUBLIC llvm_dialects)
 set_compiler_options(LLVMLgcRt)
 
 # TableGen for the lgc.rt dialect
-set(LGCRT_TABLEGEN_EXE llvm-dialects-tblgen)
+set(LGCRT_TABLEGEN_EXE ${LLVM_TOOLS_BINARY_DIR}/llvm-dialects-tblgen)
 set(LGCRT_TABLEGEN_TARGET llvm-dialects-tblgen)
 set(LLVM_TARGET_DEFINITIONS include/lgcrt/LgcRtDialect.td)
 set(LLVM_TARGET_DEPENDS lgcrt)


### PR DESCRIPTION
Same issue fixed on this PR: https://github.com/GPUOpen-Drivers/llpc/pull/2422

The parameter LGCRT_TABLEGEN_EXE is used as the 'tablegen_exe' parameter in the 'tablegen' function within the 'llvm-project/llvm/cmake/modules/TableGen.cmake' file, and eventually passed as the 'COMMAND' parameter in the 'add_custom_command' function.

Refer to the CMake specification for more information about the 'COMMAND' parameter in the 'add_custom_command' function: https://cmake.org/cmake/help/latest/command/add_custom_command.html
Please note that in cross-compiling, the executable target name will not be automatically replaced by the path of the target created at build time. Therefore, we need to manually assign the target path.