### PR TITLE
Fix warnings about unused functions and variables.

### DIFF
--- a/shared/continuations/lib/DXILContPostProcess.cpp
+++ b/shared/continuations/lib/DXILContPostProcess.cpp
@@ -290,7 +290,7 @@ static bool addGetAddrAndMDIntrinsicCalls(Module &M) {
             B.CreateCall(GetAddrAndMD, {B.CreatePtrToInt(CE, B.getInt64Ty())});
         // Can't RAUW because the CE might be used by different instructions.
         // Instead, manually replace the instruction's operand.
-        bool Found = false;
+        [[maybe_unused]] bool Found = false;
         for (unsigned OpIdx = 0, E = I->getNumOperands(); OpIdx < E; ++OpIdx) {
           if (I->getOperand(OpIdx) == CE) {
             I->setOperand(OpIdx, AddrWithMD);
@@ -308,7 +308,7 @@ static bool addGetAddrAndMDIntrinsicCalls(Module &M) {
 
 /// Checks some properties guaranteed for a module containing continuations
 /// as expected by the backend.
-static void checkContinuationsModule(const Module &M) {
+[[maybe_unused]] static void checkContinuationsModule(const Module &M) {
   // Check that all continuation.continue calls have registercount metadata.
   SmallVector<CallInst *> CallInsts;
   collectContinueCalls(M, CallInsts);

--- a/shared/continuations/lib/LowerRaytracingPipeline.cpp
+++ b/shared/continuations/lib/LowerRaytracingPipeline.cpp
@@ -954,7 +954,7 @@ void LowerRaytracingPipelinePassImpl::copyHitAttributes(
 
   // Hit attribute storage in payload storage
   Value *PayloadHitAttrs = nullptr;
-  unsigned PayloadHitAttrBytes = 0;
+  [[maybe_unused]] unsigned PayloadHitAttrBytes = 0;
 
   // Find hit attributes in layout if present
   if (Layout) {

--- a/shared/continuations/lib/PayloadAccessQualifiers.cpp
+++ b/shared/continuations/lib/PayloadAccessQualifiers.cpp
@@ -682,7 +682,8 @@ static void createNestedStructHierarchyRecursively(
     Node.LifetimeClass = Node.Children[0].LifetimeClass;
 }
 
-static void dumpPAQTree(StructType *PayloadType, const PAQNode &Node) {
+[[maybe_unused]] static void dumpPAQTree(StructType *PayloadType,
+                                         const PAQNode &Node) {
   // print for testing
   llvm::dbgs() << "PAQ qualifiers for payload struct " << PayloadType->getName()
                << ":\n";
@@ -937,7 +938,7 @@ checkSerializationLayout(const PAQSerializationLayout &Layout,
 //       structs. If at some point we also use inner nodes in serialization
 //       structs, we should also check consistency between a node and its
 //       ancestors (i.e. parent structs).
-static void checkTraceRaySerializationInfoImpl(
+[[maybe_unused]] static void checkTraceRaySerializationInfoImpl(
     ArrayRef<const PAQSerializationLayout *> Layouts,
     const SmallDenseMap<const PAQNode *, const PAQNode *> &EquivalentNodes,
     const DataLayout &DL) {
@@ -1012,7 +1013,7 @@ static void checkTraceRaySerializationInfoImpl(
 // HitGroupLayouts in TraceRaySerializationInfo are not checked.
 // However, if HitGroupLayout is non-null, its consistency with the
 // other layouts will be checked as well.
-static void checkTraceRaySerializationInfo(
+[[maybe_unused]] static void checkTraceRaySerializationInfo(
     const PAQTraceRaySerializationInfo &TraceRaySerializationInfo,
     const DataLayout &DL,
     const PAQHitGroupLayoutInfo *HitGroupLayout = nullptr) {
@@ -1782,7 +1783,7 @@ PAQHitGroupLayoutInfo PAQTraceRaySerializationInfo::createHitGroupLayoutInfo(
   return HitGroupLayoutInfo;
 }
 
-static void
+[[maybe_unused]] static void
 checkCallShaderSerializationInfo(const PAQCallShaderSerializationInfo &Info,
                                  const DataLayout &DL) {
   checkSerializationLayout(Info.CallShaderSerializationLayout, DL);


### PR DESCRIPTION
Some helper functions and variables are currently not used in every build mode. Since they could possibly be helpful, only mark them as ```[[maybe_unused]]``` to silence compiler warnings.