### PR TITLE
Add support for stand-alone ray-tracing shaders

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -12,6 +12,7 @@ ANDed = "ANDed"
 UE = "UE"
 OpBuildNDRange = "OpBuildNDRange"
 serDataNode = "serDataNode"
+rcall = "rcall"
 
 [default.extend-words]
 ba = "ba"

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2427,8 +2427,12 @@ Result Compiler::BuildRayTracingPipeline(const RayTracingPipelineBuildInfo *pipe
     size_t binaryDataSize = sizeof(BinaryData) * elfBinarys.size();
     size_t elfSize = 0;
 
-    for (auto &elf : elfBinarys)
+    for (auto &elf : elfBinarys) {
+      if (elf.size() % 8 != 0) {
+        elf.resize(alignTo(elf.size(), alignof(BinaryData)));
+      }
       elfSize += elf.size();
+    }
 
     size_t allocSize = elfSize;
     allocSize += binaryDataSize;

--- a/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
+++ b/llpc/lower/llpcSpirvProcessGpuRtLibrary.cpp
@@ -354,6 +354,7 @@ void SpirvProcessGpuRtLibrary::createConvertF32toF16WithRoundingMode(Function *f
 // @param func : The function to create
 void SpirvProcessGpuRtLibrary::createIntersectBvh(Function *func) {
   const auto *rtState = m_context->getPipelineContext()->getRayTracingState();
+  assert(rtState->bvhResDesc.dataSizeInDwords != 0);
   if (rtState->bvhResDesc.dataSizeInDwords < 4)
     return;
 

--- a/llpc/test/lit.cfg.py
+++ b/llpc/test/lit.cfg.py
@@ -43,7 +43,9 @@ config.name = 'LLPC_SHADERTEST'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.vert', '.tesc', '.tese', '.geom', '.frag', '.comp', '.spvasm', '.pipe', '.ll', '.multi-input']
+config.suffixes = ['.vert', '.tesc', '.tese', '.geom', '.frag', '.comp',
+                   '.rgen', '.rint', '.rahit', '.rchit', '.rmiss', '.rcall',
+                   '.spvasm', '.pipe', '.ll', '.multi-input']
 
 # excludes: A list of directories and files to exclude from the testsuite.
 config.excludes = ['CMakeLists.txt', 'litScripts', 'internal', 'avoid', 'error']

--- a/llpc/test/shaderdb/ray_tracing/standalone.rahit
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rahit
@@ -1,0 +1,14 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _ahit1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+void main()
+{
+}

--- a/llpc/test/shaderdb/ray_tracing/standalone.rcall
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rcall
@@ -1,0 +1,14 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _call1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+void main()
+{
+}

--- a/llpc/test/shaderdb/ray_tracing/standalone.rchit
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rchit
@@ -1,0 +1,14 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _chit1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+void main()
+{
+}

--- a/llpc/test/shaderdb/ray_tracing/standalone.rgen
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rgen
@@ -1,0 +1,14 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _gen1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+void main()
+{
+}

--- a/llpc/test/shaderdb/ray_tracing/standalone.rint
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rint
@@ -1,0 +1,14 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _int1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+void main()
+{
+}

--- a/llpc/test/shaderdb/ray_tracing/standalone.rmiss
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rmiss
@@ -1,0 +1,21 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _miss1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+layout(location = 0) rayPayloadInEXT vec3 hitValue;
+
+layout(shaderRecordEXT, std430) buffer SBT {
+  float b;
+};
+
+void main()
+{
+  hitValue = vec3(b, b, b);
+}

--- a/llpc/tool/llpcAutoLayout.cpp
+++ b/llpc/tool/llpcAutoLayout.cpp
@@ -681,6 +681,8 @@ void buildTopLevelMapping(unsigned shaderMask, const ResourceMappingNodeMap &res
   unsigned subLevelCount = 0;
   for (const auto &resNodeSet : resNodeSets)
     subLevelCount += resNodeSet.second.nodes.size();
+  if (shaderMask & Vkgc::ShaderStageAllRayTracingBit)
+    subLevelCount += 3; // see handling of ShaderStageAllRayTracingBit below
 
   size_t bufferSize = sizeof(ResourceMappingRootNode) * topLevelCount + sizeof(ResourceMappingNode) * subLevelCount;
   auto rootNodes = static_cast<ResourceMappingRootNode *>(malloc(bufferSize));
@@ -721,6 +723,50 @@ void buildTopLevelMapping(unsigned shaderMask, const ResourceMappingNodeMap &res
     rootNodes->node.offsetInDwords = topLevelOffset;
     topLevelOffset += rootNodes->node.sizeInDwords;
     rootNodes->visibility = xfbStageMask & shaderMask;
+    ++rootNodes;
+  }
+
+  if (shaderMask & Vkgc::ShaderStageAllRayTracingBit) {
+    // Add a node for RT
+    rootNodes->node.type = ResourceMappingNodeType::DescriptorTableVaPtr;
+    rootNodes->node.sizeInDwords = 1;
+    rootNodes->node.offsetInDwords = topLevelOffset;
+    topLevelOffset += rootNodes->node.sizeInDwords;
+    rootNodes->visibility = Vkgc::ShaderStageAllRayTracingBit & shaderMask;
+    rootNodes->node.tablePtr.nodeCount = 0;
+    rootNodes->node.tablePtr.pNext = nullptr;
+    ++rootNodes;
+
+    rootNodes->node.type = ResourceMappingNodeType::DescriptorTableVaPtr;
+    rootNodes->node.sizeInDwords = 1;
+    rootNodes->node.offsetInDwords = topLevelOffset;
+    topLevelOffset += rootNodes->node.sizeInDwords;
+    rootNodes->visibility = Vkgc::ShaderStageAllRayTracingBit & shaderMask;
+
+    rootNodes->node.tablePtr.nodeCount = 3;
+    rootNodes->node.tablePtr.pNext = subNodes;
+
+    subNodes->type = ResourceMappingNodeType::DescriptorConstBufferCompact;
+    subNodes->offsetInDwords = 0;
+    subNodes->sizeInDwords = 2;
+    subNodes->srdRange.set = 0x5D;
+    subNodes->srdRange.binding = 17;
+    ++subNodes;
+
+    subNodes->type = ResourceMappingNodeType::DescriptorConstBuffer;
+    subNodes->offsetInDwords = 2;
+    subNodes->sizeInDwords = 4;
+    subNodes->srdRange.set = 0x5D;
+    subNodes->srdRange.binding = 0;
+    ++subNodes;
+
+    subNodes->type = ResourceMappingNodeType::DescriptorBuffer;
+    subNodes->offsetInDwords = 6;
+    subNodes->sizeInDwords = 4;
+    subNodes->srdRange.set = 0x5D;
+    subNodes->srdRange.binding = 1;
+    ++subNodes;
+
     ++rootNodes;
   }
 

--- a/llpc/tool/llpcInputUtils.h
+++ b/llpc/tool/llpcInputUtils.h
@@ -103,7 +103,8 @@ constexpr llvm::StringLiteral LlvmIr = ".ll";
 constexpr llvm::StringLiteral IsaText = ".s";
 constexpr llvm::StringLiteral IsaBin = ".elf";
 
-constexpr llvm::StringLiteral GlslShaders[] = {".task", ".vert", ".tesc", ".tese", ".geom", ".mesh", ".frag", ".comp"};
+constexpr llvm::StringLiteral GlslShaders[] = {".task", ".vert", ".tesc", ".tese",  ".geom",  ".mesh",  ".frag",
+                                               ".comp", ".rgen", ".rint", ".rahit", ".rchit", ".rmiss", ".rcall"};
 
 } // namespace Ext
 


### PR DESCRIPTION
Add support for stand-alone ray-tracing shaders. Also adds an option to choose the raytracing mode to be used. Meant to simplify testing and for consistency with compiling stand-alone rasterization shaders.