### PR TITLE
Move SpirvLowerRayTracing to the end of lower passes

### DIFF
--- a/lgc/interface/lgc/GpurtDialect.td
+++ b/lgc/interface/lgc/GpurtDialect.td
@@ -187,7 +187,7 @@ def GpurtSetTraceParamsOp : GpurtOp<"set.trace.params", [Memory<[(write Inaccess
   }];
 }
 
-def GpurtCallClosestHitShaderOp : GpurtOp<"call.closest.hit.shader", [WillReturn]> {
+def GpurtCallClosestHitShaderOp : GpurtOp<"call.closest.hit.shader", [Memory<[(readwrite InaccessibleMem)]>, WillReturn]> {
   let arguments =  (ins V2I32:$shaderId, I32:$tableIndex);
   let results = (outs I1:$result);
 
@@ -203,7 +203,7 @@ def GpurtCallClosestHitShaderOp : GpurtOp<"call.closest.hit.shader", [WillReturn
   }];
 }
 
-def GpurtCallMissShaderOp : GpurtOp<"call.miss.shader", [WillReturn]> {
+def GpurtCallMissShaderOp : GpurtOp<"call.miss.shader", [Memory<[(readwrite InaccessibleMem)]>, WillReturn]> {
   let arguments =  (ins V2I32:$shaderId, I32:$tableIndex);
   let results = (outs I1:$result);
 
@@ -219,7 +219,7 @@ def GpurtCallMissShaderOp : GpurtOp<"call.miss.shader", [WillReturn]> {
   }];
 }
 
-def GpurtCallTriangleAnyHitShaderOp : GpurtOp<"call.triangle.any.hit.shader", [WillReturn]> {
+def GpurtCallTriangleAnyHitShaderOp : GpurtOp<"call.triangle.any.hit.shader", [Memory<[(readwrite InaccessibleMem)]>, WillReturn]> {
   let arguments =  (ins V2I32:$shaderId, I32:$tableIndex, V2F32:$attr);
   let results = (outs);
 
@@ -235,7 +235,7 @@ def GpurtCallTriangleAnyHitShaderOp : GpurtOp<"call.triangle.any.hit.shader", [W
   }];
 }
 
-def GpurtCallIntersectionShaderOp : GpurtOp<"call.intersection.shader", [WillReturn]> {
+def GpurtCallIntersectionShaderOp : GpurtOp<"call.intersection.shader", [Memory<[(readwrite InaccessibleMem)]>, WillReturn]> {
   let arguments =  (ins V2I32:$shaderId, V2I32:$anyHitShaderId, I32:$tableIndex);
   let results = (outs);
 

--- a/llpc/context/llpcRayTracingContext.h
+++ b/llpc/context/llpcRayTracingContext.h
@@ -102,10 +102,13 @@ public:
   static const unsigned TriangleHitGroup = static_cast<unsigned>(-2);
   llvm::Type *getPayloadType(lgc::Builder *builder);
   llvm::Type *getCallableDataType(lgc::Builder *builder);
+  unsigned getCallableDataSizeInBytes() { return m_callableDataMaxSize; }
   unsigned getAttributeDataSize();
+  unsigned getAttributeDataSizeInBytes() { return m_attributeDataMaxSize; };
   std::set<unsigned, std::less<unsigned>> &getBuiltIns() { return m_builtIns; }
   bool getHitAttribute() { return m_attributeDataMaxSize > 0; }
   unsigned getPayloadSizeInDword() { return m_payloadMaxSize / 4; }
+  unsigned getPayloadSizeInBytes() { return m_payloadMaxSize; }
   bool hasPipelineLibrary() { return m_pipelineInfo->hasPipelineLibrary; }
   unsigned hasLibraryStage(unsigned stageMask) { return m_pipelineInfo->pipelineLibStageMask & stageMask; }
   bool isReplay() { return m_pipelineInfo->isReplay; }

--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -207,14 +207,6 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
   // Lower SPIR-V global variables, inputs, and outputs
   passMgr.addPass(SpirvLowerGlobal());
 
-  // Lower SPIR-V ray tracing related stuff, including entry point generation, lgc.rt dialect handling, some of
-  // lgc.gpurt dialect handling.
-  // And do inlining after SpirvLowerRayTracing as it will produce some extra functions.
-  if (rayTracing) {
-    passMgr.addPass(SpirvLowerRayTracing());
-    passMgr.addPass(AlwaysInlinerPass());
-  }
-
   // Lower SPIR-V constant immediate store.
   passMgr.addPass(SpirvLowerConstImmediateStore());
 
@@ -251,6 +243,14 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 
   // Lower SPIR-V instruction metadata remove
   passMgr.addPass(SpirvLowerInstMetaRemove());
+
+  // Lower SPIR-V ray tracing related stuff, including entry point generation, lgc.rt dialect handling, some of
+  // lgc.gpurt dialect handling.
+  // And do inlining after SpirvLowerRayTracing as it will produce some extra functions.
+  if (rayTracing) {
+    passMgr.addPass(SpirvLowerRayTracing());
+    passMgr.addPass(AlwaysInlinerPass());
+  }
 
   if (rayTracing || rayQuery)
     passMgr.addPass(LowerGpuRt());

--- a/llpc/lower/llpcSpirvLowerGlobal.h
+++ b/llpc/lower/llpcSpirvLowerGlobal.h
@@ -83,6 +83,8 @@ private:
 
   void handleVolatileInput(llvm::GlobalVariable *input, llvm::Value *proxy);
 
+  void changeRtFunctionSignature();
+
   llvm::Value *addCallInstForInOutImport(llvm::Type *inOutTy, unsigned addrSpace, llvm::Constant *inOutMeta,
                                          llvm::Value *startLoc, unsigned maxLocOffset, llvm::Value *compIdx,
                                          llvm::Value *vertexIdx, unsigned interpLoc, llvm::Value *interpInfo,

--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -66,6 +66,9 @@ void SpirvLowerMath::init(Module &module) {
   SpirvLower::init(&module);
   m_changed = false;
 
+  if (m_shaderStage == ShaderStageInvalid)
+    return;
+
   auto commonShaderMode = Pipeline::getCommonShaderMode(module, getLgcShaderStage(m_shaderStage));
   m_fp16DenormFlush = commonShaderMode.fp16DenormMode == FpDenormMode::FlushOut ||
                       commonShaderMode.fp16DenormMode == FpDenormMode::FlushInOut;
@@ -180,6 +183,9 @@ bool SpirvLowerMathConstFolding::runImpl(Module &module,
   LLVM_DEBUG(dbgs() << "Run the pass Spirv-Lower-Math-Const-Folding\n");
 
   SpirvLowerMath::init(module);
+
+  if (m_shaderStage == ShaderStageInvalid)
+    return false;
 
   if (m_fp16DenormFlush || m_fp32DenormFlush || m_fp64DenormFlush) {
     // Do constant folding if we need flush denorm to zero.

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -262,8 +262,6 @@ private:
   void visitShaderIndexOp(lgc::rt::ShaderIndexOp &inst);
   void visitShaderRecordBufferOp(lgc::rt::ShaderRecordBufferOp &inst);
 
-  void visitAlloca(llvm::AllocaInst &inst);
-
   llvm::Value *createLoadInstNodeAddr();
 
   llvm::Value *m_traceParams[TraceParam::Count];           // Trace ray set parameters

--- a/shared/lgcrt/include/lgcrt/LgcRtDialect.td
+++ b/shared/lgcrt/include/lgcrt/LgcRtDialect.td
@@ -71,7 +71,7 @@ class LgcRtOp<string mnemonic_, list<Trait> traits_ = []>
     : Op<LgcRtDialect, mnemonic_, traits_ # [NoUnwind]>;
 
 // =========================================================================================================
-def AcceptHitAndEndSearchOp : LgcRtOp<"accept.hit.and.end.search", [NoReturn]> {
+def AcceptHitAndEndSearchOp : LgcRtOp<"accept.hit.and.end.search", [Memory<[(write InaccessibleMem)]>, NoReturn]> {
   let arguments = (ins);
   let results = (outs);
 
@@ -84,7 +84,7 @@ def AcceptHitAndEndSearchOp : LgcRtOp<"accept.hit.and.end.search", [NoReturn]> {
 }
 
 // =========================================================================================================
-def CallCallableShaderOp : LgcRtOp<"call.callable.shader", [WillReturn]> {
+def CallCallableShaderOp : LgcRtOp<"call.callable.shader", [Memory<[(readwrite InaccessibleMem), (readwrite ArgMem)]>, WillReturn]> {
   let arguments = (ins I32:$shaderIndex, PointerType:$param, AttrI32:$paramDataSizeBytes);
   let results = (outs);
 
@@ -142,7 +142,7 @@ def HitKindOp : LgcRtOp<"hit.kind", [Memory<[]>, WillReturn]> {
 }
 
 // =========================================================================================================
-def IgnoreHitOp : LgcRtOp<"ignore.hit", [NoReturn]> {
+def IgnoreHitOp : LgcRtOp<"ignore.hit", [Memory<[(write InaccessibleMem)]>, NoReturn]> {
   let arguments = (ins);
   let results = (outs);
 
@@ -255,7 +255,7 @@ def RayTminOp : LgcRtOp<"ray.tmin", [Memory<[]>, WillReturn]> {
 }
 
 // =========================================================================================================
-def ReportHitOp : LgcRtOp<"report.hit", []> {
+def ReportHitOp : LgcRtOp<"report.hit", [Memory<[(write InaccessibleMem), (read ArgMem)]>]> {
   let arguments = (ins F32:$thit, I32:$hitKind, PointerType:$attributes, AttrI32:$size);
   let results = (outs I1:$result);
 
@@ -344,7 +344,7 @@ def BaseTraceRayOp : OpClass<LgcRtDialect> {
 }
 
 // =========================================================================================================
-def TraceRayOp : LgcRtOp<"trace.ray", [Memory<[(read)]>, WillReturn]> {
+def TraceRayOp : LgcRtOp<"trace.ray", [Memory<[(readwrite InaccessibleMem), (readwrite ArgMem)]>, WillReturn]> {
   let superclass = BaseTraceRayOp;
   let arguments = (ins superclass);
   let results = (outs);


### PR DESCRIPTION
To make it work correctly:

Add proper memory attributes so that intrinsic calls won't get optimized away.

Use dialect for hit attribute / incoming payload / incoming callable data, as there will be no allocas after SROA pass.