### PR TITLE
Remove Sqrt/InverseSqrt fp64 workaround

### DIFF
--- a/lgc/builder/ArithBuilder.cpp
+++ b/lgc/builder/ArithBuilder.cpp
@@ -618,61 +618,6 @@ Value *BuilderImpl::CreateLog(Value *x, const Twine &instName) {
 // @param x : Input value X
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateSqrt(Value *x, const Twine &instName) {
-  if (x->getType()->getScalarType()->isDoubleTy()) {
-    // NOTE: For double type, the SQRT and RSQ instructions don't have required precision, we apply Goldschmidt's
-    // algorithm to improve the result:
-    //
-    //   y0 = rsq(x)
-    //   g0 = x * y0
-    //   h0 = 0.5 * y0
-    //
-    //   r0 = 0.5 - h0 * g0
-    //   g1 = g0 * r0 + g0
-    //   h1 = h0 * r0 + h0
-    //
-    //   r1 = 0.5 - h1 * g1 => d0 = x - g1 * g1
-    //   g2 = g1 * r1 + g1     g2 = d0 * h1 + g1
-    //   h2 = h1 * r1 + h1
-    //
-    //   r2 = 0.5 - h2 * g2 => d1 = x - g2 * g2
-    //   g3 = g2 * r2 + g2     g3 = d1 * h1 + g2
-    //
-    //   sqrt(x) = g3
-    //
-
-    // TODO: In the future, this should be totally done in LLVM backend.
-
-    // x < 2^-768
-    auto scaling = CreateFCmpOLT(x, getFpConstant(x->getType(), llvm::APFloat(llvm::APFloat::IEEEdouble(),
-                                                                              llvm::APInt(64, 0x1000000000000000))));
-    auto expTy = BuilderBase::getConditionallyVectorizedTy(getInt32Ty(), x->getType());
-    auto scaleUp = CreateSelect(scaling, ConstantInt::get(expTy, 256), ConstantInt::get(expTy, 0));
-    auto scaleDown = CreateSelect(scaling, ConstantInt::get(expTy, -128, true), ConstantInt::get(expTy, 0));
-    auto half = ConstantFP::get(x->getType(), 0.5);
-
-    x = CreateLdexp(x, scaleUp); // Scale up x if it is too small, make it a normal one
-    auto y = scalarize(x, [this](Value *x) { return CreateUnaryIntrinsic(Intrinsic::amdgcn_rsq, x); });
-    auto g = CreateFMul(x, y);
-    auto h = CreateFMul(half, y);
-
-    auto r = CreateIntrinsic(Intrinsic::fma, x->getType(), {CreateFNeg(h), g, half});
-    g = CreateIntrinsic(Intrinsic::fma, x->getType(), {g, r, g});
-    h = CreateIntrinsic(Intrinsic::fma, x->getType(), {h, r, h});
-
-    auto d = CreateIntrinsic(Intrinsic::fma, x->getType(), {CreateFNeg(g), g, x});
-    g = CreateIntrinsic(Intrinsic::fma, x->getType(), {d, h, g});
-
-    d = CreateIntrinsic(Intrinsic::fma, x->getType(), {CreateFNeg(g), g, x});
-    g = CreateIntrinsic(Intrinsic::fma, x->getType(), {d, h, g});
-
-    g = CreateLdexp(g, scaleDown); // Scale down the result
-
-    // If x is +INF, +0, or -0, use its original value
-    return CreateSelect(
-        createIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), x, g,
-        instName);
-  }
-
   return CreateUnaryIntrinsic(Intrinsic::sqrt, x, nullptr, instName);
 }
 
@@ -683,61 +628,9 @@ Value *BuilderImpl::CreateSqrt(Value *x, const Twine &instName) {
 // @param instName : Name to give instruction(s)
 Value *BuilderImpl::CreateInverseSqrt(Value *x, const Twine &instName) {
   if (x->getType()->getScalarType()->isDoubleTy()) {
-    // NOTE: For double type, the SQRT and RSQ instructions don't have required precision, we apply Goldschmidt's
-    // algorithm to improve the result:
-    //
-    //   y0 = rsq(x)
-    //   g0 = x * y0
-    //   h0 = 0.5 * y0
-    //
-    //   r0 = 0.5 - h0 * g0
-    //   g1 = g0 * r0 + g0
-    //   h1 = h0 * r0 + h0
-    //
-    //   r1 = 0.5 - h1 * g1
-    //   g2 = g1 * r1 + g1
-    //   h2 = h1 * r1 + h1
-    //
-    //   r2 = 0.5 - h2 * g2
-    //   h3 = h2 * r2 + h2
-    //
-    //   inverseSqrt(x) = 2 * h3
-    //
-
-    // TODO: In the future, this should be totally done in LLVM backend.
-
-    // x < 2^-768
-    auto scaling = CreateFCmpOLT(x, getFpConstant(x->getType(), llvm::APFloat(llvm::APFloat::IEEEdouble(),
-                                                                              llvm::APInt(64, 0x1000000000000000))));
-    auto expTy = BuilderBase::getConditionallyVectorizedTy(getInt32Ty(), x->getType());
-    auto scaleUp = CreateSelect(scaling, ConstantInt::get(expTy, 256), ConstantInt::get(expTy, 0));
-    auto scaleDown = CreateSelect(scaling, ConstantInt::get(expTy, 128), ConstantInt::get(expTy, 0));
-    auto half = ConstantFP::get(x->getType(), 0.5);
-
-    x = CreateLdexp(x, scaleUp); // Scale up x if it is too small, make it a normal one
-    auto y = scalarize(x, [this](Value *x) { return CreateUnaryIntrinsic(Intrinsic::amdgcn_rsq, x); });
-    auto g = CreateFMul(x, y);
-    auto h = CreateFMul(half, y);
-
-    auto r = CreateIntrinsic(Intrinsic::fma, x->getType(), {CreateFNeg(h), g, half});
-    g = CreateIntrinsic(Intrinsic::fma, x->getType(), {g, r, g});
-    h = CreateIntrinsic(Intrinsic::fma, x->getType(), {h, r, h});
-
-    r = CreateIntrinsic(Intrinsic::fma, x->getType(), {CreateFNeg(h), g, half});
-    g = CreateIntrinsic(Intrinsic::fma, x->getType(), {g, r, g});
-    h = CreateIntrinsic(Intrinsic::fma, x->getType(), {h, r, h});
-
-    r = CreateIntrinsic(Intrinsic::fma, x->getType(), {CreateFNeg(h), g, half});
-    h = CreateIntrinsic(Intrinsic::fma, x->getType(), {h, r, h});
-
-    h = CreateFMul(ConstantFP::get(x->getType(), 2.0), h);
-
-    h = CreateLdexp(h, scaleDown); // Scale down the result
-
-    // If x is +INF, +0, or -0, use the initial value of reciprocal square root
-    return CreateSelect(
-        createIsFPClass(x, CmpClass::PositiveInfinity | CmpClass::PositiveZero | CmpClass::NegativeZero), y, h,
-        instName);
+    // NOTE: For double type, the intrinsic amdgcn_rsq doesn't have required precision, we resort to LLVM native
+    // intrinsic sqrt since it will be expanded in backend with Goldschmidt's algorithm to improve the precision.
+    return CreateFDiv(ConstantFP::get(x->getType(), 1.0), CreateUnaryIntrinsic(Intrinsic::sqrt, x));
   }
 
   Value *result = scalarize(x, [this](Value *x) { return CreateUnaryIntrinsic(Intrinsic::amdgcn_rsq, x); });

--- a/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
+++ b/llpc/test/shaderdb/extensions/OpExtInst_TestInverseSqrtDouble_lit.frag
@@ -22,38 +22,6 @@ void main()
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
 ; SHADERTEST: %[[SQRT:[^ ,]*]] = call reassoc nnan nsz arcp contract double (...) @lgc.create.inverse.sqrt.f64(double
 ; SHADERTEST: %[[SQRT3:[^ ,]*]] = call reassoc nnan nsz arcp contract <3 x double> (...) @lgc.create.inverse.sqrt.v3f64(<3 x double>
-
-; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
-; SHADERTEST: %[[X:[^ ,]*]] = load double, ptr addrspace(7)
-; SHADERTEST: %[[SCALING:[^ ,]*]] = fcmp reassoc nnan nsz arcp contract olt double %[[X]], 0x1000000000000000
-; SHADERTEST: %[[SCALE_UP:[^ ,]*]] = select i1 %[[SCALING]], i32 256, i32 0
-; SHADERTEST: %[[SCALE_DOWN:[^ ,]*]] = select i1 %[[SCALING]], i32 128, i32 0
-; SHADERTEST: %[[SCALE_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.ldexp.f64.i32(double %[[X]], i32 %[[SCALE_UP]])
-; SHADERTEST: %[[EXP_OF_SCALE_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_X]])
-; SHADERTEST: %[[TOO_SMALL_SCALE_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_X]], -1021
-; SHADERTEST: %[[NEW_SCALE_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_X]], double 0.000000e+00, double %[[SCALE_X]]
-; SHADERTEST: %[[Y:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.amdgcn.rsq.f64(double %[[NEW_SCALE_X]])
-; SHADERTEST: %[[G0:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double %[[NEW_SCALE_X]], %[[Y]]
-; SHADERTEST: %[[H0:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double 5.000000e-01, %[[Y]]
-; SHADERTEST: %[[NEG_H0:[^ ,]*]] = fneg reassoc nnan nsz arcp contract double %[[H0]]
-; SHADERTEST: %[[R0:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H0]], double %[[G0]], double 5.000000e-01)
-; SHADERTEST: %[[G1:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[G0]], double %[[R0]], double %[[G0]])
-; SHADERTEST: %[[H1:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H0]], double %[[R0]], double %[[H0]])
-; SHADERTEST: %[[NEG_H1:[^ ,]*]] = fneg reassoc nnan nsz arcp contract double %[[H1]]
-; SHADERTEST: %[[R1:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H1]], double %[[G1]], double 5.000000e-01)
-; SHADERTEST: %[[G2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[G1]], double %[[R1]], double %[[G1]])
-; SHADERTEST: %[[H2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H1]], double %[[R1]], double %[[H1]])
-; SHADERTEST: %[[NEG_H2:[^ ,]*]] = fneg reassoc nnan nsz arcp contract double %[[H2]]
-; SHADERTEST: %[[R2:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[NEG_H2]], double %[[G2]], double 5.000000e-01)
-; SHADERTEST: %[[H3:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.fma.f64(double %[[H2]], double %[[R2]], double %[[H2]])
-; SHADERTEST: %[[RSQ_X:[^ ,]*]] = fmul reassoc nnan nsz arcp contract double 2.000000e+00, %[[H3]]
-; SHADERTEST: %[[SCALE_RSQ_X:[^ ,]*]] = call reassoc nnan nsz arcp contract double @llvm.ldexp.f64.i32(double %[[RSQ_X]], i32 %[[SCALE_DOWN]])
-; SHADERTEST: %[[EXP_OF_SCALE_RSQ_X:[^ ,]*]] = call i32 @llvm.amdgcn.frexp.exp.i32.f64(double %[[SCALE_RSQ_X]])
-; SHADERTEST: %[[TOO_SMALL_SCALE_RSQ_X:[^ ,]*]] = icmp slt i32 %[[EXP_OF_SCALE_RSQ_X]], -1021
-; SHADERTEST: %[[NEW_SCALE_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[TOO_SMALL_SCALE_RSQ_X]], double 0.000000e+00, double %[[SCALE_RSQ_X]]
-; SHADERTEST: %[[SPECIAL_X:[^ ,]*]] = call i1 @llvm.is.fpclass.f64(double %[[NEW_SCALE_X]], i32 608)
-; SHADERTEST: %[[FINAL_RSQ_X:[^ ,]*]] = select reassoc nnan nsz arcp contract i1 %[[SPECIAL_X]], double %[[Y]], double %[[NEW_SCALE_RSQ_X]]
-
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Previously, we add a workaround to fix the precision problem of fp64 Sqrt and InverseSqrt. The problem is from HW limitation. Now, LLVM backend adds the workaround with this commit:
https://github.com/GPUOpen-Drivers/llvm-project/commit/e3fd8f8. We can remove the workaround now.