### PR TITLE
Correct z-export behavior on GFX11

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -762,6 +762,17 @@ union PA_SC_SHADER_CONTROL {
   unsigned u32All;
 };
 
+union SPI_SHADER_Z_FORMAT {
+  struct {
+    unsigned int Z_EXPORT_FORMAT : 4;
+    unsigned int : 28;
+  } bits, bitfields;
+
+  unsigned int u32All;
+  signed int i32All;
+  float f32All;
+};
+
 enum CovToShaderSel {
   INPUT_COVERAGE = 0x00000000,
   INPUT_INNER_COVERAGE = 0x00000001,

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -402,6 +402,12 @@ public:
   // Get user data for a specific shader stage
   llvm::ArrayRef<unsigned> getUserDataMap(ShaderStage shaderStage) const { return m_userDataMaps[shaderStage]; }
 
+  // Set the flag for performing the copy from mrt0.z to mrtz.a
+  void setUseMrt0AToMrtzA(bool used) { m_useMrt0AToMrtzA = used; }
+
+  // Get the flag of whether to copy mrt0.a to mrtz.a
+  bool isUseMrt0AToMrtzA() const { return m_useMrt0AToMrtzA; }
+
   // -----------------------------------------------------------------------------------------------------------------
   // Utility method templates to read and write IR metadata, used by PipelineState and ShaderModes
 
@@ -582,6 +588,7 @@ private:
   bool m_outputPackState[ShaderStageGfxCount] = {}; // The output packable state per shader stage
   XfbStateMetadata m_xfbStateMetadata = {};         // Transform feedback state metadata
   llvm::SmallVector<unsigned, 32> m_userDataMaps[ShaderStageCountInternal]; // The user data per-shader
+  bool m_useMrt0AToMrtzA = false;                                           // Whether to copy mrt0.a to mrz.a
 };
 
 // =====================================================================================================================


### PR DESCRIPTION
COVERAGE_TO_MASK_ENABLE field in gfx11+. If Alpha to Mask is enabled and there is a depth export (MRT Z), the Alpha value must be copied from MRT 0 to MRT Z. Besides, we need update z_export_format to
  EXP_FORMAT_32_ABGR/EXP_FORMAT_32_AR and force alpha_to_mask_disable to
false.