### PR TITLE
[Continuations] Specify namespace for llvm_dialects

### DIFF
--- a/shared/continuations/include/continuations/ContinuationsUtil.h
+++ b/shared/continuations/include/continuations/ContinuationsUtil.h
@@ -106,7 +106,7 @@ struct GpuRtIntrinsicEntry {
   bool AccessesHitData = false;
 };
 
-extern const OpMap<GpuRtIntrinsicEntry> LgcRtGpuRtMap;
+extern const llvm_dialects::OpMap<GpuRtIntrinsicEntry> LgcRtGpuRtMap;
 
 // This must match DXIL::ShaderKind from DxilConstants.h, and also
 // DXILShaderKind in a matching definition in GPURT, because it is used

--- a/shared/continuations/lib/LowerRaytracingPipeline.cpp
+++ b/shared/continuations/lib/LowerRaytracingPipeline.cpp
@@ -1868,9 +1868,9 @@ void LowerRaytracingPipelinePassImpl::handleUnrematerializableCandidates() {
     if (!DialectUtils::isLgcRtOp(&Func))
       continue;
 
-    static const OpSet NonRematerializableDialectOps =
-        OpSet::get<TraceRayOp, ReportHitOp, CallCallableShaderOp,
-                   ShaderIndexOp>();
+    static const llvm_dialects::OpSet NonRematerializableDialectOps =
+        llvm_dialects::OpSet::get<TraceRayOp, ReportHitOp, CallCallableShaderOp,
+                                  ShaderIndexOp>();
     if (!NonRematerializableDialectOps.contains(Func)) {
       llvm::forEachCall(Func, [&](llvm::CallInst &CInst) {
         auto Data = ToProcess.find(CInst.getFunction());


### PR DESCRIPTION
llvm_dialects current has `using namespace` in a header which leads to conflicts. Specify the namespace here explicitly, so that we can remove the using.