### PR TITLE
PatchBufferOp: fix the check condition for PreservedAnalyses

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -97,7 +97,7 @@ PreservedAnalyses PatchBufferOp::run(Function &function, FunctionAnalysisManager
 #endif
 
   PatchBufferOpImpl impl(function.getContext(), *pipelineState, uniformityInfo);
-  if (!impl.run(function))
+  if (impl.run(function))
     return PreservedAnalyses::none();
   return PreservedAnalyses::all();
 }


### PR DESCRIPTION
`impl.run(function)` returns true means we should preserve nothing.