### PR TITLE
Add the missing symbol usage information in ShaderModuleData

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -569,8 +569,9 @@ struct PipelineOptions {
   bool internalRtShaders;                         ///< Whether this pipeline has internal raytracing shaders
   unsigned forceNonUniformResourceIndexStageMask; ///< Mask of the stage to force using non-uniform resource index.
   bool reserved16;
-  bool replaceSetWithResourceType; ///< For OGL only, replace 'set' with resource type during spirv translate
-  bool disableSampleMask;          ///< For OGL only, disabled if framebuffer doesn't attach multisample texture
+  bool replaceSetWithResourceType;        ///< For OGL only, replace 'set' with resource type during spirv translate
+  bool disableSampleMask;                 ///< For OGL only, disabled if framebuffer doesn't attach multisample texture
+  bool buildResourcesDataForShaderModule; ///< For OGL only, build resources usage data while building shader module
 };
 
 /// Prototype of allocator for output data buffer, used in shader-specific operations.
@@ -591,6 +592,8 @@ struct ResourceNodeData {
   unsigned set;                 ///< ID of descriptor set
   unsigned binding;             ///< ID of descriptor binding
   unsigned arraySize;           ///< Element count for arrayed binding
+  unsigned location;            ///< ID of resource location
+  BasicType basicType;          ///< Type of the variable or element
 };
 
 /// Represents the information of one shader entry in ShaderModuleExtraData
@@ -601,6 +604,14 @@ struct ShaderModuleEntryData {
   unsigned resNodeDataCount;             ///< Resource node data count
   const ResourceNodeData *pResNodeDatas; ///< Resource node data array
   unsigned pushConstSize;                ///< Push constant size in byte
+};
+
+/// Represents the shader resources
+struct ResourcesNodes {
+  ResourceNodeData *pInputSymbolInfoBuffers;
+  uint32_t inputSymbolInfoCount;
+  ResourceNodeData *pOutputSymbolInfoBuffers;
+  uint32_t outputSymbolInfoCount;
 };
 
 /// Represents usage info of a shader module
@@ -621,6 +632,7 @@ struct ShaderModuleUsage {
   bool useShadingRate;         ///< Whether shading rate is used
   bool useSampleInfo;          ///< Whether gl_SamplePosition or InterpolateAtSample are used
   bool useClipVertex;          ///< Whether gl_useClipVertex is used
+  ResourcesNodes *pResources;  ///< Resource node for buffers and opaque types
 };
 
 /// Represents common part of shader module data

--- a/llpc/context/llpcCompiler.h
+++ b/llpc/context/llpcCompiler.h
@@ -209,6 +209,10 @@ private:
   static llvm::sys::Mutex m_helperThreadMutex;  // Mutex for helper thread
   static std::condition_variable_any m_helperThreadConditionVariable; // Condition variable used by helper thread to
                                                                       // wait for main thread switching context
+
+  void buildShaderModuleResourceUsage(const ShaderModuleBuildInfo *shaderInfo, Vkgc::ResourcesNodes &resourcesNodes,
+                                      std::vector<ResourceNodeData> &inputSymbolInfo,
+                                      std::vector<ResourceNodeData> &outputSymbolInfo);
 };
 
 // Convert front-end LLPC shader stage to middle-end LGC shader stage

--- a/llpc/include/llpc.h
+++ b/llpc/include/llpc.h
@@ -107,11 +107,14 @@ struct ShaderModuleOptions {
 
 /// Represents info to build a shader module.
 struct ShaderModuleBuildInfo {
-  void *pInstance;                ///< Vulkan instance object
-  void *pUserData;                ///< User data
-  OutputAllocFunc pfnOutputAlloc; ///< Output buffer allocator
-  BinaryData shaderBin;           ///< Shader binary data (SPIR-V binary)
-  ShaderModuleOptions options;    ///< Per shader module options
+  void *pInstance;                                 ///< Vulkan instance object
+  void *pUserData;                                 ///< User data
+  OutputAllocFunc pfnOutputAlloc;                  ///< Output buffer allocator
+  BinaryData shaderBin;                            ///< Shader binary data (SPIR-V binary)
+  ShaderModuleOptions options;                     ///< Per shader module options
+  const VkSpecializationInfo *pSpecializationInfo; ///< Specialization constant info
+  const char *pEntryTarget;                        ///< Name of the target entry point (for multi-entry)
+  ShaderStage entryStage;                          ///< Vkgc Shader stage of the target entry point
 };
 
 /// Represents output of building a shader module.

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -857,6 +857,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
            << "\n";
   dumpFile << "options.replaceSetWithResourceType = " << options->replaceSetWithResourceType << "\n";
   dumpFile << "options.disableSampleMask = " << options->disableSampleMask << "\n";
+  dumpFile << "options.buildResourcesDataForShaderModule = " << options->buildResourcesDataForShaderModule << "\n";
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -488,6 +488,7 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, optimizeTessFactor, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, replaceSetWithResourceType, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, disableSampleMask, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, buildResourcesDataForShaderModule, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};


### PR DESCRIPTION
We hope that all the resource usage information can be aquired from this ShaderModuleData::ShaderModuleUsage, such as input/output symbols, default uniforms, uniform blocks, shader storage blocks, images, textures, atomics and transform feedback varaibles and some metadatas, which is required when build the resource mapping node.

This change is the first step to demo how to gether input symbol info only. other resources will be added in following changes if this demo is good to go.