### PR TITLE
Pass flags to lit in lgc

### DIFF
--- a/lgc/test/CMakeLists.txt
+++ b/lgc/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LGC_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # required by configure_lit_site_cfg
 set(LLVM_LIT_OUTPUT_DIR ${LLVM_TOOLS_BINARY_DIR})
+get_target_property(LIT_DEFINITIONS LLVMlgc INTERFACE_COMPILE_DEFINITIONS)
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/lgc/test/lit.site.cfg.py.in
+++ b/lgc/test/lit.site.cfg.py.in
@@ -8,6 +8,12 @@ config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
 config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 
+for d in "@LIT_DEFINITIONS@".split(";"):
+    def_split = d.split("=")
+    name = def_split[0].lower()
+    val = def_split[1] if len(def_split) > 1 else "ON"
+    config.available_features.add(name)
+
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
 try:


### PR DESCRIPTION
That way, tests can be disabled when some cmake flags are disabled.

Copy that code from llpc to lgc.