### PR TITLE
Improve invalid shader handling

### DIFF
--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -575,7 +575,11 @@ Result Compiler::BuildShaderModule(const ShaderModuleBuildInfo *shaderInfo, Shad
     return Result::ErrorInvalidPointer;
   }
 
-  unsigned codeSize = ShaderModuleHelper::getCodeSize(shaderInfo);
+  auto codeSizeOrErr = ShaderModuleHelper::getCodeSize(shaderInfo);
+  if (Error err = codeSizeOrErr.takeError())
+    return errorToResult(std::move(err));
+
+  const unsigned codeSize = *codeSizeOrErr;
   size_t allocSize = sizeof(ShaderModuleData) + codeSize;
 
   ShaderModuleData moduleData = {};

--- a/llpc/context/llpcCompiler.cpp
+++ b/llpc/context/llpcCompiler.cpp
@@ -2289,13 +2289,15 @@ Result Compiler::BuildComputePipeline(const ComputePipelineBuildInfo *pipelineIn
   const bool buildUsingRelocatableElf = relocatableElfRequested && canUseRelocatableComputeShaderElf(pipelineInfo);
 
   Result result = validatePipelineShaderInfo(&pipelineInfo->cs);
+  if (result != Result::Success)
+    return result;
 
   MetroHash::Hash cacheHash = {};
   MetroHash::Hash pipelineHash = {};
   cacheHash = PipelineDumper::generateHashForComputePipeline(pipelineInfo, true);
   pipelineHash = PipelineDumper::generateHashForComputePipeline(pipelineInfo, false);
 
-  if (result == Result::Success && EnableOuts()) {
+  if (EnableOuts()) {
     const ShaderModuleData *moduleData = reinterpret_cast<const ShaderModuleData *>(pipelineInfo->cs.pModuleData);
     auto moduleHash = reinterpret_cast<const MetroHash::Hash *>(&moduleData->hash[0]);
     LLPC_OUTS("\n===============================================================================\n");
@@ -2310,8 +2312,7 @@ Result Compiler::BuildComputePipeline(const ComputePipelineBuildInfo *pipelineIn
     LLPC_OUTS("\n");
   }
 
-  if (result == Result::Success)
-    dumpCompilerOptions(pipelineDumpFile);
+  dumpCompilerOptions(pipelineDumpFile);
 
   std::optional<CacheAccessor> cacheAccessor;
   if (cl::CacheFullPipelines) {
@@ -2325,40 +2326,39 @@ Result Compiler::BuildComputePipeline(const ComputePipelineBuildInfo *pipelineIn
     result = buildComputePipelineInternal(&computeContext, pipelineInfo, buildUsingRelocatableElf, &candidateElf,
                                           &pipelineOut->stageCacheAccess);
 
-    if (result == Result::Success) {
-      elfBin.codeSize = candidateElf.size();
-      elfBin.pCode = candidateElf.data();
-    }
     if (cacheAccessor && pipelineOut->pipelineCacheAccess == CacheAccessInfo::CacheNotChecked)
       pipelineOut->pipelineCacheAccess = CacheAccessInfo::CacheMiss;
+
+    if (result != Result::Success) {
+      return result;
+    }
+    elfBin.codeSize = candidateElf.size();
+    elfBin.pCode = candidateElf.data();
   } else {
     LLPC_OUTS("Cache hit for compute pipeline.\n");
     elfBin = cacheAccessor->getElfFromCache();
     pipelineOut->pipelineCacheAccess = CacheAccessInfo::InternalCacheHit;
   }
 
-  if (result == Result::Success) {
-    void *allocBuf = nullptr;
-    if (pipelineInfo->pfnOutputAlloc) {
-      allocBuf = pipelineInfo->pfnOutputAlloc(pipelineInfo->pInstance, pipelineInfo->pUserData, elfBin.codeSize);
-      if (allocBuf) {
-        uint8_t *code = static_cast<uint8_t *>(allocBuf);
-        memcpy(code, elfBin.pCode, elfBin.codeSize);
+  if (!pipelineInfo->pfnOutputAlloc) // Allocator is not specified
+    return Result::ErrorInvalidPointer;
 
-        pipelineOut->pipelineBin.codeSize = elfBin.codeSize;
-        pipelineOut->pipelineBin.pCode = code;
-      } else
-        result = Result::ErrorOutOfMemory;
-    } else {
-      // Allocator is not specified
-      result = Result::ErrorInvalidPointer;
-    }
-  }
+  void *const allocBuf =
+      pipelineInfo->pfnOutputAlloc(pipelineInfo->pInstance, pipelineInfo->pUserData, elfBin.codeSize);
+  if (!allocBuf)
+    return Result::ErrorOutOfMemory;
 
-  if (cacheAccessor && !cacheAccessor->isInCache() && result == Result::Success) {
+  uint8_t *code = static_cast<uint8_t *>(allocBuf);
+  memcpy(code, elfBin.pCode, elfBin.codeSize);
+
+  pipelineOut->pipelineBin.codeSize = elfBin.codeSize;
+  pipelineOut->pipelineBin.pCode = code;
+
+  if (cacheAccessor && !cacheAccessor->isInCache()) {
     cacheAccessor->setElfInCache(elfBin);
   }
-  return result;
+
+  return Result::Success;
 }
 
 // =====================================================================================================================

--- a/llpc/util/llpcShaderModuleHelper.h
+++ b/llpc/util/llpcShaderModuleHelper.h
@@ -32,6 +32,7 @@
 #pragma once
 #include "llpc.h"
 #include <llvm/ADT/ArrayRef.h>
+#include <llvm/Support/Error.h>
 #include <vector>
 
 namespace Llpc {
@@ -56,7 +57,8 @@ class ShaderModuleHelper {
 public:
   static ShaderModuleUsage getShaderModuleUsageInfo(const BinaryData *spvBinCode);
 
-  static unsigned trimSpirvDebugInfo(const BinaryData *spvBin, llvm::MutableArrayRef<unsigned> codeBuffer);
+  static llvm::Expected<unsigned> trimSpirvDebugInfo(const BinaryData *spvBin,
+                                                     llvm::MutableArrayRef<unsigned> codeBuffer);
 
   static Result optimizeSpirv(const BinaryData *spirvBinIn, BinaryData *spirvBinOut);
 
@@ -70,9 +72,9 @@ public:
   static Result getShaderBinaryType(BinaryData shaderBinary, BinaryType &binaryType);
   static Result getModuleData(const ShaderModuleBuildInfo *shaderInfo, llvm::MutableArrayRef<unsigned> codeBuffer,
                               Vkgc::ShaderModuleData &moduleData);
-  static unsigned getCodeSize(const ShaderModuleBuildInfo *shaderInfo);
-  static BinaryData getShaderCode(const ShaderModuleBuildInfo *shaderInfo,
-                                  llvm::MutableArrayRef<unsigned int> &codeBuffer);
+  static llvm::Expected<unsigned> getCodeSize(const ShaderModuleBuildInfo *shaderInfo);
+  static llvm::Expected<BinaryData> getShaderCode(const ShaderModuleBuildInfo *shaderInfo,
+                                                  llvm::MutableArrayRef<unsigned int> &codeBuffer);
 };
 
 } // namespace Llpc


### PR DESCRIPTION
* Prevent `trimSpirvDebugInfo` from looping indefinitely on invalid input  
  An invalid SPIR-V binary might contain data that does not match any opCode, and yields a `wordCount` of zero, triggering an infinite loop. `trimSpirvDebugInfo` now returns `Expected<unsigned>` and will give an error in such a situation. Caller functions `getShaderCode` and `getCodeSize` (as well as their callers `BuildShaderModule` and `getModuleData`) have been updated to handle the error.

* Make `BuildComputePipeline` fail if the shader does not pass validation  
  Validation might fail e.g. because the shader entry point is missing. This change allows the error to bubble up through the call stack until `vkCreateComputePipelines`, instead of killing the app later on with exit code 1. `BuildComputePipeline` is converted to early-return style.

I did not add any test for these conditions, but I could do so if it's considered valuable.