### PR TITLE
Fix build error of ray tracing

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -41,6 +41,7 @@
 #include "lgc/Pipeline.h"
 #include "llvm-dialects/Dialect/Visitor.h"
 #include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
 #include "llvm/Analysis/ProfileSummaryInfo.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/Support/CommandLine.h"


### PR DESCRIPTION
Add the missing inclusion of llvm/Analysis/BlockFrequencyInfo.h