### PR TITLE
Mesh shader: Enable row export on GFX11 and fix issues

### DIFF
--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -52,7 +52,7 @@ static cl::opt<bool> EnableTessOffChip("enable-tess-offchip", cl::desc("Enable t
 
 // -enable-row-export: enable row export for mesh shader
 static cl::opt<bool> EnableRowExport("enable-row-export", cl::desc("Enable row export for mesh shader"),
-                                     cl::init(false));
+                                     cl::init(true));
 
 cl::opt<bool> UseRegisterFieldFormat("use-register-field-format", cl::desc("Use register field format in pipeline ELF"),
                                      cl::init(true));


### PR DESCRIPTION
- The preparation of attribute ring access should be moved to entry block.
- The function attribute 'amdgpu-flat-work-group-size' is incorrect, which leads to unexpected removal of s_barrier.
- Use primOrVertexIndex to do attribute ring access as the VGPR index of buffer_store. Don't use threadIdInSubgroup because when row export is enabled, threadIdInSubgroup is not always equal to primOrVertexIndex.
- After fixing those issues, enable row export by default on GFX11. This is because mesh query will have to check msInvocations. On GFX11, HW obtains this value from the register field SPI_SHADER_GS_MESHLET_DIM.MESHLET_THREADGROUP_SIZE.