### PR TITLE
Add PartialPipelineHit in CacheAccessInfo

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -738,6 +738,15 @@ Result Compiler::buildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *p
       if (elfPackage[idx].pCode) {
         auto data = reinterpret_cast<const char *>(elfPackage[idx].pCode);
         elf[idx].assign(data, data + elfPackage[idx].codeSize);
+        if (idx == UnlinkedStageFragment) {
+          pipelineOut->stageCacheAccesses[ShaderStageFragment] = PartialPipelineHit;
+        } else {
+          for (unsigned stage = 0; stage < ShaderStageFragment; stage++) {
+            if (doesShaderStageExist(shaderInfo, static_cast<ShaderStage>(stage)) {
+              pipelineOut->stageCacheAccesses[stage] = PartialPipelineHit;
+            }
+          }
+        }
       } else {
         graphicsContext.setUnlinked(true);
         result = buildUnlinkedShaderInternal(context, shaderInfo, static_cast<UnlinkedShaderStage>(idx), elf[idx],
@@ -754,8 +763,14 @@ Result Compiler::buildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *p
     hasError |= !linkRelocatableShaderElf(elf, &pipelineElf, context);
 
     context->setDiagnosticHandler(nullptr);
-    if (hasError)
+    if (hasError) {
+      for (unsigned stage = 0; stage < ShaderStageGfxCount; stage++) {
+        if (doesShaderStageExist(shaderInfo, static_cast<ShaderStage>(stage)) {
+          pipelineOut->stageCacheAccesses[stage] = CacheMiss;
+        }
+      }
       return Result::ErrorInvalidShader;
+    }
 
     elfBin.codeSize = pipelineElf.size();
     elfBin.pCode = pipelineElf.data();

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -742,7 +742,7 @@ Result Compiler::buildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *p
           pipelineOut->stageCacheAccesses[ShaderStageFragment] = PartialPipelineHit;
         } else {
           for (unsigned stage = 0; stage < ShaderStageFragment; stage++) {
-            if (doesShaderStageExist(shaderInfo, static_cast<ShaderStage>(stage)) {
+            if (doesShaderStageExist(shaderInfo, static_cast<ShaderStage>(stage))) {
               pipelineOut->stageCacheAccesses[stage] = PartialPipelineHit;
             }
           }
@@ -765,7 +765,7 @@ Result Compiler::buildGraphicsPipelineWithElf(const GraphicsPipelineBuildInfo *p
     context->setDiagnosticHandler(nullptr);
     if (hasError) {
       for (unsigned stage = 0; stage < ShaderStageGfxCount; stage++) {
-        if (doesShaderStageExist(shaderInfo, static_cast<ShaderStage>(stage)) {
+        if (doesShaderStageExist(shaderInfo, static_cast<ShaderStage>(stage))) {
           pipelineOut->stageCacheAccesses[stage] = CacheMiss;
         }
       }

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -125,6 +125,7 @@ enum CacheAccessInfo : uint8_t {
   CacheMiss,           ///< Cache miss.
   CacheHit,            ///< Cache hit using VkPipelineCache.
   InternalCacheHit,    ///< cache hit using internal cache.
+  PartialPipelineHit,  ///< cache hit using partial pipeline
 };
 
 /// Represents output of building a graphics pipeline.


### PR DESCRIPTION
1. Add PartialPipelineHit in CacheAccessInfo
2. Set stageCacheAccesses in buildGraphicsPipelineWithElf, and use PartialPipelineHit  if input ELF is used.