### PR TITLE
Remove the shader input IsOffChip

### DIFF
--- a/lgc/include/lgc/patch/ShaderInputs.h
+++ b/lgc/include/lgc/patch/ShaderInputs.h
@@ -86,7 +86,6 @@ enum class ShaderInput : unsigned {
   GsWaveId,   // GS wave ID
 
   // Unmerged hardware ES SGPRs
-  IsOffChip,  // is_off_chip
   EsGsOffset, // ES to GS offset
 
   // Unmerged hardware HS SGPRs

--- a/lgc/patch/NggPrimShader.cpp
+++ b/lgc/patch/NggPrimShader.cpp
@@ -3117,9 +3117,7 @@ void NggPrimShader::runEs(ArrayRef<Argument *> args) {
 
   if (m_hasTes) {
     // Set up system value SGPRs
-    Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
-    esArgs.push_back(m_hasGs ? offChipLdsBase : isOffChip);
-    esArgs.push_back(m_hasGs ? isOffChip : offChipLdsBase);
+    esArgs.push_back(offChipLdsBase);
 
     if (m_hasGs)
       esArgs.push_back(esGsOffset);
@@ -3333,8 +3331,6 @@ Value *NggPrimShader::runPartEs(ArrayRef<Argument *> args, Value *position) {
 
   if (m_hasTes) {
     // Set up system value SGPRs
-    Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
-    partEsArgs.push_back(isOffChip);
     partEsArgs.push_back(offChipLdsBase);
 
     // Set up system value VGPRs
@@ -7506,8 +7502,6 @@ Value *NggPrimShader::fetchXfbOutput(Function *target, ArrayRef<Argument *> args
 
   if (m_hasTes) {
     // Set up system value SGPRs
-    Value *isOffChip = PoisonValue::get(m_builder.getInt32Ty()); // Unused
-    xfbFetcherArgs.push_back(isOffChip);
     xfbFetcherArgs.push_back(offChipLdsBase);
 
     // Set up system value VGPRs

--- a/lgc/patch/ShaderMerger.cpp
+++ b/lgc/patch/ShaderMerger.cpp
@@ -799,7 +799,6 @@ Function *ShaderMerger::generateEsGsEntryPoint(Function *esEntryPoint, Function 
     if (hasTs) {
       // Set up system value SGPRs
       esArgs.push_back(offChipLdsBase);
-      esArgs.push_back(offChipLdsBase);
       esArgs.push_back(esGsOffset);
 
       // Set up system value VGPRs


### PR DESCRIPTION
This SGPR was originally for pre-GFX9 when tessellation on-chip mode is available. Now, this SGPR is necessary when merged shader doesn't provide it since tessellation is always in off-chip mode.