### PR TITLE
lgc: Update ALPHA_TO_MASK_DISABLE in color export shader

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -195,4 +195,5 @@ void ColorExportShader::updatePalMetadata(PalMetadata &palMetadata) {
 
   palMetadata.updateSpiShaderColFormat(finalExportFormats);
   palMetadata.updateCbShaderMask(m_exports);
+  palMetadata.updateDbShaderControl();
 }

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -169,6 +169,9 @@ public:
   // Updates the CB shader mask information that depends on the exports.
   void updateCbShaderMask(llvm::ArrayRef<ColorExportInfo> exps);
 
+  // Updates the DB shader control that depends on the CB state.
+  void updateDbShaderControl();
+
   // Sets the finalized 128-bit cache hash.  The version identifies the version of LLPC used to generate the hash.
   void setFinalized128BitCacheHash(const lgc::Hash128 &finalizedCacheHash, const llvm::VersionTuple &version);
 

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -1120,10 +1120,10 @@ void PalMetadata::updateDbShaderControl() {
   if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9) {
     if (m_pipelineState->useRegisterFieldFormat()) {
       auto dbShaderControl = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters]
-                                  .getMap(true)[Util::Abi::GraphicsRegisterMetadataKey::DbShaderControl]
-                                  .getMap(true);
+                                 .getMap(true)[Util::Abi::GraphicsRegisterMetadataKey::DbShaderControl]
+                                 .getMap(true);
       dbShaderControl[Util::Abi::DbShaderControlMetadataKey::AlphaToMaskDisable] =
-        !m_pipelineState->getColorExportState().alphaToCoverageEnable;
+          !m_pipelineState->getColorExportState().alphaToCoverageEnable;
     } else {
       DB_SHADER_CONTROL dbShaderControl = {};
       dbShaderControl.u32All = getRegister(mmDB_SHADER_CONTROL);

--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -1114,6 +1114,26 @@ void PalMetadata::updateCbShaderMask(llvm::ArrayRef<ColorExportInfo> exps) {
 }
 
 // =====================================================================================================================
+//  Updates the DB shader control that depends on the CB state.
+//
+void PalMetadata::updateDbShaderControl() {
+  if (m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 9) {
+    if (m_pipelineState->useRegisterFieldFormat()) {
+      auto dbShaderControl = m_pipelineNode[Util::Abi::PipelineMetadataKey::GraphicsRegisters]
+                                  .getMap(true)[Util::Abi::GraphicsRegisterMetadataKey::DbShaderControl]
+                                  .getMap(true);
+      dbShaderControl[Util::Abi::DbShaderControlMetadataKey::AlphaToMaskDisable] =
+        !m_pipelineState->getColorExportState().alphaToCoverageEnable;
+    } else {
+      DB_SHADER_CONTROL dbShaderControl = {};
+      dbShaderControl.u32All = getRegister(mmDB_SHADER_CONTROL);
+      dbShaderControl.bitfields.ALPHA_TO_MASK_DISABLE = !m_pipelineState->getColorExportState().alphaToCoverageEnable;
+      setRegister(mmDB_SHADER_CONTROL, dbShaderControl.u32All);
+    }
+  }
+}
+
+// =====================================================================================================================
 // Fills the xglCacheInfo section of the PAL metadata with the given data.
 //
 // @param finalizedCacheHash : The finalized hash that will be used to look for this pipeline in caches.


### PR DESCRIPTION
Need to override dbShaderControl.ALPHA_TO_MASK_DISABLE in color export shader with respect to alphaToCoverage from cbState.

Affected CTS list:
dEQP-VK.pipeline.fast_linked_library.multisample_with_fragment_shading_rate.alpha_to_coverage*