### PR TITLE
Unify common internal intrinsic implementation

### DIFF
--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -233,6 +233,7 @@ if(ICD_BUILD_LLPC)
         lower/llpcSpirvLowerUtil.cpp
         lower/llpcSpirvProcessGpuRtLibrary.cpp
         lower/LowerGpuRt.cpp
+        lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
     )
 
 # llpc/translator

--- a/llpc/lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
+++ b/llpc/lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
@@ -1,0 +1,79 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
+ * @brief LLPC source file: utilities for lowering common internal library intrinsics.
+ ***********************************************************************************************************************
+ */
+
+#include "llpcSpirvLowerInternalLibraryIntrinsicUtil.h"
+#include "llpcContext.h"
+#include "lgc/Builder.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
+using namespace llvm;
+using namespace lgc;
+
+namespace Llpc {
+
+// =====================================================================================================================
+// Create function to get lane index (subgroup local invocation ID)
+//
+// @param func : The function to process
+// @param builder : The IR builder
+static void createLaneIndex(Function *func, Builder *builder) {
+  builder->CreateRet(builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(BuiltInSubgroupLocalInvocationId),
+                                                     {}, nullptr, nullptr, ""));
+}
+
+// =====================================================================================================================
+// Create function to get lane count (wave size)
+//
+// @param func : The function to process
+// @param builder : The IR builder
+static void createLaneCount(Function *func, Builder *builder) {
+  builder->CreateRet(builder->CreateGetWaveSize());
+}
+
+// =====================================================================================================================
+// Create function to generate s_sethalt intrinsic
+//
+// @param func : The function to process
+// @param builder : The IR builder
+static void createHalt(Function *func, Builder *builder) {
+  builder->CreateIntrinsic(Intrinsic::amdgcn_s_sethalt, {}, {builder->getInt32(1)});
+  builder->CreateRetVoid();
+}
+
+// =====================================================================================================================
+// Initialize library function pointer table
+InternalLibraryIntrinsicUtil::LibraryFunctionTable::LibraryFunctionTable() {
+  m_libFuncPtrs["AmdExtLaneIndex"] = &createLaneIndex;
+  m_libFuncPtrs["AmdExtLaneCount"] = &createLaneCount;
+  m_libFuncPtrs["AmdExtHalt"] = &createHalt;
+}
+
+} // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.h
+++ b/llpc/lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.h
@@ -1,0 +1,57 @@
+/*
+ ***********************************************************************************************************************
+ *
+ *  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ **********************************************************************************************************************/
+/**
+ ***********************************************************************************************************************
+ * @file  llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
+ * @brief LLPC header file: utilities for lowering common internal library intrinsics.
+ ***********************************************************************************************************************
+ */
+
+#include "llvm/ADT/DenseMap.h"
+
+namespace lgc {
+class Builder;
+}
+
+namespace llvm {
+class Function;
+class StringRef;
+} // namespace llvm
+
+namespace Llpc {
+class InternalLibraryIntrinsicUtil {
+public:
+  typedef void (*LibraryFuncPtr)(llvm::Function *, lgc::Builder *);
+
+  struct LibraryFunctionTable {
+    llvm::DenseMap<llvm::StringRef, LibraryFuncPtr> m_libFuncPtrs;
+    LibraryFunctionTable();
+    static const LibraryFunctionTable &get() {
+      static LibraryFunctionTable instance;
+      return instance;
+    }
+  };
+};
+} // namespace Llpc

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -31,6 +31,7 @@
 #include "llpcSpirvProcessGpuRtLibrary.h"
 #include "SPIRVInternal.h"
 #include "llpcContext.h"
+#include "llpcSpirvLowerInternalLibraryIntrinsicUtil.h"
 #include "llpcSpirvLowerUtil.h"
 #include "lgc/Builder.h"
 #include "lgc/GpurtDialect.h"
@@ -136,13 +137,21 @@ SpirvProcessGpuRtLibrary::LibraryFunctionTable::LibraryFunctionTable() {
 //
 // @param func : The function to process
 void SpirvProcessGpuRtLibrary::processLibraryFunction(Function *&func) {
-  auto &funcTable = LibraryFunctionTable::get().m_libFuncPtrs;
-
-  auto funcIt = funcTable.find(func->getName());
-  if (funcIt != funcTable.end()) {
-    auto funcPtr = funcIt->second;
+  auto &gpurtFuncTable = LibraryFunctionTable::get().m_libFuncPtrs;
+  auto gpurtFuncIt = gpurtFuncTable.find(func->getName());
+  if (gpurtFuncIt != gpurtFuncTable.end()) {
+    auto funcPtr = gpurtFuncIt->second;
     m_builder->SetInsertPoint(clearBlock(func));
     (this->*funcPtr)(func);
+    return;
+  }
+
+  auto &commonFuncTable = InternalLibraryIntrinsicUtil::LibraryFunctionTable::get().m_libFuncPtrs;
+  auto commonFuncIt = commonFuncTable.find(func->getName());
+  if (commonFuncIt != commonFuncTable.end()) {
+    auto funcPtr = commonFuncIt->second;
+    m_builder->SetInsertPoint(clearBlock(func));
+    (*funcPtr)(func, m_builder);
   }
 }
 


### PR DESCRIPTION
Place common internal intrinsic implementation into a separate utility file, so that RT and internal passes can share it instead of duplicating the code.