### PR TITLE
Fix mesh shader amdgpu-flat-work-group-size attribute setting

### DIFF
--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -538,11 +538,12 @@ void MeshTaskShader::processMeshShader(Function *entryPoint) {
       m_pipelineState->getShaderResourceUsage(ShaderStageGeometry)->inOutUsage.gs.calcFactor.primAmpFactor;
   // If we enable row export, the actual thread group size is determined by work group size provided from API mesh
   // shader.
-  const unsigned flatWorkgroupSize = m_pipelineState->enableMeshRowExport() ? numMeshThreads : primAmpFactor;
+  const unsigned flatWorkgroupSize =
+      alignTo(m_pipelineState->enableMeshRowExport() ? numMeshThreads : primAmpFactor, waveSize);
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         std::to_string(primAmpFactor) + std::string(",") + std::to_string(flatWorkgroupSize));
 
-  const unsigned numWaves = alignTo(flatWorkgroupSize, waveSize) / waveSize;
+  const unsigned numWaves = flatWorkgroupSize / waveSize;
   const unsigned numMeshWaves = alignTo(numMeshThreads, waveSize) / waveSize;
 
   // API mesh shader entry block


### PR DESCRIPTION
Round up the maximum flat workgroup size to a multiple of the wave size to reflect how many lanes will actually be enabled by the initial call to llvm.amdgcn.init.exec(-1).

Without this the maximum flat workgroup size could be set to 1, which would cause the backend to optimize assuming that all values are uniform. This problem is exposed by a recent upstream LLVM patch: https://reviews.llvm.org/D151341 "AMDGPU: Special case uniformity info for single lane workgroups"