### PR TITLE
Set color export state for color export shader

### DIFF
--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -197,8 +197,9 @@ void GraphicsContext::setPipelineState(Pipeline *pipeline, Util::MetroHash64 *ha
     setVertexInputDescriptions(pipeline, hasher);
   }
 
-  if (isShaderStageInMask(ShaderStageFragment, stageMask) && (!unlinked || DisableColorExportShader)) {
-    // Give the color export state to the middle-end.
+  if ((isShaderStageInMask(ShaderStageFragment, stageMask) && (!unlinked || DisableColorExportShader)) ||
+      (stageMask == 0)) {
+    // Give the color export state to the middle-end. Empty stage mask indicates color export shader.
     setColorExportState(pipeline, hasher);
   }
 


### PR DESCRIPTION
A minor fix for the previous PR which [builds color export shader explicitly](https://github.com/GPUOpen-Drivers/llpc/pull/2583).
Color export shader needs the color target information such as export formats. Thus, need to call **setColorExportState()** when compiling color export shader.

Affected CTS list:
 _dEQP-VK.pipeline.fast_linked_library.\*_