### PR TITLE
Mark the dispatchRaysConstants buffer descriptor as invariant.

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -2364,6 +2364,7 @@ void SpirvLowerRayTracing::createDispatchRaysInfoDesc() {
   if (!m_dispatchRaysInfoDesc) {
     m_dispatchRaysInfoDesc = m_builder->CreateLoadBufferDesc(
         TraceRayDescriptorSet, RayTracingResourceIndexDispatchRaysInfo, m_builder->getInt32(0), 0);
+    m_builder->CreateInvariantStart(m_dispatchRaysInfoDesc);
   }
 }
 


### PR DESCRIPTION
This allows the backend to use SMEM loads when a load from the buffer was issued.