### PR TITLE
[Continuation] Update to deprecated LLVM API

### DIFF
--- a/shared/continuations/lib/LowerRaytracingPipeline.cpp
+++ b/shared/continuations/lib/LowerRaytracingPipeline.cpp
@@ -129,8 +129,6 @@ struct PayloadCopyHelper {
     // Pointer to the node field in the local payload
     auto *LocalFieldPtr =
         B.CreateInBoundsGEP(&PayloadTy, LocalPayload, PayloadIdxList);
-    assert(cast<PointerType>(LocalFieldPtr->getType())
-               ->isOpaqueOrPointeeTypeMatches(FieldTy));
 
     // If the field is serialized in multiple intervals in the global,
     // we perform a manual bytewise copy using i32 and i8.
@@ -952,11 +950,6 @@ void LowerRaytracingPipelinePassImpl::copyPayload(
   Value *PayloadSerialization = B.CreateBitCast(
       Payload,
       Layout.SerializationTy->getPointerTo(Payload->getAddressSpace()));
-
-  assert(cast<PointerType>(PayloadSerialization->getType())
-             ->isOpaqueOrPointeeTypeMatches(Layout.SerializationTy));
-  assert(cast<PointerType>(LocalPayload->getType())
-             ->isOpaqueOrPointeeTypeMatches(&PayloadTy));
 
   PayloadCopyHelper Helper{
       *Mod,

--- a/shared/continuations/lib/RegisterBuffer.cpp
+++ b/shared/continuations/lib/RegisterBuffer.cpp
@@ -192,18 +192,15 @@ Value *RegisterBufferPass::computeMemAddr(IRBuilder<> &Builder,
   } else if (auto *Inst = dyn_cast<CastInst>(Address)) {
     auto *Src = Inst->getOperand(0);
     Value *MemSrc = computeMemAddr(Builder, Src);
-    New = Builder.CreateCast(
-        Inst->getOpcode(), MemSrc,
-        PointerType::getWithSamePointeeType(
-            cast<PointerType>(Inst->getDestTy()), Data.Addrspace));
+    New = Builder.CreateCast(Inst->getOpcode(), MemSrc,
+                             PointerType::get(Inst->getType(), Data.Addrspace));
   } else if (auto *Inst = dyn_cast<ConstantExpr>(Address)) {
     if (Inst->isCast()) {
       auto *Src = Inst->getOperand(0);
       Value *MemSrc = computeMemAddr(Builder, Src);
       New = Builder.CreateCast(
           static_cast<Instruction::CastOps>(Inst->getOpcode()), MemSrc,
-          PointerType::getWithSamePointeeType(
-              cast<PointerType>(Inst->getType()), Data.Addrspace));
+          PointerType::get(Inst->getType(), Data.Addrspace));
     } else {
       LLVM_DEBUG(Address->dump());
       llvm_unreachable(
@@ -242,8 +239,7 @@ Value *RegisterBufferPass::handleSingleLoadStore(
   // Change load/store to use addrspace(20)
   auto *AddressType = cast<PointerType>(Address->getType());
   Address = Builder.CreateAddrSpaceCast(
-      Address, PointerType::getWithSamePointeeType(AddressType,
-                                                   GlobalRegisterAddrspace));
+      Address, PointerType::get(AddressType, GlobalRegisterAddrspace));
 
   // If only registers are accessed, emit a simple load/store
   if (TotalElementCount <= Data.RegisterCount)


### PR DESCRIPTION
isOpaqueOrPointeeTypeMatches and PointerType::getWithSamePointeeType are now deprecated.