### PR TITLE
lgc: Should use isIntOrIntVectorTy() check

### DIFF
--- a/lgc/patch/FragColorExport.cpp
+++ b/lgc/patch/FragColorExport.cpp
@@ -376,7 +376,7 @@ Value *FragColorExport::convertToFloat(Value *value, bool signedness, BuilderBas
     }
   } else {
     assert(bitWidth == 32);
-    if (valueTy->isIntegerTy()) {
+    if (valueTy->isIntOrIntVectorTy()) {
       // %value = bitcast i32 %value to float
       value = builder.CreateBitCast(value, floatTy);
     }


### PR DESCRIPTION
The logic is to bitcast 'integer to float' or 'vector of integer to vector of float'. The existing check will fail to handle vector of integer correctly. And leaking vector of integer to later intrinsic which expect float argument may cause illegal IR.