### PR TITLE
Disable the export of SampleMask

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -48,7 +48,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 65
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 0
+#define LLPC_INTERFACE_MINOR_VERSION 1
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -79,6 +79,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     65.1 | Add disableSampleMask to PipelineOptions                                                              |
 //  |     65.0 | Remove updateDescInElf                                                                                |
 //  |     64.0 | Add enableColorExportShader to GraphicsPipelineBuildInfo.                                             |
 //  |     63.0 | Add Atomic Counter, its default descriptor and map its concreteType to Buffer.                        |
@@ -568,6 +569,7 @@ struct PipelineOptions {
   unsigned forceNonUniformResourceIndexStageMask; ///< Mask of the stage to force using non-uniform resource index.
   bool reserved16;
   bool replaceSetWithResourceType; ///< For OGL only, replace 'set' with resource type during spirv translate
+  bool disableSampleMask;          ///< For OGL only, disabled if framebuffer doesn't attach multisample texture
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -158,6 +158,7 @@ union Options {
     bool enableColorExportShader; // Explicitly build color export shader, UnlinkedStageFragment elf will return extra
                                   // meta data.
     bool fragCoordUsesInterpLoc;  // Determining fragCoord use InterpLoc
+    bool disableSampleMask;       // Disable export of sample mask from PS
   };
 };
 static_assert(sizeof(Options) == sizeof(Options::u32All));

--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -769,10 +769,12 @@ void LowerFragColorExport::collectExportInfoForBuiltinOutput(Function *module, B
       }
       case BuiltInSampleMask: {
         assert(output->getType()->isArrayTy());
+        if (!m_pipelineState->getOptions().disableSampleMask) {
+          // NOTE: Only gl_SampleMask[0] is valid for us.
+          m_sampleMask = builder.CreateExtractValue(output, {0});
+          m_sampleMask = builder.CreateBitCast(m_sampleMask, builder.getFloatTy());
+        }
 
-        // NOTE: Only gl_SampleMask[0] is valid for us.
-        m_sampleMask = builder.CreateExtractValue(output, {0});
-        m_sampleMask = builder.CreateBitCast(m_sampleMask, builder.getFloatTy());
         break;
       }
       case BuiltInFragStencilRef: {

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -340,6 +340,7 @@ Options PipelineContext::computePipelineOptions() const {
   // Driver report full subgroup lanes for compute shader, here we just set fullSubgroups as default options
   options.fullSubgroups = true;
   options.internalRtShaders = getPipelineOptions()->internalRtShaders;
+  options.disableSampleMask = getPipelineOptions()->disableSampleMask;
 
   return options;
 }

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -856,6 +856,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
   dumpFile << "options.forceNonUniformResourceIndexStageMask = " << options->forceNonUniformResourceIndexStageMask
            << "\n";
   dumpFile << "options.replaceSetWithResourceType = " << options->replaceSetWithResourceType << "\n";
+  dumpFile << "options.disableSampleMask = " << options->disableSampleMask << "\n";
 }
 
 // =====================================================================================================================
@@ -1630,6 +1631,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
 
   if (stage == UnlinkedStageFragment || stage == UnlinkedStageCount) {
     hasher->Update(options->enableInterpModePatch);
+    hasher->Update(options->disableSampleMask);
   }
 
   hasher->Update(options->pageMigrationEnabled);

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1640,6 +1640,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
   hasher->Update(options->reverseThreadGroup);
   hasher->Update(options->internalRtShaders);
   hasher->Update(options->forceNonUniformResourceIndexStageMask);
+  hasher->Update(options->replaceSetWithResourceType);
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -487,6 +487,7 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, internalRtShaders, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizeTessFactor, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, replaceSetWithResourceType, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, disableSampleMask, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};


### PR DESCRIPTION
Add an option 'disableSampleMask' to PipelineOptions.

For OGLP, if a frame buffer doesn't attach multisample texture,

it is expected that gl_sampleMask is not exported.