### PR TITLE
PalMetadata: fix logic error of updating SPI_PS_INPUT_CNTL

### DIFF
--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -850,6 +850,9 @@ void RegisterMetadataBuilder::buildPsRegisters() {
       spiPsInputCntlInfo.offset = UseDefaultVal;
     }
 
+    // NOTE: Set SPI_PS_INPUT_CNTL_* here, but the register can still be changed later,
+    // when it becomes known that gl_ViewportIndex is not used and fields OFFSET and FLAT_SHADE
+    // can be amended.
     spiPsInputCntElem[Util::Abi::SpiPsInputCntlMetadataKey::FlatShade] = spiPsInputCntlInfo.flatShade;
     spiPsInputCntElem[Util::Abi::SpiPsInputCntlMetadataKey::Offset] = spiPsInputCntlInfo.offset;
     spiPsInputCntElem[Util::Abi::SpiPsInputCntlMetadataKey::Fp16InterpMode] = spiPsInputCntlInfo.fp16InterMode;

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -732,7 +732,7 @@ void PalMetadata::finalizeInputControlRegisterSetting() {
                                 .getArray(true);
       // Check if pointCoordLoc is not used
       auto spiPsInputCntlElem = spiPsInputCntl[viewportIndexLoc].getMap(true);
-      if (spiPsInputCntlElem[Util::Abi::SpiPsInputCntlMetadataKey::PtSpriteTex].getBool()) {
+      if (!spiPsInputCntlElem[Util::Abi::SpiPsInputCntlMetadataKey::PtSpriteTex].getBool()) {
         // Use default value 0 for viewport array index if it is only used in FS (not set in other stages)
         constexpr unsigned defaultVal = (1 << 5);
         spiPsInputCntlElem[Util::Abi::SpiPsInputCntlMetadataKey::Offset] = defaultVal;


### PR DESCRIPTION
The condition for updating SPI_PS_INPUT_CNTL.offset/flat_shade should be SPI_PS_INPUT_CNTL.PtSpriteTex is false.
Fixes:
dEQP-VK.draw.dynamic_rendering.shader_viewport_index.fragment_shader_implicit dEQP-VK.draw.renderpass.shader_viewport_index.fragment_shader_implicit