### PR TITLE
llpc: tighten up shader module creation

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -572,13 +572,15 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
                                        codeSize / sizeof(*allocBuf));
 
   memcpy(moduleData->hash, &hash, sizeof(hash));
-  ShaderModuleHelper::getModuleData(shaderInfo, codeBuffer, *moduleData);
+  Result result = ShaderModuleHelper::getModuleData(shaderInfo, codeBuffer, *moduleData);
   shaderOut->pModuleData = moduleData;
 
-  if (moduleData->binType == BinaryType::Spirv && cl::EnablePipelineDump)
+  if (moduleData->binType == BinaryType::Spirv && cl::EnablePipelineDump) {
+    // Dump the original input binary, since the offline tool will re-run BuildShaderModule
     PipelineDumper::DumpSpirvBinary(cl::PipelineDumpDir.c_str(), &shaderInfo->shaderBin, &hash);
+  }
 
-  return Result::Success;
+  return result;
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -392,19 +392,25 @@ bool ShaderModuleHelper::isLlvmBitcode(const BinaryData *shaderBin) {
 // =====================================================================================================================
 // Returns the binary type for the given shader binary.
 //
-// @param shaderBin : Shader binary code
-// @return : The binary type for the shader or BinaryType::Unknown if it could not be determined.
-BinaryType ShaderModuleHelper::getShaderBinaryType(BinaryData shaderBinary) {
-  if (ShaderModuleHelper::isLlvmBitcode(&shaderBinary))
-    return BinaryType::LlvmBc;
+// @param shaderBinary : Shader binary code
+// @param[out] binaryType : Overwritten with the detected binary type, or BinaryType::Unknown if it could not be
+//                          determined
+// @return : Success is returned if the binary type was detected and any sanity checks have passed
+Result ShaderModuleHelper::getShaderBinaryType(BinaryData shaderBinary, BinaryType &binaryType) {
+  binaryType = BinaryType::Unknown;
+  if (ShaderModuleHelper::isLlvmBitcode(&shaderBinary)) {
+    binaryType = BinaryType::LlvmBc;
+    return Result::Success;
+  }
   if (Vkgc::isSpirvBinary(&shaderBinary)) {
+    binaryType = BinaryType::Spirv;
     if (verifySpirvBinary(&shaderBinary) != Result::Success) {
       LLPC_ERRS("Unsupported SPIR-V instructions found in the SPIR-V binary!\n");
-      return BinaryType::Unknown;
+      return Result::ErrorInvalidShader;
     }
-    return BinaryType::Spirv;
+    return Result::Success;
   }
-  return BinaryType::Unknown;
+  return Result::ErrorInvalidShader;
 }
 
 // =====================================================================================================================
@@ -419,9 +425,9 @@ Result ShaderModuleHelper::getModuleData(const ShaderModuleBuildInfo *shaderInfo
                                          llvm::MutableArrayRef<unsigned> codeBuffer,
                                          Vkgc::ShaderModuleData &moduleData) {
   const BinaryData &shaderBinary = shaderInfo->shaderBin;
-  moduleData.binType = ShaderModuleHelper::getShaderBinaryType(shaderBinary);
-  if (moduleData.binType == BinaryType::Unknown)
-    return Result::ErrorInvalidShader;
+  Result result = ShaderModuleHelper::getShaderBinaryType(shaderBinary, moduleData.binType);
+  if (result != Result::Success)
+    return result;
 
   if (moduleData.binType == BinaryType::Spirv) {
     moduleData.usage = ShaderModuleHelper::getShaderModuleUsageInfo(&shaderBinary);

--- a/llpc/util/llpcShaderModuleHelper.h
+++ b/llpc/util/llpcShaderModuleHelper.h
@@ -67,7 +67,7 @@ public:
   static Result verifySpirvBinary(const BinaryData *spvBin);
 
   static bool isLlvmBitcode(const BinaryData *shaderBin);
-  static BinaryType getShaderBinaryType(BinaryData shaderBinary);
+  static Result getShaderBinaryType(BinaryData shaderBinary, BinaryType &binaryType);
   static Result getModuleData(const ShaderModuleBuildInfo *shaderInfo, llvm::MutableArrayRef<unsigned> codeBuffer,
                               Vkgc::ShaderModuleData &moduleData);
   static unsigned getCodeSize(const ShaderModuleBuildInfo *shaderInfo);


### PR DESCRIPTION
Propagate errors detected in SPIR-V and dump the SPIR-V binary even when an error was detected.

This is primarily a debugging aid. When an application does not correctly check for the presence of an extension, and we happen to have a driver build without that extension, the compile used to crash leaving behind a .pipe file but no .spv file (if pipeline dumping was enabled), which thwarts the usual method of figuring out compiler crashes by reproducing via the offline amdllpc. With this modification, the .spv file should now be left behind as well, allowing reproduction of the problem.