### PR TITLE
Decouple primitive generated query from xfb

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -46,7 +46,7 @@
 #endif
 
 /// LLPC major interface version.
-#define LLPC_INTERFACE_MAJOR_VERSION 68
+#define LLPC_INTERFACE_MAJOR_VERSION 69
 
 /// LLPC minor interface version.
 #define LLPC_INTERFACE_MINOR_VERSION 0
@@ -80,6 +80,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     69.0 | Add enablePrimGeneratedQuery to PipelineOptions                                                       |
 //  |     68.0 | Remove ICache *cache in all PipelineBuildInfo                                                         |
 //  |     67.0 | Modify the uber fetch shader. Adds locationMask(64bit) at the beginning of uber fetch shader internal |
 //  |          | buffer which flags whether the related attribute data is valid.                                       |
@@ -603,6 +604,7 @@ struct PipelineOptions {
   bool enableCombinedTexture;             ///< For OGL only, use the 'set' for DescriptorCombinedTexture
                                           ///< for sampled images and samplers
   bool vertex64BitsAttribSingleLoc;       ///< For OGL only, dvec3/dvec4 vertex attrib only consumes 1 location.
+  bool enablePrimGeneratedQuery;          ///< If set, primitive generated query is enabled
   unsigned reserved20;
 };
 
@@ -1254,7 +1256,9 @@ struct ApiXfbOutData {
   XfbOutInfo *pXfbOutInfos;   ///< An array of XfbOutInfo items
   unsigned numXfbOutInfo;     ///< Count of XfbOutInfo items
   bool forceDisableStreamOut; ///< Force to disable stream out XFB outputs
-  bool forceEnablePrimStats;  ///< Force to enable counting generated primitives
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 69
+  bool forceEnablePrimStats; ///< Force to enable counting generated primitives
+#endif
 };
 
 /// Represents the tessellation level passed from driver API

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -396,8 +396,9 @@ public:
   // Check if transform feedback is active
   bool enableXfb() const { return m_xfbStateMetadata.enableXfb; }
 
-  // Check if we need primitive statistics counting
-  bool enablePrimStats() const { return m_xfbStateMetadata.enablePrimStats; }
+  // Check if we need count primitives if XFB is disabled
+  // NOTE: The old interface m_xfbStateMetadata.enablePrimStats will be removed later
+  bool enablePrimStats() const { return m_options.enablePrimGeneratedQuery || m_xfbStateMetadata.enablePrimStats; }
 
   // Get transform feedback strides
   const std::array<unsigned, MaxTransformFeedbackBuffers> &getXfbBufferStrides() const {

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -173,6 +173,7 @@ union Options {
     bool disableSampleMask;       // Disable export of sample mask from PS
     bool reserved20;
     RayTracingIndirectMode rtIndirectMode; // Ray tracing indirect mode
+    bool enablePrimGeneratedQuery;         // Whether to enable primitive generated counter
   };
 };
 static_assert(sizeof(Options) == sizeof(Options::u32All));

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -339,6 +339,7 @@ Options PipelineContext::computePipelineOptions() const {
   options.internalRtShaders = getPipelineOptions()->internalRtShaders;
   options.disableSampleMask = getPipelineOptions()->disableSampleMask;
   options.disableTruncCoordForGather = getPipelineOptions()->disableTruncCoordForGather;
+  options.enablePrimGeneratedQuery = getPipelineOptions()->enablePrimGeneratedQuery;
 
   return options;
 }

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -9739,8 +9739,11 @@ void SPIRVToLLVM::insertScratchBoundsChecks(SPIRVValue *memOp, const ScratchBoun
 void SPIRVToLLVM::createXfbMetadata(bool hasXfbOuts) {
   auto llpcContext = static_cast<Llpc::Context *>(m_context);
   auto pipelineBuildInfo = static_cast<const Vkgc::GraphicsPipelineBuildInfo *>(llpcContext->getPipelineBuildInfo());
-  const bool needXfbMetadata = (hasXfbOuts && !pipelineBuildInfo->apiXfbOutData.forceDisableStreamOut) ||
-                               pipelineBuildInfo->apiXfbOutData.forceEnablePrimStats;
+  bool needXfbMetadata = hasXfbOuts && !pipelineBuildInfo->apiXfbOutData.forceDisableStreamOut;
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 69
+  needXfbMetadata |= pipelineBuildInfo->apiXfbOutData.forceEnablePrimStats;
+#endif
+
   if (!needXfbMetadata)
     return;
 

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -861,6 +861,7 @@ void PipelineDumper::dumpPipelineOptions(const PipelineOptions *options, std::os
   dumpFile << "options.buildResourcesDataForShaderModule = " << options->buildResourcesDataForShaderModule << "\n";
   dumpFile << "options.disableTruncCoordForGather = " << options->disableTruncCoordForGather << "\n";
   dumpFile << "options.vertex64BitsAttribSingleLoc = " << options->vertex64BitsAttribSingleLoc << "\n";
+  dumpFile << "options.enablePrimGeneratedQuery = " << options->enablePrimGeneratedQuery << "\n";
 }
 
 // =====================================================================================================================
@@ -1016,7 +1017,9 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
 
   dumpFile << "\n[ApiXfbOutInfo]\n";
   dumpFile << "forceDisableStreamOut = " << pipelineInfo->apiXfbOutData.forceDisableStreamOut << "\n";
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 69
   dumpFile << "forceEnablePrimStats = " << pipelineInfo->apiXfbOutData.forceEnablePrimStats << "\n";
+#endif
   const auto pXfbOutInfos = pipelineInfo->apiXfbOutData.pXfbOutInfos;
   for (unsigned idx = 0; idx < pipelineInfo->apiXfbOutData.numXfbOutInfo; ++idx) {
     dumpFile << "xfbOutInfo[" << idx << "].isBuiltIn = " << pXfbOutInfos[idx].isBuiltIn << "\n";
@@ -1566,7 +1569,9 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
   }
 
   hasher->Update(pipeline->apiXfbOutData.forceDisableStreamOut);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 69
   hasher->Update(pipeline->apiXfbOutData.forceEnablePrimStats);
+#endif
 }
 
 // =====================================================================================================================
@@ -1653,6 +1658,7 @@ void PipelineDumper::updateHashForPipelineOptions(const PipelineOptions *options
   hasher->Update(options->forceNonUniformResourceIndexStageMask);
   hasher->Update(options->replaceSetWithResourceType);
   hasher->Update(options->disableTruncCoordForGather);
+  hasher->Update(options->enablePrimGeneratedQuery);
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -501,6 +501,7 @@ private:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, buildResourcesDataForShaderModule, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, disableTruncCoordForGather, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, vertex64BitsAttribSingleLoc, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionPipelineOption, enablePrimGeneratedQuery, MemberTypeBool, false);
       return addrTableInitializer;
     }();
     return {addrTable.data(), addrTable.size()};
@@ -1033,7 +1034,9 @@ private:
     static std::vector<StrToMemberAddr> addrTable = []() {
       std::vector<StrToMemberAddr> addrTableInitializer;
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionApiXfbOutput, forceDisableStreamOut, MemberTypeBool, false);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 69
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionApiXfbOutput, forceEnablePrimStats, MemberTypeBool, false);
+#endif
       INIT_MEMBER_DYNARRAY_NAME_TO_ADDR(SectionApiXfbOutput, m_xfbOutInfo, MemberTypeXfbOutInfo, true);
       return addrTableInitializer;
     }();


### PR DESCRIPTION
The query for primitive generated (pgq) is independent of transform feedback workflow. This PR aims to decouple pgq from xfb by taking pgq as a pipeline option.
- Add a new interface `PipelineOptions::enablePrimGeneratedQuery`.
- Guard the old interface `ApiXfbOutData::forceEnablePrimStats` with llpc version.