### PR TITLE
lgc: still fit small user data after spilling starts (v2)

### DIFF
--- a/llpc/test/shaderdb/bugs/PipelineCs_SpillThresholdEnable.pipe
+++ b/llpc/test/shaderdb/bugs/PipelineCs_SpillThresholdEnable.pipe
@@ -1,0 +1,48 @@
+; RUN: amdllpc -gfxip 11.0 -o - -filetype=asm %s | FileCheck -check-prefix=CHECK %s
+
+[Version]
+version = 68
+
+[CsGlsl]
+#version 450 core
+
+layout(push_constant) uniform PushConstants {
+    uint pc_index;
+    float pc_array[32];
+};
+
+layout(set = 0, binding = 0) buffer BO {
+    float x;
+} bos[8];
+
+void main() {
+    bos[0].x = pc_array[pc_index] + bos[1].x + bos[2].x + bos[3].x + bos[4].x + bos[5].x + bos[6].x + bos[7].x;
+}
+
+[CsInfo]
+entryPoint = main
+
+[ResourceMapping]
+userDataNode[0].type = DescriptorBufferCompact
+userDataNode[0].offsetInDwords = 0
+userDataNode[0].sizeInDwords = 16
+userDataNode[0].set = 0
+userDataNode[0].binding = 0
+userDataNode[0].strideInDwords = 2
+userDataNode[1].type = PushConst
+userDataNode[1].offsetInDwords = 16
+userDataNode[1].sizeInDwords = 33
+userDataNode[1].set = 0xFFFFFFFF
+userDataNode[1].binding = 0
+
+[ComputePipelineState]
+deviceIndex = 0
+
+; The shader and pipeline is set up to:
+;  - use all user data nodes
+;  - dynamically index into the push constants, which a priori forces spilling regardless of user data register
+;    availability
+;  - actually spill a descriptor
+; There was at one point a regression in which the spill threshold wasn't set low enough.
+;
+; CHECK: .spill_threshold: 0xe


### PR DESCRIPTION
For example, spilling could be triggered by an 4DW inline descriptor that is followed by smaller descriptor table offsets or push constant accesses that still fit into user data.

This is v2 of the change. Some of the history:

- This behavior had previously regressed in commit dd22a7f5288bd ("lgc: refactor user data access lowering").
- v1 of this change was committed as 80970a1d16c5b1ef12ecb82717756654996dd055
- It was then reverted in commit 970a9931c3ed3e13e77ef84c1c3c4622ffdb25c3 due to a regression in some CTS tests (including the one mentioned below)

The root cause of the regression was that the spill data threshold was set incorrectly (too high) when spilling was initially enabled due to dynamic indexing into user data.

Related: dEQP-VK.binding_model.descriptorset_random.sets32.runtimesize.ubolimithigh.sbolimitlow.sampledimglow.lowimgnotex.noiub.nouab.chit.noia.0 (regressed in v1, fixed in v2)