### PR TITLE
Fix a NGG typo when reading position data from LDS for vertex compaction

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3213,7 +3213,7 @@ Value *NggPrimShader::runPartEs(ArrayRef<Argument *> args, Value *position) {
       auto vertexItemOffset = m_builder.CreateMul(uncompactedVertexIndex, m_builder.getInt32(esGsRingItemSize));
 
       newPosition = readPerThreadDataFromLds(FixedVectorType::get(m_builder.getFloatTy(), 4), uncompactedVertexIndex,
-                                             PrimShaderLdsRegion::VertexPosition, true);
+                                             PrimShaderLdsRegion::VertexPosition, 0, true);
 
       // NOTE: For deferred vertex export, some system values could be from vertex compaction info rather than from
       // VGPRs (caused by NGG culling and vertex compaction)


### PR DESCRIPTION
The function readPerThreadDataFromLds uses default parameters with parameter offsetInRegion=0 and useDs128=false. We forgot to set 0 for offsetInRegion and the true argument for useDs128 is passed to offsetInRegion, causing wrong LDS offset calculation.