### PR TITLE
Fix crash when RT log is enabled (introduced by #2593)

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -2719,8 +2719,7 @@ void SpirvLowerRayTracing::visitGetParentId(lgc::GpurtGetParentIdOp &inst) {
 void SpirvLowerRayTracing::visitSetParentId(lgc::GpurtSetParentIdOp &inst) {
   m_builder->SetInsertPoint(&inst);
 
-  m_builder->CreateStore(m_builder->CreateLoad(m_builder->getInt32Ty(), inst.getRayId()),
-                         m_traceParams[TraceParam::ParentRayId]);
+  m_builder->CreateStore(inst.getRayId(), m_traceParams[TraceParam::ParentRayId]);
 
   m_callsToLower.push_back(&inst);
   m_funcsToLower.insert(inst.getCalledFunction());


### PR DESCRIPTION
The parameter of `lgc.gpurt.set.parent.id` is not a pointer, we should use the value directly instead of loading from it.