### PR TITLE
llpc: run LowerGpuRt when building internal raytracing shaders

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -259,7 +259,7 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
   // Lower SPIR-V instruction metadata remove
   passMgr.addPass(SpirvLowerInstMetaRemove());
 
-  if (rayTracing || rayQuery) {
+  if (rayTracing || rayQuery || isInternalRtShader) {
     passMgr.addPass(LowerGpuRt());
     passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(instCombineOpt)));
   }


### PR DESCRIPTION
In some internal configurations, BVH build shaders started to use GPURT ops.