### PR TITLE
Add support for SW primitive statistics counting

### DIFF
--- a/lgc/builder/MiscBuilder.cpp
+++ b/lgc/builder/MiscBuilder.cpp
@@ -46,8 +46,10 @@ using namespace llvm;
 Instruction *BuilderImpl::CreateEmitVertex(unsigned streamId) {
   assert(m_shaderStage == ShaderStageGeometry);
 
-  // Mark this vertex stream as active if transform feedback is enabled or this is the rasterization stream.
-  if (m_pipelineState->enableXfb() || m_pipelineState->getRasterizerState().rasterStream == streamId)
+  // Mark this vertex stream as active if transform feedback is enabled, or primitive statistics counting is enabled,
+  // or this is the rasterization stream.
+  if (m_pipelineState->enableXfb() || m_pipelineState->enablePrimStats() ||
+      m_pipelineState->getRasterizerState().rasterStream == streamId)
     m_pipelineState->setVertexStreamActive(streamId);
 
   // Get GsWaveId
@@ -68,8 +70,10 @@ Instruction *BuilderImpl::CreateEmitVertex(unsigned streamId) {
 Instruction *BuilderImpl::CreateEndPrimitive(unsigned streamId) {
   assert(m_shaderStage == ShaderStageGeometry);
 
-  // Mark this vertex stream as active if transform feedback is enabled or this is the rasterization stream.
-  if (m_pipelineState->enableXfb() || m_pipelineState->getRasterizerState().rasterStream == streamId)
+  // Mark this vertex stream as active if transform feedback is enabled, or primitive statistics counting is enabled,
+  // or this is the rasterization stream.
+  if (m_pipelineState->enableXfb() || m_pipelineState->enablePrimStats() ||
+      m_pipelineState->getRasterizerState().rasterStream == streamId)
     m_pipelineState->setVertexStreamActive(streamId);
 
   // Get GsWaveId

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -396,7 +396,7 @@ public:
   // Check if transform feedback is active
   bool enableXfb() const { return m_xfbStateMetadata.enableXfb; }
 
-  // Check if we need count primitives if XFB is disabled
+  // Check if we need primitive statistics counting
   bool enablePrimStats() const { return m_xfbStateMetadata.enablePrimStats; }
 
   // Get transform feedback strides

--- a/lgc/patch/NggPrimShader.h
+++ b/lgc/patch/NggPrimShader.h
@@ -322,6 +322,8 @@ private:
     return m_ldsLayout[region].first;
   }
 
+  void collectPrimitiveStats();
+
   llvm::Value *readValueFromLds(llvm::Type *readTy, llvm::Value *ldsOffset, bool useDs128 = false);
   void writeValueToLds(llvm::Value *writeValue, llvm::Value *ldsOffset, bool useDs128 = false);
   void atomicAdd(llvm::Value *valueToAdd, llvm::Value *ldsOffset);
@@ -394,9 +396,9 @@ private:
   bool m_hasTes = false; // Whether the pipeline has tessellation evaluation shader
   bool m_hasGs = false;  // Whether the pipeline has geometry shader
 
-  llvm::Value *m_streamOutControlBufPtr;                           // Stream-out control buffer pointer
-  llvm::Value *m_streamOutBufDescs[MaxTransformFeedbackBuffers];   // Stream-out buffer descriptors
-  llvm::Value *m_streamOutBufOffsets[MaxTransformFeedbackBuffers]; // Stream-out buffer offsets
+  llvm::Value *m_streamOutControlBufPtr = nullptr;                      // Stream-out control buffer pointer
+  llvm::Value *m_streamOutBufDescs[MaxTransformFeedbackBuffers] = {};   // Stream-out buffer descriptors
+  llvm::Value *m_streamOutBufOffsets[MaxTransformFeedbackBuffers] = {}; // Stream-out buffer offsets
 
   bool m_constPositionZ = false; // Whether the Z channel of vertex position data is constant
 


### PR DESCRIPTION
For pre-GFX11, the primitive statistics counting is performed by HW via the same mechanism of transform feedback. For GFX11+, since transform feedback is done by SW emulation, the primitive statistics counting will follow the same handling.

We add a new handler collectPrimitiveStats to deal with it. It is a reduced version of SW transform feedback, only updating HW counters of requested vertex streams. We don't merge it with SW transform feedback because this will make the logic blurry. Indeed, some duplicated codes are the trade-off.

For non-GS case, only the counter of stream 0 will be updated and generated primitive count is passed by GE (we don't modify it). For GS case, counters of all active vertex streams will be updated and we must calculate generated primitive count first before doing such update. The calculation is to count valid primitive mask bits in this NGG subgroup and add them together.

The implementation of this PR is the foundation of VK_EXT_primitives_generated_query.