### PR TITLE
Add metadata for continufy stage

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -71,6 +71,7 @@ const char *ShaderTable = "ShaderTable";
 static const char *CallAnyHitShader = "AmdTraceRayCallAnyHitShader";
 static const char *FetchTrianglePositionFromNodePointer = "FetchTrianglePositionFromNodePointer";
 static const char *RemapCapturedVaToReplayVa = "AmdTraceRayRemapCapturedVaToReplayVa";
+static const char *ContinufyStageMeta = "continufy.stage";
 } // namespace RtName
 
 namespace Llpc {
@@ -175,6 +176,10 @@ void SpirvLowerRayTracing::processTraceRayCall(BaseTraceRayOp *inst) {
       // Create the indirect function call
       result = m_builder->CreateCall(funcTy, funcPtr, args);
       result->setCallingConv(CallingConv::SPIR_FUNC);
+
+      unsigned lgcRtStage = ~0u;
+      result->setMetadata(RtName::ContinufyStageMeta,
+                          MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
     } else {
       result =
           m_builder->CreateNamedCall(RtName::TraceRayKHR, funcTy->getReturnType(), args, {Attribute::AlwaysInline});
@@ -256,6 +261,11 @@ void SpirvLowerRayTracing::visitCallCallableShaderOp(CallCallableShaderOp &inst)
       auto funcPtr = m_builder->CreateIntToPtr(shaderIdentifier, funcPtrTy);
       CallInst *result = m_builder->CreateCall(funcTy, funcPtr, args);
       result->setCallingConv(CallingConv::SPIR_FUNC);
+
+      unsigned lgcRtStage = static_cast<unsigned>(mapStageToLgcRtShaderStage(ShaderStageRayTracingCallable));
+      result->setMetadata(RtName::ContinufyStageMeta,
+                          MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
+
       m_builder->CreateStore(result, inputResult);
       m_builder->CreateBr(endBlock);
     } else {
@@ -543,6 +553,9 @@ PreservedAnalyses SpirvLowerRayTracing::run(Module &module, ModuleAnalysisManage
   }
   // Process traceRays module
   if (m_shaderStage == ShaderStageCompute) {
+    unsigned lgcRtStage = ~0u;
+    m_entryPoint->setMetadata(RtName::ContinufyStageMeta,
+                              MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
 
     CallInst *call = createTraceRay();
     inlineTraceRay(call, analysisManager);
@@ -569,6 +582,10 @@ PreservedAnalyses SpirvLowerRayTracing::run(Module &module, ModuleAnalysisManage
     m_builder->SetInsertPoint(insertPos);
     createDispatchRaysInfoDesc();
     m_spirvOpMetaKindId = m_context->getMDKindID(MetaNameSpirvOp);
+
+    unsigned lgcRtStage = static_cast<unsigned>(mapStageToLgcRtShaderStage(m_shaderStage));
+    m_entryPoint->setMetadata(RtName::ContinufyStageMeta,
+                              MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
 
     if (m_shaderStage == ShaderStageRayTracingAnyHit || m_shaderStage == ShaderStageRayTracingClosestHit ||
         m_shaderStage == ShaderStageRayTracingIntersect) {
@@ -836,6 +853,11 @@ void SpirvLowerRayTracing::createCallShader(Function *func, ShaderStage stage, u
 
     auto funcPtr = m_builder->CreateIntToPtr(shaderId, funcPtrTy);
     CallInst *result = m_builder->CreateCall(funcTy, funcPtr, args);
+
+    unsigned lgcRtStage = static_cast<unsigned>(mapStageToLgcRtShaderStage(stage));
+    result->setMetadata(RtName::ContinufyStageMeta,
+                        MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
+
     result->setCallingConv(CallingConv::SPIR_FUNC);
     storeFunctionCallResult(stage, result, traceParamsIt);
     m_builder->CreateBr(endBlock);
@@ -1262,6 +1284,11 @@ void SpirvLowerRayTracing::createRayGenEntryFunc() {
     auto funcPtr = m_builder->CreateIntToPtr(rayGenId, funcPtrTy);
     CallInst *call = m_builder->CreateCall(funcTy, funcPtr, {});
     call->setCallingConv(CallingConv::SPIR_FUNC);
+
+    unsigned lgcRtStage = static_cast<unsigned>(mapStageToLgcRtShaderStage(ShaderStageRayTracingRayGen));
+    call->setMetadata(RtName::ContinufyStageMeta,
+                      MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
+
     m_builder->CreateBr(endBlock);
   }
   // Construct end block
@@ -2931,6 +2958,11 @@ llvm::Function *SpirvLowerRayTracing::createImplFunc(CallInst &inst, ArrayRef<Va
   inst.replaceAllUsesWith(newCall);
 
   return m_module->getFunction(mangledName);
+}
+
+lgc::rt::RayTracingShaderStage SpirvLowerRayTracing::mapStageToLgcRtShaderStage(ShaderStage stage) {
+  assert((stage >= ShaderStageRayTracingRayGen) && (stage <= ShaderStageRayTracingCallable));
+  return static_cast<lgc::rt::RayTracingShaderStage>(stage - ShaderStageRayTracingRayGen);
 }
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -61,6 +61,7 @@ class PrimitiveIndexOp;
 class InstanceInclusionMaskOp;
 class ShaderIndexOp;
 class ShaderRecordBufferOp;
+enum class RayTracingShaderStage;
 } // namespace lgc::rt
 
 namespace lgc {
@@ -263,6 +264,8 @@ private:
   void visitShaderRecordBufferOp(lgc::rt::ShaderRecordBufferOp &inst);
 
   llvm::Value *createLoadInstNodeAddr();
+
+  lgc::rt::RayTracingShaderStage mapStageToLgcRtShaderStage(ShaderStage stage);
 
   llvm::Value *m_traceParams[TraceParam::Count];           // Trace ray set parameters
   llvm::Value *m_worldToObjMatrix = nullptr;               // World to Object matrix


### PR DESCRIPTION
Add "continufy.stage" metadata for on functions and indirect calls for Continufy pass to determine ray tracing stages.