### PR TITLE
Set wavefrontsize to entry-point attribute earlier

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -145,9 +145,15 @@ Function *ColorExportShader::createColorExportFunc() {
   BasicBlock *block = BasicBlock::Create(func->getContext(), "", func);
   BuilderBase builder(block);
   builder.CreateRetVoid();
+
   AttrBuilder attribBuilder(func->getContext());
   attribBuilder.addAttribute("InitialPSInputAddr", std::to_string(0xFFFFFFFF));
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 10) {
+    const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageFragment);
+    attribBuilder.addAttribute("target-features", ",+wavefrontsize" + std::to_string(waveSize)); // Set wavefront size
+  }
   func->addFnAttrs(attribBuilder);
+
   return func;
 }
 

--- a/lgc/elfLinker/FetchShader.cpp
+++ b/lgc/elfLinker/FetchShader.cpp
@@ -328,5 +328,12 @@ Function *FetchShader::createFetchFunc() {
     retVal = builder.CreateInsertValue(retVal, func->getArg(i), i);
   builder.CreateRet(retVal);
 
+  AttrBuilder attribBuilder(func->getContext());
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 10) {
+    const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageVertex);
+    attribBuilder.addAttribute("target-features", ",+wavefrontsize" + std::to_string(waveSize)); // Set wavefront size
+  }
+  func->addFnAttrs(attribBuilder);
+
   return func;
 }

--- a/lgc/elfLinker/NullFragmentShader.cpp
+++ b/lgc/elfLinker/NullFragmentShader.cpp
@@ -44,7 +44,7 @@ using namespace llvm;
 // @returns : The module containing the null fragment shader.
 Module *NullFragmentShader::generate() {
   Module *module = generateEmptyModule();
-  Function *entryPoint = FragColorExport::generateNullFragmentShader(*module, getGlueShaderName());
+  Function *entryPoint = FragColorExport::generateNullFragmentShader(*module, m_pipelineState, getGlueShaderName());
   addDummyExportIfNecessary(entryPoint);
   return module;
 }

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -65,8 +65,10 @@ public:
                                   llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);
   static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
   static llvm::CallInst *addDummyExport(BuilderBase &builder);
-  static llvm::Function *generateNullFragmentShader(llvm::Module &module, llvm::StringRef entryPointName);
-  static llvm::Function *generateNullFragmentEntryPoint(llvm::Module &module, llvm::StringRef entryPointName);
+  static llvm::Function *generateNullFragmentShader(llvm::Module &module, PipelineState *pipelineState,
+                                                    llvm::StringRef entryPointName);
+  static llvm::Function *generateNullFragmentEntryPoint(llvm::Module &module, PipelineState *pipelineState,
+                                                        llvm::StringRef entryPointName);
   static void generateNullFragmentShaderBody(llvm::Function *entryPoint);
 
 private:

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -551,6 +551,8 @@ Function *NggPrimShader::generate(Function *esMain, Function *gsMain, Function *
 
   Function *primShader = Function::Create(primShaderTy, GlobalValue::ExternalLinkage, lgcName::NggPrimShaderEntryPoint);
   primShader->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
+  const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageGeometry);
+  primShader->addFnAttr("target-features", ",+wavefrontsize" + std::to_string(waveSize)); // Set wavefront size
   primShader->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)
 

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -181,6 +181,11 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
     entryPoint->getArg(i)->setName(argNames[i]);
   }
 
+  // Set wavefront size
+  const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageCopyShader);
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 10)
+    entryPoint->addFnAttr("target-features", ",+wavefrontsize" + std::to_string(waveSize));
+
   // Create ending basic block, and terminate it with return.
   auto endBlock = BasicBlock::Create(*m_context, "", entryPoint, nullptr);
   builder.SetInsertPoint(endBlock);

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -78,7 +78,7 @@ bool PatchNullFragShader::runImpl(Module &module, PipelineState *pipelineState) 
   if (hasFs || !pipelineState->isGraphics())
     return false;
 
-  FragColorExport::generateNullFragmentShader(module, lgcName::NullFsEntryPoint);
+  FragColorExport::generateNullFragmentShader(module, pipelineState, lgcName::NullFsEntryPoint);
   updatePipelineState(pipelineState);
   return true;
 }

--- a/lgc/patch/PatchSetupTargetFeatures.cpp
+++ b/lgc/patch/PatchSetupTargetFeatures.cpp
@@ -137,10 +137,11 @@ void PatchSetupTargetFeatures::setupTargetFeatures(Module *module) {
     auto gfxIp = m_pipelineState->getTargetInfo().getGfxIpVersion();
 
     if (gfxIp.major >= 10) {
-      // Setup wavefront size per shader stage
-      unsigned waveSize = m_pipelineState->getShaderWaveSize(shaderStage);
-
-      targetFeatures += ",+wavefrontsize" + std::to_string(waveSize);
+      // NOTE: The sub-attribute 'wavefrontsize' of 'target-features' is set in advance to let optimization
+      // pass know we are in which wavesize mode. Here, we read back it and append it to finalized target
+      // feature strings.
+      if (func->hasFnAttribute("target-features"))
+        targetFeatures += func->getFnAttribute("target-features").getValueAsString();
 
       if (m_pipelineState->getShaderWgpMode(shaderStage))
         targetFeatures += ",-cumode";

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -323,6 +323,9 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
 
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)
+  const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageTessControl);
+  if (m_gfxIp.major >= 10)
+    entryPoint->addFnAttr("target-features", ",+wavefrontsize" + std::to_string(waveSize)); // Set wavefront size
   applyTuningAttributes(entryPoint, tuningAttrs);
 
   for (auto &arg : entryPoint->args()) {
@@ -382,7 +385,6 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
   auto threadIdInWave =
       builder.CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {builder.getInt32(-1), builder.getInt32(0)});
 
-  unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageTessControl);
   if (waveSize == 64) {
     threadIdInWave = builder.CreateIntrinsic(Intrinsic::amdgcn_mbcnt_hi, {}, {builder.getInt32(-1), threadIdInWave});
   }
@@ -664,6 +666,9 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
 
   entryPoint->addFnAttr("amdgpu-flat-work-group-size",
                         "128,128"); // Force s_barrier to be present (ignore optimization)
+  const unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageGeometry);
+  if (m_gfxIp.major >= 10)
+    entryPoint->addFnAttr("target-features", ",+wavefrontsize" + std::to_string(waveSize)); // Set wavefront size
   applyTuningAttributes(entryPoint, tuningAttrs);
 
   for (auto &arg : entryPoint->args()) {
@@ -718,7 +723,6 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
   auto threadIdInWave =
       builder.CreateIntrinsic(Intrinsic::amdgcn_mbcnt_lo, {}, {builder.getInt32(-1), builder.getInt32(0)});
 
-  unsigned waveSize = m_pipelineState->getShaderWaveSize(ShaderStageGeometry);
   if (waveSize == 64) {
     threadIdInWave = builder.CreateIntrinsic(Intrinsic::amdgcn_mbcnt_hi, {}, {builder.getInt32(-1), threadIdInWave});
   }


### PR DESCRIPTION
Previously, we set this sub-attribute before passing finalized IR to backend. At that time, the wavefrontsize string is attached. However, it is somewhat later when optimization passes do need to know this info to make their decisions, such as removing unnecessary mbcnt.hi.

This change moves the setting of wavefrontsize earlier to avoid such cases.