### PR TITLE
lgc: add waveSize into compute shader mode

### DIFF
--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -658,7 +658,7 @@ struct ComputeShaderMode {
   unsigned workgroupSizeX;    // X dimension of workgroup size. 0 is taken to be 1
   unsigned workgroupSizeY;    // Y dimension of workgroup size. 0 is taken to be 1
   unsigned workgroupSizeZ;    // Z dimension of workgroup size. 0 is taken to be 1
-  unsigned waveSize;          // If non-zero, wave size should be overridden
+  unsigned subgroupSize;      // Override for the wave size if it is non-zero
   DerivativeMode derivatives; // derivativeMode for computeShader
 };
 

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -658,6 +658,7 @@ struct ComputeShaderMode {
   unsigned workgroupSizeX;    // X dimension of workgroup size. 0 is taken to be 1
   unsigned workgroupSizeY;    // Y dimension of workgroup size. 0 is taken to be 1
   unsigned workgroupSizeZ;    // Z dimension of workgroup size. 0 is taken to be 1
+  unsigned waveSize;          // If non-zero, wave size should be overridden
   DerivativeMode derivatives; // derivativeMode for computeShader
 };
 

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1427,6 +1427,9 @@ void PipelineState::setShaderDefaultWaveSize(ShaderStage stage) {
     checkingStage = hasShaderStage(ShaderStageTessEval) ? ShaderStageTessEval : ShaderStageVertex;
   }
 
+  if (checkingStage == ShaderStageCompute)
+    m_waveSize[checkingStage] = m_shaderModes.getComputeShaderMode().waveSize;
+
   if (!m_waveSize[checkingStage]) {
     unsigned waveSize = getTargetInfo().getGpuProperty().waveSize;
     unsigned subgroupSize = waveSize;

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1428,7 +1428,7 @@ void PipelineState::setShaderDefaultWaveSize(ShaderStage stage) {
   }
 
   if (checkingStage == ShaderStageCompute)
-    m_waveSize[checkingStage] = m_shaderModes.getComputeShaderMode().waveSize;
+    m_waveSize[checkingStage] = m_shaderModes.getComputeShaderMode().subgroupSize;
 
   if (!m_waveSize[checkingStage]) {
     unsigned waveSize = getTargetInfo().getGpuProperty().waveSize;


### PR DESCRIPTION
Because DXIL has an entry point metadata tag kDxilWaveSizeTag and it is easier to handle it in shader mode since it is not coming from shade options.