### PR TITLE
Further cleanup and dialectification of userdata accesses

### DIFF
--- a/lgc/builder/BuilderImpl.cpp
+++ b/lgc/builder/BuilderImpl.cpp
@@ -489,11 +489,6 @@ static Value *traceNonUniformIndex(Value *nonUniformVal) {
         return nonUniformVal;
       }
 
-      if (auto calledFunc = call->getCalledFunction()) {
-        if (calledFunc->getName().startswith(lgcName::DescriptorTableAddr))
-          continue; // is always uniform, no need to propagate
-      }
-
       if (isa<UserDataOp>(call) || isa<LoadUserDataOp>(call))
         continue; // is always uniform, no need to propagate
 

--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -215,15 +215,6 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
     getPipelineState()->getPalMetadata()->setUserDataSpillUsage(pushConstantNode->offsetInDwords);
     return true;
   }
-  if (name == reloc::ShadowDescriptorTableEnabled) {
-    value = m_pipelineState->getOptions().highAddrOfFmask != ShadowDescriptorTableDisable;
-    return true;
-  }
-
-  if (name == reloc::ShadowDescriptorTable) {
-    value = m_pipelineState->getOptions().highAddrOfFmask;
-    return true;
-  }
 
   return false;
 }

--- a/lgc/elfLinker/RelocHandler.cpp
+++ b/lgc/elfLinker/RelocHandler.cpp
@@ -162,22 +162,6 @@ bool RelocHandler::getValue(StringRef name, uint64_t &value) {
     }
   }
 
-  if (name.startswith(reloc::DescriptorStride)) {
-    // Descriptor stride in bytes.
-    unsigned descSet = 0;
-    unsigned binding = 0;
-    ResourceNodeType type = ResourceNodeType::Unknown;
-    if (parseDescSetBinding(name.drop_front(strlen(reloc::DescriptorStride)), descSet, binding, type)) {
-      const ResourceNode *outerNode = nullptr;
-      const ResourceNode *node = nullptr;
-      std::tie(outerNode, node) = getPipelineState()->findResourceNode(type, descSet, binding);
-      if (!node)
-        report_fatal_error("No resource node for " + name);
-      value = node->stride * sizeof(uint32_t);
-      return true;
-    }
-  }
-
   if (name.startswith(reloc::CompactBuffer)) {
     // Descriptor stride in bytes.
     unsigned descSet = 0;

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -318,8 +318,8 @@ private:
   llvm::Value *getStride(ResourceNodeType descType, const ResourceNode *node);
 
   // Get a pointer to a descriptor, as a pointer to i8
-  llvm::Value *getDescPtr(ResourceNodeType concreteType, ResourceNodeType abstractType, uint64_t descSet,
-                          unsigned binding, const ResourceNode *topNode, const ResourceNode *node);
+  llvm::Value *getDescPtr(ResourceNodeType concreteType, const ResourceNode *topNode, const ResourceNode *node,
+                          unsigned binding);
 
   llvm::Value *scalarizeIfUniform(llvm::Value *value, bool isNonUniform);
 

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -315,7 +315,7 @@ private:
                                    const ResourceNode *topNode, const ResourceNode *node, bool shadow);
 
   // Get the stride (in bytes) of a descriptor.
-  llvm::Value *getStride(ResourceNodeType descType, uint64_t descSet, unsigned binding, const ResourceNode *node);
+  llvm::Value *getStride(ResourceNodeType descType, const ResourceNode *node);
 
   // Get a pointer to a descriptor, as a pointer to i8
   llvm::Value *getDescPtr(ResourceNodeType concreteType, ResourceNodeType abstractType, uint64_t descSet,

--- a/lgc/include/lgc/patch/PatchEntryPointMutate.h
+++ b/lgc/include/lgc/patch/PatchEntryPointMutate.h
@@ -99,12 +99,6 @@ private:
     llvm::SmallVector<unsigned> loadSizes;
     // Entry argument index for each user data dword that has one.
     llvm::SmallVector<unsigned> entryArgIdxs;
-    // Per-table lists of lgc.descriptor.table.addr calls
-    // When the user data nodes are available, a table is identifed by its
-    // index in the user data nodes.  Using this index allows for the possibility that a descriptor
-    // set is split over multiple tables.  When it is not available, a table is identified by the
-    // descriptor set it contains, which is consistent with the Vulkan binding model.
-    llvm::SmallVector<UserDataLoad, 8> descriptorTables;
     // Per-UserDataMapping lists of lgc.special.user.data calls
     llvm::SmallVector<SpecialUserDataNodeUsage, 18> specialUserData;
     // Usage of streamout table

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -103,16 +103,6 @@ const static char DeviceIdx[] = "$deviceIdx";
 // The value of the relocation is the offset of the pushconst resource node in the pipeline state.
 const static char Pushconst[] = "pushconst";
 
-// Whether the shadow descriptor is enabled or not.
-//
-// The value of the relocation is either:
-//  * 0: the shadow descriptor table is disabled.
-//  * 1: the shadow descriptor table is enabled.
-const static char ShadowDescriptorTableEnabled[] = "$shadowenabled";
-
-// The high 32-bits of the address of the shadow descriptor table.
-const static char ShadowDescriptorTable[] = "$shadowdesctable";
-
 } // namespace reloc
 
 // =====================================================================================================================

--- a/lgc/include/lgc/state/AbiUnlinked.h
+++ b/lgc/include/lgc/state/AbiUnlinked.h
@@ -69,16 +69,6 @@ const static char DescriptorUseSpillTable[] = "dusespill_";
 //
 const static char DescriptorTableOffset[] = "descset_";
 
-// Descriptor stride is "dstride_X_Y" where:
-// * X is the descriptor set number
-// * Y is the binding number
-//
-// The value of the relocation is stride in bytes of the requested array of descriptors in its descriptor set
-// table. It is illegal for the specified descriptor not to exist, and it must be a resource, fmask or sampler
-// descriptor. (The reason the stride needs to be a reloc is that the requested descriptor might or might not
-// be part of a combined texture descriptor.)
-const static char DescriptorStride[] = "dstride_";
-
 // The buffer type is "compactbuffer_X_Y" where:
 // * X is the descriptor set number
 // * Y is the binding number

--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -49,9 +49,6 @@ const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
 const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
 const static char SwizzleWorkgroupId[] = "lgc.swizzle.workgroup.id";
 
-// Get pointer to the descriptor table for the given resource. First arg is the descriptor set number; second arg
-// is the binding number; third arg is the value to use for the high half of the address, or HighAddrPc to use PC.
-const static char DescriptorTableAddr[] = "lgc.descriptor.table.addr";
 // Get special user data input. Arg is UserDataMapping enum value. The optional second arg causes the 32-bit
 // value to be extended to 64-bit pointer and specifies the value to use for the high half, or
 // ShadowDescriptorTable::Disable to use PC.

--- a/lgc/include/lgc/util/AddressExtender.h
+++ b/lgc/include/lgc/util/AddressExtender.h
@@ -61,6 +61,14 @@ public:
   // @returns : 64-bit pointer value
   llvm::Instruction *extend(llvm::Value *addr32, llvm::Value *highHalf, llvm::Type *ptrTy, llvm::IRBuilder<> &builder);
 
+  // Extend an i32 into a 64-bit pointer using the high 32-bits of the PC
+  //
+  // @param addr32 : Address as 32-bit value
+  // @param ptrTy : Type to cast pointer to
+  // @param builder : IRBuilder to use, already set to the required insert point
+  // @returns : 64-bit pointer value
+  llvm::Instruction *extendWithPc(llvm::Value *addr32, llvm::Type *ptrTy, llvm::IRBuilder<> &builder);
+
 private:
   // Get PC value as v2i32.
   llvm::Instruction *getPc();

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -729,7 +729,7 @@ llvm::Value *LowerFragColorExport::jumpColorExport(llvm::Function *fragEntryPoin
   auto funcTyPtr = funcTy->getPointerTo(ADDR_SPACE_CONST);
   auto colorShaderAddr = ShaderInputs::getSpecialUserData(UserDataMapping::ColorExportAddr, builder);
   AddressExtender addrExt(builder.GetInsertPoint()->getParent()->getParent());
-  auto funcPtr = addrExt.extend(colorShaderAddr, builder.getInt32(HighAddrPc), funcTyPtr, builder);
+  auto funcPtr = addrExt.extendWithPc(colorShaderAddr, funcTyPtr, builder);
 
   // Jump
   auto callInst = builder.CreateCall(funcTy, funcPtr, argVal);

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -837,8 +837,7 @@ void PatchEntryPointMutate::fixupUserDataUses(Module &module) {
     if (userDataUsage->spillTableEntryArgIdx != 0) {
       builder.SetInsertPoint(addressExtender.getFirstInsertionPt());
       Argument *arg = getFunctionArgument(&func, userDataUsage->spillTableEntryArgIdx);
-      spillTable = addressExtender.extend(arg, builder.getInt32(HighAddrPc),
-                                          builder.getInt8Ty()->getPointerTo(ADDR_SPACE_CONST), builder);
+      spillTable = addressExtender.extendWithPc(arg, builder.getPtrTy(ADDR_SPACE_CONST), builder);
     }
 
     // Handle direct uses of the spill table that were generated in DescBuilder.

--- a/lgc/test/TextureRange.lgc
+++ b/lgc/test/TextureRange.lgc
@@ -1,15 +1,16 @@
 
 ; RUN: lgc %s -print-after=lgc-builder-replayer -o /dev/null 2>&1 - <%s | FileCheck --check-prefixes=CHECK %s
 
-; CHECK: [[desc0:%[0-9]+]] = call ptr addrspace(4) @lgc.descriptor.table.addr(i32 6
-; CHECK-NEXT: %{{.*}} = getelementptr i8, ptr addrspace(4) [[desc0]], i32 16
 ; CHECK: call <2 x i32> @lgc.load.user.data.v2i32(i32 24)
 ; CHECK: call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32>
 ; CHECK: [[varindex0:%[0-9]+]] = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32>
 ; CHECK: [[varindex1:%[0-9]+]] = load i32, ptr addrspace(7) [[varindex0]], align 4
 ; CHECK-NEXT: [[varindex2:%[0-9]+]] = sext i32 [[varindex1]] to i64
 ; CHECK-NEXT: getelementptr <{ [4294967295 x float] }>, ptr addrspace(7) %{{.*}}, i64 0, i32 0, i64 [[varindex2]]
-; CHECK: [[desc1:%[0-9]+]] = call ptr addrspace(4) @lgc.descriptor.table.addr(i32 1
+; CHECK: [[desc1lo:%[0-9]+]] = call i32 @lgc.load.user.data.i32(i32 4
+; CHECK-NEXT: [[desc1vec:%[0-9]+]] = insertelement <2 x i32> %{{[^,]+}}, i32 [[desc1lo]], i64 0
+; CHECK-NEXT: [[desc1lohi:%[0-9]+]] = bitcast <2 x i32> [[desc1vec]] to i64
+; CHECK-NEXT: [[desc1:%[0-9]+]] = inttoptr i64 [[desc1lohi]] to ptr addrspace(4)
 ; CHECK-NEXT: %{{.*}} = getelementptr i8, ptr addrspace(4) [[desc1]], i32 32
 
 ; RUN: lgc -mcpu=gfx1030 -o - - <%s | FileCheck --check-prefixes=SHADER_TEST %s

--- a/lgc/test/Transforms/CpsLowering/cps-entry-point.lgc
+++ b/lgc/test/Transforms/CpsLowering/cps-entry-point.lgc
@@ -9,9 +9,7 @@ declare ptr addrspace(32) @lgc.cps.get.vsp() #2
 
 define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc.shaderstage !3 {
 .entry:
-  %table = call ptr addrspace(4) @lgc.descriptor.table.addr(i32 6, i32 6, i64 0, i32 0, i32 -1) #1
-  %p_desc = getelementptr i8, ptr addrspace(4) %table, i32 0
-  %desc = load <4 x i32>, ptr addrspace(4) %p_desc, align 16
+  %desc = call <4 x i32> @lgc.load.user.data.v4i32(i32 0)
   %ptr = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc)
   %p0 = getelementptr i32, ptr addrspace(7) %ptr, i32 0
   %i_vsp = load i32, ptr addrspace(7) %p0, align 4
@@ -32,7 +30,7 @@ define dllexport spir_func void @lgc.shader.CS.main() local_unnamed_addr #0 !lgc
   unreachable
 }
 
-declare ptr addrspace(4) @lgc.descriptor.table.addr(i32, i32, i64, i32, i32) #4
+declare <4 x i32> @lgc.load.user.data.v4i32(i32) #4
 
 declare ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32>) #5
 
@@ -42,15 +40,14 @@ attributes #2 = { nounwind willreturn memory(inaccessiblemem: read) }
 attributes #4 = { nounwind memory(none) }
 attributes #5 = { nounwind willreturn memory(none) }
 
-!lgc.user.data.nodes = !{!0, !1}
+!lgc.user.data.nodes = !{!1}
 !llpc.compute.mode = !{!2}
 
-!0 = !{!"DescriptorTableVaPtr", i32 0, i32 0, i32 2, i32 1, i32 1}
-!1 = !{!"DescriptorBuffer", i32 6, i32 0, i32 0, i32 4, i64 0, i32 0, i32 4}
+!1 = !{!"DescriptorBuffer", i32 6, i32 6, i32 0, i32 4, i64 0, i32 0, i32 4}
 !2 = !{i32 8, i32 4, i32 1}
 !3 = !{i32 7}
 ; CHECK-LABEL: define {{[^@]+}}@lgc.shader.CS.main
-; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[USERDATA0:%.*]], i32 inreg [[USERDATA1:%.*]], i32 inreg [[USERDATA2:%.*]], i32 inreg [[PAD3:%.*]], i32 inreg [[PAD4:%.*]], i32 inreg [[PAD5:%.*]], i32 inreg [[PAD6:%.*]], i32 inreg [[PAD7:%.*]], i32 inreg [[PAD8:%.*]], i32 inreg [[PAD9:%.*]], i32 inreg [[PAD10:%.*]], i32 inreg [[PAD11:%.*]], i32 inreg [[SPILLTABLE:%.*]], <3 x i32> inreg [[WORKGROUPID:%.*]], i32 inreg [[MULTIDISPATCHINFO:%.*]], <3 x i32> [[LOCALINVOCATIONID:%.*]]) #[[ATTR3:[0-9]+]] !lgc.shaderstage !5 {
+; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[USERDATA0:%.*]], i32 inreg [[USERDATA1:%.*]], i32 inreg [[USERDATA2:%.*]], i32 inreg [[USERDATA3:%.*]], i32 inreg [[PAD4:%.*]], i32 inreg [[PAD5:%.*]], i32 inreg [[PAD6:%.*]], i32 inreg [[PAD7:%.*]], i32 inreg [[PAD8:%.*]], i32 inreg [[PAD9:%.*]], i32 inreg [[PAD10:%.*]], i32 inreg [[PAD11:%.*]], i32 inreg [[SPILLTABLE:%.*]], <3 x i32> inreg [[WORKGROUPID:%.*]], i32 inreg [[MULTIDISPATCHINFO:%.*]], <3 x i32> [[LOCALINVOCATIONID:%.*]]) #[[ATTR3:[0-9]+]] !lgc.shaderstage !4 {
 ; CHECK-NEXT:  .entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
 ; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.amdgcn.s.getpc()
@@ -60,67 +57,66 @@ attributes #5 = { nounwind willreturn memory(none) }
 ; CHECK-NEXT:    [[TMP5:%.*]] = inttoptr i64 [[TMP4]] to ptr addrspace(4)
 ; CHECK-NEXT:    [[TMP6:%.*]] = call i64 @llvm.amdgcn.s.getpc()
 ; CHECK-NEXT:    [[TMP7:%.*]] = bitcast i64 [[TMP6]] to <2 x i32>
-; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <2 x i32> [[TMP2]], i32 [[USERDATA2]], i64 0
-; CHECK-NEXT:    [[TMP9:%.*]] = bitcast <2 x i32> [[TMP8]] to i64
-; CHECK-NEXT:    [[TMP10:%.*]] = inttoptr i64 [[TMP9]] to ptr addrspace(4)
-; CHECK-NEXT:    [[P_DESC:%.*]] = getelementptr i8, ptr addrspace(4) [[TMP10]], i32 0
-; CHECK-NEXT:    [[DESC:%.*]] = load <4 x i32>, ptr addrspace(4) [[P_DESC]], align 16
-; CHECK-NEXT:    [[PTR:%.*]] = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> [[DESC]])
+; CHECK-NEXT:    [[TMP8:%.*]] = insertelement <4 x i32> poison, i32 [[USERDATA0]], i64 0
+; CHECK-NEXT:    [[TMP9:%.*]] = insertelement <4 x i32> [[TMP8]], i32 [[USERDATA1]], i64 1
+; CHECK-NEXT:    [[TMP10:%.*]] = insertelement <4 x i32> [[TMP9]], i32 [[USERDATA2]], i64 2
+; CHECK-NEXT:    [[TMP11:%.*]] = insertelement <4 x i32> [[TMP10]], i32 [[USERDATA3]], i64 3
+; CHECK-NEXT:    [[PTR:%.*]] = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> [[TMP11]])
 ; CHECK-NEXT:    [[P0:%.*]] = getelementptr i32, ptr addrspace(7) [[PTR]], i32 0
 ; CHECK-NEXT:    [[I_VSP:%.*]] = load i32, ptr addrspace(7) [[P0]], align 4
-; CHECK-NEXT:    [[TMP11:%.*]] = inttoptr i32 [[I_VSP]] to ptr addrspace(5)
-; CHECK-NEXT:    store ptr addrspace(5) [[TMP11]], ptr addrspace(5) [[TMP0]], align 4
+; CHECK-NEXT:    [[TMP12:%.*]] = inttoptr i32 [[I_VSP]] to ptr addrspace(5)
+; CHECK-NEXT:    store ptr addrspace(5) [[TMP12]], ptr addrspace(5) [[TMP0]], align 4
 ; CHECK-NEXT:    [[P1:%.*]] = getelementptr i32, ptr addrspace(7) [[PTR]], i32 1
 ; CHECK-NEXT:    [[CR:%.*]] = load i32, ptr addrspace(7) [[P1]], align 4
 ; CHECK-NEXT:    [[P2:%.*]] = getelementptr i32, ptr addrspace(7) [[PTR]], i32 2
 ; CHECK-NEXT:    [[ARG:%.*]] = load i32, ptr addrspace(7) [[P2]], align 4
 ; CHECK-NEXT:    [[STATE:%.*]] = insertvalue { i32 } poison, i32 [[ARG]], 0
-; CHECK-NEXT:    [[TMP12:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
 ; CHECK-NEXT:    [[TMP13:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
-; CHECK-NEXT:    store { i32 } [[STATE]], ptr addrspace(5) [[TMP13]], align 4
-; CHECK-NEXT:    [[TMP14:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP13]], i32 4
-; CHECK-NEXT:    [[TMP15:%.*]] = ptrtoint ptr addrspace(5) [[TMP12]] to i32
+; CHECK-NEXT:    [[TMP14:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
+; CHECK-NEXT:    store { i32 } [[STATE]], ptr addrspace(5) [[TMP14]], align 4
+; CHECK-NEXT:    [[TMP15:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP14]], i32 4
+; CHECK-NEXT:    [[TMP16:%.*]] = ptrtoint ptr addrspace(5) [[TMP13]] to i32
 ; CHECK-NEXT:    br label [[TAIL_BLOCK:%.*]]
 ; CHECK:       tail.block:
-; CHECK-NEXT:    [[TMP16:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } poison, i32 [[CR]], 0
-; CHECK-NEXT:    [[TMP17:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP16]], ptr addrspace(5) [[TMP14]], 1
-; CHECK-NEXT:    [[TMP18:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP17]], i32 [[ARG]], 2
-; CHECK-NEXT:    [[TMP19:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP18]], i32 [[TMP15]], 3
-; CHECK-NEXT:    [[TMP20:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
-; CHECK-NEXT:    [[TMP21:%.*]] = bitcast i64 [[TMP20]] to <2 x i32>
-; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <2 x i32> [[TMP21]], i64 0
-; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i32> [[TMP21]], i64 1
-; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[TMP22]], i64 1
-; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[TMP23]], i64 2
-; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[USERDATA0]], i64 3
-; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[USERDATA1]], i64 4
-; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[USERDATA2]], i64 5
-; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[PAD3]], i64 6
-; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[PAD4]], i64 7
-; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[PAD5]], i64 8
-; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[PAD6]], i64 9
-; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[PAD7]], i64 10
-; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[PAD8]], i64 11
-; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[PAD9]], i64 12
-; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[PAD10]], i64 13
-; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[PAD11]], i64 14
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[SPILLTABLE]], i64 15
-; CHECK-NEXT:    [[TMP40:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP19]], 0
-; CHECK-NEXT:    [[TMP41:%.*]] = icmp ne i32 [[TMP40]], 0
-; CHECK-NEXT:    [[TMP42:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP41]])
-; CHECK-NEXT:    [[TMP43:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP42]], i1 true)
-; CHECK-NEXT:    [[TMP44:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP40]], i32 [[TMP43]])
-; CHECK-NEXT:    [[TMP45:%.*]] = icmp eq i32 [[TMP40]], [[TMP44]]
-; CHECK-NEXT:    [[TMP46:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP45]])
-; CHECK-NEXT:    [[TMP47:%.*]] = icmp eq i32 [[TMP44]], 0
-; CHECK-NEXT:    br i1 [[TMP47]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
+; CHECK-NEXT:    [[TMP17:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } poison, i32 [[CR]], 0
+; CHECK-NEXT:    [[TMP18:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP17]], ptr addrspace(5) [[TMP15]], 1
+; CHECK-NEXT:    [[TMP19:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP18]], i32 [[ARG]], 2
+; CHECK-NEXT:    [[TMP20:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP19]], i32 [[TMP16]], 3
+; CHECK-NEXT:    [[TMP21:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
+; CHECK-NEXT:    [[TMP22:%.*]] = bitcast i64 [[TMP21]] to <2 x i32>
+; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i32> [[TMP22]], i64 0
+; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <2 x i32> [[TMP22]], i64 1
+; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[TMP23]], i64 1
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[TMP24]], i64 2
+; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[USERDATA0]], i64 3
+; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[USERDATA1]], i64 4
+; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[USERDATA2]], i64 5
+; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[USERDATA3]], i64 6
+; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP39b:%.*]] = insertelement <16 x i32> [[TMP39]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i32> [[TMP39b]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP41:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP20]], 0
+; CHECK-NEXT:    [[TMP42:%.*]] = icmp ne i32 [[TMP41]], 0
+; CHECK-NEXT:    [[TMP43:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP42]])
+; CHECK-NEXT:    [[TMP44:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP43]], i1 true)
+; CHECK-NEXT:    [[TMP45:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP41]], i32 [[TMP44]])
+; CHECK-NEXT:    [[TMP46:%.*]] = icmp eq i32 [[TMP41]], [[TMP45]]
+; CHECK-NEXT:    [[TMP47:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP46]])
+; CHECK-NEXT:    [[TMP48:%.*]] = icmp eq i32 [[TMP45]], 0
+; CHECK-NEXT:    br i1 [[TMP48]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
 ; CHECK:       chain.block:
-; CHECK-NEXT:    [[TMP48:%.*]] = and i32 [[TMP44]], -64
-; CHECK-NEXT:    [[TMP49:%.*]] = insertelement <2 x i32> [[TMP7]], i32 [[TMP48]], i64 0
-; CHECK-NEXT:    [[TMP50:%.*]] = bitcast <2 x i32> [[TMP49]] to i64
-; CHECK-NEXT:    [[TMP51:%.*]] = inttoptr i64 [[TMP50]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr [[TMP51]], i32 [[TMP46]], <16 x i32> [[TMP39]], { i32, ptr addrspace(5), i32, i32 } [[TMP19]], i32 0)
+; CHECK-NEXT:    [[TMP49:%.*]] = and i32 [[TMP45]], -64
+; CHECK-NEXT:    [[TMP50:%.*]] = insertelement <2 x i32> [[TMP7]], i32 [[TMP49]], i64 0
+; CHECK-NEXT:    [[TMP51:%.*]] = bitcast <2 x i32> [[TMP50]] to i64
+; CHECK-NEXT:    [[TMP52:%.*]] = inttoptr i64 [[TMP51]] to ptr
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr [[TMP52]], i32 [[TMP47]], <16 x i32> [[TMP40]], { i32, ptr addrspace(5), i32, i32 } [[TMP20]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void

--- a/lgc/util/AddressExtender.cpp
+++ b/lgc/util/AddressExtender.cpp
@@ -71,6 +71,20 @@ Instruction *AddressExtender::extend(Value *addr32, Value *highHalf, Type *ptrTy
 }
 
 // =====================================================================================================================
+// Extend an i32 into a 64-bit pointer using the high 32 bits of the PC
+//
+// @param addr32 : Address as 32-bit value
+// @param highHalf : Value to use for high half; The constant HighAddrPc to use PC
+// @param ptrTy : Type to cast pointer to
+// @param builder : IRBuilder to use, already set to the required insert point
+// @returns : 64-bit pointer value
+Instruction *AddressExtender::extendWithPc(Value *addr32, Type *ptrTy, IRBuilder<> &builder) {
+  Value *ptr = builder.CreateInsertElement(getPc(), addr32, uint64_t(0));
+  ptr = builder.CreateBitCast(ptr, builder.getInt64Ty());
+  return cast<Instruction>(builder.CreateIntToPtr(ptr, ptrTy));
+}
+
+// =====================================================================================================================
 // Get PC value as v2i32. The caller is only using the high half, so this only writes a single instance of the
 // code at the start of the function.
 Instruction *AddressExtender::getPc() {

--- a/llpc/test/shaderdb/core/TestReverseThreadGroup.comp
+++ b/llpc/test/shaderdb/core/TestReverseThreadGroup.comp
@@ -15,10 +15,13 @@ void main()
 // BEGIN_REVERSETEST
 // RUN: amdllpc -v %gfxip %s --reverse-thread-group=1 | FileCheck -check-prefix=REVERSETEST %s
 // REVERSETEST-LABEL: {{^// LLPC}} pipeline before-patching results
-// There should be a call to get the gl_NumWorkGroups
-// REVERSETEST: %{{[0-9]+}} = call ptr addrspace(4) @lgc.special.user.data.Workgroup(i32 268435462)
-// There should be a call to get the internal buffer descriptor
-// REVERSETEST: %{{[0-9]+}} = call ptr addrspace(4) @lgc.descriptor.table.addr(i32 10, i32 10, i64 4294967295, i32 7, i32 -1)
+// There should be a calls to:
+//  - get the descriptor table containing the buffer descriptor
+//  - get the gl_NumWorkGroups
+//  - get the internal descriptor table
+// REVERSETEST-DAG: %{{[0-9]+}} = call i32 @lgc.load.user.data.i32(i32 0)
+// REVERSETEST-DAG: %{{[0-9]+}} = call ptr addrspace(4) @lgc.special.user.data.Workgroup(i32 268435462)
+// REVERSETEST-DAG: %{{[0-9]+}} = call i32 @lgc.load.user.data.i32(i32 4)
 // There should be a select between the reversed thread group ID and original thread group ID
 // REVERSETEST: %{{[0-9]+}} = select i1 %{{[0-9]+}}, <3 x i32> %{{[0-9]+}}, <3 x i32> %{{[0-9]+}}
 // REVERSETEST: AMDLLPC SUCCESS

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
@@ -8,7 +8,10 @@
 ; SHADERTEST: call void (...) @lgc.create.write.generic.output(<4 x float> [[Value]], i32 0, i32 0, i32 0, i32 0, i32 0, i32 poison)
 
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: [[Desc:%[0-9]*]] = call ptr addrspace(4) @lgc.descriptor.table.addr(i32 9, i32 9, i64 4294967295, i32 0, i32 -1)
+; SHADERTEST: [[DescLo:%[0-9]*]] = call i32 @lgc.load.user.data.i32(i32 4)
+; SHADERTEST: [[DescVec:%[0-9]*]] = insertelement <2 x i32> %{{[^,]*}}, i32 [[DescLo]], i64 0
+; SHADERTEST: [[Desc64:%[0-9]*]] = bitcast <2 x i32> [[DescVec]] to i64
+; SHADERTEST: [[Desc:%[0-9]*]] = inttoptr i64 [[Desc64]] to ptr addrspace(4)
 ; SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, ptr addrspace(4) [[Desc]], align 16
 ; SHADERTEST: call void @lgc.output.export.generic.i32.i32.v4f32(i32 0, i32 0, <4 x float> [[Value]])
 

--- a/llpc/test/shaderdb/general/TestWorkgroupIdOpt.comp
+++ b/llpc/test/shaderdb/general/TestWorkgroupIdOpt.comp
@@ -16,11 +16,11 @@ void main()
     test = gl_WorkGroupID.x;
 }
 // CHECK-LABEL: define {{[^@]+}}@_amdgpu_cs_main
-// CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], i32 inreg [[DESCTABLE0:%.*]], i32 inreg [[WORKGROUPID1:%.*]], i32 inreg [[MULTIDISPATCHINFO:%.*]], <3 x i32> [[LOCALINVOCATIONID:%.*]]) #[[ATTR0:[0-9]+]] !lgc.shaderstage !5 {
+// CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], i32 inreg [[USERDATA0:%.*]], i32 inreg [[WORKGROUPID1:%.*]], i32 inreg [[MULTIDISPATCHINFO:%.*]], <3 x i32> [[LOCALINVOCATIONID:%.*]]) #[[ATTR0:[0-9]+]] !lgc.shaderstage !5 {
 // CHECK-NEXT:  .entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.amdgcn.s.getpc()
 // CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], -4294967296
-// CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[DESCTABLE0]] to i64
+// CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[USERDATA0]] to i64
 // CHECK-NEXT:    [[TMP3:%.*]] = or i64 [[TMP1]], [[TMP2]]
 // CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(4)
 // CHECK-NEXT:    [[TMP5:%.*]] = load <4 x i32>, ptr addrspace(4) [[TMP4]], align 16
@@ -30,6 +30,5 @@ void main()
 //.
 // CHECK: attributes #[[ATTR0]] = { nounwind memory(readwrite) "amdgpu-flat-work-group-size"="256,256" "amdgpu-memory-bound"="false" "amdgpu-no-workgroup-id-y" "amdgpu-no-workgroup-id-z" "amdgpu-unroll-threshold"="700" "amdgpu-wave-limiter"="false" "amdgpu-work-group-info-arg-no"="3" "denormal-fp-math-f32"="preserve-sign" "target-features"=",+wavefrontsize64,+cumode,+enable-flat-scratch" }
 // CHECK: attributes #[[ATTR1:[0-9]+]] = { nounwind willreturn memory(none) }
-// CHECK: attributes #[[ATTR2:[0-9]+]] = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 // CHECK: attributes #[[ATTR3:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(write) }
 //.

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_EnableColorExport.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_EnableColorExport.pipe
@@ -79,10 +79,10 @@ attribute[0].offset = 0
 ; SHADERTEST-NEXT:    [[PERSPINTERPCENTER_I1:%.*]] = extractelement <2 x float> [[PERSPINTERPCENTER:%.*]], i64 1
 ; SHADERTEST-NEXT:    [[PERSPINTERPCENTER_I0:%.*]] = extractelement <2 x float> [[PERSPINTERPCENTER]], i64 0
 ; SHADERTEST-NEXT:    [[TMP11:%.*]] = call i64 @llvm.amdgcn.s.getpc()
-; SHADERTEST-NEXT:    [[TMP16:%.*]] = call float @llvm.amdgcn.interp.p1(float [[PERSPINTERPCENTER_I0]], i32 immarg 0, i32 immarg 0, i32 [[PRIMMASK:%.*]]) #[[ATTR2:[0-9]+]]
-; SHADERTEST-NEXT:    [[TMP17:%.*]] = call float @llvm.amdgcn.interp.p2(float [[TMP16]], float [[PERSPINTERPCENTER_I1]], i32 immarg 0, i32 immarg 0, i32 [[PRIMMASK]]) #[[ATTR2]]
-; SHADERTEST-NEXT:    [[TMP18:%.*]] = call float @llvm.amdgcn.interp.p1(float [[PERSPINTERPCENTER_I0]], i32 immarg 1, i32 immarg 0, i32 [[PRIMMASK]]) #[[ATTR2]]
-; SHADERTEST-NEXT:    [[TMP19:%.*]] = call float @llvm.amdgcn.interp.p2(float [[TMP18]], float [[PERSPINTERPCENTER_I1]], i32 immarg 1, i32 immarg 0, i32 [[PRIMMASK]]) #[[ATTR2]]
+; SHADERTEST-NEXT:    [[TMP16:%.*]] = call float @llvm.amdgcn.interp.p1(float [[PERSPINTERPCENTER_I0]], i32 immarg 0, i32 immarg 0, i32 [[PRIMMASK:%.*]])
+; SHADERTEST-NEXT:    [[TMP17:%.*]] = call float @llvm.amdgcn.interp.p2(float [[TMP16]], float [[PERSPINTERPCENTER_I1]], i32 immarg 0, i32 immarg 0, i32 [[PRIMMASK]])
+; SHADERTEST-NEXT:    [[TMP18:%.*]] = call float @llvm.amdgcn.interp.p1(float [[PERSPINTERPCENTER_I0]], i32 immarg 1, i32 immarg 0, i32 [[PRIMMASK]])
+; SHADERTEST-NEXT:    [[TMP19:%.*]] = call float @llvm.amdgcn.interp.p2(float [[TMP18]], float [[PERSPINTERPCENTER_I1]], i32 immarg 1, i32 immarg 0, i32 [[PRIMMASK]])
 ; SHADERTEST-NEXT:    [[DOTI0:%.*]] = fptosi float [[TMP17]] to i32
 ; SHADERTEST-NEXT:    [[DOTI1:%.*]] = fptosi float [[TMP19]] to i32
 ; SHADERTEST-NEXT:    [[TMP12:%.*]] = and i64 [[TMP11]], -4294967296
@@ -141,7 +141,7 @@ attribute[0].offset = 0
 ; SHADERTEST-NEXT:    [[TMP3:%.*]] = extractelement <4 x float> [[TMP0]], i64 1
 ; SHADERTEST-NEXT:    [[TMP4:%.*]] = extractelement <4 x float> [[TMP0]], i64 2
 ; SHADERTEST-NEXT:    [[TMP5:%.*]] = extractelement <4 x float> [[TMP0]], i64 3
-; SHADERTEST-NEXT:    call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float [[TMP2]], float [[TMP3]], float [[TMP4]], float [[TMP5]], i1 immarg true, i1 immarg true) #[[ATTR2]]
+; SHADERTEST-NEXT:    call void @llvm.amdgcn.exp.f32(i32 immarg 0, i32 immarg 15, float [[TMP2]], float [[TMP3]], float [[TMP4]], float [[TMP5]], i1 immarg true, i1 immarg true)
 ; SHADERTEST-NEXT:    ret void
 ;
 ; SHADERTEST-LABEL: color_export_shader:


### PR DESCRIPTION
This continues the cleanup started in PR #2626 and finishes in so far as all of the PAL userdata is now accessed via either `lgc.user.data` or `lgc.load.user.data`. The series is built on #2625 and contains a bunch of further cleanup of code that is dead now that we no longer allow compiling without a resource mapping.