### PR TITLE
Fix unstable barycentric

### DIFF
--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -92,6 +92,9 @@ enum class ShaderInput : unsigned {
   // Unmerged hardware HS SGPRs
   TfBufferBase, // TF buffer base
 
+  // FS SGPRs
+  ProvokingVtxInfo, // Provoking vertex info
+
   FirstVgpr, // Enums less than this are SGPRs
 
   // API VS VGPRs

--- a/lgc/include/lgc/state/AbiMetadata.h
+++ b/lgc/include/lgc/state/AbiMetadata.h
@@ -182,6 +182,7 @@ static constexpr char TrapPresent[] = ".trap_present";
 static constexpr char UserSgprs[] = ".user_sgprs";
 static constexpr char MemOrdered[] = ".mem_ordered";
 static constexpr char WgpMode[] = ".wgp_mode";
+static constexpr char LoadProvokingVtx[] = ".load_provoking_vtx";
 static constexpr char OffchipLdsEn[] = ".offchip_lds_en";
 static constexpr char UserDataRegMap[] = ".user_data_reg_map";
 static constexpr char ImageOp[] = ".image_op";

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -621,9 +621,10 @@ struct InterfaceData {
           unsigned w; // W channel
         } fragCoord;
 
-        unsigned frontFacing;    // FrontFacing
-        unsigned ancillary;      // Ancillary
-        unsigned sampleCoverage; // Sample coverage
+        unsigned frontFacing;      // FrontFacing
+        unsigned ancillary;        // Ancillary
+        unsigned sampleCoverage;   // Sample coverage
+        unsigned provokingVtxInfo; // Provoking vertex info
       } fs;
 
       // Compute shader

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1561,6 +1561,10 @@ template <typename T> void ConfigBuilder::buildPsRegConfig(ShaderStage shaderSta
     SET_REG_GFX9_FIELD(&config->psRegs, SPI_SHADER_PGM_RSRC2_PS, USER_SGPR_MSB, userSgprMsb);
   }
 
+  if (m_gfxIp >= GfxIpVersion{10, 3} && (intfData->entryArgIdxs.fs.provokingVtxInfo != 0)) {
+    SET_REG_GFX10_3_PLUS_EXCLUSIVE_FIELD(&config->psRegs, SPI_SHADER_PGM_RSRC1_PS, LOAD_PROVOKING_VTX, true);
+  }
+
   if (m_gfxIp.major >= 11) {
     // Pixel wait sync+
     SET_REG_GFX11_FIELD(&config->psRegs, SPI_SHADER_PGM_RSRC4_PS, IMAGE_OP, resUsage->useImageOp);

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -774,6 +774,11 @@ void RegisterMetadataBuilder::buildPsRegisters() {
     spiBarycCntl[Util::Abi::SpiBarycCntlMetadataKey::PosFloatLocation] = 0;
   }
 
+  // Provoking vtx
+  if (m_gfxIp >= GfxIpVersion{10, 3} &&
+      (m_pipelineState->getShaderInterfaceData(shaderStage)->entryArgIdxs.fs.provokingVtxInfo != 0))
+    getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::PsLoadProvokingVtx] = true;
+
   // PA_SC_MODE_CNTL_1
   getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::PsIterSample] =
       m_pipelineState->getShaderResourceUsage(shaderStage)->builtInUsage.fs.runAtSampleRate > 0;

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -234,6 +234,8 @@ const char *ShaderInputs::getInputName(ShaderInput inputKind) {
     return "EsGsOffset";
   case ShaderInput::TfBufferBase:
     return "TfBufferBase";
+  case ShaderInput::ProvokingVtxInfo:
+    return "ProvokingVtxInfo";
   case ShaderInput::VertexId:
     return "VertexId";
   case ShaderInput::RelVertexId:
@@ -491,6 +493,7 @@ static const ShaderInputDesc GsSgprInputs[] = {
 // SGPRs: FS
 static const ShaderInputDesc FsSgprInputs[] = {
     {ShaderInput::PrimMask, offsetof(InterfaceData, entryArgIdxs.fs.primMask), true},
+    {ShaderInput::ProvokingVtxInfo, offsetof(InterfaceData, entryArgIdxs.fs.provokingVtxInfo), false},
 };
 
 // SGPRs: CS

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestBarycentric_tri_fan.pipe
@@ -143,16 +143,39 @@ attribute[1].format = VK_FORMAT_R32G32B32A32_SFLOAT
 attribute[1].offset = 16
 
 ; SHADERTEST-LABEL: amdgpu_ps_main:
-; SHADERTEST:         s_mov_b32 m0, s1
-; SHADERTEST-NEXT:    v_interp_mov_f32_e32 v3, p0, attr0.x
-; SHADERTEST-NEXT:    v_sub_f32_e32 v2, 1.0, v0
-; SHADERTEST-NEXT:    v_and_b32_e32 v3, 1, v3
-; SHADERTEST-NEXT:    v_sub_f32_e32 v2, v2, v1
-; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v3
-; SHADERTEST-NEXT:    v_cndmask_b32_e32 v3, v1, v2, vcc
-; SHADERTEST-NEXT:    v_cndmask_b32_e32 v2, v2, v0, vcc
+; SHADERTEST:         v_mbcnt_lo_u32_b32 v2, -1, 0
+; SHADERTEST-NEXT:    v_mbcnt_hi_u32_b32 v2, -1, v2
+; SHADERTEST-NEXT:    v_lshrrev_b32_e32 v2, 1, v2
+; SHADERTEST-NEXT:    v_and_b32_e32 v2, 62, v2
+; SHADERTEST-NEXT:    v_bfe_u32 v2, s2, v2, 2
+; SHADERTEST-NEXT:    v_add_u32_e32 v3, vcc, 2, v2
+; SHADERTEST-NEXT:    s_mov_b32 s0, 0x55555556
+; SHADERTEST-NEXT:    v_mul_hi_i32 v4, v3, s0
+; SHADERTEST-NEXT:    v_sub_f32_e32 v5, 1.0, v0
+; SHADERTEST-NEXT:    v_sub_f32_e32 v5, v5, v1
+; SHADERTEST-NEXT:    v_mul_u32_u24_e32 v4, 3, v4
+; SHADERTEST-NEXT:    v_sub_u32_e32 v3, vcc, v3, v4
+; SHADERTEST-NEXT:    v_add_u32_e32 v4, vcc, 3, v2
+; SHADERTEST-NEXT:    v_mul_hi_i32 v6, v4, s0
+; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v3
+; SHADERTEST-NEXT:    v_cndmask_b32_e32 v7, v0, v1, vcc
+; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 2, v3
+; SHADERTEST-NEXT:    v_mul_u32_u24_e32 v6, 3, v6
+; SHADERTEST-NEXT:    v_or_b32_e32 v2, 4, v2
+; SHADERTEST-NEXT:    v_cndmask_b32_e32 v3, v7, v5, vcc
+; SHADERTEST-NEXT:    v_sub_u32_e32 v4, vcc, v4, v6
+; SHADERTEST-NEXT:    v_mul_hi_i32 v6, v2, s0
+; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v4
+; SHADERTEST-NEXT:    v_cndmask_b32_e32 v7, v0, v1, vcc
+; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 2, v4
+; SHADERTEST-NEXT:    v_mul_u32_u24_e32 v6, 3, v6
+; SHADERTEST-NEXT:    v_cndmask_b32_e32 v4, v7, v5, vcc
+; SHADERTEST-NEXT:    v_sub_u32_e32 v2, vcc, v2, v6
+; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v2
 ; SHADERTEST-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; SHADERTEST-NEXT:    v_cvt_pkrtz_f16_f32 v1, v3, v2
+; SHADERTEST-NEXT:    v_cmp_eq_u32_e32 vcc, 2, v2
+; SHADERTEST-NEXT:    v_cndmask_b32_e32 v0, v0, v5, vcc
+; SHADERTEST-NEXT:    v_cvt_pkrtz_f16_f32 v1, v3, v4
 ; SHADERTEST-NEXT:    v_cvt_pkrtz_f16_f32 v0, v0, 1.0
 ; SHADERTEST-NEXT:    exp mrt0 v1, v1, v0, v0 done compr vm
 ; SHADERTEST-NEXT:    s_endpgm


### PR DESCRIPTION
Original barycentric calculation depends on gl_PrimitiveID, If a pipeline contains GS or TES, gl_PrimitiveID will be uncontrollable, so we get unstable barycentric.

Starting from gfx10.3, the SPI adds a new PS SGPR that contains the 2-bit provoking vertex for up to 16 primitives in a PS wave. And the SPI also snoop PROVOKING_VTX_LAST, when the provoking vertex is last, the SPI will add 1 to each provokingVert value before loading them into their SGPR. By doing this calculation up front, the rotation in the shader will look identical to the provoking vertex first case.