### PR TITLE
Pass ray flags to intersection shader

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -1990,6 +1990,7 @@ SmallSet<unsigned, 4> SpirvLowerRayTracing::getShaderExtraInputParams(ShaderStag
     params.insert(TraceParam::TCurrent);
     params.insert(TraceParam::Kind);
     params.insert(TraceParam::DuplicateAnyHit);
+    params.insert(TraceParam::RayFlags);
     break;
   default:
     break;


### PR DESCRIPTION
When handling OpReportIntersectionKHR(lgc.rt.report.hit), we need the ray flags to determine whether to terminate on first hit.

(I'm surprised there is no CTS for this)