### PR TITLE
Explictly capture `this` in lambdas

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -114,7 +114,7 @@ Value *BuilderImpl::CreateFpTruncWithRounding(Value *value, Type *destTy, Roundi
     // RTN/RTP: Use fptrunc_round intrinsic.
     StringRef roundingModeStr = convertRoundingModeToStr(roundingMode).value();
     Value *roundingMode = MetadataAsValue::get(getContext(), MDString::get(getContext(), roundingModeStr));
-    Value *result = scalarize(value, [=](Value *inValue) {
+    Value *result = scalarize(value, [=, this](Value *inValue) {
       return CreateIntrinsic(Intrinsic::fptrunc_round, {getHalfTy(), inValue->getType()}, {inValue, roundingMode});
     });
     result->setName(instName);

--- a/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -82,7 +82,7 @@ void SPIRVToLLVMDbgTran::createCompilationUnit() {
 }
 
 DIFile *SPIRVToLLVMDbgTran::getDIFile(const string &FileName) {
-  return getOrInsert(FileMap, FileName, [=]() {
+  return getOrInsert(FileMap, FileName, [=, this]() {
     SplitFileName Split(FileName);
     return Builder.createFile(Split.BaseName, Split.Path);
   });

--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -918,7 +918,7 @@ public:
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
     assert(Pairs.size() % 2 == 0);
-    foreachPair([=](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
+    foreachPair([=, this](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
       assert(IncomingV->isForward() || IncomingV->getType() == Type);
       assert(IncomingBB->isBasicBlock() || IncomingBB->isForward());
     });


### PR DESCRIPTION
C++20 deprecates implicit `this` capture when a default = capture is used.