### PR TITLE
Fix the merge issue for llpcSpirvLower.cpp

### DIFF
--- a/llpc/lower/llpcSpirvLower.cpp
+++ b/llpc/lower/llpcSpirvLower.cpp
@@ -262,13 +262,12 @@ void SpirvLower::addPasses(Context *context, ShaderStage stage, lgc::PassManager
 
   if (rayTracing || rayQuery || isInternalRtShader) {
     passMgr.addPass(LowerGpuRt());
-    passMgr.addPass(createModuleToFunctionPassAdaptor(InstCombinePass(instCombineOpt)));
-  }
 
-  FunctionPassManager fpm;
-  fpm.addPass(SROAPass(SROAOptions::PreserveCFG));
-  fpm.addPass(InstCombinePass(instCombineOpt));
-  passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
+    FunctionPassManager fpm;
+    fpm.addPass(SROAPass(SROAOptions::PreserveCFG));
+    fpm.addPass(InstCombinePass(instCombineOpt));
+    passMgr.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
+  }
 
   // Stop timer for lowering passes.
   if (lowerTimer)

--- a/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestArithmeticOp_lit.frag
+++ b/llpc/test/shaderdb/gfx9/ExtShaderFloat16_TestArithmeticOp_lit.frag
@@ -31,8 +31,8 @@ void main()
 ; SHADERTEST: fadd reassoc nnan nsz arcp contract afn <4 x half> %{{[0-9]*}}, %{{[0-9]*}}
 ; SHADERTEST: fmul reassoc nnan nsz arcp contract afn <4 x half> %{{[0-9]*}}, %{{[0-9]*}}
 ; SHADERTEST: fsub reassoc nnan nsz arcp contract afn <4 x half> %{{[0-9]*}}, %{{[0-9]*}}
-; SHADERTEST: fdiv reassoc nnan nsz arcp contract afn <4 x half> %{{[0-9]*}}, %{{[0-9]*}}
-; SHADERTEST: fpext <4 x half> %{{[0-9]*}} to <4 x float>
+; SHADERTEST: fdiv reassoc nnan nsz arcp contract afn <4 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>,
+; SHADERTEST: fmul reassoc nnan nsz arcp contract afn <4 x half>
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: AMDLLPC SUCCESS
 */


### PR DESCRIPTION
The changes in commit 9c64ede9 were mistakenly overwritten during the last release, which has now been fixed.

Commit-URL: https://github.com/GPUOpen-Drivers/llpc/commit/9c64ede92ee806714079f8d165bff4ceb7a05a74