### PR TITLE
Fix testOptLevel

### DIFF
--- a/llpc/unittests/context/testOptLevel.cpp
+++ b/llpc/unittests/context/testOptLevel.cpp
@@ -48,8 +48,6 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
 
   LgcContext::initialize();
 
-  Context *context = new Context(GfxIp);
-
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
   // Old version of the code
   for (auto optLevel : {Level::None, Level::Less, Level::Default, Level::Aggressive}) {
@@ -59,12 +57,15 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
   for (auto optLevel :
        {CodeGenOptLevel::None, CodeGenOptLevel::Less, CodeGenOptLevel::Default, CodeGenOptLevel::Aggressive}) {
 #endif
+
+    Context context(GfxIp);
+
     GraphicsPipelineBuildInfo pipelineInfo = {};
     pipelineInfo.options.optimizationLevel = static_cast<uint32_t>(optLevel);
 
     GraphicsContext graphicsContext(GfxIp, &pipelineInfo, &pipelineHash, &cacheHash);
 
-    context->attachPipelineContext(&graphicsContext);
+    context.attachPipelineContext(&graphicsContext);
 
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
     // Old version of the code
@@ -75,9 +76,9 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
     if (optLevel == CodeGenOptLevel::None) {
 #endif
       // None might not be possible, so accept >= Level::None
-      EXPECT_GE(context->getLgcContext()->getOptimizationLevel(), optLevel);
+      EXPECT_GE(context.getLgcContext()->getOptimizationLevel(), optLevel);
     } else {
-      EXPECT_EQ(context->getLgcContext()->getOptimizationLevel(), optLevel);
+      EXPECT_EQ(context.getLgcContext()->getOptimizationLevel(), optLevel);
     }
   }
 
@@ -90,12 +91,15 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
   for (auto optLevel :
        {CodeGenOptLevel::None, CodeGenOptLevel::Less, CodeGenOptLevel::Default, CodeGenOptLevel::Aggressive}) {
 #endif
+
+    Context context(GfxIp);
+
     ComputePipelineBuildInfo pipelineInfo = {};
     pipelineInfo.options.optimizationLevel = static_cast<uint32_t>(optLevel);
 
     ComputeContext computeContext(GfxIp, &pipelineInfo, &pipelineHash, &cacheHash);
 
-    context->attachPipelineContext(&computeContext);
+    context.attachPipelineContext(&computeContext);
 
 #if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 474768
     // Old version of the code
@@ -106,9 +110,9 @@ TEST(LlpcContextTests, MatchPipelineOptLevel) {
     if (optLevel == CodeGenOptLevel::None) {
 #endif
       // None might not be possible, so accept >= Level::None
-      EXPECT_GE(context->getLgcContext()->getOptimizationLevel(), optLevel);
+      EXPECT_GE(context.getLgcContext()->getOptimizationLevel(), optLevel);
     } else {
-      EXPECT_EQ(context->getLgcContext()->getOptimizationLevel(), optLevel);
+      EXPECT_EQ(context.getLgcContext()->getOptimizationLevel(), optLevel);
     }
   }
 }


### PR DESCRIPTION
Recreate LLPC context between iterations. The LLPC context is not meant to be reused.

Related to #2434.
Fixes check-amdllpc-units on Windows.