### PR TITLE
Fix the issue of output*_enable using channelWriteMask

### DIFF
--- a/lgc/state/PalMetadata.cpp
+++ b/lgc/state/PalMetadata.cpp
@@ -1049,10 +1049,11 @@ void PalMetadata::updateCbShaderMask(llvm::ArrayRef<ColorExportInfo> exps) {
   for (auto &exp : exps) {
     if (exp.hwColorTarget == MaxColorTargets)
       continue;
-    const unsigned channelWriteMask = m_pipelineState->getColorExportFormat(exp.location).channelWriteMask;
-    if (m_pipelineState->computeExportFormat(exp.ty, exp.location) != 0 && channelWriteMask != 0) {
-      cbShaderMask |= (channelWriteMask << (4 * exp.location));
-    }
+    unsigned channelWriteMask = m_pipelineState->getColorExportFormat(exp.location).channelWriteMask;
+    bool needUpdateMask = (m_pipelineState->computeExportFormat(exp.ty, exp.location) != 0) &&
+                          (channelWriteMask > 0 || m_pipelineState->getColorExportState().alphaToCoverageEnable);
+    if (needUpdateMask)
+      cbShaderMask |= (0xF << (4 * exp.location));
   }
 
   if (m_pipelineState->useRegisterFieldFormat()) {

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -328,7 +328,7 @@ void GraphicsContext::setColorExportState(Pipeline *pipeline, Util::MetroHash64 
   if (state.alphaToCoverageEnable && formats.empty()) {
     // NOTE: We must export alpha channel for alpha to coverage, if there is no color export,
     // we force a dummy color export.
-    formats.push_back({BufDataFormat32, BufNumFormatFloat});
+    formats.push_back({BufDataFormat32, BufNumFormatFloat, 0, 0, 0xF});
   }
 
   pipeline->setColorExportState(formats, state);


### PR DESCRIPTION
commit 58f91b causes corruptions on games (Doom, Ghost Recon: Breakpoint,
Rainbow Six:siege, Red Dead Redemption 2, Wolfenstein II, Wolfenstein: Young
Blood, World War Z, Dota2, Dirt4, F1 22, Cyberpunk 2077). One reason is
that channelWriteMask is used to update `cb_shader_mask` and it
should use `0xF`. The other reason is that color format is not taken
into consideration for killing unused output components.