### PR TITLE
Disable Xfb for relocatable compilation..

### DIFF
--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -113,6 +113,8 @@ ShaderModuleUsage ShaderModuleHelper::getShaderModuleUsageInfo(const BinaryData 
       case ExecutionModePixelCenterInteger:
         shaderModuleUsage.pixelCenterInteger = true;
         break;
+      case ExecutionModeXfb:
+        shaderModuleUsage.enableXfb = true;
       default: {
         break;
       }


### PR DESCRIPTION
On gfx11, Xfb depends on the count of primitive vertex. If

UnlinkedStageVertexProcess only contains VS (no TES and GS),

the primitive type might be unknown at compiling VS time, so

we have to fall back to full pipeline.

Currently, We treat Traingle_list as the default value. Therefore,

we only disable relocatable compilation when primitive is point or

line.