### PR TITLE
Clean up instcombine maxIterations

### DIFF
--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -211,10 +211,10 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, T
     fpm.addPass(PatchBufferOp());
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 452298
     // Old version of the code
-    unsigned instCombineOpt = 2;
+    unsigned instCombineOpt = 1;
 #else
     // New version of the code (also handles unknown version, which we treat as latest)
-    auto instCombineOpt = InstCombineOptions().setMaxIterations(2);
+    auto instCombineOpt = InstCombineOptions().setMaxIterations(1);
 #endif
     fpm.addPass(InstCombinePass(instCombineOpt));
     passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));

--- a/lgc/patch/Patch.cpp
+++ b/lgc/patch/Patch.cpp
@@ -209,14 +209,7 @@ void Patch::addPasses(PipelineState *pipelineState, lgc::PassManager &passMgr, T
   } else {
     FunctionPassManager fpm;
     fpm.addPass(PatchBufferOp());
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 452298
-    // Old version of the code
-    unsigned instCombineOpt = 1;
-#else
-    // New version of the code (also handles unknown version, which we treat as latest)
-    auto instCombineOpt = InstCombineOptions().setMaxIterations(1);
-#endif
-    fpm.addPass(InstCombinePass(instCombineOpt));
+    fpm.addPass(InstCombinePass());
     passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
   }
 
@@ -345,14 +338,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, uint32_t optLevel) 
 
   passMgr.addPass(ForceFunctionAttrsPass());
   FunctionPassManager fpm;
-#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 452298
-  // Old version of the code
-  unsigned instCombineOpt = 1;
-#else
-  // New version of the code (also handles unknown version, which we treat as latest)
-  auto instCombineOpt = InstCombineOptions().setMaxIterations(1);
-#endif
-  fpm.addPass(InstCombinePass(instCombineOpt));
+  fpm.addPass(InstCombinePass());
   fpm.addPass(SimplifyCFGPass());
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 444780
   // Old version of the code
@@ -366,7 +352,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, uint32_t optLevel) 
   fpm.addPass(CorrelatedValuePropagationPass());
   fpm.addPass(SimplifyCFGPass());
   fpm.addPass(AggressiveInstCombinePass());
-  fpm.addPass(InstCombinePass(instCombineOpt));
+  fpm.addPass(InstCombinePass());
   fpm.addPass(PatchPeepholeOpt());
   fpm.addPass(SimplifyCFGPass());
   fpm.addPass(ReassociatePass());
@@ -375,7 +361,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, uint32_t optLevel) 
   lpm.addPass(LICMPass(LICMOptions()));
   fpm.addPass(createFunctionToLoopPassAdaptor(std::move(lpm), true));
   fpm.addPass(SimplifyCFGPass());
-  fpm.addPass(InstCombinePass(instCombineOpt));
+  fpm.addPass(InstCombinePass());
   LoopPassManager lpm2;
   lpm2.addPass(IndVarSimplifyPass());
   lpm2.addPass(LoopIdiomRecognizePass());
@@ -397,7 +383,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, uint32_t optLevel) 
   fpm.addPass(InstSimplifyPass());
   fpm.addPass(NewGVNPass());
   fpm.addPass(BDCEPass());
-  fpm.addPass(InstCombinePass(instCombineOpt));
+  fpm.addPass(InstCombinePass());
   fpm.addPass(CorrelatedValuePropagationPass());
   fpm.addPass(ADCEPass());
   fpm.addPass(createFunctionToLoopPassAdaptor(LoopRotatePass()));
@@ -411,7 +397,7 @@ void Patch::addOptimizationPasses(lgc::PassManager &passMgr, uint32_t optLevel) 
   fpm.addPass(SROAPass(SROAOptions::ModifyCFG));
   // uses UniformityAnalysis
   fpm.addPass(PatchReadFirstLane());
-  fpm.addPass(InstCombinePass(instCombineOpt));
+  fpm.addPass(InstCombinePass());
   passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
   passMgr.addPass(ConstantMergePass());
   FunctionPassManager fpm2;


### PR DESCRIPTION
https://reviews.llvm.org/D154579 changed InstCombineDefaultMaxIterations
from 1000 to 1, so there is no need for LLPC to pass 1 as an extra argument,
which is now the default.

Also, reduce instcombine iterations form 2 to 1 for non-NGG. The instcombine 
is run earlier a couple of times so in most cases it is not required to run it again 
with 2 iterations. Out of 10K test shaders only a handful is affected by this 
change, and the differences are negligible. This also makes it consistent with 
the NGG path.