### PR TITLE
Pass RT mode to LGC and call SetVsp

### DIFF
--- a/include/gpurt-compiler.h
+++ b/include/gpurt-compiler.h
@@ -92,6 +92,15 @@ struct DispatchRaysConstantData {
   unsigned profileMaxIterations;        ///< Maximum traversal iterations for profiling
   unsigned traceRayGpuVaLo;             ///< Traversal shader (shader table) base address low 32-bits
   unsigned traceRayGpuVaHi;             ///< Traversal shader (shader table) base address high 32-bits
+  unsigned counterMode;                 ///< Counter capture mode. see TraceRayCounterMode
+  unsigned counterRayIdRangeBegin;      ///< Counter capture ray ID range begin
+  unsigned counterRayIdRangeEnd;        ///< Counter capture ray ID range end
+  unsigned cpsBackendStackSize;         ///< The scratch memory used as stacks are divided into two parts:
+                                        ///<  (a) Used by a compiler backend, start at offset 0.
+  unsigned cpsFrontendStackSize; ///<  (b) Used by IR (Intermediate Representation), for a continuation passing shader.
+  unsigned cpsGlobalMemoryAddressLo; ///< Separate CPS stack memory base address low 32-bits
+  unsigned cpsGlobalMemoryAddressHi; ///< Separate CPS stack memory base address high 32-bits
+  unsigned counterMask;              ///< Mask for filtering ray history token
 };
 #pragma pack(pop)
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -103,6 +103,14 @@ enum class ThreadGroupSwizzleMode : unsigned {
   Count,
 };
 
+// Enumerate the ray tracing indirect modes.
+enum class RayTracingIndirectMode : unsigned {
+  NotIndirect = 0,            // Not in indirect mode (or not ray tracing pipeline)
+  Legacy = 1,                 // Legacy indirect mode
+  ContinuationsContinufy = 2, // Continuations flow that based on Continufy pass
+  Continuations = 3,          // Continuations flow that based on LowerRaytracingPipeline pass
+};
+
 // Value for shadowDescriptorTable pipeline option.
 static const unsigned ShadowDescriptorTableDisable = ~0U;
 
@@ -113,7 +121,7 @@ static const char SampleShadingMetaName[] = "lgc.sample.shading";
 // The front-end should zero-initialize a struct with "= {}" in case future changes add new fields.
 // Note: new fields must be added to the end of this structure to maintain test compatibility.
 union Options {
-  unsigned u32All[32];
+  unsigned u32All[34];
   struct {
     uint64_t hash[2];                    // Pipeline hash to set in ELF PAL metadata
     unsigned includeDisassembly;         // If set, the disassembly for all compiled shaders will be included
@@ -159,6 +167,8 @@ union Options {
                                   // meta data.
     bool fragCoordUsesInterpLoc;  // Determining fragCoord use InterpLoc
     bool disableSampleMask;       // Disable export of sample mask from PS
+    bool reserved20;
+    RayTracingIndirectMode rtIndirectMode; // Ray tracing indirect mode
   };
 };
 static_assert(sizeof(Options) == sizeof(Options::u32All));

--- a/llpc/context/llpcContext.cpp
+++ b/llpc/context/llpcContext.cpp
@@ -62,6 +62,7 @@
 using namespace lgc;
 using namespace lgc::rt;
 using namespace llvm;
+using namespace lgc::cps;
 
 namespace Llpc {
 
@@ -69,7 +70,7 @@ namespace Llpc {
 //
 // @param gfxIp : Graphics IP version info
 Context::Context(GfxIpVersion gfxIp) : LLVMContext(), m_gfxIp(gfxIp) {
-  m_dialectContext = llvm_dialects::DialectContext::make<LgcDialect, GpurtDialect, LgcRtDialect>(*this);
+  m_dialectContext = llvm_dialects::DialectContext::make<LgcDialect, GpurtDialect, LgcRtDialect, LgcCpsDialect>(*this);
   reset();
 }
 

--- a/llpc/context/llpcRayTracingContext.cpp
+++ b/llpc/context/llpcRayTracingContext.cpp
@@ -273,6 +273,11 @@ lgc::Options RayTracingContext::computePipelineOptions() const {
   lgc::Options options = PipelineContext::computePipelineOptions();
   // NOTE: raytracing waveSize and subgroupSize can be different.
   options.fullSubgroups = false;
+
+  // TODO: Add a mode in Vkgc::LlpcRaytracingMode to represent lgc::RayTracingIndirectMode::Continuations.
+  if (m_pipelineInfo->mode == Vkgc::LlpcRaytracingMode::Continuations)
+    options.rtIndirectMode = lgc::RayTracingIndirectMode::ContinuationsContinufy;
+
   return options;
 }
 

--- a/llpc/context/llpcRayTracingContext.h
+++ b/llpc/context/llpcRayTracingContext.h
@@ -112,6 +112,7 @@ public:
   bool hasPipelineLibrary() { return m_pipelineInfo->hasPipelineLibrary; }
   unsigned hasLibraryStage(unsigned stageMask) { return m_pipelineInfo->pipelineLibStageMask & stageMask; }
   bool isReplay() { return m_pipelineInfo->isReplay; }
+  Vkgc::LlpcRaytracingMode getRaytracingMode() { return m_pipelineInfo->mode; }
 
 protected:
   // Give the pipeline options to the middle-end, and/or hash them.


### PR DESCRIPTION
1. Tell LGC about the RT indirect mode, so that it can determine which passes
to use.

2. When continuations is enabled, use lgc.cps.set.vsp to setup stack pointer
in SpirvLowerRayTracing pass.