### PR TITLE
Fix the failure for multisample_shader_builtin.sample_mask cases

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -486,6 +486,8 @@ struct RasterizerState {
   unsigned rasterStream;                   // Which vertex stream to rasterize
   ProvokingVertexMode provokingVertexMode; // Specifies which vertex of a primitive is the _provoking vertex_,
                                            // this impacts which vertex's "flat" VS outputs are passed to the PS.
+  unsigned pixelShaderSamples;             // Controls the pixel shader execution rate. Must be less than or equal to
+                                           //  coverageSamples. Valid values are 1, 2, 4, and 8.
 };
 
 // Struct to pass to depth/stencil state

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -489,6 +489,7 @@ void GraphicsContext::setGraphicsStateInPipeline(Pipeline *pipeline, Util::Metro
     rasterizerState.perSampleShading = inputRsState.perSampleShading;
     rasterizerState.numSamples = inputRsState.numSamples;
     rasterizerState.samplePatternIdx = inputRsState.samplePatternIdx;
+    rasterizerState.pixelShaderSamples = inputRsState.pixelShaderSamples;
   }
 
   if (pipeline)


### PR DESCRIPTION
Need handle the cases when "numSamples == 4 && pixelShaderSamples == 2" and "numSamples == 8 && pixelShaderSamples == 2" and "numSamples == 8 && pixelShaderSamples == 4" cases.