### PR TITLE
Remove reference to RewriteSymbolsLegacyPass

### DIFF
--- a/lgc/state/LgcContext.cpp
+++ b/lgc/state/LgcContext.cpp
@@ -133,7 +133,6 @@ void LgcContext::initialize() {
   initializeCodeGen(passRegistry);
   initializeShadowStackGCLoweringPass(passRegistry);
   initializeExpandReductionsPass(passRegistry);
-  initializeRewriteSymbolsLegacyPassPass(passRegistry);
 
   // Initialize LGC passes so they can be referenced by -stop-before etc.
   initializeUtilPasses(passRegistry);


### PR DESCRIPTION
This pass has been removed by upstream LLVM patch https://reviews.llvm.org/D153679 "[LegacyPM] Remove RewriteSymbolsLegacyPass"