### PR TITLE
Implement extension VK_KHR_shader_subgroup_rotate in LLPC.

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -268,6 +268,8 @@ StringRef BuilderRecorder::getCallName(BuilderOpcode opcode) {
     return "subgroup.any";
   case BuilderOpcode::SubgroupAllEqual:
     return "subgroup.all.equal";
+  case BuilderOpcode::SubgroupRotate:
+    return "subgroup.rotate";
   case BuilderOpcode::SubgroupBroadcast:
     return "subgroup.broadcast";
   case BuilderOpcode::SubgroupBroadcastWaterfall:
@@ -1797,6 +1799,18 @@ Value *Builder::CreateSubgroupShuffleDown(Value *const value, Value *const offse
 }
 
 // =====================================================================================================================
+// Create a subgroup rotate call.
+//
+// @param value : The value to read from the chosen rotated lane to all active lanes.
+// @param delta : The delta/offset added to lane id.
+// @param clusterSize : The cluster size if exists.
+// @param instName : Name to give instruction.
+Value *Builder::CreateSubgroupRotate(Value *const value, Value *const delta, Value *const clusterSize,
+                                     const Twine &instName) {
+  return record(BuilderOpcode::SubgroupRotate, value->getType(), {value, delta, clusterSize}, instName);
+}
+
+// =====================================================================================================================
 // Create a subgroup clustered reduction.
 //
 // @param groupArithOp : The group operation to perform
@@ -2058,6 +2072,7 @@ Instruction *Builder::record(BuilderOpcode opcode, Type *resultTy, ArrayRef<Valu
       break;
     case BuilderOpcode::SubgroupAll:
     case BuilderOpcode::SubgroupAllEqual:
+    case BuilderOpcode::SubgroupRotate:
     case BuilderOpcode::SubgroupAny:
     case BuilderOpcode::SubgroupBallot:
     case BuilderOpcode::SubgroupBroadcast:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -164,6 +164,7 @@ enum BuilderOpcode : unsigned {
   SubgroupAll,
   SubgroupAny,
   SubgroupAllEqual,
+  SubgroupRotate,
   SubgroupBroadcast,
   SubgroupBroadcastWaterfall,
   SubgroupBroadcastFirst,

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -739,6 +739,9 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
   case BuilderOpcode::SubgroupAllEqual: {
     return m_builder->CreateSubgroupAllEqual(args[0]);
   }
+  case BuilderOpcode::SubgroupRotate: {
+    return m_builder->CreateSubgroupRotate(args[0], args[1], isa<PoisonValue>(args[2]) ? nullptr : &*args[2]);
+  }
   case BuilderOpcode::SubgroupBroadcast: {
     return m_builder->CreateSubgroupBroadcast(args[0], args[1]);
   }

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -650,6 +650,10 @@ public:
   // Create a subgroup all.
   llvm::Value *CreateSubgroupAll(llvm::Value *const value, const llvm::Twine &instName = "");
 
+  // Create a subgroup rotate.
+  llvm::Value *CreateSubgroupRotate(llvm::Value *const value, llvm::Value *const delta, llvm::Value *const clusterSize,
+                                    const llvm::Twine &instName = "");
+
   // Create a subgroup any
   llvm::Value *CreateSubgroupAny(llvm::Value *const value, const llvm::Twine &instName = "");
 

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1397,6 +1397,15 @@ public:
   // @param instName : Name to give instruction(s)
   llvm::Value *CreateSubgroupAllEqual(llvm::Value *const value, const llvm::Twine &instName = "");
 
+  // Create a subgroup rotate call.
+  //
+  // @param value : The value to read from the chosen rotated lane to all active lanes.
+  // @param delta : The delta/offset added to lane id.
+  // @param clusterSize : The cluster size if exists.
+  // @param instName : Name to give instruction.
+  llvm::Value *CreateSubgroupRotate(llvm::Value *const value, llvm::Value *const delta, llvm::Value *const clusterSize,
+                                    const llvm::Twine &instName = "");
+
   // Create a subgroup broadcast.
   //
   // @param value : The value to broadcast


### PR DESCRIPTION
1. Support new extension KHR_shader_subgroup_rotate.

2. Support rotate instr with or without an explicit cluster size.

3. Add a new call op for subgroup.rotate.