### PR TITLE
Fix clang10 compiling warning

### DIFF
--- a/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llpc/translator/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -911,7 +911,7 @@ public:
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
     assert(Pairs.size() % 2 == 0);
-    foreachPair([=, this](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
+    foreachPair([&](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
       assert(IncomingV->isForward() || IncomingV->getType() == Type);
       assert(IncomingBB->isBasicBlock() || IncomingBB->isForward());
     });


### PR DESCRIPTION
warning: lambda capture 'this' is not used [-Wunused-lambda-capture]