### PR TITLE
Include <set>

### DIFF
--- a/lgc/include/lgc/patch/PatchResourceCollect.h
+++ b/lgc/include/lgc/patch/PatchResourceCollect.h
@@ -34,6 +34,7 @@
 #include "lgc/state/PipelineShaders.h"
 #include "lgc/state/PipelineState.h"
 #include "llvm/IR/InstVisitor.h"
+#include <set>
 #include <unordered_set>
 
 namespace lgc {


### PR DESCRIPTION
This is no longer transitively included after upstream LLVM patch https://reviews.llvm.org/D153728 "[llvm] Move AttributeMask to a separate header".