### PR TITLE
llpc: Add Intrinsics implementation for FloatOpWithRoundMode

### DIFF
--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -387,7 +387,7 @@ void SpirvProcessGpuRtLibrary::createFloatOpWithRoundMode(Function *func) {
   Value *src0 = m_builder->CreateLoad(retType, argIt++);
   Value *src1 = m_builder->CreateLoad(retType, argIt);
 
-  Value *fpExcpt = MetadataAsValue::get(*m_context, MDString::get(*m_context, "fpexcept.strict"));
+  Value *fpExcpt = MetadataAsValue::get(*m_context, MDString::get(*m_context, "fpexcept.ignore"));
 
   auto rmDefault = BasicBlock::Create(*m_context, ".rmDefault", func, nullptr);
   auto opDefault = BasicBlock::Create(*m_context, ".opDefault", func, nullptr);

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -355,6 +355,7 @@ void SpirvProcessGpuRtLibrary::createConvertF32toF16WithRoundingMode(Function *f
 // Create function to do the float op with the round Mode.
 //
 // @param func : The function to process
+// 
 void SpirvProcessGpuRtLibrary::createFloatOpWithRoundMode(Function *func) {
 
   enum OperationType : uint32_t { Add = 0, Sub, Mul };
@@ -375,6 +376,9 @@ void SpirvProcessGpuRtLibrary::createFloatOpWithRoundMode(Function *func) {
   Value *result = PoisonValue::get(retType);
 
   // Try to get the op and roundMode through the store intrinsic directly.
+  // Note : we avoid the switch-case for checking the round mode and op type here,
+  // because these args are constant value in SPV code, so just get them from the used calls directly,
+  // and then replace all uesed calls with the operation.
   SmallVector<CallInst *> callsToBeRemoved;
   for (auto user : func->users()) {
     assert(isa<CallInst>(user));
@@ -434,8 +438,8 @@ void SpirvProcessGpuRtLibrary::createFloatOpWithRoundMode(Function *func) {
     call->eraseFromParent();
   }
 
-  m_builder->SetInsertPoint(&func->getEntryBlock());
-  m_builder->CreateRetVoid();
+  func->dropAllReferences();
+  func->eraseFromParent();
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -355,7 +355,6 @@ void SpirvProcessGpuRtLibrary::createConvertF32toF16WithRoundingMode(Function *f
 // Create function to do the float op with the round Mode.
 //
 // @param func : The function to process
-// 
 void SpirvProcessGpuRtLibrary::createFloatOpWithRoundMode(Function *func) {
 
   enum OperationType : uint32_t { Add = 0, Sub, Mul };

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.h
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.h
@@ -85,5 +85,6 @@ private:
   void createDispatchRayIndex(llvm::Function *func);
   void createGetStaticId(llvm::Function *func);
   llvm::Value *createGetBvhSrd(llvm::Value *expansion, llvm::Value *boxSortMode);
+  void createFloatOpWithRoundMode(llvm::Function *func);
 };
 } // namespace Llpc


### PR DESCRIPTION
add the missed floatOp with roundMode support for RT

HLSL:

static float FloatOpWithRoundMode(uint roundMode, uint operation, float src0, float src1)
{
    return AmdExtD3DShaderIntrinsics_FloatOpWithRoundMode(roundMode, operation, src0, src1);
}

SPV:
               OpStore %479 %uint_1
               OpStore %480 %uint_1
               OpStore %481 %4548
               OpStore %482 %4551
       %4589 = OpFunctionCall %v3float %AmdExtD3DShaderIntrinsics_FloatOpWithRoundMode %479 %480 %481 %482
