### PR TITLE
lgc: memset Options to avoid garbage in padding bits

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -552,7 +552,7 @@ private:
   bool m_preRasterHasGs = false;                        // Whether pre-rasterization part has a geometry shader
   bool m_computeLibrary = false;                        // Whether pipeline is in fact a compute library
   std::string m_client;                                 // Client name for PAL metadata
-  Options m_options = {};                               // Per-pipeline options
+  Options m_options;                                    // Per-pipeline options
   std::vector<ShaderOptions> m_shaderOptions;           // Per-shader options
   std::unique_ptr<ResourceNode[]> m_allocUserDataNodes; // Allocated buffer for user data
   llvm::ArrayRef<ResourceNode> m_userDataNodes;         // Top-level user data node table

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -283,7 +283,7 @@ void PipelineContext::setPipelineState(Pipeline *pipeline, Util::MetroHash64 *ha
 // @param [in/out] pipeline : Middle-end pipeline object; nullptr if only hashing
 // @param [in/out] hasher : Hasher object; nullptr if only setting LGC pipeline state
 Options PipelineContext::computePipelineOptions() const {
-  Options options = {};
+  Options options;
   options.hash[0] = getPipelineHashCode();
   options.hash[1] = get64BitCacheHashCode();
 


### PR DESCRIPTION
Options will be written into LLVM metadata as i32. Explicitly memset it will help avoid unexpected padding bits being written into metadata.