### PR TITLE
Move Entry function mutation

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -168,11 +168,12 @@ private:
   void initGlobalPayloads();
   void initGlobalCallableData();
   void initShaderBuiltIns();
-  void createEntryFunc(llvm::Function *func);
+  llvm::Instruction *createEntryFunc(llvm::Function *func);
+  void createEntryTerminator(llvm::Function *func);
   llvm::FunctionType *getShaderEntryFuncTy(ShaderStage stage);
   llvm::FunctionType *getCallableShaderEntryFuncTy();
   llvm::FunctionType *getTraceRayFuncTy();
-  void createCallableShaderEntryFunc(llvm::Function *func);
+  llvm::Instruction *createCallableShaderEntryFunc(llvm::Function *func);
   void getFuncRets(llvm::Function *func, llvm::SmallVector<llvm::Instruction *, 4> &rets);
   llvm::SmallSet<unsigned, 4> getShaderExtraInputParams(ShaderStage stage);
   llvm::SmallSet<unsigned, 4> getShaderExtraRets(ShaderStage stage);

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -174,6 +174,7 @@ private:
   llvm::FunctionType *getCallableShaderEntryFuncTy();
   llvm::FunctionType *getTraceRayFuncTy();
   llvm::Instruction *createCallableShaderEntryFunc(llvm::Function *func);
+  void createCallableShaderEntryTerminator(llvm::Function *func);
   void getFuncRets(llvm::Function *func, llvm::SmallVector<llvm::Instruction *, 4> &rets);
   llvm::SmallSet<unsigned, 4> getShaderExtraInputParams(ShaderStage stage);
   llvm::SmallSet<unsigned, 4> getShaderExtraRets(ShaderStage stage);


### PR DESCRIPTION
Move Entry function mutation from post module lowering to the pre module lowering. so later, global variables can be removed/sourced from function arguments.