### PR TITLE
Remove global static ID

### DIFF
--- a/lgc/interface/lgc/GpurtDialect.td
+++ b/lgc/interface/lgc/GpurtDialect.td
@@ -292,3 +292,15 @@ def GpurtSetParentIdOp : GpurtOp<"set.parent.id", [Memory<[(write InaccessibleMe
 
   let summary = "Store TraceRay rayId";
 }
+
+def GpurtSetRayStaticIdOp : GpurtOp<"set.ray.static.id", [Memory<[(write InaccessibleMem)]>, WillReturn]> {
+  let arguments = (ins I32:$id);
+  let results = (outs);
+  let summary = "set a unique static ID for a ray";
+}
+
+def GpurtGetRayStaticIdOp : GpurtOp<"get.ray.static.id", [Memory<[(read InaccessibleMem)]>, WillReturn]> {
+  let arguments = (ins);
+  let results = (outs I32:$result);
+  let summary = "get current ray static ID";
+}

--- a/llpc/lower/LowerGpuRt.cpp
+++ b/llpc/lower/LowerGpuRt.cpp
@@ -46,7 +46,7 @@ static const char *LdsStack = "LdsStack";
 
 namespace Llpc {
 // =====================================================================================================================
-LowerGpuRt::LowerGpuRt() : m_stack(nullptr), m_stackTy(nullptr), m_lowerStack(false) {
+LowerGpuRt::LowerGpuRt() : m_stack(nullptr), m_stackTy(nullptr), m_lowerStack(false), m_rayStaticId(nullptr) {
 }
 // =====================================================================================================================
 // Executes this SPIR-V lowering pass on the specified LLVM module.
@@ -61,6 +61,10 @@ PreservedAnalyses LowerGpuRt::run(Module &module, ModuleAnalysisManager &analysi
   m_lowerStack = (m_entryPoint->getName().startswith("_ahit") || m_entryPoint->getName().startswith("_sect")) &&
                  (gfxip.major < 11);
   createGlobalStack();
+
+  if (m_context->getPipelineContext()->getRayTracingState()->enableRayTracingCounters)
+    createRayStaticIdValue();
+
   static auto visitor = llvm_dialects::VisitorBuilder<LowerGpuRt>()
                             .setStrategy(llvm_dialects::VisitorStrategy::ByFunctionDeclaration)
                             .add(&LowerGpuRt::visitGetStackSize)
@@ -74,6 +78,8 @@ PreservedAnalyses LowerGpuRt::run(Module &module, ModuleAnalysisManager &analysi
                             .add(&LowerGpuRt::visitGetStaticFlags)
                             .add(&LowerGpuRt::visitGetTriangleCompressionMode)
                             .add(&LowerGpuRt::visitGetFlattenedGroupThreadId)
+                            .add(&LowerGpuRt::visitSetRayStaticId)
+                            .add(&LowerGpuRt::visitGetRayStaticId)
                             .build();
 
   visitor.visit(*this, *m_module);
@@ -135,6 +141,13 @@ void LowerGpuRt::createGlobalStack() {
 
   ldsStack->setAlignment(MaybeAlign(4));
   m_stack = ldsStack;
+}
+
+// =====================================================================================================================
+// Create ray static ID value
+void LowerGpuRt::createRayStaticIdValue() {
+  m_builder->SetInsertPointPastAllocas(m_entryPoint);
+  m_rayStaticId = m_builder->CreateAlloca(m_builder->getInt32Ty());
 }
 
 // =====================================================================================================================
@@ -330,6 +343,36 @@ void LowerGpuRt::visitGetTriangleCompressionMode(GpurtGetTriangleCompressionMode
 void LowerGpuRt::visitGetFlattenedGroupThreadId(GpurtGetFlattenedGroupThreadIdOp &inst) {
   m_builder->SetInsertPoint(&inst);
   inst.replaceAllUsesWith(getThreadIdInGroup());
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Visit "GpurtSetRayStaticIdOp" instruction
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::visitSetRayStaticId(GpurtSetRayStaticIdOp &inst) {
+  m_builder->SetInsertPoint(&inst);
+
+  assert(m_rayStaticId);
+  auto rayStaticId = inst.getId();
+  auto storeInst = m_builder->CreateStore(rayStaticId, m_rayStaticId);
+
+  inst.replaceAllUsesWith(storeInst);
+  m_callsToLower.push_back(&inst);
+  m_funcsToLower.insert(inst.getCalledFunction());
+}
+
+// =====================================================================================================================
+// Visit "GpurtGetRayStaticIdOp" instruction
+//
+// @param inst : The dialect instruction to process
+void LowerGpuRt::visitGetRayStaticId(GpurtGetRayStaticIdOp &inst) {
+  m_builder->SetInsertPoint(&inst);
+
+  assert(m_rayStaticId);
+  auto rayStaticId = m_builder->CreateLoad(m_builder->getInt32Ty(), m_rayStaticId);
+  inst.replaceAllUsesWith(rayStaticId);
   m_callsToLower.push_back(&inst);
   m_funcsToLower.insert(inst.getCalledFunction());
 }

--- a/llpc/lower/LowerGpuRt.h
+++ b/llpc/lower/LowerGpuRt.h
@@ -46,6 +46,8 @@ class GpurtGetBoxSortHeuristicModeOp;
 class GpurtGetStaticFlagsOp;
 class GpurtGetTriangleCompressionModeOp;
 class GpurtGetFlattenedGroupThreadIdOp;
+class GpurtSetRayStaticIdOp;
+class GpurtGetRayStaticIdOp;
 } // namespace lgc
 
 namespace llvm {
@@ -64,6 +66,7 @@ private:
   uint32_t getWorkgroupSize() const;
   llvm::Value *getThreadIdInGroup() const;
   void createGlobalStack();
+  void createRayStaticIdValue();
   void visitGetStackSize(lgc::GpurtGetStackSizeOp &inst);
   void visitGetStackBase(lgc::GpurtGetStackBaseOp &inst);
   void visitGetStackStride(lgc::GpurtGetStackStrideOp &inst);
@@ -75,10 +78,13 @@ private:
   void visitGetStaticFlags(lgc::GpurtGetStaticFlagsOp &inst);
   void visitGetTriangleCompressionMode(lgc::GpurtGetTriangleCompressionModeOp &inst);
   void visitGetFlattenedGroupThreadId(lgc::GpurtGetFlattenedGroupThreadIdOp &inst);
+  void visitSetRayStaticId(lgc::GpurtSetRayStaticIdOp &inst);
+  void visitGetRayStaticId(lgc::GpurtGetRayStaticIdOp &inst);
   llvm::Value *m_stack;                                  // Stack array to hold stack value
   llvm::Type *m_stackTy;                                 // Stack type
   bool m_lowerStack;                                     // If it is lowerStack
   llvm::SmallVector<llvm::Instruction *> m_callsToLower; // Call instruction to lower
   llvm::SmallSet<llvm::Function *, 4> m_funcsToLower;    // Functions to lower
+  llvm::Value *m_rayStaticId;                            // Ray static ID value
 };
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerRayQuery.h
+++ b/llpc/lower/llpcSpirvLowerRayQuery.h
@@ -129,7 +129,6 @@ protected:
   void processShaderFunction(llvm::Function *func, unsigned opcode);
   void createGlobalLdsUsage();
   void createGlobalRayQueryObj();
-  void createGlobalTraceRayStaticId();
   void initGlobalVariable();
   void generateTraceRayStaticId();
   llvm::Value *createTransformMatrix(unsigned builtInId, llvm::Value *accelStruct, llvm::Value *instanceId,
@@ -139,7 +138,6 @@ protected:
   llvm::Value *createLoadInstanceIndex(llvm::Value *instNodeAddr);
   llvm::Value *createLoadInstanceId(llvm::Value *instNodeAddr);
   llvm::Value *createLoadMatrixFromAddr(llvm::Value *matrixAddr);
-  llvm::GlobalVariable *m_traceRayStaticId; // Static trace ray call site identifier
 
   bool m_rayQueryLibrary;       // Whether the module is ray query library
   unsigned m_spirvOpMetaKindId; // Metadata kind ID for "spirv.op"

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -103,6 +103,7 @@ SpirvProcessGpuRtLibrary::LibraryFunctionTable::LibraryFunctionTable() {
   m_libFuncPtrs["AmdTraceRayGetParentId"] = &SpirvProcessGpuRtLibrary::createGetParentId;
   m_libFuncPtrs["AmdTraceRaySetParentId"] = &SpirvProcessGpuRtLibrary::createSetParentId;
   m_libFuncPtrs["AmdTraceRayDispatchRaysIndex"] = &SpirvProcessGpuRtLibrary::createDispatchRayIndex;
+  m_libFuncPtrs["AmdTraceRayGetStaticId"] = &SpirvProcessGpuRtLibrary::createGetStaticId;
 }
 
 // =====================================================================================================================
@@ -629,6 +630,14 @@ void SpirvProcessGpuRtLibrary::createSetParentId(llvm::Function *func) {
 // @param func : The function to create
 void SpirvProcessGpuRtLibrary::createDispatchRayIndex(llvm::Function *func) {
   m_builder->CreateRet(m_builder->create<DispatchRaysIndexOp>());
+}
+
+// =====================================================================================================================
+// Create function to get ray static ID
+//
+// @param func : The function to create
+void SpirvProcessGpuRtLibrary::createGetStaticId(llvm::Function *func) {
+  m_builder->CreateRet(m_builder->create<GpurtGetRayStaticIdOp>());
 }
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.h
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.h
@@ -83,6 +83,7 @@ private:
   void createGetParentId(llvm::Function *func);
   void createSetParentId(llvm::Function *func);
   void createDispatchRayIndex(llvm::Function *func);
+  void createGetStaticId(llvm::Function *func);
   llvm::Value *createGetBvhSrd(llvm::Value *expansion, llvm::Value *boxSortMode);
 };
 } // namespace Llpc


### PR DESCRIPTION
Remove this global variable and turn the access to it into dialect.

Note that this approach is based on the assumption that SpirvLowerRayQuery and SpirvLowerRayTracing passes are ran before LowerGpuRt pass.