### PR TITLE
llpc: Remove manipulation of FAdd fast math flags

### DIFF
--- a/llpc/lower/llpcSpirvLowerMath.h
+++ b/llpc/lower/llpcSpirvLowerMath.h
@@ -47,7 +47,6 @@ protected:
   void init(llvm::Module &module);
 
   void flushDenormIfNeeded(llvm::Instruction *inst);
-  bool isOperandNoContract(llvm::Value *operand);
 
   bool m_changed;         // Whether the module is changed
   bool m_fp16DenormFlush; // Whether FP mode wants f16 denorms to be flushed to zero


### PR DESCRIPTION
Remove code which attempts to clear contract flag from FAdd operations if any operand (recursively) has a NoContraction decoration.

Removal on the basis of:
1. code is quite old and has no lit tests or clear motivation.
2. it is applied too late to effect all relevant manipulations.
3. implementation of isOperandNoContract was incorrect such that it would not properly recurse other than the first operand. Which means any manipulation of flags was partial at best.

Analysis suggests this change only affects one or two older game titles.  If this is required then it should be added back as tuning enable workaround.
I plan to add support for this in a follow up patch.