### PR TITLE
Make tests compatible with upstream llvm

### DIFF
--- a/lgc/test/TaskShaderOps.lgc
+++ b/lgc/test/TaskShaderOps.lgc
@@ -39,7 +39,7 @@
 ; CHECK-NEXT: [[newBaseAddrHi32:%[0-9]*]] = trunc i64 [[newBaseAddrHi64]] to i32
 ; CHECK-NEXT: [[newBaseAddrHi:%[0-9]*]] = and i32 [[newBaseAddrHi32]], 65535
 ; CHECK-NEXT: [[newDescWord1Tmp:%[0-9]*]] = and i32 [[descWord1]], -65536
-; CHECK-NEXT: [[newDescWord1:%[0-9]*]] = or i32 [[newDescWord1Tmp]], [[newBaseAddrHi]]
+; CHECK-NEXT: [[newDescWord1:%[0-9]*]] = or {{(disjoint )?}}i32 [[newDescWord1Tmp]], [[newBaseAddrHi]]
 ; CHECK-NEXT: [[newPayloadRingDescTmp:%[0-9]*]] = insertelement <4 x i32> [[payloadRingDesc]], i32 [[newDescWord0]], i64 0
 ; CHECK-NEXT: [[newPayloadRingDesc:%[0-9]*]] = insertelement <4 x i32> [[newPayloadRingDescTmp]], i32 [[newDescWord1]], i64 1
 ; CHECK: %{{[0-9]*}} = call i32 @llvm.amdgcn.raw.atomic.buffer.load.i32(<4 x i32> [[newPayloadRingDesc]], i32 %{{.*}}, i32 0, i32 5)

--- a/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
+++ b/llpc/test/shaderdb/general/PipelineVsFs_TestIndirectResourceLayout.pipe
@@ -18,7 +18,7 @@
 ; SHADERTEST-LABEL: {{^// LLPC}} pipeline patching results
 ; SHADERTEST: define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 inreg noundef %{{[^,]*}}, i32 inreg noundef %userdata1,
 ; SHADERTEST: [[Addr0:%[0-9]*]] = zext i32 %userdata1 to i64
-; SHADERTEST: [[Addr1:%[0-9]*]] = or i64 %{{[0-9]*}}, [[Addr0]]
+; SHADERTEST: [[Addr1:%[0-9]*]] = or {{(disjoint )?}}i64 %{{[0-9]*}}, [[Addr0]]
 ; SHADERTEST: [[Addr2:%[0-9]*]] = inttoptr i64 [[Addr1]] to ptr addrspace(4)
 ; SHADERTEST: [[Value:%[0-9]*]] = load <4 x float>, ptr addrspace(4) [[Addr2]], align 16
 ; SHADERTEST: [[Value3:%[.a-zA-Z0-9]+]] = extractelement <4 x float> [[Value]], i64 3

--- a/llpc/test/shaderdb/general/TestWorkgroupIdOpt.comp
+++ b/llpc/test/shaderdb/general/TestWorkgroupIdOpt.comp
@@ -21,7 +21,7 @@ void main()
 // CHECK-NEXT:    [[TMP0:%.*]] = call i64 @llvm.amdgcn.s.getpc()
 // CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], -4294967296
 // CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[USERDATA0]] to i64
-// CHECK-NEXT:    [[TMP3:%.*]] = or i64 [[TMP1]], [[TMP2]]
+// CHECK-NEXT:    [[TMP3:%.*]] = or {{(disjoint )?}}i64 [[TMP1]], [[TMP2]]
 // CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(4)
 // CHECK-NEXT:    [[TMP5:%.*]] = load <4 x i32>, ptr addrspace(4) [[TMP4]], align 16
 // CHECK-NEXT:    call void @llvm.amdgcn.raw.buffer.store.i32(i32 [[WORKGROUPID1]], <4 x i32> [[TMP5]], i32 0, i32 0, i32 0)

--- a/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_EnableColorExport.pipe
+++ b/llpc/test/shaderdb/relocatable_shaders/PipelineVsFs_EnableColorExport.pipe
@@ -85,7 +85,7 @@ attribute[0].offset = 0
 ; SHADERTEST-NEXT:    [[DOTI1:%.*]] = fptosi float [[TMP19]] to i32
 ; SHADERTEST-NEXT:    [[TMP12:%.*]] = and i64 [[TMP11]], -4294967296
 ; SHADERTEST-NEXT:    [[TMP13:%.*]] = zext i32 [[DESCTABLE0:%.*]] to i64
-; SHADERTEST-NEXT:    [[TMP14:%.*]] = or i64 [[TMP12]], [[TMP13]]
+; SHADERTEST-NEXT:    [[TMP14:%.*]] = or {{(disjoint )?}}i64 [[TMP12]], [[TMP13]]
 ; SHADERTEST-NEXT:    [[TMP15:%.*]] = inttoptr i64 [[TMP14]] to ptr addrspace(4)
 ; SHADERTEST-NEXT:    [[TMP20:%.*]] = load <8 x i32>, ptr addrspace(4) [[TMP15]], align 32, !invariant.load !10
 ; SHADERTEST-NEXT:    [[TMP21:%.*]] = load <4 x i32>, ptr addrspace(4) [[TMP15]], align 16, !invariant.load !10
@@ -94,7 +94,7 @@ attribute[0].offset = 0
 ; SHADERTEST-NEXT:    [[TMP23:%.*]] = call reassoc nnan nsz arcp contract afn <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float [[DOTI01]], float [[DOTI12]], <8 x i32> [[TMP20]], <4 x i32> [[TMP21]], i1 false, i32 0, i32 0)
 ; SHADERTEST-NEXT:    [[TMP24:%.*]] = insertvalue { <4 x float> } poison, <4 x float> [[TMP23]], 0
 ; SHADERTEST-NEXT:    [[TMP25:%.*]] = zext i32 [[COLOREXPADDR:%.*]] to i64
-; SHADERTEST-NEXT:    [[TMP26:%.*]] = or i64 [[TMP12]], [[TMP25]]
+; SHADERTEST-NEXT:    [[TMP26:%.*]] = or {{(disjoint )?}}i64 [[TMP12]], [[TMP25]]
 ; SHADERTEST-NEXT:    [[TMP27:%.*]] = inttoptr i64 [[TMP26]] to ptr addrspace(4)
 ; SHADERTEST-NEXT:    call amdgpu_gfx addrspace(4) void [[TMP27]]({ <4 x float> } [[TMP24]])
 ; SHADERTEST-NEXT:    unreachable


### PR DESCRIPTION
Allow the new disjoint flag on `or`s, which was recently added upstream.