### PR TITLE
Add streamActive to XfbMetadata

### DIFF
--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -46,6 +46,10 @@ using namespace llvm;
 Instruction *BuilderImpl::CreateEmitVertex(unsigned streamId) {
   assert(m_shaderStage == ShaderStageGeometry);
 
+  // Mark this vertex stream as active if transform feedback is enabled or this is the rasterization stream.
+  if (m_pipelineState->enableXfb() || m_pipelineState->getRasterizerState().rasterStream == streamId)
+    m_pipelineState->setVertexStreamActive(streamId);
+
   // Get GsWaveId
   std::string callName = lgcName::InputImportBuiltIn;
   callName += "GsWaveId.i32.i32";
@@ -63,6 +67,10 @@ Instruction *BuilderImpl::CreateEmitVertex(unsigned streamId) {
 // @param streamId : Stream number, 0 if only one stream is present
 Instruction *BuilderImpl::CreateEndPrimitive(unsigned streamId) {
   assert(m_shaderStage == ShaderStageGeometry);
+
+  // Mark this vertex stream as active if transform feedback is enabled or this is the rasterization stream.
+  if (m_pipelineState->enableXfb() || m_pipelineState->getRasterizerState().rasterStream == streamId)
+    m_pipelineState->setVertexStreamActive(streamId);
 
   // Get GsWaveId
   std::string callName = lgcName::InputImportBuiltIn;

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -102,8 +102,9 @@ struct NggControl {
 // Represents transform feedback state metadata
 struct XfbStateMetadata {
   bool enableXfb;                                               // Whether transform feedback is active
-  std::array<unsigned, MaxTransformFeedbackBuffers> xfbStrides; // The strides of each XFB buffer.
-  std::array<int, MaxGsStreams> streamXfbBuffers;               // The stream-out XFB buffers bit mask per stream.
+  std::array<unsigned, MaxTransformFeedbackBuffers> xfbStrides; // The strides of each XFB buffer
+  std::array<int, MaxGsStreams> streamXfbBuffers;               // The stream-out XFB buffers bit mask per stream
+  std::array<bool, MaxGsStreams> streamActive;                  // Flag indicating which vertex stream is active
 };
 
 // =====================================================================================================================
@@ -371,12 +372,6 @@ public:
   // Set transform feedback state metadata
   void setXfbStateMetadata(llvm::Module *module);
 
-  // Get XFB state metadata
-  const XfbStateMetadata &getXfbStateMetadata() const { return m_xfbStateMetadata; }
-
-  // Get XFB state metadata
-  XfbStateMetadata &getXfbStateMetadata() { return m_xfbStateMetadata; }
-
   // Check if transform feedback is active
   bool enableXfb() const { return m_xfbStateMetadata.enableXfb; }
 
@@ -393,6 +388,16 @@ public:
 
   // Get transform feedback buffers used for each stream
   std::array<int, MaxGsStreams> &getStreamXfbBuffers() { return m_xfbStateMetadata.streamXfbBuffers; }
+
+  // Set the activness for a vertex stream
+  void setVertexStreamActive(unsigned streamId) { m_xfbStateMetadata.streamActive[streamId] = true; }
+
+  // Get the activeness for a vertex stream
+  bool isVertexStreamActive(unsigned streamId) {
+    if (getRasterizerState().rasterStream == streamId)
+      return true; // Rasterization stream is always active
+    return m_xfbStateMetadata.streamActive[streamId];
+  }
 
   // Set user data for a specific shader stage
   void setUserDataMap(ShaderStage shaderStage, llvm::ArrayRef<unsigned> userDataValues) {


### PR DESCRIPTION
We should check if a vertex stream is active when we encounter EmitVertex or EndPrimitive. Currently, set its activeness of if transform feedback is enabled or the stream itself is the rasterization stream.

In the future, when generated primitive counting is enable, we should set the activeness of a vertex stream as well.