### PR TITLE
Support vertex offset mode with new D3D12_VERTEX_BUFFER_VIEW

### DIFF
--- a/include/vkgcDefs.h
+++ b/include/vkgcDefs.h
@@ -49,7 +49,7 @@
 #define LLPC_INTERFACE_MAJOR_VERSION 70
 
 /// LLPC minor interface version.
-#define LLPC_INTERFACE_MINOR_VERSION 1
+#define LLPC_INTERFACE_MINOR_VERSION 2
 
 #ifndef LLPC_CLIENT_INTERFACE_MAJOR_VERSION
 #error LLPC client version is not defined
@@ -80,6 +80,7 @@
 //  %Version History
 //  | %Version | Change Description                                                                                    |
 //  | -------- | ----------------------------------------------------------------------------------------------------- |
+//  |     70.2 | Add useVtxBufOffsetMode to GraphicsPipelineBuildInfo                                                  |
 //  |     70.1 | Add cpsFlags to RayTracingPipelineBuildInfo                                                           |
 //  |     70.0 | Add enablePrimGeneratedQuery to PipelineOptions                                                       |
 //  |     69.1 | Add useBarycentric to ShaderModuleUsage                                                               |
@@ -1368,6 +1369,7 @@ struct GraphicsPipelineBuildInfo {
   bool enableUberFetchShader;   ///< Use uber fetch shader
   bool enableColorExportShader; ///< Explicitly build color export shader, UnlinkedStageFragment elf will
                                 ///  return extra meta data.
+  bool useVtxBufOffsetMode;     ///< Use vertex buffer offset mode
   bool enableEarlyCompile;      ///< Whether enable early compile
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
   BinaryData shaderLibrary; ///< SPIR-V library binary data

--- a/lgc/elfLinker/FetchShader.cpp
+++ b/lgc/elfLinker/FetchShader.cpp
@@ -101,7 +101,8 @@ Module *FetchShader::generate() {
 //
 // @param [in/out] fetchFunc : The function for the fetch shader.
 void FetchShader::generateFetchShaderBody(Function *fetchFunc) { // Process each vertex input.
-  std::unique_ptr<VertexFetch> vertexFetch(VertexFetch::create(m_lgcContext));
+  std::unique_ptr<VertexFetch> vertexFetch(
+      VertexFetch::create(m_lgcContext, m_pipelineState->getOptions().useVtxBufOffsetMode));
   auto ret = cast<ReturnInst>(fetchFunc->back().getTerminator());
   BuilderImpl builder(m_pipelineState);
   builder.SetInsertPoint(ret);

--- a/lgc/include/lgc/patch/VertexFetch.h
+++ b/lgc/include/lgc/patch/VertexFetch.h
@@ -46,7 +46,7 @@ public:
   virtual ~VertexFetch() {}
 
   // Create a VertexFetch
-  static VertexFetch *create(LgcContext *lgcContext);
+  static VertexFetch *create(LgcContext *lgcContext, bool useVtxBufOffsetMode);
 
   // Generate code to fetch a vertex value
   virtual llvm::Value *fetchVertex(llvm::Type *inputTy, const VertexInputDescription *description, unsigned location,

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -181,6 +181,7 @@ union Options {
     RayTracingIndirectMode rtIndirectMode; // Ray tracing indirect mode
     bool enablePrimGeneratedQuery;         // Whether to enable primitive generated counter
     bool enableFragColor;                  // If enabled, do frag color broadcast
+    bool useVtxBufOffsetMode;              // Use vertex buffer offset mode
     unsigned cpsFlags;                     // CPS feature flags
   };
 };

--- a/llpc/context/llpcGraphicsContext.cpp
+++ b/llpc/context/llpcGraphicsContext.cpp
@@ -249,6 +249,7 @@ Options GraphicsContext::computePipelineOptions() const {
   auto pipelineInfo = static_cast<const GraphicsPipelineBuildInfo *>(getPipelineBuildInfo());
   options.enableUberFetchShader = pipelineInfo->enableUberFetchShader;
   options.enableColorExportShader = pipelineInfo->enableColorExportShader;
+  options.useVtxBufOffsetMode = pipelineInfo->useVtxBufOffsetMode;
   if (getGfxIpVersion().major >= 10) {
     // Only set NGG options for a GFX10+ graphics pipeline.
     const auto &nggState = pipelineInfo->nggState;

--- a/tool/dumper/vkgcPipelineDumper.cpp
+++ b/tool/dumper/vkgcPipelineDumper.cpp
@@ -953,6 +953,7 @@ void PipelineDumper::dumpGraphicsStateInfo(const GraphicsPipelineBuildInfo *pipe
   dumpFile << "enableUberFetchShader = " << pipelineInfo->enableUberFetchShader << "\n";
   dumpFile << "enableEarlyCompile = " << pipelineInfo->enableEarlyCompile << "\n";
   dumpFile << "enableColorExportShader = " << pipelineInfo->enableColorExportShader << "\n";
+  dumpFile << "useVtxBufOffsetMode = " << pipelineInfo->useVtxBufOffsetMode << "\n";
   dumpPipelineOptions(&pipelineInfo->options, dumpFile);
 
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
@@ -1573,6 +1574,7 @@ void PipelineDumper::updateHashForNonFragmentState(const GraphicsPipelineBuildIn
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 70
   hasher->Update(pipeline->apiXfbOutData.forceEnablePrimStats);
 #endif
+  hasher->Update(pipeline->useVtxBufOffsetMode);
 }
 
 // =====================================================================================================================

--- a/tool/vfx/vfx.h
+++ b/tool/vfx/vfx.h
@@ -535,6 +535,7 @@ struct GraphicsPipelineState {
   bool enableUberFetchShader;   // Use uber fetch shader
   bool enableEarlyCompile;      // Enable early compile
   bool enableColorExportShader; // Enable color export shader
+  bool useVtxBufOffsetMode;     // Use vertex buffer offset mode
 
   float tessLevelInner[2];
   float tessLevelOuter[4];

--- a/tool/vfx/vfxPipelineDoc.cpp
+++ b/tool/vfx/vfxPipelineDoc.cpp
@@ -155,6 +155,7 @@ VfxPipelineStatePtr PipelineDocument::getDocument() {
     gfxPipelineInfo->enableUberFetchShader = graphicState.enableUberFetchShader;
     gfxPipelineInfo->enableEarlyCompile = graphicState.enableEarlyCompile;
     gfxPipelineInfo->enableColorExportShader = graphicState.enableColorExportShader;
+    gfxPipelineInfo->useVtxBufOffsetMode = graphicState.useVtxBufOffsetMode;
 #if LLPC_CLIENT_INTERFACE_MAJOR_VERSION < 62
     gfxPipelineInfo->shaderLibrary = graphicState.shaderLibrary;
 #endif

--- a/tool/vfx/vfxVkSection.h
+++ b/tool/vfx/vfxVkSection.h
@@ -811,6 +811,7 @@ public:
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableUberFetchShader, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableEarlyCompile, MemberTypeBool, false);
       INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, enableColorExportShader, MemberTypeBool, false);
+      INIT_STATE_MEMBER_NAME_TO_ADDR(SectionGraphicsState, useVtxBufOffsetMode, MemberTypeBool, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_shaderLibrary, MemberTypeString, false);
       INIT_MEMBER_NAME_TO_ADDR(SectionGraphicsState, m_rtState, MemberTypeRtState, true);
       INIT_MEMBER_ARRAY_NAME_TO_ADDR(SectionGraphicsState, tessLevelInner, MemberTypeFloat, 2, false);


### PR DESCRIPTION
In vertex offset mode. we will use D3D12_VERTEX_BUFFER_VIEW to replace SRD, the address and size fields are already in the right place. We only need to get stride and fill the fourth DWORD. Then we calculate offset with stride and vertex index.

For Uber fetch shader, SRD will be updated in driver.