### PR TITLE
Fix signed zero issues of FRem

### DIFF
--- a/lgc/builder/BuilderRecorder.cpp
+++ b/lgc/builder/BuilderRecorder.cpp
@@ -82,6 +82,8 @@ StringRef BuilderRecorder::getCallName(BuilderOpcode opcode) {
     return "smod";
   case BuilderOpcode::FMod:
     return "fmod";
+  case BuilderOpcode::FRem:
+    return "frem";
   case BuilderOpcode::Fma:
     return "fma";
   case BuilderOpcode::Tan:
@@ -848,14 +850,23 @@ Value *Builder::CreateSMod(Value *dividend, Value *divisor, const Twine &instNam
 }
 
 // =====================================================================================================================
-// Create FP modulo operation, where the sign of the result (if not zero) is the same as the sign
-// of the divisor.
+// Create FP modulo operation, where the sign of the result is the same as the sign of the divisor.
 //
 // @param dividend : Dividend value
 // @param divisor : Divisor value
 // @param instName : Name to give instruction(s)
 Value *Builder::CreateFMod(Value *dividend, Value *divisor, const Twine &instName) {
   return record(BuilderOpcode::FMod, dividend->getType(), {dividend, divisor}, instName);
+}
+
+// =====================================================================================================================
+// Create FP modulo operation, where the sign of the result is the same as the sign of the dividend.
+//
+// @param dividend : Dividend value
+// @param divisor : Divisor value
+// @param instName : Name to give instruction(s)
+Value *Builder::CreateFRem(Value *dividend, Value *divisor, const Twine &instName) {
+  return record(BuilderOpcode::FRem, dividend->getType(), {dividend, divisor}, instName);
 }
 
 // =====================================================================================================================
@@ -2025,6 +2036,7 @@ Instruction *Builder::record(BuilderOpcode opcode, Type *resultTy, ArrayRef<Valu
     case BuilderOpcode::FMin3:
     case BuilderOpcode::FMix:
     case BuilderOpcode::FMod:
+    case BuilderOpcode::FRem:
     case BuilderOpcode::FSign:
     case BuilderOpcode::FaceForward:
     case BuilderOpcode::FindSMsb:

--- a/lgc/builder/BuilderRecorder.h
+++ b/lgc/builder/BuilderRecorder.h
@@ -59,6 +59,7 @@ enum BuilderOpcode : unsigned {
   QuantizeToFp16,
   SMod,
   FMod,
+  FRem,
   Fma,
   Tan,
   ASin,

--- a/lgc/builder/BuilderReplayer.cpp
+++ b/lgc/builder/BuilderReplayer.cpp
@@ -214,6 +214,10 @@ Value *BuilderReplayer::processCall(unsigned opcode, CallInst *call) {
     return m_builder->CreateFMod(args[0], args[1]);
   }
 
+  case BuilderOpcode::FRem: {
+    return m_builder->CreateFRem(args[0], args[1]);
+  }
+
   case BuilderOpcode::Fma: {
     return m_builder->CreateFma(args[0], args[1], args[2]);
   }

--- a/lgc/include/lgc/builder/BuilderImpl.h
+++ b/lgc/include/lgc/builder/BuilderImpl.h
@@ -152,6 +152,7 @@ public:
   // Create signed integer or FP modulo operation.
   llvm::Value *CreateSMod(llvm::Value *dividend, llvm::Value *divisor, const llvm::Twine &instName = "");
   llvm::Value *CreateFMod(llvm::Value *dividend, llvm::Value *divisor, const llvm::Twine &instName = "");
+  llvm::Value *CreateFRem(llvm::Value *dividend, llvm::Value *divisor, const llvm::Twine &instName = "");
 
   // Create scalar/vector float/half fused multiply-and-add, to compute a * b + c
   llvm::Value *CreateFma(llvm::Value *a, llvm::Value *b, llvm::Value *c, const llvm::Twine &instName = "");

--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -485,13 +485,21 @@ public:
   // @param instName : Name to give instruction(s)
   llvm::Value *CreateSMod(llvm::Value *dividend, llvm::Value *divisor, const llvm::Twine &instName = "");
 
-  // Create FP modulo operation, where the sign of the result (if not zero) is the same as
-  // the sign of the divisor. The result is undefined if divisor is zero.
+  // Create FP modulo operation, where the sign of the result is the same as the sign of the divisor. The result
+  // is undefined if divisor is zero.
   //
   // @param dividend : Dividend value
   // @param divisor : Divisor value
   // @param instName : Name to give instruction(s)
   llvm::Value *CreateFMod(llvm::Value *dividend, llvm::Value *divisor, const llvm::Twine &instName = "");
+
+  // Create FP modulo operation, where the sign of the result is the same as the sign of the dividend. The result
+  // is undefined if divisor is zero.
+  //
+  // @param dividend : Dividend value
+  // @param divisor : Divisor value
+  // @param instName : Name to give instruction(s)
+  llvm::Value *CreateFRem(llvm::Value *dividend, llvm::Value *divisor, const llvm::Twine &instName = "");
 
   // Create scalar/vector float/half fused multiply-and-add, to compute a * b + c
   //

--- a/llpc/translator/lib/SPIRV/SPIRVReader.cpp
+++ b/llpc/translator/lib/SPIRV/SPIRVReader.cpp
@@ -5367,6 +5367,12 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *bv, Function *f, Bas
     Value *val1 = transValue(bc->getDivisor(), f, bb);
     return mapValue(bc, getBuilder()->CreateFMod(val0, val1));
   }
+  case OpFRem: {
+    SPIRVBinary *bc = static_cast<SPIRVBinary *>(bv);
+    Value *val0 = transValue(bc->getOperand(0), f, bb);
+    Value *val1 = transValue(bc->getOperand(1), f, bb);
+    return mapValue(bc, getBuilder()->CreateFRem(val0, val1));
+  }
   case OpFNegate: {
     SPIRVUnary *bc = static_cast<SPIRVUnary *>(bv);
     Value *val0 = transValue(bc->getOperand(0), f, bb);


### PR DESCRIPTION
We use IR builder CreateFRem to translate OpFRem to LLVM native frem instruction. The instruction is further lowered by backend following such formula on our HW:

`  frem(x, y) = x - y * trunc(x/y)`

There is a latent issue when x=-0.0. Although SPIR-V spec says nothing about the case when x = 0.0, C fmod function does specify the sign of the result is the same as that of the dividend even if it is signed zero. But when we input x=-0.0 to above formula, we finally get the addition of (-0.0) + 0.0. The result is +0.0 returned by HW. Hence, we have to manually check this special case when nsz fast math flag is not specified.