### PR TITLE
Rename some constants of copy shader

### DIFF
--- a/lgc/include/lgc/state/Defs.h
+++ b/lgc/include/lgc/state/Defs.h
@@ -44,7 +44,6 @@ const static char OutputImportBuiltIn[] = "lgc.output.import.builtin.";
 const static char OutputExportGeneric[] = "lgc.output.export.generic.";
 const static char OutputExportBuiltIn[] = "lgc.output.export.builtin.";
 const static char OutputExportXfb[] = "lgc.output.export.xfb.";
-const static char TfBufferStore[] = "lgc.tfbuffer.store.";
 const static char StreamOutBufferStore[] = "lgc.streamoutbuffer.store";
 const static char ReconfigureLocalInvocationId[] = "lgc.reconfigure.local.invocation.id";
 const static char SwizzleWorkgroupId[] = "lgc.swizzle.workgroup.id";

--- a/lgc/include/lgc/state/IntrinsDefs.h
+++ b/lgc/include/lgc/state/IntrinsDefs.h
@@ -67,17 +67,17 @@ static const unsigned GetRealTime = 0x83; // [7] = 1, [6:0] = 3
 // Count of user SGPRs used in copy shader
 static const unsigned CopyShaderUserSgprCount = 3;
 
-// User SGPR index for the stream info in copy shader
-static const unsigned CopyShaderUserSgprIdxStreamInfo = 3;
+// Entry-point argument index for the stream info in copy shader
+static const unsigned CopyShaderEntryArgIdxStreamInfo = 3;
 
-// User SGPR index for the stream-out write index in copy shader
-static const unsigned CopyShaderUserSgprIdxWriteIndex = 4;
+// Entry-point argument index for the stream-out write index in copy shader
+static const unsigned CopyShaderEntryArgIdxWriteIndex = 4;
 
-// User SGPR index for the stream offsets in copy shader
-static const unsigned CopyShaderUserSgprIdxStreamOffset = 5;
+// Entry-point argument index for the stream offsets in copy shader
+static const unsigned CopyShaderEntryArgIdxStreamOffset = 5;
 
-// Start offset of currently-processed vertex in GS-VS ring buffer
-static const unsigned CopyShaderUserSgprIdxVertexOffset = 9;
+// Entry-point argument index for the LDS offset of current vertices in GS-VS ring
+static const unsigned CopyShaderEntryArgIdxVertexOffset = 9;
 
 // Enumerates address spaces valid for AMD GPU (similar to LLVM header AMDGPU.h)
 enum AddrSpace {

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -252,7 +252,7 @@ bool PatchCopyShader::runImpl(Module &module, PipelineShadersResult &pipelineSha
   if (outputStreamCount > 1 && m_pipelineState->enableXfb()) {
     if (!m_pipelineState->getNggControl()->enableNgg) {
       // StreamId = streamInfo[25:24]
-      auto streamInfo = getFunctionArgument(entryPoint, CopyShaderUserSgprIdxStreamInfo);
+      auto streamInfo = getFunctionArgument(entryPoint, CopyShaderEntryArgIdxStreamInfo);
 
       Value *streamId = builder.CreateIntrinsic(Intrinsic::amdgcn_ubfe, builder.getInt32Ty(),
                                                 {
@@ -539,7 +539,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
 Value *PatchCopyShader::calcGsVsRingOffsetForInput(unsigned location, unsigned compIdx, unsigned streamId,
                                                    BuilderBase &builder) {
   auto entryPoint = builder.GetInsertBlock()->getParent();
-  Value *vertexOffset = getFunctionArgument(entryPoint, CopyShaderUserSgprIdxVertexOffset);
+  Value *vertexOffset = getFunctionArgument(entryPoint, CopyShaderEntryArgIdxVertexOffset);
 
   auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageCopyShader);
 

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -3913,11 +3913,11 @@ void PatchInOutImportExport::storeValueToStreamOutBuffer(Value *storeValue, unsi
   } else {
     assert(m_shaderStage == ShaderStageCopyShader);
 
-    writeIndex = CopyShaderUserSgprIdxWriteIndex;
-    streamInfo = CopyShaderUserSgprIdxStreamInfo;
+    writeIndex = CopyShaderEntryArgIdxWriteIndex;
+    streamInfo = CopyShaderEntryArgIdxStreamInfo;
 
     const auto &xfbStrides = m_pipelineState->getXfbBufferStrides();
-    unsigned streamOffset = CopyShaderUserSgprIdxStreamOffset;
+    unsigned streamOffset = CopyShaderEntryArgIdxStreamOffset;
 
     for (unsigned i = 0; i < MaxTransformFeedbackBuffers; ++i) {
       if (xfbStrides[i] > 0)


### PR DESCRIPTION
The names are not accurate. They are entry-point argument indices, not user SGPR indices.