### PR TITLE
Add workaround to fix GPU hang caused by incorrect scratch offset

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1307,6 +1307,18 @@ uint64_t PatchEntryPointMutate::generateEntryPointArgTys(ShaderInputs *shaderInp
     }
   }
 
+  // NOTE: We encounter a HW defect on GFX9. When there is only one user SGPR (corresponds to global table, s0),
+  // the SGPR corresponding to scratch offset (s2) of PS is incorrectly initialized. This leads to invalid scratch
+  // memory access, causing GPU hang. Thus, we detect such case and add a dummy user SGPR in order not to map scratch
+  // offset to s2.
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major == 9 && m_shaderStage == ShaderStageFragment) {
+    if (userDataIdx == 1) {
+      argTys.push_back(builder.getInt32Ty());
+      argNames.push_back("dummyInit");
+      userDataIdx += 1;
+    }
+  }
+
   intfData->userDataCount = userDataIdx;
   inRegMask = (1ull << argTys.size()) - 1;
 


### PR DESCRIPTION
We find a HW defect on GFX9. When there is only one user SGPR (global table, s0), the scratch offset (s2) of PS will be incorrectly initialized by HW. This leads to invalud scratch memory access. Note that s1 is primitive mask and is always present according to HW spec. This defect only occurs when scratch offset is mapped to s2.

In order to workaround this defect, we add a dummy user SGPR to avoid mapping scratch offset to s2.

This defect is found when we made this PR:
https://github.com/GPUOpen-Drivers/llpc/pull/2624. The per-shader table occupying s1 was removed, which leads to the CTS failure: VK.graphicsfuzz.arr-value-set-to-arr-value-squared.