### PR TITLE
Add default constructors for optional_bool

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -60,6 +60,8 @@ class TypeLowering;
 class BufferOpLowering {
   // Hide operator bool to safe-guard against accidents.
   struct optional_bool : private std::optional<bool> {
+    optional_bool() = default;
+    optional_bool(const optional_bool &rhs) = default;
     optional_bool &operator=(const optional_bool &rhs) = default;
     optional_bool &operator=(bool rhs) {
       std::optional<bool>::operator=(rhs);


### PR DESCRIPTION
optional_bool has a copy assignment operator so add a copy constructor per the C++ "rule of three". Without this Clang would warn:

lgc/include/lgc/patch/PatchBufferOp.h:45:20: warning: definition of implicit copy constructor for 'optional_bool' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
    optional_bool &operator=(const optional_bool &rhs) = default;
                   ^
lgc/include/lgc/patch/PatchBufferOp.h:55:10: note: in implicit copy constructor for 'lgc::BufferOpLowering::optional_bool' first required here
  struct DescriptorInfo {
         ^
lgc/patch/PatchBufferOp.cpp:226:23: note: in implicit copy constructor for 'lgc::BufferOpLowering::DescriptorInfo' first required here
  DescriptorInfo di = m_descriptors[desc];
                      ^