### PR TITLE
Workaround perf drop in RT demo

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -207,6 +207,14 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
   // Lower SPIR-V global variables, inputs, and outputs
   passMgr.addPass(SpirvLowerGlobal());
 
+  // Lower SPIR-V ray tracing related stuff, including entry point generation, lgc.rt dialect handling, some of
+  // lgc.gpurt dialect handling.
+  // And do inlining after SpirvLowerRayTracing as it will produce some extra functions.
+  if (rayTracing) {
+    passMgr.addPass(SpirvLowerRayTracing());
+    passMgr.addPass(AlwaysInlinerPass());
+  }
+
   // Lower SPIR-V constant immediate store.
   passMgr.addPass(SpirvLowerConstImmediateStore());
 
@@ -243,14 +251,6 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 
   // Lower SPIR-V instruction metadata remove
   passMgr.addPass(SpirvLowerInstMetaRemove());
-
-  // Lower SPIR-V ray tracing related stuff, including entry point generation, lgc.rt dialect handling, some of
-  // lgc.gpurt dialect handling.
-  // And do inlining after SpirvLowerRayTracing as it will produce some extra functions.
-  if (rayTracing) {
-    passMgr.addPass(SpirvLowerRayTracing());
-    passMgr.addPass(AlwaysInlinerPass());
-  }
 
   if (rayTracing || rayQuery) {
     passMgr.addPass(LowerGpuRt());


### PR DESCRIPTION
This commit workarounds the performance drop observed in GPSnoopy's RayTracingInVulkan demo.

The perf drop is caused by an extra `s_waitcnt vmcnt(2)` being generated, when the input IR has the difference on the order of `phi`s. Detail are discussed in an internal mail thread.

Before the root cause is addressed, apply this workaround to unblock promotion.

This is a regression caused by https://github.com/GPUOpen-Drivers/llpc/commit/538825fbcfbb5e3be1e751fc7755c495679c10c4