### PR TITLE
Update CodeGenOpt unit tests

### DIFF
--- a/lgc/unittests/interface/OptLevelTest.cpp
+++ b/lgc/unittests/interface/OptLevelTest.cpp
@@ -41,7 +41,15 @@ TEST(LgcInterfaceTests, DefaultOptLevel) {
   unsigned palAbiVersion = 0xFFFFFFFF;
   StringRef gpuName = "gfx802";
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
+  // Old version of the code
   for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  // Returns the optimization level for the context.
+  for (auto optLevel :
+       {CodeGenOptLevel::None, CodeGenOptLevel::Less, CodeGenOptLevel::Default, CodeGenOptLevel::Aggressive}) {
+#endif
     std::unique_ptr<TargetMachine> targetMachine = LgcContext::createTargetMachine(gpuName, optLevel);
     std::unique_ptr<LgcContext> lgcContext(LgcContext::create(&*targetMachine, context, palAbiVersion));
     EXPECT_EQ(lgcContext->getOptimizationLevel(), optLevel);

--- a/llpc/unittests/context/testOptLevel.cpp
+++ b/llpc/unittests/context/testOptLevel.cpp
@@ -50,15 +50,30 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
 
   Context *context = new Context(GfxIp);
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
+  // Old version of the code
   for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  // Returns the optimization level for the context.
+  for (auto optLevel :
+       {CodeGenOptLevel::None, CodeGenOptLevel::Less, CodeGenOptLevel::Default, CodeGenOptLevel::Aggressive}) {
+#endif
     GraphicsPipelineBuildInfo pipelineInfo = {};
-    pipelineInfo.options.optimizationLevel = optLevel;
+    pipelineInfo.options.optimizationLevel = static_cast<uint32_t>(optLevel);
 
     GraphicsContext graphicsContext(GfxIp, &pipelineInfo, &pipelineHash, &cacheHash);
 
     context->attachPipelineContext(&graphicsContext);
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
+    // Old version of the code
     if (optLevel == Level::None) {
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    // Returns the optimization level for the context.
+    if (optLevel == CodeGenOptLevel::None) {
+#endif
       // None might not be possible, so accept >= Level::None
       EXPECT_GE(context->getLgcContext()->getOptimizationLevel(), optLevel);
     } else {
@@ -66,15 +81,30 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
     }
   }
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
+  // Old version of the code
   for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
+#else
+  // New version of the code (also handles unknown version, which we treat as latest)
+  // Returns the optimization level for the context.
+  for (auto optLevel :
+       {CodeGenOptLevel::None, CodeGenOptLevel::Less, CodeGenOptLevel::Default, CodeGenOptLevel::Aggressive}) {
+#endif
     ComputePipelineBuildInfo pipelineInfo = {};
-    pipelineInfo.options.optimizationLevel = optLevel;
+    pipelineInfo.options.optimizationLevel = static_cast<uint32_t>(optLevel);
 
     ComputeContext computeContext(GfxIp, &pipelineInfo, &pipelineHash, &cacheHash);
 
     context->attachPipelineContext(&computeContext);
 
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
+    // Old version of the code
     if (optLevel == Level::None) {
+#else
+    // New version of the code (also handles unknown version, which we treat as latest)
+    // Returns the optimization level for the context.
+    if (optLevel == CodeGenOptLevel::None) {
+#endif
       // None might not be possible, so accept >= Level::None
       EXPECT_GE(context->getLgcContext()->getOptimizationLevel(), optLevel);
     } else {


### PR DESCRIPTION
There is a flag-day change around CodeGen enums in https://github.com/llvm/llvm-project/pull/66295.

Changes were made in https://github.com/GPUOpen-Drivers/llpc/pull/2770 but some unit tests were missed.