### PR TITLE
Freeze shift instructions

### DIFF
--- a/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestShiftOp_lit.comp
+++ b/llpc/test/shaderdb/gfx9/ExtShaderInt8_TestShiftOp_lit.comp
@@ -23,9 +23,12 @@ void main()
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIR-V lowering results
-; SHADERTEST: %{{[0-9]*}} = ashr i8 %{{[0-9]*}}, 3
-; SHADERTEST: %{{[0-9]*}} = lshr i8 %{{[0-9]*}}, 3
-; SHADERTEST: %{{[0-9]*}} = shl i8 %{{[0-9]*}}, 3
+; SHADERTEST: %.fr = freeze i8 %{{[0-9]*}}
+; SHADERTEST: %{{[0-9]*}} = ashr i8 %.fr, 3
+; SHADERTEST: %.fr3 = freeze i8 %{{[0-9]*}}
+; SHADERTEST: %{{[0-9]*}} = lshr i8 %.fr3, 3
+; SHADERTEST: %.fr4 = freeze i8 %{{[0-9]*}}
+; SHADERTEST: %{{[0-9]*}} = shl i8 %.fr4, 3
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: AMDLLPC SUCCESS
 */

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -1272,8 +1272,11 @@ Value *SPIRVToLLVM::transShiftLogicalBitwiseInst(SPIRVValue *bv, BasicBlock *bb,
   if (shift->getType()->isIntOrIntVectorTy())
     shift = getBuilder()->CreateZExtOrTrunc(shift, base->getType());
 
-  auto inst = BinaryOperator::Create(bo, base, shift, bv->getName(), bb);
+  Instruction *inst = BinaryOperator::Create(bo, base, shift, bv->getName(), bb);
   setFastMathFlags(inst);
+
+  if (isShiftOpCode(op))
+    inst = new FreezeInst(inst, "shift.freeze", bb);
 
   return inst;
 }


### PR DESCRIPTION
In SPIR-V the result of a shift with an out-of-range shift amount is an undefined value. In LLVM IR it is poison, which is more undefined. To avoid correctness problems, freeze the result of every shift just in case it is poison. LLVM middle end optimizations should be able to remove many of these freeze instructions, for example if it can prove that the shift amount is in-range.

This is prompted by some recent LLVM patches which optimize poison values more aggressively.