### PR TITLE
Add input/output semantic metadata in partial pipeline

### DIFF
--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -153,6 +153,8 @@ static constexpr char ApiCreateInfo[] = ".api_create_info";
 static constexpr char PsSampleMask[] = ".ps_sample_mask";
 static constexpr char GraphicsRegisters[] = ".graphics_registers";
 static constexpr char ComputeRegisters[] = ".compute_registers";
+static constexpr char PsInputSemantic[] = ".ps_input_semantic";
+static constexpr char PrerasterOutputSemantic[] = ".preraster_output_semantic";
 }; // namespace PipelineMetadataKey
 
 namespace HardwareStageMetadataKey {
@@ -542,6 +544,15 @@ static constexpr char AncillaryEna[] = ".ancillary_ena";
 static constexpr char SampleCoverageEna[] = ".sample_coverage_ena";
 static constexpr char PosFixedPtEna[] = ".pos_fixed_pt_ena";
 }; // namespace SpiPsInputAddrMetadataKey
+
+namespace PrerasterOutputSemanticMetadataKey {
+static constexpr char Semantic[] = ".semantic";
+static constexpr char Index[] = ".index";
+}; // namespace PrerasterOutputSemanticMetadataKey
+
+namespace PsInputSemanticMetadataKey {
+static constexpr char Semantic[] = ".semantic";
+}; // namespace PsInputSemanticMetadataKey
 
 } // namespace Abi
 

--- a/lgc/interface/lgc/BuiltIns.h
+++ b/lgc/interface/lgc/BuiltIns.h
@@ -36,6 +36,9 @@ namespace lgc {
 // Max spirv builtIn value
 static constexpr unsigned BuiltInInternalBase = 0x10000000;
 
+// Max builtIn value = BuiltInInternalBase + 13
+static constexpr unsigned MaxBuiltIn = 0x1000000D;
+
 // Define built-in kind enum.
 enum BuiltInKind : unsigned {
 #define BUILTIN(name, number, out, in, type) BuiltIn##name = number,


### PR DESCRIPTION
Currently, we fail to link relocatable shaders if FS has builtIn inputs. 
To support this kind of case, we add two ArrayDocNodes in ELF: 

`.ps_input_semantic` has one member - `.semantic`
`.preraster_output_semantic` has two members - `.semantic` and `.index`. 

Where `.semantic` encodes builtIn Id and location to perform matching operation and '.index` is used to update the SPI_PS_INPUT_CNTL_*.OFFSET. 