### PR TITLE
lgc/cps: Add InReg attribute for uniform arguments of amdgcn.cs.chain

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -433,7 +433,10 @@ bool PatchEntryPointMutate::lowerCpsOps(Function *func) {
   // New version of the code (also handles unknown version, which we treat as
   // latest)
   Type *chainTys[] = {builder.getPtrTy(), builder.getIntNTy(waveSize), userDataVec->getType(), vgprArg->getType()};
-  builder.CreateIntrinsic(Intrinsic::amdgcn_cs_chain, chainTys, chainArgs);
+  auto *chainCall = builder.CreateIntrinsic(Intrinsic::amdgcn_cs_chain, chainTys, chainArgs);
+  // Add inreg attribute for (fn, exec, sgprs).
+  for (unsigned arg = 0; arg < 3; arg++)
+    chainCall->addParamAttr(arg, Attribute::InReg);
 #endif
   builder.CreateUnreachable();
 

--- a/lgc/test/Transforms/CpsLowering/continuation-basic.lgc
+++ b/lgc/test/Transforms/CpsLowering/continuation-basic.lgc
@@ -17,66 +17,66 @@ entry:
 
 !0 = !{i32 1} ; level 1
 ; CHECK-LABEL: define {{[^@]+}}@test
-; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[TMP0:%.*]], i32 inreg [[TMP1:%.*]], i32 inreg [[TMP2:%.*]], i32 inreg [[TMP3:%.*]], i32 inreg [[TMP4:%.*]], i32 inreg [[TMP5:%.*]], i32 inreg [[TMP6:%.*]], i32 inreg [[TMP7:%.*]], i32 inreg [[TMP8:%.*]], i32 inreg [[TMP9:%.*]], i32 inreg [[TMP10:%.*]], i32 inreg [[TMP11:%.*]], i32 inreg [[SPILLTABLE:%.*]], i32 [[VCR:%.*]], ptr addrspace(5) [[VSP:%.*]], i32 [[ARG:%.*]], ptr [[TABLE:%.*]]) #[[ATTR1:[0-9]+]] align 64 !lgc.cps !2 {
+; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[PAD0:%.*]], i32 inreg [[PAD1:%.*]], i32 inreg [[PAD2:%.*]], i32 inreg [[PAD3:%.*]], i32 inreg [[PAD4:%.*]], i32 inreg [[PAD5:%.*]], i32 inreg [[PAD6:%.*]], i32 inreg [[PAD7:%.*]], i32 inreg [[PAD8:%.*]], i32 inreg [[PAD9:%.*]], i32 inreg [[PAD10:%.*]], i32 inreg [[PAD11:%.*]], i32 inreg [[SPILLTABLE:%.*]], i32 [[VCR:%.*]], ptr addrspace(5) [[VSP:%.*]], i32 [[ARG:%.*]], ptr [[TABLE:%.*]]) #[[ATTR1:[0-9]+]] align 64 !lgc.cps !2 {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP12:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
-; CHECK-NEXT:    [[TMP13:%.*]] = call i64 @llvm.amdgcn.s.getpc()
-; CHECK-NEXT:    [[TMP14:%.*]] = bitcast i64 [[TMP13]] to <2 x i32>
-; CHECK-NEXT:    [[TMP15:%.*]] = getelementptr inbounds i8, ptr addrspace(5) [[VSP]], i32 -4
-; CHECK-NEXT:    [[CPS_STATE:%.*]] = load { i32 }, ptr addrspace(5) [[TMP15]], align 4
-; CHECK-NEXT:    store ptr addrspace(5) [[TMP15]], ptr addrspace(5) [[TMP12]], align 4
+; CHECK-NEXT:    [[TMP0:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.amdgcn.s.getpc()
+; CHECK-NEXT:    [[TMP2:%.*]] = bitcast i64 [[TMP1]] to <2 x i32>
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds i8, ptr addrspace(5) [[VSP]], i32 -4
+; CHECK-NEXT:    [[CPS_STATE:%.*]] = load { i32 }, ptr addrspace(5) [[TMP3]], align 4
+; CHECK-NEXT:    store ptr addrspace(5) [[TMP3]], ptr addrspace(5) [[TMP0]], align 4
 ; CHECK-NEXT:    [[V:%.*]] = extractvalue { i32 } [[CPS_STATE]], 0
 ; CHECK-NEXT:    [[TABLE_0:%.*]] = getelementptr i32, ptr [[TABLE]], i32 0
 ; CHECK-NEXT:    [[CR_THEN:%.*]] = load i32, ptr [[TABLE_0]], align 4
 ; CHECK-NEXT:    [[THEN_ARG:%.*]] = add i32 [[ARG]], 1
 ; CHECK-NEXT:    [[V_THEN:%.*]] = mul i32 [[V]], 2
 ; CHECK-NEXT:    [[STATE_THEN:%.*]] = insertvalue { i32 } poison, i32 [[V_THEN]], 0
-; CHECK-NEXT:    [[TMP16:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP12]], align 4
-; CHECK-NEXT:    store { i32 } [[STATE_THEN]], ptr addrspace(5) [[TMP16]], align 4
-; CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP16]], i32 4
+; CHECK-NEXT:    [[TMP4:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
+; CHECK-NEXT:    store { i32 } [[STATE_THEN]], ptr addrspace(5) [[TMP4]], align 4
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP4]], i32 4
 ; CHECK-NEXT:    br label [[TAIL_BLOCK:%.*]]
 ; CHECK:       tail.block:
-; CHECK-NEXT:    [[TMP18:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } poison, i32 [[CR_THEN]], 0
-; CHECK-NEXT:    [[TMP19:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP18]], ptr addrspace(5) [[TMP17]], 1
-; CHECK-NEXT:    [[TMP20:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP19]], i32 [[THEN_ARG]], 2
-; CHECK-NEXT:    [[TMP21:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
-; CHECK-NEXT:    [[TMP22:%.*]] = bitcast i64 [[TMP21]] to <2 x i32>
-; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i32> [[TMP22]], i64 0
-; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <2 x i32> [[TMP22]], i64 1
-; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[TMP23]], i64 1
-; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[TMP24]], i64 2
-; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[TMP0]], i64 3
-; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[TMP1]], i64 4
-; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[TMP2]], i64 5
-; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[TMP3]], i64 6
-; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[TMP4]], i64 7
-; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[TMP5]], i64 8
-; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[TMP6]], i64 9
-; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[TMP7]], i64 10
-; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[TMP8]], i64 11
-; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[TMP9]], i64 12
-; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[TMP10]], i64 13
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[TMP11]], i64 14
-; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i32> [[TMP39]], i32 [[SPILLTABLE]], i64 15
-; CHECK-NEXT:    [[TMP41:%.*]] = extractvalue { i32, ptr addrspace(5), i32 } [[TMP20]], 0
-; CHECK-NEXT:    [[TMP42:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg(i32 [[TMP41]], i32 [[VCR]])
-; CHECK-NEXT:    [[TMP43:%.*]] = icmp ne i32 [[TMP42]], 0
-; CHECK-NEXT:    [[TMP44:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP43]])
-; CHECK-NEXT:    [[TMP45:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP44]], i1 true)
-; CHECK-NEXT:    [[TMP46:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP42]], i32 [[TMP45]])
-; CHECK-NEXT:    [[TMP47:%.*]] = icmp eq i32 [[TMP42]], [[TMP46]]
-; CHECK-NEXT:    [[TMP48:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP47]])
-; CHECK-NEXT:    [[TMP49:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP46]])
-; CHECK-NEXT:    [[TMP50:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP48]])
-; CHECK-NEXT:    [[TMP51:%.*]] = icmp eq i32 [[TMP49]], 0
-; CHECK-NEXT:    br i1 [[TMP51]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
+; CHECK-NEXT:    [[TMP6:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } poison, i32 [[CR_THEN]], 0
+; CHECK-NEXT:    [[TMP7:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP6]], ptr addrspace(5) [[TMP5]], 1
+; CHECK-NEXT:    [[TMP8:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP7]], i32 [[THEN_ARG]], 2
+; CHECK-NEXT:    [[TMP9:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
+; CHECK-NEXT:    [[TMP10:%.*]] = bitcast i64 [[TMP9]] to <2 x i32>
+; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <2 x i32> [[TMP10]], i64 0
+; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <2 x i32> [[TMP10]], i64 1
+; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
+; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <16 x i32> [[TMP13]], i32 [[TMP11]], i64 1
+; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <16 x i32> [[TMP14]], i32 [[TMP12]], i64 2
+; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <16 x i32> [[TMP15]], i32 [[PAD0]], i64 3
+; CHECK-NEXT:    [[TMP17:%.*]] = insertelement <16 x i32> [[TMP16]], i32 [[PAD1]], i64 4
+; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <16 x i32> [[TMP17]], i32 [[PAD2]], i64 5
+; CHECK-NEXT:    [[TMP19:%.*]] = insertelement <16 x i32> [[TMP18]], i32 [[PAD3]], i64 6
+; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> [[TMP19]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP29:%.*]] = extractvalue { i32, ptr addrspace(5), i32 } [[TMP8]], 0
+; CHECK-NEXT:    [[TMP30:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg(i32 [[TMP29]], i32 [[VCR]])
+; CHECK-NEXT:    [[TMP31:%.*]] = icmp ne i32 [[TMP30]], 0
+; CHECK-NEXT:    [[TMP32:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP31]])
+; CHECK-NEXT:    [[TMP33:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP32]], i1 true)
+; CHECK-NEXT:    [[TMP34:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP30]], i32 [[TMP33]])
+; CHECK-NEXT:    [[TMP35:%.*]] = icmp eq i32 [[TMP30]], [[TMP34]]
+; CHECK-NEXT:    [[TMP36:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP35]])
+; CHECK-NEXT:    [[TMP37:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP34]])
+; CHECK-NEXT:    [[TMP38:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP36]])
+; CHECK-NEXT:    [[TMP39:%.*]] = icmp eq i32 [[TMP37]], 0
+; CHECK-NEXT:    br i1 [[TMP39]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
 ; CHECK:       chain.block:
-; CHECK-NEXT:    [[TMP52:%.*]] = and i32 [[TMP49]], -64
-; CHECK-NEXT:    [[TMP53:%.*]] = insertelement <2 x i32> [[TMP14]], i32 [[TMP52]], i64 0
-; CHECK-NEXT:    [[TMP54:%.*]] = bitcast <2 x i32> [[TMP53]] to i64
-; CHECK-NEXT:    [[TMP55:%.*]] = inttoptr i64 [[TMP54]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32s(ptr [[TMP55]], i32 [[TMP50]], <16 x i32> [[TMP40]], { i32, ptr addrspace(5), i32 } [[TMP20]], i32 0)
+; CHECK-NEXT:    [[TMP40:%.*]] = and i32 [[TMP37]], -64
+; CHECK-NEXT:    [[TMP41:%.*]] = insertelement <2 x i32> [[TMP2]], i32 [[TMP40]], i64 0
+; CHECK-NEXT:    [[TMP42:%.*]] = bitcast <2 x i32> [[TMP41]] to i64
+; CHECK-NEXT:    [[TMP43:%.*]] = inttoptr i64 [[TMP42]] to ptr
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32s(ptr inreg [[TMP43]], i32 inreg [[TMP38]], <16 x i32> inreg [[TMP28]], { i32, ptr addrspace(5), i32 } [[TMP8]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void

--- a/lgc/test/Transforms/CpsLowering/cps-entry-point.lgc
+++ b/lgc/test/Transforms/CpsLowering/cps-entry-point.lgc
@@ -87,21 +87,21 @@ attributes #5 = { nounwind willreturn memory(none) }
 ; CHECK-NEXT:    [[TMP23:%.*]] = extractelement <2 x i32> [[TMP22]], i64 0
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <2 x i32> [[TMP22]], i64 1
 ; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[TMP23]], i64 1
-; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[TMP24]], i64 2
-; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[USERDATA0]], i64 3
-; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[USERDATA1]], i64 4
-; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[USERDATA2]], i64 5
-; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[USERDATA3]], i64 6
-; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[PAD4]], i64 7
-; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[PAD5]], i64 8
-; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[PAD6]], i64 9
-; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[PAD7]], i64 10
-; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[PAD8]], i64 11
-; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[PAD9]], i64 12
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[PAD10]], i64 13
-; CHECK-NEXT:    [[TMP39b:%.*]] = insertelement <16 x i32> [[TMP39]], i32 [[PAD11]], i64 14
-; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i32> [[TMP39b]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[TMP23]], i64 1
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[TMP24]], i64 2
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[USERDATA0]], i64 3
+; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[USERDATA1]], i64 4
+; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[USERDATA2]], i64 5
+; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[USERDATA3]], i64 6
+; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i32> [[TMP39]], i32 [[SPILLTABLE]], i64 15
 ; CHECK-NEXT:    [[TMP41:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP20]], 0
 ; CHECK-NEXT:    [[TMP42:%.*]] = icmp ne i32 [[TMP41]], 0
 ; CHECK-NEXT:    [[TMP43:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP42]])
@@ -116,7 +116,7 @@ attributes #5 = { nounwind willreturn memory(none) }
 ; CHECK-NEXT:    [[TMP50:%.*]] = insertelement <2 x i32> [[TMP7]], i32 [[TMP49]], i64 0
 ; CHECK-NEXT:    [[TMP51:%.*]] = bitcast <2 x i32> [[TMP50]] to i64
 ; CHECK-NEXT:    [[TMP52:%.*]] = inttoptr i64 [[TMP51]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr [[TMP52]], i32 [[TMP47]], <16 x i32> [[TMP40]], { i32, ptr addrspace(5), i32, i32 } [[TMP20]], i32 0)
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr inreg [[TMP52]], i32 inreg [[TMP47]], <16 x i32> inreg [[TMP40]], { i32, ptr addrspace(5), i32, i32 } [[TMP20]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void

--- a/lgc/test/Transforms/CpsLowering/cps-stack-lowering.lgc
+++ b/lgc/test/Transforms/CpsLowering/cps-stack-lowering.lgc
@@ -63,53 +63,55 @@ define void @test.2({ ptr addrspace(32) } %state) !lgc.cps !{i32 1} {
 ; CHECK-NEXT:    store i8 99, ptr addrspace(5) [[TMP7]], align 1
 ; CHECK-NEXT:    [[Q1:%.*]] = ptrtoint ptr addrspace(5) [[TMP6]] to i32
 ; CHECK-NEXT:    [[STATE:%.*]] = insertvalue { ptr addrspace(5) } poison, ptr addrspace(5) [[TMP7]], 0
-; CHECK:    [[TMP8:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP1]], align 4
-; CHECK-NEXT:    store { ptr addrspace(5) } [[STATE]], ptr addrspace(5) [[TMP8]], align 4
-; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP8]], i32 4
-; CHECK-NEXT:    [[TMP10:%.*]] = ptrtoint ptr addrspace(5) [[TMP7]] to i32
+; CHECK-NEXT:    [[TMP8:%.*]] = or i32 ptrtoint (ptr @test.1 to i32), 1
+; CHECK-NEXT:    [[TMP9:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP1]], align 4
+; CHECK-NEXT:    store { ptr addrspace(5) } [[STATE]], ptr addrspace(5) [[TMP9]], align 4
+; CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP9]], i32 4
+; CHECK-NEXT:    [[TMP11:%.*]] = ptrtoint ptr addrspace(5) [[TMP7]] to i32
 ; CHECK-NEXT:    br label [[TAIL_BLOCK:%.*]]
 ; CHECK:       tail.block:
-; CHECK:    [[TMP11:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } {{.*}}, ptr addrspace(5) [[TMP9]], 1
-; CHECK-NEXT:    [[TMP12:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP11]], i32 [[TMP10]], 2
-; CHECK-NEXT:    [[TMP13:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP12]], i32 [[Q1]], 3
-; CHECK-NEXT:    [[TMP14:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
-; CHECK-NEXT:    [[TMP15:%.*]] = bitcast i64 [[TMP14]] to <2 x i32>
-; CHECK-NEXT:    [[TMP16:%.*]] = extractelement <2 x i32> [[TMP15]], i64 0
-; CHECK-NEXT:    [[TMP17:%.*]] = extractelement <2 x i32> [[TMP15]], i64 1
-; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP19:%.*]] = insertelement <16 x i32> [[TMP18]], i32 [[TMP16]], i64 1
-; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> [[TMP19]], i32 [[TMP17]], i64 2
-; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[PAD0]], i64 3
-; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[PAD1]], i64 4
-; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD2]], i64 5
-; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD3]], i64 6
-; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD4]], i64 7
-; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[PAD5]], i64 8
-; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[PAD6]], i64 9
-; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[PAD7]], i64 10
-; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[PAD8]], i64 11
-; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[PAD9]], i64 12
-; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[PAD10]], i64 13
-; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[PAD11]], i64 14
-; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[SPILLTABLE]], i64 15
-; CHECK-NEXT:    [[TMP34:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP13]], 0
-; CHECK-NEXT:    [[TMP35:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg(i32 [[TMP34]], i32 [[VCR]])
-; CHECK-NEXT:    [[TMP36:%.*]] = icmp ne i32 [[TMP35]], 0
-; CHECK-NEXT:    [[TMP37:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP36]])
-; CHECK-NEXT:    [[TMP38:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP37]], i1 true)
-; CHECK-NEXT:    [[TMP39:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP35]], i32 [[TMP38]])
-; CHECK-NEXT:    [[TMP40:%.*]] = icmp eq i32 [[TMP35]], [[TMP39]]
-; CHECK-NEXT:    [[TMP41:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP40]])
-; CHECK-NEXT:    [[TMP42:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP39]])
-; CHECK-NEXT:    [[TMP43:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP41]])
-; CHECK-NEXT:    [[TMP44:%.*]] = icmp eq i32 [[TMP42]], 0
-; CHECK-NEXT:    br i1 [[TMP44]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
+; CHECK-NEXT:    [[TMP12:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } poison, i32 [[TMP8]], 0
+; CHECK-NEXT:    [[TMP13:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP12]], ptr addrspace(5) [[TMP10]], 1
+; CHECK-NEXT:    [[TMP14:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP13]], i32 [[TMP11]], 2
+; CHECK-NEXT:    [[TMP15:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP14]], i32 [[Q1]], 3
+; CHECK-NEXT:    [[TMP16:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
+; CHECK-NEXT:    [[TMP17:%.*]] = bitcast i64 [[TMP16]] to <2 x i32>
+; CHECK-NEXT:    [[TMP18:%.*]] = extractelement <2 x i32> [[TMP17]], i64 0
+; CHECK-NEXT:    [[TMP19:%.*]] = extractelement <2 x i32> [[TMP17]], i64 1
+; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
+; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[TMP18]], i64 1
+; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[TMP19]], i64 2
+; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD0]], i64 3
+; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD1]], i64 4
+; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD2]], i64 5
+; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[PAD3]], i64 6
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP36:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP15]], 0
+; CHECK-NEXT:    [[TMP37:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg(i32 [[TMP36]], i32 [[VCR]])
+; CHECK-NEXT:    [[TMP38:%.*]] = icmp ne i32 [[TMP37]], 0
+; CHECK-NEXT:    [[TMP39:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP38]])
+; CHECK-NEXT:    [[TMP40:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP39]], i1 true)
+; CHECK-NEXT:    [[TMP41:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP37]], i32 [[TMP40]])
+; CHECK-NEXT:    [[TMP42:%.*]] = icmp eq i32 [[TMP37]], [[TMP41]]
+; CHECK-NEXT:    [[TMP43:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP42]])
+; CHECK-NEXT:    [[TMP44:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP41]])
+; CHECK-NEXT:    [[TMP45:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP43]])
+; CHECK-NEXT:    [[TMP46:%.*]] = icmp eq i32 [[TMP44]], 0
+; CHECK-NEXT:    br i1 [[TMP46]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
 ; CHECK:       chain.block:
-; CHECK-NEXT:    [[TMP45:%.*]] = and i32 [[TMP42]], -64
-; CHECK-NEXT:    [[TMP46:%.*]] = insertelement <2 x i32> [[TMP3]], i32 [[TMP45]], i64 0
-; CHECK-NEXT:    [[TMP47:%.*]] = bitcast <2 x i32> [[TMP46]] to i64
-; CHECK-NEXT:    [[TMP48:%.*]] = inttoptr i64 [[TMP47]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr [[TMP48]], i32 [[TMP43]], <16 x i32> [[TMP33]], { i32, ptr addrspace(5), i32, i32 } [[TMP13]], i32 0)
+; CHECK-NEXT:    [[TMP47:%.*]] = and i32 [[TMP44]], -64
+; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <2 x i32> [[TMP3]], i32 [[TMP47]], i64 0
+; CHECK-NEXT:    [[TMP49:%.*]] = bitcast <2 x i32> [[TMP48]] to i64
+; CHECK-NEXT:    [[TMP50:%.*]] = inttoptr i64 [[TMP49]] to ptr
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr inreg [[TMP50]], i32 inreg [[TMP45]], <16 x i32> inreg [[TMP35]], { i32, ptr addrspace(5), i32, i32 } [[TMP15]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void
@@ -124,48 +126,50 @@ define void @test.2({ ptr addrspace(32) } %state) !lgc.cps !{i32 1} {
 ; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i32 [[Q1]] to ptr addrspace(5)
 ; CHECK-NEXT:    [[N111:%.*]] = load i32, ptr addrspace(5) [[TMP4]], align 4
 ; CHECK-NEXT:    [[N99:%.*]] = load i8, ptr addrspace(5) [[P2]], align 1
-; CHECK:    [[TMP5:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP1]], align 4
+; CHECK-NEXT:    [[TMP5:%.*]] = or i32 ptrtoint (ptr @test.2 to i32), 1
+; CHECK-NEXT:    [[TMP6:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP1]], align 4
 ; CHECK-NEXT:    br label [[TAIL_BLOCK:%.*]]
 ; CHECK:       tail.block:
-; CHECK:    [[TMP6:%.*]] = insertvalue { i32, ptr addrspace(5) } {{.*}}, ptr addrspace(5) [[TMP5]], 1
-; CHECK-NEXT:    [[TMP7:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
-; CHECK-NEXT:    [[TMP8:%.*]] = bitcast i64 [[TMP7]] to <2 x i32>
-; CHECK-NEXT:    [[TMP9:%.*]] = extractelement <2 x i32> [[TMP8]], i64 0
-; CHECK-NEXT:    [[TMP10:%.*]] = extractelement <2 x i32> [[TMP8]], i64 1
-; CHECK-NEXT:    [[TMP11:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP12:%.*]] = insertelement <16 x i32> [[TMP11]], i32 [[TMP9]], i64 1
-; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <16 x i32> [[TMP12]], i32 [[TMP10]], i64 2
-; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <16 x i32> [[TMP13]], i32 [[PAD0]], i64 3
-; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <16 x i32> [[TMP14]], i32 [[PAD1]], i64 4
-; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <16 x i32> [[TMP15]], i32 [[PAD2]], i64 5
-; CHECK-NEXT:    [[TMP17:%.*]] = insertelement <16 x i32> [[TMP16]], i32 [[PAD3]], i64 6
-; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <16 x i32> [[TMP17]], i32 [[PAD4]], i64 7
-; CHECK-NEXT:    [[TMP19:%.*]] = insertelement <16 x i32> [[TMP18]], i32 [[PAD5]], i64 8
-; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> [[TMP19]], i32 [[PAD6]], i64 9
-; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[PAD7]], i64 10
-; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[PAD8]], i64 11
-; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD9]], i64 12
-; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD10]], i64 13
-; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD11]], i64 14
-; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[SPILLTABLE]], i64 15
-; CHECK-NEXT:    [[TMP27:%.*]] = extractvalue { i32, ptr addrspace(5) } [[TMP6]], 0
-; CHECK-NEXT:    [[TMP28:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg.1(i32 [[TMP27]], i32 [[VCR]])
-; CHECK-NEXT:    [[TMP29:%.*]] = icmp ne i32 [[TMP28]], 0
-; CHECK-NEXT:    [[TMP30:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP29]])
-; CHECK-NEXT:    [[TMP31:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP30]], i1 true)
-; CHECK-NEXT:    [[TMP32:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP28]], i32 [[TMP31]])
-; CHECK-NEXT:    [[TMP33:%.*]] = icmp eq i32 [[TMP28]], [[TMP32]]
-; CHECK-NEXT:    [[TMP34:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP33]])
-; CHECK-NEXT:    [[TMP35:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP32]])
-; CHECK-NEXT:    [[TMP36:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP34]])
-; CHECK-NEXT:    [[TMP37:%.*]] = icmp eq i32 [[TMP35]], 0
-; CHECK-NEXT:    br i1 [[TMP37]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
+; CHECK-NEXT:    [[TMP7:%.*]] = insertvalue { i32, ptr addrspace(5) } poison, i32 [[TMP5]], 0
+; CHECK-NEXT:    [[TMP8:%.*]] = insertvalue { i32, ptr addrspace(5) } [[TMP7]], ptr addrspace(5) [[TMP6]], 1
+; CHECK-NEXT:    [[TMP9:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
+; CHECK-NEXT:    [[TMP10:%.*]] = bitcast i64 [[TMP9]] to <2 x i32>
+; CHECK-NEXT:    [[TMP11:%.*]] = extractelement <2 x i32> [[TMP10]], i64 0
+; CHECK-NEXT:    [[TMP12:%.*]] = extractelement <2 x i32> [[TMP10]], i64 1
+; CHECK-NEXT:    [[TMP13:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
+; CHECK-NEXT:    [[TMP14:%.*]] = insertelement <16 x i32> [[TMP13]], i32 [[TMP11]], i64 1
+; CHECK-NEXT:    [[TMP15:%.*]] = insertelement <16 x i32> [[TMP14]], i32 [[TMP12]], i64 2
+; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <16 x i32> [[TMP15]], i32 [[PAD0]], i64 3
+; CHECK-NEXT:    [[TMP17:%.*]] = insertelement <16 x i32> [[TMP16]], i32 [[PAD1]], i64 4
+; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <16 x i32> [[TMP17]], i32 [[PAD2]], i64 5
+; CHECK-NEXT:    [[TMP19:%.*]] = insertelement <16 x i32> [[TMP18]], i32 [[PAD3]], i64 6
+; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> [[TMP19]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP29:%.*]] = extractvalue { i32, ptr addrspace(5) } [[TMP8]], 0
+; CHECK-NEXT:    [[TMP30:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg.1(i32 [[TMP29]], i32 [[VCR]])
+; CHECK-NEXT:    [[TMP31:%.*]] = icmp ne i32 [[TMP30]], 0
+; CHECK-NEXT:    [[TMP32:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP31]])
+; CHECK-NEXT:    [[TMP33:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP32]], i1 true)
+; CHECK-NEXT:    [[TMP34:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP30]], i32 [[TMP33]])
+; CHECK-NEXT:    [[TMP35:%.*]] = icmp eq i32 [[TMP30]], [[TMP34]]
+; CHECK-NEXT:    [[TMP36:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP35]])
+; CHECK-NEXT:    [[TMP37:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP34]])
+; CHECK-NEXT:    [[TMP38:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP36]])
+; CHECK-NEXT:    [[TMP39:%.*]] = icmp eq i32 [[TMP37]], 0
+; CHECK-NEXT:    br i1 [[TMP39]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
 ; CHECK:       chain.block:
-; CHECK-NEXT:    [[TMP38:%.*]] = and i32 [[TMP35]], -64
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <2 x i32> [[TMP3]], i32 [[TMP38]], i64 0
-; CHECK-NEXT:    [[TMP40:%.*]] = bitcast <2 x i32> [[TMP39]] to i64
-; CHECK-NEXT:    [[TMP41:%.*]] = inttoptr i64 [[TMP40]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5) }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5s(ptr [[TMP41]], i32 [[TMP36]], <16 x i32> [[TMP26]], { i32, ptr addrspace(5) } [[TMP6]], i32 0)
+; CHECK-NEXT:    [[TMP40:%.*]] = and i32 [[TMP37]], -64
+; CHECK-NEXT:    [[TMP41:%.*]] = insertelement <2 x i32> [[TMP3]], i32 [[TMP40]], i64 0
+; CHECK-NEXT:    [[TMP42:%.*]] = bitcast <2 x i32> [[TMP41]] to i64
+; CHECK-NEXT:    [[TMP43:%.*]] = inttoptr i64 [[TMP42]] to ptr
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5) }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5s(ptr inreg [[TMP43]], i32 inreg [[TMP38]], <16 x i32> inreg [[TMP28]], { i32, ptr addrspace(5) } [[TMP8]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void
@@ -225,7 +229,7 @@ define void @test.2({ ptr addrspace(32) } %state) !lgc.cps !{i32 1} {
 ; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <2 x i32> [[TMP3]], i32 [[TMP39]], i64 0
 ; CHECK-NEXT:    [[TMP41:%.*]] = bitcast <2 x i32> [[TMP40]] to i64
 ; CHECK-NEXT:    [[TMP42:%.*]] = inttoptr i64 [[TMP41]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5) }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5s(ptr [[TMP42]], i32 [[TMP37]], <16 x i32> [[TMP28]], { i32, ptr addrspace(5) } { i32 0, ptr addrspace(5) poison }, i32 0)
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5) }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5s(ptr inreg [[TMP42]], i32 inreg [[TMP37]], <16 x i32> inreg [[TMP28]], { i32, ptr addrspace(5) } { i32 0, ptr addrspace(5) poison }, i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void

--- a/lgc/test/Transforms/CpsLowering/cps-unify-exits.lgc
+++ b/lgc/test/Transforms/CpsLowering/cps-unify-exits.lgc
@@ -47,14 +47,14 @@ else:
 
 !0 = !{i32 1} ; level 1
 ; CHECK-LABEL: define {{[^@]+}}@unify_jumps
-; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[TMP0:%.*]], i32 inreg [[TMP1:%.*]], i32 inreg [[TMP2:%.*]], i32 inreg [[TMP3:%.*]], i32 inreg [[TMP4:%.*]], i32 inreg [[TMP5:%.*]], i32 inreg [[TMP6:%.*]], i32 inreg [[TMP7:%.*]], i32 inreg [[TMP8:%.*]], i32 inreg [[TMP9:%.*]], i32 inreg [[TMP10:%.*]], i32 inreg [[TMP11:%.*]], i32 inreg [[SPILLTABLE:%.*]], i32 [[VCR:%.*]], ptr addrspace(5) [[VSP:%.*]], i32 [[ARG:%.*]], ptr [[TABLE:%.*]]) #[[ATTR1:[0-9]+]] align 64 !lgc.cps !2 {
+; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[PAD0:%.*]], i32 inreg [[PAD1:%.*]], i32 inreg [[PAD2:%.*]], i32 inreg [[PAD3:%.*]], i32 inreg [[PAD4:%.*]], i32 inreg [[PAD5:%.*]], i32 inreg [[PAD6:%.*]], i32 inreg [[PAD7:%.*]], i32 inreg [[PAD8:%.*]], i32 inreg [[PAD9:%.*]], i32 inreg [[PAD10:%.*]], i32 inreg [[PAD11:%.*]], i32 inreg [[SPILLTABLE:%.*]], i32 [[VCR:%.*]], ptr addrspace(5) [[VSP:%.*]], i32 [[ARG:%.*]], ptr [[TABLE:%.*]]) #[[ATTR1:[0-9]+]] align 64 !lgc.cps !2 {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP12:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
-; CHECK-NEXT:    [[TMP13:%.*]] = call i64 @llvm.amdgcn.s.getpc()
-; CHECK-NEXT:    [[TMP14:%.*]] = bitcast i64 [[TMP13]] to <2 x i32>
-; CHECK-NEXT:    [[TMP15:%.*]] = getelementptr inbounds i8, ptr addrspace(5) [[VSP]], i32 -4
-; CHECK-NEXT:    [[CPS_STATE:%.*]] = load { i32 }, ptr addrspace(5) [[TMP15]], align 4
-; CHECK-NEXT:    store ptr addrspace(5) [[TMP15]], ptr addrspace(5) [[TMP12]], align 4
+; CHECK-NEXT:    [[TMP0:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.amdgcn.s.getpc()
+; CHECK-NEXT:    [[TMP2:%.*]] = bitcast i64 [[TMP1]] to <2 x i32>
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds i8, ptr addrspace(5) [[VSP]], i32 -4
+; CHECK-NEXT:    [[CPS_STATE:%.*]] = load { i32 }, ptr addrspace(5) [[TMP3]], align 4
+; CHECK-NEXT:    store ptr addrspace(5) [[TMP3]], ptr addrspace(5) [[TMP0]], align 4
 ; CHECK-NEXT:    [[V:%.*]] = extractvalue { i32 } [[CPS_STATE]], 0
 ; CHECK-NEXT:    [[COND:%.*]] = icmp ult i32 [[V]], 3
 ; CHECK-NEXT:    br i1 [[COND]], label [[THEN:%.*]], label [[ELSE:%.*]]
@@ -64,78 +64,78 @@ else:
 ; CHECK-NEXT:    [[THEN_ARG:%.*]] = add i32 [[ARG]], 1
 ; CHECK-NEXT:    [[V_THEN:%.*]] = mul i32 [[V]], 2
 ; CHECK-NEXT:    [[STATE_THEN:%.*]] = insertvalue { i32 } poison, i32 [[V_THEN]], 0
-; CHECK-NEXT:    [[TMP16:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP12]], align 4
-; CHECK-NEXT:    store { i32 } [[STATE_THEN]], ptr addrspace(5) [[TMP16]], align 4
-; CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP16]], i32 4
+; CHECK-NEXT:    [[TMP4:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
+; CHECK-NEXT:    store { i32 } [[STATE_THEN]], ptr addrspace(5) [[TMP4]], align 4
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP4]], i32 4
 ; CHECK-NEXT:    br label [[TAIL_BLOCK:%.*]]
 ; CHECK:       else:
 ; CHECK-NEXT:    [[TABLE_1:%.*]] = getelementptr i32, ptr [[TABLE]], i32 1
 ; CHECK-NEXT:    [[CR_ELSE:%.*]] = load i32, ptr [[TABLE_1]], align 4
 ; CHECK-NEXT:    [[ELSE_ARG:%.*]] = uitofp i32 [[ARG]] to float
-; CHECK-NEXT:    [[TMP18:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP12]], align 4
-; CHECK-NEXT:    [[TMP19:%.*]] = bitcast float [[ELSE_ARG]] to i32
+; CHECK-NEXT:    [[TMP6:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
+; CHECK-NEXT:    [[TMP7:%.*]] = bitcast float [[ELSE_ARG]] to i32
 ; CHECK-NEXT:    br label [[TAIL_BLOCK]]
 ; CHECK:       tail.block:
-; CHECK-NEXT:    [[TMP20:%.*]] = phi i32 [ [[CR_ELSE]], [[ELSE]] ], [ [[CR_THEN]], [[THEN]] ]
-; CHECK-NEXT:    [[TMP21:%.*]] = phi ptr addrspace(5) [ [[TMP18]], [[ELSE]] ], [ [[TMP17]], [[THEN]] ]
-; CHECK-NEXT:    [[TMP22:%.*]] = phi i32 [ [[TMP19]], [[ELSE]] ], [ [[THEN_ARG]], [[THEN]] ]
-; CHECK-NEXT:    [[TMP23:%.*]] = phi i32 [ 5, [[ELSE]] ], [ poison, [[THEN]] ]
-; CHECK-NEXT:    [[TMP24:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } poison, i32 [[TMP20]], 0
-; CHECK-NEXT:    [[TMP25:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP24]], ptr addrspace(5) [[TMP21]], 1
-; CHECK-NEXT:    [[TMP26:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP25]], i32 [[TMP22]], 2
-; CHECK-NEXT:    [[TMP27:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP26]], i32 [[TMP23]], 3
-; CHECK-NEXT:    [[TMP28:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
-; CHECK-NEXT:    [[TMP29:%.*]] = bitcast i64 [[TMP28]] to <2 x i32>
-; CHECK-NEXT:    [[TMP30:%.*]] = extractelement <2 x i32> [[TMP29]], i64 0
-; CHECK-NEXT:    [[TMP31:%.*]] = extractelement <2 x i32> [[TMP29]], i64 1
-; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[TMP30]], i64 1
-; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[TMP31]], i64 2
-; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[TMP0]], i64 3
-; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[TMP1]], i64 4
-; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[TMP2]], i64 5
-; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[TMP3]], i64 6
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[TMP4]], i64 7
-; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i32> [[TMP39]], i32 [[TMP5]], i64 8
-; CHECK-NEXT:    [[TMP41:%.*]] = insertelement <16 x i32> [[TMP40]], i32 [[TMP6]], i64 9
-; CHECK-NEXT:    [[TMP42:%.*]] = insertelement <16 x i32> [[TMP41]], i32 [[TMP7]], i64 10
-; CHECK-NEXT:    [[TMP43:%.*]] = insertelement <16 x i32> [[TMP42]], i32 [[TMP8]], i64 11
-; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <16 x i32> [[TMP43]], i32 [[TMP9]], i64 12
-; CHECK-NEXT:    [[TMP45:%.*]] = insertelement <16 x i32> [[TMP44]], i32 [[TMP10]], i64 13
-; CHECK-NEXT:    [[TMP46:%.*]] = insertelement <16 x i32> [[TMP45]], i32 [[TMP11]], i64 14
-; CHECK-NEXT:    [[TMP47:%.*]] = insertelement <16 x i32> [[TMP46]], i32 [[SPILLTABLE]], i64 15
-; CHECK-NEXT:    [[TMP48:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP27]], 0
-; CHECK-NEXT:    [[TMP49:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg(i32 [[TMP48]], i32 [[VCR]])
-; CHECK-NEXT:    [[TMP50:%.*]] = icmp ne i32 [[TMP49]], 0
-; CHECK-NEXT:    [[TMP51:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP50]])
-; CHECK-NEXT:    [[TMP52:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP51]], i1 true)
-; CHECK-NEXT:    [[TMP53:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP49]], i32 [[TMP52]])
-; CHECK-NEXT:    [[TMP54:%.*]] = icmp eq i32 [[TMP49]], [[TMP53]]
-; CHECK-NEXT:    [[TMP55:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP54]])
-; CHECK-NEXT:    [[TMP56:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP53]])
-; CHECK-NEXT:    [[TMP57:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP55]])
-; CHECK-NEXT:    [[TMP58:%.*]] = icmp eq i32 [[TMP56]], 0
-; CHECK-NEXT:    br i1 [[TMP58]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi i32 [ [[CR_ELSE]], [[ELSE]] ], [ [[CR_THEN]], [[THEN]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = phi ptr addrspace(5) [ [[TMP6]], [[ELSE]] ], [ [[TMP5]], [[THEN]] ]
+; CHECK-NEXT:    [[TMP10:%.*]] = phi i32 [ [[TMP7]], [[ELSE]] ], [ [[THEN_ARG]], [[THEN]] ]
+; CHECK-NEXT:    [[TMP11:%.*]] = phi i32 [ 5, [[ELSE]] ], [ poison, [[THEN]] ]
+; CHECK-NEXT:    [[TMP12:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } poison, i32 [[TMP8]], 0
+; CHECK-NEXT:    [[TMP13:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP12]], ptr addrspace(5) [[TMP9]], 1
+; CHECK-NEXT:    [[TMP14:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP13]], i32 [[TMP10]], 2
+; CHECK-NEXT:    [[TMP15:%.*]] = insertvalue { i32, ptr addrspace(5), i32, i32 } [[TMP14]], i32 [[TMP11]], 3
+; CHECK-NEXT:    [[TMP16:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
+; CHECK-NEXT:    [[TMP17:%.*]] = bitcast i64 [[TMP16]] to <2 x i32>
+; CHECK-NEXT:    [[TMP18:%.*]] = extractelement <2 x i32> [[TMP17]], i64 0
+; CHECK-NEXT:    [[TMP19:%.*]] = extractelement <2 x i32> [[TMP17]], i64 1
+; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
+; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[TMP18]], i64 1
+; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[TMP19]], i64 2
+; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD0]], i64 3
+; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD1]], i64 4
+; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD2]], i64 5
+; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[PAD3]], i64 6
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP36:%.*]] = extractvalue { i32, ptr addrspace(5), i32, i32 } [[TMP15]], 0
+; CHECK-NEXT:    [[TMP37:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg(i32 [[TMP36]], i32 [[VCR]])
+; CHECK-NEXT:    [[TMP38:%.*]] = icmp ne i32 [[TMP37]], 0
+; CHECK-NEXT:    [[TMP39:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP38]])
+; CHECK-NEXT:    [[TMP40:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP39]], i1 true)
+; CHECK-NEXT:    [[TMP41:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP37]], i32 [[TMP40]])
+; CHECK-NEXT:    [[TMP42:%.*]] = icmp eq i32 [[TMP37]], [[TMP41]]
+; CHECK-NEXT:    [[TMP43:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP42]])
+; CHECK-NEXT:    [[TMP44:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP41]])
+; CHECK-NEXT:    [[TMP45:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP43]])
+; CHECK-NEXT:    [[TMP46:%.*]] = icmp eq i32 [[TMP44]], 0
+; CHECK-NEXT:    br i1 [[TMP46]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
 ; CHECK:       chain.block:
-; CHECK-NEXT:    [[TMP59:%.*]] = and i32 [[TMP56]], -64
-; CHECK-NEXT:    [[TMP60:%.*]] = insertelement <2 x i32> [[TMP14]], i32 [[TMP59]], i64 0
-; CHECK-NEXT:    [[TMP61:%.*]] = bitcast <2 x i32> [[TMP60]] to i64
-; CHECK-NEXT:    [[TMP62:%.*]] = inttoptr i64 [[TMP61]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr [[TMP62]], i32 [[TMP57]], <16 x i32> [[TMP47]], { i32, ptr addrspace(5), i32, i32 } [[TMP27]], i32 0)
+; CHECK-NEXT:    [[TMP47:%.*]] = and i32 [[TMP44]], -64
+; CHECK-NEXT:    [[TMP48:%.*]] = insertelement <2 x i32> [[TMP2]], i32 [[TMP47]], i64 0
+; CHECK-NEXT:    [[TMP49:%.*]] = bitcast <2 x i32> [[TMP48]] to i64
+; CHECK-NEXT:    [[TMP50:%.*]] = inttoptr i64 [[TMP49]] to ptr
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32, i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32i32s(ptr inreg [[TMP50]], i32 inreg [[TMP45]], <16 x i32> inreg [[TMP35]], { i32, ptr addrspace(5), i32, i32 } [[TMP15]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void
 ;
 ;
 ; CHECK-LABEL: define {{[^@]+}}@unify_jump_ret
-; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[TMP0:%.*]], i32 inreg [[TMP1:%.*]], i32 inreg [[TMP2:%.*]], i32 inreg [[TMP3:%.*]], i32 inreg [[TMP4:%.*]], i32 inreg [[TMP5:%.*]], i32 inreg [[TMP6:%.*]], i32 inreg [[TMP7:%.*]], i32 inreg [[TMP8:%.*]], i32 inreg [[TMP9:%.*]], i32 inreg [[TMP10:%.*]], i32 inreg [[TMP11:%.*]], i32 inreg [[SPILLTABLE:%.*]], i32 [[VCR:%.*]], ptr addrspace(5) [[VSP:%.*]], i32 [[ARG:%.*]], ptr [[TABLE:%.*]]) #[[ATTR1]] align 64 !lgc.cps !2 {
+; CHECK-SAME: (i32 inreg [[GLOBALTABLE:%.*]], ptr addrspace(4) inreg [[NUMWORKGROUPSPTR:%.*]], i32 inreg [[PAD0:%.*]], i32 inreg [[PAD1:%.*]], i32 inreg [[PAD2:%.*]], i32 inreg [[PAD3:%.*]], i32 inreg [[PAD4:%.*]], i32 inreg [[PAD5:%.*]], i32 inreg [[PAD6:%.*]], i32 inreg [[PAD7:%.*]], i32 inreg [[PAD8:%.*]], i32 inreg [[PAD9:%.*]], i32 inreg [[PAD10:%.*]], i32 inreg [[PAD11:%.*]], i32 inreg [[SPILLTABLE:%.*]], i32 [[VCR:%.*]], ptr addrspace(5) [[VSP:%.*]], i32 [[ARG:%.*]], ptr [[TABLE:%.*]]) #[[ATTR1]] align 64 !lgc.cps !2 {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[TMP12:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
-; CHECK-NEXT:    [[TMP13:%.*]] = call i64 @llvm.amdgcn.s.getpc()
-; CHECK-NEXT:    [[TMP14:%.*]] = bitcast i64 [[TMP13]] to <2 x i32>
-; CHECK-NEXT:    [[TMP15:%.*]] = getelementptr inbounds i8, ptr addrspace(5) [[VSP]], i32 -4
-; CHECK-NEXT:    [[CPS_STATE:%.*]] = load { i32 }, ptr addrspace(5) [[TMP15]], align 4
-; CHECK-NEXT:    store ptr addrspace(5) [[TMP15]], ptr addrspace(5) [[TMP12]], align 4
+; CHECK-NEXT:    [[TMP0:%.*]] = alloca ptr addrspace(5), align 4, addrspace(5)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i64 @llvm.amdgcn.s.getpc()
+; CHECK-NEXT:    [[TMP2:%.*]] = bitcast i64 [[TMP1]] to <2 x i32>
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds i8, ptr addrspace(5) [[VSP]], i32 -4
+; CHECK-NEXT:    [[CPS_STATE:%.*]] = load { i32 }, ptr addrspace(5) [[TMP3]], align 4
+; CHECK-NEXT:    store ptr addrspace(5) [[TMP3]], ptr addrspace(5) [[TMP0]], align 4
 ; CHECK-NEXT:    [[V:%.*]] = extractvalue { i32 } [[CPS_STATE]], 0
 ; CHECK-NEXT:    [[COND:%.*]] = icmp ult i32 [[V]], 3
 ; CHECK-NEXT:    br i1 [[COND]], label [[THEN:%.*]], label [[ELSE:%.*]]
@@ -145,57 +145,57 @@ else:
 ; CHECK-NEXT:    [[THEN_ARG:%.*]] = add i32 [[ARG]], 1
 ; CHECK-NEXT:    [[V_THEN:%.*]] = mul i32 [[V]], 2
 ; CHECK-NEXT:    [[STATE_THEN:%.*]] = insertvalue { i32 } poison, i32 [[V_THEN]], 0
-; CHECK-NEXT:    [[TMP16:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP12]], align 4
-; CHECK-NEXT:    store { i32 } [[STATE_THEN]], ptr addrspace(5) [[TMP16]], align 4
-; CHECK-NEXT:    [[TMP17:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP16]], i32 4
+; CHECK-NEXT:    [[TMP4:%.*]] = load ptr addrspace(5), ptr addrspace(5) [[TMP0]], align 4
+; CHECK-NEXT:    store { i32 } [[STATE_THEN]], ptr addrspace(5) [[TMP4]], align 4
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i8, ptr addrspace(5) [[TMP4]], i32 4
 ; CHECK-NEXT:    br label [[TAIL_BLOCK:%.*]]
 ; CHECK:       else:
 ; CHECK-NEXT:    br label [[TAIL_BLOCK]]
 ; CHECK:       tail.block:
-; CHECK-NEXT:    [[TMP18:%.*]] = phi i32 [ [[CR_THEN]], [[THEN]] ], [ 0, [[ELSE]] ]
-; CHECK-NEXT:    [[TMP19:%.*]] = phi ptr addrspace(5) [ [[TMP17]], [[THEN]] ], [ poison, [[ELSE]] ]
-; CHECK-NEXT:    [[TMP20:%.*]] = phi i32 [ [[THEN_ARG]], [[THEN]] ], [ poison, [[ELSE]] ]
-; CHECK-NEXT:    [[TMP21:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } poison, i32 [[TMP18]], 0
-; CHECK-NEXT:    [[TMP22:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP21]], ptr addrspace(5) [[TMP19]], 1
-; CHECK-NEXT:    [[TMP23:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP22]], i32 [[TMP20]], 2
-; CHECK-NEXT:    [[TMP24:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
-; CHECK-NEXT:    [[TMP25:%.*]] = bitcast i64 [[TMP24]] to <2 x i32>
-; CHECK-NEXT:    [[TMP26:%.*]] = extractelement <2 x i32> [[TMP25]], i64 0
-; CHECK-NEXT:    [[TMP27:%.*]] = extractelement <2 x i32> [[TMP25]], i64 1
-; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
-; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[TMP26]], i64 1
-; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[TMP27]], i64 2
-; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[TMP0]], i64 3
-; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <16 x i32> [[TMP31]], i32 [[TMP1]], i64 4
-; CHECK-NEXT:    [[TMP33:%.*]] = insertelement <16 x i32> [[TMP32]], i32 [[TMP2]], i64 5
-; CHECK-NEXT:    [[TMP34:%.*]] = insertelement <16 x i32> [[TMP33]], i32 [[TMP3]], i64 6
-; CHECK-NEXT:    [[TMP35:%.*]] = insertelement <16 x i32> [[TMP34]], i32 [[TMP4]], i64 7
-; CHECK-NEXT:    [[TMP36:%.*]] = insertelement <16 x i32> [[TMP35]], i32 [[TMP5]], i64 8
-; CHECK-NEXT:    [[TMP37:%.*]] = insertelement <16 x i32> [[TMP36]], i32 [[TMP6]], i64 9
-; CHECK-NEXT:    [[TMP38:%.*]] = insertelement <16 x i32> [[TMP37]], i32 [[TMP7]], i64 10
-; CHECK-NEXT:    [[TMP39:%.*]] = insertelement <16 x i32> [[TMP38]], i32 [[TMP8]], i64 11
-; CHECK-NEXT:    [[TMP40:%.*]] = insertelement <16 x i32> [[TMP39]], i32 [[TMP9]], i64 12
-; CHECK-NEXT:    [[TMP41:%.*]] = insertelement <16 x i32> [[TMP40]], i32 [[TMP10]], i64 13
-; CHECK-NEXT:    [[TMP42:%.*]] = insertelement <16 x i32> [[TMP41]], i32 [[TMP11]], i64 14
-; CHECK-NEXT:    [[TMP43:%.*]] = insertelement <16 x i32> [[TMP42]], i32 [[SPILLTABLE]], i64 15
-; CHECK-NEXT:    [[TMP44:%.*]] = extractvalue { i32, ptr addrspace(5), i32 } [[TMP23]], 0
-; CHECK-NEXT:    [[TMP45:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg.1(i32 [[TMP44]], i32 [[VCR]])
-; CHECK-NEXT:    [[TMP46:%.*]] = icmp ne i32 [[TMP45]], 0
-; CHECK-NEXT:    [[TMP47:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP46]])
-; CHECK-NEXT:    [[TMP48:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP47]], i1 true)
-; CHECK-NEXT:    [[TMP49:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP45]], i32 [[TMP48]])
-; CHECK-NEXT:    [[TMP50:%.*]] = icmp eq i32 [[TMP45]], [[TMP49]]
-; CHECK-NEXT:    [[TMP51:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP50]])
-; CHECK-NEXT:    [[TMP52:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP49]])
-; CHECK-NEXT:    [[TMP53:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP51]])
-; CHECK-NEXT:    [[TMP54:%.*]] = icmp eq i32 [[TMP52]], 0
-; CHECK-NEXT:    br i1 [[TMP54]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
+; CHECK-NEXT:    [[TMP6:%.*]] = phi i32 [ [[CR_THEN]], [[THEN]] ], [ 0, [[ELSE]] ]
+; CHECK-NEXT:    [[TMP7:%.*]] = phi ptr addrspace(5) [ [[TMP5]], [[THEN]] ], [ poison, [[ELSE]] ]
+; CHECK-NEXT:    [[TMP8:%.*]] = phi i32 [ [[THEN_ARG]], [[THEN]] ], [ poison, [[ELSE]] ]
+; CHECK-NEXT:    [[TMP9:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } poison, i32 [[TMP6]], 0
+; CHECK-NEXT:    [[TMP10:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP9]], ptr addrspace(5) [[TMP7]], 1
+; CHECK-NEXT:    [[TMP11:%.*]] = insertvalue { i32, ptr addrspace(5), i32 } [[TMP10]], i32 [[TMP8]], 2
+; CHECK-NEXT:    [[TMP12:%.*]] = ptrtoint ptr addrspace(4) [[NUMWORKGROUPSPTR]] to i64
+; CHECK-NEXT:    [[TMP13:%.*]] = bitcast i64 [[TMP12]] to <2 x i32>
+; CHECK-NEXT:    [[TMP14:%.*]] = extractelement <2 x i32> [[TMP13]], i64 0
+; CHECK-NEXT:    [[TMP15:%.*]] = extractelement <2 x i32> [[TMP13]], i64 1
+; CHECK-NEXT:    [[TMP16:%.*]] = insertelement <16 x i32> poison, i32 [[GLOBALTABLE]], i64 0
+; CHECK-NEXT:    [[TMP17:%.*]] = insertelement <16 x i32> [[TMP16]], i32 [[TMP14]], i64 1
+; CHECK-NEXT:    [[TMP18:%.*]] = insertelement <16 x i32> [[TMP17]], i32 [[TMP15]], i64 2
+; CHECK-NEXT:    [[TMP19:%.*]] = insertelement <16 x i32> [[TMP18]], i32 [[PAD0]], i64 3
+; CHECK-NEXT:    [[TMP20:%.*]] = insertelement <16 x i32> [[TMP19]], i32 [[PAD1]], i64 4
+; CHECK-NEXT:    [[TMP21:%.*]] = insertelement <16 x i32> [[TMP20]], i32 [[PAD2]], i64 5
+; CHECK-NEXT:    [[TMP22:%.*]] = insertelement <16 x i32> [[TMP21]], i32 [[PAD3]], i64 6
+; CHECK-NEXT:    [[TMP23:%.*]] = insertelement <16 x i32> [[TMP22]], i32 [[PAD4]], i64 7
+; CHECK-NEXT:    [[TMP24:%.*]] = insertelement <16 x i32> [[TMP23]], i32 [[PAD5]], i64 8
+; CHECK-NEXT:    [[TMP25:%.*]] = insertelement <16 x i32> [[TMP24]], i32 [[PAD6]], i64 9
+; CHECK-NEXT:    [[TMP26:%.*]] = insertelement <16 x i32> [[TMP25]], i32 [[PAD7]], i64 10
+; CHECK-NEXT:    [[TMP27:%.*]] = insertelement <16 x i32> [[TMP26]], i32 [[PAD8]], i64 11
+; CHECK-NEXT:    [[TMP28:%.*]] = insertelement <16 x i32> [[TMP27]], i32 [[PAD9]], i64 12
+; CHECK-NEXT:    [[TMP29:%.*]] = insertelement <16 x i32> [[TMP28]], i32 [[PAD10]], i64 13
+; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <16 x i32> [[TMP29]], i32 [[PAD11]], i64 14
+; CHECK-NEXT:    [[TMP31:%.*]] = insertelement <16 x i32> [[TMP30]], i32 [[SPILLTABLE]], i64 15
+; CHECK-NEXT:    [[TMP32:%.*]] = extractvalue { i32, ptr addrspace(5), i32 } [[TMP11]], 0
+; CHECK-NEXT:    [[TMP33:%.*]] = call i32 @llvm.amdgcn.setinactive.chain.arg.1(i32 [[TMP32]], i32 [[VCR]])
+; CHECK-NEXT:    [[TMP34:%.*]] = icmp ne i32 [[TMP33]], 0
+; CHECK-NEXT:    [[TMP35:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP34]])
+; CHECK-NEXT:    [[TMP36:%.*]] = call i32 @llvm.cttz.i32(i32 [[TMP35]], i1 true)
+; CHECK-NEXT:    [[TMP37:%.*]] = call i32 @llvm.amdgcn.readlane(i32 [[TMP33]], i32 [[TMP36]])
+; CHECK-NEXT:    [[TMP38:%.*]] = icmp eq i32 [[TMP33]], [[TMP37]]
+; CHECK-NEXT:    [[TMP39:%.*]] = call i32 @llvm.amdgcn.ballot.i32(i1 [[TMP38]])
+; CHECK-NEXT:    [[TMP40:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP37]])
+; CHECK-NEXT:    [[TMP41:%.*]] = call i32 @llvm.amdgcn.wwm.i32(i32 [[TMP39]])
+; CHECK-NEXT:    [[TMP42:%.*]] = icmp eq i32 [[TMP40]], 0
+; CHECK-NEXT:    br i1 [[TMP42]], label [[RET_BLOCK:%.*]], label [[CHAIN_BLOCK:%.*]]
 ; CHECK:       chain.block:
-; CHECK-NEXT:    [[TMP55:%.*]] = and i32 [[TMP52]], -64
-; CHECK-NEXT:    [[TMP56:%.*]] = insertelement <2 x i32> [[TMP14]], i32 [[TMP55]], i64 0
-; CHECK-NEXT:    [[TMP57:%.*]] = bitcast <2 x i32> [[TMP56]] to i64
-; CHECK-NEXT:    [[TMP58:%.*]] = inttoptr i64 [[TMP57]] to ptr
-; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32s(ptr [[TMP58]], i32 [[TMP53]], <16 x i32> [[TMP43]], { i32, ptr addrspace(5), i32 } [[TMP23]], i32 0)
+; CHECK-NEXT:    [[TMP43:%.*]] = and i32 [[TMP40]], -64
+; CHECK-NEXT:    [[TMP44:%.*]] = insertelement <2 x i32> [[TMP2]], i32 [[TMP43]], i64 0
+; CHECK-NEXT:    [[TMP45:%.*]] = bitcast <2 x i32> [[TMP44]] to i64
+; CHECK-NEXT:    [[TMP46:%.*]] = inttoptr i64 [[TMP45]] to ptr
+; CHECK-NEXT:    call void (ptr, i32, <16 x i32>, { i32, ptr addrspace(5), i32 }, i32, ...) @llvm.amdgcn.cs.chain.p0.i32.v16i32.sl_i32p5i32s(ptr inreg [[TMP46]], i32 inreg [[TMP41]], <16 x i32> inreg [[TMP31]], { i32, ptr addrspace(5), i32 } [[TMP11]], i32 0)
 ; CHECK-NEXT:    unreachable
 ; CHECK:       ret.block:
 ; CHECK-NEXT:    ret void


### PR DESCRIPTION
The backend is starting to verify that the SGPRs should have InReg attribute, I think it should be ok to just add the attribute for all uniform arguments. See (https://reviews.llvm.org/D156409) for the LLVM change.