### PR TITLE
Translate SPIR-V OpUndef to LLVM "freeze poison"

### DIFF
--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDifferentInputVecSizes_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDifferentInputVecSizes_lit.spvasm
@@ -5,12 +5,12 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> <double poison, double poison, double undef, double undef>, <4 x double> %1, <2 x i32> <i32 7, i32 6>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> undef, <4 x double> %1, <2 x i32> <i32 7, i32 6>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> <double poison, double poison, double undef, double undef>, <2 x i32> <i32 3, i32 2>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <2 x i32> <i32 3, i32 2>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UndefVariable_lit.spvasm
+++ b/llpc/test/shaderdb/core/OpVectorShuffle_TestDvec4UndefVariable_lit.spvasm
@@ -2,11 +2,11 @@
 ; BEGIN_SHADERTEST
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> <double poison, double poison, double undef, double undef>, <4 x double> %1, <2 x i32> <i32 7, i32 6>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> undef, <4 x double> %1, <2 x i32> <i32 7, i32 6>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> [[TEMP_VEC]], <4 x i32> <i32 4, i32 5, i32 2, i32 3>
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> <double poison, double poison, double undef, double undef>, <2 x i32> <i32 3, i32 2>
+; SHADERTEST: %{{.*}} = shufflevector <4 x double> %{{.*}}, <4 x double> undef, <2 x i32> <i32 3, i32 2>
 ; SHADERTEST: [[TEMP_VEC:%[0-9]+]] = shufflevector <2 x double> %{{.*}}, <2 x double> {{undef|poison}}, <4 x i32> <i32 0, i32 1, i32 {{undef|poison}}, i32 {{undef|poison}}>
 ; SHADERTEST: %{{.*}} = shufflevector <4 x double> [[TEMP_VEC]], <4 x double> %{{.*}}, <4 x i32> <i32 0, i32 1, i32 6, i32 7>
 ; SHADERTEST: AMDLLPC SUCCESS

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4770,7 +4770,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
   }
 
   case OpUndef:
-    return mapValue(bv, PoisonValue::get(transType(bv->getType())));
+    // TODO: Stop using UndefValue since it is deprecated in favor of PoisonValue. A more faithful translation of
+    // OpUndef semantics would be to insert "freeze poison" before each _use_ of it in a function, but what about uses
+    // that are not in any function?
+    return mapValue(bv, UndefValue::get(transType(bv->getType())));
 
   case OpFunctionParameter: {
     auto ba = static_cast<SPIRVFunctionParameter *>(bv);


### PR DESCRIPTION
Translating OpUndef to poison causes CTS failures because poison is too undefined.