### PR TITLE
Represent .semantic with 16-bit integer

### DIFF
--- a/lgc/interface/lgc/BuiltIns.h
+++ b/lgc/interface/lgc/BuiltIns.h
@@ -36,8 +36,8 @@ namespace lgc {
 // Max spirv builtIn value
 static constexpr unsigned BuiltInInternalBase = 0x10000000;
 
-// Max builtIn value = BuiltInInternalBase + 13
-static constexpr unsigned MaxBuiltIn = 0x1000000D;
+// Max builtIn value for PS semantic (unsigned 16-bit)
+static constexpr unsigned MaxBuiltInSemantic = 0x0000000F;
 
 // Define built-in kind enum.
 enum BuiltInKind : unsigned {

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -187,7 +187,7 @@ void RegisterMetadataBuilder::buildPalMetadata() {
         for (auto locInfoPair : outputLocInfoMap) {
           auto preRasterOutputSemanticElem = preRasterOutputSemanticNode[elemIdx].getMap(true);
           preRasterOutputSemanticElem[Util::Abi::PrerasterOutputSemanticMetadataKey::Semantic] =
-              MaxBuiltIn + locInfoPair.first.getLocation();
+              MaxBuiltInSemantic + locInfoPair.first.getLocation();
           preRasterOutputSemanticElem[Util::Abi::PrerasterOutputSemanticMetadataKey::Index] =
               locInfoPair.second.getLocation();
           ++elemIdx;
@@ -196,6 +196,7 @@ void RegisterMetadataBuilder::buildPalMetadata() {
         for (auto locPair : builtInOutputLocMap) {
           if (locPair.first == BuiltInClipDistance || locPair.first == BuiltInCullDistance ||
               locPair.first == BuiltInLayer || locPair.first == BuiltInViewportIndex) {
+            assert(locPair.first < MaxBuiltInSemantic);
             auto preRasterOutputSemanticElem = preRasterOutputSemanticNode[elemIdx].getMap(true);
             preRasterOutputSemanticElem[Util::Abi::PrerasterOutputSemanticMetadataKey::Semantic] = locPair.first;
             preRasterOutputSemanticElem[Util::Abi::PrerasterOutputSemanticMetadataKey::Index] = locPair.second;
@@ -954,13 +955,14 @@ void RegisterMetadataBuilder::buildPsRegisters() {
       for (auto locInfoPair : inputLocInfoMap) {
         auto psInputSemanticElem = psInputSemanticNode[elemIdx].getMap(true);
         psInputSemanticElem[Util::Abi::PsInputSemanticMetadataKey::Semantic] =
-            MaxBuiltIn + locInfoPair.first.getLocation();
+            MaxBuiltInSemantic + locInfoPair.first.getLocation();
         ++elemIdx;
       }
 
       for (auto locPair : builtInInputLocMap) {
         if (locPair.first == BuiltInClipDistance || locPair.first == BuiltInCullDistance ||
             locPair.first == BuiltInLayer || locPair.first == BuiltInViewportIndex) {
+          assert(locPair.first < MaxBuiltInSemantic);
           auto psInputSemanticElem = psInputSemanticNode[elemIdx].getMap(true);
           psInputSemanticElem[Util::Abi::PsInputSemanticMetadataKey::Semantic] = locPair.first;
           ++elemIdx;


### PR DESCRIPTION
PAL uses uint16 to represent `.semantic`. It is wrong to set it based on `MaxBuiltIn` whose most significant digit is 1. We modify it correctly and rename to `MaxBuiltInSemantic`.