### PR TITLE
Remove the unused user data EsGsLdsSize

### DIFF
--- a/lgc/include/lgc/state/IntrinsDefs.h
+++ b/lgc/include/lgc/state/IntrinsDefs.h
@@ -65,19 +65,19 @@ static const unsigned GsEmitCutStreamIdMask = 0x300; // Mask of STREAM_ID of the
 static const unsigned GetRealTime = 0x83; // [7] = 1, [6:0] = 3
 
 // Count of user SGPRs used in copy shader
-static const unsigned CopyShaderUserSgprCount = 3;
+static const unsigned CopyShaderUserSgprCount = 2;
 
 // Entry-point argument index for the stream info in copy shader
-static const unsigned CopyShaderEntryArgIdxStreamInfo = 3;
+static const unsigned CopyShaderEntryArgIdxStreamInfo = 2;
 
 // Entry-point argument index for the stream-out write index in copy shader
-static const unsigned CopyShaderEntryArgIdxWriteIndex = 4;
+static const unsigned CopyShaderEntryArgIdxWriteIndex = 3;
 
 // Entry-point argument index for the stream offsets in copy shader
-static const unsigned CopyShaderEntryArgIdxStreamOffset = 5;
+static const unsigned CopyShaderEntryArgIdxStreamOffset = 4;
 
 // Entry-point argument index for the LDS offset of current vertices in GS-VS ring
-static const unsigned CopyShaderEntryArgIdxVertexOffset = 9;
+static const unsigned CopyShaderEntryArgIdxVertexOffset = 8;
 
 // Enumerates address spaces valid for AMD GPU (similar to LLVM header AMDGPU.h)
 enum AddrSpace {

--- a/lgc/include/lgc/state/ResourceUsage.h
+++ b/lgc/include/lgc/state/ResourceUsage.h
@@ -513,7 +513,6 @@ struct InterfaceData {
   struct {
     // Geometry shader
     struct {
-      unsigned copyShaderEsGsLdsSize;    // ES -> GS ring LDS size (for copy shader)
       unsigned copyShaderStreamOutTable; // Stream-out table (for copy shader)
     } gs;
 

--- a/lgc/patch/ConfigBuilderBase.cpp
+++ b/lgc/patch/ConfigBuilderBase.cpp
@@ -209,14 +209,6 @@ void ConfigBuilderBase::setPsSampleMask(bool value) {
 }
 
 // =====================================================================================================================
-// Set ES_GS_LDS_BYTE_SIZE
-//
-// @param value : Value to set
-void ConfigBuilderBase::setEsGsLdsByteSize(unsigned value) {
-  m_pipelineNode[Util::Abi::PipelineMetadataKey::EsGsLdsSize] = value;
-}
-
-// =====================================================================================================================
 // Set hardware stage wavefront
 //
 // @param hwStage : Hardware shader stage
@@ -287,17 +279,6 @@ void ConfigBuilderBase::setLdsSizeByteSize(Util::Abi::HardwareStage hwStage, uns
 
   auto hwShaderNode = getHwShaderNode(hwStage);
   hwShaderNode[Util::Abi::HardwareStageMetadataKey::LdsSize] = value;
-}
-
-// =====================================================================================================================
-// Set ES-GS LDS byte size
-//
-// @param value : Value to set
-void ConfigBuilderBase::setEsGsLdsSize(unsigned value) {
-  if (value == 0)
-    return; // Optional
-
-  m_pipelineNode[Util::Abi::PipelineMetadataKey::EsGsLdsSize] = value;
 }
 
 // =====================================================================================================================

--- a/lgc/patch/ConfigBuilderBase.h
+++ b/lgc/patch/ConfigBuilderBase.h
@@ -80,12 +80,10 @@ protected:
   void setPsWritesUavs(bool value);
   void setPsWritesDepth(bool value);
   void setPsSampleMask(bool value);
-  void setEsGsLdsByteSize(unsigned value);
   void setWaveFrontSize(Util::Abi::HardwareStage hwStage, unsigned value);
   void setApiName(const char *value);
   void setPipelineType(Util::Abi::PipelineType value);
   void setLdsSizeByteSize(Util::Abi::HardwareStage hwStage, unsigned value);
-  void setEsGsLdsSize(unsigned value);
   void setNggSubgroupSize(unsigned value);
   void setThreadgroupDimensions(llvm::ArrayRef<unsigned> values);
   void setStreamOutVertexStrides(llvm::ArrayRef<unsigned> values);

--- a/lgc/patch/Gfx9ConfigBuilder.cpp
+++ b/lgc/patch/Gfx9ConfigBuilder.cpp
@@ -1151,7 +1151,6 @@ void ConfigBuilder::buildEsGsRegConfig(ShaderStage shaderStage1, ShaderStage sha
   SET_REG_FIELD(&config->esGsRegs, SPI_SHADER_PGM_RSRC2_GS, LDS_SIZE, ldsSize);
 
   setLdsSizeByteSize(Util::Abi::HardwareStage::Gs, ldsSizeInDwords * 4);
-  setEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 
   unsigned maxVertOut = std::max(1u, static_cast<unsigned>(geometryMode.outputVertices));
   SET_REG_FIELD(&config->esGsRegs, VGT_GS_MAX_VERT_OUT, MAX_VERT_OUT, maxVertOut);
@@ -1163,8 +1162,6 @@ void ConfigBuilder::buildEsGsRegConfig(ShaderStage shaderStage1, ShaderStage sha
     SET_REG_FIELD(&config->esGsRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_ON);
     SET_REG_FIELD(&config->esGsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
     SET_REG_FIELD(&config->esGsRegs, VGT_GS_MODE, GS_WRITE_OPTIMIZE, false);
-
-    setEsGsLdsByteSize(calcFactor.esGsLdsSize * 4);
   } else {
     SET_REG_FIELD(&config->esGsRegs, VGT_GS_MODE, ONCHIP, VGT_GS_MODE_ONCHIP_OFF);
     SET_REG_FIELD(&config->esGsRegs, VGT_GS_MODE, ES_WRITE_OPTIMIZE, false);
@@ -1366,7 +1363,6 @@ void ConfigBuilder::buildPrimShaderRegConfig(ShaderStage shaderStage1, ShaderSta
   const unsigned ldsSize = ldsSizeInDwords >> ldsSizeDwordGranularityShift;
   SET_REG_FIELD(&config->primShaderRegs, SPI_SHADER_PGM_RSRC2_GS, LDS_SIZE, ldsSize);
   setLdsSizeByteSize(Util::Abi::HardwareStage::Gs, ldsSizeInDwords * 4);
-  setEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 
   if (m_gfxIp.major >= 11) {
     // Pixel wait sync+

--- a/lgc/patch/PatchResourceCollect.cpp
+++ b/lgc/patch/PatchResourceCollect.cpp
@@ -727,8 +727,7 @@ bool PatchResourceCollect::checkGsOnChipValidity() {
     gsResUsage->inOutUsage.gs.calcFactor.esVertsPerSubgroup = esVertsPerSubgroup;
     gsResUsage->inOutUsage.gs.calcFactor.gsPrimsPerSubgroup = gsPrimsPerSubgroup;
 
-    // EsGsLdsSize is passed in a user data SGPR to the merged shader so that the API GS knows where to start
-    // reading out of LDS. EsGsLdsSize is unnecessary when there is no API GS.
+    // EsGsLdsSize is unnecessary when there is no API GS.
     gsResUsage->inOutUsage.gs.calcFactor.esGsLdsSize = hasGs ? expectedEsLdsSize : 0;
     gsResUsage->inOutUsage.gs.calcFactor.gsOnChipLdsSize = needsLds ? ldsSizeDwords : 0;
 

--- a/lgc/patch/RegisterMetadataBuilder.cpp
+++ b/lgc/patch/RegisterMetadataBuilder.cpp
@@ -402,7 +402,6 @@ void RegisterMetadataBuilder::buildEsGsRegisters() {
 
   auto hwShaderNode = getHwShaderNode(Util::Abi::HardwareStage::Gs);
   hwShaderNode[Util::Abi::HardwareStageMetadataKey::LdsSize] = calcLdsSize(ldsSizeInDwords);
-  setEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 }
 
 // =====================================================================================================================
@@ -673,8 +672,6 @@ void RegisterMetadataBuilder::buildPrimShaderRegisters() {
 
   auto hwShaderNode = getHwShaderNode(Util::Abi::HardwareStage::Gs);
   hwShaderNode[Util::Abi::HardwareStageMetadataKey::LdsSize] = calcLdsSize(ldsSizeInDwords);
-  if (!m_hasMesh)
-    setEsGsLdsSize(calcFactor.esGsLdsSize * 4);
 }
 
 // =====================================================================================================================

--- a/lgc/patch/ShaderInputs.cpp
+++ b/lgc/patch/ShaderInputs.cpp
@@ -57,8 +57,6 @@ const char *ShaderInputs::getSpecialUserDataName(UserDataMapping kind) {
     return "DrawIndex";
   case UserDataMapping::Workgroup:
     return "Workgroup";
-  case UserDataMapping::EsGsLdsSize:
-    return "EsGsLdsSize";
   case UserDataMapping::ViewId:
     return "ViewId";
   case UserDataMapping::StreamOutTable:

--- a/llpc/test/shaderdb/gfx11/SgprUserDataInit_Fs.pipe
+++ b/llpc/test/shaderdb/gfx11/SgprUserDataInit_Fs.pipe
@@ -302,12 +302,11 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:         .offchip_lds_en: false
 ; CHECK-NEXT:         .scratch_en:     false
 ; CHECK-NEXT:         .scratch_memory_size: 0
-; CHECK-NEXT:         .sgpr_count:     0xc
+; CHECK-NEXT:         .sgpr_count:     0xb
 ; CHECK-NEXT:         .sgpr_limit:     0x6a
 ; CHECK-NEXT:         .trap_present:   0
 ; CHECK-NEXT:         .user_data_reg_map:
 ; CHECK-NEXT:           - 0x10000000
-; CHECK-NEXT:           - 0x1000000a
 ; CHECK-NEXT:           - 0x10000003
 ; CHECK-NEXT:           - 0x10000004
 ; CHECK-NEXT:           - 0xffffffff
@@ -338,7 +337,8 @@ colorBuffer[0].blendSrcAlphaToColor = 0
 ; CHECK-NEXT:           - 0xffffffff
 ; CHECK-NEXT:           - 0xffffffff
 ; CHECK-NEXT:           - 0xffffffff
-; CHECK-NEXT:         .user_sgprs:     0x4
+; CHECK-NEXT:           - 0xffffffff
+; CHECK-NEXT:         .user_sgprs:     0x3
 ; CHECK-NEXT:         .vgpr_count:     0x9
 ; CHECK-NEXT:         .vgpr_limit:     0x100
 ; CHECK-NEXT:         .wavefront_size: 0x40


### PR DESCRIPTION
This user data was added to keep some compatibility with old PAL. At that time, PAL expected this user data to handle ES-GS merged shader and NGG correctly on GFX9 and GFX10.1. But LLPC doesn't need this user data at all since we always know ES stage when building the pipeline. And the LDS calculation and allocation of GS stage are applied to full ES-GS pipeline.

In this change, the user data EsGsLdsSize is not added to entry-point argument. This SGPR is saved. Also, we don't need to tell PAL with metadata EsGsLdsSize.