### PR TITLE
llpc: Fix the failures for the cases:spirv_assembly.instruction.compu…

### DIFF
--- a/lgc/state/ShaderModes.cpp
+++ b/lgc/state/ShaderModes.cpp
@@ -183,7 +183,7 @@ void ShaderModes::setComputeShaderMode(Module &module, const ComputeShaderMode &
   mode.workgroupSizeZ = std::max(1U, mode.workgroupSizeZ);
   assert(mode.workgroupSizeX <= MaxComputeWorkgroupSize && mode.workgroupSizeY <= MaxComputeWorkgroupSize &&
          mode.workgroupSizeZ <= MaxComputeWorkgroupSize);
-  PipelineState::setNamedMetadataToArrayOfInt32(&module, inMode, ComputeShaderModeMetadataName);
+  PipelineState::setNamedMetadataToArrayOfInt32(&module, mode, ComputeShaderModeMetadataName);
 }
 
 // =====================================================================================================================

--- a/llpc/test/shaderdb/general/WorkgroupSizeLiteral.spvasm
+++ b/llpc/test/shaderdb/general/WorkgroupSizeLiteral.spvasm
@@ -1,0 +1,62 @@
+; BEGIN_SHADERTEST
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST-LABEL: {{^// LLPC}} pipeline before-patching results
+; SHADERTEST: call <3 x i32> @lgc.shader.input.WorkgroupId(i32 0) #1
+; SHADERTEST: %{{[0-9]*}} = mul <3 x i32> %{{[0-9]*}}, <i32 1, i32 1, i32 1>
+; SHADERTEST: AMDLLPC SUCCESS
+; END_SHADERTEST
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos SPIR-V Tools Assembler; 0
+; Bound: 32
+; Schema: 0
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %gl_GlobalInvocationID
+               OpSource GLSL 430
+               OpName %main "main"
+               OpName %gl_GlobalInvocationID "gl_GlobalInvocationID"
+               OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+               OpDecorate %_struct_4 BufferBlock
+               OpDecorate %5 DescriptorSet 0
+               OpDecorate %5 Binding 0
+               OpDecorate %6 DescriptorSet 0
+               OpDecorate %6 Binding 1
+               OpDecorate %_runtimearr_float ArrayStride 4
+               OpMemberDecorate %_struct_4 0 Offset 0
+       %bool = OpTypeBool
+       %void = OpTypeVoid
+         %10 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+     %v3uint = OpTypeVector %uint 3
+    %v3float = OpTypeVector %float 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%_ptr_Uniform_int = OpTypePointer Uniform %int
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+%_runtimearr_int = OpTypeRuntimeArray %int
+%_runtimearr_float = OpTypeRuntimeArray %float
+  %_struct_4 = OpTypeStruct %_runtimearr_float
+%_ptr_Uniform__struct_4 = OpTypePointer Uniform %_struct_4
+          %5 = OpVariable %_ptr_Uniform__struct_4 Uniform
+          %6 = OpVariable %_ptr_Uniform__struct_4 Uniform
+%gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+   %uint_1_0 = OpConstant %uint 1
+   %uint_1_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1_0 %uint_1_1
+       %main = OpFunction %void None %10
+         %25 = OpLabel
+         %26 = OpLoad %v3uint %gl_GlobalInvocationID
+         %27 = OpCompositeExtract %uint %26 0
+         %28 = OpAccessChain %_ptr_Uniform_float %5 %int_0 %27
+         %29 = OpLoad %float %28
+         %30 = OpFNegate %float %29
+         %31 = OpAccessChain %_ptr_Uniform_float %6 %int_0 %27
+               OpStore %31 %30
+               OpReturn
+               OpFunctionEnd

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7642,7 +7642,8 @@ bool SPIRVToLLVM::transMetadata() {
         for (unsigned i = 0, e = m_bm->getNumConstants(); i != e; ++i) {
           auto bv = m_bm->getConstant(i);
           SPIRVWord builtIn = SPIRVID_INVALID;
-          if ((bv->getOpCode() == OpSpecConstant || bv->getOpCode() == OpSpecConstantComposite) &&
+          if ((bv->getOpCode() == OpSpecConstant || bv->getOpCode() == OpSpecConstantComposite ||
+               bv->getOpCode() == OpConstant || bv->getOpCode() == OpConstantComposite) &&
               bv->hasDecorate(DecorationBuiltIn, 0, &builtIn)) {
             if (builtIn == spv::BuiltInWorkgroupSize) {
               // NOTE: Overwrite values of local sizes specified in execution


### PR DESCRIPTION
…te.localsize.*_wgsize_literal_*

There will be some failures when run "dEQP-VK.spirv_assembly.instruction.compute.localsize.*_wgsize_literal* cases.

## Root Cause:
1. For the workgroupSize is not set correctly in SPIRVReader.cpp(which only under OpSpecConstant and OpSpecConstantComposite cases), so for literal case, the workgroupSize will always be <0,0,0> here.

2. The code under ShaderModes::setComputeShaderMode is incorrect, which will not update the workgroupSize.x/y/z = std:max<0,1> value in pal metaData.

Due to these two reasons, the "amdgpu-flat-work-group-size" in function attribute will be <0,0>, so the GlobalInvocation id will be calculated incorrectly which cause the load value is also incorrect.

## Solution
1. Add the OpCode support when translate SPIRV:"%gl_WorkGroupSize = OpConstantComposite %uvec3 %wgs_0 %wgs_1 %wgs_2"
2. Fix the incorrect code under ShaderModes::setComputeShaderMode