### PR TITLE
lgc: extend InputAssemlyState::enableMultiView to an enum

### DIFF
--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1964,7 +1964,7 @@ Value *BuilderImpl::patchCubeDescriptor(Value *desc, unsigned dim) {
 Value *BuilderImpl::handleFragCoordViewIndex(Value *coord, unsigned flags, unsigned &dim) {
   bool useViewIndex = false;
   if (flags & ImageFlagCheckMultiView) {
-    if (getPipelineState()->getInputAssemblyState().multiView != MultiViewModeDisable) {
+    if (getPipelineState()->getInputAssemblyState().multiView != MultiViewMode::Disable) {
       useViewIndex = true;
       dim = Dim2DArray;
       unsigned coordCount = cast<FixedVectorType>(coord->getType())->getNumElements();
@@ -2032,7 +2032,7 @@ Value *BuilderImpl::handleFragCoordViewIndex(Value *coord, unsigned flags, unsig
     Type *builtInTy = getInt32Ty();
     addTypeMangling(builtInTy, {}, callName);
     Value *rtLayer = CreateNamedCall(callName, builtInTy, getInt32(BuiltInViewIndex), {});
-    if (getPipelineState()->getInputAssemblyState().multiView == MultiViewModePerView)
+    if (getPipelineState()->getInputAssemblyState().multiView == MultiViewMode::PerView)
       rtLayer = CreateLShr(rtLayer, getInt32(8)); // RT layer id is in the high 24 bits of view index.
     rtLayer->setName("Layer");
     coord = CreateInsertElement(coord, rtLayer, 2);

--- a/lgc/builder/ImageBuilder.cpp
+++ b/lgc/builder/ImageBuilder.cpp
@@ -1964,7 +1964,7 @@ Value *BuilderImpl::patchCubeDescriptor(Value *desc, unsigned dim) {
 Value *BuilderImpl::handleFragCoordViewIndex(Value *coord, unsigned flags, unsigned &dim) {
   bool useViewIndex = false;
   if (flags & ImageFlagCheckMultiView) {
-    if (getPipelineState()->getInputAssemblyState().enableMultiView) {
+    if (getPipelineState()->getInputAssemblyState().multiView != MultiViewModeDisable) {
       useViewIndex = true;
       dim = Dim2DArray;
       unsigned coordCount = cast<FixedVectorType>(coord->getType())->getNumElements();
@@ -2031,9 +2031,11 @@ Value *BuilderImpl::handleFragCoordViewIndex(Value *coord, unsigned flags, unsig
     std::string callName = lgcName::InputImportBuiltIn;
     Type *builtInTy = getInt32Ty();
     addTypeMangling(builtInTy, {}, callName);
-    Value *viewIndex = CreateNamedCall(callName, builtInTy, getInt32(BuiltInViewIndex), {});
-    viewIndex->setName("ViewIndex");
-    coord = CreateInsertElement(coord, viewIndex, 2);
+    Value *rtLayer = CreateNamedCall(callName, builtInTy, getInt32(BuiltInViewIndex), {});
+    if (getPipelineState()->getInputAssemblyState().multiView == MultiViewModePerView)
+      rtLayer = CreateLShr(rtLayer, getInt32(8)); // RT layer id is in the high 24 bits of view index.
+    rtLayer->setName("Layer");
+    coord = CreateInsertElement(coord, rtLayer, 2);
   }
 
   return coord;

--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -1310,7 +1310,7 @@ Value *BuilderImpl::readVsBuiltIn(BuiltInKind builtIn, const Twine &instName) {
   case BuiltInInstanceIndex:
     return ShaderInputs::getInstanceIndex(builder, *getLgcContext());
   case BuiltInViewIndex:
-    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
       return ShaderInputs::getSpecialUserData(UserDataMapping::ViewId, builder);
     return builder.getInt32(0);
   case BuiltInVertexId:

--- a/lgc/include/lgc/patch/PatchInOutImportExport.h
+++ b/lgc/include/lgc/patch/PatchInOutImportExport.h
@@ -218,7 +218,7 @@ private:
   // and gl_Layer is 16-bit low part). Thus, the export is delayed with them merged together.
   llvm::Value *m_viewportIndex; // Correspond to "out int gl_ViewportIndex"
   llvm::Value *m_layer;         // Correspond to "out int gl_Layer"
-  llvm::Value *m_viewIndex;     // Correspond to "in int gl_Layer"
+  llvm::Value *m_viewIndex;     // Correspond to "in int gl_ViewIndex"
   llvm::Value *m_edgeFlag;      // Correspond to "EdgeFlag output"
 
   bool m_hasTs; // Whether the pipeline has tessellation shaders

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -463,12 +463,20 @@ struct ColorExportState {
   unsigned dynamicDualSourceBlendEnable; // Dynamic dual source blend enable
 };
 
+// MultiView supporting mode
+enum MultiViewMode : unsigned {
+  MultiViewModeDisable = 0, // Disabled
+  MultiViewModeSimple = 1,  // Current Vulkan behavior, i.e. RT layer set to view index, viewport index set by shader
+  MultiViewModePerView = 2, // Both RT layer and viewport index set by shader (with shader output defaulting to 0),
+                            // offset by a base that's taken from the ViewId userdata
+};
+
 // Struct to pass to SetInputAssemblyState.
 struct InputAssemblyState {
   PrimitiveType primitiveType;       // Primitive type
   unsigned disableVertexReuse;       // Disable reusing vertex shader output for indexed draws
   unsigned switchWinding;            // Whether to reverse vertex ordering for tessellation
-  unsigned enableMultiView;          // Whether to enable multi-view support
+  MultiViewMode multiView;           // MultiView mode
   unsigned useVertexBufferDescArray; // Whether vertex buffer descriptors are in a descriptor array binding instead of
                                      // the VertexBufferTable
 };

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -464,11 +464,11 @@ struct ColorExportState {
 };
 
 // MultiView supporting mode
-enum MultiViewMode : unsigned {
-  MultiViewModeDisable = 0, // Disabled
-  MultiViewModeSimple = 1,  // Current Vulkan behavior, i.e. RT layer set to view index, viewport index set by shader
-  MultiViewModePerView = 2, // Both RT layer and viewport index set by shader (with shader output defaulting to 0),
-                            // offset by a base that's taken from the ViewId userdata
+enum class MultiViewMode : unsigned {
+  Disable = 0, // Disabled
+  Simple = 1,  // Current Vulkan behavior, i.e. RT layer set to view index, viewport index set by shader
+  PerView = 2, // Both RT layer and viewport index set by shader (with shader output defaulting to 0),
+               // offset by a base that's taken from the ViewId userdata
 };
 
 // Struct to pass to SetInputAssemblyState.

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -452,6 +452,10 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
     cullDistanceCount = builtInUsage.gs.cullDistance;
   }
 
+  // In this mode, API shader may not export viewport index but LGC does so.
+  if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView)
+    useViewportIndex = true;
+
   SET_REG_FIELD(&config->vsRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, usePrimitiveId);
   SET_REG_FIELD(&config->vsRegs, SPI_VS_OUT_CONFIG, VS_EXPORT_COUNT, resUsage->inOutUsage.expCount - 1);
   setUsesViewportArrayIndex(useViewportIndex);
@@ -472,7 +476,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
 
   SET_REG_FIELD(&config->vsRegs, VGT_VERTEX_REUSE_BLOCK_CNTL, VTX_REUSE_DEPTH, 14);
 
-  useLayer = useLayer || m_pipelineState->getInputAssemblyState().enableMultiView;
+  useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
 
   bool miscExport = usePointSize || useLayer || useViewportIndex || useEdgeFlag;
   if (miscExport) {

--- a/lgc/patch/Gfx6ConfigBuilder.cpp
+++ b/lgc/patch/Gfx6ConfigBuilder.cpp
@@ -453,7 +453,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
   }
 
   // In this mode, API shader may not export viewport index but LGC does so.
-  if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView)
+  if (m_pipelineState->getInputAssemblyState().multiView == MultiViewMode::PerView)
     useViewportIndex = true;
 
   SET_REG_FIELD(&config->vsRegs, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, usePrimitiveId);
@@ -476,7 +476,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
 
   SET_REG_FIELD(&config->vsRegs, VGT_VERTEX_REUSE_BLOCK_CNTL, VTX_REUSE_DEPTH, 14);
 
-  useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
+  useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable;
 
   bool miscExport = usePointSize || useLayer || useViewportIndex || useEdgeFlag;
   if (miscExport) {

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1864,7 +1864,7 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
   SET_REG_FIELD(&config->meshRegs, GE_NGG_SUBGRP_CNTL, PRIM_AMP_FACTOR, calcFactor.primAmpFactor);
   SET_REG_FIELD(&config->meshRegs, GE_NGG_SUBGRP_CNTL, THDS_PER_SUBGRP, calcFactor.primAmpFactor);
 
-  const bool enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
+  const bool enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
   bool hasPrimitivePayload =
       builtInUsage.layer || builtInUsage.viewportIndex || builtInUsage.primitiveShadingRate || enableMultiView;
   if (m_gfxIp.major < 11)
@@ -2166,7 +2166,9 @@ template <typename T> void ConfigBuilder::setupPaSpecificRegisters(T *config) {
       expCount = resUsage->inOutUsage.expCount;
     }
 
-    useLayer = useLayer || m_pipelineState->getInputAssemblyState().enableMultiView;
+    useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
+    if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView)
+      useViewportIndex = true;
 
     if (usePrimitiveId) {
       SET_REG_FIELD(config, VGT_PRIMITIVEID_EN, PRIMITIVEID_EN, true);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1864,7 +1864,7 @@ template <typename T> void ConfigBuilder::buildMeshRegConfig(ShaderStage shaderS
   SET_REG_FIELD(&config->meshRegs, GE_NGG_SUBGRP_CNTL, PRIM_AMP_FACTOR, calcFactor.primAmpFactor);
   SET_REG_FIELD(&config->meshRegs, GE_NGG_SUBGRP_CNTL, THDS_PER_SUBGRP, calcFactor.primAmpFactor);
 
-  const bool enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
+  const bool enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable;
   bool hasPrimitivePayload =
       builtInUsage.layer || builtInUsage.viewportIndex || builtInUsage.primitiveShadingRate || enableMultiView;
   if (m_gfxIp.major < 11)
@@ -2166,8 +2166,8 @@ template <typename T> void ConfigBuilder::setupPaSpecificRegisters(T *config) {
       expCount = resUsage->inOutUsage.expCount;
     }
 
-    useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
-    if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView)
+    useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable;
+    if (m_pipelineState->getInputAssemblyState().multiView == MultiViewMode::PerView)
       useViewportIndex = true;
 
     if (usePrimitiveId) {

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1242,7 +1242,7 @@ void MeshTaskShader::lowerGetMeshBuiltinInput(GetMeshBuiltinInputOp &getMeshBuil
     break;
   }
   case BuiltInViewIndex: {
-    if (m_pipelineState->getInputAssemblyState().enableMultiView) {
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable) {
       auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageMesh)->entryArgIdxs.mesh;
       input = getFunctionArgument(entryPoint, entryArgIdxs.viewIndex);
     } else {
@@ -1754,23 +1754,46 @@ void MeshTaskShader::exportPrimitive() {
   if (builtInUsage.layer)
     layer = readMeshBuiltInFromLds(BuiltInLayer);
 
-  Value *viewIndex = nullptr;
-  const bool enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
+  Value *viewportIndex = nullptr;
+  if (builtInUsage.viewportIndex)
+    viewportIndex = readMeshBuiltInFromLds(BuiltInViewportIndex);
+
+  Value *layerForFs = layer;
+  Value *viewportIndexForFs = viewportIndex;
+
+  const bool enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
   if (enableMultiView) {
     auto entryPoint = m_builder.GetInsertBlock()->getParent();
     const auto entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageMesh)->entryArgIdxs.mesh;
-    viewIndex = getFunctionArgument(entryPoint, entryArgIdxs.viewIndex);
+    Value *viewId = getFunctionArgument(entryPoint, entryArgIdxs.viewIndex);
+
+    // RT layer id is view id in simple mode (view index only).
+    Value *layerFromViewId = viewId;
+    if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView) {
+      // RT layer id is in the high 24 bits of view id in per-view mode.
+      layerFromViewId = m_builder.CreateLShr(viewId, m_builder.getInt32(8));
+      if (layer)
+        layerFromViewId = m_builder.CreateAdd(layerFromViewId, layer);
+      // Viewport index is in [7:4] of view id.
+      Value *viewportIndexFromViewId =
+          m_builder.CreateAnd(m_builder.CreateLShr(viewId, m_builder.getInt32(4)), m_builder.getInt32(0xF));
+      if (viewportIndex)
+        viewportIndexFromViewId = m_builder.CreateAdd(viewportIndexFromViewId, viewportIndex);
+      viewportIndex = viewportIndexFromViewId;
+    }
+
+    layer = layerFromViewId;
   }
 
-  if (enableMultiView || builtInUsage.layer) {
+  if (layer) {
     // [19:17] = RT slice index (on GFX11, [12:0] = RT slice index)
     // When multi-view is enabled, the input view index is treated as the output layer.
     Value *layerMaskAndShift = nullptr;
     if (m_gfxIp.major < 11) {
-      layerMaskAndShift = m_builder.CreateAnd(enableMultiView ? viewIndex : layer, 0x7);
+      layerMaskAndShift = m_builder.CreateAnd(layer, 0x7);
       layerMaskAndShift = m_builder.CreateShl(layerMaskAndShift, 17);
     } else {
-      layerMaskAndShift = m_builder.CreateAnd(enableMultiView ? viewIndex : layer, 0x1FFF);
+      layerMaskAndShift = m_builder.CreateAnd(layer, 0x1FFF);
     }
     if (primitivePayload)
       primitivePayload = m_builder.CreateOr(primitivePayload, layerMaskAndShift);
@@ -1778,10 +1801,8 @@ void MeshTaskShader::exportPrimitive() {
       primitivePayload = layerMaskAndShift;
   }
 
-  Value *viewportIndex = nullptr;
-  if (builtInUsage.viewportIndex) {
+  if (viewportIndex) {
     // [23:20] = Viewport index
-    viewportIndex = readMeshBuiltInFromLds(BuiltInViewportIndex);
     auto viewportIndexMaskAndShift = m_builder.CreateAnd(viewportIndex, 0xF);
     viewportIndexMaskAndShift = m_builder.CreateShl(viewportIndexMaskAndShift, 20);
     if (primitivePayload)
@@ -1853,7 +1874,7 @@ void MeshTaskShader::exportPrimitive() {
       if (fsBuiltInUsage.layer) {
         // NOTE: In such case, mesh shader doesn't export layer while fragment shader expects to read it. We
         // export 0 to fragment shader, which is required by the spec.
-        layer = m_builder.getInt32(0);
+        layerForFs = m_builder.getInt32(0);
         exportLayer = true;
       }
     }
@@ -1861,9 +1882,9 @@ void MeshTaskShader::exportPrimitive() {
 
   if (exportLayer) {
     if (inOutUsage.mesh.perPrimitiveBuiltInExportLocs.count(BuiltInLayer) > 0) {
-      assert(layer);
+      assert(layerForFs);
       const unsigned exportLoc = inOutUsage.mesh.perPrimitiveBuiltInExportLocs[BuiltInLayer];
-      primAttrExports.push_back({startLoc + exportLoc, layer});
+      primAttrExports.push_back({startLoc + exportLoc, layerForFs});
       ++inOutUsage.primExpCount;
     }
   }
@@ -1878,7 +1899,7 @@ void MeshTaskShader::exportPrimitive() {
       if (fsBuiltInUsage.viewportIndex) {
         // NOTE: In such case, mesh shader doesn't export viewport index while fragment shader expects to read it. We
         // export 0 to fragment shader, which is required by spec.
-        viewportIndex = m_builder.getInt32(0);
+        viewportIndexForFs = m_builder.getInt32(0);
         exportViewportIndex = true;
       }
     }
@@ -1886,9 +1907,9 @@ void MeshTaskShader::exportPrimitive() {
 
   if (exportViewportIndex) {
     if (inOutUsage.mesh.perPrimitiveBuiltInExportLocs.count(BuiltInViewportIndex) > 0) {
-      assert(viewportIndex);
+      assert(viewportIndexForFs);
       const unsigned exportLoc = inOutUsage.mesh.perPrimitiveBuiltInExportLocs[BuiltInViewportIndex];
-      primAttrExports.push_back({startLoc + exportLoc, viewportIndex});
+      primAttrExports.push_back({startLoc + exportLoc, viewportIndexForFs});
       ++inOutUsage.primExpCount;
     }
   }

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -511,7 +511,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
   if (builtInUsage.viewportIndex)
     builtInPairs.push_back(std::make_pair(BuiltInViewportIndex, builder.getInt32Ty()));
 
-  if (m_pipelineState->getInputAssemblyState().enableMultiView)
+  if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
     builtInPairs.push_back(std::make_pair(BuiltInViewIndex, builder.getInt32Ty()));
 
   if (builtInUsage.primitiveShadingRate)

--- a/lgc/patch/PatchCopyShader.cpp
+++ b/lgc/patch/PatchCopyShader.cpp
@@ -511,7 +511,7 @@ void PatchCopyShader::exportOutput(unsigned streamId, BuilderBase &builder) {
   if (builtInUsage.viewportIndex)
     builtInPairs.push_back(std::make_pair(BuiltInViewportIndex, builder.getInt32Ty()));
 
-  if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
+  if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
     builtInPairs.push_back(std::make_pair(BuiltInViewIndex, builder.getInt32Ty()));
 
   if (builtInUsage.primitiveShadingRate)

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1459,7 +1459,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
 
     // NOTE: The user data to emulate gl_ViewIndex is somewhat common. To make it consistent for GFX9
     // merged shader, we place it prior to any other special user data.
-    if (m_pipelineState->getInputAssemblyState().enableMultiView) {
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable) {
       unsigned *argIdx = nullptr;
       auto userDataValue = UserDataMapping::ViewId;
       switch (m_shaderStage) {
@@ -1571,7 +1571,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "drawIndex", UserDataMapping::DrawIndex,
                                                 &intfData->entryArgIdxs.mesh.drawIndex));
     }
-    if (m_pipelineState->getInputAssemblyState().enableMultiView) {
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable) {
       specialUserDataArgs.push_back(
           UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.mesh.viewIndex));
     }
@@ -1587,7 +1587,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
                                                 &intfData->entryArgIdxs.mesh.pipeStatsBuf));
     }
   } else if (m_shaderStage == ShaderStageFragment) {
-    if (m_pipelineState->getInputAssemblyState().enableMultiView &&
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable &&
         m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->builtInUsage.fs.viewIndex) {
       // NOTE: Only add special user data of view index when multi-view is enabled and gl_ViewIndex is used in fragment
       // shader.

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1459,7 +1459,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
 
     // NOTE: The user data to emulate gl_ViewIndex is somewhat common. To make it consistent for GFX9
     // merged shader, we place it prior to any other special user data.
-    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable) {
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable) {
       unsigned *argIdx = nullptr;
       auto userDataValue = UserDataMapping::ViewId;
       switch (m_shaderStage) {
@@ -1571,7 +1571,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       specialUserDataArgs.push_back(UserDataArg(builder.getInt32Ty(), "drawIndex", UserDataMapping::DrawIndex,
                                                 &intfData->entryArgIdxs.mesh.drawIndex));
     }
-    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable) {
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable) {
       specialUserDataArgs.push_back(
           UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.mesh.viewIndex));
     }
@@ -1587,7 +1587,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
                                                 &intfData->entryArgIdxs.mesh.pipeStatsBuf));
     }
   } else if (m_shaderStage == ShaderStageFragment) {
-    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable &&
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable &&
         m_pipelineState->getShaderResourceUsage(ShaderStageFragment)->builtInUsage.fs.viewIndex) {
       // NOTE: Only add special user data of view index when multi-view is enabled and gl_ViewIndex is used in fragment
       // shader.

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1090,7 +1090,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
 
         // NOTE: Implicitly store the value of view index to GS-VS ring buffer for raster stream if multi-view is
         // enabled. Copy shader will read the value from GS-VS ring and export it to vertex position data.
-        if (m_pipelineState->getInputAssemblyState().enableMultiView) {
+        if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable) {
           auto resUsage = m_pipelineState->getShaderResourceUsage(ShaderStageGeometry);
           auto rasterStream = m_pipelineState->getRasterizerState().rasterStream;
 
@@ -1252,7 +1252,7 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
       cullDistanceCount = builtInUsage.cullDistance;
     }
 
-    const auto enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
+    const auto enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
     if (enableMultiView) {
       if (m_shaderStage == ShaderStageVertex) {
         auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageVertex)->entryArgIdxs.vs;
@@ -1445,23 +1445,46 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
 
     // Export gl_Layer and gl_ViewportIndex before entry-point returns
     if (m_gfxIp.major >= 9 && (useLayer || useViewportIndex || enableMultiView)) {
+      Value *viewportIndex = nullptr;
+      Value *layer = nullptr;
       Value *viewportIndexAndLayer = ConstantInt::get(Type::getInt32Ty(*m_context), 0);
+
+      BuilderBase builder(*m_context);
+      builder.SetInsertPoint(insertPos);
+
+      if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView) {
+        assert(m_viewIndex);
+        // Get viewportIndex from viewIndex.
+        viewportIndex = builder.CreateAnd(builder.CreateLShr(m_viewIndex, builder.getInt32(4)), builder.getInt32(0xF));
+        // Get layer from viewIndex
+        layer = builder.CreateLShr(m_viewIndex, builder.getInt32(8));
+        if (useLayer)
+          layer = builder.CreateAdd(m_layer, layer);
+      } else if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModeSimple) {
+        assert(m_viewIndex);
+        layer = m_viewIndex;
+      } else if (useLayer) {
+        assert(!enableMultiView && m_layer);
+        layer = m_layer;
+      }
 
       if (useViewportIndex) {
         assert(m_viewportIndex);
-        viewportIndexAndLayer = BinaryOperator::CreateShl(
-            m_viewportIndex, ConstantInt::get(Type::getInt32Ty(*m_context), 16), "", insertPos);
+        if (viewportIndex)
+          viewportIndex = builder.CreateAdd(m_viewportIndex, viewportIndex);
+        else
+          viewportIndex = m_viewportIndex;
       }
 
-      if (enableMultiView) {
-        assert(m_viewIndex);
-        viewportIndexAndLayer = BinaryOperator::CreateOr(viewportIndexAndLayer, m_viewIndex, "", insertPos);
-      } else if (useLayer) {
-        assert(m_layer);
-        viewportIndexAndLayer = BinaryOperator::CreateOr(viewportIndexAndLayer, m_layer, "", insertPos);
+      if (viewportIndex) {
+        viewportIndexAndLayer = builder.CreateShl(viewportIndex, builder.getInt32(16));
       }
 
-      viewportIndexAndLayer = new BitCastInst(viewportIndexAndLayer, Type::getFloatTy(*m_context), "", insertPos);
+      if (layer) {
+        viewportIndexAndLayer = builder.CreateOr(viewportIndexAndLayer, layer);
+      }
+
+      viewportIndexAndLayer = builder.CreateBitCast(viewportIndexAndLayer, Type::getFloatTy(*m_context));
 
       Value *args[] = {
           ConstantInt::get(Type::getInt32Ty(*m_context), EXP_TARGET_POS_1), // tgt
@@ -1474,7 +1497,7 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           ConstantInt::get(Type::getInt1Ty(*m_context), false)              // vm
       };
 
-      emitCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_context), args, {}, insertPos);
+      builder.CreateNamedCall("llvm.amdgcn.exp.f32", Type::getVoidTy(*m_context), args, {});
 
       // NOTE: We have to export gl_ViewportIndex via generic outputs as well.
       if (useViewportIndex) {
@@ -1489,7 +1512,7 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           assert(builtInOutLocs.find(BuiltInViewportIndex) != builtInOutLocs.end());
           const unsigned loc = builtInOutLocs.find(BuiltInViewportIndex)->second;
 
-          Value *viewportIndex = new BitCastInst(m_viewportIndex, Type::getFloatTy(*m_context), "", insertPos);
+          Value *viewportIndex = builder.CreateBitCast(m_viewportIndex, Type::getFloatTy(*m_context));
 
           recordVertexAttribExport(loc, {viewportIndex, poison, poison, poison});
         }
@@ -1508,7 +1531,7 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
           assert(builtInOutLocs.find(BuiltInLayer) != builtInOutLocs.end());
           const unsigned loc = builtInOutLocs.find(BuiltInLayer)->second;
 
-          Value *layer = new BitCastInst(m_layer, Type::getFloatTy(*m_context), "", insertPos);
+          Value *layer = builder.CreateBitCast(m_layer, Type::getFloatTy(*m_context));
 
           recordVertexAttribExport(loc, {layer, poison, poison, poison});
         }
@@ -2179,7 +2202,7 @@ Value *PatchInOutImportExport::patchTcsBuiltInInputImport(Type *inputTy, unsigne
     break;
   }
   case BuiltInViewIndex: {
-    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
       input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     else
       input = builder.getInt32(0);
@@ -2307,7 +2330,7 @@ Value *PatchInOutImportExport::patchTesBuiltInInputImport(Type *inputTy, unsigne
     break;
   }
   case BuiltInViewIndex: {
-    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
       input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     else
       input = builder.getInt32(0);
@@ -2358,7 +2381,7 @@ Value *PatchInOutImportExport::patchGsBuiltInInputImport(Type *inputTy, unsigned
     break;
   }
   case BuiltInViewIndex: {
-    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
       input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     else
       input = builder.getInt32(0);
@@ -2565,7 +2588,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
     break;
   }
   case BuiltInViewIndex: {
-    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
       input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
     else
       input = builder.getInt32(0);
@@ -4964,7 +4987,7 @@ void PatchInOutImportExport::addExportInstForBuiltInOutput(Value *output, unsign
 
     // NOTE: Only export gl_Layer when multi-view is disabled. Otherwise, we will export gl_ViewIndex to vertex position
     // data.
-    const auto enableMultiView = m_pipelineState->getInputAssemblyState().enableMultiView;
+    const auto enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
     if (!enableMultiView) {
       Value *args[] = {
           ConstantInt::get(Type::getInt32Ty(*m_context), EXP_TARGET_POS_1), // tgt

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1238,7 +1238,7 @@ bool PatchResourceCollect::isVertexReuseDisabled() {
   } else if (hasVs)
     useViewportIndex = m_pipelineState->getShaderResourceUsage(ShaderStageVertex)->builtInUsage.vs.viewportIndex;
 
-  if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView)
+  if (m_pipelineState->getInputAssemblyState().multiView == MultiViewMode::PerView)
     useViewportIndex = true;
 
   disableVertexReuse |= useViewportIndex;
@@ -2356,7 +2356,7 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
     if (builtInUsage.gs.viewportIndex)
       mapGsBuiltInOutput(BuiltInViewportIndex, 1);
 
-    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
       mapGsBuiltInOutput(BuiltInViewIndex, 1);
 
     if (builtInUsage.gs.primitiveShadingRate)

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -1238,6 +1238,9 @@ bool PatchResourceCollect::isVertexReuseDisabled() {
   } else if (hasVs)
     useViewportIndex = m_pipelineState->getShaderResourceUsage(ShaderStageVertex)->builtInUsage.vs.viewportIndex;
 
+  if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView)
+    useViewportIndex = true;
+
   disableVertexReuse |= useViewportIndex;
 
   return disableVertexReuse;
@@ -2353,7 +2356,7 @@ void PatchResourceCollect::mapBuiltInToGenericInOut() {
     if (builtInUsage.gs.viewportIndex)
       mapGsBuiltInOutput(BuiltInViewportIndex, 1);
 
-    if (m_pipelineState->getInputAssemblyState().enableMultiView)
+    if (m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable)
       mapGsBuiltInOutput(BuiltInViewIndex, 1);
 
     if (builtInUsage.gs.primitiveShadingRate)

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -563,7 +563,7 @@ void RegisterMetadataBuilder::buildPrimShaderRegisters() {
   if (m_hasMesh) {
     maxVertsPerSubgroup = std::min(meshMode.outputVertices, NggMaxThreadsPerSubgroup);
     threadsPerSubgroup = calcFactor.primAmpFactor;
-    const bool enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
+    const bool enableMultiView = m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable;
     bool hasPrimitivePayload = meshBuiltInUsage.layer || meshBuiltInUsage.viewportIndex ||
                                meshBuiltInUsage.primitiveShadingRate || enableMultiView;
     if (m_gfxIp.major < 11)
@@ -1208,9 +1208,9 @@ void RegisterMetadataBuilder::buildPaSpecificRegisters() {
       expCount = resUsage->inOutUsage.expCount;
     }
 
-    useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewModeDisable;
+    useLayer = useLayer || m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable;
     // useViewportIndex must be set in this mode as API shader may not export viewport index.
-    if (m_pipelineState->getInputAssemblyState().multiView == MultiViewModePerView) {
+    if (m_pipelineState->getInputAssemblyState().multiView == MultiViewMode::PerView) {
       useViewportIndexImplicitly = !useViewportIndex;
       useViewportIndex = true;
     }

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -433,7 +433,7 @@ void GraphicsContext::setGraphicsStateInPipeline(Pipeline *pipeline, Util::Metro
   const auto &inputRsState = static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->rsState;
 
   InputAssemblyState inputAssemblyState = {};
-  inputAssemblyState.enableMultiView = inputIaState.enableMultiView;
+  inputAssemblyState.multiView = inputIaState.enableMultiView ? MultiViewModeSimple : MultiViewModeDisable;
   RasterizerState rasterizerState = {};
 
   if (stageMask & ~shaderStageToMask(ShaderStageFragment)) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -433,7 +433,7 @@ void GraphicsContext::setGraphicsStateInPipeline(Pipeline *pipeline, Util::Metro
   const auto &inputRsState = static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo())->rsState;
 
   InputAssemblyState inputAssemblyState = {};
-  inputAssemblyState.multiView = inputIaState.enableMultiView ? MultiViewModeSimple : MultiViewModeDisable;
+  inputAssemblyState.multiView = inputIaState.enableMultiView ? MultiViewMode::Simple : MultiViewMode::Disable;
   RasterizerState rasterizerState = {};
 
   if (stageMask & ~shaderStageToMask(ShaderStageFragment)) {


### PR DESCRIPTION
Vulkan view index is used to set RT layer when multiview extension is enabled. But HLSL SV_ViewID stands for a combination of viewport index, RT layer and view index. To support HLSL and future Vulkan extension, this bool enableMultiView is expandede as an enum which is one of:

- Disabled
- Simple: Current Vulkan behavior, i.e. RT layer set to view index, viewport index set by shader
- PerView: both RT layer and viewport index set by shader (with shader output defaulting to 0), offset by a base that's taken from the ViewId userdata

There is also key change in RegisterMetadataBuilder because even the viewport index is written when multiView is PerView mode, vertex reuse can still be enabled because the viewport index is uniform.