### PR TITLE
Update llpc to handle new version of llvm

### DIFF
--- a/shared/continuations/lib/LowerAwait.cpp
+++ b/shared/continuations/lib/LowerAwait.cpp
@@ -171,7 +171,7 @@ static void processContinuations(
   //    co.flag = llvm.coro.suspend.retcon
   //       unreachable
   auto &Context = M.getContext();
-  auto *I8Ptr = Type::getInt8PtrTy(Context);
+  auto *I8Ptr = Type::getInt8Ty(Context)->getPointerTo();
   auto *I32 = Type::getInt32Ty(Context);
   auto *I64 = Type::getInt64Ty(Context);
 


### PR DESCRIPTION
Handle upstream llvm changes for https://github.com/llvm/llvm-project/commit/7b9d73c2f90c0ed8497339a16fc39785349d9610
[NFC] Remove Type::getInt8PtrTy (#71029)