### PR TITLE
vkgc: add shader mapping interface for continuations

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2194,6 +2194,17 @@ Result Compiler::BuildRayTracingPipeline(const RayTracingPipelineBuildInfo *pipe
           shaderHandles[i].intersectionId = getModuleIdByIndex(shaderGroup->intersectionShader);
       }
     }
+
+    // By convention, we're in indirect mode if we produced more than one ELF.
+    if (pipelineOut->pipelineBinCount > 1) {
+      pipelineOut->shaderGroupHandle.shaderMapping = RayTracingShaderIdentifierMapping::ElfModuleGpuVa;
+      pipelineOut->shaderGroupHandle.anyHitMapping = RayTracingShaderIdentifierMapping::ElfModuleGpuVa;
+      pipelineOut->shaderGroupHandle.intersectionMapping = RayTracingShaderIdentifierMapping::ElfModuleGpuVa;
+    } else {
+      pipelineOut->shaderGroupHandle.shaderMapping = RayTracingShaderIdentifierMapping::None;
+      pipelineOut->shaderGroupHandle.anyHitMapping = RayTracingShaderIdentifierMapping::None;
+      pipelineOut->shaderGroupHandle.intersectionMapping = RayTracingShaderIdentifierMapping::None;
+    }
   }
 
   return result;


### PR DESCRIPTION
Allow the compiler to output additional information required to set up the shader group handles.

The outline of the required mapping procedure in the driver is, in pseudocode:

    uint64_t shaderId = rtsgh->shaderHandles[i].shaderId;
    shaderId = applyShaderIdentifierMapping(shaderId, rtsgh->shaderMapping, ...);
    if (rtsgh->extraBits)
      shaderId |= rtsgh->extraBits[i].shader;

    // and analogously for anyHit and intersection shader IDs

There are at least 4 possible usage modes that this supports:

- no mapping at all, for unified/inline pipeline builds
- traditional mapping to a full GPU VA
- mapping to a full GPU VA, but with LSBs filled with metadata determined by the compiler
- mapping to the low 32 bits of the GPU VA, with high bits filled with metadata determined by the compiler