### PR TITLE
Don't create xfb call if forceDisableStreamOut is enabled

### DIFF
--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -2424,6 +2424,10 @@ void SpirvLowerGlobal::addCallInstForXfbOutput(const ShaderInOutMetadata &output
   DenseMap<unsigned, Vkgc::XfbOutInfo> *locXfbMapPtr = outputMeta.IsBuiltIn ? &m_builtInXfbMap : &m_genericXfbMap;
   bool hasXfbMetadata = m_entryPoint->getMetadata(lgc::XfbStateMetadataName);
   bool hasXfbOut = hasXfbMetadata && (!locXfbMapPtr->empty() || outputMeta.IsXfb);
+#if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 70
+  auto pipelineBuildInfo = static_cast<const Vkgc::GraphicsPipelineBuildInfo *>(m_context->getPipelineBuildInfo());
+  hasXfbOut &= !pipelineBuildInfo->apiXfbOutData.forceDisableStreamOut;
+#endif
   if (!hasXfbOut)
     return;
 


### PR DESCRIPTION
Commit b26fa0f missed the check for `forceDisableStreamOut` in llpc version less than 70, which causes a regression on the case that there are xfb outputs but the flag `forceDisableStreamOut` is enabled. This change will add the check on it to avoid creating xfb call for this case.