### PR TITLE
Fix wrong comments in llpcSpirvProcessGpuRtLibrary

### DIFF
--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -24,8 +24,8 @@
  **********************************************************************************************************************/
 /**
  ***********************************************************************************************************************
- * @file  llpcSpirvLowerExecutionGraph.cpp
- * @brief LLPC source file: contains implementation of class Llpc::SpirvLowerExecutionGraph.
+ * @file  llpcSpirvProcessGpuRtLibrary.cpp
+ * @brief LLPC source file: contains implementation of class Llpc::SpirvProcessGpuRtLibrary.
  ***********************************************************************************************************************
  */
 #include "llpcSpirvProcessGpuRtLibrary.h"


### PR DESCRIPTION
Comments referred to a non-existant class.