### PR TITLE
Add assertion for load ptr(7),ptr(7) in PatchBufferOp 

### DIFF
--- a/lgc/patch/PatchBufferOp.cpp
+++ b/lgc/patch/PatchBufferOp.cpp
@@ -1503,6 +1503,7 @@ Value *BufferOpLowering::replaceLoadStore(Instruction &inst) {
     assert(newInst);
 
     if (type->isPointerTy()) {
+      assert(type->getPointerAddressSpace() != ADDR_SPACE_BUFFER_FAT_POINTER);
       newInst = m_builder.CreateBitCast(newInst, m_builder.getIntNTy(bytesToHandle * 8));
       copyMetadata(newInst, &inst);
       newInst = m_builder.CreateIntToPtr(newInst, type);


### PR DESCRIPTION
As ‘the pattern "load ptr(7),ptr(7)" hasn't been generated in any actual case. 
So just adding the assertion instead of trying fix on PR: https://github.com/GPUOpen-Drivers/llpc/pull/2878