### PR TITLE
lgc: Various cleanups in the color export logic

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -176,49 +176,5 @@ Function *ColorExportShader::createColorExportFunc() {
 //
 // @param [in/out] outStream : The PAL metadata object in which to update the color format.
 void ColorExportShader::updatePalMetadata(PalMetadata &palMetadata) {
-  SmallVector<ExportFormat> finalExportFormats;
-  bool hasDepthExpFmtZero = true;
-  for (auto &info : m_exports) {
-    if (info.hwColorTarget != MaxColorTargets) {
-      ExportFormat expFmt = m_exportFormat[info.hwColorTarget];
-      if (expFmt != EXP_FORMAT_ZERO)
-        finalExportFormats.push_back(expFmt);
-    } else {
-      hasDepthExpFmtZero = false;
-      unsigned depthMask = info.location;
-      if (!m_killEnabled && m_pipelineState->getTargetInfo().getGfxIpVersion().major >= 11 &&
-          m_pipelineState->getColorExportState().alphaToCoverageEnable) {
-        for (auto &curInfo : m_exports) {
-          if (curInfo.hwColorTarget == EXP_TARGET_MRT_0 && (m_exportFormat[EXP_TARGET_MRT_0] > EXP_FORMAT_32_GR)) {
-            // Mrt0 is enabled and its alpha channel is enabled
-            depthMask |= 0x8;
-            break;
-          }
-        }
-      }
-
-      unsigned depthExpFmt = EXP_FORMAT_ZERO;
-      if (depthMask & 0x4)
-        depthExpFmt = EXP_FORMAT_32_ABGR;
-      else if (depthMask & 0x2)
-        depthExpFmt = (depthMask & 0x8) ? EXP_FORMAT_32_ABGR : EXP_FORMAT_32_GR;
-      else if (depthMask & 0x1)
-        depthExpFmt = (depthMask & 0x8) ? EXP_FORMAT_32_AR : EXP_FORMAT_32_R;
-      palMetadata.setSpiShaderZFormat(depthExpFmt);
-    }
-  }
-
-  if (finalExportFormats.size() == 0 && hasDepthExpFmtZero) {
-    if (m_pipelineState->getTargetInfo().getGfxIpVersion().major < 10 || m_killEnabled) {
-      // NOTE: Hardware requires that fragment shader always exports "something" (color or depth) to the SX.
-      // If both SPI_SHADER_Z_FORMAT and SPI_SHADER_COL_FORMAT are zero, we need to override
-      // SPI_SHADER_COL_FORMAT to export one channel to MRT0. This dummy export format will be masked
-      // off by updateCbShaderMask().
-      finalExportFormats.push_back(EXP_FORMAT_32_R);
-    }
-  }
-
-  palMetadata.updateSpiShaderColFormat(finalExportFormats);
-  palMetadata.updateCbShaderMask(m_exports);
   palMetadata.updateDbShaderControl();
 }

--- a/lgc/elfLinker/ColorExportShader.h
+++ b/lgc/elfLinker/ColorExportShader.h
@@ -79,7 +79,6 @@ private:
   // have access to PipelineState, so we can hash the information here and let the front-end use it as the
   // key for a cache of glue shaders.
   llvm::SmallVector<ColorExportInfo, 8> m_exports;
-  ExportFormat m_exportFormat[MaxColorTargets] = {}; // The export format for each hw color target.
   // The encoded or hashed (in some way) single string version of the above.
   std::string m_shaderString;
   bool m_killEnabled; // True if this fragment shader has kill enabled.

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -95,10 +95,9 @@ private:
 };
 
 // The information needed for an export to a hardware color target.
-struct ColorExportValueInfo {
-  std::vector<llvm::Value *> value; // The value of each component to be exported.
-  unsigned location;                // The location that corresponds to the hardware color target.
-  bool isSigned;                    // True if the values should be interpreted as signed integers.
+struct ColorOutputValueInfo {
+  std::array<llvm::Value *, 4> value; // The value of each component to be exported.
+  bool isSigned;                      // True if the values should be interpreted as signed integers.
 };
 
 // =====================================================================================================================
@@ -113,8 +112,8 @@ public:
   static llvm::StringRef name() { return "Lower fragment color export calls"; }
 
 private:
-  void updateFragColors(llvm::CallInst *callInst, ColorExportValueInfo expFragColors[], BuilderBase &builder);
-  llvm::Value *getOutputValue(llvm::ArrayRef<llvm::Value *> expFragColor, unsigned int location, BuilderBase &builder);
+  void updateFragColors(llvm::CallInst *callInst, llvm::MutableArrayRef<ColorOutputValueInfo> outFragColors,
+                        BuilderBase &builder);
   void collectExportInfoForGenericOutputs(llvm::Function *fragEntryPoint, BuilderBase &builder);
   void collectExportInfoForBuiltinOutput(llvm::Function *module, BuilderBase &builder);
   llvm::Value *generateValueForOutput(llvm::Value *value, llvm::Type *outputTy, BuilderBase &builder);

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -62,7 +62,7 @@ public:
   FragColorExport(llvm::LLVMContext *context, PipelineState *pipelineState);
 
   void generateExportInstructions(llvm::ArrayRef<lgc::ColorExportInfo> info, llvm::ArrayRef<llvm::Value *> values,
-                                  llvm::ArrayRef<ExportFormat> exportFormat, bool dummyExport, BuilderBase &builder);
+                                  bool dummyExport, BuilderBase &builder);
   static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
   static llvm::CallInst *addDummyExport(BuilderBase &builder);
   static llvm::Function *generateNullFragmentShader(llvm::Module &module, PipelineState *pipelineState,

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -117,8 +117,7 @@ private:
   void collectExportInfoForGenericOutputs(llvm::Function *fragEntryPoint, BuilderBase &builder);
   void collectExportInfoForBuiltinOutput(llvm::Function *module, BuilderBase &builder);
   llvm::Value *generateValueForOutput(llvm::Value *value, llvm::Type *outputTy, BuilderBase &builder);
-  llvm::Value *generateReturn(llvm::Function *fragEntryPoint, BuilderBase &builder);
-  llvm::Value *jumpColorExport(llvm::Function *fragEntryPoint, BuilderBase &builder);
+  void createTailJump(llvm::Function *fragEntryPoint, BuilderBase &builder);
 
   llvm::LLVMContext *m_context;                        // The context the pass is being run in.
   PipelineState *m_pipelineState;                      // The pipeline state

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -473,17 +473,8 @@ struct ResourceUsage {
     } mesh;
 
     struct {
-      // Original shader specified locations before location map (from tightly packed locations to shader
-      // specified locations)
-      //
-      // NOTE: This collected info is used to revise the calculated CB shader channel mask. Hardware requires
-      // the targets of fragment color export (MRTs) to be tightly packed while the CB shader channel masks
-      // should correspond to original shader specified targets.
-      unsigned outputOrigLocs[MaxColorTargets];
-
       std::vector<FsInterpInfo> interpInfo;   // Array of interpolation info
       BasicType outputTypes[MaxColorTargets]; // Array of basic types of fragment outputs
-      unsigned cbShaderMask;                  // CB shader channel mask (correspond to register CB_SHADER_MASK)
       bool isNullFs;                          // Is null FS, so should set final cbShaderMask to 0
     } fs;
   } inOutUsage;

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -185,7 +185,7 @@ enum InvariantLoadsOption : unsigned { Auto = 0, EnableOptimization = 1, Disable
 // Struct with the information for one color export
 struct ColorExportInfo {
   unsigned hwColorTarget;
-  unsigned location;
+  unsigned location; // Overloaded to a bitmask for mrtz exports
   bool isSigned;
   llvm::Type *ty;
 };

--- a/lgc/patch/PatchNullFragShader.cpp
+++ b/lgc/patch/PatchNullFragShader.cpp
@@ -92,7 +92,6 @@ void PatchNullFragShader::updatePipelineState(PipelineState *pipelineState) cons
   pipelineState->setShaderStageMask(pipelineState->getShaderStageMask() | shaderStageToMask(ShaderStageFragment));
 
   // Add usage info for dummy output
-  resUsage->inOutUsage.fs.cbShaderMask = 0;
   resUsage->inOutUsage.fs.isNullFs = true;
   InOutLocationInfo origLocInfo;
   origLocInfo.setLocation(0);

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1645,10 +1645,6 @@ void PatchResourceCollect::matchGenericInOut() {
   }
 
   if (!outLocInfoMap.empty()) {
-    auto &outOrigLocs = inOutUsage.fs.outputOrigLocs;
-    if (m_shaderStage == ShaderStageFragment)
-      memset(&outOrigLocs, InvalidValue, sizeof(inOutUsage.fs.outputOrigLocs));
-
     assert(inOutUsage.outputMapLocCount == 0);
 
     // Update the value of outLocMap for non pack case
@@ -1672,9 +1668,6 @@ void PatchResourceCollect::matchGenericInOut() {
         inOutUsage.outputMapLocCount = std::max(inOutUsage.outputMapLocCount, newLoc + 1);
         LLPC_OUTS("(" << getShaderStageAbbreviation(m_shaderStage) << ") Output: loc = " << origLoc
                       << ", comp = " << origComp << "  =>  Mapped = " << newLoc << ", " << newComp << "\n");
-
-        if (m_shaderStage == ShaderStageFragment)
-          outOrigLocs[newLoc] = origLoc;
       }
     }
     LLPC_OUTS("\n");

--- a/lgc/state/ResourceUsage.cpp
+++ b/lgc/state/ResourceUsage.cpp
@@ -51,7 +51,6 @@ ResourceUsage::ResourceUsage(ShaderStage shaderStage) {
       inOutUsage.fs.outputTypes[i] = BasicType::Unknown;
     }
 
-    inOutUsage.fs.cbShaderMask = 0;
     inOutUsage.fs.isNullFs = false;
   }
 }


### PR DESCRIPTION
This is a sequence of self-contained commits that try to be small and digestable.

The underlying philosophy here is that color export is split into two phases:

1.   Collect the outputs written by the application shader code. This is primarily about the locations of outputs.
2.    Generate export instructions for the shader, referencing the collected outputs as required. This is primarily about the hwExportTarget of outputs.

The changes aim at bringing us closer to this ideal, which helps make future changes.

In the case of a full pipeline compile, these phases happen right after each other as part of the fragment color export pass. When color export shaders are used, the first phase happens during the fragment color export pass, and the second phase happens when the color export shader is compiled.