### PR TITLE
Enable GitHub syntax highlighting for file endings. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Enable shader syntax highlighting
+*.rahit linguist-language=GLSL
+*.rcall linguist-language=GLSL
+*.rgen linguist-language=GLSL
+*.rint linguist-language=GLSL

--- a/llpc/test/shaderdb/ray_tracing/standalone.rahit
+++ b/llpc/test/shaderdb/ray_tracing/standalone.rahit
@@ -1,0 +1,14 @@
+// BEGIN_SHADERTEST
+/*
+; RUN: amdllpc -v %gfxip %s | FileCheck -check-prefix=SHADERTEST %s
+; SHADERTEST: _ahit1:
+; SHADERTEST: AMDLLPC SUCCESS
+*/
+// END_SHADERTEST
+
+#version 460
+#extension GL_EXT_ray_tracing : enable
+
+void main()
+{
+}


### PR DESCRIPTION
Noted that in https://github.com/GPUOpen-Drivers/llpc/pull/2732, we introduce several new shader types that are not correctly syntax highlighted in the GitHub UI. This PR should set syntax highlighting for the new file endings.
Linguist already marks .rchit and .rmiss as GLSL (https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml), this PR adds the additional file endings, including a test shader (taken from above PR as well).