### PR TITLE
llpc: Fix non-determinism in SpirvLowerRayQuery

### DIFF
--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -1265,7 +1265,7 @@ void SpirvLowerRayQuery::initGlobalVariable() {
 unsigned SpirvLowerRayQuery::generateTraceRayStaticId() {
   Util::MetroHash64 hasher;
   hasher.Update(m_nextTraceRayId++);
-  hasher.Update(m_module->getName());
+  hasher.Update(m_module->getName().bytes_begin(), m_module->getName().size());
 
   MetroHash::Hash hash = {};
   hasher.Finalize(hash.bytes);


### PR DESCRIPTION
In SpirvLowerRayQuery, we generate a unique id for each traceRay call. This id is generated by hasing an increasing ID number, and the name of the module.

However, the implementation was instead hashing the binary representation of a StringRef object, thereby hashing a pointer.

This resulted in non-deterministic IR being generated.