### PR TITLE
Add inliner pass for GPURT library

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1865,6 +1865,7 @@ std::unique_ptr<Module> Compiler::createGpurtShaderLibrary(Context *context) {
 
   lowerPassMgr->addPass(SpirvProcessGpuRtLibrary());
   lowerPassMgr->addPass(SpirvLowerRayQuery(true));
+  lowerPassMgr->addPass(AlwaysInlinerPass());
   // Stop timer for translate.
   timerProfiler.addTimerStartStopPass(*lowerPassMgr, TimerTranslate, false);
 

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -528,20 +528,6 @@ bool SpirvLowerRayTracing::runImpl(Module &module) {
   }
   // Process traceRays module
   if (m_shaderStage == ShaderStageCompute) {
-#if VKI_AMD_ABORT_LONG_RAYS
-    // NOTE: If the extension is enabled, redirect all calls of TraceRay to TraceLongRayAMD. Their inner implementation
-    // is completely the same, except that TraceRay set earlyTerminateThreshold to 0.0 while TraceLongRayAMD uses the
-    // given value.
-    StringRef traceRayFuncName =
-        m_context->getPipelineContext()->getRayTracingFunctionName(Vkgc::RT_ENTRY_TRACE_LONG_RAY_AMD);
-#else
-    StringRef traceRayFuncName = m_context->getPipelineContext()->getRayTracingFunctionName(Vkgc::RT_ENTRY_TRACE_RAY);
-#endif
-    assert(!traceRayFuncName.empty());
-    auto traceRayFunc = m_module->getFunction(traceRayFuncName);
-    assert(traceRayFunc);
-    traceRayFunc->setLinkage(GlobalValue::ExternalLinkage);
-
     static auto visitor = llvm_dialects::VisitorBuilder<SpirvLowerRayTracing>()
                               .setStrategy(llvm_dialects::VisitorStrategy::ByFunctionDeclaration)
                               .add(&SpirvLowerRayTracing::visitGetHitAttributes)

--- a/util/gpurtshim/GpurtShim.cpp
+++ b/util/gpurtshim/GpurtShim.cpp
@@ -103,4 +103,8 @@ void gpurt::getFuncTable(RtIpVersion rtIpVersion, GpurtFuncTable &table) {
   unmangleDxilName(table.pFunc[RT_ENTRY_INSTANCE_ID], gpurtTable.intrinsic.pGetInstanceID);
   unmangleDxilName(table.pFunc[RT_ENTRY_OBJECT_TO_WORLD_TRANSFORM], gpurtTable.intrinsic.pGetObjectToWorldTransform);
   unmangleDxilName(table.pFunc[RT_ENTRY_WORLD_TO_OBJECT_TRANSFORM], gpurtTable.intrinsic.pGetWorldToObjectTransform);
+  unmangleDxilName(table.pFunc[RT_ENTRY_FETCH_HIT_TRIANGLE_FROM_NODE_POINTER],
+                   gpurtTable.intrinsic.pFetchTrianglePositionFromNodePointer);
+  unmangleDxilName(table.pFunc[RT_ENTRY_FETCH_HIT_TRIANGLE_FROM_RAY_QUERY],
+                   gpurtTable.intrinsic.pFetchTrianglePositionFromRayQuery);
 }


### PR DESCRIPTION
Move all linkage setting into SpirvProcessGpuRtLibrary pass, and add an inliner pass at the end of GPURT library creation.