### PR TITLE
Remove the method isTessOffChip

### DIFF
--- a/lgc/include/lgc/state/PipelineState.h
+++ b/lgc/include/lgc/state/PipelineState.h
@@ -295,9 +295,6 @@ public:
   const RasterizerState &getRasterizerState() const { return m_rasterizerState; }
   const DepthStencilState &getDepthStencilState() const { return m_depthStencilState; }
 
-  // Determine whether to use off-chip tessellation mode
-  bool isTessOffChip();
-
   // Set GS on-chip mode
   void setGsOnChip(bool gsOnChip) { m_gsOnChip = gsOnChip; }
 

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -953,9 +953,7 @@ template <typename T> void ConfigBuilder::buildVsRegConfig(ShaderStage shaderSta
       SET_REG_FIELD(&config->vsRegs, SPI_SHADER_PGM_RSRC1_VS, VGPR_COMP_CNT, 2);
     }
 
-    if (m_pipelineState->isTessOffChip()) {
-      SET_REG_FIELD(&config->vsRegs, SPI_SHADER_PGM_RSRC2_VS, OC_LDS_EN, true);
-    }
+    SET_REG_FIELD(&config->vsRegs, SPI_SHADER_PGM_RSRC2_VS, OC_LDS_EN, true);
   }
 
   setupPaSpecificRegisters(&config->vsRegs);
@@ -1016,7 +1014,6 @@ void ConfigBuilder::buildLsHsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   SET_REG_FIELD(&config->lsHsRegs, SPI_SHADER_PGM_RSRC2_HS, USER_SGPR, userDataCount);
 
   const auto &calcFactor = tcsResUsage->inOutUsage.tcs.calcFactor;
-  assert(m_pipelineState->isTessOffChip()); // Must be off-chip on GFX9+
 
   const unsigned ldsSizeDwordGranularityShift =
       m_pipelineState->getTargetInfo().getGpuProperty().ldsSizeDwordGranularityShift;
@@ -2055,10 +2052,7 @@ void ConfigBuilder::setupVgtTfParam(LsHsRegConfig *config) {
   SET_REG_FIELD(config, VGT_TF_PARAM, TYPE, primType);
   SET_REG_FIELD(config, VGT_TF_PARAM, PARTITIONING, partition);
   SET_REG_FIELD(config, VGT_TF_PARAM, TOPOLOGY, topology);
-
-  if (m_pipelineState->isTessOffChip()) {
-    SET_REG_FIELD(config, VGT_TF_PARAM, DISTRIBUTION_MODE, TRAPEZOIDS);
-  }
+  SET_REG_FIELD(config, VGT_TF_PARAM, DISTRIBUTION_MODE, TRAPEZOIDS);
 }
 
 // =====================================================================================================================

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3117,11 +3117,9 @@ void NggPrimShader::runEs(ArrayRef<Argument *> args) {
 
   if (m_hasTes) {
     // Set up system value SGPRs
-    if (m_pipelineState->isTessOffChip()) {
-      Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
-      esArgs.push_back(m_hasGs ? offChipLdsBase : isOffChip);
-      esArgs.push_back(m_hasGs ? isOffChip : offChipLdsBase);
-    }
+    Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
+    esArgs.push_back(m_hasGs ? offChipLdsBase : isOffChip);
+    esArgs.push_back(m_hasGs ? isOffChip : offChipLdsBase);
 
     if (m_hasGs)
       esArgs.push_back(esGsOffset);
@@ -3335,11 +3333,9 @@ Value *NggPrimShader::runPartEs(ArrayRef<Argument *> args, Value *position) {
 
   if (m_hasTes) {
     // Set up system value SGPRs
-    if (m_pipelineState->isTessOffChip()) {
-      Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
-      partEsArgs.push_back(isOffChip);
-      partEsArgs.push_back(offChipLdsBase);
-    }
+    Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
+    partEsArgs.push_back(isOffChip);
+    partEsArgs.push_back(offChipLdsBase);
 
     // Set up system value VGPRs
     partEsArgs.push_back(tessCoordX);
@@ -7510,11 +7506,9 @@ Value *NggPrimShader::fetchXfbOutput(Function *target, ArrayRef<Argument *> args
 
   if (m_hasTes) {
     // Set up system value SGPRs
-    if (m_pipelineState->isTessOffChip()) {
-      Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
-      xfbFetcherArgs.push_back(isOffChip);
-      xfbFetcherArgs.push_back(offChipLdsBase);
-    }
+    Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
+    xfbFetcherArgs.push_back(isOffChip);
+    xfbFetcherArgs.push_back(offChipLdsBase);
 
     // Set up system value VGPRs
     xfbFetcherArgs.push_back(tessCoordX);

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -248,7 +248,6 @@ void RegisterMetadataBuilder::buildLsHsRegisters() {
   getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::LsVgprCompCnt] = lsVgprCompCnt;
 
   // Set LDS_SIZE of SPI_SHADER_PGM_RSRC2_HS
-  assert(m_pipelineState->isTessOffChip()); // Must be off-chip on GFX9+
   unsigned ldsSizeInDwords = calcFactor.tessOnChipLdsSize;
   ldsSizeInDwords += calcFactor.rayQueryLdsStackSize;
 
@@ -743,8 +742,7 @@ void RegisterMetadataBuilder::buildHwVsRegisters() {
     else
       getGraphicsRegNode()[Util::Abi::GraphicsRegisterMetadataKey::VsVgprCompCnt] = 2;
 
-    if (m_pipelineState->isTessOffChip())
-      getHwShaderNode(Util::Abi::HardwareStage::Vs)[Util::Abi::HardwareStageMetadataKey::OffchipLdsEn] = true;
+    getHwShaderNode(Util::Abi::HardwareStage::Vs)[Util::Abi::HardwareStageMetadataKey::OffchipLdsEn] = true;
   }
 }
 
@@ -1563,8 +1561,7 @@ void RegisterMetadataBuilder::setVgtTfParam() {
   vgtTfParam[Util::Abi::VgtTfParamMetadataKey::Type] = primType;
   vgtTfParam[Util::Abi::VgtTfParamMetadataKey::Partitioning] = partition;
   vgtTfParam[Util::Abi::VgtTfParamMetadataKey::Topology] = topology;
-  if (m_pipelineState->isTessOffChip())
-    vgtTfParam[Util::Abi::VgtTfParamMetadataKey::DistributionMode] = TRAPEZOIDS;
+  vgtTfParam[Util::Abi::VgtTfParamMetadataKey::DistributionMode] = TRAPEZOIDS;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -609,23 +609,20 @@ uint64_t ShaderInputs::getShaderArgTys(PipelineState *pipelineState, ShaderStage
     }
     break;
   case ShaderStageTessControl:
-    if (pipelineState->isTessOffChip()) {
-      // LDS buffer base for off-chip
-      getShaderInputUsage(shaderStage, ShaderInput::OffChipLdsBase)->enable();
-    }
+    // LDS buffer base for off-chip
+    getShaderInputUsage(shaderStage, ShaderInput::OffChipLdsBase)->enable();
     break;
   case ShaderStageTessEval:
-    if (pipelineState->isTessOffChip()) {
-      // LDS buffer base for off-chip
-      getShaderInputUsage(shaderStage, ShaderInput::OffChipLdsBase)->enable();
-      // is_off_chip register. Enabling it here only has an effect when TES is hardware ES.
-      getShaderInputUsage(shaderStage, ShaderInput::IsOffChip)->enable();
-    }
+    // LDS buffer base for off-chip
+    getShaderInputUsage(shaderStage, ShaderInput::OffChipLdsBase)->enable();
+    // is_off_chip register. Enabling it here only has an effect when TES is hardware ES.
+    getShaderInputUsage(shaderStage, ShaderInput::IsOffChip)->enable();
+
     if (!hasGs) {
       // TES as hardware VS: handle HW stream-out. StreamOutInfo is required for off-chip even if there is no
       // stream-out.
-      if (pipelineState->isTessOffChip() || enableHwXfb)
-        getShaderInputUsage(shaderStage, ShaderInput::StreamOutInfo)->enable();
+      getShaderInputUsage(shaderStage, ShaderInput::StreamOutInfo)->enable();
+
       if (enableHwXfb) {
         getShaderInputUsage(shaderStage, ShaderInput::StreamOutWriteIndex)->enable();
         for (unsigned i = 0; i < MaxTransformFeedbackBuffers; ++i) {

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -523,8 +523,7 @@ Function *ShaderMerger::generateLsHsEntryPoint(Function *lsEntryPoint, Function 
     appendUserData(builder, hsArgs, hsEntryPoint, 0, userData, intfData->userDataCount, substitutions);
 
     // Set up system value SGPRs
-    if (m_pipelineState->isTessOffChip())
-      hsArgs.push_back(offChipLdsBase);
+    hsArgs.push_back(offChipLdsBase);
     hsArgs.push_back(tfBufferBase);
 
     // Set up system value VGPRs
@@ -799,10 +798,8 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
 
     if (hasTs) {
       // Set up system value SGPRs
-      if (m_pipelineState->isTessOffChip()) {
-        esArgs.push_back(offChipLdsBase);
-        esArgs.push_back(offChipLdsBase);
-      }
+      esArgs.push_back(offChipLdsBase);
+      esArgs.push_back(offChipLdsBase);
       esArgs.push_back(esGsOffset);
 
       // Set up system value VGPRs

--- a/lgc/state/PipelineState.cpp
+++ b/lgc/state/PipelineState.cpp
@@ -1334,13 +1334,6 @@ unsigned PipelineState::getNumPatchControlPoints() const {
 }
 
 // =====================================================================================================================
-// Determine whether to use off-chip tessellation mode
-bool PipelineState::isTessOffChip() {
-  // For GFX9+, always enable tessellation off-chip mode
-  return EnableTessOffChip || getLgcContext()->getTargetInfo().getGfxIpVersion().major >= 9;
-}
-
-// =====================================================================================================================
 // Gets wave size for the specified shader stage
 //
 // NOTE: Need to be called after PatchResourceCollect pass, so usage of subgroupSize is confirmed.


### PR DESCRIPTION
On GFX9+, tessellation is always in off-chip mode. Since we just support GFX10+, the method isTessOffChip always returns TRUE for us.