### PR TITLE
Fix continufy.stage metadata for TraceRay library

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -554,12 +554,13 @@ PreservedAnalyses SpirvLowerRayTracing::run(Module &module, ModuleAnalysisManage
   }
   // Process traceRays module
   if (m_shaderStage == ShaderStageCompute) {
+    CallInst *call = createTraceRay();
+    inlineTraceRay(call, analysisManager);
+
     unsigned lgcRtStage = ~0u;
     m_entryPoint->setMetadata(RtName::ContinufyStageMeta,
                               MDNode::get(*m_context, ConstantAsMetadata::get(m_builder->getInt32(lgcRtStage))));
 
-    CallInst *call = createTraceRay();
-    inlineTraceRay(call, analysisManager);
     static auto visitor = llvm_dialects::VisitorBuilder<SpirvLowerRayTracing>()
                               .setStrategy(llvm_dialects::VisitorStrategy::ByFunctionDeclaration)
                               .add(&SpirvLowerRayTracing::visitGetHitAttributes)


### PR DESCRIPTION
The metadata is set to the wrong function. `m_entryPoint` is the entry function of GPURT library, after `createTraceRay()`, `m_entryPoint` is set to the real entry function of the module, we need to set metadata to it.