### PR TITLE
Fix a latent issue of mesh query on Navi2x

### DIFF
--- a/lgc/patch/MeshTaskShader.cpp
+++ b/lgc/patch/MeshTaskShader.cpp
@@ -765,6 +765,11 @@ void MeshTaskShader::processMeshShader(Function *entryPoint) {
     m_builder.SetInsertPoint(dummyAllocReqBlock);
 
     m_builder.CreateIntrinsic(Intrinsic::amdgcn_s_sendmsg, {}, {m_builder.getInt32(GsAllocReq), m_builder.getInt32(0)});
+
+    // We still collect mesh shader statistics in this special case. This is a valid mesh shader usage when the
+    // primitive/vertex count is not specified by SetMeshOutputs (both are treated as zeros).
+    collectMeshStatsInfo(entryPoint, m_builder.getInt32(0));
+
     m_builder.CreateBr(endDummyAllocReqBlock);
   }
 


### PR DESCRIPTION
For such mesh shader:

```
layout(local_size_x=1, local_size_y=1, local_size_z=128) in; 
layout(triangles, max_vertices=0, max_primitives=0) out;

void main() {
}
```

It is valid when SetMeshOutputs is missing. We will do dummy export with vertexCount=0 and primitiveCount=0. But the dummy export doesn't write the data to mesh pipeline statistics buffer. The mesh query will fail.

On Navi2x, mesh statistics still rely on SW compiler emulation and we must do it by calling collectMeshStatsInfo.