### PR TITLE
lgc: generalize traceNonUniformIndex

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -30,8 +30,10 @@
  */
 #include "lgc/builder/BuilderImpl.h"
 #include "lgc/LgcContext.h"
+#include "lgc/LgcDialect.h"
 #include "lgc/state/PipelineState.h"
 #include "lgc/state/TargetInfo.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 
 using namespace lgc;
@@ -338,23 +340,13 @@ BranchInst *BuilderImpl::createIf(Value *condition, bool wantElse, const Twine &
 // find the non-uniform index used in it. If that fails, we just use the
 // operand value as the index.
 //
-// Note: this code has to cope with relocs as well, this is why we have to
-// have a worklist of instructions to trace back
-// through. Something like this:
-// %1 = call .... @lgc.descriptor.set(...)          ;; Known uniform base
-// %2 = call .... @llvm.amdgcn.reloc.constant(...)  ;; Known uniform reloc constant
-// %3 = ptrtoint ... %1 to i64
-// %4 = zext ... %2 to i64
-// %5 = add i64 %3, %4
-// %6 = inttoptr i64 %5 to ....
-// %7 = bitcast .... %6 to ....
-// %8 = getelementptr .... %7, i64 %offset
+// Note that this function may return null, which means that the given value has been shown to be uniform.
 //
-// As long as the base pointer %7 can be traced back to a descriptor set and
-// reloc we can infer that it is truly uniform and use the gep index as the waterfall index safely.
+// This uses a fairly simple heuristic that nevertheless allows temporary expansion of the search breadth to handle
+// the common case where a base pointer is assembled from separate high and low halves.
 //
 // @param nonUniformVal : Value representing non-uniform descriptor
-// @return : Value representing the non-uniform index
+// @return : Value representing the non-uniform index, or null if nonUniformVal could be proven to be uniform
 static Value *traceNonUniformIndex(Value *nonUniformVal) {
   auto load = dyn_cast<LoadInst>(nonUniformVal);
   if (!load) {
@@ -388,90 +380,133 @@ static Value *traceNonUniformIndex(Value *nonUniformVal) {
     }
   }
 
-  SmallVector<Value *, 2> worklist;
-  Value *base = load->getOperand(0);
-  Value *index = nullptr;
+  auto getSize = [](Value *value) -> uint64_t {
+    uint64_t size = value->getType()->getPrimitiveSizeInBits().getFixedValue();
+    return size ? size : std::numeric_limits<uint64_t>::max();
+  };
 
-  // Loop until a descriptor table reference or unexpected operation is reached.
-  // In the worst case this may visit all instructions in a function.
-  for (;;) {
-    if (auto bitcast = dyn_cast<BitCastInst>(base)) {
-      base = bitcast->getOperand(0);
+  uint64_t nonUniformValSize = getSize(nonUniformVal);
+
+  // Loop until all nonUniforms have been found to be uniform or a heuristic abort criterion has been reached.
+  Value *candidateIndex = nullptr;
+  SmallVector<Instruction *, 2> nonUniforms;
+  nonUniforms.push_back(load);
+
+  auto propagate = [&](Value *value) -> bool {
+    if (auto inst = dyn_cast<Instruction>(value)) {
+      if (nonUniforms.size() >= 2)
+        return false;
+      nonUniforms.push_back(inst);
+      return true;
+    }
+    return isa<Constant>(value);
+  };
+
+  do {
+    Instruction *current = nonUniforms.pop_back_val();
+
+    // Immediately replace the current nonUniformVal by a strictly smaller one if possible.
+    if (!candidateIndex && nonUniforms.empty() && current != nonUniformVal) {
+      uint64_t size = getSize(current);
+      if (size < nonUniformValSize) {
+        nonUniformVal = current;
+        nonUniformValSize = size;
+      }
+    }
+
+    // See if we can propagate the search further.
+    if (current->isCast() || current->isUnaryOp()) {
+      if (!propagate(current->getOperand(0)))
+        return nonUniformVal;
       continue;
     }
-    if (auto gep = dyn_cast<GetElementPtrInst>(base)) {
+
+    if (current->isBinaryOp()) {
+      if (!propagate(current->getOperand(0)) || !propagate(current->getOperand(1)))
+        return nonUniformVal;
+      continue;
+    }
+
+    if (auto *load = dyn_cast<LoadInst>(current)) {
+      Value *ptr = load->getPointerOperand();
+      unsigned as = ptr->getType()->getPointerAddressSpace();
+      if (as == ADDR_SPACE_FLAT || as == ADDR_SPACE_PRIVATE)
+        return nonUniformVal; // load is a source of divergence, can't propagate
+
+      if (!propagate(ptr))
+        return nonUniformVal;
+      continue;
+    }
+
+    if (auto gep = dyn_cast<GetElementPtrInst>(current)) {
       if (gep->hasAllConstantIndices()) {
-        base = gep->getPointerOperand();
+        if (!propagate(gep->getPointerOperand()))
+          return nonUniformVal;
         continue;
       }
-      // Variable GEP, to provide the index for the waterfall.
-      if (index || gep->getNumIndices() != 1)
-        break;
-      index = *gep->idx_begin();
-      base = gep->getPointerOperand();
-      continue;
-    }
-    if (auto extract = dyn_cast<ExtractValueInst>(base)) {
-      if (extract->getIndices().size() == 1 && extract->getIndices()[0] == 0) {
-        base = extract->getAggregateOperand();
-        continue;
-      }
-      break;
-    }
-    if (auto insert = dyn_cast<InsertValueInst>(base)) {
-      if (insert->getIndices()[0] != 0) {
-        base = insert->getAggregateOperand();
-        continue;
-      }
-      if (insert->getIndices().size() == 1 && insert->getIndices()[0] == 0) {
-        base = insert->getInsertedValueOperand();
-        continue;
-      }
-      break;
-    }
-    if (auto intToPtr = dyn_cast<IntToPtrInst>(base)) {
-      base = intToPtr->getOperand(0);
-      continue;
-    }
-    if (auto ptrToInt = dyn_cast<PtrToIntInst>(base)) {
-      base = ptrToInt->getOperand(0);
-      continue;
-    }
-    if (auto zExt = dyn_cast<ZExtInst>(base)) {
-      base = zExt->getOperand(0);
-      continue;
-    }
-    if (auto call = dyn_cast<CallInst>(base)) {
-      if (index) {
-        if (auto calledFunc = call->getCalledFunction()) {
-          if (calledFunc->getName().startswith(lgcName::DescriptorTableAddr) ||
-              calledFunc->getName().startswith("llvm.amdgcn.reloc.constant")) {
-            if (!worklist.empty()) {
-              base = worklist.pop_back_val();
-              continue;
-            }
-            nonUniformVal = index;
-            break;
-          }
-        }
-      }
-    }
-    if (auto addInst = dyn_cast<Instruction>(base)) {
-      // In this case we have to trace back both operands
-      // Set one to base for continued processing and put the other onto the worklist
-      // Give up if the worklist already has an entry - too complicated
-      if (addInst->isBinaryOp() && addInst->getOpcode() == Instruction::BinaryOps::Add) {
-        if (!worklist.empty())
-          break;
-        base = addInst->getOperand(0);
-        worklist.push_back(addInst->getOperand(1));
-        continue;
-      }
-    }
-    break;
-  }
 
-  return nonUniformVal;
+      // Variable GEP, assume that the index is non-uniform.
+      if (candidateIndex || gep->getNumIndices() != 1)
+        return nonUniformVal;
+
+      if (!propagate(gep->getPointerOperand()))
+        return nonUniformVal;
+
+      candidateIndex = *gep->idx_begin();
+      if (getSize(candidateIndex) > nonUniformValSize)
+        return nonUniformVal; // propagating further is worthless
+      continue;
+    }
+
+    if (auto extract = dyn_cast<ExtractValueInst>(current)) {
+      if (!propagate(extract->getAggregateOperand()))
+        return nonUniformVal;
+      continue;
+    }
+    if (auto insert = dyn_cast<InsertValueInst>(current)) {
+      if (!propagate(insert->getAggregateOperand()) || !propagate(insert->getInsertedValueOperand()))
+        return nonUniformVal;
+      continue;
+    }
+    if (auto extract = dyn_cast<ExtractElementInst>(current)) {
+      if (!isa<Constant>(extract->getIndexOperand()) || !propagate(extract->getVectorOperand()))
+        return nonUniformVal;
+      continue;
+    }
+    if (auto insert = dyn_cast<InsertElementInst>(current)) {
+      if (!isa<Constant>(insert->getOperand(2)) || !propagate(insert->getOperand(0)) ||
+          !propagate(insert->getOperand(1)))
+        return nonUniformVal;
+      continue;
+    }
+
+    if (auto call = dyn_cast<CallInst>(current)) {
+      if (auto intrinsic = dyn_cast<IntrinsicInst>(call)) {
+        unsigned id = intrinsic->getIntrinsicID();
+        if (id == Intrinsic::amdgcn_readfirstlane || id == Intrinsic::amdgcn_s_getpc ||
+            id == Intrinsic::amdgcn_reloc_constant)
+          continue; // is always uniform, no need to propagate
+        return nonUniformVal;
+      }
+
+      if (auto calledFunc = call->getCalledFunction()) {
+        if (calledFunc->getName().startswith(lgcName::DescriptorTableAddr))
+          continue; // is always uniform, no need to propagate
+      }
+
+      if (isa<UserDataOp>(call) || isa<LoadUserDataOp>(call))
+        continue; // is always uniform, no need to propagate
+
+      return nonUniformVal;
+    }
+
+    // If we reach this point, it means we don't understand the instruction. It's likely a fairly complex instruction
+    // and we should heuristically abort the propagation anyway. It may even be a source of divergence, in which case
+    // propagating further would be incorrect.
+    return nonUniformVal;
+  } while (!nonUniforms.empty());
+
+  return candidateIndex;
 }
 
 // =====================================================================================================================
@@ -526,8 +561,11 @@ Instruction *BuilderImpl::createWaterfallLoop(Instruction *nonUniformInst, Array
   SmallVector<Value *, 2> nonUniformIndices;
   for (unsigned operandIdx : operandIdxs) {
     Value *nonUniformIndex = traceNonUniformIndex(nonUniformInst->getOperand(operandIdx));
-    nonUniformIndices.push_back(nonUniformIndex);
+    if (nonUniformIndex)
+      nonUniformIndices.push_back(nonUniformIndex);
   }
+  if (nonUniformIndices.empty())
+    return nonUniformInst;
 
   // For any index that is 64 bit, change it back to 32 bit for comparison at the top of the
   // waterfall loop.

--- a/lgc/test/PatchInvalidImageDescriptor.lgc
+++ b/lgc/test/PatchInvalidImageDescriptor.lgc
@@ -70,10 +70,13 @@ define dllexport spir_func void @lgc.shader.VS.main() local_unnamed_addr #0 !lgc
   %.query.size = call <2 x i32> (...) @lgc.create.image.query.size.v2i32(i32 1, i32 128, <8 x i32> %.desc, i32 0)
   %.query.levels = call i32 (...) @lgc.create.image.query.levels.i32(i32 1, i32 128, <8 x i32> %.desc)
 
+  %lane = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)  ; just some source of divergence
+  %ofs = mul i32 %lane, 32
+
   ; Use a waterfall loop with last.use to test that is also handled correctly
   %.desc2.ptr2 = call <8 x i32> addrspace(4)* (...) @lgc.create.get.desc.ptr.p4v8i32(i32 1, i32 1, i32 3, i32 4)
   %.desc2.ptr1 = bitcast <8 x i32> addrspace(4)* %.desc2.ptr2 to i8 addrspace(4)*
-  %.desc2.ptr0 = getelementptr i8, i8 addrspace(4)* %.desc2.ptr1, i64 0
+  %.desc2.ptr0 = getelementptr i8, i8 addrspace(4)* %.desc2.ptr1, i32 %ofs
   %.desc2.ptr = bitcast i8 addrspace(4)* %.desc2.ptr0 to <8 x i32> addrspace(4)*
   %.desc2 = load <8 x i32>, <8 x i32> addrspace(4)* %.desc2.ptr, align 32
   call void (...) @lgc.create.image.store(<4 x float> zeroinitializer, i32 0, i32 8, <8 x i32> %.desc2, i32 zeroinitializer)
@@ -91,6 +94,8 @@ declare i32 @lgc.create.image.atomic.i32(...) #0
 declare <2 x float> @lgc.create.image.get.lod.v2f32(...) #0
 declare <2 x i32> @lgc.create.image.query.size.v2i32(...) #0
 declare i32 @lgc.create.image.query.levels.i32(...) #0
+
+declare i32 @llvm.amdgcn.mbcnt.lo(i32, i32)
 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readonly }


### PR DESCRIPTION
Clarify what the search of this function does: it scans through the data flow graph, trying to prove inputs to the original nonUniformVal uniform. It heuristically picks a GEP argument as a "remaining" non-uniform index.

Allow propagation through more instruction types in preparation for future changes.