### PR TITLE
CI: Reenable UBSAN/ASAN configs

### DIFF
--- a/.github/workflows/check-amdllpc-docker.yml
+++ b/.github/workflows/check-amdllpc-docker.yml
@@ -18,7 +18,9 @@ jobs:
         image-template:      ["amdvlkadmin/amdvlk_%s%s:nightly"]
         config:              [Release]
         feature-set:         ["+gcc", "+gcc+assertions",
-                              "+clang"]
+                              "+clang",
+                              "+clang+ubsan+asan",
+                              "+clang+ubsan+asan+assertions"]
     steps:
       - name: Free up disk space
         if: contains(matrix.feature-set, '+ubsan') || contains(matrix.feature-set, '+asan') || contains(matrix.feature-set, '+tsan') || contains(matrix.feature-set, '+coverage')


### PR DESCRIPTION
Commit b655ae3ecd9 ("Remove LLPC_ENABLE_SHADER_CACHE option") had to temporarily remove those configs until the AMDVLK build process has run through to create new base images.