### PR TITLE
Task shader: Change EmitMeshTasks to dialects Op

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -228,8 +228,6 @@ StringRef BuilderRecorder::getCallName(BuilderOpcode opcode) {
     return "demote.to.helper.invocation";
   case BuilderOpcode::IsHelperInvocation:
     return "is.helper.invocation";
-  case BuilderOpcode::EmitMeshTasks:
-    return "emit.mesh.tasks";
   case BuilderOpcode::SetMeshOutputs:
     return "set.mesh.outputs";
   case BuilderOpcode::ImageLoad:
@@ -894,20 +892,6 @@ Instruction *Builder::CreateDemoteToHelperInvocation(const Twine &instName) {
 // @param instName : Name to give final instruction
 Value *Builder::CreateIsHelperInvocation(const Twine &instName) {
   return record(BuilderOpcode::IsHelperInvocation, getInt1Ty(), {}, instName);
-}
-
-// =====================================================================================================================
-// In the task shader, emit the current values of all per-task output variables to the current task output by
-// specifying the group count XYZ of the launched child mesh tasks.
-//
-// @param groupCountX : X dimension of the launched child mesh tasks
-// @param groupCountY : Y dimension of the launched child mesh tasks
-// @param groupCountZ : Z dimension of the launched child mesh tasks
-// @param instName : Name to give final instruction
-// @returns Instruction to emit mesh tasks
-Instruction *Builder::CreateEmitMeshTasks(Value *groupCountX, Value *groupCountY, Value *groupCountZ,
-                                          const Twine &instName) {
-  return record(BuilderOpcode::EmitMeshTasks, nullptr, {groupCountX, groupCountY, groupCountZ}, instName);
 }
 
 // =====================================================================================================================
@@ -2124,7 +2108,6 @@ Instruction *Builder::record(BuilderOpcode opcode, Type *resultTy, ArrayRef<Valu
     case BuilderOpcode::ImageQuerySamples:
     case BuilderOpcode::ImageQuerySize:
     case BuilderOpcode::IsHelperInvocation:
-    case BuilderOpcode::EmitMeshTasks:
     case BuilderOpcode::SetMeshOutputs:
     case BuilderOpcode::Kill:
     case BuilderOpcode::ReadClock:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -155,7 +155,6 @@ enum BuilderOpcode : unsigned {
   Derivative,
   DemoteToHelperInvocation,
   IsHelperInvocation,
-  EmitMeshTasks,
   SetMeshOutputs,
   GetWaveSize,
   DebugBreak,

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -686,9 +686,6 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   case BuilderOpcode::DebugBreak: {
     return m_builder->CreateDebugBreak();
   }
-  case BuilderOpcode::EmitMeshTasks: {
-    return m_builder->CreateEmitMeshTasks(args[0], args[1], args[2]);
-  }
   case BuilderOpcode::SetMeshOutputs: {
     return m_builder->CreateSetMeshOutputs(args[0], args[1]);
   }

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -126,21 +126,6 @@ Value *BuilderImpl::CreateIsHelperInvocation(const Twine &instName) {
 }
 
 // =====================================================================================================================
-// In the task shader, emit the current values of all per-task output variables to the current task output by
-// specifying the group count XYZ of the launched child mesh tasks.
-//
-// @param groupCountX : X dimension of the launched child mesh tasks
-// @param groupCountY : Y dimension of the launched child mesh tasks
-// @param groupCountZ : Z dimension of the launched child mesh tasks
-// @param instName : Name to give final instruction
-// @returns Instruction to emit mesh tasks
-Instruction *BuilderImpl::CreateEmitMeshTasks(Value *groupCountX, Value *groupCountY, Value *groupCountZ,
-                                              const Twine &instName) {
-  assert(m_shaderStage == ShaderStageTask); // Only valid for task shader
-  return CreateNamedCall(lgcName::MeshTaskEmitMeshTasks, getVoidTy(), {groupCountX, groupCountY, groupCountZ}, {});
-}
-
-// =====================================================================================================================
 // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
 // emit upon completion.
 //

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -627,11 +627,6 @@ public:
   // Create a helper invocation query. Only allowed in a fragment shader.
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName = "");
 
-  // In the task shader, emit the current values of all per-task output variables to the current task output by
-  // specifying the group count XYZ of the launched child mesh tasks.
-  llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, llvm::Value *groupCountZ,
-                                         const llvm::Twine &instName = "");
-
   // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
   // emit upon completion.
   llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount,

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -50,7 +50,6 @@ const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invoca
 const static char SwizzleWorkgroupId[] = "lgc.swizzle.workgroup.id";
 
 const static char MeshTaskCallPrefix[] = "lgc.mesh.task.";
-const static char MeshTaskEmitMeshTasks[] = "lgc.mesh.task.emit.mesh.tasks";
 const static char MeshTaskSetMeshOutputs[] = "lgc.mesh.task.set.mesh.outputs";
 const static char MeshTaskSetPrimitiveIndices[] = "lgc.mesh.task.set.primitive.indices.";
 const static char MeshTaskSetPrimitiveCulled[] = "lgc.mesh.task.set.primitive.culled";

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1362,17 +1362,6 @@ public:
   // @param instName : Name to give instruction(s)
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName = "");
 
-  // In the task shader, emit the current values of all per-task output variables to the current task output by
-  // specifying the group count XYZ of the launched child mesh tasks.
-  //
-  // @param groupCountX : X dimension of the launched child mesh tasks
-  // @param groupCountY : Y dimension of the launched child mesh tasks
-  // @param groupCountZ : Z dimension of the launched child mesh tasks
-  // @param instName : Name to give final instruction
-  // @returns Instruction to emit mesh tasks
-  llvm::Instruction *CreateEmitMeshTasks(llvm::Value *groupCountX, llvm::Value *groupCountY, // NOLINT
-                                         llvm::Value *groupCountZ, const llvm::Twine &instName = "");
-
   // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
   // emit upon completion.
   //

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -108,6 +108,21 @@ def TaskPayloadPtrOp : LgcOp<"task.payload.ptr", [Memory<[]>, WillReturn]> {
   }];
 }
 
+def EmitMeshTasksOp : LgcOp<"emit.mesh.tasks", [Memory<[]>]> {
+  let arguments = (ins I32:$groupCountX, I32:$groupCountY, I32:$groupCountZ);
+  let results = (outs);
+
+  let summary = "emit the current values of all per-task output variables to the current task output";
+  let description = [{
+    In the task shader, emit the current values of all per-task output variables to the current task output by
+    specifying the group count XYZ of the launched child mesh tasks.
+
+    `groupCountX` is X dimension of the launched child mesh tasks.
+    `groupCountY` is Y dimension of the launched child mesh tasks.
+    `groupCountZ` is Z dimension of the launched child mesh tasks.
+  }];
+}
+
 def GenericLocationOp : OpClass<LgcDialect> {
   let arguments = (ins AttrI1:$perPrimitive, AttrI32:$location, I32:$locOffset, I32:$elemIdx, I32:$arrayIndex);
 

--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -81,6 +81,7 @@ private:
   void processMeshShader(llvm::Function *entryPoint);
 
   void lowerTaskPayloadPtr(TaskPayloadPtrOp &taskPayloadPtrOp);
+  void lowerEmitMeshTasks(EmitMeshTasksOp &emitMeshTasksOp);
 
   void initWaveThreadInfo(llvm::Function *entryPoint);
   llvm::Value *getShaderRingEntryIndex(llvm::Function *entryPoint);
@@ -88,7 +89,6 @@ private:
   llvm::Value *getPayloadRingEntryOffset(llvm::Function *entryPoint);
   llvm::Value *getDrawDataRingEntryOffset(llvm::Function *entryPoint);
   llvm::Value *getDrawDataReadyBit(llvm::Function *entryPoint);
-  void emitTaskMeshs(llvm::Value *groupCountX, llvm::Value *groupCountY, llvm::Value *groupCountZ);
 
   llvm::Value *convertToDivergent(llvm::Value *value);
 

--- a/lgc/test/TaskShaderOps.lgc
+++ b/lgc/test/TaskShaderOps.lgc
@@ -44,9 +44,9 @@
 ; CHECK-NEXT: [[newPayloadRingDesc:%[0-9]*]] = insertelement <4 x i32> [[newPayloadRingDescTmp]], i32 [[newDescWord1]], i64 1
 ; CHECK: %{{[0-9]*}} = call i32 @llvm.amdgcn.raw.atomic.buffer.load.i32(<4 x i32> [[newPayloadRingDesc]], i32 %{{.*}}, i32 0, i32 5)
 ; CHECK: call void @llvm.amdgcn.raw.buffer.store.i32(i32 %{{[0-9]*}}, <4 x i32> [[newPayloadRingDesc]], i32 %{{.*}}, i32 0, i32 1)
-; CHECK: br i1 %{{[0-9]*}}, label %.emitMeshs, label %.endEmitMeshs
+; CHECK: br i1 %{{[0-9]*}}, label %.emitMeshTasks, label %.endEmitMeshTasks
 ;
-; CHECK: .emitMeshs:
+; CHECK: .emitMeshTasks:
 ; CHECK: [[meshPipeStatsBufAddr2x32:%[0-9]*]] = insertelement <2 x i32> %{{[0-9]*}}, i32 %meshPipeStatsBuf, i64 0
 ; CHECK-NEXT: [[meshPipeStatsBufAddr64:%[0-9]*]] = bitcast <2 x i32> [[meshPipeStatsBufAddr2x32]] to i64
 ; CHECK-NEXT: [[meshPipeStatsBufAddr:%[0-9]*]] = inttoptr i64 [[meshPipeStatsBufAddr64]] to ptr addrspace(1)
@@ -64,9 +64,9 @@
 ; CHECK-NEXT: [[readyBit:%[0-9]*]] = icmp ne i32 [[checkReadyBit]], 0
 ; CHECK-NEXT: [[readyBit8:%[0-9]*]] = zext i1 [[readyBit]] to i8
 ; CHECK-NEXT: call void @llvm.amdgcn.raw.buffer.store.i8(i8 [[readyBit8]], <4 x i32> [[drawDataRingDesc]], i32 12, i32 [[entryOffset]], i32 0)
-; CHECK-NEXT: br label %.endEmitMeshs
+; CHECK-NEXT: br label %.endEmitMeshTasks
 ;
-; CHECK: .endEmitMeshs:
+; CHECK: .endEmitMeshTasks:
 ; CHECK-NEXT: ret void
 
 ; ModuleID = 'llpc_task_1'
@@ -85,12 +85,12 @@ define dllexport spir_func void @main() local_unnamed_addr #0 !spirv.ExecutionMo
   %4 = load atomic float, ptr addrspace(7) %3 unordered, align 4
   %5 = getelementptr [32 x float], ptr addrspace(7) %0, i32 0, i32 %2
   store atomic float %4, ptr addrspace(7) %5 unordered, align 4
-  call void (...) @lgc.create.emit.mesh.tasks(i32 3, i32 1, i32 1)
+  call void (...) @lgc.emit.mesh.tasks(i32 3, i32 1, i32 1)
   ret void
 }
 
 ; Function Attrs: nounwind
-declare void @lgc.create.emit.mesh.tasks(...) local_unnamed_addr #0
+declare void @lgc.emit.mesh.tasks(...) local_unnamed_addr #0
 
 ; Function Attrs: nounwind willreturn memory(read)
 declare <3 x i32> @lgc.create.read.builtin.input.v3i32(...) local_unnamed_addr #1

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3823,7 +3823,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpEmitMeshTasksEXT>(SPIRVVa
   Value *const groupCountX = transValue(spvOperands[0], func, block);
   Value *const groupCountY = transValue(spvOperands[1], func, block);
   Value *const groupCountZ = transValue(spvOperands[2], func, block);
-  getBuilder()->CreateEmitMeshTasks(groupCountX, groupCountY, groupCountZ);
+  getBuilder()->create<lgc::EmitMeshTasksOp>(groupCountX, groupCountY, groupCountZ);
   // NOTE: According to SPIR-V spec, OpEmitMeshTasksEXT is a terminator. Hence, we have to insert
   // a return instruction to implement this semantics.
   return getBuilder()->CreateRetVoid();


### PR DESCRIPTION
Define new dialects Op: EmitMeshTasksOp. Change original handling function to lowerEmitMeshTasks. Remove EmitMeshTasks from LLPC builder.