### PR TITLE
Inline gpurt traceRay entryfunction

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayQuery.h
+++ b/llpc/lower/llpcSpirvLowerRayQuery.h
@@ -117,7 +117,7 @@ public:
   SpirvLowerRayQuery();
   SpirvLowerRayQuery(bool rayQueryLibrary);
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
-  virtual bool runImpl(llvm::Module &module);
+  bool runImpl(llvm::Module &module);
   llvm::Value *getThreadIdInGroup() const;
 
   static llvm::StringRef name() { return "Lower SPIR-V RayQuery operations"; }

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -512,7 +512,7 @@ PreservedAnalyses SpirvLowerRayTracing::run(Module &module, ModuleAnalysisManage
     m_shaderStage = ShaderStageRayTracingRayGen;
     createRayGenEntryFunc();
     rayTracingContext->setEntryName("main");
-    goto end;
+    return PreservedAnalyses::none();
   }
 
   if (m_shaderStage == ShaderStageRayTracingClosestHit || m_shaderStage == ShaderStageRayTracingAnyHit ||
@@ -633,7 +633,7 @@ PreservedAnalyses SpirvLowerRayTracing::run(Module &module, ModuleAnalysisManage
     func->dropAllReferences();
     func->eraseFromParent();
   }
-end:
+
   LLVM_DEBUG(dbgs() << "After the pass Spirv-Lower-Ray-Tracing " << module);
   return PreservedAnalyses::none();
 }

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -497,16 +497,6 @@ void SpirvLowerRayTracing::visitReportHitOp(ReportHitOp &inst) {
 // @param [in/out] module : LLVM module to be run on
 // @param [in/out] analysisManager : Analysis manager to use for this transformation
 PreservedAnalyses SpirvLowerRayTracing::run(Module &module, ModuleAnalysisManager &analysisManager) {
-  runImpl(module, analysisManager);
-  return PreservedAnalyses::none();
-}
-
-// =====================================================================================================================
-// Executes this SPIR-V lowering pass on the specified LLVM module.
-//
-// @param [in,out] module : LLVM module to be run on
-// @param [in/out] analysisManager : Analysis manager to use for this transformation
-bool SpirvLowerRayTracing::runImpl(Module &module, ModuleAnalysisManager &analysisManager) {
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Ray-Tracing\n");
 
   SpirvLower::init(&module);
@@ -516,15 +506,15 @@ bool SpirvLowerRayTracing::runImpl(Module &module, ModuleAnalysisManager &analys
   initGlobalPayloads();
   initShaderBuiltIns();
   initGlobalCallableData();
-
+  Instruction *insertPos = nullptr;
   // Create empty raygen main module
   if (module.empty()) {
     m_shaderStage = ShaderStageRayTracingRayGen;
     createRayGenEntryFunc();
     rayTracingContext->setEntryName("main");
-    return true;
+    goto end;
   }
-  Instruction *insertPos = nullptr;
+
   if (m_shaderStage == ShaderStageRayTracingClosestHit || m_shaderStage == ShaderStageRayTracingAnyHit ||
       m_shaderStage == ShaderStageRayTracingIntersect || m_shaderStage == ShaderStageRayTracingMiss) {
     insertPos = createEntryFunc(m_entryPoint);
@@ -643,10 +633,9 @@ bool SpirvLowerRayTracing::runImpl(Module &module, ModuleAnalysisManager &analys
     func->dropAllReferences();
     func->eraseFromParent();
   }
-
+end:
   LLVM_DEBUG(dbgs() << "After the pass Spirv-Lower-Ray-Tracing " << module);
-
-  return true;
+  return PreservedAnalyses::none();
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -150,7 +150,7 @@ class SpirvLowerRayTracing : public SpirvLowerRayQuery {
 public:
   SpirvLowerRayTracing();
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
-  virtual bool runImpl(llvm::Module &module);
+  bool runImpl(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
 
   static llvm::StringRef name() { return "Lower SPIR-V RayTracing operations"; }
 
@@ -161,7 +161,7 @@ private:
   void replaceGlobal(llvm::GlobalVariable *global, llvm::Value *replacedGlobal);
   void processShaderRecordBuffer(llvm::GlobalVariable *global, llvm::Value *bufferDesc, llvm::Value *tableIndex,
                                  llvm::Instruction *insertPos);
-  void createTraceRay();
+  llvm::CallInst *createTraceRay();
   void createSetHitAttributes(llvm::Function *func, unsigned instArgsNum, unsigned traceParamsOffset);
   void createSetTraceParams(llvm::Function *func, unsigned instArgNum);
   void createAnyHitFunc(llvm::Value *shaderIdentifier, llvm::Value *shaderRecordIndex);
@@ -186,6 +186,7 @@ private:
   void initGlobalPayloads();
   void initGlobalCallableData();
   void initShaderBuiltIns();
+  void inlineTraceRay(llvm::CallInst *callInst, ModuleAnalysisManager &analysisManager);
   llvm::Instruction *createEntryFunc(llvm::Function *func);
   void createEntryTerminator(llvm::Function *func);
   llvm::FunctionType *getShaderEntryFuncTy(ShaderStage stage);

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -150,7 +150,6 @@ class SpirvLowerRayTracing : public SpirvLowerRayQuery {
 public:
   SpirvLowerRayTracing();
   llvm::PreservedAnalyses run(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
-  bool runImpl(llvm::Module &module, llvm::ModuleAnalysisManager &analysisManager);
 
   static llvm::StringRef name() { return "Lower SPIR-V RayTracing operations"; }
 


### PR DESCRIPTION
This is for future refactoring where payload or callable data can refactored directly in the lowerRaytracing class