### PR TITLE
Fix an assertion triggered in vkgcPipelineDumper

### DIFF
--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -1983,14 +1983,16 @@ OStream &operator<<(OStream &out, ElfReader<Elf> &reader) {
             switch (node->getKind()) {
             case msgpack::Type::Int:
             case msgpack::Type::UInt: {
+              uint64_t data =
+                  (node->getKind() == msgpack::Type::UInt) ? node->getUInt() : static_cast<uint64_t>(node->getInt());
               if (msgIterStatus == MsgPackIteratorMapKey) {
-                unsigned regId = static_cast<unsigned>(node->getUInt());
+                unsigned regId = static_cast<unsigned>(data);
                 const char *regName = PipelineDumper::getRegisterNameString(regId);
 
                 snprintf(formatBuf, sizeof(formatBuf), "%-45s ", regName);
                 out << formatBuf;
               } else {
-                snprintf(formatBuf, sizeof(formatBuf), "0x%016" PRIX64 " ", node->getUInt());
+                snprintf(formatBuf, sizeof(formatBuf), "0x%016" PRIX64 " ", data);
                 out << formatBuf;
               }
               break;


### PR DESCRIPTION
Although we can still get meaningful value with `getUInt()` on a node with `Int` type, we are triggering assertion.