### PR TITLE
Refine the SPI_SHADER_Z_FORMAT register for color export shader

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -180,6 +180,26 @@ void ColorExportShader::updatePalMetadata(PalMetadata &palMetadata) {
         finalExportFormats.push_back(expFmt);
     } else {
       hasDepthExpFmtZero = false;
+      unsigned depthMask = info.location;
+      if (!m_killEnabled && m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 11 &&
+          m_pipelineState->getColorExportState().alphaToCoverageEnable) {
+        for (auto& curInfo : m_exports) {
+          if (curInfo.hwColorTarget == EXP_TARGET_MRT_0 && (m_exportFormat[EXP_TARGET_MRT_0] > EXP_FORMAT_32_GR)) {
+            // Mrt0 is enabled and its alpha channel is enabled
+            depthMask |= 0x8;
+            break;
+          }
+        }
+      }
+
+      unsigned depthExpFmt = EXP_FORMAT_ZERO;
+      if (depthMask & 0x4)
+        depthExpFmt = EXP_FORMAT_32_ABGR;
+      else if (depthMask & 0x2)
+        depthExpFmt = (depthMask & 0x8) ? EXP_FORMAT_32_ABGR : EXP_FORMAT_32_GR;
+      else if (depthMask & 0x1)
+        depthExpFmt = (depthMask & 0x8) ? EXP_FORMAT_32_AR : EXP_FORMAT_32_R;
+      palMetadata.setSpiShaderZFormat(depthExpFmt);
     }
   }
 

--- a/lgc/elfLinker/ColorExportShader.h
+++ b/lgc/elfLinker/ColorExportShader.h
@@ -65,7 +65,8 @@ public:
   // and export info.
   void updatePalMetadata(PalMetadata &palMetadata) override;
 
-  void enableKill() { m_killEnabled = true; };
+  // Fragment shader enables kill state.
+  void enableKill() { m_killEnabled = true; }
 
 protected:
   // Generate the glue shader to IR module

--- a/lgc/elfLinker/ElfLinker.cpp
+++ b/lgc/elfLinker/ElfLinker.cpp
@@ -363,13 +363,18 @@ ArrayRef<StringRef> ElfLinkerImpl::getGlueInfo() {
   return m_glueStrings;
 }
 
+// =====================================================================================================================
+// Build color export shader
+//
+// @param exports : Fragment export info
+// @param enableKill : Whether this fragment shader has kill enabled.
+// @param zFmt : depth-export-format
 StringRef ElfLinkerImpl::buildColorExportShader(ArrayRef<ColorExportInfo> exports, bool enableKill) {
   assert(m_glueShaders.empty());
   m_glueShaders.push_back(GlueShader::createColorExportShader(m_pipelineState, exports));
   ColorExportShader *copyColorShader = static_cast<ColorExportShader *>(m_glueShaders[0].get());
   if (enableKill)
     copyColorShader->enableKill();
-  copyColorShader->updatePalMetadata(*m_pipelineState->getPalMetadata());
   return copyColorShader->getElfBlob();
 }
 

--- a/lgc/include/lgc/state/PalMetadata.h
+++ b/lgc/include/lgc/state/PalMetadata.h
@@ -169,6 +169,9 @@ public:
   // Updates the CB shader mask information that depends on the exports.
   void updateCbShaderMask(llvm::ArrayRef<ColorExportInfo> exps);
 
+  // Sets the z-export-format
+  void setSpiShaderZFormat(unsigned zExportFormat);
+
   // Sets the finalized 128-bit cache hash.  The version identifies the version of LLPC used to generate the hash.
   void setFinalized128BitCacheHash(const lgc::Hash128 &finalizedCacheHash, const llvm::VersionTuple &version);
 

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -402,12 +402,6 @@ public:
   // Get user data for a specific shader stage
   llvm::ArrayRef<unsigned> getUserDataMap(ShaderStage shaderStage) const { return m_userDataMaps[shaderStage]; }
 
-  // Set the flag for performing the copy from mrt0.z to mrtz.a
-  void setUseMrt0AToMrtzA(bool used) { m_useMrt0AToMrtzA = used; }
-
-  // Get the flag of whether to copy mrt0.a to mrtz.a
-  bool isUseMrt0AToMrtzA() const { return m_useMrt0AToMrtzA; }
-
   // -----------------------------------------------------------------------------------------------------------------
   // Utility method templates to read and write IR metadata, used by PipelineState and ShaderModes
 
@@ -588,7 +582,6 @@ private:
   bool m_outputPackState[ShaderStageGfxCount] = {}; // The output packable state per shader stage
   XfbStateMetadata m_xfbStateMetadata = {};         // Transform feedback state metadata
   llvm::SmallVector<unsigned, 32> m_userDataMaps[ShaderStageCountInternal]; // The user data per-shader
-  bool m_useMrt0AToMrtzA = false;                                           // Whether to copy mrt0.a to mrz.a
 };
 
 // =====================================================================================================================

--- a/lgc/interface/lgc/ElfLinker.h
+++ b/lgc/interface/lgc/ElfLinker.h
@@ -76,6 +76,10 @@ public:
   // retrieve the compiled glue code to store in the cache.
   virtual llvm::ArrayRef<llvm::StringRef> getGlueInfo() = 0;
 
+  // Build color export shader
+  //
+  // @param exports : Fragment export info
+  // @param enableKill : Whether this fragment shader has kill enabled.
   virtual llvm::StringRef buildColorExportShader(llvm::ArrayRef<ColorExportInfo> exports, bool enableKill) = 0;
 
   // Add a blob for a particular chunk of glue code, typically retrieved from a cache. The blob is not copied,

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -905,18 +905,6 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
                 (fragmentMode.earlyFragmentTests && resUsage->resourceWrite));
   SET_REG_FIELD(&config->psRegs, DB_SHADER_CONTROL, EXEC_ON_HIER_FAIL, execOnHeirFail);
 
-  unsigned depthExpFmt = EXP_FORMAT_ZERO;
-  if (builtInUsage.sampleMask)
-    depthExpFmt = EXP_FORMAT_32_ABGR;
-  else if (builtInUsage.fragStencilRef)
-    depthExpFmt = EXP_FORMAT_32_GR;
-  else if (builtInUsage.fragDepth)
-    depthExpFmt = EXP_FORMAT_32_R;
-  SET_REG_FIELD(&config->psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
-
-  unsigned cbShaderMask = resUsage->inOutUsage.fs.cbShaderMask;
-  cbShaderMask = resUsage->inOutUsage.fs.isNullFs ? 0 : cbShaderMask;
-  SET_REG(&config->psRegs, CB_SHADER_MASK, cbShaderMask);
   SET_REG_FIELD(&config->psRegs, SPI_PS_IN_CONTROL, NUM_INTERP, resUsage->inOutUsage.fs.interpInfo.size());
 
   unsigned pointCoordLoc = InvalidValue;

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1627,19 +1627,6 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
                              fragmentMode.postDepthCoverage);
   }
 
-  unsigned depthExpFmt = EXP_FORMAT_ZERO;
-  if (builtInUsage.sampleMask)
-    depthExpFmt = EXP_FORMAT_32_ABGR;
-  else if (builtInUsage.fragStencilRef)
-    depthExpFmt = EXP_FORMAT_32_GR;
-  else if (builtInUsage.fragDepth)
-    depthExpFmt = EXP_FORMAT_32_R;
-  SET_REG_FIELD(&config->psRegs, SPI_SHADER_Z_FORMAT, Z_EXPORT_FORMAT, depthExpFmt);
-
-  unsigned cbShaderMask = resUsage->inOutUsage.fs.cbShaderMask;
-  cbShaderMask = resUsage->inOutUsage.fs.isNullFs ? 0 : cbShaderMask;
-  SET_REG(&config->psRegs, CB_SHADER_MASK, cbShaderMask);
-
   const auto waveSize = m_pipelineState->getShaderWaveSize(shaderStage);
   SET_REG_GFX10_PLUS_FIELD(&config->psRegs, SPI_PS_IN_CONTROL, PS_W32_EN, (waveSize == 32));
 

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -783,16 +783,6 @@ void RegisterMetadataBuilder::buildPsRegisters() {
     dbShaderControl[Util::Abi::DbShaderControlMetadataKey::PreShaderDepthCoverageEnable] =
         fragmentMode.postDepthCoverage;
 
-  // SPI_SHADER_Z_FORMAT
-  unsigned depthExpFmt = EXP_FORMAT_ZERO;
-  if (builtInUsage.sampleMask)
-    depthExpFmt = EXP_FORMAT_32_ABGR;
-  else if (builtInUsage.fragStencilRef)
-    depthExpFmt = EXP_FORMAT_32_GR;
-  else if (builtInUsage.fragDepth)
-    depthExpFmt = EXP_FORMAT_32_R;
-  getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::SpiShaderZFormat] = depthExpFmt;
-
   // SPI_PS_INPUT_CNTL_0..31
   // NOTE: PAL expects at least one mmSPI_PS_INPUT_CNTL_0 register set, so we always patch it at least one if none
   // were identified in the shader.
@@ -918,19 +908,6 @@ void RegisterMetadataBuilder::buildPsRegisters() {
   } else {
     hwShaderNode[Util::Abi::HardwareStageMetadataKey::UsesUavs] = resUsage->resourceWrite;
   }
-
-  // CB_SHADER_MASK
-  unsigned cbShaderMask = resUsage->inOutUsage.fs.cbShaderMask;
-  cbShaderMask = resUsage->inOutUsage.fs.isNullFs ? 0 : cbShaderMask;
-  auto cbShaderMaskNode = getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::CbShaderMask].getMap(true);
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output0Enable] = cbShaderMask & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output1Enable] = (cbShaderMask >> 4) & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output2Enable] = (cbShaderMask >> 8) & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output3Enable] = (cbShaderMask >> 12) & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output4Enable] = (cbShaderMask >> 16) & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output5Enable] = (cbShaderMask >> 20) & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output6Enable] = (cbShaderMask >> 24) & 0xF;
-  cbShaderMaskNode[Util::Abi::CbShaderMaskMetadataKey::Output7Enable] = (cbShaderMask >> 28) & 0xF;
 }
 
 // =====================================================================================================================

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestNullFs.pipe
@@ -140,7 +140,6 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:         - 0
 ; CHECK-NEXT:         - 0
 ; CHECK-NEXT:         - 0
-; CHECK-NEXT:       .spi_shader_z_format: 0
 ; CHECK-NEXT:       .spi_vs_out_config:
 ; CHECK-NEXT:         .no_pc_export:   true
 ; CHECK-NEXT:       .vgt_reuse_off:  false

--- a/llpc/test/shaderdb/gfx10/PipelineVsFs_TestVsOutMiscSideBusEna.pipe
+++ b/llpc/test/shaderdb/gfx10/PipelineVsFs_TestVsOutMiscSideBusEna.pipe
@@ -164,7 +164,6 @@ entryPoint = main
 ; SHADERTEST-NEXT:         - 0
 ; SHADERTEST-NEXT:         - 0
 ; SHADERTEST-NEXT:         - 0
-; SHADERTEST-NEXT:       .spi_shader_z_format: 0
 ; SHADERTEST-NEXT:       .spi_vs_out_config:
 ; SHADERTEST-NEXT:         .no_pc_export:   true
 ; SHADERTEST-NEXT:       .vgt_reuse_off:  false

--- a/llpc/test/shaderdb/gfx11/SgprUserDataInit_Fs.pipe
+++ b/llpc/test/shaderdb/gfx11/SgprUserDataInit_Fs.pipe
@@ -261,7 +261,6 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:         - 0
 ; CHECK-NEXT:         - 0
 ; CHECK-NEXT:         - 0
-; CHECK-NEXT:       .spi_shader_z_format: 0
 ; CHECK-NEXT:       .spi_vs_out_config:
 ; CHECK-NEXT:         .no_pc_export:   true
 ; CHECK-NEXT:       .vgt_esgs_ring_itemsize: 0x1


### PR DESCRIPTION
Depth export format may be modified in color export shader if enable

alpha-to-coverage, so we need to extract register value from fragment

ELF as input of color export shader, then fix up SPI_SHADER_Z_FORMAT.