### PR TITLE
Fix the failures on VK.pipeline.monolithic.multisample.mixed_attachme…

### DIFF
--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2455,20 +2455,22 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
 
     Value *sampleMaskIn = sampleCoverage;
     if (m_pipelineState->getRasterizerState().perSampleShading || builtInUsage.runAtSampleRate) {
-      // Fix the failure for multisample_shader_builtin.sample_mask cases "gl_SampleMaskIn" should contain one
-      // or multiple covered sample bit.
-      // (1) If the 4 samples is divided into 2 sub invocation groups, broadcast sample mask bit <0, 1>
-      // to sample <2, 3>.
-      // (2) If the 8 samples is divided into 2 sub invocation groups, broadcast sample mask bit <0, 1>
-      // to sample <2, 3>, then re-broadcast sample mask bit <0, 1, 2, 3> to sample <4, 5, 6, 7>.
-      // (3) If the 8 samples is divided into 4 sub invocation groups, patch to broadcast sample mask bit
-      // <0, 1, 2, 3> to sample <4, 5, 6, 7>.
-
       unsigned baseMask = 1;
-      unsigned baseMaskSamples = m_pipelineState->getRasterizerState().pixelShaderSamples;
-      while (baseMaskSamples < m_pipelineState->getRasterizerState().numSamples) {
-        baseMask |= baseMask << baseMaskSamples;
-        baseMaskSamples *= 2;
+      if (!builtInUsage.sampleId) {
+        // Fix the failure for multisample_shader_builtin.sample_mask cases "gl_SampleMaskIn" should contain one
+        // or multiple covered sample bit.
+        // (1) If the 4 samples is divided into 2 sub invocation groups, broadcast sample mask bit <0, 1>
+        // to sample <2, 3>.
+        // (2) If the 8 samples is divided into 2 sub invocation groups, broadcast sample mask bit <0, 1>
+        // to sample <2, 3>, then re-broadcast sample mask bit <0, 1, 2, 3> to sample <4, 5, 6, 7>.
+        // (3) If the 8 samples is divided into 4 sub invocation groups, patch to broadcast sample mask bit
+        // <0, 1, 2, 3> to sample <4, 5, 6, 7>.
+
+        unsigned baseMaskSamples = m_pipelineState->getRasterizerState().pixelShaderSamples;
+        while (baseMaskSamples < m_pipelineState->getRasterizerState().numSamples) {
+          baseMask |= baseMask << baseMaskSamples;
+          baseMaskSamples *= 2;
+        }
       }
 
       // gl_SampleMaskIn[0] = (SampleCoverage & (baseMask << gl_SampleID))


### PR DESCRIPTION
…nt_samples.shader_builtins.* cases

The failures are caused by the regression from commit-id: d6d61e6b5baba To fix this issue, it can only broadcast sample mask when the depthstencil test is disable.