### PR TITLE
Rename PipelineShaderOptions noContract to noContractOpDot.

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -45,10 +45,10 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 65
+#define LLPC_INTERFACE_MAJOR_VERSION 66
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 0
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -79,6 +79,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     66.0 | Rename noContract in PipelineShaderOptions to noContractOpDot
 //  |     65.1 | Add disableSampleMask to PipelineOptions                                                              |
 //  |     65.0 | Remove updateDescInElf                                                                                |
 //  |     64.0 | Add enableColorExportShader to GraphicsPipelineBuildInfo.                                             |
@@ -796,8 +797,8 @@ struct PipelineShaderOptions {
   /// Threshold to use for loops with "DontUnroll" hint (0 = use llvm.llop.unroll.disable).
   unsigned dontUnrollHintThreshold;
 
-  /// Whether fastmath contract could be disabled
-  bool noContract;
+  /// Whether fastmath contract could be disabled on Dot operations.
+  bool noContractOpDot;
 
   /// The enabled fast math flags (0 = depends on input language).
   unsigned fastMathFlags;

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -1973,9 +1973,9 @@ std::unique_ptr<Module> Compiler::createGpurtShaderLibrary(Context *context) {
   shaderInfo.pEntryTarget = Vkgc::getEntryPointNameFromSpirvBinary(&rtState->gpurtShaderLibrary);
   shaderInfo.pModuleData = &moduleData;
 
-  // Disable fast math Contract when there is no hardware intersectRay
+  // Disable fast math contract on OpDot when there is no hardware intersectRay
   bool hwIntersectRay = rtState->bvhResDesc.dataSizeInDwords > 0;
-  shaderInfo.options.noContract = !hwIntersectRay;
+  shaderInfo.options.noContractOpDot = !hwIntersectRay;
 
   auto module = std::make_unique<Module>(RtName::TraceRayKHR, *context);
   context->setModuleTargetMachine(module.get());

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -4680,7 +4680,7 @@ template <> Value *SPIRVToLLVM::transValueWithOpcode<OpOuterProduct>(SPIRVValue 
 //
 // @param spvValue : A SPIR-V value.
 template <> Value *SPIRVToLLVM::transValueWithOpcode<OpDot>(SPIRVValue *const spvValue) {
-  if (m_shaderOptions->noContract) {
+  if (m_shaderOptions->noContractOpDot) {
     auto fmf = getBuilder()->getFastMathFlags();
     fmf.setAllowContract(false);
     getBuilder()->setFastMathFlags(fmf);


### PR DESCRIPTION
It only effects OpDot in SPIRV reader.