### PR TITLE
lgc: rename entryArgIdxs.viewIndex to viewId

### DIFF
--- a/lgc/builder/InOutBuilder.cpp
+++ b/lgc/builder/InOutBuilder.cpp
@@ -821,7 +821,7 @@ Value *BuilderImpl::CreateReadBuiltInInput(BuiltInKind builtIn, InOutInfo inputI
   assert(isBuiltInInput(builtIn));
   Value *builtInVal = readBuiltIn(false, builtIn, inputInfo, vertexIndex, index, instName);
   if (builtIn == BuiltInViewIndex)
-    // View index can only use bit[3:0] of view id register.
+    // View index can only use bit[3:0] of view ID register.
     builtInVal = CreateAnd(builtInVal, getInt32(0xF));
   return builtInVal;
 }

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -542,7 +542,7 @@ struct InterfaceData {
         unsigned relVertexId;        // Relative vertex ID (index of vertex within thread group)
         unsigned instanceId;         // Instance ID
         unsigned primitiveId;        // Primitive ID
-        unsigned viewIndex;          // View Index
+        unsigned viewId;             // View ID
         unsigned vbTablePtr;         // Pointer of vertex buffer table
         unsigned esGsOffset;         // ES-GS ring buffer offset
         StreamOutData streamOutData; // Stream-out Data
@@ -554,7 +554,7 @@ struct InterfaceData {
         unsigned relPatchId;     // Relative patch ID (control point ID included)
         unsigned tfBufferBase;   // Base offset of tessellation factor(TF) buffer
         unsigned offChipLdsBase; // Base offset of off-chip LDS buffer
-        unsigned viewIndex;      // View Index
+        unsigned viewId;         // View ID
       } tcs;
 
       // Tessellation evaluation shader
@@ -565,7 +565,7 @@ struct InterfaceData {
         unsigned patchId;            // Patch ID
         unsigned esGsOffset;         // ES-GS ring buffer offset
         unsigned offChipLdsBase;     // Base offset of off-chip LDS buffer
-        unsigned viewIndex;          // View Index
+        unsigned viewId;             // View ID
         StreamOutData streamOutData; // Stream-out Data
       } tes;
 
@@ -576,14 +576,14 @@ struct InterfaceData {
         unsigned esGsOffsets[MaxEsGsOffsetCount]; // ES -> GS ring offset
         unsigned primitiveId;                     // Primitive ID
         unsigned invocationId;                    // Invocation ID
-        unsigned viewIndex;                       // View Index
+        unsigned viewId;                          // View ID
         StreamOutData streamOutData;              // Stream-out Data
       } gs;
 
       // Mesh shader
       struct {
         unsigned drawIndex;          // Draw index
-        unsigned viewIndex;          // View index
+        unsigned viewId;             // View ID
         unsigned dispatchDims;       // Dispatch dimensions
         unsigned baseRingEntryIndex; // Base entry index (first workgroup) of mesh/task shader ring for current dispatch
         unsigned pipeStatsBuf;       // Pipeline statistics buffer
@@ -593,7 +593,7 @@ struct InterfaceData {
 
       // Fragment shader
       struct {
-        unsigned viewIndex;  // View Index
+        unsigned viewId;     // View ID
         unsigned primMask;   // Primitive mask
         unsigned sampleInfo; // Sample Info: numSample + samplePattern
 

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1765,7 +1765,7 @@ void MeshTaskShader::exportPrimitive() {
   if (enableMultiView) {
     auto entryPoint = m_builder.GetInsertBlock()->getParent();
     const auto entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageMesh)->entryArgIdxs.mesh;
-    Value *viewId = getFunctionArgument(entryPoint, entryArgIdxs.viewIndex);
+    Value *viewId = getFunctionArgument(entryPoint, entryArgIdxs.viewId);
 
     // RT layer id is view id in simple mode (view index only).
     Value *layerFromViewId = viewId;

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1244,7 +1244,7 @@ void MeshTaskShader::lowerGetMeshBuiltinInput(GetMeshBuiltinInputOp &getMeshBuil
   case BuiltInViewIndex: {
     if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable) {
       auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageMesh)->entryArgIdxs.mesh;
-      input = getFunctionArgument(entryPoint, entryArgIdxs.viewIndex);
+      input = getFunctionArgument(entryPoint, entryArgIdxs.viewId);
     } else {
       input = m_builder.getInt32(0);
     }
@@ -1618,7 +1618,7 @@ Function *MeshTaskShader::mutateMeshShaderEntryPoint(Function *entryPoint) {
   // Adjust indices of existing entry-point arguments
   auto &entryArgIdx = m_pipelineState->getShaderInterfaceData(ShaderStageMesh)->entryArgIdxs.mesh;
   entryArgIdx.drawIndex += NumSpecialSgprInputs;
-  entryArgIdx.viewIndex += NumSpecialSgprInputs;
+  entryArgIdx.viewId += NumSpecialSgprInputs;
   entryArgIdx.dispatchDims += NumSpecialSgprInputs;
   entryArgIdx.baseRingEntryIndex += NumSpecialSgprInputs;
   entryArgIdx.pipeStatsBuf += NumSpecialSgprInputs;

--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -1767,14 +1767,14 @@ void MeshTaskShader::exportPrimitive() {
     const auto entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageMesh)->entryArgIdxs.mesh;
     Value *viewId = getFunctionArgument(entryPoint, entryArgIdxs.viewId);
 
-    // RT layer id is view id in simple mode (view index only).
+    // RT layer is view ID in simple mode (view index only).
     Value *layerFromViewId = viewId;
     if (m_pipelineState->getInputAssemblyState().multiView == MultiViewMode::PerView) {
-      // RT layer id is in the high 24 bits of view id in per-view mode.
+      // RT layer is in the high 24 bits of view ID in per-view mode.
       layerFromViewId = m_builder.CreateLShr(viewId, m_builder.getInt32(8));
       if (layer)
         layerFromViewId = m_builder.CreateAdd(layerFromViewId, layer);
-      // Viewport index is in [7:4] of view id.
+      // Viewport index is in [7:4] of view ID.
       Value *viewportIndexFromViewId =
           m_builder.CreateAnd(m_builder.CreateLShr(viewId, m_builder.getInt32(4)), m_builder.getInt32(0xF));
       if (viewportIndex)

--- a/lgc/patch/PatchEntryPointMutate.cpp
+++ b/lgc/patch/PatchEntryPointMutate.cpp
@@ -1466,16 +1466,16 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       auto userDataValue = UserDataMapping::ViewId;
       switch (m_shaderStage) {
       case ShaderStageVertex:
-        argIdx = &entryArgIdxs.vs.viewIndex;
+        argIdx = &entryArgIdxs.vs.viewId;
         break;
       case ShaderStageTessControl:
-        argIdx = &entryArgIdxs.tcs.viewIndex;
+        argIdx = &entryArgIdxs.tcs.viewId;
         break;
       case ShaderStageTessEval:
-        argIdx = &entryArgIdxs.tes.viewIndex;
+        argIdx = &entryArgIdxs.tes.viewId;
         break;
       case ShaderStageGeometry:
-        argIdx = &entryArgIdxs.gs.viewIndex;
+        argIdx = &entryArgIdxs.gs.viewId;
         break;
       default:
         llvm_unreachable("Unexpected shader stage");
@@ -1575,7 +1575,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
     }
     if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable) {
       specialUserDataArgs.push_back(
-          UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.mesh.viewIndex));
+          UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.mesh.viewId));
     }
     specialUserDataArgs.push_back(UserDataArg(FixedVectorType::get(builder.getInt32Ty(), 3), "meshTaskDispatchDims",
                                               UserDataMapping::MeshTaskDispatchDims,
@@ -1594,7 +1594,7 @@ void PatchEntryPointMutate::addSpecialUserDataArgs(SmallVectorImpl<UserDataArg> 
       // NOTE: Only add special user data of view index when multi-view is enabled and gl_ViewIndex is used in fragment
       // shader.
       specialUserDataArgs.push_back(
-          UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.fs.viewIndex));
+          UserDataArg(builder.getInt32Ty(), "viewId", UserDataMapping::ViewId, &intfData->entryArgIdxs.fs.viewId));
     }
 
     if (userDataUsage->isSpecialUserDataUsed(UserDataMapping::ColorExportAddr)) {

--- a/lgc/patch/PatchInOutImportExport.cpp
+++ b/lgc/patch/PatchInOutImportExport.cpp
@@ -1096,7 +1096,7 @@ void PatchInOutImportExport::visitCallInst(CallInst &callInst) {
 
           if (emitStream == rasterStream) {
             auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageGeometry)->entryArgIdxs.gs;
-            auto viewIndex = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+            auto viewIndex = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
 
             const auto &builtInOutLocMap = resUsage->inOutUsage.builtInOutputLocMap;
             assert(builtInOutLocMap.find(BuiltInViewIndex) != builtInOutLocMap.end());
@@ -1256,10 +1256,10 @@ void PatchInOutImportExport::visitReturnInst(ReturnInst &retInst) {
     if (enableMultiView) {
       if (m_shaderStage == ShaderStageVertex) {
         auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageVertex)->entryArgIdxs.vs;
-        m_viewIndex = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+        m_viewIndex = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
       } else if (m_shaderStage == ShaderStageTessEval) {
         auto &entryArgIdxs = m_pipelineState->getShaderInterfaceData(ShaderStageTessEval)->entryArgIdxs.tes;
-        m_viewIndex = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+        m_viewIndex = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
       } else {
         assert(m_shaderStage == ShaderStageCopyShader);
         assert(m_viewIndex); // Must have been explicitly loaded in copy shader
@@ -2203,7 +2203,7 @@ Value *PatchInOutImportExport::patchTcsBuiltInInputImport(Type *inputTy, unsigne
   }
   case BuiltInViewIndex: {
     if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
-      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
     else
       input = builder.getInt32(0);
     break;
@@ -2331,7 +2331,7 @@ Value *PatchInOutImportExport::patchTesBuiltInInputImport(Type *inputTy, unsigne
   }
   case BuiltInViewIndex: {
     if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
-      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
     else
       input = builder.getInt32(0);
     break;
@@ -2382,7 +2382,7 @@ Value *PatchInOutImportExport::patchGsBuiltInInputImport(Type *inputTy, unsigned
   }
   case BuiltInViewIndex: {
     if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
-      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
     else
       input = builder.getInt32(0);
     break;
@@ -2589,7 +2589,7 @@ Value *PatchInOutImportExport::patchFsBuiltInInputImport(Type *inputTy, unsigned
   }
   case BuiltInViewIndex: {
     if (m_pipelineState->getInputAssemblyState().multiView != MultiViewMode::Disable)
-      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewIndex);
+      input = getFunctionArgument(m_entryPoint, entryArgIdxs.viewId);
     else
       input = builder.getInt32(0);
     break;


### PR DESCRIPTION
As a userdata, it may consist of more field other than viewIndex.

It also matches the name in Pal.