### PR TITLE
lgc: cmake func for adding LLVM external projects

### DIFF
--- a/cmake/lgc.cmake
+++ b/cmake/lgc.cmake
@@ -1,0 +1,42 @@
+##
+ #######################################################################################################################
+ #
+ #  Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+ #
+ #  Permission is hereby granted, free of charge, to any person obtaining a copy
+ #  of this software and associated documentation files (the "Software"), to deal
+ #  in the Software without restriction, including without limitation the rights
+ #  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ #  copies of the Software, and to permit persons to whom the Software is
+ #  furnished to do so, subject to the following conditions:
+ #
+ #  The above copyright notice and this permission notice shall be included in all
+ #  copies or substantial portions of the Software.
+ #
+ #  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ #  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ #  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ #  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ #  SOFTWARE.
+ #
+ #######################################################################################################################
+
+set(LLPC_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+
+# Function to add LGC and its dependencies as LLVM external projects.
+# This appends the project names to LLVM_EXTERNAL_PROJECTS and sets each LLVM_EXTERNAL_*_SOURCE_DIR,
+# all in the caller's scope.
+function(add_lgc_projects)
+    if (NOT "${LLVM_EXTERNAL_LGC_SOURCE_DIR}")
+        if (NOT "${LLVM_EXTERNAL_LLVM_DIALECTS_SOURCE_DIR}")
+            list(APPEND LLVM_EXTERNAL_PROJECTS llvm_dialects)
+            set(LLVM_EXTERNAL_LLVM_DIALECTS_SOURCE_DIR "${LLPC_SOURCE_DIR}/imported/llvm-dialects" PARENT_SCOPE)
+        endif()
+        list(APPEND LLVM_EXTERNAL_PROJECTS LgcCps lgc)
+        set(LLVM_EXTERNAL_PROJECTS "${LLVM_EXTERNAL_PROJECTS}" PARENT_SCOPE)
+        set(LLVM_EXTERNAL_LGCCPS_SOURCE_DIR "${LLPC_SOURCE_DIR}/shared/lgccps" PARENT_SCOPE)
+        set(LLVM_EXTERNAL_LGC_SOURCE_DIR "${LLPC_SOURCE_DIR}/lgc" PARENT_SCOPE)
+    endif()
+endfunction()

--- a/lgc/CMakeLists.txt
+++ b/lgc/CMakeLists.txt
@@ -264,5 +264,4 @@ if (LLPC_BUILD_TESTS)
   add_subdirectory(unittests)
 endif()
 
-target_link_libraries(LLVMlgc PUBLIC LLVMLgcRt)
 target_link_libraries(LLVMlgc PRIVATE LLVMLgcCps)

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -43,12 +43,11 @@ endif()
 
 ### Set Options and build LLVM #########################################################################################
 if(ICD_BUILD_LLPC)
-    # Set LLVM options and build LLVM
-    # Add LGC as an LLVM external project, but only if its CMakeLists.txt exists.
-    set(LLVM_EXTERNAL_PROJECTS llvm-dialects lgc LgcRt LgcCps)
-    set(LLVM_EXTERNAL_LGCCPS_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../shared/lgccps)
-    set(LLVM_EXTERNAL_LLVM_DIALECTS_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../imported/llvm-dialects)
-    set(LLVM_EXTERNAL_LGC_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../lgc)
+    # Add LGC and its dependencies as LLVM external projects.
+    include("../cmake/lgc.cmake")
+    add_lgc_projects()
+    # Add other LLPC dependencies as LLVM external projects.
+    list(APPEND LLVM_EXTERNAL_PROJECTS LgcRt)
     set(LLVM_EXTERNAL_LGCRT_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../shared/lgcrt)
 
     # Set other LLVM settings.
@@ -131,7 +130,7 @@ if(ICD_BUILD_LLPC)
     endif()
 
     # Always link statically against libLLVMlgc
-    llvm_map_components_to_libnames(extra_llvm_libs lgc LgcCps)
+    llvm_map_components_to_libnames(extra_llvm_libs LgcRt lgc)
     if(NOT WIN32)
         foreach (lib ${extra_llvm_libs})
             target_compile_options(${lib} PRIVATE "-fno-aligned-new")

--- a/llpc/CMakeLists.txt
+++ b/llpc/CMakeLists.txt
@@ -130,7 +130,7 @@ if(ICD_BUILD_LLPC)
     endif()
 
     # Always link statically against libLLVMlgc
-    llvm_map_components_to_libnames(extra_llvm_libs LgcRt lgc)
+    llvm_map_components_to_libnames(extra_llvm_libs LgcRt lgc LgcCps)
     if(NOT WIN32)
         foreach (lib ${extra_llvm_libs})
             target_compile_options(${lib} PRIVATE "-fno-aligned-new")


### PR DESCRIPTION
LGC is an LLVM external project, and thus cmake variables need to be set up to tell LLVM about it. Now that it is gaining dependencies that are themselves LLVM external projects (llvm-dialects, LgcCps), this gives a single place to update the cmake variable setting up.

This commit introduces:
* cmake/lgc.cmake provides add_lgc_projects to add LGC and its dependencies.