### PR TITLE
Fix a typo when calculating tessCoordY in NGG compaction mode

### DIFF
--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3290,7 +3290,7 @@ Value *NggPrimShader::runPartEs(ArrayRef<Argument *> args, Value *position) {
           tessCoordX = createPhi({{newTessCoordX, uncompactVertexBlock}, {tessCoordX, exportVertexBlock}});
 
         if (newTessCoordY)
-          tessCoordX = createPhi({{newTessCoordY, uncompactVertexBlock}, {tessCoordY, exportVertexBlock}});
+          tessCoordY = createPhi({{newTessCoordY, uncompactVertexBlock}, {tessCoordY, exportVertexBlock}});
 
         assert(newRelPatchId);
         relPatchId = createPhi({{newRelPatchId, uncompactVertexBlock}, {relPatchId, exportVertexBlock}});


### PR DESCRIPTION
The tessCoordY is mistakenly written with tessCoordX, leading to wrong value of tessCoordY when NGG compaction mode is turned on. This issue is found by TessMark.