### PR TITLE
Fix caching and PAL metadata for color export shaders

### DIFF
--- a/lgc/elfLinker/ColorExportShader.cpp
+++ b/lgc/elfLinker/ColorExportShader.cpp
@@ -70,6 +70,7 @@ StringRef ColorExportShader::getString() {
     constexpr uint32_t estimatedTypeSize = 10;
     uint32_t sizeEstimate = (sizeof(ColorExportInfo) + estimatedTypeSize) * m_exports.size();
     sizeEstimate += sizeof(m_killEnabled);
+    sizeEstimate += sizeof(ColorExportState) + MaxColorTargets * sizeof(ColorExportFormat);
     m_shaderString.reserve(sizeEstimate);
 
     for (ColorExportInfo colorExportInfo : m_exports) {
@@ -82,6 +83,13 @@ StringRef ColorExportShader::getString() {
       m_shaderString += getTypeName(colorExportInfo.ty);
     }
     m_shaderString += StringRef(reinterpret_cast<const char *>(&m_killEnabled), sizeof(m_killEnabled));
+
+    const ColorExportState *colorExportState = &m_pipelineState->getColorExportState();
+    m_shaderString += StringRef(reinterpret_cast<const char *>(colorExportState), sizeof(*colorExportState));
+    for (unsigned location = 0; location < MaxColorTargets; ++location) {
+      const ColorExportFormat *colorExportFormat = &m_pipelineState->getColorExportFormat(location);
+      m_shaderString += StringRef(reinterpret_cast<const char *>(colorExportFormat), sizeof(*colorExportFormat));
+    }
   }
   return m_shaderString;
 }

--- a/lgc/elfLinker/GlueShader.cpp
+++ b/lgc/elfLinker/GlueShader.cpp
@@ -47,21 +47,8 @@ void GlueShader::compile(raw_pwrite_stream &outStream) {
   // Generate the glue shader IR module.
   std::unique_ptr<Module> module(generate());
 
-  // For explicit color export shader, some registers are required.
-  if (m_pipelineState->getOptions().enableColorExportShader) {
-    m_pipelineState->getPalMetadata()->updateDbShaderControl();
-  }
-
-  // Record pipeline state
-  m_pipelineState->record(&*module);
-
-  // For explicit color export shader, meta data have added some registers.
-  if (!m_pipelineState->getOptions().enableColorExportShader) {
-    // Add empty PAL metadata, to ensure that the back-end writes its PAL metadata in MsgPack format.
-    PalMetadata *palMetadata = new PalMetadata(nullptr, m_pipelineState->useRegisterFieldFormat());
-    palMetadata->record(&*module);
-    delete palMetadata;
-  }
+  // Record pipeline state so that it is available during the subsequent generic IR passes.
+  m_pipelineState->recordExceptPalMetadata(&*module);
 
   // Get the pass managers and run them on the module, generating ELF.
   std::pair<lgc::PassManager &, LegacyPassManager &> passManagers =

--- a/lgc/include/lgc/patch/FragColorExport.h
+++ b/lgc/include/lgc/patch/FragColorExport.h
@@ -62,7 +62,7 @@ public:
   FragColorExport(llvm::LLVMContext *context, PipelineState *pipelineState);
 
   void generateExportInstructions(llvm::ArrayRef<lgc::ColorExportInfo> info, llvm::ArrayRef<llvm::Value *> values,
-                                  bool dummyExport, BuilderBase &builder);
+                                  bool dummyExport, PalMetadata *palMetadata, BuilderBase &builder);
   static void setDoneFlag(llvm::Value *exportInst, BuilderBase &builder);
   static llvm::CallInst *addDummyExport(BuilderBase &builder);
   static llvm::Function *generateNullFragmentShader(llvm::Module &module, PipelineState *pipelineState,

--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -238,6 +238,8 @@ public:
   // Record pipeline state into IR metadata of specified module.
   void record(llvm::Module *module);
 
+  void recordExceptPalMetadata(llvm::Module *module);
+
   // Print pipeline state
   void print(llvm::raw_ostream &out) const;
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -435,14 +435,25 @@ void PipelineState::clear(Module *module) {
 //
 // @param [in/out] module : Module to record the IR metadata in
 void PipelineState::record(Module *module) {
+  recordExceptPalMetadata(module);
+  if (m_palMetadata)
+    m_palMetadata->record(module);
+}
+
+// =====================================================================================================================
+// Record pipeline state except for PAL metadata into IR metadata of specified module.
+//
+// TODO: This method shouldn't exist. It is a temporary workaround to the fact that the entire main pipeline state
+//       leaks into glue shader compilation, but we mustn't have all associated PAL metadata in the glue shader ELF.
+//
+// @param [in/out] module : Module to record the IR metadata in
+void PipelineState::recordExceptPalMetadata(Module *module) {
   recordOptions(module);
   recordUserDataNodes(module);
   recordDeviceIndex(module);
   recordVertexInputDescriptions(module);
   recordColorExportState(module);
   recordGraphicsState(module);
-  if (m_palMetadata)
-    m_palMetadata->record(module);
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
The second commit fixes a regression from a recent cleanup.

The core underlying design problem is that the PipelineState from the outer pipeline compile (the one that requests the glue shader) leaks into the generation of glue shaders. This is a problem because glue shaders can be cached.

The more immediate problem in the regression was that instead of writing color export-related PAL metadata into the glue shader ELF, it was written into the metadata for3 the overall pipeline compile, which meant that it wasn't available in the cache. This previously worked because the PAL metadata was recomputed each time, but that required duplicating the logic and/or keeping it separate from where the actual exports instructions are created, which makes for hard-to-maintain code (basically, two very separate pieces of code would need to be kept in sync).

The solution is to write the PAL metadata into the glue shader ELF.

The first commit is a precaution against likely future regressions with PRs to optimize exports from the color export shader based on pieces of pipeline state.