### PR TITLE
test: Allow .ll test file

### DIFF
--- a/lgc/test/lit.cfg.py
+++ b/lgc/test/lit.cfg.py
@@ -22,7 +22,7 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files. This is overridden
 # by individual lit.local.cfg files in the test subdirectories.
-config.suffixes = ['.lgc', '.txt']
+config.suffixes = ['.lgc', '.txt', '.ll']
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent


### PR DESCRIPTION
As we used .ll file format, it is reasonable to include .ll test in lgc.