### PR TITLE
lgc: innerCoverage bug fix

### DIFF
--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1247,10 +1247,6 @@ void PipelineState::readColorExportState(Module *module) {
 void PipelineState::setGraphicsState(const InputAssemblyState &iaState, const RasterizerState &rsState) {
   m_inputAssemblyState = iaState;
   m_rasterizerState = rsState;
-
-  const auto &fragmentMode = getShaderModes()->getFragmentShaderMode();
-  if (fragmentMode.innerCoverage)
-    m_rasterizerState.innerCoverage = 1;
 }
 
 // =====================================================================================================================
@@ -1311,6 +1307,11 @@ void PipelineState::readGraphicsState(Module *module) {
   auto nameMeta = module->getNamedMetadata(SampleShadingMetaName);
   if (nameMeta)
     m_rasterizerState.perSampleShading |= 1;
+
+  // fragmentMode is updated after ShaderModes::readModesFromPipeline()
+  const auto &fragmentMode = getShaderModes()->getFragmentShaderMode();
+  if (fragmentMode.innerCoverage)
+    m_rasterizerState.innerCoverage = 1;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
- only can get fragmentMode after ShaderModes::readModesFromPipeline(), so move the m_rasterizerState.innerCoverage = 1 to PipelineState::readGraphicsState