### PR TITLE
[LGC] Move SROAPass after LoopUnrollPass

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -378,6 +378,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
   fpm.addPass(createFunctionToLoopPassAdaptor(std::move(lpm2), true));
   fpm.addPass(LoopUnrollPass(
       LoopUnrollOptions(optLevel).setPeeling(true).setRuntime(false).setUpperBound(false).setPartial(false)));
+  fpm.addPass(SROAPass(SROAOptions::ModifyCFG));
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 464212
   // Old version of the code
   fpm.addPass(ScalarizerPass());
@@ -402,6 +403,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, CodeGenOpt::Level o
                                   .needCanonicalLoops(true)
                                   .sinkCommonInsts(true)));
   fpm.addPass(LoopUnrollPass(LoopUnrollOptions(optLevel)));
+  fpm.addPass(SROAPass(SROAOptions::ModifyCFG));
   // uses UniformityAnalysis
   fpm.addPass(PatchReadFirstLane());
   fpm.addPass(InstCombinePass(instCombineOpt));


### PR DESCRIPTION
One of the LLVM changes (https://reviews.llvm.org/D156398) removed SROAPass which was performed after AMDGPUPromoteAlloca. This change caused to generate multiple scratch accesses in some of the shaders. By moving existing SROAPass after LoopUnrollPass in LLPC we are able to eliminate almost all scratch accesses caused by the LLVM change.

By unrolling loops, single GEP instruction with variable idx may be replaced with multiple GEPs with constant indices. Later SROAPass may remove alloca/store/load instructions. SROAPass is not able to handle variable indices.