### PR TITLE
Mesh shader: Use input proxy for mesh shader input

### DIFF
--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -108,8 +108,7 @@ private:
                                           llvm::Value *vertexIdx, BuilderBase &builder);
   llvm::Value *patchGsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *vertexIdx,
                                          BuilderBase &builder);
-  llvm::Value *patchMeshBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *elemIdx,
-                                           BuilderBase &builder);
+  llvm::Value *patchMeshBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, BuilderBase &builder);
   llvm::Value *patchFsBuiltInInputImport(llvm::Type *inputTy, unsigned builtInId, llvm::Value *sampleId,
                                          BuilderBase &builder);
   llvm::Value *getSamplePosOffset(llvm::Type *inputTy, llvm::Value *sampleId, BuilderBase &builder);

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -596,10 +596,9 @@ void SpirvLowerGlobal::mapGlobalVariableToProxy(GlobalVariable *globalVar) {
 //
 // @param input : Input to be mapped
 void SpirvLowerGlobal::mapInputToProxy(GlobalVariable *input) {
-  // NOTE: For tessellation shader or mesh shader, we do not map inputs to real proxy variables. Instead, we directly
+  // NOTE: For tessellation shader, we do not map inputs to real proxy variables. Instead, we directly
   // replace "load" instructions with import calls in the lowering operation.
-  if (m_shaderStage == ShaderStageTessControl || m_shaderStage == ShaderStageTessEval ||
-      m_shaderStage == ShaderStageMesh) {
+  if (m_shaderStage == ShaderStageTessControl || m_shaderStage == ShaderStageTessEval) {
     m_inputProxyMap[input] = nullptr;
     m_lowerInputInPlace = true;
     return;


### PR DESCRIPTION
This is to re-apply the commit
https://github.com/GPUOpen-Drivers/llpc/commit/a81a964 since we have already reworked task payload by
https://github.com/GPUOpen-Drivers/llpc/pull/2604.

The mesh inputs are all built-ins and are not relevant to any buffer/LDS memory. They can use input proxy to simplify the handling especially input element indexing.