### PR TITLE
Fix perf drop in SaschaWillems rayquery sample

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -252,8 +252,10 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
     passMgr.addPass(AlwaysInlinerPass());
   }
 
-  if (rayTracing || rayQuery)
+  if (rayTracing || rayQuery) {
     passMgr.addPass(LowerGpuRt());
+    passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(instCombineOpt)));
+  }
 
   // Stop timer for lowering passes.
   if (lowerTimer)


### PR DESCRIPTION
Caused by https://github.com/GPUOpen-Drivers/llpc/commit/9d3ae8a568b0114bb6cc8d311b468d76e34231a3.

Root cause:
After the dialectification of some GPURT intrinsic functions that returns a constant value (specifically, GetBoxSortHeuristicMode, GetStaticFlags and GetTriangleCompressionMode), unused `@lgc.create.load.buffer.desc` can no longer be eliminated before the module gets into LGC, as LowerGpuRt is the last lowering pass. This results in unnecessary `writes_uavs` and `uses_uav` being set, and different field of `DB_SHADER_CONTROL` register being set, which will prevent some optimization in PAL being made.

Solution:
Add an InstCombine pass after dialect ops have been processed.