### PR TITLE
Include StringExtras.h

### DIFF
--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -39,6 +39,7 @@
 #include "lgc/Pipeline.h"
 #include "lgc/state/AbiMetadata.h"
 #include "lgc/state/IntrinsDefs.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 #include <map>
 

--- a/lgc/state/ShaderModes.cpp
+++ b/lgc/state/ShaderModes.cpp
@@ -32,6 +32,7 @@
 #include "lgc/state/ShaderModes.h"
 #include "lgc/state/IntrinsDefs.h"
 #include "lgc/state/PipelineState.h"
+#include "llvm/ADT/StringExtras.h"
 
 #define DEBUG_TYPE "lgc-shader-modes"
 

--- a/llpc/tool/llpcRayTracingPipelineBuilder.cpp
+++ b/llpc/tool/llpcRayTracingPipelineBuilder.cpp
@@ -40,6 +40,7 @@
 #include "llpcUtil.h"
 #include "vkgcUtil.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Path.h"
 
 using namespace llvm;


### PR DESCRIPTION
After LLVM patch https://reviews.llvm.org/D155018, StringExtras.h is no longer included transitively.