### PR TITLE
lgc: Pass Layer and ViewportIndex from VS to HS/GS and from HS to DS

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1782,11 +1782,11 @@ void BuilderImpl::markBuiltInOutputUsage(BuiltInKind builtIn, unsigned arraySize
     case BuiltInTessLevelInner:
       usage.tcs.tessLevelInner = true;
       break;
-    case BuiltInViewportIndex:
-      usage.tcs.viewportIndex = true;
-      break;
     case BuiltInLayer:
       usage.tcs.layer = true;
+      break;
+    case BuiltInViewportIndex:
+      usage.tcs.viewportIndex = true;
       break;
     default:
       break;

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1474,6 +1474,12 @@ void BuilderImpl::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySize
     case BuiltInViewIndex:
       usage.tcs.viewIndex = true;
       break;
+    case BuiltInLayer:
+      usage.tcs.layerIn = true;
+      break;
+    case BuiltInViewportIndex:
+      usage.tcs.viewportIndexIn = true;
+      break;
     default:
       break;
     }
@@ -1512,6 +1518,12 @@ void BuilderImpl::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySize
     case BuiltInViewIndex:
       usage.tes.viewIndex = true;
       break;
+    case BuiltInLayer:
+      usage.tes.layerIn = true;
+      break;
+    case BuiltInViewportIndex:
+      usage.tes.viewportIndexIn = true;
+      break;
     default:
       break;
     }
@@ -1540,6 +1552,12 @@ void BuilderImpl::markBuiltInInputUsage(BuiltInKind &builtIn, unsigned arraySize
       break;
     case BuiltInViewIndex:
       usage.gs.viewIndex = true;
+      break;
+    case BuiltInLayer:
+      usage.gs.layerIn = true;
+      break;
+    case BuiltInViewportIndex:
+      usage.gs.viewportIndexIn = true;
       break;
     default:
       break;
@@ -1763,6 +1781,12 @@ void BuilderImpl::markBuiltInOutputUsage(BuiltInKind builtIn, unsigned arraySize
       break;
     case BuiltInTessLevelInner:
       usage.tcs.tessLevelInner = true;
+      break;
+    case BuiltInViewportIndex:
+      usage.tcs.viewportIndex = true;
+      break;
+    case BuiltInLayer:
+      usage.tcs.layer = true;
       break;
     default:
       break;

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -201,16 +201,16 @@ struct ResourceUsage {
       // Tessellation control shader
       struct {
         // Input
-        unsigned pointSizeIn : 1;    // Whether gl_in[].gl_PointSize is used
-        unsigned positionIn : 1;     // Whether gl_in[].gl_Position is used
-        unsigned clipDistanceIn : 4; // Array size of gl_in[].gl_ClipDistance[] (0 means unused)
-        unsigned cullDistanceIn : 4; // Array size of gl_in[].gl_CullDistance[] (0 means unused)
-        unsigned patchVertices : 1;  // Whether gl_PatchVerticesIn is used
-        unsigned primitiveId : 1;    // Whether gl_PrimitiveID is used
-        unsigned invocationId : 1;   // Whether gl_InvocationID is used
-        unsigned viewIndex : 1;      // Whether gl_ViewIndex is used
-        unsigned viewportIndexIn : 1;// Whether DX SV_ViewportArrayIndex is used
-        unsigned layerIn : 1;        // Whether DX SV_RenderTargetArrayIndex is used
+        unsigned pointSizeIn : 1;     // Whether gl_in[].gl_PointSize is used
+        unsigned positionIn : 1;      // Whether gl_in[].gl_Position is used
+        unsigned clipDistanceIn : 4;  // Array size of gl_in[].gl_ClipDistance[] (0 means unused)
+        unsigned cullDistanceIn : 4;  // Array size of gl_in[].gl_CullDistance[] (0 means unused)
+        unsigned patchVertices : 1;   // Whether gl_PatchVerticesIn is used
+        unsigned primitiveId : 1;     // Whether gl_PrimitiveID is used
+        unsigned invocationId : 1;    // Whether gl_InvocationID is used
+        unsigned viewIndex : 1;       // Whether gl_ViewIndex is used
+        unsigned viewportIndexIn : 1; // Whether DX SV_ViewportArrayIndex is used
+        unsigned layerIn : 1;         // Whether DX SV_RenderTargetArrayIndex is used
         // Output
         unsigned pointSize : 1;      // Whether gl_out[].gl_PointSize is used
         unsigned position : 1;       // Whether gl_out[].gl_Position is used
@@ -218,25 +218,25 @@ struct ResourceUsage {
         unsigned cullDistance : 4;   // Array size of gl_out[].gl_CullDistance[] (0 means unused)
         unsigned tessLevelOuter : 1; // Whether gl_TessLevelOuter[] is used
         unsigned tessLevelInner : 1; // Whether gl_TessLevelInner[] is used
-        unsigned viewportIndex  : 1; // Whether DX SV_ViewportArrayIndex is used
+        unsigned viewportIndex : 1;  // Whether DX SV_ViewportArrayIndex is used
         unsigned layer;              // Whether DX SV_RenderTargetArrayIndex is used
       } tcs;
 
       // Tessellation evaluation shader
       struct {
         // Input
-        unsigned pointSizeIn : 1;    // Whether gl_in[].gl_PointSize is used
-        unsigned positionIn : 1;     // Whether gl_in[].gl_Position is used
-        unsigned clipDistanceIn : 4; // Array size of gl_in[].gl_ClipDistance[] (0 means unused)
-        unsigned cullDistanceIn : 4; // Array size of gl_in[].gl_CullDistance[] (0 means unused)
-        unsigned patchVertices : 1;  // Whether gl_PatchVerticesIn is used
-        unsigned primitiveId : 1;    // Whether gl_PrimitiveID is used
-        unsigned tessCoord : 1;      // Whether gl_TessCoord is used
-        unsigned tessLevelOuter : 1; // Whether gl_TessLevelOuter[] is used
-        unsigned tessLevelInner : 1; // Whether gl_TessLevelInner[] is used
-        unsigned viewIndex : 1;      // Whether gl_ViewIndex is used
-        unsigned viewportIndexIn : 1;// Whether DX SV_ViewportArrayIndex is used
-        unsigned layerIn : 1;        // Whether DX SV_RenderTargetArrayIndex is used
+        unsigned pointSizeIn : 1;     // Whether gl_in[].gl_PointSize is used
+        unsigned positionIn : 1;      // Whether gl_in[].gl_Position is used
+        unsigned clipDistanceIn : 4;  // Array size of gl_in[].gl_ClipDistance[] (0 means unused)
+        unsigned cullDistanceIn : 4;  // Array size of gl_in[].gl_CullDistance[] (0 means unused)
+        unsigned patchVertices : 1;   // Whether gl_PatchVerticesIn is used
+        unsigned primitiveId : 1;     // Whether gl_PrimitiveID is used
+        unsigned tessCoord : 1;       // Whether gl_TessCoord is used
+        unsigned tessLevelOuter : 1;  // Whether gl_TessLevelOuter[] is used
+        unsigned tessLevelInner : 1;  // Whether gl_TessLevelInner[] is used
+        unsigned viewIndex : 1;       // Whether gl_ViewIndex is used
+        unsigned viewportIndexIn : 1; // Whether DX SV_ViewportArrayIndex is used
+        unsigned layerIn : 1;         // Whether DX SV_RenderTargetArrayIndex is used
         // Output
         unsigned pointSize : 1;     // Whether gl_PointSize is used
         unsigned position : 1;      // Whether gl_Position is used

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -249,15 +249,15 @@ struct ResourceUsage {
       // Geometry shader
       struct {
         // Input
-        unsigned pointSizeIn : 1;    // Whether gl_in[].gl_PointSize is used
-        unsigned positionIn : 1;     // Whether gl_in[].gl_Position is used
-        unsigned clipDistanceIn : 4; // Array size of gl_in[].gl_ClipDistance[] (0 means unused)
-        unsigned cullDistanceIn : 4; // Array size of gl_in[].gl_CullDistance[] (0 means unused)
-        unsigned primitiveIdIn : 1;  // Whether gl_PrimitiveIDIn is used
-        unsigned invocationId : 1;   // Whether gl_InvocationID is used
-        unsigned viewIndex : 1;      // Whether gl_ViewIndex is used
-        unsigned viewportIndex : 1;  // Whether DX SV_ViewportArrayIndex is used
-        unsigned layerIn : 1;        // Whether DX SV_RenderTargetArrayIndex is used
+        unsigned pointSizeIn : 1;     // Whether gl_in[].gl_PointSize is used
+        unsigned positionIn : 1;      // Whether gl_in[].gl_Position is used
+        unsigned clipDistanceIn : 4;  // Array size of gl_in[].gl_ClipDistance[] (0 means unused)
+        unsigned cullDistanceIn : 4;  // Array size of gl_in[].gl_CullDistance[] (0 means unused)
+        unsigned primitiveIdIn : 1;   // Whether gl_PrimitiveIDIn is used
+        unsigned invocationId : 1;    // Whether gl_InvocationID is used
+        unsigned viewIndex : 1;       // Whether gl_ViewIndex is used
+        unsigned viewportIndexIn : 1; // Whether DX SV_ViewportArrayIndex is used
+        unsigned layerIn : 1;         // Whether DX SV_RenderTargetArrayIndex is used
         // Output
         unsigned pointSize : 1;            // Whether gl_PointSize is used
         unsigned position : 1;             // Whether gl_Position is used

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -209,6 +209,8 @@ struct ResourceUsage {
         unsigned primitiveId : 1;    // Whether gl_PrimitiveID is used
         unsigned invocationId : 1;   // Whether gl_InvocationID is used
         unsigned viewIndex : 1;      // Whether gl_ViewIndex is used
+        unsigned viewportIndexIn : 1;// Whether DX SV_ViewportArrayIndex is used
+        unsigned layerIn : 1;        // Whether DX SV_RenderTargetArrayIndex is used
         // Output
         unsigned pointSize : 1;      // Whether gl_out[].gl_PointSize is used
         unsigned position : 1;       // Whether gl_out[].gl_Position is used
@@ -216,6 +218,8 @@ struct ResourceUsage {
         unsigned cullDistance : 4;   // Array size of gl_out[].gl_CullDistance[] (0 means unused)
         unsigned tessLevelOuter : 1; // Whether gl_TessLevelOuter[] is used
         unsigned tessLevelInner : 1; // Whether gl_TessLevelInner[] is used
+        unsigned viewportIndex  : 1; // Whether DX SV_ViewportArrayIndex is used
+        unsigned layer;              // Whether DX SV_RenderTargetArrayIndex is used
       } tcs;
 
       // Tessellation evaluation shader
@@ -231,6 +235,8 @@ struct ResourceUsage {
         unsigned tessLevelOuter : 1; // Whether gl_TessLevelOuter[] is used
         unsigned tessLevelInner : 1; // Whether gl_TessLevelInner[] is used
         unsigned viewIndex : 1;      // Whether gl_ViewIndex is used
+        unsigned viewportIndexIn : 1;// Whether DX SV_ViewportArrayIndex is used
+        unsigned layerIn : 1;        // Whether DX SV_RenderTargetArrayIndex is used
         // Output
         unsigned pointSize : 1;     // Whether gl_PointSize is used
         unsigned position : 1;      // Whether gl_Position is used
@@ -250,6 +256,8 @@ struct ResourceUsage {
         unsigned primitiveIdIn : 1;  // Whether gl_PrimitiveIDIn is used
         unsigned invocationId : 1;   // Whether gl_InvocationID is used
         unsigned viewIndex : 1;      // Whether gl_ViewIndex is used
+        unsigned viewportIndex : 1;  // Whether DX SV_ViewportArrayIndex is used
+        unsigned layerIn : 1;        // Whether DX SV_RenderTargetArrayIndex is used
         // Output
         unsigned pointSize : 1;            // Whether gl_PointSize is used
         unsigned position : 1;             // Whether gl_Position is used

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -74,7 +74,7 @@ BUILTIN(GlobalInvocationId, 28, N, TMC, v3i32)           // Invocation ID within
 BUILTIN(HelperInvocation, 23, N, P, i1)                  // Helper invocation flag
 BUILTIN(InstanceIndex, 43, N, V, i32)                    // Instance index
 BUILTIN(InvocationId, 8, N, HG, i32)                     // Invocation ID
-BUILTIN(Layer, 9, MVDG, P, i32)                          // Layer of multi-layer framebuffer attachment
+BUILTIN(Layer, 9, MVHDG,  HDGP, i32)                     // Layer of multi-layer framebuffer attachment
 BUILTIN(LocalInvocationId, 27, N, TMC, v3i32)            // Invocation location within local workgroup
 BUILTIN(LocalInvocationIndex, 29, N, TMC, i32)           // Linearized LocalInvocationId
 BUILTIN(NumSubgroups, 38, N, TMC, i32)                   // Number of subgroups in the local workgroup
@@ -102,7 +102,7 @@ BUILTIN(TessLevelInner, 12, H, D, a2f32)                 // Tessellation inner l
 BUILTIN(TessLevelOuter, 11, H, D, a4f32)                 // Tessellation outer levels
 BUILTIN(VertexIndex, 42, N, V, i32)                      // Index of current vertex
 BUILTIN(ViewIndex, 4440, N, MVHDGP, i32)                 // View index
-BUILTIN(ViewportIndex, 10, MVDG, P, i32)                 // Viewport index
+BUILTIN(ViewportIndex, 10, MVHDG, HDGP, i32)             // Viewport index
 BUILTIN(WorkgroupId, 26, N, TMC, v3i32)                  // ID of global workgroup
 BUILTIN(WorkgroupSize, 25, N, TMC, v3i32)                // Size of global workgroup
 BUILTIN(CullPrimitive, 5299, N, M, i1)                   // Whether primitive should be culled

--- a/lgc/interface/lgc/BuiltInDefs.h
+++ b/lgc/interface/lgc/BuiltInDefs.h
@@ -74,7 +74,7 @@ BUILTIN(GlobalInvocationId, 28, N, TMC, v3i32)           // Invocation ID within
 BUILTIN(HelperInvocation, 23, N, P, i1)                  // Helper invocation flag
 BUILTIN(InstanceIndex, 43, N, V, i32)                    // Instance index
 BUILTIN(InvocationId, 8, N, HG, i32)                     // Invocation ID
-BUILTIN(Layer, 9, MVHDG,  HDGP, i32)                     // Layer of multi-layer framebuffer attachment
+BUILTIN(Layer, 9, MVHDG, HDGP, i32)                      // Layer of multi-layer framebuffer attachment
 BUILTIN(LocalInvocationId, 27, N, TMC, v3i32)            // Invocation location within local workgroup
 BUILTIN(LocalInvocationIndex, 29, N, TMC, i32)           // Linearized LocalInvocationId
 BUILTIN(NumSubgroups, 38, N, TMC, i32)                   // Number of subgroups in the local workgroup

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2360,7 +2360,7 @@ Value *PatchInOutImportExport::patchGsBuiltInInputImport(Type *inputTy, unsigned
   case BuiltInClipDistance:
   case BuiltInCullDistance:
   case BuiltInLayer:
-  case BuiltInViewportIndex:  {
+  case BuiltInViewportIndex: {
     assert(inOutUsage.builtInInputLocMap.find(builtInId) != inOutUsage.builtInInputLocMap.end());
     const unsigned loc = inOutUsage.builtInInputLocMap.find(builtInId)->second;
     assert(loc != InvalidValue);

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2131,7 +2131,9 @@ Value *PatchInOutImportExport::patchTcsBuiltInInputImport(Type *inputTy, unsigne
 
     break;
   }
-  case BuiltInPointSize: {
+  case BuiltInPointSize:
+  case BuiltInLayer:
+  case BuiltInViewportIndex: {
     assert(!elemIdx);
     assert(builtInInLocMap.find(builtInId) != builtInInLocMap.end());
     const unsigned loc = builtInInLocMap.find(builtInId)->second;
@@ -2181,14 +2183,6 @@ Value *PatchInOutImportExport::patchTcsBuiltInInputImport(Type *inputTy, unsigne
       input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     else
       input = builder.getInt32(0);
-    break;
-  }
-  case BuiltInLayer:
-  case BuiltInViewportIndex: {
-    assert(builtInInLocMap.find(builtInId) != builtInInLocMap.end());
-    const unsigned loc = builtInInLocMap.find(builtInId)->second;
-    auto ldsOffset = calcLdsOffsetForTcsInput(inputTy, loc, nullptr, elemIdx, vertexIdx, builder);
-    input = readValueFromLds(false, inputTy, ldsOffset, builder);
     break;
   }
   default: {
@@ -3089,9 +3083,13 @@ void PatchInOutImportExport::patchTcsBuiltInOutputExport(Value *output, unsigned
 
   switch (builtInId) {
   case BuiltInPosition:
-  case BuiltInPointSize: {
+  case BuiltInPointSize:
+  case BuiltInLayer:
+  case BuiltInViewportIndex: {
     if ((builtInId == BuiltInPosition && !builtInUsage.position) ||
-        (builtInId == BuiltInPointSize && !builtInUsage.pointSize))
+        (builtInId == BuiltInPointSize && !builtInUsage.pointSize) ||
+        (builtInId == BuiltInLayer && !builtInUsage.layer) ||
+        (builtInId == BuiltInViewportIndex && !builtInUsage.viewportIndex))
       return;
 
     assert(builtInId != BuiltInPointSize || !elemIdx);
@@ -3128,14 +3126,6 @@ void PatchInOutImportExport::patchTcsBuiltInOutputExport(Value *output, unsigned
       writeValueToLds(m_pipelineState->isTessOffChip(), output, ldsOffset, builder);
     }
 
-    break;
-  }
-  case BuiltInLayer:
-  case BuiltInViewportIndex: {
-    assert(builtInOutLocMap.find(builtInId) != builtInOutLocMap.end());
-    unsigned loc = builtInOutLocMap.find(builtInId)->second;
-    auto ldsOffset = calcLdsOffsetForTcsOutput(outputTy, loc, nullptr, elemIdx, vertexIdx, builder);
-    writeValueToLds(m_pipelineState->isTessOffChip(), output, ldsOffset, builder);
     break;
   }
   case BuiltInTessLevelOuter:

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -2223,7 +2223,9 @@ Value *PatchInOutImportExport::patchTesBuiltInInputImport(Type *inputTy, unsigne
 
     break;
   }
-  case BuiltInPointSize: {
+  case BuiltInPointSize:
+  case BuiltInLayer:
+  case BuiltInViewportIndex: {
     assert(!elemIdx);
     assert(builtInInLocMap.find(builtInId) != builtInInLocMap.end());
     const unsigned loc = builtInInLocMap.find(builtInId)->second;
@@ -2309,20 +2311,6 @@ Value *PatchInOutImportExport::patchTesBuiltInInputImport(Type *inputTy, unsigne
       input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     else
       input = builder.getInt32(0);
-    break;
-  }
-  case BuiltInLayer: {
-    assert(builtInInLocMap.find(builtInId) != builtInInLocMap.end());
-    const unsigned loc = builtInInLocMap.find(builtInId)->second;
-    auto ldsOffset = calcLdsOffsetForTesInput(inputTy, loc, nullptr, elemIdx, vertexIdx, builder);
-    input = readValueFromLds(m_pipelineState->isTessOffChip(), inputTy, ldsOffset, builder);
-    break;
-  }
-  case BuiltInViewportIndex: {
-    assert(builtInInLocMap.find(builtInId) != builtInInLocMap.end());
-    const unsigned loc = builtInInLocMap.find(builtInId)->second;
-    auto ldsOffset = calcLdsOffsetForTesInput(inputTy, loc, nullptr, elemIdx, vertexIdx, builder);
-    input = readValueFromLds(m_pipelineState->isTessOffChip(), inputTy, ldsOffset, builder);
     break;
   }
   default: {

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1850,8 +1850,22 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       } else
         builtInUsage.vs.cullDistance = 0;
 
-      builtInUsage.vs.layer = false;
-      builtInUsage.vs.viewportIndex = false;
+      if (nextBuiltInUsage.layerIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
+        inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      } else
+        builtInUsage.vs.layer = false;
+
+      if (nextBuiltInUsage.viewportIndexIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
+        inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      } else
+        builtInUsage.vs.viewportIndex = false;
+
       builtInUsage.vs.primitiveShadingRate = false;
     } else if (nextStage == ShaderStageGeometry) {
       // VS  ==>  GS
@@ -1890,8 +1904,22 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       } else
         builtInUsage.vs.cullDistance = 0;
 
-      builtInUsage.vs.layer = false;
-      builtInUsage.vs.viewportIndex = false;
+      if (nextBuiltInUsage.layerIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
+        inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      } else
+        builtInUsage.vs.layer = 0;
+
+      if (nextBuiltInUsage.viewportIndexIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
+        inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      } else
+        builtInUsage.vs.viewportIndex = 0;
+
       builtInUsage.vs.primitiveShadingRate = false;
     } else if (nextStage == ShaderStageInvalid) {
       // VS only
@@ -1945,6 +1973,12 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       if (builtInUsage.tcs.cullDistanceIn > 4)
         ++availInMapLoc;
     }
+
+    if (builtInUsage.tcs.layerIn)
+      inOutUsage.builtInInputLocMap[BuiltInLayer] = availInMapLoc++;
+
+    if (builtInUsage.tcs.viewportIndexIn)
+      inOutUsage.builtInInputLocMap[BuiltInViewportIndex] = availInMapLoc++;
 
     // Map built-in outputs to generic ones
     if (nextStage == ShaderStageTessEval) {
@@ -2002,6 +2036,20 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
           builtInUsage.tcs.cullDistance = 0;
       }
 
+      if (nextBuiltInUsage.layerIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
+        inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      }
+
+      if (nextBuiltInUsage.viewportIndexIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
+        inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      }
+
       // NOTE: We shouldn't clear the usage of tessellation levels if the next stage doesn't read them back because they
       // are always required to be written to TF buffer.
       if (nextBuiltInUsage.tessLevelOuter) {
@@ -2055,6 +2103,12 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         if (builtInUsage.tcs.cullDistance > 4)
           ++availOutMapLoc;
       }
+
+      if (builtInUsage.tcs.layerIn)
+        inOutUsage.builtInOutputLocMap[BuiltInLayer] = availOutMapLoc++;
+
+      if (builtInUsage.tcs.viewportIndexIn)
+        inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = availOutMapLoc++;
 
       if (builtInUsage.tcs.tessLevelOuter)
         inOutUsage.perPatchBuiltInOutputLocMap[BuiltInTessLevelOuter] = availPerPatchOutMapLoc++;
@@ -2110,6 +2164,12 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       if (cullDistanceCount > 4)
         ++availInMapLoc;
     }
+
+    if (builtInUsage.tes.layerIn)
+      inOutUsage.builtInInputLocMap[BuiltInLayer] = availInMapLoc++;
+
+    if (builtInUsage.tes.viewportIndexIn)
+      inOutUsage.builtInInputLocMap[BuiltInViewportIndex] = availInMapLoc++;
 
     if (builtInUsage.tes.tessLevelOuter)
       inOutUsage.perPatchBuiltInInputLocMap[BuiltInTessLevelOuter] = availPerPatchInMapLoc++;
@@ -2186,8 +2246,21 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       } else
         builtInUsage.tes.cullDistance = 0;
 
-      builtInUsage.tes.layer = false;
-      builtInUsage.tes.viewportIndex = false;
+      if (nextBuiltInUsage.layerIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
+        inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      } else
+        builtInUsage.tes.layer = 0;
+
+      if (nextBuiltInUsage.viewportIndexIn) {
+        assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
+        const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
+        inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
+        availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
+      } else
+        builtInUsage.tes.viewportIndex = 0;
     } else if (nextStage == ShaderStageInvalid) {
       // TES only
       if (builtInUsage.tes.clipDistance > 0 || builtInUsage.tes.cullDistance > 0) {
@@ -2240,6 +2313,12 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
       if (builtInUsage.gs.cullDistanceIn > 4)
         ++availInMapLoc;
     }
+
+    if (builtInUsage.gs.layerIn)
+      inOutUsage.builtInInputLocMap[BuiltInLayer] = availInMapLoc++;
+
+    if (builtInUsage.gs.viewportIndexIn)
+      inOutUsage.builtInInputLocMap[BuiltInViewportIndex] = availInMapLoc++;
 
     // Map built-in outputs to generic ones (for GS)
     if (builtInUsage.gs.position)

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1823,48 +1823,54 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInPosition];
         inOutUsage.builtInOutputLocMap[BuiltInPosition] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.position = false;
+      }
 
       if (nextBuiltInUsage.pointSizeIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInPointSize) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInPointSize];
         inOutUsage.builtInOutputLocMap[BuiltInPointSize] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.pointSize = false;
+      }
 
       if (nextBuiltInUsage.clipDistanceIn > 0) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInClipDistance) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInClipDistance];
         inOutUsage.builtInOutputLocMap[BuiltInClipDistance] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + (nextBuiltInUsage.clipDistanceIn > 4 ? 2u : 1u));
-      } else
+      } else {
         builtInUsage.vs.clipDistance = 0;
+      }
 
       if (nextBuiltInUsage.cullDistanceIn > 0) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInCullDistance) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInCullDistance];
         inOutUsage.builtInOutputLocMap[BuiltInCullDistance] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + (nextBuiltInUsage.cullDistanceIn > 4 ? 2u : 1u));
-      } else
+      } else {
         builtInUsage.vs.cullDistance = 0;
+      }
 
       if (nextBuiltInUsage.layerIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.layer = false;
+      }
 
       if (nextBuiltInUsage.viewportIndexIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
         inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.viewportIndex = false;
+      }
 
       builtInUsage.vs.primitiveShadingRate = false;
     } else if (nextStage == ShaderStageGeometry) {
@@ -1877,48 +1883,54 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInPosition];
         inOutUsage.builtInOutputLocMap[BuiltInPosition] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.position = false;
+      }
 
       if (nextBuiltInUsage.pointSizeIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInPointSize) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInPointSize];
         inOutUsage.builtInOutputLocMap[BuiltInPointSize] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.pointSize = false;
+      }
 
       if (nextBuiltInUsage.clipDistanceIn > 0) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInClipDistance) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInClipDistance];
         inOutUsage.builtInOutputLocMap[BuiltInClipDistance] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + (nextBuiltInUsage.clipDistanceIn > 4 ? 2u : 1u));
-      } else
+      } else {
         builtInUsage.vs.clipDistance = 0;
+      }
 
       if (nextBuiltInUsage.cullDistanceIn > 0) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInCullDistance) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInCullDistance];
         inOutUsage.builtInOutputLocMap[BuiltInCullDistance] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + (nextBuiltInUsage.cullDistanceIn > 4 ? 2u : 1u));
-      } else
+      } else {
         builtInUsage.vs.cullDistance = 0;
+      }
 
       if (nextBuiltInUsage.layerIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.layer = 0;
+      }
 
       if (nextBuiltInUsage.viewportIndexIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
         inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.vs.viewportIndex = 0;
+      }
 
       builtInUsage.vs.primitiveShadingRate = false;
     } else if (nextStage == ShaderStageInvalid) {
@@ -2219,48 +2231,54 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInPosition];
         inOutUsage.builtInOutputLocMap[BuiltInPosition] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.tes.position = false;
+      }
 
       if (nextBuiltInUsage.pointSizeIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInPointSize) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInPointSize];
         inOutUsage.builtInOutputLocMap[BuiltInPointSize] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.tes.pointSize = false;
+      }
 
       if (nextBuiltInUsage.clipDistanceIn > 0) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInClipDistance) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInClipDistance];
         inOutUsage.builtInOutputLocMap[BuiltInClipDistance] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + (nextBuiltInUsage.clipDistanceIn > 4 ? 2u : 1u));
-      } else
+      } else {
         builtInUsage.tes.clipDistance = 0;
+      }
 
       if (nextBuiltInUsage.cullDistanceIn > 0) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInCullDistance) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInCullDistance];
         inOutUsage.builtInOutputLocMap[BuiltInCullDistance] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + (nextBuiltInUsage.cullDistanceIn > 4 ? 2u : 1u));
-      } else
+      } else {
         builtInUsage.tes.cullDistance = 0;
+      }
 
       if (nextBuiltInUsage.layerIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInLayer) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInLayer];
         inOutUsage.builtInOutputLocMap[BuiltInLayer] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.tes.layer = 0;
+      }
 
       if (nextBuiltInUsage.viewportIndexIn) {
         assert(nextInOutUsage.builtInInputLocMap.find(BuiltInViewportIndex) != nextInOutUsage.builtInInputLocMap.end());
         const unsigned mapLoc = nextInOutUsage.builtInInputLocMap[BuiltInViewportIndex];
         inOutUsage.builtInOutputLocMap[BuiltInViewportIndex] = mapLoc;
         availOutMapLoc = std::max(availOutMapLoc, mapLoc + 1);
-      } else
+      } else {
         builtInUsage.tes.viewportIndex = 0;
+      }
     } else if (nextStage == ShaderStageInvalid) {
       // TES only
       if (builtInUsage.tes.clipDistance > 0 || builtInUsage.tes.cullDistance > 0) {


### PR DESCRIPTION
DX spec allows SV_RenderTargetArrayIndex/SV_ViewportArrayIndex to be used in those shader stages.