### PR TITLE
Move fragment out struct to vkgcDefs

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -83,6 +83,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     65.1 | Add FragmentOutputs and FsOutInfo                                                                     |
 //  |     65.0 | Remove updateDescInElf                                                                                |
 //  |     64.0 | Add enableColorExportShader to GraphicsPipelineBuildInfo.                                             |
 //  |     63.0 | Add Atomic Counter, its default descriptor and map its concreteType to Buffer.                        |
@@ -962,6 +963,21 @@ constexpr uint32_t UberFetchShaderAttribMaskComponent1 = 0x0020000u;
 constexpr uint32_t UberFetchShaderAttribMaskComponent2 = 0x0040000u;
 constexpr uint32_t UberFetchShaderAttribMaskComponent3 = 0x0080000u;
 constexpr uint32_t UberFetchShaderAttribMaskIsBgra = 0x0100000u;
+
+// Represents fragment shader output info
+struct FsOutInfo {
+  unsigned hwColorTarget; // HW color output index
+  unsigned location;      // Output location in resource layout
+  bool isSigned;          // Whether is signed
+  char typeName[8];       // Output data type Name, like v3f32
+};
+
+// Represents shader meta data
+struct FragmentOutputs {
+  FsOutInfo *fsOutInfos;   // The color export information.
+  unsigned fsOutInfoCount; // The number of color exports.
+  bool discard;            // Whether this fragment shader has kill enabled.
+};
 
 /// Represents info of a shader attached to a to-be-built pipeline.
 struct PipelineShaderInfo {

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -649,21 +649,6 @@ enum class PipelineLink : unsigned {
                  //  pass its packed input mapping to the compile of the rest of the pipeline.
 };
 
-// Represents fragment shader output info
-struct FsOutInfo {
-  unsigned hwColorTarget; // HW color output index
-  unsigned location;      // Output location in resource layout
-  bool isSigned;          // Whether is signed
-  char typeName[8];       // Output data type Name, like v3f32
-};
-
-// Represents shader meta data
-struct FragmentOutputs {
-  FsOutInfo *fsOutInfos;   // The color export information.
-  unsigned fsOutInfoCount; // The number of color exports.
-  bool discard;            // Whether this fragment shader has kill enabled.
-};
-
 // =====================================================================================================================
 // The public API of the middle-end pipeline state exposed to the front-end for setting state and linking and
 // generating the pipeline

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -372,8 +372,10 @@ std::string PipelineDumper::getPipelineInfoFileName(PipelineBuildInfo pipelineIn
         fileNamePrefix = "PipelineLibGs";
       else if (pipelineInfo.pGraphicsInfo->mesh.pModuleData)
         fileNamePrefix = "PipelineLibMesh";
-      else
+      else if (pipelineInfo.pGraphicsInfo->fs.pModuleData)
         fileNamePrefix = "PipelineLibFs";
+      else
+        fileNamePrefix = "PipelineLibColExp";
     } else if (pipelineInfo.pGraphicsInfo->tes.pModuleData && pipelineInfo.pGraphicsInfo->gs.pModuleData)
       fileNamePrefix = "PipelineGsTess";
     else if (pipelineInfo.pGraphicsInfo->gs.pModuleData)


### PR DESCRIPTION
Move _FragmentOutputs_ and _FsOutInfo_  to vkgcDefs.h so that the ICD could use those two structs to calculate hash for color export shader.
Also, add the dump file prefix for color export shader.