### PR TITLE
Fix build on clang < 13

### DIFF
--- a/llpc/util/llpcShaderModuleHelper.cpp
+++ b/llpc/util/llpcShaderModuleHelper.cpp
@@ -540,7 +540,7 @@ Expected<BinaryData> ShaderModuleHelper::getShaderCode(const ShaderModuleBuildIn
   if (trimDebugInfo) {
     auto sizeOrErr = trimSpirvDebugInfo(&shaderBinary, codeBuffer);
     if (Error err = sizeOrErr.takeError())
-      return err;
+      return std::move(err);
     code.codeSize = *sizeOrErr;
   } else {
     assert(shaderBinary.codeSize <= codeBuffer.size() * sizeof(codeBuffer.front()));


### PR DESCRIPTION
An explicit std::move is needed to select the correct Error constructor.
The error was introduced in c7656ef95a4e8fee461160b4f2bcc4069e2141a7