### PR TITLE
Fix an issue of setting function attribute 'amdgpu-no-workgroup-id'

### DIFF
--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1975,9 +1975,16 @@ void ConfigBuilder::buildCsRegConfig(ShaderStage shaderStage, CsRegConfig *confi
       break;
     }
   }
-  SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TGID_X_EN, !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-x"));
-  SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TGID_Y_EN, !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-y"));
-  SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TGID_Z_EN, !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-z"));
+  // NOTE: We enable TGID if we don't find any function using the attributes 'amdgpu-no-workgroup-id'. If shader
+  // cache is enabled, the cached ELFs will be reused. In such case, we might not find any entry-point functions.
+  // Since the cached ELFs will be reused, it is still safe to enable TGID because the register metadata will not
+  // be actually used.
+  const bool tgidXEn = !attribFunc || !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-x");
+  const bool tgidYEn = !attribFunc || !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-y");
+  const bool tgidZEn = !attribFunc || !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-z");
+  SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TGID_X_EN, tgidXEn);
+  SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TGID_Y_EN, tgidYEn);
+  SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TGID_Z_EN, tgidZEn);
   SET_REG_FIELD(config, COMPUTE_PGM_RSRC2, TG_SIZE_EN, true);
 
   // 0 = X, 1 = XY, 2 = XYZ

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -945,12 +945,17 @@ void RegisterMetadataBuilder::buildCsRegisters(ShaderStage shaderStage) {
         break;
       }
     }
-    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidXEn] =
-        !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-x");
-    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidYEn] =
-        !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-y");
-    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidZEn] =
-        !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-z");
+
+    // NOTE: We enable TGID if we don't find any function using the attributes 'amdgpu-no-workgroup-id'. If shader
+    // cache is enabled, the cached ELFs will be reused. In such case, we might not find any entry-point functions.
+    // Since the cached ELFs will be reused, it is still safe to enable TGID because the register metadata will not
+    // be actually used.
+    const bool tgidXEn = !attribFunc || !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-x");
+    const bool tgidYEn = !attribFunc || !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-y");
+    const bool tgidZEn = !attribFunc || !attribFunc->hasFnAttribute("amdgpu-no-workgroup-id-z");
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidXEn] = tgidXEn;
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidYEn] = tgidYEn;
+    getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidZEn] = tgidZEn;
 
   } else {
     getComputeRegNode()[Util::Abi::ComputeRegisterMetadataKey::TgidXEn] = true;


### PR DESCRIPTION
We try to find the function that might use the attribute 'amdgpu-no-workgroup-id'. This is true when such entry-point function exists. However, in the case that shader cache is enabled, such functions might be absent in current module because we deliberately remove the duplicated shader entry-points by reusing cached ELFs. Therefore, we must check such case when trying to find the entry-point function.

The failure is found in the CTS group: VK.binding_model.descriptorset_random. sets*.*.noubo.nosbo.nosampledimg.outimgonly.noiub.*uab.task.noia.0