### PR TITLE
Metadata3.0: add missing or wrong registers setting in Non-Ngg mode

### DIFF
--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -1294,10 +1294,6 @@ unsigned PalMetadata::getFragmentShaderBuiltInLoc(unsigned builtin) {
 unsigned PalMetadata::getCallingConventionForFirstHardwareShaderStage(std::string &hwStageName) {
   if (m_useRegisterFieldFormat) {
     auto hardwareStages = m_pipelineNode[Util::Abi::PipelineMetadataKey::HardwareStages].getMap(true);
-    hwStageName = HwStageNames[static_cast<unsigned>(Util::Abi::HardwareStage::Vs)];
-    if (hardwareStages.find(hwStageName) != hardwareStages.end())
-      return CallingConv::AMDGPU_VS;
-
     hwStageName = HwStageNames[static_cast<unsigned>(Util::Abi::HardwareStage::Hs)];
     if (hardwareStages.find(hwStageName) != hardwareStages.end())
       return CallingConv::AMDGPU_HS;
@@ -1305,6 +1301,10 @@ unsigned PalMetadata::getCallingConventionForFirstHardwareShaderStage(std::strin
     hwStageName = HwStageNames[static_cast<unsigned>(Util::Abi::HardwareStage::Gs)];
     if (hardwareStages.find(hwStageName) != hardwareStages.end())
       return CallingConv::AMDGPU_GS;
+
+    hwStageName = HwStageNames[static_cast<unsigned>(Util::Abi::HardwareStage::Vs)];
+    if (hardwareStages.find(hwStageName) != hardwareStages.end())
+      return CallingConv::AMDGPU_VS;
 
     hwStageName = HwStageNames[static_cast<unsigned>(Util::Abi::HardwareStage::Cs)];
     return CallingConv::AMDGPU_CS;


### PR DESCRIPTION
Add the missing setting:
- Set user data entries for the copy shader as hardware VS.
- Set vgtGsOnChipCntl node with default values in `buildLsHsRegisters`.
- Set `.offchip_lds_en` true for vertex shader with `isTessOffChip` enabled.

Modify some register fields for XFB:
- set `VsStreamoutEn` that is deserialized in PAL instead of `VsSoEn`.
- call `setStreamOutVertexStrides` to replace VGT_STRMOUT_VTX_STRIDE_*

Fix VGT_GSVS_RING_OFFSET that has 3 not 4 arary elements.

Use mmSPI_SHADER_PGM_LO_GS to set `NggCullingDataReg` that can align with PAL.

The code of updating PsSampleMask node in `mergeMetaNote()` should be shared by old and new path.