### PR TITLE
[Continuations] Support new LLVM

### DIFF
--- a/shared/continuations/include/continuations/ContinuationsUtil.h
+++ b/shared/continuations/include/continuations/ContinuationsUtil.h
@@ -637,6 +637,11 @@ findIntrImplEntryByIntrinsicCall(CallInst *Call);
 // during DXILContPostProcess, so we cannot remove all unused declarations right
 // at the end of LowerRaytracingPipeline.
 bool removeUnusedFunctionDecls(Module *Mod, bool OnlyIntrinsics = true);
+
+// Replacement for PointerType::getWithSamePointeeType that works with new LLVM.
+// Returns a typed pointer type if the pointer type is typed.
+PointerType *getWithSamePointeeType(PointerType *PtrTy, unsigned AddressSpace);
+
 } // namespace llvm
 
 #endif

--- a/shared/continuations/lib/ContinuationsUtil.cpp
+++ b/shared/continuations/lib/ContinuationsUtil.cpp
@@ -110,3 +110,14 @@ bool llvm::removeUnusedFunctionDecls(Module *Mod, bool OnlyIntrinsics) {
 
   return DidChange;
 }
+
+PointerType *llvm::getWithSamePointeeType(PointerType *PtrTy,
+                                          unsigned AddressSpace) {
+#if LLVM_MAIN_REVISION && LLVM_MAIN_REVISION < 482880
+  return PointerType::getWithSamePointeeType(PtrTy, AddressSpace);
+#else
+  // New version of the code (also handles unknown version, which we treat as
+  // latest)
+  return PointerType::get(PtrTy->getContext(), AddressSpace);
+#endif
+}

--- a/shared/continuations/lib/LowerRaytracingPipeline.cpp
+++ b/shared/continuations/lib/LowerRaytracingPipeline.cpp
@@ -129,8 +129,6 @@ struct PayloadCopyHelper {
     // Pointer to the node field in the local payload
     auto *LocalFieldPtr =
         B.CreateInBoundsGEP(&PayloadTy, LocalPayload, PayloadIdxList);
-    assert(cast<PointerType>(LocalFieldPtr->getType())
-               ->isOpaqueOrPointeeTypeMatches(FieldTy));
 
     // If the field is serialized in multiple intervals in the global,
     // we perform a manual bytewise copy using i32 and i8.
@@ -952,11 +950,6 @@ void LowerRaytracingPipelinePassImpl::copyPayload(
   Value *PayloadSerialization = B.CreateBitCast(
       Payload,
       Layout.SerializationTy->getPointerTo(Payload->getAddressSpace()));
-
-  assert(cast<PointerType>(PayloadSerialization->getType())
-             ->isOpaqueOrPointeeTypeMatches(Layout.SerializationTy));
-  assert(cast<PointerType>(LocalPayload->getType())
-             ->isOpaqueOrPointeeTypeMatches(&PayloadTy));
 
   PayloadCopyHelper Helper{
       *Mod,

--- a/shared/continuations/lib/RegisterBuffer.cpp
+++ b/shared/continuations/lib/RegisterBuffer.cpp
@@ -194,16 +194,16 @@ Value *RegisterBufferPass::computeMemAddr(IRBuilder<> &Builder,
     Value *MemSrc = computeMemAddr(Builder, Src);
     New = Builder.CreateCast(
         Inst->getOpcode(), MemSrc,
-        PointerType::getWithSamePointeeType(
-            cast<PointerType>(Inst->getDestTy()), Data.Addrspace));
+        getWithSamePointeeType(cast<PointerType>(Inst->getDestTy()),
+                               Data.Addrspace));
   } else if (auto *Inst = dyn_cast<ConstantExpr>(Address)) {
     if (Inst->isCast()) {
       auto *Src = Inst->getOperand(0);
       Value *MemSrc = computeMemAddr(Builder, Src);
       New = Builder.CreateCast(
           static_cast<Instruction::CastOps>(Inst->getOpcode()), MemSrc,
-          PointerType::getWithSamePointeeType(
-              cast<PointerType>(Inst->getType()), Data.Addrspace));
+          getWithSamePointeeType(cast<PointerType>(Inst->getType()),
+                                 Data.Addrspace));
     } else {
       LLVM_DEBUG(Address->dump());
       llvm_unreachable(
@@ -242,8 +242,7 @@ Value *RegisterBufferPass::handleSingleLoadStore(
   // Change load/store to use addrspace(20)
   auto *AddressType = cast<PointerType>(Address->getType());
   Address = Builder.CreateAddrSpaceCast(
-      Address, PointerType::getWithSamePointeeType(AddressType,
-                                                   GlobalRegisterAddrspace));
+      Address, getWithSamePointeeType(AddressType, GlobalRegisterAddrspace));
 
   // If only registers are accessed, emit a simple load/store
   if (TotalElementCount <= Data.RegisterCount)


### PR DESCRIPTION
Remove uses of typed pointer functions removed in upstream LLVM.

* Remove  uses of `isOpaqueOrPointeeTypeMatches` without replacement. These were just used in asserts that would soon turn into no-ops anyways.
* Add a new helper replacing `PointerType::getWithSamePointeeType` which falls back to untyped pointers on new LLVM. This helper can be removed once untyped pointer support is no longer needed.

(This is a GPUOpen port of an already landed internal fix.)