### PR TITLE
llpc: [ComputeShader] Fix the failures for the cases:spirv_assembly.i…

### DIFF
--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -7735,7 +7735,8 @@ bool SPIRVToLLVM::transMetadata() {
         for (unsigned i = 0, e = m_bm->getNumConstants(); i != e; ++i) {
           auto bv = m_bm->getConstant(i);
           SPIRVWord builtIn = SPIRVID_INVALID;
-          if ((bv->getOpCode() == OpSpecConstant || bv->getOpCode() == OpSpecConstantComposite) &&
+          if ((bv->getOpCode() == OpSpecConstant || bv->getOpCode() == OpSpecConstantComposite ||
+               bv->getOpCode() == OpConstant || bv->getOpCode() == OpConstantComposite) &&
               bv->hasDecorate(DecorationBuiltIn, 0, &builtIn)) {
             if (builtIn == spv::BuiltInWorkgroupSize) {
               // NOTE: Overwrite values of local sizes specified in execution


### PR DESCRIPTION
…nstruction.compute.localsize.*_wgsize_literal_*

1. The previous fix(4be31524d3) has only added for mesh_shader case
2. The compute_shader and task_shader should also be applied with the change