### PR TITLE
Mesh shader: Change some mesh shader calls to dialects Op

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -228,8 +228,6 @@ StringRef BuilderRecorder::getCallName(BuilderOpcode opcode) {
     return "demote.to.helper.invocation";
   case BuilderOpcode::IsHelperInvocation:
     return "is.helper.invocation";
-  case BuilderOpcode::SetMeshOutputs:
-    return "set.mesh.outputs";
   case BuilderOpcode::ImageLoad:
     return "image.load";
   case BuilderOpcode::ImageLoadWithFmask:
@@ -892,18 +890,6 @@ Instruction *Builder::CreateDemoteToHelperInvocation(const Twine &instName) {
 // @param instName : Name to give final instruction
 Value *Builder::CreateIsHelperInvocation(const Twine &instName) {
   return record(BuilderOpcode::IsHelperInvocation, getInt1Ty(), {}, instName);
-}
-
-// =====================================================================================================================
-// In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
-// emit upon completion.
-//
-// @param vertexCount : Actual output size of the vertices
-// @param primitiveCount : Actual output size of the primitives
-// @param instName : Name to give final instruction
-// @returns Instruction to set the actual size of mesh outputs
-Instruction *Builder::CreateSetMeshOutputs(Value *vertexCount, Value *primitiveCount, const Twine &instName) {
-  return record(BuilderOpcode::SetMeshOutputs, nullptr, {vertexCount, primitiveCount}, instName);
 }
 
 // =====================================================================================================================
@@ -2108,7 +2094,6 @@ Instruction *Builder::record(BuilderOpcode opcode, Type *resultTy, ArrayRef<Valu
     case BuilderOpcode::ImageQuerySamples:
     case BuilderOpcode::ImageQuerySize:
     case BuilderOpcode::IsHelperInvocation:
-    case BuilderOpcode::SetMeshOutputs:
     case BuilderOpcode::Kill:
     case BuilderOpcode::ReadClock:
     case BuilderOpcode::DebugBreak:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -155,7 +155,6 @@ enum BuilderOpcode : unsigned {
   Derivative,
   DemoteToHelperInvocation,
   IsHelperInvocation,
-  SetMeshOutputs,
   GetWaveSize,
   DebugBreak,
 

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -686,9 +686,6 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   case BuilderOpcode::DebugBreak: {
     return m_builder->CreateDebugBreak();
   }
-  case BuilderOpcode::SetMeshOutputs: {
-    return m_builder->CreateSetMeshOutputs(args[0], args[1]);
-  }
   case BuilderOpcode::TransposeMatrix: {
     return m_builder->CreateTransposeMatrix(args[0]);
   }

--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -126,19 +126,6 @@ Value *BuilderImpl::CreateIsHelperInvocation(const Twine &instName) {
 }
 
 // =====================================================================================================================
-// In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
-// emit upon completion.
-//
-// @param vertexCount : Actual output size of the vertices
-// @param primitiveCount : Actual output size of the primitives
-// @param instName : Name to give final instruction
-// @returns Instruction to set the actual size of mesh outputs
-Instruction *BuilderImpl::CreateSetMeshOutputs(Value *vertexCount, Value *primitiveCount, const Twine &instName) {
-  assert(m_shaderStage == ShaderStageMesh); // Only valid for mesh shader
-  return CreateNamedCall(lgcName::MeshTaskSetMeshOutputs, getVoidTy(), {vertexCount, primitiveCount}, {});
-}
-
-// =====================================================================================================================
 // Create a "readclock".
 //
 // @param realtime : Whether to read real-time clock counter

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -635,11 +635,6 @@ public:
   // Create a helper invocation query. Only allowed in a fragment shader.
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName = "");
 
-  // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
-  // emit upon completion.
-  llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount,
-                                          const llvm::Twine &instName = "");
-
   // -------------------------------------------------------------------------------------------------------------------
   // Builder implementation subclass for subgroup operations
 public:

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -49,14 +49,6 @@ const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
 const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
 const static char SwizzleWorkgroupId[] = "lgc.swizzle.workgroup.id";
 
-const static char MeshTaskCallPrefix[] = "lgc.mesh.task.";
-const static char MeshTaskSetMeshOutputs[] = "lgc.mesh.task.set.mesh.outputs";
-const static char MeshTaskSetPrimitiveIndices[] = "lgc.mesh.task.set.primitive.indices.";
-const static char MeshTaskSetPrimitiveCulled[] = "lgc.mesh.task.set.primitive.culled";
-const static char MeshTaskGetMeshInput[] = "lgc.mesh.task.get.mesh.input.";
-const static char MeshTaskWriteVertexOutput[] = "lgc.mesh.task.write.vertex.output.";
-const static char MeshTaskWritePrimitiveOutput[] = "lgc.mesh.task.write.primitive.output.";
-
 // Get pointer to spill table (as pointer to i8)
 const static char SpillTable[] = "lgc.spill.table";
 // Get pointer to push constant (as pointer type indicated by the return type)

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1362,16 +1362,6 @@ public:
   // @param instName : Name to give instruction(s)
   llvm::Value *CreateIsHelperInvocation(const llvm::Twine &instName = "");
 
-  // In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
-  // emit upon completion.
-  //
-  // @param vertexCount : Actual output size of the vertices
-  // @param primitiveCount : Actual output size of the primitives
-  // @param instName : Name to give final instruction
-  // @returns Instruction to set the actual size of mesh outputs
-  llvm::Instruction *CreateSetMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount, // NOLINT
-                                          const llvm::Twine &instName = "");
-
   // -----------------------------------------------------------------------------------------------------------------
   // Subgroup operations
 

--- a/lgc/interface/lgc/LgcDialect.td
+++ b/lgc/interface/lgc/LgcDialect.td
@@ -123,6 +123,88 @@ def EmitMeshTasksOp : LgcOp<"emit.mesh.tasks", [Memory<[]>]> {
   }];
 }
 
+def SetMeshOutputsOp : LgcOp<"set.mesh.outputs", [Memory<[]>]> {
+  let arguments = (ins I32:$vertexCount, I32:$primitiveCount);
+  let results = (outs);
+
+  let summary = "set the actual output size of the primitives and vertices that the mesh shader workgroup will emit";
+  let description = [{
+    In the mesh shader, set the actual output size of the primitives and vertices that the mesh shader workgroup will
+    emit upon completion.
+
+    `vertexCount` is the actual output size of the vertices.
+    `primitiveCount` is the actual output size of the primitives.
+  }];
+}
+
+def SetMeshPrimitiveIndicesOp : LgcOp<"set.mesh.primitive.indices", [Memory<[]>]> {
+  let arguments = (ins I32:$primitiveIndex, (ScalarOrFixedVector I32):$primitiveIndices);
+  let results = (outs);
+
+  let summary = "set primitive indices for mesh shader";
+  let description = [{
+    In the mesh shader, set primitive indices by forming primitive connectivity data and writing it to LDS.
+
+    `primitiveIndex` is the primitive index specifying which primitive to set.
+    `primitiveIndices` are all vertex index values that are used to form this primitive.
+  }];
+}
+
+def SetMeshPrimitiveCulledOp : LgcOp<"set.mesh.primitive.culled", [Memory<[]>]> {
+  let arguments = (ins I32:$primitiveIndex, I1:$isCulled);
+  let results = (outs);
+
+  let summary = "set primitive culled state for mesh shader";
+  let description = [{
+    In the mesh shader, set primitive culled state by writing the null primitive flag to LDS.
+
+    `primitiveIndex` is the primitive index specifying which primitive to set.
+    `isCulled` is a boolean flag indicating whether this primitive is culled.
+  }];
+}
+
+def GetMeshBuiltinInputOp : LgcOp<"get.mesh.builtin.input", [Memory<[]>, WillReturn]> {
+  let arguments = (ins AttrI32:$builtin);
+  let results = (outs value:$result);
+
+  let defaultBuilderHasExplicitResultType = true;
+
+  let summary = "return the value of mesh built-in input";
+  let description = [{
+    Return the value of mesh built-in input.
+
+    `builtIn` is the input built-in ID of mesh shader.
+  }];
+}
+
+def WriteMeshVertexOutputOp : LgcOp<"write.mesh.vertex.output", [Memory<[]>]> {
+  let arguments = (ins I32:$outputOffset, I32:$vertexIndex, value:$outputValue);
+  let results = (outs);
+
+  let summary = "Write mesh shader vertex outputs";
+  let description = [{
+    In the mesh shader, write mesh shader vertex outputs to LDS.
+
+    `outputOffset` is the relative offset of this output (in dwords) within all outputs of the indexed vertex.
+    `vertexIndex` is the vertex index specifying which vertex to write.
+    `outputValue` is the output value to write.
+  }];
+}
+
+def WriteMeshPrimitiveOutputOp : LgcOp<"write.mesh.primitive.output", [Memory<[]>]> {
+  let arguments = (ins I32:$outputOffset, I32:$primitiveIndex, value:$outputValue);
+  let results = (outs);
+
+  let summary = "Write mesh shader primitive outputs";
+  let description = [{
+    In the mesh shader, write mesh shader primitive outputs to LDS.
+
+    `outputOffset` is the relative offset of this output (in dwords) within all outputs of the indexed primitive.
+    `primitiveIndex` is the primitive index specifying which primitive to write.
+    `outputValue` is the output value to write.
+  }];
+}
+
 def GenericLocationOp : OpClass<LgcDialect> {
   let arguments = (ins AttrI1:$perPrimitive, AttrI32:$location, I32:$locOffset, I32:$elemIdx, I32:$arrayIndex);
 

--- a/lgc/patch/MeshTaskShader.h
+++ b/lgc/patch/MeshTaskShader.h
@@ -82,6 +82,12 @@ private:
 
   void lowerTaskPayloadPtr(TaskPayloadPtrOp &taskPayloadPtrOp);
   void lowerEmitMeshTasks(EmitMeshTasksOp &emitMeshTasksOp);
+  void lowerSetMeshOutputs(SetMeshOutputsOp &setMeshOutputsOp);
+  void lowerSetMeshPrimitiveIndices(SetMeshPrimitiveIndicesOp &setMeshPrimitiveIndicesOp);
+  void lowerSetMeshPrimitiveCulled(SetMeshPrimitiveCulledOp &setMeshPrimitiveCulledOp);
+  void lowerGetMeshBuiltinInput(GetMeshBuiltinInputOp &getMeshBuiltinInputOp);
+  void lowerWriteMeshVertexOutput(WriteMeshVertexOutputOp &writeMeshVertexOutputOp);
+  void lowerWriteMeshPrimitiveOutput(WriteMeshPrimitiveOutputOp &writeMeshPrimitiveOutputOp);
 
   void initWaveThreadInfo(llvm::Function *entryPoint);
   llvm::Value *getShaderRingEntryIndex(llvm::Function *entryPoint);
@@ -94,12 +100,6 @@ private:
 
   llvm::Function *mutateMeshShaderEntryPoint(llvm::Function *entryPoint);
   void lowerMeshShaderBody(llvm::BasicBlock *apiMeshEntryBlock, llvm::BasicBlock *apiMeshExitBlock);
-  void setMeshOutputs(llvm::Value *vertexCount, llvm::Value *primitiveCount);
-  void setPrimitiveIndices(llvm::Value *primitiveIndex, llvm::Value *primitiveIndices);
-  void setPrimitiveCulled(llvm::Value *primitiveIndex, llvm::Value *isCulled);
-  llvm::Value *getMeshInput(BuiltInKind builtIn);
-  void writeVertexOutput(llvm::Value *outputOffset, llvm::Value *vertexIndex, llvm::Value *outputValue);
-  void writePrimitiveOutput(llvm::Value *outputOffset, llvm::Value *primitiveIndex, llvm::Value *outputValue);
 
   void exportPrimitive();
   void exportVertex();

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -3857,7 +3857,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpSetMeshOutputsEXT>(SPIRVV
   Function *const func = getBuilder()->GetInsertBlock()->getParent();
   Value *const vertexCount = transValue(spvOperands[0], func, block);
   Value *const primitiveCount = transValue(spvOperands[1], func, block);
-  return getBuilder()->CreateSetMeshOutputs(vertexCount, primitiveCount);
+  return getBuilder()->create<lgc::SetMeshOutputsOp>(vertexCount, primitiveCount);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
Define those new dialects Op:
- SetMeshOutputs
- SetMeshPrimitiveIndices
- SetMeshPrimitiveCulled
- GetMeshBuiltinInput
- WriteMeshVertexOutput
- WriteMeshPrimitiveOutput

Change the handling to dialects visitor and refactor their handlers to make them adapt to dialects visitor.