### PR TITLE
lgc: Simplify the workgroupId optimization logic

### DIFF
--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -196,7 +196,7 @@ public:
   void gatherUsage(llvm::Module &module);
 
   // Fix up uses of shader inputs to use entry args directly
-  void fixupUses(llvm::Module &module, PipelineState *pipelineState);
+  void fixupUses(llvm::Module &module, PipelineState *pipelineState, bool computeWithIndirectCall);
 
   // Get argument types for shader inputs
   uint64_t getShaderArgTys(PipelineState *pipelineState, ShaderStage shaderStage, llvm::Function *origFunc,

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -171,7 +171,7 @@ bool PatchEntryPointMutate::runImpl(Module &module, PipelineShadersResult &pipel
   m_userDataUsage.clear();
 
   // Fix up shader input uses to use entry args.
-  shaderInputs.fixupUses(*m_module, m_pipelineState);
+  shaderInputs.fixupUses(*m_module, m_pipelineState, isComputeWithCalls());
 
   m_cpsShaderInputCache.clear();
   return true;


### PR DESCRIPTION
We only can optimize WorkGroupId for entry-point compute shader. For both amdgpu_gfx or amdgpu_cs_chain, we cannot optimize on them. So simplify the logic to only work on entry-point compute shader.