### PR TITLE
.editorconfig: Fix indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 end_of_line = lf
-indent_size = 4
+indent_size = 2
 indent_style = space
 insert_final_newline = true
 max_line_length = 120


### PR DESCRIPTION
.editorconfig specified an indent level of 4, but we use an indent of 2 in LLPC.

The value used to be correct, but was incorrectly updated because an internal-only subproject uses 4.

In an internal follow-up, we can add a local .editorconfig for that subproject with an indent of 4.