### PR TITLE
[LLPC] Stop claiming that we have memory libfuncs (#2195)

### DIFF
--- a/lgc/interface/lgc/LgcContext.h
+++ b/lgc/interface/lgc/LgcContext.h
@@ -126,12 +126,6 @@ public:
   // @param pipeline : Ignored
   Builder *createBuilder(Pipeline *pipeline);
 
-  // Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not
-  // think that we have library functions.
-  //
-  // @param [in/out] passMgr : Pass manager
-  void preparePassManager(lgc::PassManager &passMgr);
-
   // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
   void addTargetPasses(lgc::LegacyPassManager &passMgr, llvm::Timer *codeGenTimer, llvm::raw_pwrite_stream &outStream);
 

--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -202,9 +202,6 @@ bool PipelineState::generate(Module *pipelineModule, raw_pwrite_stream &outStrea
   passMgr->registerFunctionAnalysis([&] { return getLgcContext()->getTargetMachine()->getTargetIRAnalysis(); });
   passMgr->registerModuleAnalysis([&] { return PipelineShaders(); });
 
-  // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-  getLgcContext()->preparePassManager(*passMgr);
-
   // Ensure m_stageMask is set up in this PipelineState, as Patch::addPasses uses it.
   readShaderStageMask(&*pipelineModule);
 

--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -310,25 +310,6 @@ Builder *LgcContext::createBuilder(Pipeline *pipeline) {
 }
 
 // =====================================================================================================================
-// Prepare a pass manager. This manually adds a target-aware TLI pass, so middle-end optimizations do not think that
-// we have library functions.
-//
-// @param [in/out] passMgr : Pass manager
-void LgcContext::preparePassManager(lgc::PassManager &passMgr) {
-  TargetLibraryInfoImpl targetLibInfo(getTargetMachine()->getTargetTriple());
-
-  // Adjust it to allow memcpy and memset.
-  // TODO: Investigate why the latter is necessary. I found that
-  // test/shaderdb/ObjStorageBlock_TestMemCpyInt32.comp
-  // got unrolled far too much, and at too late a stage for the descriptor loads to be commoned up. It might
-  // be an unfortunate interaction between LoopIdiomRecognize and fat pointer laundering.
-  targetLibInfo.setAvailable(LibFunc_memcpy);
-  targetLibInfo.setAvailable(LibFunc_memset);
-
-  passMgr.registerFunctionAnalysis([&] { return TargetLibraryAnalysis(targetLibInfo); });
-}
-
-// =====================================================================================================================
 // Adds target passes to pass manager, depending on "-filetype" and "-emit-llvm" options
 //
 // @param [in/out] passMgr : Pass manager to add passes to

--- a/lgc/state/PassManagerCache.cpp
+++ b/lgc/state/PassManagerCache.cpp
@@ -94,9 +94,6 @@ std::pair<lgc::PassManager &, LegacyPassManager &> PassManagerCache::getPassMana
   passManagers.first->registerFunctionAnalysis([&] { return m_lgcContext->getTargetMachine()->getTargetIRAnalysis(); });
   passManagers.first->registerModuleAnalysis([&] { return PipelineStateWrapper(m_lgcContext); });
 
-  // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-  m_lgcContext->preparePassManager(*passManagers.first);
-
   // Add a few optimizations.
   FunctionPassManager fpm;
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 452298

--- a/lgc/tool/lgc/lgc.cpp
+++ b/lgc/tool/lgc/lgc.cpp
@@ -144,9 +144,6 @@ static bool runPassPipeline(Pipeline &pipeline, Module &module, raw_pwrite_strea
   passMgr->registerModuleAnalysis([&] { return PipelineStateWrapper(static_cast<PipelineState *>(&pipeline)); });
   Patch::registerPasses(*passMgr);
 
-  // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-  lgcContext->preparePassManager(*passMgr);
-
   PassBuilder passBuilder(lgcContext->getTargetMachine(), PipelineTuningOptions(), {},
                           &passMgr->getInstrumentationCallbacks());
   Patch::registerPasses(passBuilder);

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -176,9 +176,6 @@ void SpirvLower::removeConstantExpr(Context *context, GlobalVariable *global) {
 // @param isInternalRtShader : Whether we are lowering an internal ray tracing shader
 void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager &passMgr, Timer *lowerTimer,
                            bool rayTracing, bool rayQuery, bool isInternalRtShader) {
-  // Manually add a target-aware TLI pass, so optimizations do not think that we have library functions.
-  context->getLgcContext()->preparePassManager(passMgr);
-
   // Start timer for lowering passes.
   if (lowerTimer)
     LgcContext::createAndAddStartStopTimer(passMgr, lowerTimer, true);

--- a/llpc/test/shaderdb/object/ObjStorageBlock_TestMemCpyInt32.comp
+++ b/llpc/test/shaderdb/object/ObjStorageBlock_TestMemCpyInt32.comp
@@ -17,8 +17,39 @@ void main() {
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call <4 x i32> @llvm.amdgcn.raw.buffer.load.v4i32(
-; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST: call i32 @llvm.amdgcn.raw.buffer.load.i32(
+; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST

--- a/llpc/test/shaderdb/object/ObjStorageBlock_TestMemSetInt32.comp
+++ b/llpc/test/shaderdb/object/ObjStorageBlock_TestMemSetInt32.comp
@@ -16,7 +16,8 @@ void main() {
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
-; SHADERTEST: call void @llvm.amdgcn.raw.buffer.store.v4i32(<4 x i32> zeroinitializer
+; SHADERTEST-COUNT-32: call void @llvm.amdgcn.raw.buffer.store.i32(i32 0,
+; SHADERTEST-LABEL: {{^// LLPC}} final pipeline module info
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
After this upstream LLVM patch:
https://reviews.llvm.org/D152383 "CodeGen: Expand memory intrinsics in PreISelIntrinsicLowering" if we claim that we have libfuncs for memcpy and memset then they will not get expanded by the PreISelIntrinsicLowering pass, and will fail instruction selection.

Original author: Jay.Foad@amd.com