### PR TITLE
Apply extended robust access on global buffer access

### DIFF
--- a/lgc/include/lgc/patch/PatchBufferOp.h
+++ b/lgc/include/lgc/patch/PatchBufferOp.h
@@ -118,6 +118,8 @@ private:
   llvm::Value *replaceLoadStore(llvm::Instruction &inst);
   llvm::Instruction *makeLoop(llvm::Value *const loopStart, llvm::Value *const loopEnd, llvm::Value *const loopStride,
                               llvm::Instruction *const insertPos);
+  Value *createGlobalPointerAccess(llvm::Value *const bufferDesc, llvm::Value *const offset, llvm::Type *const type,
+                                   llvm::Instruction &inst, const llvm::function_ref<Value *(Value *)> callback);
 
   TypeLowering &m_typeLowering;
   llvm::IRBuilder<> m_builder;

--- a/lgc/interface/lgc/Pipeline.h
+++ b/lgc/interface/lgc/Pipeline.h
@@ -187,6 +187,7 @@ union Options {
     unsigned rtStaticPipelineFlags;          // Ray tracing static pipeline flags
     unsigned rtTriCompressMode;              // Ray tracing triangle compression mode
     bool useGpurt;                           // Whether GPURT is used
+    bool enableExtendedRobustBufferAccess;   // Enable the extended robust buffer access
   };
 };
 static_assert(sizeof(Options) == sizeof(Options::u32All));

--- a/lgc/test/Transforms/PatchBufferOp/simple.lgc
+++ b/lgc/test/Transforms/PatchBufferOp/simple.lgc
@@ -29,16 +29,21 @@ define amdgpu_gfx float @uniform_select(<4 x i32> inreg %desc0, <4 x i32> inreg 
 define amdgpu_gfx float @divergent_select(<4 x i32> inreg %desc0, <4 x i32> inreg %desc1, i1 %sel) !lgc.shaderstage !0 {
 ; CHECK-LABEL: @divergent_select(
 ; CHECK-NEXT:    [[PTR_0:%.*]] = select i1 [[SEL:%.*]], <4 x i32> [[DESC0:%.*]], <4 x i32> [[DESC1:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TMP0:%.*]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   %ptr0 = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc0)
   %ptr1 = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc1)
@@ -50,16 +55,21 @@ define amdgpu_gfx float @divergent_select(<4 x i32> inreg %desc0, <4 x i32> inre
 define amdgpu_gfx float @divergent_select1(<4 x i32> %desc0, <4 x i32> inreg %desc1, i1 inreg %sel) !lgc.shaderstage !0 {
 ; CHECK-LABEL: @divergent_select1(
 ; CHECK-NEXT:    [[PTR_0:%.*]] = select i1 [[SEL:%.*]], <4 x i32> [[DESC0:%.*]], <4 x i32> [[DESC1:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TMP0:%.*]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   %ptr0 = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc0)
   %ptr1 = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc1)
@@ -71,16 +81,21 @@ define amdgpu_gfx float @divergent_select1(<4 x i32> %desc0, <4 x i32> inreg %de
 define amdgpu_gfx float @divergent_select2(<4 x i32> inreg %desc0, <4 x i32> %desc1, i1 inreg %sel) !lgc.shaderstage !0 {
 ; CHECK-LABEL: @divergent_select2(
 ; CHECK-NEXT:    [[PTR_0:%.*]] = select i1 [[SEL:%.*]], <4 x i32> [[DESC0:%.*]], <4 x i32> [[DESC1:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TMP0:%.*]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   %ptr0 = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc0)
   %ptr1 = call ptr addrspace(7) @lgc.buffer.desc.to.ptr(<4 x i32> %desc1)
@@ -131,16 +146,21 @@ define amdgpu_gfx float @divergent_input0_phi(<4 x i32> %desc0, <4 x i32> inreg 
 ; CHECK-NEXT:    br label [[TAIL]]
 ; CHECK:       tail:
 ; CHECK-NEXT:    [[PTR_0:%.*]] = phi <4 x i32> [ [[DESC0:%.*]], [[A]] ], [ [[DESC1:%.*]], [[B]] ]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TAIL]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   br i1 %sel, label %a, label %b
 
@@ -167,16 +187,21 @@ define amdgpu_gfx float @divergent_input1_phi(<4 x i32> inreg %desc0, <4 x i32> 
 ; CHECK-NEXT:    br label [[TAIL]]
 ; CHECK:       tail:
 ; CHECK-NEXT:    [[PTR_0:%.*]] = phi <4 x i32> [ [[DESC0:%.*]], [[A]] ], [ [[DESC1:%.*]], [[B]] ]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TAIL]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   br i1 %sel, label %a, label %b
 
@@ -203,16 +228,21 @@ define amdgpu_gfx float @divergent_sync_phi(<4 x i32> inreg %desc0, <4 x i32> in
 ; CHECK-NEXT:    br label [[TAIL]]
 ; CHECK:       tail:
 ; CHECK-NEXT:    [[PTR_0:%.*]] = phi <4 x i32> [ [[DESC0:%.*]], [[A]] ], [ [[DESC1:%.*]], [[B]] ]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TAIL]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   br i1 %sel, label %a, label %b
 

--- a/lgc/test/Transforms/PatchBufferOp/uniform-phi.lgc
+++ b/lgc/test/Transforms/PatchBufferOp/uniform-phi.lgc
@@ -16,16 +16,21 @@ define amdgpu_gfx float @uniform_phi(<4 x i32> inreg %desc0, <4 x i32> inreg %de
 ; CHECK-NEXT:    br label [[TAIL]]
 ; CHECK:       tail:
 ; CHECK-NEXT:    [[PTR_0:%.*]] = phi <4 x i32> [ [[DESC0:%.*]], [[A]] ], [ [[DESC1:%.*]], [[B]] ]
-; CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
-; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i32> [[TMP1]], <i32 -1, i32 65535>
-; CHECK-NEXT:    [[TMP3:%.*]] = bitcast <2 x i32> [[TMP2]] to i64
-; CHECK-NEXT:    [[TMP4:%.*]] = inttoptr i64 [[TMP3]] to ptr addrspace(1)
-; CHECK-NEXT:    [[TMP5:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
-; CHECK-NEXT:    [[TMP6:%.*]] = icmp ult i32 0, [[TMP5]]
-; CHECK-NEXT:    [[TMP7:%.*]] = select i1 [[TMP6]], i32 0, i32 0
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP4]], i32 [[TMP7]]
-; CHECK-NEXT:    [[TMP9:%.*]] = load float, ptr addrspace(1) [[TMP8]], align 4
-; CHECK-NEXT:    ret float [[TMP9]]
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[PTR_0]], i64 2
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 0, [[TMP1]]
+; CHECK-NEXT:    br i1 true, label [[TMP3:%.*]], label [[TMP11:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP4:%.*]] = shufflevector <4 x i32> [[PTR_0]], <4 x i32> poison, <2 x i32> <i32 0, i32 1>
+; CHECK-NEXT:    [[TMP5:%.*]] = and <2 x i32> [[TMP4]], <i32 -1, i32 65535>
+; CHECK-NEXT:    [[TMP6:%.*]] = bitcast <2 x i32> [[TMP5]] to i64
+; CHECK-NEXT:    [[TMP7:%.*]] = inttoptr i64 [[TMP6]] to ptr addrspace(1)
+; CHECK-NEXT:    [[TMP8:%.*]] = select i1 [[TMP2]], i32 0, i32 0
+; CHECK-NEXT:    [[TMP9:%.*]] = getelementptr i8, ptr addrspace(1) [[TMP7]], i32 [[TMP8]]
+; CHECK-NEXT:    [[TMP10:%.*]] = load float, ptr addrspace(1) [[TMP9]], align 4
+; CHECK-NEXT:    br label [[TMP11]]
+; CHECK:       11:
+; CHECK-NEXT:    [[NEWVALUE:%.*]] = phi float [ 0.000000e+00, [[TAIL]] ], [ [[TMP10]], [[TMP3]] ]
+; CHECK-NEXT:    ret float [[NEWVALUE]]
 ;
   br i1 %sel, label %a, label %b
 

--- a/llpc/context/llpcPipelineContext.cpp
+++ b/llpc/context/llpcPipelineContext.cpp
@@ -328,6 +328,7 @@ Options PipelineContext::computePipelineOptions() const {
   }
 
   options.allowNullDescriptor = getPipelineOptions()->extendedRobustness.nullDescriptor;
+  options.enableExtendedRobustBufferAccess = getPipelineOptions()->extendedRobustness.robustBufferAccess;
   options.disableImageResourceCheck = getPipelineOptions()->disableImageResourceCheck;
   options.optimizeTessFactor = getPipelineOptions()->optimizeTessFactor;
   options.enableInterpModePatch = getPipelineOptions()->enableInterpModePatch;


### PR DESCRIPTION
This change will perform defined behavior for global buffer access in
the case of null descriptor or out-of-bound if the application need the
extended `robustnessAccess`.
NOTE: we use dword2 to check null descriptor.