### PR TITLE
Simplify calls to Builder::ReadBuiltInInput.

### DIFF
--- a/lgc/interface/lgc/Builder.h
+++ b/lgc/interface/lgc/Builder.h
@@ -1261,8 +1261,8 @@ public:
   // @param vertexIndex : For TCS/TES/GS per-vertex input: vertex index, else nullptr
   // @param index : Array or vector index to access part of an input, else nullptr
   // @param instName : Name to give instruction(s)
-  llvm::Value *CreateReadBuiltInInput(BuiltInKind builtIn, InOutInfo inputInfo, llvm::Value *vertexIndex,
-                                      llvm::Value *index, const llvm::Twine &instName = "");
+  llvm::Value *CreateReadBuiltInInput(BuiltInKind builtIn, InOutInfo inputInfo = {}, llvm::Value *vertexIndex = nullptr,
+                                      llvm::Value *index = nullptr, const llvm::Twine &instName = "");
 
   // Create a read of (part of) a built-in output value.
   // The type of the returned value is the fixed type of the specified built-in (see BuiltInDefs.h),

--- a/lgc/patch/LowerGpuRt.cpp
+++ b/lgc/patch/LowerGpuRt.cpp
@@ -118,8 +118,7 @@ unsigned LowerGpuRt::getWorkgroupSize() const {
 Value *LowerGpuRt::getThreadIdInGroup() const {
   // Todo: for graphics shader, subgroupId * waveSize + subgroupLocalInvocationId()
   unsigned builtIn = m_pipelineState->isGraphics() ? BuiltInSubgroupLocalInvocationId : BuiltInLocalInvocationIndex;
-  InOutInfo inputInfo = {};
-  return m_builder->CreateReadBuiltInInput(static_cast<BuiltInKind>(builtIn), inputInfo, nullptr, nullptr, "");
+  return m_builder->CreateReadBuiltInInput(static_cast<BuiltInKind>(builtIn));
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerGlobal.cpp
+++ b/llpc/lower/llpcSpirvLowerGlobal.cpp
@@ -1125,8 +1125,8 @@ Value *SpirvLowerGlobal::addCallInstForInOutImport(Type *inOutTy, unsigned addrS
           inOutInfo.setInterpLoc(interpLoc);
           assert(!inOutMeta.PerPrimitive); // No per-primitive arrayed built-in
           if (addrSpace == SPIRAS_Input) {
-            inOutValue = m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(inOutMeta.Value), inOutInfo,
-                                                           vertexIdx, nullptr);
+            inOutValue =
+                m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(inOutMeta.Value), inOutInfo, vertexIdx);
           } else {
             inOutValue = m_builder->CreateReadBuiltInOutput(static_cast<lgc::BuiltInKind>(inOutMeta.Value), inOutInfo,
                                                             vertexIdx, nullptr);

--- a/llpc/lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
+++ b/llpc/lower/llpcSpirvLowerInternalLibraryIntrinsicUtil.cpp
@@ -45,8 +45,7 @@ namespace Llpc {
 // @param func : The function to process
 // @param builder : The IR builder
 static void createLaneIndex(Function *func, Builder *builder) {
-  builder->CreateRet(builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(BuiltInSubgroupLocalInvocationId),
-                                                     {}, nullptr, nullptr, ""));
+  builder->CreateRet(builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(BuiltInSubgroupLocalInvocationId)));
 }
 
 // =====================================================================================================================

--- a/llpc/lower/llpcSpirvLowerRayQuery.cpp
+++ b/llpc/lower/llpcSpirvLowerRayQuery.cpp
@@ -500,17 +500,16 @@ template <> void SpirvLowerRayQuery::createRayQueryFunc<OpRayQueryInitializeKHR>
 Value *SpirvLowerRayQuery::getDispatchId() {
   Value *zero = m_builder->getInt32(0);
   Value *dispatchId = nullptr;
-  lgc::InOutInfo inputInfo = {};
   // Local thread ID for graphics shader Stage, global thread ID for compute/raytracing shader stage
   if (m_shaderStage < ShaderStageCompute) {
-    auto subThreadId =
-        m_builder->CreateReadBuiltInInput(lgc::BuiltInSubgroupLocalInvocationId, inputInfo, nullptr, nullptr, "");
+    auto subThreadId = m_builder->CreateReadBuiltInInput(lgc::BuiltInSubgroupLocalInvocationId);
     dispatchId = PoisonValue::get(FixedVectorType::get(m_builder->getInt32Ty(), 3));
     dispatchId = m_builder->CreateInsertElement(dispatchId, subThreadId, uint64_t(0));
     dispatchId = m_builder->CreateInsertElement(dispatchId, zero, 1);
     dispatchId = m_builder->CreateInsertElement(dispatchId, zero, 2);
-  } else
-    dispatchId = m_builder->CreateReadBuiltInInput(lgc::BuiltInGlobalInvocationId, inputInfo, nullptr, nullptr, "");
+  } else {
+    dispatchId = m_builder->CreateReadBuiltInInput(lgc::BuiltInGlobalInvocationId);
+  }
 
   return dispatchId;
 }
@@ -1421,8 +1420,7 @@ Value *SpirvLowerRayQuery::getThreadIdInGroup() const {
   // Todo: for graphics shader, subgroupId * waveSize + subgroupLocalInvocationId()
   unsigned builtIn = m_context->getPipelineType() == PipelineType::Graphics ? BuiltInSubgroupLocalInvocationId
                                                                             : BuiltInLocalInvocationIndex;
-  lgc::InOutInfo inputInfo = {};
-  return m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(builtIn), inputInfo, nullptr, nullptr, "");
+  return m_builder->CreateReadBuiltInInput(static_cast<lgc::BuiltInKind>(builtIn));
 }
 
 } // namespace Llpc

--- a/llpc/lower/llpcSpirvLowerRayTracing.cpp
+++ b/llpc/lower/llpcSpirvLowerRayTracing.cpp
@@ -1260,8 +1260,7 @@ void SpirvLowerRayTracing::createRayGenEntryFunc() {
   createDispatchRaysInfoDesc();
   Value *launchSize = loadShaderTableVariable(ShaderTable::LaunchSize, m_dispatchRaysInfoDesc);
   auto builtIn = lgc::BuiltInGlobalInvocationId;
-  lgc::InOutInfo inputInfo = {};
-  auto launchlId = m_builder->CreateReadBuiltInInput(builtIn, inputInfo, nullptr, nullptr, "");
+  auto launchlId = m_builder->CreateReadBuiltInInput(builtIn);
   auto launchSizeX = m_builder->CreateExtractElement(launchSize, uint64_t(0));
   auto launchSizeY = m_builder->CreateExtractElement(launchSize, 1);
   auto launchIdX = m_builder->CreateExtractElement(launchlId, uint64_t(0));
@@ -2633,7 +2632,7 @@ void SpirvLowerRayTracing::visitSetParentId(lgc::GpurtSetParentIdOp &inst) {
 void SpirvLowerRayTracing::visitDispatchRayIndex(lgc::rt::DispatchRaysIndexOp &inst) {
   m_builder->SetInsertPoint(&inst);
 
-  auto dispatchRayIndex = m_builder->CreateReadBuiltInInput(lgc::BuiltInGlobalInvocationId, {}, nullptr, nullptr, "");
+  auto dispatchRayIndex = m_builder->CreateReadBuiltInInput(lgc::BuiltInGlobalInvocationId);
   inst.replaceAllUsesWith(dispatchRayIndex);
 
   m_callsToLower.push_back(&inst);


### PR DESCRIPTION
In many places, we are calling Builder::CreateReadBuiltInInput with default arguments, cluttering the call signature. This change simplifies that a bit by adding default arguments to the declaration.