### PR TITLE
lgc: change the spill threshold to 0xffff according to pal demand.

### DIFF
--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -248,7 +248,7 @@ private:
   void finalizeInputControlRegisterSetting();
 
   // The maximum possible value for the spill threshold entry in the PAL metadata.
-  static constexpr uint64_t MAX_SPILL_THRESHOLD = UINT_MAX;
+  static constexpr uint64_t MAX_SPILL_THRESHOLD = USHRT_MAX;
 
   unsigned getUserDataCount(unsigned callingConv);
   unsigned getCallingConventionForFirstHardwareShaderStage(std::string &hwStageName);

--- a/lgc/test/BuiltIns/cs-numworkgroups.lgc
+++ b/lgc/test/BuiltIns/cs-numworkgroups.lgc
@@ -74,7 +74,7 @@ attributes #0 = { nounwind }
 ; CHECK-NEXT:           - 0
 ; CHECK-NEXT:         .hardware_mapping:
 ; CHECK-NEXT:           - .cs
-; CHECK-NEXT:     .spill_threshold: 0xffffffff
+; CHECK-NEXT:     .spill_threshold: 0xffff
 ; CHECK-NEXT:     .type:           Cs
 ; CHECK-NEXT:     .user_data_limit: 0x3
 ; CHECK-NEXT: amdpal.version:

--- a/lgc/test/BuiltIns/cs-workgroupid.lgc
+++ b/lgc/test/BuiltIns/cs-workgroupid.lgc
@@ -70,7 +70,7 @@ attributes #0 = { nounwind }
 ; CHECK-NEXT:           - 0
 ; CHECK-NEXT:         .hardware_mapping:
 ; CHECK-NEXT:           - .cs
-; CHECK-NEXT:     .spill_threshold: 0xffffffff
+; CHECK-NEXT:     .spill_threshold: 0xffff
 ; CHECK-NEXT:     .type:           Cs
 ; CHECK-NEXT:     .user_data_limit: 0x3
 ; CHECK-NEXT: amdpal.version:

--- a/lgc/test/TaskShaderRegConfig.lgc
+++ b/lgc/test/TaskShaderRegConfig.lgc
@@ -117,7 +117,7 @@ attributes #0 = { nounwind }
 ; CHECK-NEXT:           - 0
 ; CHECK-NEXT:         .hardware_mapping:
 ; CHECK-NEXT:           - .cs
-; CHECK-NEXT:     .spill_threshold: 0xffffffff
+; CHECK-NEXT:     .spill_threshold: 0xffff
 ; CHECK-NEXT:     .user_data_limit: 0x1
 ; CHECK-NEXT:     .xgl_cache_info:
 ; CHECK-NEXT:       .128_bit_cache_hash:

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
@@ -285,7 +285,7 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:           - 0
 ; CHECK-NEXT:         .hardware_mapping:
 ; CHECK-NEXT:           - .vs
-; CHECK-NEXT:     .spill_threshold: 0xffffffff
+; CHECK-NEXT:     .spill_threshold: 0xffff
 ; CHECK-NEXT:     .streamout_vertex_strides:
 ; CHECK-NEXT:       - 0
 ; CHECK-NEXT:       - 0

--- a/llpc/test/shaderdb/gfx10/PipelineVsFs_TestVsOutMiscSideBusEna.pipe
+++ b/llpc/test/shaderdb/gfx10/PipelineVsFs_TestVsOutMiscSideBusEna.pipe
@@ -309,7 +309,7 @@ entryPoint = main
 ; SHADERTEST-NEXT:           - 0
 ; SHADERTEST-NEXT:         .hardware_mapping:
 ; SHADERTEST-NEXT:           - .vs
-; SHADERTEST-NEXT:     .spill_threshold: 0xffffffff
+; SHADERTEST-NEXT:     .spill_threshold: 0xffff
 ; SHADERTEST-NEXT:     .streamout_vertex_strides:
 ; SHADERTEST-NEXT:       - 0
 ; SHADERTEST-NEXT:       - 0

--- a/llpc/test/shaderdb/gfx11/SgprUserDataInit_Cs.pipe
+++ b/llpc/test/shaderdb/gfx11/SgprUserDataInit_Cs.pipe
@@ -228,7 +228,7 @@ options.threadGroupSwizzleMode = Default
 ; CHECK-NEXT:           - 0
 ; CHECK-NEXT:         .hardware_mapping:
 ; CHECK-NEXT:           - .cs
-; CHECK-NEXT:     .spill_threshold: 0xffffffff
+; CHECK-NEXT:     .spill_threshold: 0xffff
 ; CHECK-NEXT:     .type:           Cs
 ; CHECK-NEXT:     .user_data_limit: 0x1
 ; CHECK-NEXT:     .xgl_cache_info:

--- a/llpc/test/shaderdb/gfx11/SgprUserDataInit_Fs.pipe
+++ b/llpc/test/shaderdb/gfx11/SgprUserDataInit_Fs.pipe
@@ -417,7 +417,7 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:           - 0
 ; CHECK-NEXT:         .hardware_mapping:
 ; CHECK-NEXT:           - .gs
-; CHECK-NEXT:     .spill_threshold: 0xffffffff
+; CHECK-NEXT:     .spill_threshold: 0xffff
 ; CHECK-NEXT:     .type:           Ngg
 ; CHECK-NEXT:     .user_data_limit: 0x13
 ; CHECK-NEXT:     .xgl_cache_info:


### PR DESCRIPTION
from pal: 0xFFFF for NoUserDataSpilling, so the max spill threshold should not be uint_max.