### PR TITLE
lgc: make irLink() more robust

### DIFF
--- a/lgc/state/Compiler.cpp
+++ b/lgc/state/Compiler.cpp
@@ -141,7 +141,7 @@ Module *PipelineState::irLink(ArrayRef<Module *> modules, PipelineLink pipelineL
     pipelineModule = new Module("lgcPipeline", getContext());
     TargetMachine *targetMachine = getLgcContext()->getTargetMachine();
     pipelineModule->setTargetTriple(targetMachine->getTargetTriple().getTriple());
-    pipelineModule->setDataLayout(targetMachine->createDataLayout());
+    pipelineModule->setDataLayout(modules.front()->getDataLayout());
 
     Linker linker(*pipelineModule);
     for (Module *module : modules) {


### PR DESCRIPTION
Just use the datalayout from one of the modules, the modules to be linked should already get the same datalayout. This make the code more robust to possible datalayout modifications.