### PR TITLE
Lower OpFNegate directly to fneg

### DIFF
--- a/llpc/lower/llpcSpirvLowerMath.cpp
+++ b/llpc/lower/llpcSpirvLowerMath.cpp
@@ -476,15 +476,6 @@ bool SpirvLowerMathFloatOp::runImpl(Module &module) {
 }
 
 // =====================================================================================================================
-// Visits unary operator instruction.
-//
-// @param unaryOp : Unary operator instruction
-void SpirvLowerMathFloatOp::visitUnaryOperator(UnaryOperator &unaryOp) {
-  if (unaryOp.getOpcode() == Instruction::FNeg)
-    flushDenormIfNeeded(&unaryOp);
-}
-
-// =====================================================================================================================
 // Visits binary operator instruction.
 //
 // @param binaryOp : Binary operator instruction

--- a/llpc/lower/llpcSpirvLowerMath.h
+++ b/llpc/lower/llpcSpirvLowerMath.h
@@ -98,7 +98,6 @@ public:
   bool runImpl(llvm::Module &module);
 
   virtual void visitBinaryOperator(llvm::BinaryOperator &binaryOp);
-  virtual void visitUnaryOperator(llvm::UnaryOperator &unaryOp);
   virtual void visitCallInst(llvm::CallInst &callInst);
   virtual void visitFPTruncInst(llvm::FPTruncInst &fptruncInst);
 

--- a/llpc/test/shaderdb/core/OpFNegate_TestMat2X3_lit.frag
+++ b/llpc/test/shaderdb/core/OpFNegate_TestMat2X3_lit.frag
@@ -17,7 +17,7 @@ void main()
 /*
 ; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
 ; SHADERTEST-LABEL: {{^// LLPC}} SPIRV-to-LLVM translation results
-; SHADERTEST-COUNT-2: fsub reassoc nnan nsz arcp contract afn <3 x float>
+; SHADERTEST-COUNT-2: fneg reassoc nnan nsz arcp contract afn <3 x float>
 ; SHADERTEST: AMDLLPC SUCCESS
 */
 // END_SHADERTEST


### PR DESCRIPTION
Update SPIRVReader to lower OpFNegate directly to fneg. By doing this the code in SpirvLowerMath can be updated to remove the change to add a canonicalize for any fneg.

The motivation for this is that InstCombine can introduce fneg instructions (after some recent upstream llvm changes) and in this case we don't want to blindly add a canonicalize as this invalidates e.g. xor 0x8000000 val -> fneg val.

It makes more sense to handle the requirement to treat OpFNegate as a floating point instruction at the point it is lowered (llvm fneg is not, hence the reason we may need the canonicalize intrinsic).