### PR TITLE
lgc: fix backtracking of user data when spill is required

### DIFF
--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1674,7 +1674,7 @@ void PatchEntryPointMutate::finalizeUserDataArgs(SmallVectorImpl<UserDataArg> &u
             // No space left for the spill table, we need to backtrack.
             assert(lastSize > 0);
             userDataArgs.erase(userDataArgs.end() - lastSize, userDataArgs.end());
-            userDataEnd -= size;
+            userDataEnd -= lastSize;
             spillUsage = lastIdx;
           }
           --userDataAvailable;


### PR DESCRIPTION
We need to backtrack by the size of the *last* node, not by the size of the *current* node.

Fixes: dd22a7f5288 ("lgc: refactor user data access lowering")