### PR TITLE
Set condition to use ParentId/RayStaticId

### DIFF
--- a/lgc/interface/lgc/GpurtDialect.td
+++ b/lgc/interface/lgc/GpurtDialect.td
@@ -293,12 +293,6 @@ def GpurtSetParentIdOp : GpurtOp<"set.parent.id", [Memory<[(write InaccessibleMe
   let summary = "Store TraceRay rayId";
 }
 
-def GpurtSetRayStaticIdOp : GpurtOp<"set.ray.static.id", [Memory<[(write InaccessibleMem)]>, WillReturn]> {
-  let arguments = (ins I32:$id);
-  let results = (outs);
-  let summary = "set a unique static ID for a ray";
-}
-
 def GpurtGetRayStaticIdOp : GpurtOp<"get.ray.static.id", [Memory<[(read InaccessibleMem)]>, WillReturn]> {
   let arguments = (ins);
   let results = (outs I32:$result);

--- a/llpc/lower/LowerGpuRt.h
+++ b/llpc/lower/LowerGpuRt.h
@@ -46,8 +46,6 @@ class GpurtGetBoxSortHeuristicModeOp;
 class GpurtGetStaticFlagsOp;
 class GpurtGetTriangleCompressionModeOp;
 class GpurtGetFlattenedGroupThreadIdOp;
-class GpurtSetRayStaticIdOp;
-class GpurtGetRayStaticIdOp;
 } // namespace lgc
 
 namespace llvm {
@@ -78,13 +76,10 @@ private:
   void visitGetStaticFlags(lgc::GpurtGetStaticFlagsOp &inst);
   void visitGetTriangleCompressionMode(lgc::GpurtGetTriangleCompressionModeOp &inst);
   void visitGetFlattenedGroupThreadId(lgc::GpurtGetFlattenedGroupThreadIdOp &inst);
-  void visitSetRayStaticId(lgc::GpurtSetRayStaticIdOp &inst);
-  void visitGetRayStaticId(lgc::GpurtGetRayStaticIdOp &inst);
   llvm::Value *m_stack;                                  // Stack array to hold stack value
   llvm::Type *m_stackTy;                                 // Stack type
   bool m_lowerStack;                                     // If it is lowerStack
   llvm::SmallVector<llvm::Instruction *> m_callsToLower; // Call instruction to lower
   llvm::SmallSet<llvm::Function *, 4> m_funcsToLower;    // Functions to lower
-  llvm::Value *m_rayStaticId;                            // Ray static ID value
 };
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -1262,7 +1262,7 @@ void SpirvLowerRayQuery::initGlobalVariable() {
 // =====================================================================================================================
 // Generate a static ID for current Trace Ray call
 //
-void SpirvLowerRayQuery::generateTraceRayStaticId() {
+unsigned SpirvLowerRayQuery::generateTraceRayStaticId() {
   Util::MetroHash64 hasher;
   hasher.Update(m_nextTraceRayId++);
   hasher.Update(m_module->getName());
@@ -1270,7 +1270,7 @@ void SpirvLowerRayQuery::generateTraceRayStaticId() {
   MetroHash::Hash hash = {};
   hasher.Finalize(hash.bytes);
 
-  m_builder->create<lgc::GpurtSetRayStaticIdOp>(m_builder->getInt32(MetroHash::compact32(&hash)));
+  return MetroHash::compact32(&hash);
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerRayQuery.h
+++ b/llpc/lower/llpcSpirvLowerRayQuery.h
@@ -130,7 +130,7 @@ protected:
   void createGlobalLdsUsage();
   void createGlobalRayQueryObj();
   void initGlobalVariable();
-  void generateTraceRayStaticId();
+  unsigned generateTraceRayStaticId();
   llvm::Value *createTransformMatrix(unsigned builtInId, llvm::Value *accelStruct, llvm::Value *instanceId,
                                      llvm::Instruction *insertPos);
   void eraseFunctionBlocks(llvm::Function *func);

--- a/llpc/lower/llpcSpirvLowerRayTracing.h
+++ b/llpc/lower/llpcSpirvLowerRayTracing.h
@@ -76,6 +76,7 @@ class GpurtSetTriangleIntersectionAttributesOp;
 class GpurtSetHitTriangleNodePointerOp;
 class GpurtGetParentIdOp;
 class GpurtSetParentIdOp;
+class GpurtGetRayStaticIdOp;
 } // namespace lgc
 
 namespace Llpc {
@@ -100,6 +101,7 @@ enum : unsigned {
   ParentRayId,                // Ray ID of the parent TraceRay call
   HitTriangleVertexPositions, // Hit triangle vertex positions
   Payload,                    // Payload
+  RayStaticId,                // Ray static ID
   Count                       // Count of the trace attributes
 };
 }
@@ -242,6 +244,7 @@ private:
   void visitSetHitTriangleNodePointer(lgc::GpurtSetHitTriangleNodePointerOp &inst);
   void visitGetParentId(lgc::GpurtGetParentIdOp &inst);
   void visitSetParentId(lgc::GpurtSetParentIdOp &inst);
+  void visitGetRayStaticId(lgc::GpurtGetRayStaticIdOp &inst);
   void visitDispatchRayIndex(lgc::rt::DispatchRaysIndexOp &inst);
   void visitDispatchRaysDimensionsOp(lgc::rt::DispatchRaysDimensionsOp &inst);
   void visitWorldRayOriginOp(lgc::rt::WorldRayOriginOp &inst);


### PR DESCRIPTION
These two function parameters are used for developer GPURT logging.  In most cases, these two variables are not used and would generate two more vgprs for the indirect/continuation shaders. So guard them with enableRayTracingCounter

Also do a little refactoring to the  RayStaticIdOp processing